### PR TITLE
Update jsx-a11y label rule to only require ID, not ID+nesting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,9 @@ module.exports = {
 		eqeqeq: 'error',
 		'func-call-spacing': 'error',
 		indent: [ 'error', 'tab', { SwitchCase: 1 } ],
+		'jsx-a11y/label-has-for': [ 'error', {
+			required: 'id',
+		} ],
 		'jsx-quotes': 'error',
 		'key-spacing': 'error',
 		'keyword-spacing': 'error',


### PR DESCRIPTION
A small fix to make the jsx-a11y label rule less strict and to match with Gutenberg.

### How to test the changes in this Pull Request:

Add this code to a JS file:

```html
<label htmlFor="id">Test</label>
<input id="id" type="text" />
```

1. Run eslint on that file `npx eslint assets/js/[… your file].js`
2. On master, you'll see the `jsx-a11y/label-has-for` error, asking you to use ID and nesting
3. Expect: You should not have any errors

This will also pass:

```html
<label htmlFor="id">Test <input id="id" type="text" /></label>
```

This should error:

```html
<label>Test</label>
<input type="text" />
```

```html
<label>Test <input type="text" /></label>
```