### PR TITLE
Add all dependencies used in the product block to the script registration

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -50,14 +50,14 @@ function wgpb_extra_gutenberg_scripts() {
 	wp_enqueue_script(
 		'react-transition-group',
 		plugins_url( 'assets/js/vendor/react-transition-group.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element' ),
+		array(),
 		'2.2.1'
 	);
 
 	wp_register_script(
 		'woocommerce-products-block-editor',
 		plugins_url( 'assets/js/products-block.js', __FILE__ ),
-		array( 'wp-blocks', 'wp-element', 'react-transition-group' ),
+		array( 'wp-element', 'wp-components', 'wp-blocks', 'wp-editor', 'wp-i18n', 'react-transition-group' ),
 		WGPB_VERSION
 	);
 


### PR DESCRIPTION
Fixes #120, supersedes #119 – When using the WP 5.0 beta, the plugin causes `Uncaught TypeError: Cannot read property 'Toolbar' of undefined` on posts/pages. This is because we're not enqueuing all the dependencies we need (Toolbar is from `wp-components`, specifically). This PR explicitly adds all the required dependencies to the script registration.

**To test**

- With the developer console open, go to create a new post
- Add a product block
- Expected: the block exists, there should be no errors when adding it