### PR TITLE
Products block Orderby options

### DIFF
--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -936,9 +936,16 @@ registerBlockType('woocommerce/products', {
 			}
 		}
 
-		// @todo Add support for price_desc and price_asc to shortcode.
-		if (!['specific', 'price_desc', 'price_asc'].includes(display)) {
-			shortcode_atts.set('orderby', orderby);
+		if ('specific' !== display) {
+			if ('price_desc' === orderby) {
+				shortcode_atts.set('orderby', 'price');
+				shortcode_atts.set('order', 'DESC');
+			} else if ('price_asc' === orderby) {
+				shortcode_atts.set('orderby', 'price');
+				shortcode_atts.set('order', 'ASC');
+			} else {
+				shortcode_atts.set('orderby', orderby);
+			}
 		}
 
 		// Build the shortcode string out of the set shortcode attributes.

--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -100,9 +100,8 @@ var _wp$components = wp.components,
     Dropdown = _wp$components.Dropdown,
     Dashicon = _wp$components.Dashicon,
     RangeControl = _wp$components.RangeControl,
-    Tooltip = _wp$components.Tooltip;
-var ToggleControl = InspectorControls.ToggleControl,
-    SelectControl = InspectorControls.SelectControl;
+    Tooltip = _wp$components.Tooltip,
+    SelectControl = _wp$components.SelectControl;
 
 
 /**
@@ -133,16 +132,6 @@ var PRODUCTS_BLOCK_DISPLAY_SETTINGS = {
 		title: __('Featured products'),
 		description: '',
 		value: 'featured'
-	},
-	'best_sellers': {
-		title: __('Best sellers'),
-		description: '',
-		value: 'best_sellers'
-	},
-	'best_rated': {
-		title: __('Best rated'),
-		description: '',
-		value: 'best_rated'
 	},
 	'on_sale': {
 		title: __('On sale'),
@@ -431,7 +420,7 @@ var ProductsBlockSettingsEditor = function (_React$Component3) {
 
 			var heading = null;
 			if (this.state.display) {
-				var group_options = ['featured', 'best_sellers', 'best_rated', 'on_sale', 'attribute'];
+				var group_options = ['featured', 'on_sale', 'attribute'];
 				var should_group_expand = group_options.includes(this.state.display) ? this.state.display : '';
 				var menu_link = wp.element.createElement(
 					'button',
@@ -571,6 +560,7 @@ var ProductsBlockPreview = withAPIData(function (_ref) {
 	    rows = attributes.rows,
 	    display = attributes.display,
 	    display_setting = attributes.display_setting,
+	    orderby = attributes.orderby,
 	    block_layout = attributes.block_layout;
 
 
@@ -591,12 +581,17 @@ var ProductsBlockPreview = withAPIData(function (_ref) {
 		}
 	} else if ('featured' === display) {
 		query.featured = 1;
-	} else if ('best_sellers' === display) {
-		// @todo Not possible in the API yet.
-	} else if ('best_rated' === display) {
-		// @todo Not possible in the API yet.
 	} else if ('on_sale' === display) {
 		query.on_sale = 1;
+	}
+
+	// @todo Add support for orderby by sales, rating, and random to the API.
+	if ('specific' !== display && ('title' === orderby || 'date' === orderby)) {
+		query.orderby = orderby;
+
+		if ('title' === orderby) {
+			query.order = 'asc';
+		}
 	}
 
 	var query_string = '?';
@@ -703,6 +698,14 @@ registerBlockType('woocommerce/products', {
 		},
 
 		/**
+   * How to order the products: 'date', 'popularity', 'rand', 'rating', 'title'.
+   */
+		orderby: {
+			type: 'string',
+			default: 'date'
+		},
+
+		/**
    * Whether the block is in edit or preview mode.
    */
 		edit_mode: {
@@ -725,6 +728,7 @@ registerBlockType('woocommerce/products', {
 		    columns = attributes.columns,
 		    display = attributes.display,
 		    display_setting = attributes.display_setting,
+		    orderby = attributes.orderby,
 		    edit_mode = attributes.edit_mode;
 
 		/**
@@ -749,6 +753,35 @@ registerBlockType('woocommerce/products', {
 				});
 			}
 
+			// Orderby settings don't make sense for specific-selected products display.
+			var orderControl = null;
+			if ('specific' !== display) {
+				orderControl = wp.element.createElement(SelectControl, {
+					key: 'query-panel-select',
+					label: __('Products Order'),
+					value: orderby,
+					options: [{
+						label: __('Newness'),
+						value: 'date'
+					}, {
+						label: __('Title'),
+						value: 'title'
+					}, {
+						label: __('Sales'),
+						value: 'popularity'
+					}, {
+						label: __('Rating'),
+						value: 'rating'
+					}, {
+						label: __('Random'),
+						value: 'rand'
+					}],
+					onChange: function onChange(value) {
+						return setAttributes({ orderby: value });
+					}
+				});
+			}
+
 			return wp.element.createElement(
 				InspectorControls,
 				{ key: 'inspector' },
@@ -766,7 +799,8 @@ registerBlockType('woocommerce/products', {
 					},
 					min: 1,
 					max: 6
-				})
+				}),
+				orderControl
 			);
 		};
 
@@ -866,7 +900,8 @@ registerBlockType('woocommerce/products', {
 		    rows = _props$attributes.rows,
 		    columns = _props$attributes.columns,
 		    display = _props$attributes.display,
-		    display_setting = _props$attributes.display_setting;
+		    display_setting = _props$attributes.display_setting,
+		    orderby = _props$attributes.orderby;
 
 
 		var shortcode_atts = new Map();
@@ -886,10 +921,6 @@ registerBlockType('woocommerce/products', {
 			shortcode_atts.set('category', display_setting.join(','));
 		} else if ('featured' === display) {
 			shortcode_atts.set('visibility', 'featured');
-		} else if ('best_sellers' === display) {
-			shortcode_atts.set('best_selling', '1');
-		} else if ('best_rated' === display) {
-			shortcode_atts.set('orderby', 'rating');
 		} else if ('on_sale' === display) {
 			shortcode_atts.set('on_sale', '1');
 		} else if ('attribute' === display) {
@@ -900,6 +931,10 @@ registerBlockType('woocommerce/products', {
 			if (terms.length) {
 				shortcode_atts.set('terms', terms);
 			}
+		}
+
+		if ('specific' !== display) {
+			shortcode_atts.set('orderby', orderby);
 		}
 
 		// Build the shortcode string out of the set shortcode attributes.

--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -758,26 +758,26 @@ registerBlockType('woocommerce/products', {
 			if ('specific' !== display) {
 				orderControl = wp.element.createElement(SelectControl, {
 					key: 'query-panel-select',
-					label: __('Products Order'),
+					label: __('Order Products By'),
 					value: orderby,
 					options: [{
-						label: __('Newness'),
+						label: __('Newness - newest first'),
 						value: 'date'
 					}, {
-						label: __('Title'),
-						value: 'title'
-					}, {
-						label: __('Sales'),
-						value: 'popularity'
-					}, {
-						label: __('Rating'),
-						value: 'rating'
-					}, {
-						label: __('Increasing Price'),
+						label: __('Price - low to high'),
 						value: 'price_asc'
 					}, {
-						label: __('Decreasing Price'),
+						label: __('Price - high to low'),
 						value: 'price_desc'
+					}, {
+						label: __('Rating - highest first'),
+						value: 'rating'
+					}, {
+						label: __('Sales - most first'),
+						value: 'popularity'
+					}, {
+						label: __('Title - alphabetical'),
+						value: 'title'
 					}],
 					onChange: function onChange(value) {
 						return setAttributes({ orderby: value });

--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -585,7 +585,7 @@ var ProductsBlockPreview = withAPIData(function (_ref) {
 		query.on_sale = 1;
 	}
 
-	// @todo Add support for orderby by sales, rating, and random to the API.
+	// @todo Add support for orderby by sales, rating, and price to the API.
 	if ('specific' !== display && ('title' === orderby || 'date' === orderby)) {
 		query.orderby = orderby;
 
@@ -698,7 +698,7 @@ registerBlockType('woocommerce/products', {
 		},
 
 		/**
-   * How to order the products: 'date', 'popularity', 'rand', 'rating', 'title'.
+   * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
    */
 		orderby: {
 			type: 'string',
@@ -773,8 +773,11 @@ registerBlockType('woocommerce/products', {
 						label: __('Rating'),
 						value: 'rating'
 					}, {
-						label: __('Random'),
-						value: 'rand'
+						label: __('Increasing Price'),
+						value: 'price_asc'
+					}, {
+						label: __('Decreasing Price'),
+						value: 'price_desc'
 					}],
 					onChange: function onChange(value) {
 						return setAttributes({ orderby: value });
@@ -933,7 +936,8 @@ registerBlockType('woocommerce/products', {
 			}
 		}
 
-		if ('specific' !== display) {
+		// @todo Add support for price_desc and price_asc to shortcode.
+		if (!['specific', 'price_desc', 'price_asc'].includes(display)) {
 			shortcode_atts.set('orderby', orderby);
 		}
 

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -352,7 +352,7 @@ const ProductsBlockPreview = withAPIData( ( { attributes } ) => {
 		query.on_sale = 1;
 	}
 
-	// @todo Add support for orderby by sales, rating, and random to the API.
+	// @todo Add support for orderby by sales, rating, and price to the API.
 	if ( 'specific' !== display && ( 'title' === orderby || 'date' === orderby ) ) {
 		query.orderby = orderby;
 
@@ -442,7 +442,7 @@ registerBlockType( 'woocommerce/products', {
 		},
 
 		/**
-		 * How to order the products: 'date', 'popularity', 'rand', 'rating', 'title'.
+		 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
 		 */
 		orderby: {
 			type: 'string',
@@ -512,8 +512,12 @@ registerBlockType( 'woocommerce/products', {
 								value: 'rating',
 							},
 							{
-								label: __( 'Random' ),
-								value: 'rand',
+								label: __( 'Increasing Price' ),
+								value: 'price_asc',
+							},
+							{
+								label: __( 'Decreasing Price' ),
+								value: 'price_desc',
 							},
 						] }
 						onChange={ ( value ) => setAttributes( { orderby: value } ) }
@@ -659,7 +663,8 @@ registerBlockType( 'woocommerce/products', {
 			}
 		}
 
-		if ( 'specific' !== display ) {
+		// @todo Add support for price_desc and price_asc to shortcode.
+		if ( ! ['specific', 'price_desc', 'price_asc'].includes( display ) ) {
 			shortcode_atts.set( 'orderby', orderby );
 		}
 

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -492,32 +492,32 @@ registerBlockType( 'woocommerce/products', {
 				orderControl = (
 					<SelectControl
 						key="query-panel-select"
-						label={ __( 'Products Order' ) }
+						label={ __( 'Order Products By' ) }
 						value={ orderby }
 						options={ [
 							{
-								label: __( 'Newness' ),
+								label: __( 'Newness - newest first' ),
 								value: 'date',
 							},
 							{
-								label: __( 'Title' ),
-								value: 'title',
-							},
-							{
-								label: __( 'Sales' ),
-								value: 'popularity',
-							},
-							{
-								label: __( 'Rating' ),
-								value: 'rating',
-							},
-							{
-								label: __( 'Increasing Price' ),
+								label: __( 'Price - low to high' ),
 								value: 'price_asc',
 							},
 							{
-								label: __( 'Decreasing Price' ),
+								label: __( 'Price - high to low' ),
 								value: 'price_desc',
+							},
+							{
+								label: __( 'Rating - highest first' ),
+								value: 'rating',
+							},
+							{
+								label: __( 'Sales - most first' ),
+								value: 'popularity',
+							},
+							{
+								label: __( 'Title - alphabetical' ),
+								value: 'title',
 							},
 						] }
 						onChange={ ( value ) => setAttributes( { orderby: value } ) }

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -663,9 +663,16 @@ registerBlockType( 'woocommerce/products', {
 			}
 		}
 
-		// @todo Add support for price_desc and price_asc to shortcode.
-		if ( ! ['specific', 'price_desc', 'price_asc'].includes( display ) ) {
-			shortcode_atts.set( 'orderby', orderby );
+		if ( 'specific' !== display ) {
+			if ( 'price_desc' === orderby ) {
+				shortcode_atts.set( 'orderby', 'price' );
+				shortcode_atts.set( 'order', 'DESC' )
+			} else if ( 'price_asc' === orderby ) {
+				shortcode_atts.set( 'orderby', 'price' );
+				shortcode_atts.set( 'order', 'ASC' )
+			} else {
+				shortcode_atts.set( 'orderby', orderby );
+			}
 		}
 
 		// Build the shortcode string out of the set shortcode attributes.


### PR DESCRIPTION
Closes #55 

<img width="298" alt="screen shot 2018-03-15 at 11 07 28 am" src="https://user-images.githubusercontent.com/7317227/37482225-165ebed8-2841-11e8-9017-1ae887f2ad82.png">

Disclaimer: The WC API doesn't support ordering by sales, rating, and random and doesn't have filters for modifying it from the feature plugin to support them. We will have to add these features in API v3. Until then the Gutenberg preview won't accurately reflect the orderby setting sometimes, but the frontend will accurately reflect the orderby setting.