### PR TITLE
Each attribute doesnt need a loading indicator

### DIFF
--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -2125,12 +2125,8 @@ var UncachedProductAttributeElement = withAPIData(function (props) {
 	    addTerm = _ref2.addTerm,
 	    removeTerm = _ref2.removeTerm;
 
-	if (!terms.data) {
-		return __('Loading');
-	}
-
-	if (0 === terms.data.length) {
-		return __('No attribute options found');
+	if (!terms.data || 0 === terms.data.length) {
+		return null;
 	}
 
 	// Populate cache.

--- a/assets/js/views/attribute-select.jsx
+++ b/assets/js/views/attribute-select.jsx
@@ -191,12 +191,8 @@ const UncachedProductAttributeElement = withAPIData( ( props ) => {
 			terms: '/wc/v2/products/attributes/' + props.attribute.id + '/terms'
 		};
 	} )( ( { terms, selectedAttribute, selectedTerms, attribute, setSelectedAttribute, addTerm, removeTerm } ) => {
-		if ( ! terms.data ) {
-			return __( 'Loading' );
-		}
-
-		if ( 0 === terms.data.length ) {
-			return __( 'No attribute options found' );
+		if ( ! terms.data || 0 === terms.data.length ) {
+			return null;
 		}
 
 		// Populate cache.


### PR DESCRIPTION
Fixes #51 

I don't think it really makes sense to have loading indicators or "No result" messages for individual attribute results (one message for each attribute as it's being fetched). The one loading message when all the attributes are being fetched is plenty.