### PR TITLE
Create a reusable search + list control for category selection

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -34,3 +34,16 @@
 		transition: none;
 	}
 }
+
+// Hide an element from sighted users, but availble to screen reader users.
+@mixin visually-hidden() {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	width: 1px;
+	margin: -1px;
+	overflow: hidden;
+	/* Many screen reader and browser combinations announce broken words as they would appear visually. */
+	word-wrap: normal !important;
+}

--- a/assets/css/abstracts/_variables.scss
+++ b/assets/css/abstracts/_variables.scss
@@ -1,0 +1,7 @@
+$gap-largest: 40px;
+$gap-larger: 36px;
+$gap-large: 24px;
+$gap: 16px;
+$gap-small: 12px;
+$gap-smaller: 8px;
+$gap-smallest: 4px;

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -9,3 +9,16 @@
 .wc-block-products-category__selection {
 	width: 100%;
 }
+
+.components-panel {
+	.woocommerce-search-list__selected {
+		margin: 0 0 $gap;
+		padding: 0;
+		border-top: none;
+	}
+	.woocommerce-search-list__search {
+		margin: 0 0 $gap;
+		padding: 0;
+		border-top: none;
+	}
+}

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -11,6 +11,9 @@
 }
 
 .components-panel {
+	.woocommerce-search-list {
+		padding: 0;
+	}
 	.woocommerce-search-list__selected {
 		margin: 0 0 $gap;
 		padding: 0;

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -7,12 +7,5 @@
 }
 
 .wc-block-products-category__selection {
-	margin-top: 16px;
-	padding: 16px;
 	width: 100%;
-	border-top: 1px solid $core-grey-light-500;
-
-	.components-spinner {
-		float: none;
-	}
 }

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -4,6 +4,10 @@
 
 .wc-block-products-category {
 	overflow: hidden;
+
+	&.components-placeholder {
+		padding: 2em 1em;
+	}
 }
 
 .wc-block-products-category__selection {

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
+import { _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
 import { find } from 'lodash';
+import { MenuItem } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
@@ -18,6 +20,7 @@ class ProductCategoryControl extends Component {
 		this.state = {
 			list: [],
 		};
+		this.renderListItem = this.renderListItem.bind( this );
 	}
 
 	componentDidMount() {
@@ -30,6 +33,36 @@ class ProductCategoryControl extends Component {
 			.catch( () => {
 				this.setState( { list: [] } );
 			} );
+	}
+
+	renderListItem( { getHighlightedName, item, onSelect, search } ) {
+		return (
+			<MenuItem
+				key={ item.id }
+				className="woocommerce-search-list__item"
+				onClick={ onSelect( item ) }
+				aria-label={ sprintf(
+					_n(
+						'%s, has %d product',
+						'%s, has %d products',
+						item.count,
+						'woocommerce'
+					),
+					item.name,
+					item.count
+				) }
+			>
+				<span
+					className="woocommerce-search-list__item-name"
+					dangerouslySetInnerHTML={ {
+						__html: getHighlightedName( item.name, search ),
+					} }
+				/>
+				<span className="woocommerce-search-list__item-count">
+					{ item.count }
+				</span>
+			</MenuItem>
+		);
 	}
 
 	render() {

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -10,7 +10,6 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import SearchListControl from '../search-list-control';
 
 class ProductCategoryControl extends Component {

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -4,6 +4,7 @@
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
+import { find } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -17,7 +18,6 @@ class ProductCategoryControl extends Component {
 		super( ...arguments );
 		this.state = {
 			list: [],
-			selected: [],
 		};
 	}
 
@@ -34,13 +34,13 @@ class ProductCategoryControl extends Component {
 	}
 
 	render() {
-		const { list, selected } = this.state;
-		const onChange = ( newList ) => this.setState( { selected: newList } );
+		const { list } = this.state;
+		const { selected, onChange } = this.props;
 		return (
 			<SearchListControl
 				className="woocommerce-product-categories"
 				list={ list }
-				selected={ selected }
+				selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
 				onChange={ onChange }
 			/>
 		);
@@ -48,7 +48,8 @@ class ProductCategoryControl extends Component {
 }
 
 ProductCategoryControl.propTypes = {
-	className: PropTypes.string,
+	onChange: PropTypes.func.isRequired,
+	selected: PropTypes.array.isRequired,
 };
 
 export default ProductCategoryControl;

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -20,7 +20,7 @@ class ProductCategoryControl extends Component {
 		this.state = {
 			list: [],
 		};
-		this.renderListItem = this.renderListItem.bind( this );
+		this.renderItem = this.renderItem.bind( this );
 	}
 
 	componentDidMount() {
@@ -35,7 +35,7 @@ class ProductCategoryControl extends Component {
 			} );
 	}
 
-	renderListItem( { getHighlightedName, item, onSelect, search } ) {
+	renderItem( { getHighlightedName, item, onSelect, search } ) {
 		return (
 			<MenuItem
 				key={ item.id }
@@ -92,7 +92,7 @@ class ProductCategoryControl extends Component {
 				list={ list }
 				selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
 				onChange={ onChange }
-				renderListItem={ this.renderListItem }
+				renderItem={ this.renderItem }
 				messages={ messages }
 			/>
 		);
@@ -100,7 +100,13 @@ class ProductCategoryControl extends Component {
 }
 
 ProductCategoryControl.propTypes = {
+	/**
+	 * Callback to update the selected product categories.
+	 */
 	onChange: PropTypes.func.isRequired,
+	/**
+	 * The list of currently selected category IDs.
+	 */
 	selected: PropTypes.array.isRequired,
 };
 

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { _n, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
@@ -68,12 +68,32 @@ class ProductCategoryControl extends Component {
 	render() {
 		const { list } = this.state;
 		const { selected, onChange } = this.props;
+
+		const messages = {
+			clear: __( 'Clear all product categories', 'woocommerce' ),
+			list: __( 'Product Categories', 'woocommerce' ),
+			search: __( 'Search for product categories', 'woocommerce' ),
+			selected: ( n ) =>
+				sprintf(
+					_n(
+						'%d category selected',
+						'%d categories selected',
+						n,
+						'woocommerce'
+					),
+					n
+				),
+			updated: __( 'Category search results updated.', 'woocommerce' ),
+		};
+
 		return (
 			<SearchListControl
 				className="woocommerce-product-categories"
 				list={ list }
 				selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
 				onChange={ onChange }
+				renderListItem={ this.renderListItem }
+				messages={ messages }
 			/>
 		);
 	}

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import { Component } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import SearchListControl from '../search-list-control';
+
+class ProductCategoryControl extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			list: [],
+			selected: [],
+		};
+	}
+
+	componentDidMount() {
+		apiFetch( {
+			path: addQueryArgs( '/wc/v3/products/categories', { per_page: -1 } ),
+		} )
+			.then( ( list ) => {
+				this.setState( { list } );
+			} )
+			.catch( () => {
+				this.setState( { list: [] } );
+			} );
+	}
+
+	render() {
+		const { list, selected } = this.state;
+		const onChange = ( newList ) => this.setState( { selected: newList } );
+		return (
+			<SearchListControl
+				className="woocommerce-product-categories"
+				list={ list }
+				selected={ selected }
+				onChange={ onChange }
+			/>
+		);
+	}
+}
+
+ProductCategoryControl.propTypes = {
+	className: PropTypes.string,
+};
+
+export default ProductCategoryControl;

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import SearchListControl from '../search-list-control';
 
 class ProductCategoryControl extends Component {
@@ -39,7 +40,7 @@ class ProductCategoryControl extends Component {
 		return (
 			<MenuItem
 				key={ item.id }
-				className="woocommerce-search-list__item"
+				className="woocommerce-product-categories__item woocommerce-search-list__item"
 				onClick={ onSelect( item ) }
 				aria-label={ sprintf(
 					_n(
@@ -53,12 +54,12 @@ class ProductCategoryControl extends Component {
 				) }
 			>
 				<span
-					className="woocommerce-search-list__item-name"
+					className="woocommerce-product-categories__item-name"
 					dangerouslySetInnerHTML={ {
 						__html: getHighlightedName( item.name, search ),
 					} }
 				/>
-				<span className="woocommerce-search-list__item-count">
+				<span className="woocommerce-product-categories__item-count">
 					{ item.count }
 				</span>
 			</MenuItem>

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -1,0 +1,20 @@
+.woocommerce-product-categories {
+	.woocommerce-product-categories__item {
+		display: flex;
+		align-items: center;
+	}
+
+	.woocommerce-product-categories__item-name {
+		flex: 1;
+	}
+
+	.woocommerce-product-categories__item-count {
+		flex: 0;
+		padding: $gap-smallest/2 $gap-smaller;
+		border: 1px solid $core-grey-light-500;
+		border-radius: 12px;
+		font-size: 0.8em;
+		line-height: 1.4;
+		color: $core-grey-dark-300;
+	}
+}

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -1,0 +1,4 @@
+
+.woocommerce-product-categories {
+	text-align: left;
+}

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -1,4 +1,0 @@
-
-.woocommerce-product-categories {
-	text-align: left;
-}

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -16,5 +16,6 @@
 		font-size: 0.8em;
 		line-height: 1.4;
 		color: $core-grey-dark-300;
+		background: $white;
 	}
 }

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -89,7 +89,11 @@ export class SearchListControl extends Component {
 									selected.length
 								) }
 							</strong>
-							<Button isLink onClick={ this.onClear }>
+							<Button
+								isLink
+								onClick={ this.onClear }
+								aria-label={ __( 'Clear all product categories', 'woocommerce' ) }
+							>
 								{ __( 'Clear all', 'woocommerce' ) }
 							</Button>
 						</div>

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -117,7 +117,7 @@ export class SearchListControl extends Component {
 					<div className="woocommerce-search-list__selected">
 						<div className="woocommerce-search-list__selected-header">
 							<strong>{ messages.selected( selectedCount ) }</strong>
-							<Button isLink onClick={ this.onClear } aria-label={ messages.clear }>
+							<Button isLink isDestructive onClick={ this.onClear } aria-label={ messages.clear }>
 								{ __( 'Clear all', 'woocommerce' ) }
 							</Button>
 						</div>

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -1,11 +1,16 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import {
+	Button,
+	MenuItem,
+	MenuGroup,
+	TextControl,
+} from '@wordpress/components';
+import { Component } from '@wordpress/element';
 import { compose, withInstanceId, withState } from '@wordpress/compose';
 import { findIndex } from 'lodash';
-import { MenuItem, MenuGroup, TextControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { Tag } from '@woocommerce/components';
 
@@ -23,6 +28,7 @@ export class SearchListControl extends Component {
 
 		this.onSelect = this.onSelect.bind( this );
 		this.onRemove = this.onRemove.bind( this );
+		this.onClear = this.onClear.bind( this );
 	}
 
 	onRemove( id ) {
@@ -40,6 +46,10 @@ export class SearchListControl extends Component {
 		};
 	}
 
+	onClear() {
+		this.props.onChange( [] );
+	}
+
 	isSelected( item ) {
 		return -1 !== findIndex( this.props.selected, { id: item.id } );
 	}
@@ -49,19 +59,32 @@ export class SearchListControl extends Component {
 		return (
 			<div className={ `woocommerce-search-list ${ className }` }>
 				{ selected.length ? (
-					<Fragment>
-						<div className="woocommerce-search-list__selected">
-							{ selected.map( ( item, i ) => (
-								<Tag
-									key={ i }
-									label={ item.name }
-									id={ item.id }
-									remove={ this.onRemove }
-								/>
-							) ) }
+					<div className="woocommerce-search-list__selected">
+						<div className="woocommerce-search-list__selected-header">
+							<strong>
+								{ sprintf(
+									_n(
+										'%d category selected',
+										'%d categories selected',
+										selected.length,
+										'woocommerce'
+									),
+									selected.length
+								) }
+							</strong>
+							<Button isLink onClick={ this.onClear }>
+								{ __( 'Clear all', 'woocommerce' ) }
+							</Button>
 						</div>
-						<hr />
-					</Fragment>
+						{ selected.map( ( item, i ) => (
+							<Tag
+								key={ i }
+								label={ item.name }
+								id={ item.id }
+								remove={ this.onRemove }
+							/>
+						) ) }
+					</div>
 				) : null }
 
 				<div className="woocommerce-search-list__search">

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { compose, withInstanceId, withState } from '@wordpress/compose';
+import { findIndex } from 'lodash';
+import { MenuItem, MenuGroup, TextControl } from '@wordpress/components';
+import PropTypes from 'prop-types';
+import { Tag } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Component to display a searchable, selectable list of items.
+ */
+export class SearchListControl extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.onSelect = this.onSelect.bind( this );
+		this.onRemove = this.onRemove.bind( this );
+	}
+
+	onRemove( id ) {
+		const { selected, onChange } = this.props;
+		return () => {
+			const i = findIndex( selected, { id } );
+			onChange( [ ...selected.slice( 0, i ), ...selected.slice( i + 1 ) ] );
+		};
+	}
+
+	onSelect( item ) {
+		const { selected, onChange } = this.props;
+		return () => {
+			onChange( [ ...selected, item ] );
+		};
+	}
+
+	isSelected( item ) {
+		return -1 !== findIndex( this.props.selected, { id: item.id } );
+	}
+
+	render() {
+		const { className, list, search, selected, setState } = this.props;
+		return (
+			<div className={ `woocommerce-search-list ${ className }` }>
+				{ selected.length ? (
+					<Fragment>
+						<div className="woocommerce-search-list__selected">
+							{ selected.map( ( item, i ) => (
+								<Tag
+									key={ i }
+									label={ item.name }
+									id={ item.id }
+									remove={ this.onRemove }
+								/>
+							) ) }
+						</div>
+						<hr />
+					</Fragment>
+				) : null }
+
+				<div className="woocommerce-search-list__search">
+					<TextControl
+						label={ __( 'Search for product categories', 'woocommerce' ) }
+						value={ search }
+						onChange={ ( value ) => setState( { search: value } ) }
+					/>
+				</div>
+
+				<MenuGroup
+					label={ __( 'Product Categories', 'woocommerce' ) }
+					className="woocommerce-search-list__list"
+				>
+					{ list.map(
+						( item ) =>
+							this.isSelected( item ) ? null : (
+								<MenuItem
+									key={ item.id }
+									className="woocommerce-search-list__item"
+									onClick={ this.onSelect( item ) }
+								>
+									<span className="woocommerce-search-list__item-name">
+										{ item.name }
+									</span>
+									<span className="woocommerce-search-list__item-count">
+										{ item.count }
+									</span>
+								</MenuItem>
+							)
+					) }
+				</MenuGroup>
+			</div>
+		);
+	}
+}
+
+SearchListControl.propTypes = {
+	className: PropTypes.string,
+	list: PropTypes.array,
+	onChange: PropTypes.func,
+	selected: PropTypes.array,
+	// from withState
+	search: PropTypes.string,
+	setState: PropTypes.func,
+	// from withInstanceId
+	instanceId: PropTypes.string,
+};
+
+export default compose( [
+	withState( {
+		search: '',
+	} ),
+	withInstanceId,
+] )( SearchListControl );

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -107,16 +107,16 @@ export class SearchListControl extends Component {
 		const { className, search, selected, setState } = this.props;
 		const messages = { ...defaultMessages, ...this.props.messages };
 		const list = this.getFilteredList( this.props.list, search );
-		const renderItem = this.props.renderItem || this.defaultRenderItem;
-
 		const noResults = search ? sprintf( messages.noResults, search ) : null;
+		const renderItem = this.props.renderItem || this.defaultRenderItem;
+		const selectedCount = selected.length;
 
 		return (
 			<div className={ `woocommerce-search-list ${ className }` }>
-				{ selected.length ? (
+				{ selectedCount > 0 ? (
 					<div className="woocommerce-search-list__selected">
 						<div className="woocommerce-search-list__selected-header">
-							<strong>{ messages.selected( selected.length ) }</strong>
+							<strong>{ messages.selected( selectedCount ) }</strong>
 							<Button isLink onClick={ this.onClear } aria-label={ messages.clear }>
 								{ __( 'Clear all', 'woocommerce' ) }
 							</Button>

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -40,7 +40,7 @@ export class SearchListControl extends Component {
 		this.onSelect = this.onSelect.bind( this );
 		this.onRemove = this.onRemove.bind( this );
 		this.onClear = this.onClear.bind( this );
-		this.fallbackrenderItem = this.fallbackrenderItem.bind( this );
+		this.defaultRenderItem = this.defaultRenderItem.bind( this );
 	}
 
 	onRemove( id ) {
@@ -86,7 +86,7 @@ export class SearchListControl extends Component {
 		return name.replace( re, '<strong>$&</strong>' );
 	}
 
-	fallbackrenderItem( { getHighlightedName, item, onSelect, search } ) {
+	defaultRenderItem( { getHighlightedName, item, onSelect, search } ) {
 		return (
 			<MenuItem
 				key={ item.id }
@@ -107,7 +107,7 @@ export class SearchListControl extends Component {
 		const { className, search, selected, setState } = this.props;
 		const messages = { ...defaultMessages, ...this.props.messages };
 		const list = this.getFilteredList( this.props.list, search );
-		const renderItem = this.props.renderItem || this.fallbackrenderItem;
+		const renderItem = this.props.renderItem || this.defaultRenderItem;
 
 		const noResults = search ? sprintf( messages.noResults, search ) : null;
 

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -58,7 +58,7 @@ export class SearchListControl extends Component {
 		const re = new RegExp( escapeRegExp( search ), 'i' );
 		return list
 			.map( ( item ) => ( re.test( item.name ) ? item : false ) )
-			.filter( Boolean );
+			.filter( ( item ) => item && ! this.isSelected( item ) );
 	}
 
 	getHighlightName( name, search ) {
@@ -116,36 +116,33 @@ export class SearchListControl extends Component {
 					label={ __( 'Product Categories', 'woocommerce' ) }
 					className="woocommerce-search-list__list"
 				>
-					{ list.map(
-						( item ) =>
-							this.isSelected( item ) ? null : (
-								<MenuItem
-									key={ item.id }
-									className="woocommerce-search-list__item"
-									onClick={ this.onSelect( item ) }
-									aria-label={ sprintf(
-										_n(
-											'%s, has %d item',
-											'%s, has %d items',
-											item.count,
-											'woocommerce'
-										),
-										item.name,
-										item.count
-									) }
-								>
-									<span
-										className="woocommerce-search-list__item-name"
-										dangerouslySetInnerHTML={ {
-											__html: this.getHighlightName( item.name, search ),
-										} }
-									/>
-									<span className="woocommerce-search-list__item-count">
-										{ item.count }
-									</span>
-								</MenuItem>
-							)
-					) }
+					{ list.map( ( item ) => (
+						<MenuItem
+							key={ item.id }
+							className="woocommerce-search-list__item"
+							onClick={ this.onSelect( item ) }
+							aria-label={ sprintf(
+								_n(
+									'%s, has %d item',
+									'%s, has %d items',
+									item.count,
+									'woocommerce'
+								),
+								item.name,
+								item.count
+							) }
+						>
+							<span
+								className="woocommerce-search-list__item-name"
+								dangerouslySetInnerHTML={ {
+									__html: this.getHighlightName( item.name, search ),
+								} }
+							/>
+							<span className="woocommerce-search-list__item-count">
+								{ item.count }
+							</span>
+						</MenuItem>
+					) ) }
 				</MenuGroup>
 			</div>
 		);

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -228,7 +228,7 @@ SearchListControl.propTypes = {
 	// from withSpokenMessages
 	debouncedSpeak: PropTypes.func,
 	// from withInstanceId
-	instanceId: PropTypes.string,
+	instanceId: PropTypes.number,
 };
 
 export default compose( [

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -29,6 +29,7 @@ export class SearchListControl extends Component {
 		this.onSelect = this.onSelect.bind( this );
 		this.onRemove = this.onRemove.bind( this );
 		this.onClear = this.onClear.bind( this );
+		this.fallbackRenderListItem = this.fallbackRenderListItem.bind( this );
 	}
 
 	onRemove( id ) {
@@ -61,7 +62,7 @@ export class SearchListControl extends Component {
 			.filter( ( item ) => item && ! this.isSelected( item ) );
 	}
 
-	getHighlightName( name, search ) {
+	getHighlightedName( name, search ) {
 		if ( ! search ) {
 			return name;
 		}
@@ -69,10 +70,28 @@ export class SearchListControl extends Component {
 		return name.replace( re, '<strong>$&</strong>' );
 	}
 
+	fallbackRenderListItem( { getHighlightedName, item, onSelect, search } ) {
+		return (
+			<MenuItem
+				key={ item.id }
+				className="woocommerce-search-list__item"
+				onClick={ onSelect( item ) }
+			>
+				<span
+					className="woocommerce-search-list__item-name"
+					dangerouslySetInnerHTML={ {
+						__html: getHighlightedName( item.name, search ),
+					} }
+				/>
+			</MenuItem>
+		);
+	}
+
 	render() {
 		const { className, search, selected, setState } = this.props;
-
 		const list = this.getFilteredList( this.props.list, search );
+		const renderListItem = this.props.renderListItem || this.fallbackRenderListItem;
+
 		return (
 			<div className={ `woocommerce-search-list ${ className }` }>
 				{ selected.length ? (
@@ -120,33 +139,14 @@ export class SearchListControl extends Component {
 					label={ __( 'Product Categories', 'woocommerce' ) }
 					className="woocommerce-search-list__list"
 				>
-					{ list.map( ( item ) => (
-						<MenuItem
-							key={ item.id }
-							className="woocommerce-search-list__item"
-							onClick={ this.onSelect( item ) }
-							aria-label={ sprintf(
-								_n(
-									'%s, has %d item',
-									'%s, has %d items',
-									item.count,
-									'woocommerce'
-								),
-								item.name,
-								item.count
+					{ list.map( ( item ) =>
+						renderListItem( {
+							getHighlightedName: this.getHighlightedName,
+							item,
+							onSelect: this.onSelect,
+							search,
+						} )
 							) }
-						>
-							<span
-								className="woocommerce-search-list__item-name"
-								dangerouslySetInnerHTML={ {
-									__html: this.getHighlightName( item.name, search ),
-								} }
-							/>
-							<span className="woocommerce-search-list__item-count">
-								{ item.count }
-							</span>
-						</MenuItem>
-					) ) }
 				</MenuGroup>
 			</div>
 		);

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -56,6 +56,10 @@
 		border-bottom: 1px solid $core-grey-light-500 !important;
 		color: $core-grey-dark-500;
 
+		@include hover-state {
+			background: $core-grey-light-100;
+		}
+
 		&:last-of-type {
 			border-bottom: none !important;
 		}

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -49,8 +49,6 @@
 	}
 
 	.woocommerce-search-list__item {
-		display: flex;
-		align-items: center;
 		margin-bottom: 0;
 		padding: $gap;
 		background: $white;
@@ -61,22 +59,5 @@
 		&:last-of-type {
 			border-bottom: none !important;
 		}
-	}
-
-	.woocommerce-search-list__item-input {
-		flex: 0;
-	}
-
-	.woocommerce-search-list__item-name {
-		flex: 1;
-	}
-
-	.woocommerce-search-list__item-count {
-		flex: 0;
-		padding: $gap-smallest/2 $gap-smaller;
-		border: 1px solid $core-grey-light-500;
-		border-radius: 12px;
-		line-height: 1.4;
-		color: $core-grey-dark-300;
 	}
 }

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -1,0 +1,44 @@
+.woocommerce-search-list {
+	margin-bottom: $gap-large;
+}
+
+.woocommerce-search-list__search {
+	.components-base-control__field {
+		margin-bottom: $gap;
+	}
+}
+
+.woocommerce-search-list__list {
+	max-height: 20em;
+	overflow-x: scroll;
+	list-style: none;
+	border: 1px solid $core-grey-light-500;
+	border-bottom: none;
+
+	.woocommerce-search-list__item {
+		display: flex;
+		align-items: flex-start;
+		margin-bottom: 0;
+		padding: $gap;
+		background: $white;
+		// !important to keep the border around on hover
+		border-bottom: 1px solid $core-grey-light-500 !important;
+		color: $core-grey-dark-500;
+	}
+
+	.woocommerce-search-list__item-input {
+		flex: 0;
+	}
+
+	.woocommerce-search-list__item-name {
+		flex: 1;
+	}
+
+	.woocommerce-search-list__item-count {
+		flex: 0;
+		padding: 0 $gap-smaller;
+		border: 1px solid $core-grey-light-500;
+		border-radius: 30%;
+		color: $core-grey-dark-300;
+	}
+}

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -1,5 +1,7 @@
 .woocommerce-search-list {
 	width: 100%;
+	padding: 0 0 $gap;
+	text-align: left;
 }
 
 .woocommerce-search-list__selected {

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -1,29 +1,64 @@
 .woocommerce-search-list {
-	margin-bottom: $gap-large;
+	width: 100%;
+}
+
+.woocommerce-search-list__selected {
+	margin: $gap 0;
+	padding: $gap 0 0;
+	border-top: 1px solid $core-grey-light-500;
+
+	.woocommerce-search-list__selected-header {
+		margin-bottom: $gap-smaller;
+
+		button {
+			margin-left: $gap-small;
+		}
+	}
+
+	.woocommerce-tag__text {
+		max-width: 13em;
+	}
 }
 
 .woocommerce-search-list__search {
+	margin: $gap 0;
+	padding: $gap 0 0;
+	border-top: 1px solid $core-grey-light-500;
+
 	.components-base-control__field {
 		margin-bottom: $gap;
 	}
 }
 
 .woocommerce-search-list__list {
+	padding: 0;
 	max-height: 20em;
 	overflow-x: scroll;
-	list-style: none;
-	border: 1px solid $core-grey-light-500;
-	border-bottom: none;
+	border-top: 1px solid $core-grey-light-500;
+	border-bottom: 1px solid $core-grey-light-500;
+
+	.components-menu-group__label {
+		@include visually-hidden;
+	}
+
+	& > [role="menu"] {
+		border: 1px solid $core-grey-light-500;
+		border-bottom: none;
+	}
 
 	.woocommerce-search-list__item {
 		display: flex;
-		align-items: flex-start;
+		align-items: center;
 		margin-bottom: 0;
 		padding: $gap;
 		background: $white;
 		// !important to keep the border around on hover
 		border-bottom: 1px solid $core-grey-light-500 !important;
 		color: $core-grey-dark-500;
+
+		&:last-of-type {
+			border-bottom: none !important;
+		}
 	}
 
 	.woocommerce-search-list__item-input {
@@ -36,9 +71,10 @@
 
 	.woocommerce-search-list__item-count {
 		flex: 0;
-		padding: 0 $gap-smaller;
+		padding: $gap-smallest/2 $gap-smaller;
 		border: 1px solid $core-grey-light-500;
-		border-radius: 30%;
+		border-radius: 12px;
+		line-height: 1.4;
 		color: $core-grey-dark-300;
 	}
 }

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -18,6 +18,7 @@ import {
 	SelectControl,
 	Spinner,
 	Toolbar,
+	withSpokenMessages,
 } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { registerBlockType } from '@wordpress/blocks';
@@ -38,7 +39,7 @@ const validAlignments = [ 'center', 'wide', 'full' ];
 /**
  * Component to handle edit mode of "Products by Category".
  */
-class ProductByCategoryBlock extends Component {
+export default class ProductByCategoryBlock extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
@@ -159,7 +160,11 @@ class ProductByCategoryBlock extends Component {
 	}
 
 	renderEditMode() {
-		const { setAttributes } = this.props;
+		const { debouncedSpeak, setAttributes } = this.props;
+		const onDone = () => {
+			setAttributes( { editMode: false } );
+			debouncedSpeak( __( 'Showing product block preview.', 'woocommerce' ) );
+		};
 
 		return (
 			<Placeholder
@@ -174,7 +179,7 @@ class ProductByCategoryBlock extends Component {
 					{ this.getProductCategoryControl() }
 					<Button
 						isDefault
-						onClick={ () => setAttributes( { editMode: false } ) }
+						onClick={ onDone }
 					>
 						{ __( 'Done', 'woocommerce' ) }
 					</Button>
@@ -244,9 +249,11 @@ ProductByCategoryBlock.propTypes = {
 	 * A callback to update attributes
 	 */
 	setAttributes: PropTypes.func.isRequired,
+	// from withSpokenMessages
+	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-export default ProductByCategoryBlock;
+const WrappedProductByCategoryBlock = withSpokenMessages( ProductByCategoryBlock );
 
 /**
  * Register and run the "Products by Category" block.
@@ -282,7 +289,7 @@ registerBlockType( 'woocommerce/product-category', {
 	 * Renders and manages the block.
 	 */
 	edit( props ) {
-		return <ProductByCategoryBlock { ...props } />;
+		return <WrappedProductByCategoryBlock { ...props } />;
 	},
 
 	/**

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -162,6 +162,7 @@ export default class ProductByCategoryBlock extends Component {
 			<Placeholder
 				icon="category"
 				label={ __( 'Products by Category', 'woocommerce' ) }
+				className="wc-block-products-category"
 			>
 				{ __(
 					'Display a grid of products from your selected categories',

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -79,20 +79,6 @@ export default class ProductByCategoryBlock extends Component {
 			} );
 	}
 
-	getProductCategoryControl() {
-		const { attributes, setAttributes } = this.props;
-		const { categories } = attributes;
-		return (
-			<ProductCategoryControl
-				selected={ categories }
-				onChange={ ( value = [] ) => {
-					const ids = value.map( ( { id } ) => id );
-					setAttributes( { categories: ids } );
-				} }
-			/>
-		);
-	}
-
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
 		const { columns, orderby, rows } = attributes;
@@ -100,7 +86,13 @@ export default class ProductByCategoryBlock extends Component {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody title={ __( 'Product Category', 'woocommerce' ) } initialOpen>
-					{ this.getProductCategoryControl() }
+					<ProductCategoryControl
+						selected={ attributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { categories: ids } );
+						} }
+					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Layout', 'woocommerce' ) } initialOpen={ false }>
 					<RangeControl
@@ -160,7 +152,7 @@ export default class ProductByCategoryBlock extends Component {
 	}
 
 	renderEditMode() {
-		const { debouncedSpeak, setAttributes } = this.props;
+		const { attributes, debouncedSpeak, setAttributes } = this.props;
 		const onDone = () => {
 			setAttributes( { editMode: false } );
 			debouncedSpeak( __( 'Showing product block preview.', 'woocommerce' ) );
@@ -176,7 +168,13 @@ export default class ProductByCategoryBlock extends Component {
 					'woocommerce'
 				) }
 				<div className="wc-block-products-category__selection">
-					{ this.getProductCategoryControl() }
+					<ProductCategoryControl
+						selected={ attributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { categories: ids } );
+						} }
+					/>
 					<Button
 						isDefault
 						onClick={ onDone }

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -84,8 +84,9 @@ class ProductByCategoryBlock extends Component {
 		return (
 			<ProductCategoryControl
 				selected={ categories }
-				onChange={ ( value ) => {
-					setAttributes( { categories: value ? value : [] } );
+				onChange={ ( value = [] ) => {
+					const ids = value.map( ( { id } ) => id );
+					setAttributes( { categories: ids } );
 				} }
 			/>
 		);

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import {
 	BlockAlignmentToolbar,
@@ -18,7 +18,6 @@ import {
 	SelectControl,
 	Spinner,
 	Toolbar,
-	TreeSelect,
 } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { registerBlockType } from '@wordpress/blocks';
@@ -29,6 +28,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import '../css/product-category-block.scss';
 import getQuery from './utils/get-query';
 import getShortcode from './utils/get-shortcode';
+import ProductCategoryControl from './components/product-category-control';
 import ProductPreview from './components/product-preview';
 import sharedAttributes from './utils/shared-attributes';
 
@@ -42,22 +42,12 @@ class ProductByCategoryBlock extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
-			categoriesList: [],
 			products: [],
 			loaded: false,
 		};
 	}
 
 	componentDidMount() {
-		apiFetch( {
-			path: addQueryArgs( '/wc/v3/products/categories', { per_page: -1 } ),
-		} )
-			.then( ( categoriesList ) => {
-				this.setState( { categoriesList } );
-			} )
-			.catch( () => {
-				this.setState( { categoriesList: [] } );
-			} );
 		if ( this.props.attributes.categories ) {
 			this.getProducts();
 		}
@@ -88,23 +78,27 @@ class ProductByCategoryBlock extends Component {
 			} );
 	}
 
+	getProductCategoryControl() {
+		const { attributes, setAttributes } = this.props;
+		const { categories } = attributes;
+		return (
+			<ProductCategoryControl
+				selected={ categories }
+				onChange={ ( value ) => {
+					setAttributes( { categories: value ? value : [] } );
+				} }
+			/>
+		);
+	}
+
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, orderby, rows, categories } = attributes;
-		const { categoriesList } = this.state;
+		const { columns, orderby, rows } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody title={ __( 'Product Category', 'woocommerce' ) } initialOpen>
-					<TreeSelect
-						label={ __( 'Product Category', 'woocommerce' ) }
-						tree={ categoriesList }
-						selectedId={ categories }
-						multiple
-						onChange={ ( value ) => {
-							setAttributes( { categories: value ? value : [] } );
-						} }
-					/>
+					{ this.getProductCategoryControl() }
 				</PanelBody>
 				<PanelBody title={ __( 'Layout', 'woocommerce' ) } initialOpen={ false }>
 					<RangeControl
@@ -165,8 +159,6 @@ class ProductByCategoryBlock extends Component {
 
 	renderEditMode() {
 		const { setAttributes } = this.props;
-		const { categories } = this.props.attributes;
-		const { categoriesList } = this.state;
 
 		return (
 			<Placeholder
@@ -177,29 +169,15 @@ class ProductByCategoryBlock extends Component {
 					'Display a grid of products from your selected categories',
 					'woocommerce'
 				) }
-				{ categoriesList.length ? (
-					<div className="wc-block-products-category__selection">
-						<TreeSelect
-							label={ __( 'Product Category', 'woocommerce' ) }
-							tree={ categoriesList }
-							selectedId={ categories }
-							multiple
-							onChange={ ( value ) => {
-								setAttributes( { categories: value ? value : [] } );
-							} }
-						/>
-						<Button
-							isDefault
-							onClick={ () => setAttributes( { editMode: false } ) }
-						>
-							{ __( 'Done', 'woocommerce' ) }
-						</Button>
-					</div>
-				) : (
-					<div className="wc-block-products-category__selection">
-						<Spinner />
-					</div>
-				) }
+				<div className="wc-block-products-category__selection">
+					{ this.getProductCategoryControl() }
+					<Button
+						isDefault
+						onClick={ () => setAttributes( { editMode: false } ) }
+					>
+						{ __( 'Done', 'woocommerce' ) }
+					</Button>
+				</div>
 			</Placeholder>
 		);
 	}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,7 @@ const GutenbergBlocksConfig = {
 							includePaths: [ 'assets/css/abstracts' ],
 							data:
 								'@import "_colors"; ' +
+								'@import "_variables"; ' +
 								'@import "_breakpoints"; ' +
 								'@import "_mixins"; ',
 						},


### PR DESCRIPTION
This PR introduces two new components, `ProductCategoryControl` and `SearchListControl`. 

`SearchListControl` renders a search box and list of selectable items, along with a list of "selected" items (which are removed from the selectable list) as removable `Tag`s. Removing a selected item puts it back into the main selectable list. Searching using the text box runs a simple text search over the item's `name`. This is a "simple" component, in that it does not do anything with an API or saving attribute data itself.

`ProductCategoryControl` wraps around `SearchListControl` and handles fetching all categories from the API, and also passes through a render function for customizing the item display (which lets us show the product category's count). This also passes through customized `messages`, again letting us specify "category" copy.

The goal with `SearchListControl` is to be reusable, since we'll have a similar interface for handpicked products.

Other additions in the PR:

- Spacing variables from wc-admin
- A new mixin called `visually-hidden`, which applies the same rules as `screen-reader-text` (for when we can't add a class)

I'll add snapshot tests in a following PR, but wanted this up for testing today.

### Screenshots

First, in edit mode, when we start the selected list is empty, so we just see the search box and list of all categories.

![edit-mode-empty](https://user-images.githubusercontent.com/541093/49188451-d5791300-f338-11e8-88ce-4755fab926cb.png)

After selecting some categories, we see them above, and no longer in the list.

![edit-mode-selected](https://user-images.githubusercontent.com/541093/49188478-e88be300-f338-11e8-9072-ccb337d450e8.png)

We can search for items and it will highlight the search terms:

![edit-mode-search-results](https://user-images.githubusercontent.com/541093/49188461-da3dc700-f338-11e8-9ddc-d794d5f1c3b9.png)

If there are no results, we just say so (this can be improved 🙂 )

![edit-mode-no-results](https://user-images.githubusercontent.com/541093/49188490-f477a500-f338-11e8-8537-e24ef7b5ca25.png)

Once we click Done, we see the block preview. Now we can see the same interface in the sidebar

![sidebar](https://user-images.githubusercontent.com/541093/49188533-1d983580-f339-11e8-8e20-e80a9168a0f7.png)

And searching here…

![sidebar-search](https://user-images.githubusercontent.com/541093/49188532-1d983580-f339-11e8-9b66-035c335679ea.png)

Changes to the selected categories here triggers another API request & updates the block preview.

### Accessibility ⌨️ 

These components are usable via keyboard navigation, all clickable actions are also keyboard-focusable (the search input, selecting items, tag remove icons). Unfortunately this is not working perfectly with a screen reader, when selected items are removed from the list, it pulls focus out of the page 🙁  I'll need to investigate further for any focus management solutions. Given the state of gutenberg + screen readers in general, I think this is OK for this release.

### How to test the changes in this Pull Request:

1. Add a products by category block
2. Try selecting various categories, and searching for others

~⚠️  I haven't tested with 100+ categories, I'm pretty sure this iteration won't work for that many but I'll address that in a following PR.~ Nevermind, `apiFetch` [is smart and automatically paginates!](https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/fetch-all-middleware.js#L42)