### PR TITLE
Create a new control for searching and choosing product categories

### DIFF
--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	BaseControl,
+	CheckboxControl,
+	Spinner,
+	TextControl,
+} from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { flatMap, repeat, unescape as unescapeString, uniq, uniqBy } from 'lodash';
+import PropTypes from 'prop-types';
+import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function getSelectOptions( tree, level = 0 ) {
+	return flatMap( tree, ( treeNode ) => [
+		{
+			value: treeNode.id,
+			label: repeat( '\u00A0', level * 3 ) + unescapeString( treeNode.name ),
+		},
+		...getSelectOptions( treeNode.children || [], level + 1 ),
+	] );
+}
+
+/**
+ * Component to handle edit mode of "Products by Category".
+ */
+class CategoryControl extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			list: [],
+			search: '',
+			loaded: false,
+		};
+
+		this.onValueChange = this.onValueChange.bind( this );
+		this.getCategories = this.getCategories.bind( this );
+	}
+
+	componentDidMount() {
+		this.getCategories();
+	}
+
+	getCategories() {
+		this.setState( { list: [], loaded: false } );
+		const { selected } = this.props;
+		const { search } = this.state;
+		const query = {
+			per_page: 10,
+			orderby: 'count',
+			order: 'desc',
+		};
+		Promise.all( [
+			apiFetch( {
+				path: addQueryArgs( '/wc/v3/products/categories', { ...query, search } ),
+			} ),
+			apiFetch( {
+				path: addQueryArgs( '/wc/v3/products/categories', {
+					...query,
+					include: selected.join( ',' ),
+				} ),
+			} ),
+		] )
+			.then( ( [ results, current ] ) => {
+				const list = uniqBy( [
+					...getSelectOptions( current ),
+					...getSelectOptions( results ),
+				], 'value' );
+
+				this.setState( { list, loaded: true } );
+			} )
+			.catch( () => {
+				this.setState( { list: [], loaded: true } );
+			} );
+	}
+
+	onValueChange( value ) {
+		const { onChange, selected } = this.props;
+		return () => {
+			const i = selected.indexOf( value + '' );
+			if ( -1 === i ) {
+				const newSelected = uniq( [ ...selected, value + '' ] );
+				onChange( newSelected );
+			} else {
+				onChange( [ ...selected.slice( 0, i ), ...selected.slice( i + 1 ) ] );
+			}
+		};
+	}
+
+	render() {
+		const { className, help, instanceId, label, selected = [] } = this.props;
+		const { list, search } = this.state;
+		const id = `wc-list-checkbox-${ instanceId }`;
+		const isSelected = ( value ) => -1 !== selected.indexOf( value + '' );
+
+		return (
+			<BaseControl
+				id={ id }
+				help={ help }
+				className={ 'wc-category-control ' + className }
+			>
+				<TextControl
+					label={ __( 'Search Product Categories', 'woocomerce' ) }
+					type="search"
+					value={ search }
+					onChange={ ( value ) =>
+						this.setState( { search: value }, this.getCategories )
+					}
+				/>
+
+				{ this.state.loaded ? (
+					<fieldset
+						className="wc-category-control__list"
+						describedby={ `${ id }__help` }
+					>
+						<legend className="screen-reader-text">{ label }</legend>
+						{ list.map( ( option, index ) => (
+							<CheckboxControl
+								key={ `${ option.label }-${ option.value }-${ index }` }
+								label={ option.label }
+								checked={ isSelected( option.value ) }
+								onChange={ this.onValueChange( option.value ) }
+							/>
+						) ) }
+					</fieldset>
+				) : (
+					<Spinner />
+				) }
+			</BaseControl>
+		);
+	}
+}
+
+CategoryControl.propTypes = {
+	className: PropTypes.string,
+	help: PropTypes.string,
+	instanceId: PropTypes.number,
+	label: PropTypes.string.isRequired,
+	onChange: PropTypes.func.isRequired,
+	selected: PropTypes.array,
+};
+
+export default withInstanceId( CategoryControl );

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -1,0 +1,8 @@
+
+.wc-category-control__list {
+	text-align: left;
+
+	.components-base-control {
+		margin-bottom: 0.5em !important;
+	}
+}

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import {
 	BlockAlignmentToolbar,
@@ -18,7 +18,6 @@ import {
 	SelectControl,
 	Spinner,
 	Toolbar,
-	TreeSelect,
 } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { registerBlockType } from '@wordpress/blocks';
@@ -29,6 +28,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import '../css/product-category-block.scss';
 import getQuery from './utils/get-query';
 import getShortcode from './utils/get-shortcode';
+import ProductCategoryControl from './components/product-category-control';
 import ProductPreview from './components/product-preview';
 import sharedAttributes from './utils/shared-attributes';
 
@@ -42,22 +42,12 @@ class ProductByCategoryBlock extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
-			categoriesList: [],
 			products: [],
 			loaded: false,
 		};
 	}
 
 	componentDidMount() {
-		apiFetch( {
-			path: addQueryArgs( '/wc/v3/products/categories', { per_page: -1 } ),
-		} )
-			.then( ( categoriesList ) => {
-				this.setState( { categoriesList } );
-			} )
-			.catch( () => {
-				this.setState( { categoriesList: [] } );
-			} );
 		if ( this.props.attributes.categories ) {
 			this.getProducts();
 		}
@@ -88,23 +78,29 @@ class ProductByCategoryBlock extends Component {
 			} );
 	}
 
