### PR TITLE
Check that the translation function exists before using it

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -99,7 +99,9 @@ function wgpb_extra_gutenberg_scripts() {
 	);
 	wp_localize_script( 'woocommerce-products-block-editor', 'wc_product_block_data', $product_block_data );
 
-	wp_set_script_translations( 'woocommerce-products-category-block', 'woocommerce' );
+	if ( function_exists( 'wp_set_script_translations' ) ) {
+		wp_set_script_translations( 'woocommerce-products-category-block', 'woocommerce' );
+	}
 
 	wp_enqueue_script( 'woocommerce-products-block-editor' );
 	wp_enqueue_script( 'woocommerce-products-category-block' );


### PR DESCRIPTION
Fixes #148 – [Following this post](https://make.wordpress.org/core/2018/11/09/new-javascript-i18n-support-in-wordpress/), I used the new support for i18n/translations in JS files. Unfortunately, that function only exists in WP 5.0. This PR checks for existence of the function before adding it. This does mean the translations will not be loaded for WP 4.9 (but translations are not being correctly loaded currently, anyway).

### How to test the changes in this Pull Request:

1. Have a site on WP 4.9 + Gutenberg
2. Active the plugin
3. Go to add or edit a post
4. Expect: You can, no error on the page
