### PR TITLE
Hide the legacy products block from the block inserter

### DIFF
--- a/assets/js/legacy/products-block.jsx
+++ b/assets/js/legacy/products-block.jsx
@@ -903,6 +903,9 @@ registerBlockType( 'woocommerce/products', {
 	icon: 'screenoptions',
 	category: 'widgets',
 	description: __( 'Display a grid of products from a variety of sources.' ),
+	supports: {
+		inserter: false,
+	},
 
 	attributes: {
 


### PR DESCRIPTION
This PR removes inserter support for the original products block. It's still a registered block, so users can still interact with already-existing blocks, but they can't add new "Products" blocks. This can be merged whenever we decide to deprecate this block, whether that's part of 1.2 or later. The code for the block can then stay in place for a few versions, as we create transforms or [a deprecation path](https://wordpress.org/gutenberg/handbook/block-api/deprecated-blocks/).

### How to test the changes in this Pull Request:

1. Try to insert a product block by searching in the inserter (or by looking in the widgets category)
2. Expect: You should only see "Products by Category"
