### PR TITLE
Category Selection: Add hierarchy support for nested categories

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -37,7 +37,6 @@
 
 // Hide an element from sighted users, but availble to screen reader users.
 @mixin visually-hidden() {
-	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
 	height: 1px;
@@ -45,5 +44,16 @@
 	margin: -1px;
 	overflow: hidden;
 	/* Many screen reader and browser combinations announce broken words as they would appear visually. */
+	overflow-wrap: normal !important;
 	word-wrap: normal !important;
+}
+
+// Unhide a visually hidden element
+@mixin visually-shown() {
+	clip: auto;
+	clip-path: none;
+	height: auto;
+	width: auto;
+	margin: unset;
+	overflow: hidden;
 }

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -46,6 +46,10 @@ class ProductCategoryControl extends Component {
 			classes.push( 'is-searching' );
 		}
 
+		const accessibleName = ! item.breadcrumbs.length ?
+			item.name :
+			`${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
+
 		return (
 			<MenuItem
 				key={ item.id }
@@ -58,7 +62,7 @@ class ProductCategoryControl extends Component {
 						item.count,
 						'woocommerce'
 					),
-					item.name,
+					accessibleName,
 					item.count
 				) }
 			>

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -45,6 +45,9 @@ class ProductCategoryControl extends Component {
 		if ( search.length ) {
 			classes.push( 'is-searching' );
 		}
+		if ( depth === 0 && item.parent !== 0 ) {
+			classes.push( 'is-skip-level' );
+		}
 
 		const accessibleName = ! item.breadcrumbs.length ?
 			item.name :

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -36,11 +36,17 @@ class ProductCategoryControl extends Component {
 			} );
 	}
 
-	renderItem( { getHighlightedName, item, onSelect, search } ) {
+	renderItem( { getHighlightedName, item, onSelect, search, depth = 0 } ) {
+		const classes = [
+			'woocommerce-search-list__item',
+			'woocommerce-product-categories__item',
+			`depth-${ depth }`,
+		];
+
 		return (
 			<MenuItem
 				key={ item.id }
-				className="woocommerce-product-categories__item woocommerce-search-list__item"
+				className={ classes.join( ' ' ) }
 				onClick={ onSelect( item ) }
 				aria-label={ sprintf(
 					_n(
@@ -95,6 +101,7 @@ class ProductCategoryControl extends Component {
 				onChange={ onChange }
 				renderItem={ this.renderItem }
 				messages={ messages }
+				isHierarchical
 			/>
 		);
 	}

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -5,7 +5,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
-import { find } from 'lodash';
+import { find, last } from 'lodash';
 import { MenuItem } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -42,6 +42,9 @@ class ProductCategoryControl extends Component {
 			'woocommerce-product-categories__item',
 			`depth-${ depth }`,
 		];
+		if ( search.length ) {
+			classes.push( 'is-searching' );
+		}
 
 		return (
 			<MenuItem
@@ -59,12 +62,20 @@ class ProductCategoryControl extends Component {
 					item.count
 				) }
 			>
-				<span
-					className="woocommerce-product-categories__item-name"
-					dangerouslySetInnerHTML={ {
-						__html: getHighlightedName( item.name, search ),
-					} }
-				/>
+				<span className="woocommerce-product-categories__item-label">
+					{ !! item.breadcrumbs.length && (
+						<span className="woocommerce-product-categories__item-prefix">
+							{ item.breadcrumbs.length > 1 ? '… ' : null }
+							{ last( item.breadcrumbs ) }
+						</span>
+					) }
+					<span
+						className="woocommerce-product-categories__item-name"
+						dangerouslySetInnerHTML={ {
+							__html: getHighlightedName( item.name, search ),
+						} }
+					/>
+				</span>
 				<span className="woocommerce-product-categories__item-count">
 					{ item.count }
 				</span>

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -3,25 +3,53 @@
 		display: flex;
 		align-items: center;
 	}
+}
 
-	.woocommerce-product-categories__item-name {
-		flex: 1;
-	}
+.woocommerce-product-categories__item-label {
+	display: flex;
+	flex: 1;
 
-	.depth-1 .woocommerce-product-categories__item-name {
+	.depth-1 & {
 		padding-left: $gap-small;
 	}
 
-	.depth-2 .woocommerce-product-categories__item-name {
+	.depth-2 & {
 		padding-left: $gap-small * 2;
 	}
 
-	.depth-3 .woocommerce-product-categories__item-name {
+	.depth-3 & {
 		padding-left: $gap-small * 3;
 	}
 
-	.depth-4 .woocommerce-product-categories__item-name {
+	.depth-4 & {
 		padding-left: $gap-small * 4;
+	}
+}
+
+.woocommerce-product-categories__item {
+	.woocommerce-product-categories__item-name {
+		display: inline-block;
+	}
+
+	.woocommerce-product-categories__item-prefix {
+		display: inline-block;
+		@include visually-hidden;
+		color: $core-grey-dark-300;
+	}
+
+	&.is-searching {
+		.woocommerce-product-categories__item-name {
+			color: $core-grey-dark-900;
+		}
+
+		.woocommerce-product-categories__item-prefix {
+			@include visually-shown;
+			margin-right: $gap-smallest;
+
+			&:after {
+				content: ' ›';
+			}
+		}
 	}
 
 	.woocommerce-product-categories__item-count {

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -32,8 +32,7 @@
 	}
 
 	.woocommerce-product-categories__item-prefix {
-		display: inline-block;
-		@include visually-hidden;
+		display: none;
 		color: $core-grey-dark-300;
 	}
 
@@ -43,7 +42,7 @@
 		}
 
 		.woocommerce-product-categories__item-prefix {
-			@include visually-shown;
+			display: inline-block;
 			margin-right: $gap-smallest;
 
 			&:after {

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -36,11 +36,7 @@
 		color: $core-grey-dark-300;
 	}
 
-	&.is-searching {
-		.woocommerce-product-categories__item-name {
-			color: $core-grey-dark-900;
-		}
-
+	&.is-searching, &.is-skip-level {
 		.woocommerce-product-categories__item-prefix {
 			display: inline-block;
 			margin-right: $gap-smallest;
@@ -48,6 +44,12 @@
 			&:after {
 				content: ' ›';
 			}
+		}
+	}
+
+	&.is-searching {
+		.woocommerce-product-categories__item-name {
+			color: $core-grey-dark-900;
 		}
 	}
 

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -8,6 +8,22 @@
 		flex: 1;
 	}
 
+	.depth-1 .woocommerce-product-categories__item-name {
+		padding-left: $gap-small;
+	}
+
+	.depth-2 .woocommerce-product-categories__item-name {
+		padding-left: $gap-small * 2;
+	}
+
+	.depth-3 .woocommerce-product-categories__item-name {
+		padding-left: $gap-small * 3;
+	}
+
+	.depth-4 .woocommerce-product-categories__item-name {
+		padding-left: $gap-small * 4;
+	}
+
 	.woocommerce-product-categories__item-count {
 		flex: 0;
 		padding: $gap-smallest/2 $gap-smaller;

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -9,6 +9,15 @@
 	display: flex;
 	flex: 1;
 
+	// Anything deeper than 5 levels will use this fallback depth
+	[class*="depth-"] & {
+		padding-left: $gap-small * 5;
+	}
+
+	.depth-0 & {
+		padding-left: 0;
+	}
+
 	.depth-1 & {
 		padding-left: $gap-small;
 	}

--- a/assets/js/components/search-list-control/hierarchy.js
+++ b/assets/js/components/search-list-control/hierarchy.js
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import { groupBy } from 'lodash';
+
+/**
+ * Returns terms in a tree form.
+ *
+ * @param {Array} flatTerms  Array of terms in flat format.
+ *
+ * @return {Array} Array of terms in tree format.
+ */
+export function buildTermsTree( flatTerms ) {
+	const termsByParent = groupBy( flatTerms, 'parent' );
+	const fillWithChildren = ( terms ) => {
+		return terms.map( ( term ) => {
+			const children = termsByParent[ term.id ];
+			return {
+				...term,
+				children: children && children.length ?
+					fillWithChildren( children ) :
+					[],
+			};
+		} );
+	};
+
+	return fillWithChildren( termsByParent[ '0' ] || [] );
+}

--- a/assets/js/components/search-list-control/hierarchy.js
+++ b/assets/js/components/search-list-control/hierarchy.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy } from 'lodash';
+import { forEach, groupBy } from 'lodash';
 
 /**
  * Returns terms in a tree form.
@@ -15,6 +15,7 @@ export function buildTermsTree( flatTerms ) {
 	const fillWithChildren = ( terms ) => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];
+			delete termsByParent[ term.id ];
 			return {
 				...term,
 				children: children && children.length ?
@@ -24,5 +25,14 @@ export function buildTermsTree( flatTerms ) {
 		} );
 	};
 
-	return fillWithChildren( termsByParent[ '0' ] || [] );
+	// return fillWithChildren( termsByParent[ '0' ] || [] );
+	const tree = fillWithChildren( termsByParent[ '0' ] || [] );
+	delete termsByParent[ '0' ];
+
+	// anything left in termsByParent has no visible parent
+	forEach( termsByParent, ( terms ) => {
+		tree.push( ...fillWithChildren( terms || [] ) );
+	} );
+
+	return tree;
 }

--- a/assets/js/components/search-list-control/hierarchy.js
+++ b/assets/js/components/search-list-control/hierarchy.js
@@ -6,7 +6,8 @@ import { forEach, groupBy, keyBy } from 'lodash';
 /**
  * Returns terms in a tree form.
  *
- * @param {Array} flatTerms  Array of terms in flat format.
+ * @param {Array} filteredList  Array of terms, possibly a subset of all terms, in flat format.
+ * @param {Array} list  Array of the full list of terms, defaults to the filteredList.
  *
  * @return {Array} Array of terms in tree format.
  */
@@ -35,7 +36,6 @@ export function buildTermsTree( filteredList, list = filteredList ) {
 		} );
 	};
 
-	// return fillWithChildren( termsByParent[ '0' ] || [] );
 	const tree = fillWithChildren( termsByParent[ '0' ] || [] );
 	delete termsByParent[ '0' ];
 

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -72,7 +72,8 @@ export class SearchListControl extends Component {
 		const { isHierarchical } = this.props;
 		if ( ! search && isHierarchical ) {
 			return buildTermsTree(
-				list.filter( ( item ) => item && ! this.isSelected( item ) )
+				list.filter( ( item ) => item && ! this.isSelected( item ) ),
+				list
 			);
 		} else if ( ! search ) {
 			return list.filter( ( item ) => item && ! this.isSelected( item ) );
@@ -83,7 +84,7 @@ export class SearchListControl extends Component {
 		const filteredList = list
 			.map( ( item ) => ( re.test( item.name ) ? item : false ) )
 			.filter( ( item ) => item && ! this.isSelected( item ) );
-		return isHierarchical ? buildTermsTree( filteredList ) : filteredList;
+		return isHierarchical ? buildTermsTree( filteredList, list ) : filteredList;
 	}
 
 	getHighlightedName( name, search ) {

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -95,11 +95,18 @@ export class SearchListControl extends Component {
 		return name.replace( re, '<strong>$&</strong>' );
 	}
 
-	defaultRenderItem( { getHighlightedName, item, onSelect, search } ) {
+	defaultRenderItem( { depth = 0, getHighlightedName, item, onSelect, search = '' } ) {
+		const classes = [
+			'woocommerce-search-list__item',
+		];
+		if ( this.props.isHierarchical ) {
+			classes.push( `depth-${ depth }` );
+		}
+
 		return (
 			<MenuItem
 				key={ item.id }
-				className="woocommerce-search-list__item"
+				className={ classes.join( ' ' ) }
 				onClick={ onSelect( item ) }
 			>
 				<span
@@ -115,6 +122,9 @@ export class SearchListControl extends Component {
 	renderList( list, depth = 0 ) {
 		const { search } = this.props;
 		const renderItem = this.props.renderItem || this.defaultRenderItem;
+		if ( ! list ) {
+			return null;
+		}
 		return list.map( ( item ) => (
 			<Fragment key={ item.id }>
 				{ renderItem( {

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -205,7 +205,7 @@ SearchListControl.propTypes = {
 	 * Whether the list of items is hierarchical or not. If true, each list item is expected to
 	 * have a parent property.
 	 */
-	isHierarchical: PropTypes.string,
+	isHierarchical: PropTypes.bool,
 	/**
 	 * A complete list of item objects, each with id, name properties. This is displayed as a
 	 * clickable/keyboard-able list, and possibly filtered by the search term (searches name).

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -9,7 +9,7 @@ import {
 	TextControl,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { compose, withInstanceId, withState } from '@wordpress/compose';
 import { escapeRegExp, findIndex } from 'lodash';
 import PropTypes from 'prop-types';
@@ -19,6 +19,7 @@ import { Tag } from '@woocommerce/components';
  * Internal dependencies
  */
 import './style.scss';
+import { buildTermsTree } from './hierarchy';
 
 const defaultMessages = {
 	clear: __( 'Clear all selected items', 'woocommerce' ),
@@ -41,6 +42,7 @@ export class SearchListControl extends Component {
 		this.onRemove = this.onRemove.bind( this );
 		this.onClear = this.onClear.bind( this );
 		this.defaultRenderItem = this.defaultRenderItem.bind( this );
+		this.renderList = this.renderList.bind( this );
 	}
 
 	onRemove( id ) {
@@ -67,15 +69,21 @@ export class SearchListControl extends Component {
 	}
 
 	getFilteredList( list, search ) {
-		if ( ! search ) {
+		const { isHierarchical } = this.props;
+		if ( ! search && isHierarchical ) {
+			return buildTermsTree(
+				list.filter( ( item ) => item && ! this.isSelected( item ) )
+			);
+		} else if ( ! search ) {
 			return list.filter( ( item ) => item && ! this.isSelected( item ) );
 		}
 		const messages = { ...defaultMessages, ...this.props.messages };
 		const re = new RegExp( escapeRegExp( search ), 'i' );
 		this.props.debouncedSpeak( messages.updated );
-		return list
+		const filteredList = list
 			.map( ( item ) => ( re.test( item.name ) ? item : false ) )
 			.filter( ( item ) => item && ! this.isSelected( item ) );
+		return isHierarchical ? buildTermsTree( filteredList ) : filteredList;
 	}
 
 	getHighlightedName( name, search ) {
@@ -103,12 +111,28 @@ export class SearchListControl extends Component {
 		);
 	}
 
+	renderList( list, depth = 0 ) {
+		const { search } = this.props;
+		const renderItem = this.props.renderItem || this.defaultRenderItem;
+		return list.map( ( item ) => (
+			<Fragment key={ item.id }>
+				{ renderItem( {
+					getHighlightedName: this.getHighlightedName,
+					item,
+					onSelect: this.onSelect,
+					search,
+					depth,
+				} ) }
+				{ this.renderList( item.children, depth + 1 ) }
+			</Fragment>
+		) );
+	}
+
 	render() {
 		const { className = '', search, selected, setState } = this.props;
 		const messages = { ...defaultMessages, ...this.props.messages };
 		const list = this.getFilteredList( this.props.list, search );
 		const noResults = search ? sprintf( messages.noResults, search ) : null;
-		const renderItem = this.props.renderItem || this.defaultRenderItem;
 		const selectedCount = selected.length;
 
 		return (
@@ -117,7 +141,12 @@ export class SearchListControl extends Component {
 					<div className="woocommerce-search-list__selected">
 						<div className="woocommerce-search-list__selected-header">
 							<strong>{ messages.selected( selectedCount ) }</strong>
-							<Button isLink isDestructive onClick={ this.onClear } aria-label={ messages.clear }>
+							<Button
+								isLink
+								isDestructive
+								onClick={ this.onClear }
+								aria-label={ messages.clear }
+							>
 								{ __( 'Clear all', 'woocommerce' ) }
 							</Button>
 						</div>
@@ -148,14 +177,7 @@ export class SearchListControl extends Component {
 						label={ messages.list }
 						className="woocommerce-search-list__list"
 					>
-						{ list.map( ( item ) =>
-							renderItem( {
-								getHighlightedName: this.getHighlightedName,
-								item,
-								onSelect: this.onSelect,
-								search,
-							} )
-						) }
+						{ this.renderList( list ) }
 					</MenuGroup>
 				) }
 			</div>
@@ -168,6 +190,11 @@ SearchListControl.propTypes = {
 	 * Additional CSS classes.
 	 */
 	className: PropTypes.string,
+	/**
+	 * Whether the list of items is hierarchical or not. If true, each list item is expected to
+	 * have a parent property.
+	 */
+	isHierarchical: PropTypes.string,
 	/**
 	 * A complete list of item objects, each with id, name properties. This is displayed as a
 	 * clickable/keyboard-able list, and possibly filtered by the search term (searches name).

--- a/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
+++ b/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
@@ -1,5 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SearchListControl should render a search box and list of hierarchical options 1`] = `
+<div
+  className="woocommerce-search-list "
+>
+  <div
+    className="woocommerce-search-list__search"
+  >
+    <div
+      className="components-base-control"
+    >
+      <div
+        className="components-base-control__field"
+      >
+        <label
+          className="components-base-control__label"
+          htmlFor="inspector-text-control-10"
+        >
+          Search for items
+        </label>
+        <input
+          className="components-text-control__input"
+          id="inspector-text-control-10"
+          onChange={[Function]}
+          type="search"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    className="woocommerce-search-list__list components-menu-group"
+  >
+    <div
+      className="components-menu-group__label"
+      id="components-menu-group-label-8"
+    >
+      Results
+    </div>
+    <div
+      aria-labelledby="components-menu-group-label-8"
+      aria-orientation="vertical"
+      onKeyDown={[Function]}
+      role="menu"
+    >
+      <button
+        className="components-button components-menu-item__button woocommerce-search-list__item depth-0"
+        onClick={[Function]}
+        role="menuitem"
+        type="button"
+      >
+        <span
+          className="woocommerce-search-list__item-name"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Apricots",
+            }
+          }
+        />
+      </button>
+      <button
+        className="components-button components-menu-item__button woocommerce-search-list__item depth-1"
+        onClick={[Function]}
+        role="menuitem"
+        type="button"
+      >
+        <span
+          className="woocommerce-search-list__item-name"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Clementine",
+            }
+          }
+        />
+      </button>
+      <button
+        className="components-button components-menu-item__button woocommerce-search-list__item depth-1"
+        onClick={[Function]}
+        role="menuitem"
+        type="button"
+      >
+        <span
+          className="woocommerce-search-list__item-name"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Elderberry",
+            }
+          }
+        />
+      </button>
+      <button
+        className="components-button components-menu-item__button woocommerce-search-list__item depth-2"
+        onClick={[Function]}
+        role="menuitem"
+        type="button"
+      >
+        <span
+          className="woocommerce-search-list__item-name"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Guava",
+            }
+          }
+        />
+      </button>
+      <button
+        className="components-button components-menu-item__button woocommerce-search-list__item depth-0"
+        onClick={[Function]}
+        role="menuitem"
+        type="button"
+      >
+        <span
+          className="woocommerce-search-list__item-name"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Lychee",
+            }
+          }
+        />
+      </button>
+      <button
+        className="components-button components-menu-item__button woocommerce-search-list__item depth-0"
+        onClick={[Function]}
+        role="menuitem"
+        type="button"
+      >
+        <span
+          className="woocommerce-search-list__item-name"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Mulberry",
+            }
+          }
+        />
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`SearchListControl should render a search box and list of options 1`] = `
 <div
   className="woocommerce-search-list "

