### PR TITLE
Load only published products in the preview

### DIFF
--- a/assets/js/legacy/products-block.jsx
+++ b/assets/js/legacy/products-block.jsx
@@ -412,6 +412,7 @@ class ProductsBlockPreview extends Component {
 		const { columns, rows, display, display_setting, orderby } = this.props.attributes;
 
 		const query = {
+			status: 'publish',
 			per_page: rows * columns,
 		};
 

--- a/assets/js/legacy/views/specific-select.jsx
+++ b/assets/js/legacy/views/specific-select.jsx
@@ -216,7 +216,7 @@ class ProductSpecificSearchResults extends Component {
 			return '';
 		}
 
-		return '/wc/v2/products?per_page=10&search=' + this.props.searchString;
+		return '/wc/v2/products?per_page=10&status=publish&search=' + this.props.searchString;
 	}
 
 	/**

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -2,6 +2,7 @@ export default function getQuery( attributes ) {
 	const { categories, columns, orderby, rows } = attributes;
 
 	const query = {
+		status: 'publish',
 		per_page: rows * columns,
 	};
 

--- a/assets/js/utils/test/get-query.js
+++ b/assets/js/utils/test/get-query.js
@@ -83,6 +83,7 @@ describe( 'getQuery', () => {
 			expect( query ).toEqual( {
 				orderby: 'date',
 				per_page: 12,
+				status: 'publish',
 			} );
 		} );
 
@@ -93,6 +94,7 @@ describe( 'getQuery', () => {
 				category: '',
 				orderby: 'date',
 				per_page: 12,
+				status: 'publish',
 			} );
 		} );
 
@@ -103,6 +105,7 @@ describe( 'getQuery', () => {
 				category: '1',
 				orderby: 'date',
 				per_page: 12,
+				status: 'publish',
 			} );
 		} );
 
@@ -113,6 +116,7 @@ describe( 'getQuery', () => {
 				category: '1,2',
 				orderby: 'date',
 				per_page: 12,
+				status: 'publish',
 			} );
 		} );
 	} );


### PR DESCRIPTION
This PR changes the default query sent to load products into the block preview– only published posts will be returned now. Previously this was defaulting to `any`, which let draft, pending, private, or published products visible in the preview. Now this is restricted just to "published" products.

Fixes #124 

### How to test the changes in this Pull Request:

1. Create a new product, but leave it as a draft (or pick an existing product, and make it "Private")
2. Open a new post/page
3. Add a "Products" block, sorted by "newest first"
4. Expect: You don't see your non-published product in the preview
5. Add a "Products by Category" block, sorted by "newest first"
6. Expect: You don't see your non-published product in the preview
7. Save the post, view it
8. Expect: You don't see your non-published product on the site
