### PR TITLE
Add order DESC attribute when ordering by newest first

### DIFF
--- a/assets/js/products-block.js
+++ b/assets/js/products-block.js
@@ -1195,6 +1195,9 @@ registerBlockType('woocommerce/products', {
 			} else if ('price_asc' === orderby) {
 				shortcode_atts.set('orderby', 'price');
 				shortcode_atts.set('order', 'ASC');
+			} else if ('date' === orderby) {
+				shortcode_atts.set('orderby', 'date');
+				shortcode_atts.set('order', 'DESC');
 			} else {
 				shortcode_atts.set('orderby', orderby);
 			}

--- a/assets/js/products-block.jsx
+++ b/assets/js/products-block.jsx
@@ -74,8 +74,8 @@ const PRODUCTS_BLOCK_DISPLAY_SETTINGS = {
  * @return bool
  */
 function supportsOrderby( display ) {
-	return ! ( PRODUCTS_BLOCK_DISPLAY_SETTINGS.hasOwnProperty( display ) 
-	&& PRODUCTS_BLOCK_DISPLAY_SETTINGS[ display ].hasOwnProperty( 'no_orderby' ) 
+	return ! ( PRODUCTS_BLOCK_DISPLAY_SETTINGS.hasOwnProperty( display )
+	&& PRODUCTS_BLOCK_DISPLAY_SETTINGS[ display ].hasOwnProperty( 'no_orderby' )
 	&& PRODUCTS_BLOCK_DISPLAY_SETTINGS[ display ].no_orderby );
 }
 
@@ -834,6 +834,9 @@ registerBlockType( 'woocommerce/products', {
 			} else if ( 'price_asc' === orderby ) {
 				shortcode_atts.set( 'orderby', 'price' );
 				shortcode_atts.set( 'order', 'ASC' )
+			} else if ( 'date' === orderby ) {
+				shortcode_atts.set( 'orderby', 'date' );
+				shortcode_atts.set( 'order', 'DESC' )
 			} else {
 				shortcode_atts.set( 'orderby', orderby );
 			}


### PR DESCRIPTION
Adds the `order="DESC"` attribute to shortcodes when ordering by "Newness" so that in the frontend products are displayed in the correct order.

To test, add a new "Products" block, select a type such as "All Products", and order by Newness. In the frontend you should see the products in the correct order.

Closes #101.