### PR TITLE
Update eslint config to ignore legacy block

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,4 @@ build-module
 coverage
 node_modules
 vendor
+legacy

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,11 @@ module.exports = {
 		'jsx-a11y',
 		'jest',
 	],
+	settings: {
+		react: {
+			"version": "16.6",
+		}
+	},
 	rules: {
 		'array-bracket-spacing': [ 'error', 'always' ],
 		'arrow-parens': [ 'error', 'always' ],


### PR DESCRIPTION
Currently there are a number of warnings being triggered by the legacy block files (114). We're not planning on fixing these, as it would take away time from developing future blocks. Instead, let's just disable eslint on the legacy files, so we can focus on actionable errors and warnings.

This also adds a react version setting, to fix a warning when running eslint:

> Warning: React version not specified in eslint-plugin-react settings.

### How to test the changes in this Pull Request:

1. Run `npm run lint`
2. Expect: No errors, warnings, or notices