--- a/assets/js/components/search-list-control/test/hierarchy.js
+++ b/assets/js/components/search-list-control/test/hierarchy.js
@@ -1,0 +1,85 @@
+/**
+ * Internal dependencies
+ */
+import { buildTermsTree } from '../hierarchy';
+
+describe( 'buildTermsTree', () => {
+	test( 'should return an empty array on empty input', () => {
+		const tree = buildTermsTree( [] );
+		expect( tree ).toEqual( [] );
+	} );
+
+	test( 'should return a tree of items', () => {
+		const items = [
+			{ id: 1, name: 'Apricots', parent: 0 },
+			{ id: 2, name: 'Clementine', parent: 0 },
+			{ id: 3, name: 'Elderberry', parent: 2 },
+			{ id: 4, name: 'Guava', parent: 2 },
+			{ id: 5, name: 'Lychee', parent: 3 },
+			{ id: 6, name: 'Mulberry', parent: 0 },
+		];
+		const tree = buildTermsTree( items );
+		expect( tree ).toEqual( [
+			{ id: 1, name: 'Apricots', parent: 0, children: [] },
+			{
+				id: 2,
+				name: 'Clementine',
+				parent: 0,
+				children: [
+					{
+						id: 3,
+						name: 'Elderberry',
+						parent: 2,
+						children: [ { id: 5, name: 'Lychee', parent: 3, children: [] } ],
+					},
+					{ id: 4, name: 'Guava', parent: 2, children: [] },
+				],
+			},
+			{ id: 6, name: 'Mulberry', parent: 0, children: [] },
+		] );
+	} );
+
+	test( 'should return a tree of items, with orphan categories appended to the end', () => {
+		const items = [
+			{ id: 1, name: 'Apricots', parent: 0 },
+			{ id: 2, name: 'Clementine', parent: 0 },
+			{ id: 4, name: 'Guava', parent: 2 },
+			{ id: 5, name: 'Lychee', parent: 3 },
+			{ id: 6, name: 'Mulberry', parent: 0 },
+		];
+		const tree = buildTermsTree( items );
+		expect( tree ).toEqual( [
+			{ id: 1, name: 'Apricots', parent: 0, children: [] },
+			{
+				id: 2,
+				name: 'Clementine',
+				parent: 0,
+				children: [ { id: 4, name: 'Guava', parent: 2, children: [] } ],
+			},
+			{ id: 6, name: 'Mulberry', parent: 0, children: [] },
+			{ id: 5, name: 'Lychee', parent: 3, children: [] },
+		] );
+	} );
+
+	test( 'should return a tree of items, with orphan categories appended to the end, with children of thier own', () => {
+		const items = [
+			{ id: 1, name: 'Apricots', parent: 0 },
+			{ id: 3, name: 'Elderberry', parent: 2 },
+			{ id: 4, name: 'Guava', parent: 2 },
+			{ id: 5, name: 'Lychee', parent: 3 },
+			{ id: 6, name: 'Mulberry', parent: 0 },
+		];
+		const tree = buildTermsTree( items );
+		expect( tree ).toEqual( [
+			{ id: 1, name: 'Apricots', parent: 0, children: [] },
+			{ id: 6, name: 'Mulberry', parent: 0, children: [] },
+			{
+				id: 3,
+				name: 'Elderberry',
+				parent: 2,
+				children: [ { id: 5, name: 'Lychee', parent: 3, children: [] } ],
+			},
+			{ id: 4, name: 'Guava', parent: 2, children: [] },
+		] );
+	} );
+} );

