### PR TITLE
Fix React warning for array items needed unique key props

### DIFF
--- a/assets/js/legacy/products-block.jsx
+++ b/assets/js/legacy/products-block.jsx
@@ -187,7 +187,7 @@ class ProductsBlockSettingsEditorDisplayOptions extends Component {
 
 		const display_settings = [];
 		for ( const setting_key in PRODUCTS_BLOCK_DISPLAY_SETTINGS ) {
-			display_settings.push( <ProductsBlockSettingsEditorDisplayOption { ...PRODUCTS_BLOCK_DISPLAY_SETTINGS[ setting_key ] } update_display_callback={ this.props.update_display_callback } extended={ this.props.extended } current={ this.props.current } /> );
+			display_settings.push( <ProductsBlockSettingsEditorDisplayOption { ...PRODUCTS_BLOCK_DISPLAY_SETTINGS[ setting_key ] } update_display_callback={ this.props.update_display_callback } extended={ this.props.extended } current={ this.props.current } key={ setting_key } /> );
 		}
 
 		const arrow = <span className="wc-products-display-options--popover__arrow"></span>;
@@ -847,7 +847,7 @@ class ProductsBlock extends Component {
 	 * @return Component
 	 */
 	getPreview() {
-		return <ProductsBlockPreview attributes={ this.props.attributes } />;
+		return <ProductsBlockPreview key="preview" attributes={ this.props.attributes } />;
 	}
 
 	/**
@@ -874,6 +874,7 @@ class ProductsBlock extends Component {
 
 		return (
 			<ProductsBlockSettingsEditor
+				key="settings-editor"
 				attributes={ attributes }
 				selected_display={ display }
 				selected_display_setting={ display_setting }


### PR DESCRIPTION
I noticed the following error in the legacy product block when testing:

```
Warning: Each child in an array or iterator should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.
```

This PR adds the key props to all array components.

### How to test the changes in this Pull Request:

1. With SCRIPT_DEBUG on, load up the Products block
2. Expect: No warnings (well, you might see `Warning: Unsafe lifecycle methods…`, but I see that with our plugin disabled too)
