### PR TITLE
Category Selection: Add the first category to deeply nested items

### DIFF
--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -5,7 +5,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Component } from '@wordpress/element';
-import { find, last } from 'lodash';
+import { find, first, last } from 'lodash';
 import { MenuItem } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -35,6 +35,17 @@ class ProductCategoryControl extends Component {
 			.catch( () => {
 				this.setState( { list: [] } );
 			} );
+	}
+
+	getBreadcrumbsForDisplay( breadcrumbs ) {
+		if ( breadcrumbs.length === 1 ) {
+			return first( breadcrumbs );
+		}
+		if ( breadcrumbs.length === 2 ) {
+			return first( breadcrumbs ) + ' › ' + last( breadcrumbs );
+		}
+
+		return first( breadcrumbs ) + ' … ' + last( breadcrumbs );
 	}
 
 	renderItem( { getHighlightedName, isSelected, item, onSelect, search, depth = 0 } ) {
@@ -78,8 +89,7 @@ class ProductCategoryControl extends Component {
 				<span className="woocommerce-product-categories__item-label">
 					{ !! item.breadcrumbs.length && (
 						<span className="woocommerce-product-categories__item-prefix">
-							{ item.breadcrumbs.length > 1 ? '… ' : null }
-							{ last( item.breadcrumbs ) }
+							{ this.getBreadcrumbsForDisplay( item.breadcrumbs ) }
 						</span>
 					) }
 					<span


### PR DESCRIPTION
Fixes #188 – Add the top-level category to nested items. In deeply nested items, this adds the top level category before the …, while for categories 2-levels deep, we just add the grandparent › parent › category.

### Screenshots

<img width="435" alt="screen shot 2018-12-03 at 11 36 37 am" src="https://user-images.githubusercontent.com/541093/49387591-35343d00-f6f0-11e8-8bbc-2b9911320b82.png">

<img width="419" alt="screen shot 2018-12-03 at 11 31 28 am" src="https://user-images.githubusercontent.com/541093/49387592-35343d00-f6f0-11e8-86d7-767111d3296a.png">


### How to test the changes in this Pull Request:

1. Have categories with deep hierarchy (at least 3 levels)
2. Add the Products by Category block
3. Search for your nested categories
4. Expect: you should always see the top-level category
