### PR TITLE
Show the Layout settings as open by default

### DIFF
--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -85,7 +85,7 @@ export default class ProductByCategoryBlock extends Component {
 
 		return (
 			<InspectorControls key="inspector">
-				<PanelBody title={ __( 'Product Category', 'woocommerce' ) } initialOpen>
+				<PanelBody title={ __( 'Product Category', 'woocommerce' ) } initialOpen={ false }>
 					<ProductCategoryControl
 						selected={ attributes.categories }
 						onChange={ ( value = [] ) => {
@@ -94,7 +94,7 @@ export default class ProductByCategoryBlock extends Component {
 						} }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Layout', 'woocommerce' ) } initialOpen={ false }>
+				<PanelBody title={ __( 'Layout', 'woocommerce' ) } initialOpen>
 					<RangeControl
 						label={ __( 'Columns', 'woocommerce' ) }
 						value={ columns }


### PR DESCRIPTION
Fixes #171 – Rather than have the Product Category section open by default, we'll open the Layout panel.

### Screenshots

![screen shot 2018-11-29 at 6 46 35 pm](https://user-images.githubusercontent.com/541093/49259372-1fc8c580-f407-11e8-99ce-ad7d203b33fd.png)

### How to test the changes in this Pull Request:

1. Insert a Products by Category block
2. Expect: in the sidebar, the Layout section is the only expanded panel
3. Click a category, click Done
4. Expect: in the sidebar, the Layout section is (still) the only expanded panel