+	getListControl() {
+		const { attributes, setAttributes } = this.props;
+		const { categories } = attributes;
+
+		return (
+			<ProductCategoryControl
+				label={ __( 'Product Category', 'woocommerce' ) }
+				selected={ categories }
+				onChange={ ( value ) => {
+					setAttributes( { categories: value ? value : [] } );
+				} }
+			/>
+		);
+	}
+
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, orderby, rows, categories } = attributes;
-		const { categoriesList } = this.state;
+		const { columns, orderby, rows } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody title={ __( 'Product Category', 'woocommerce' ) } initialOpen>
-					<TreeSelect
-						label={ __( 'Product Category', 'woocommerce' ) }
-						tree={ categoriesList }
-						selectedId={ categories }
-						multiple
-						onChange={ ( value ) => {
-							setAttributes( { categories: value ? value : [] } );
-						} }
-					/>
+					{ this.getListControl() }
 				</PanelBody>
 				<PanelBody title={ __( 'Layout', 'woocommerce' ) } initialOpen={ false }>
 					<RangeControl
@@ -165,8 +161,6 @@ class ProductByCategoryBlock extends Component {
 
 	renderEditMode() {
 		const { setAttributes } = this.props;
-		const { categories } = this.props.attributes;
-		const { categoriesList } = this.state;
 
 		return (
 			<Placeholder
@@ -177,29 +171,15 @@ class ProductByCategoryBlock extends Component {
 					'Display a grid of products from your selected categories',
 					'woocommerce'
 				) }
-				{ categoriesList.length ? (
-					<div className="wc-block-products-category__selection">
-						<TreeSelect
-							label={ __( 'Product Category', 'woocommerce' ) }
-							tree={ categoriesList }
-							selectedId={ categories }
-							multiple
-							onChange={ ( value ) => {
-								setAttributes( { categories: value ? value : [] } );
-							} }
-						/>
-						<Button
-							isDefault
-							onClick={ () => setAttributes( { editMode: false } ) }
-						>
-							{ __( 'Done', 'woocommerce' ) }
-						</Button>
-					</div>
-				) : (
-					<div className="wc-block-products-category__selection">
-						<Spinner />
-					</div>
-				) }
+				<div className="wc-block-products-category__selection">
+					{ this.getListControl() }
+					<Button
+						isDefault
+						onClick={ () => setAttributes( { editMode: false } ) }
+					>
+						{ __( 'Done', 'woocommerce' ) }
+					</Button>
+				</div>
 			</Placeholder>
 		);
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const externals = {
 	'@wordpress/editor': { this: [ 'wp', 'editor' ] },
 	'@wordpress/element': { this: [ 'wp', 'element' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
+	lodash: 'lodash',
 };
 
 /**
@@ -58,7 +59,7 @@ const GutenbergBlocksConfig = {
 								'@import "_breakpoints"; ' +
 								'@import "_mixins"; ',
 						},
-					}
+					},
 				],
 			},
 		],

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -76,7 +76,7 @@ function wgpb_extra_gutenberg_scripts() {
 	wp_register_script(
 		'woocommerce-products-category-block',
 		plugins_url( 'build/product-category-block.js', __FILE__ ),
-		array( 'wp-element', 'wp-blocks', 'wp-i18n' ),
+		array( 'wp-element', 'wp-blocks', 'wp-i18n', 'lodash' ),
 		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/product-category-block.js' ) : WGPB_VERSION,
 		true
 	);


### PR DESCRIPTION
Fixes #138 – This new component will be used to load and select product categories from the site. It can be used in placeholders and in the inspector sidebar (which will be useful in other blocks that have category selects). It shows a max of 10 categories, ordered by most-used, and searching immediately triggers matching categories to load.

Currently this is in-progress style-wise, but I wanted to get some designer feedback on the structure/interactions for the search flow. cc @jameskoster @LevinMedia 

### Screenshots

The empty block's initial state:

![intial-state](https://user-images.githubusercontent.com/541093/48857082-0d56e800-ed86-11e8-88d9-2e12af9e87cb.png)

Selected items stay on top
![selected-on-top](https://user-images.githubusercontent.com/541093/48857086-0d56e800-ed86-11e8-978d-0ce3c63d1328.png)

Even when searching (to make it clear which categories are selected)
<img width="428" alt="screen shot 2018-11-21 at 12 06 49 pm" src="https://user-images.githubusercontent.com/541093/48857088-0d56e800-ed86-11e8-985f-d590b021f630.png">

This is also used in the sidebar:
![sidebar](https://user-images.githubusercontent.com/541093/48857084-0d56e800-ed86-11e8-91a8-72e3dddf42b4.png)

### How to test the changes in this Pull Request:

1. Add a products by category block
2. Try selecting various categories, and searching for others
