### PR TITLE
Adjust category list max-height

### DIFF
--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -34,7 +34,7 @@
 
 .woocommerce-search-list__list {
 	padding: 0;
-	max-height: 20em;
+	max-height: 18.5em;
 	overflow-x: scroll;
 	border-top: 1px solid $core-grey-light-500;
 	border-bottom: 1px solid $core-grey-light-500;


### PR DESCRIPTION
Noticed that the current max-height value doesn't make it obvious that the list scrolls;

![scroll?](https://cldup.com/m_Ed8OCYGb-3000x3000.png)

A small tweak makes it more obvious;

![scroll](https://cldup.com/0J5L6qV-FW-2000x2000.png)