### PR TITLE
Update test snapshots after markup changes in 182

### DIFF
--- a/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
+++ b/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
@@ -44,47 +44,51 @@ exports[`SearchListControl should render a search box and list of hierarchical o
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item depth-0"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -95,47 +99,51 @@ exports[`SearchListControl should render a search box and list of hierarchical o
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item depth-1"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -146,47 +154,51 @@ exports[`SearchListControl should render a search box and list of hierarchical o
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item depth-1"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -197,47 +209,51 @@ exports[`SearchListControl should render a search box and list of hierarchical o
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item depth-2"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -248,47 +264,51 @@ exports[`SearchListControl should render a search box and list of hierarchical o
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item depth-0"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -299,47 +319,51 @@ exports[`SearchListControl should render a search box and list of hierarchical o
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item depth-0"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -398,47 +422,51 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -449,47 +477,51 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -500,47 +532,51 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -551,47 +587,51 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -602,47 +642,51 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -653,47 +697,51 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -752,47 +800,51 @@ exports[`SearchListControl should render a search box and list of options with a
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -803,47 +855,51 @@ exports[`SearchListControl should render a search box and list of options with a
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -854,47 +910,51 @@ exports[`SearchListControl should render a search box and list of options with a
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -905,47 +965,51 @@ exports[`SearchListControl should render a search box and list of options with a
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -956,47 +1020,51 @@ exports[`SearchListControl should render a search box and list of options with a
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1007,47 +1075,51 @@ exports[`SearchListControl should render a search box and list of options with a
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1178,47 +1250,51 @@ exports[`SearchListControl should render a search box and list of options, with 
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1229,47 +1305,51 @@ exports[`SearchListControl should render a search box and list of options, with 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1280,47 +1360,51 @@ exports[`SearchListControl should render a search box and list of options, with 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1331,47 +1415,51 @@ exports[`SearchListControl should render a search box and list of options, with 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1382,47 +1470,51 @@ exports[`SearchListControl should render a search box and list of options, with 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1433,47 +1525,51 @@ exports[`SearchListControl should render a search box and list of options, with 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1597,47 +1693,51 @@ exports[`SearchListControl should render a search box with a search term, and on
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1648,47 +1748,51 @@ exports[`SearchListControl should render a search box with a search term, and on
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1748,47 +1852,51 @@ exports[`SearchListControl should render a search box with a search term, and on
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1799,47 +1907,51 @@ exports[`SearchListControl should render a search box with a search term, and on
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -1962,47 +2074,51 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2013,47 +2129,51 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
         />
       </button>
       <button
-        aria-selected={true}
+        aria-checked={true}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 1H2.7778C1.791 1 1 1.8 1 2.7778v12.4444C1 16.2 1.7911 17 2.7778 17h12.4444C16.209 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2089 1 15.2222 1zm-8 12.4444L2.7778 9 4.031 7.7467l3.1911 3.1822 6.7467-6.7467 1.2533 1.2622-8 8z"
-              id="checked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="checked-mask"
-            >
-              <use
-                xlinkHref="#checked"
+            <defs>
+              <path
+                d="M15.2222 1H2.7778C1.791 1 1 1.8 1 2.7778v12.4444C1 16.2 1.7911 17 2.7778 17h12.4444C16.209 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2089 1 15.2222 1zm-8 12.4444L2.7778 9 4.031 7.7467l3.1911 3.1822 6.7467-6.7467 1.2533 1.2622-8 8z"
+                id="checked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#1E8CBE"
-              mask="url(#checked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="checked-mask"
+              >
+                <use
+                  xlinkHref="#checked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#1E8CBE"
+                mask="url(#checked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2064,47 +2184,51 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2115,47 +2239,51 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2166,47 +2294,51 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2217,47 +2349,51 @@ exports[`SearchListControl should render a search box, a list of options, and 1 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2425,47 +2561,51 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
       role="menu"
     >
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2476,47 +2616,51 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
         />
       </button>
       <button
-        aria-selected={true}
+        aria-checked={true}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 1H2.7778C1.791 1 1 1.8 1 2.7778v12.4444C1 16.2 1.7911 17 2.7778 17h12.4444C16.209 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2089 1 15.2222 1zm-8 12.4444L2.7778 9 4.031 7.7467l3.1911 3.1822 6.7467-6.7467 1.2533 1.2622-8 8z"
-              id="checked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="checked-mask"
-            >
-              <use
-                xlinkHref="#checked"
+            <defs>
+              <path
+                d="M15.2222 1H2.7778C1.791 1 1 1.8 1 2.7778v12.4444C1 16.2 1.7911 17 2.7778 17h12.4444C16.209 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2089 1 15.2222 1zm-8 12.4444L2.7778 9 4.031 7.7467l3.1911 3.1822 6.7467-6.7467 1.2533 1.2622-8 8z"
+                id="checked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#1E8CBE"
-              mask="url(#checked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="checked-mask"
+              >
+                <use
+                  xlinkHref="#checked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#1E8CBE"
+                mask="url(#checked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2527,47 +2671,51 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2578,47 +2726,51 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
         />
       </button>
       <button
-        aria-selected={true}
+        aria-checked={true}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 1H2.7778C1.791 1 1 1.8 1 2.7778v12.4444C1 16.2 1.7911 17 2.7778 17h12.4444C16.209 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2089 1 15.2222 1zm-8 12.4444L2.7778 9 4.031 7.7467l3.1911 3.1822 6.7467-6.7467 1.2533 1.2622-8 8z"
-              id="checked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="checked-mask"
-            >
-              <use
-                xlinkHref="#checked"
+            <defs>
+              <path
+                d="M15.2222 1H2.7778C1.791 1 1 1.8 1 2.7778v12.4444C1 16.2 1.7911 17 2.7778 17h12.4444C16.209 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2089 1 15.2222 1zm-8 12.4444L2.7778 9 4.031 7.7467l3.1911 3.1822 6.7467-6.7467 1.2533 1.2622-8 8z"
+                id="checked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#1E8CBE"
-              mask="url(#checked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="checked-mask"
+              >
+                <use
+                  xlinkHref="#checked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#1E8CBE"
+                mask="url(#checked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2629,47 +2781,51 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={
@@ -2680,47 +2836,51 @@ exports[`SearchListControl should render a search box, a list of options, and 2 
         />
       </button>
       <button
-        aria-selected={false}
+        aria-checked={false}
         className="components-button components-menu-item__button woocommerce-search-list__item"
         onClick={[Function]}
-        role="menuitem"
+        role="menuitemcheckbox"
         type="button"
       >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          height="16"
-          role="img"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
+        <span
+          className="woocommerce-search-list__item-state"
         >
-          <defs>
-            <path
-              d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
-              id="unchecked"
-            />
-          </defs>
-          <g
-            fill="none"
-            fillRule="evenodd"
-            transform="translate(-1 -1)"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
           >
-            <mask
-              fill="#fff"
-              id="unchecked-mask"
-            >
-              <use
-                xlinkHref="#unchecked"
+            <defs>
+              <path
+                d="M15.2222 2.7778v12.4444H2.7778V2.7778h12.4444zm0-1.7778H2.7778C1.8 1 1 1.8 1 2.7778v12.4444C1 16.2 1.8 17 2.7778 17h12.4444C16.2 17 17 16.2 17 15.2222V2.7778C17 1.8 16.2 1 15.2222 1z"
+                id="unchecked"
               />
-            </mask>
-            <path
-              d="M0 0h18v18H0z"
-              fill="#6C7781"
-              mask="url(#unchecked-mask)"
-            />
-          </g>
-        </svg>
+            </defs>
+            <g
+              fill="none"
+              fillRule="evenodd"
+              transform="translate(-1 -1)"
+            >
+              <mask
+                fill="#fff"
+                id="unchecked-mask"
+              >
+                <use
+                  xlinkHref="#unchecked"
+                />
+              </mask>
+              <path
+                d="M0 0h18v18H0z"
+                fill="#6C7781"
+                mask="url(#unchecked-mask)"
+              />
+            </g>
+          </svg>
+        </span>
         <span
           className="woocommerce-search-list__item-name"
           dangerouslySetInnerHTML={


### PR DESCRIPTION
Accidentally merged with broken tests in #182, due to markup changes for the SVG wrapper and fixing accessibility on the menu items. This PR just updates the snapshots to the correct (new) markup.

The diff looks intimidating, but each change should just be adding a span wrapper, and updating some aria/role attributes.

### How to test the changes in this Pull Request:

1. Run `npm test`
2. Expect: All should be passing
