### PR TITLE
Update “tested up to” versions for WC and WP

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster
 Tags: gutenberg, woocommerce, woo commerce, products
 Requires at least: 4.7
-Tested up to: 4.9
+Tested up to: 5.0
 Requires PHP: 5.2
 Stable tag: 1.1.2
 License: GPLv3

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -9,7 +9,7 @@
  * Text Domain:  woocommerce
  * Domain Path:  /languages
  * WC requires at least: 3.3
- * WC tested up to: 3.4
+ * WC tested up to: 3.5
  */
 
 defined( 'ABSPATH' ) || die();
@@ -29,7 +29,7 @@ function wgpb_initialize() {
 		add_action( 'rest_api_init', 'wgpb_register_api_routes' );
 		add_action( 'enqueue_block_editor_assets', 'wgpb_extra_gutenberg_scripts' );
 	}
-	
+
 	if ( defined( 'WGPB_DEVELOPMENT_MODE' ) && WGPB_DEVELOPMENT_MODE && ! $files_exist ) {
 		add_action( 'admin_notices', 'wgpb_plugins_notice' );
 	}


### PR DESCRIPTION
This PR updates the "tested up to" versions in the readme and plugin header. The plugin should work with WP 5.0 and WC 3.5. We still want to support 4.9+ with Gutenberg, so I've left the minimum versions alone.

Fixes #114 

### How to test the changes in this Pull Request:

1. Roll back WooCoomerce to v 3.4
2. Check the plugins page, there should be a section on the WooCommerce plugin row which says "Heads up! The versions of the following plugins you're running haven't been tested with the latest version of WooCommerce (3.5)."
3. WooCommerce Gutenberg Products Block should not be on that list.
