### PR TITLE
Specific Select improvements

### DIFF
--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -458,8 +458,9 @@ var ProductsBlockSettingsEditor = function (_React$Component3) {
 				{ type: 'button', className: 'button wc-products-settings__footer-button', onClick: this.props.done_callback },
 				__('Done')
 			);
-			if (['specific', 'category', 'attribute'].includes(this.state.display) && !this.props.selected_display_setting.length) {
+			if (['', 'specific', 'category', 'attribute'].includes(this.state.display) && !this.props.selected_display_setting.length) {
 				var done_tooltips = {
+					'': __('Please make a selection'),
 					specific: __('Please search for and select products to display'),
 					category: __('Please select at least one category to display'),
 					attribute: __('Please select an attribute')

--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -460,7 +460,7 @@ var ProductsBlockSettingsEditor = function (_React$Component3) {
 			);
 			if (['', 'specific', 'category', 'attribute'].includes(this.state.display) && !this.props.selected_display_setting.length) {
 				var done_tooltips = {
-					'': __('Please make a selection'),
+					'': __('Please select which products you\'d like to display'),
 					specific: __('Please search for and select products to display'),
 					category: __('Please select at least one category to display'),
 					attribute: __('Please select an attribute')

--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -871,7 +871,7 @@ registerBlockType('woocommerce/products', {
 		}
 
 		if ('specific' === display) {
-			shortcode_atts.set('include', display_setting.join(','));
+			shortcode_atts.set('ids', display_setting.join(','));
 		} else if ('category' === display) {
 			shortcode_atts.set('category', display_setting.join(','));
 		} else if ('featured' === display) {
@@ -962,6 +962,13 @@ var _wp$components = wp.components,
 var _ReactTransitionGroup = ReactTransitionGroup,
     TransitionGroup = _ReactTransitionGroup.TransitionGroup,
     CSSTransition = _ReactTransitionGroup.CSSTransition;
+
+/**
+ * Product data cache.
+ * Reduces the number of API calls and makes UI smoother and faster.
+ */
+
+var PRODUCT_DATA = {};
 
 /**
  * When the display mode is 'Specific products' search for and add products to the block.
@@ -1074,7 +1081,7 @@ var ProductsSpecificSelect = exports.ProductsSpecificSelect = function (_React$C
 					selectedProducts: this.state.selectedProducts
 				}),
 				wp.element.createElement(ProductSpecificSelectedProducts, {
-					products: this.state.selectedProducts,
+					productIds: this.state.selectedProducts,
 					removeProductCallback: this.removeProduct.bind(this)
 				})
 			);
@@ -1228,6 +1235,32 @@ var ProductSpecificSearchResults = withAPIData(function (props) {
 		return __('No products found');
 	}
 
+	// Populate the cache.
+	var _iteratorNormalCompletion2 = true;
+	var _didIteratorError2 = false;
+	var _iteratorError2 = undefined;
+
+	try {
+		for (var _iterator2 = products.data[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+			var product = _step2.value;
+
+			PRODUCT_DATA[product.id] = product;
+		}
+	} catch (err) {
+		_didIteratorError2 = true;
+		_iteratorError2 = err;
+	} finally {
+		try {
+			if (!_iteratorNormalCompletion2 && _iterator2.return) {
+				_iterator2.return();
+			}
+		} finally {
+			if (_didIteratorError2) {
+				throw _iteratorError2;
+			}
+		}
+	}
+
 	return wp.element.createElement(ProductSpecificSearchResultsDropdown, {
 		products: products.data,
 		addProductCallback: addProductCallback,
@@ -1264,13 +1297,13 @@ var ProductSpecificSearchResultsDropdown = function (_React$Component3) {
 
 			var productElements = [];
 
-			var _iteratorNormalCompletion2 = true;
-			var _didIteratorError2 = false;
-			var _iteratorError2 = undefined;
+			var _iteratorNormalCompletion3 = true;
+			var _didIteratorError3 = false;
+			var _iteratorError3 = undefined;
 
 			try {
-				for (var _iterator2 = products[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
-					var product = _step2.value;
+				for (var _iterator3 = products[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+					var product = _step3.value;
 
 					if (selectedProducts.includes(product.id)) {
 						continue;
@@ -1290,16 +1323,16 @@ var ProductSpecificSearchResultsDropdown = function (_React$Component3) {
 					));
 				}
 			} catch (err) {
-				_didIteratorError2 = true;
-				_iteratorError2 = err;
+				_didIteratorError3 = true;
+				_iteratorError3 = err;
 			} finally {
 				try {
-					if (!_iteratorNormalCompletion2 && _iterator2.return) {
-						_iterator2.return();
+					if (!_iteratorNormalCompletion3 && _iterator3.return) {
+						_iterator3.return();
 					}
 				} finally {
-					if (_didIteratorError2) {
-						throw _iteratorError2;
+					if (_didIteratorError3) {
+						throw _iteratorError3;
 					}
 				}
 			}
@@ -1395,25 +1428,144 @@ var ProductSpecificSearchResultsDropdownElement = function (_React$Component4) {
 
 var ProductSpecificSelectedProducts = withAPIData(function (props) {
 
-	if (!props.products.length) {
+	if (!props.productIds.length) {
 		return {
 			products: []
 		};
 	}
 
-	return {
-		products: '/wc/v2/products?include=' + props.products.join(',')
-	};
-})(function (_ref2) {
-	var products = _ref2.products,
-	    removeProductCallback = _ref2.removeProductCallback;
+	// Determine which products are not already in the cache and only fetch uncached products.
+	var uncachedProducts = [];
+	var _iteratorNormalCompletion4 = true;
+	var _didIteratorError4 = false;
+	var _iteratorError4 = undefined;
 
-	if (!products.data) {
-		return null;
+	try {
+		for (var _iterator4 = props.productIds[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+			var productId = _step4.value;
+
+			if (!PRODUCT_DATA.hasOwnProperty(productId)) {
+				uncachedProducts.push(productId);
+			}
+		}
+	} catch (err) {
+		_didIteratorError4 = true;
+		_iteratorError4 = err;
+	} finally {
+		try {
+			if (!_iteratorNormalCompletion4 && _iterator4.return) {
+				_iterator4.return();
+			}
+		} finally {
+			if (_didIteratorError4) {
+				throw _iteratorError4;
+			}
+		}
 	}
 
-	if (0 === products.data.length) {
+	return {
+		products: uncachedProducts.length ? '/wc/v2/products?include=' + uncachedProducts.join(',') : []
+	};
+})(function (_ref2) {
+	var productIds = _ref2.productIds,
+	    products = _ref2.products,
+	    removeProductCallback = _ref2.removeProductCallback;
+
+
+	// Add new products to cache.
+	if (products.data) {
+		var _iteratorNormalCompletion5 = true;
+		var _didIteratorError5 = false;
+		var _iteratorError5 = undefined;
+
+		try {
+			for (var _iterator5 = products.data[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+				var product = _step5.value;
+
+				PRODUCT_DATA[product.id] = product;
+			}
+		} catch (err) {
+			_didIteratorError5 = true;
+			_iteratorError5 = err;
+		} finally {
+			try {
+				if (!_iteratorNormalCompletion5 && _iterator5.return) {
+					_iterator5.return();
+				}
+			} finally {
+				if (_didIteratorError5) {
+					throw _iteratorError5;
+				}
+			}
+		}
+	}
+
+	if (0 === productIds.length) {
 		return __('No products selected');
+	}
+
+	var productElements = [];
+
+	var _loop = function _loop(productId) {
+
+		// Skip products that aren't in the cache yet or failed to fetch.
+		if (!PRODUCT_DATA.hasOwnProperty(productId)) {
+			return 'continue';
+		}
+
+		var productData = PRODUCT_DATA[productId];
+
+		productElements.push(wp.element.createElement(
+			'li',
+			{ className: 'wc-products-list-card__item' },
+			wp.element.createElement(
+				'div',
+				{ className: 'wc-products-list-card__content' },
+				wp.element.createElement('img', { src: productData.images[0].src }),
+				wp.element.createElement(
+					'span',
+					{ className: 'wc-products-list-card__content-item-name' },
+					productData.name
+				),
+				wp.element.createElement(
+					'button',
+					{
+						type: 'button',
+						id: 'product-' + productData.id,
+						onClick: function onClick() {
+							removeProductCallback(productData.id);
+						} },
+					wp.element.createElement(Dashicon, { icon: 'no-alt' })
+				)
+			)
+		));
+	};
+
+	var _iteratorNormalCompletion6 = true;
+	var _didIteratorError6 = false;
+	var _iteratorError6 = undefined;
+
+	try {
+		for (var _iterator6 = productIds[Symbol.iterator](), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
+			var productId = _step6.value;
+
+			var _ret = _loop(productId);
+
+			if (_ret === 'continue') continue;
+		}
+	} catch (err) {
+		_didIteratorError6 = true;
+		_iteratorError6 = err;
+	} finally {
+		try {
+			if (!_iteratorNormalCompletion6 && _iterator6.return) {
+				_iterator6.return();
+			}
+		} finally {
+			if (_didIteratorError6) {
+				throw _iteratorError6;
+			}
+		}
 	}
 
 	return wp.element.createElement(
@@ -1425,32 +1577,7 @@ var ProductSpecificSelectedProducts = withAPIData(function (props) {
 			wp.element.createElement(
 				'ul',
 				null,
-				products.data.map(function (product) {
-					return wp.element.createElement(
-						'li',
-						{ className: 'wc-products-list-card__item' },
-						wp.element.createElement(
-							'div',
-							{ className: 'wc-products-list-card__content' },
-							wp.element.createElement('img', { src: product.images[0].src }),
-							wp.element.createElement(
-								'span',
-								{ className: 'wc-products-list-card__content-item-name' },
-								product.name
-							),
-							wp.element.createElement(
-								'button',
-								{
-									type: 'button',
-									id: 'product-' + product.id,
-									onClick: function onClick() {
-										removeProductCallback(product.id);
-									} },
-								wp.element.createElement(Dashicon, { icon: 'no-alt' })
-							)
-						)
-					);
-				})
+				productElements
 			)
 		)
 	);

--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -798,12 +798,20 @@ registerBlockType('woocommerce/products', {
    * @return Component
    */
 		function getSettingsEditor() {
+
+			var update_display_callback = function update_display_callback(value) {
+				if (display !== value) {
+					setAttributes({
+						display: value,
+						display_setting: []
+					});
+				}
+			};
+
 			return wp.element.createElement(ProductsBlockSettingsEditor, {
 				selected_display: display,
 				selected_display_setting: display_setting,
-				update_display_callback: function update_display_callback(value) {
-					return setAttributes({ display: value });
-				},
+				update_display_callback: update_display_callback,
 				update_display_setting_callback: function update_display_setting_callback(value) {
 					return setAttributes({ display_setting: value });
 				},

--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -99,7 +99,8 @@ var _wp$components = wp.components,
     withAPIData = _wp$components.withAPIData,
     Dropdown = _wp$components.Dropdown,
     Dashicon = _wp$components.Dashicon,
-    RangeControl = _wp$components.RangeControl;
+    RangeControl = _wp$components.RangeControl,
+    Tooltip = _wp$components.Tooltip;
 var ToggleControl = InspectorControls.ToggleControl,
     SelectControl = InspectorControls.SelectControl;
 
@@ -452,6 +453,29 @@ var ProductsBlockSettingsEditor = function (_React$Component3) {
 				);
 			}
 
+			var done_button = wp.element.createElement(
+				'button',
+				{ type: 'button', className: 'button wc-products-settings__footer-button', onClick: this.props.done_callback },
+				__('Done')
+			);
+			if (['specific', 'category', 'attribute'].includes(this.state.display) && !this.props.selected_display_setting.length) {
+				var done_tooltips = {
+					specific: __('Please search for and select products to display'),
+					category: __('Please select at least one category to display'),
+					attribute: __('Please select an attribute')
+				};
+
+				done_button = wp.element.createElement(
+					Tooltip,
+					{ text: done_tooltips[this.state.display] },
+					wp.element.createElement(
+						'button',
+						{ type: 'button', className: 'button wc-products-settings__footer-button disabled' },
+						__('Done')
+					)
+				);
+			}
+
 			return wp.element.createElement(
 				'div',
 				{ className: 'wc-products-settings ' + (this.state.expanded_group ? 'expanded-group-' + this.state.expanded_group : '') },
@@ -468,11 +492,7 @@ var ProductsBlockSettingsEditor = function (_React$Component3) {
 				wp.element.createElement(
 					'div',
 					{ className: 'wc-products-settings__footer' },
-					wp.element.createElement(
-						'button',
-						{ type: 'button', className: 'button wc-products-settings__footer-button', onClick: this.props.done_callback },
-						__('Done')
-					)
+					done_button
 				)
 			);
 		}

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -268,8 +268,9 @@ class ProductsBlockSettingsEditor extends React.Component {
 		}
 
 		let done_button = <button type="button" className="button wc-products-settings__footer-button" onClick={ this.props.done_callback }>{ __( 'Done' ) }</button>;
-		if ( [ 'specific', 'category', 'attribute' ].includes( this.state.display ) && ! this.props.selected_display_setting.length ) {
+		if ( ['', 'specific', 'category', 'attribute'].includes( this.state.display ) && ! this.props.selected_display_setting.length ) {
 			const done_tooltips = {
+				'': __( 'Please make a selection' ),
 				specific: __( 'Please search for and select products to display' ),
 				category: __( 'Please select at least one category to display' ),
 				attribute: __( 'Please select an attribute' ),

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -1,7 +1,7 @@
 const { __ } = wp.i18n;
 const { RawHTML } = wp.element;
 const { registerBlockType, InspectorControls, BlockControls } = wp.blocks;
-const { Toolbar, withAPIData, Dropdown, Dashicon, RangeControl } = wp.components;
+const { Toolbar, withAPIData, Dropdown, Dashicon, RangeControl, Tooltip } = wp.components;
 const { ToggleControl, SelectControl } = InspectorControls;
 
 import { ProductsSpecificSelect } from './views/specific-select.jsx';
@@ -267,6 +267,22 @@ class ProductsBlockSettingsEditor extends React.Component {
 			);
 		}
 
+		let done_button = <button type="button" className="button wc-products-settings__footer-button" onClick={ this.props.done_callback }>{ __( 'Done' ) }</button>;
+		if ( [ 'specific', 'category', 'attribute' ].includes( this.state.display ) && ! this.props.selected_display_setting.length ) {
+			const done_tooltips = {
+				specific: __( 'Please search for and select products to display' ),
+				category: __( 'Please select at least one category to display' ),
+				attribute: __( 'Please select an attribute' ),
+			}
+
+			done_button = (
+				<Tooltip text={ done_tooltips[ this.state.display ] } >
+					<button type="button" className="button wc-products-settings__footer-button disabled">{ __( 'Done' ) }</button>
+				</Tooltip>
+			);
+		}
+
+
 		return (
 			<div className={ 'wc-products-settings ' + ( this.state.expanded_group ? 'expanded-group-' + this.state.expanded_group : '' ) }>
 				<h4 className="wc-products-settings__title"><Dashicon icon={ 'universal-access-alt' } /> { __( 'Products' ) }</h4>
@@ -278,7 +294,7 @@ class ProductsBlockSettingsEditor extends React.Component {
 				{ extra_settings }
 
 				<div className="wc-products-settings__footer">
-					<button type="button" className="button wc-products-settings__footer-button" onClick={ this.props.done_callback }>{ __( 'Done' ) }</button>
+					{ done_button }
 				</div>
 			</div>
 		);

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -590,7 +590,7 @@ registerBlockType( 'woocommerce/products', {
 		}
 
 		if ( 'specific' === display ) {
-			shortcode_atts.set( 'include', display_setting.join( ',' ) );
+			shortcode_atts.set( 'ids', display_setting.join( ',' ) );
 		} else if ( 'category' === display ) {
 			shortcode_atts.set( 'category', display_setting.join( ',' ) );
 		} else if ( 'featured' === display ) {

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -270,7 +270,7 @@ class ProductsBlockSettingsEditor extends React.Component {
 		let done_button = <button type="button" className="button wc-products-settings__footer-button" onClick={ this.props.done_callback }>{ __( 'Done' ) }</button>;
 		if ( ['', 'specific', 'category', 'attribute'].includes( this.state.display ) && ! this.props.selected_display_setting.length ) {
 			const done_tooltips = {
-				'': __( 'Please make a selection' ),
+				'': __( 'Please select which products you\'d like to display' ),
 				specific: __( 'Please search for and select products to display' ),
 				category: __( 'Please select at least one category to display' ),
 				attribute: __( 'Please select an attribute' ),

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -526,11 +526,21 @@ registerBlockType( 'woocommerce/products', {
 		 * @return Component
 		 */
 		function getSettingsEditor() {
+
+			const update_display_callback = ( value ) => {
+				if ( display !== value ) {
+					setAttributes( {
+						display: value,
+						display_setting: [],
+					} );
+				}
+			};
+
 			return (
 				<ProductsBlockSettingsEditor
 					selected_display={ display }
 					selected_display_setting={ display_setting }
-					update_display_callback={ ( value ) => setAttributes( { display: value } ) }
+					update_display_callback={ update_display_callback }
 					update_display_setting_callback={ ( value ) => setAttributes( { display_setting: value } ) }
 					done_callback={ () => setAttributes( { edit_mode: false } ) }
 				/>


### PR DESCRIPTION
- Closes #49 (Refactored the way that section is rendered to use caching)
- Closes #33 (Disabled "Done" button on product, attribute, and category select screens if nothing is selected)
- Fixes frontend specific product rendering (Was using `include` shortcode attribute when it should be using `ids`)
- Fixes bug where selecting some products then switching to category or attribute select mode would end up with product ids in the list of category/attribute ids.