### PR TITLE
Update script dependencies, add all packages used in blocks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,9 +13,12 @@ const externals = {
 	'@wordpress/blocks': { this: [ 'wp', 'blocks' ] },
 	'@wordpress/components': { this: [ 'wp', 'components' ] },
 	'@wordpress/compose': { this: [ 'wp', 'compose' ] },
-	'@wordpress/editor': { this: [ 'wp', 'editor' ] },
+	'@wordpress/data': { this: [ 'wp', 'data' ] },
 	'@wordpress/element': { this: [ 'wp', 'element' ] },
+	'@wordpress/editor': { this: [ 'wp', 'editor' ] },
 	'@wordpress/i18n': { this: [ 'wp', 'i18n' ] },
+	'@wordpress/url': { this: [ 'wp', 'url' ] },
+	lodash: 'lodash',
 };
 
 /**
@@ -58,7 +61,7 @@ const GutenbergBlocksConfig = {
 								'@import "_breakpoints"; ' +
 								'@import "_mixins"; ',
 						},
-					}
+					},
 				],
 			},
 		],

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -76,7 +76,18 @@ function wgpb_extra_gutenberg_scripts() {
 	wp_register_script(
 		'woocommerce-products-category-block',
 		plugins_url( 'build/product-category-block.js', __FILE__ ),
-		array( 'wp-element', 'wp-blocks', 'wp-i18n' ),
+		array(
+			'wp-api-fetch',
+			'wp-blocks',
+			'wp-components',
+			'wp-compose',
+			'wp-data',
+			'wp-element',
+			'wp-editor',
+			'wp-i18n',
+			'wp-url',
+			'lodash',
+		),
 		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/product-category-block.js' ) : WGPB_VERSION,
 		true
 	);


### PR DESCRIPTION
This PR updates the script registration to specify all the dependencies used, currently we're relying on chained dependencies to import all the `wp.*` packages.

I've also added `lodash` as an external, and added that as a dependency of the block script, even though it's not technically used yet– if we merge this now, we'll prevent future issues with using lodash, and conflicts with duplicate registration of `_` (which was breaking core blocks).

### How to test the changes in this Pull Request:

1. Make sure everything still loads correctly