--- a/assets/js/components/search-list-control/test/hierarchy.js
+++ b/assets/js/components/search-list-control/test/hierarchy.js
@@ -3,83 +3,150 @@
  */
 import { buildTermsTree } from '../hierarchy';
 
+const list = [
+	{ id: 1, name: 'Apricots', parent: 0 },
+	{ id: 2, name: 'Clementine', parent: 0 },
+	{ id: 3, name: 'Elderberry', parent: 2 },
+	{ id: 4, name: 'Guava', parent: 2 },
+	{ id: 5, name: 'Lychee', parent: 3 },
+	{ id: 6, name: 'Mulberry', parent: 0 },
+	{ id: 7, name: 'Tamarind', parent: 5 },
+];
+
 describe( 'buildTermsTree', () => {
 	test( 'should return an empty array on empty input', () => {
 		const tree = buildTermsTree( [] );
 		expect( tree ).toEqual( [] );
 	} );
 
-	test( 'should return a tree of items', () => {
-		const items = [
+	test( 'should return a flat array when there are no parent relationships', () => {
+		const tree = buildTermsTree( [
 			{ id: 1, name: 'Apricots', parent: 0 },
 			{ id: 2, name: 'Clementine', parent: 0 },
-			{ id: 3, name: 'Elderberry', parent: 2 },
-			{ id: 4, name: 'Guava', parent: 2 },
-			{ id: 5, name: 'Lychee', parent: 3 },
-			{ id: 6, name: 'Mulberry', parent: 0 },
-		];
-		const tree = buildTermsTree( items );
+		] );
 		expect( tree ).toEqual( [
-			{ id: 1, name: 'Apricots', parent: 0, children: [] },
+			{ id: 1, name: 'Apricots', parent: 0, breadcrumbs: [], children: [] },
+			{ id: 2, name: 'Clementine', parent: 0, breadcrumbs: [], children: [] },
+		] );
+	} );
+
+	test( 'should return a tree of items', () => {
+		const tree = buildTermsTree( list );
+		expect( tree ).toEqual( [
+			{ id: 1, name: 'Apricots', parent: 0, breadcrumbs: [], children: [] },
 			{
 				id: 2,
 				name: 'Clementine',
 				parent: 0,
+				breadcrumbs: [],
 				children: [
 					{
 						id: 3,
 						name: 'Elderberry',
 						parent: 2,
-						children: [ { id: 5, name: 'Lychee', parent: 3, children: [] } ],
+						breadcrumbs: [ 'Clementine' ],
+						children: [
+							{
+								id: 5,
+								name: 'Lychee',
+								parent: 3,
+								breadcrumbs: [ 'Clementine', 'Elderberry' ],
+								children: [
+									{
+										id: 7,
+										name: 'Tamarind',
+										parent: 5,
+										breadcrumbs: [ 'Clementine', 'Elderberry', 'Lychee' ],
+										children: [],
+									},
+								],
+							},
+						],
 					},
-					{ id: 4, name: 'Guava', parent: 2, children: [] },
+					{
+						id: 4,
+						name: 'Guava',
+						parent: 2,
+						breadcrumbs: [ 'Clementine' ],
+						children: [],
+					},
 				],
 			},
-			{ id: 6, name: 'Mulberry', parent: 0, children: [] },
+			{ id: 6, name: 'Mulberry', parent: 0, breadcrumbs: [], children: [] },
 		] );
 	} );
 
 	test( 'should return a tree of items, with orphan categories appended to the end', () => {
-		const items = [
+		const filteredList = [
 			{ id: 1, name: 'Apricots', parent: 0 },
 			{ id: 2, name: 'Clementine', parent: 0 },
 			{ id: 4, name: 'Guava', parent: 2 },
 			{ id: 5, name: 'Lychee', parent: 3 },
 			{ id: 6, name: 'Mulberry', parent: 0 },
 		];
-		const tree = buildTermsTree( items );
+		const tree = buildTermsTree( filteredList, list );
 		expect( tree ).toEqual( [
-			{ id: 1, name: 'Apricots', parent: 0, children: [] },
+			{ id: 1, name: 'Apricots', parent: 0, breadcrumbs: [], children: [] },
 			{
 				id: 2,
 				name: 'Clementine',
 				parent: 0,
-				children: [ { id: 4, name: 'Guava', parent: 2, children: [] } ],
+				breadcrumbs: [],
+				children: [
+					{
+						id: 4,
+						name: 'Guava',
+						parent: 2,
+						breadcrumbs: [ 'Clementine' ],
+						children: [],
+					},
+				],
 			},
-			{ id: 6, name: 'Mulberry', parent: 0, children: [] },
-			{ id: 5, name: 'Lychee', parent: 3, children: [] },
+			{ id: 6, name: 'Mulberry', parent: 0, breadcrumbs: [], children: [] },
+			{
+				id: 5,
+				name: 'Lychee',
+				parent: 3,
+				breadcrumbs: [ 'Clementine', 'Elderberry' ],
+				children: [],
+			},
 		] );
 	} );
 
 	test( 'should return a tree of items, with orphan categories appended to the end, with children of thier own', () => {
-		const items = [
+		const filteredList = [
 			{ id: 1, name: 'Apricots', parent: 0 },
 			{ id: 3, name: 'Elderberry', parent: 2 },
 			{ id: 4, name: 'Guava', parent: 2 },
 			{ id: 5, name: 'Lychee', parent: 3 },
 			{ id: 6, name: 'Mulberry', parent: 0 },
 		];
-		const tree = buildTermsTree( items );
+		const tree = buildTermsTree( filteredList, list );
 		expect( tree ).toEqual( [
-			{ id: 1, name: 'Apricots', parent: 0, children: [] },
-			{ id: 6, name: 'Mulberry', parent: 0, children: [] },
+			{ id: 1, name: 'Apricots', parent: 0, breadcrumbs: [], children: [] },
+			{ id: 6, name: 'Mulberry', parent: 0, breadcrumbs: [], children: [] },
 			{
 				id: 3,
 				name: 'Elderberry',
 				parent: 2,
-				children: [ { id: 5, name: 'Lychee', parent: 3, children: [] } ],
+				breadcrumbs: [ 'Clementine' ],
+				children: [
+					{
+						id: 5,
+						name: 'Lychee',
+						parent: 3,
+						breadcrumbs: [ 'Clementine', 'Elderberry' ],
+						children: [],
+					},
+				],
 			},
-			{ id: 4, name: 'Guava', parent: 2, children: [] },
+			{
+				id: 4,
+				name: 'Guava',
+				parent: 2,
+				breadcrumbs: [ 'Clementine' ],
+				children: [],
+			},
 		] );
 	} );
 } );

--- a/assets/js/components/search-list-control/test/index.js
+++ b/assets/js/components/search-list-control/test/index.js
@@ -18,59 +18,115 @@ const list = [
 	{ id: 6, name: 'Mulberry' },
 ];
 
+const hierarchicalList = [
+	{ id: 1, name: 'Apricots', parent: 0 },
+	{ id: 2, name: 'Clementine', parent: 1 },
+	{ id: 3, name: 'Elderberry', parent: 1 },
+	{ id: 4, name: 'Guava', parent: 3 },
+	{ id: 5, name: 'Lychee', parent: 0 },
+	{ id: 6, name: 'Mulberry', parent: 0 },
+];
+
 describe( 'SearchListControl', () => {
 	test( 'should render a search box and list of options', () => {
 		const component = renderer.create(
-			<SearchListControl list={ list } selected={ [] } onChange={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				selected={ [] }
+				onChange={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and list of options with a custom className', () => {
 		const component = renderer.create(
-			<SearchListControl className="test-search" list={ list } selected={ [] } onChange={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				className="test-search"
+				list={ list }
+				selected={ [] }
+				onChange={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box, a list of options, and 1 selected item', () => {
 		const component = renderer.create(
-			<SearchListControl list={ list } selected={ [ list[ 1 ] ] } onChange={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				selected={ [ list[ 1 ] ] }
+				onChange={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box, a list of options, and 2 selected item', () => {
 		const component = renderer.create(
-			<SearchListControl list={ list } selected={ [ list[ 1 ], list[ 3 ] ] } onChange={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				selected={ [ list[ 1 ], list[ 3 ] ] }
+				onChange={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and no options', () => {
 		const component = renderer.create(
-			<SearchListControl list={ [] } selected={ [] } onChange={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ [] }
+				selected={ [] }
+				onChange={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box with a search term, and only matching options', () => {
 		const component = renderer.create(
-			<SearchListControl list={ list } search="berry" selected={ [] } onChange={ noop } debouncedSpeak={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				search="berry"
+				selected={ [] }
+				onChange={ noop }
+				debouncedSpeak={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box with a search term, and only matching options, regardless of case sensitivity', () => {
 		const component = renderer.create(
-			<SearchListControl list={ list } search="bERry" selected={ [] } onChange={ noop } debouncedSpeak={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				search="bERry"
+				selected={ [] }
+				onChange={ noop }
+				debouncedSpeak={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box with a search term, and no matching options', () => {
 		const component = renderer.create(
-			<SearchListControl list={ list } search="no matches" selected={ [] } onChange={ noop } debouncedSpeak={ noop } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				search="no matches"
+				selected={ [] }
+				onChange={ noop }
+				debouncedSpeak={ noop }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
@@ -78,15 +134,40 @@ describe( 'SearchListControl', () => {
 	test( 'should render a search box and list of options, with a custom search input message', () => {
 		const messages = { search: 'Testing search label' };
 		const component = renderer.create(
-			<SearchListControl list={ list } selected={ [] } onChange={ noop } messages={ messages } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				selected={ [] }
+				onChange={ noop }
+				messages={ messages }
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
 	test( 'should render a search box and list of options, with a custom render callback for each item', () => {
-		const renderItem = ( { item } ) => <div key={ item.id }>{ item.name }!</div>; // eslint-disable-line
+		const renderItem = ({ item }) => <div key={item.id}>{item.name}!</div>; // eslint-disable-line
 		const component = renderer.create(
-			<SearchListControl list={ list } selected={ [] } onChange={ noop } renderItem={ renderItem } />
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				selected={ [] }
+				onChange={ noop }
+				renderItem={ renderItem }
+			/>
+		);
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a search box and list of hierarchical options', () => {
+		const component = renderer.create(
+			<SearchListControl
+				instanceId={ 1 }
+				list={ hierarchicalList }
+				selected={ [] }
+				onChange={ noop }
+				isHierarchical
+			/>
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );


### PR DESCRIPTION
Fixes #178 – Product categories can be hierarchical, meaning there can be categories nested under other categories, potentially with duplicate names, and/or potentially many levels deep.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader 
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

When you load up the block, no parent categories are shown but the items are indented:

<img width="436" alt="default" src="https://user-images.githubusercontent.com/541093/49305802-4f76dc80-f49e-11e8-8db6-ef8c5a3b35fa.png">

If you're searching, the immediate parent category is shown, with `…` if there is more than 1 level of parents:

<img width="433" alt="search" src="https://user-images.githubusercontent.com/541093/49305803-500f7300-f49e-11e8-87f4-29f0b5096269.png">

If the parent category is also selected, it's removed from the list, which means we need to indicate parent somehow… so I'm using the same method as searching, but only for those "missing parent" categories:

<img width="455" alt="selected" src="https://user-images.githubusercontent.com/541093/49305801-4f76dc80-f49e-11e8-9ff6-344e4c04c4ca.png">

I'm a little stuck on showing the selected tags' parent hierarchy on hover, right now the Tag component has a `screenReaderLabel` prop but that _only_ applies to screen readers. and I can't just use the `alt` tag. 

### How to test the changes in this Pull Request:

1. Set up hierarchical categories, at least some 2 levels deep.
2. Add a block, test out using the category selection
3. Try selecting top level categories, nested categories, try searching, etc.
