### PR TITLE
Add .editorconfig file for editor integration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.txt]
+trim_trailing_whitespace = false
+
+[*.{md,json,yml}]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */


### PR DESCRIPTION
Adds an `.editorconfig` file so that text editors [with support](https://editorconfig.org/) will automatically switch into the correct formatting styles.

This file was pulled from woocommerce, it matches the gutenberg style but is slightly more descriptive.

(this PR also removes a stray `@format` from webpack.config.js, not needed since we're not using prettier here)