### PR TITLE
Category Selection: Prevent scrollbar on bottom of category selection screen

### DIFF
--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -35,7 +35,8 @@
 .woocommerce-search-list__list {
 	padding: 0;
 	max-height: 18.5em;
-	overflow-x: scroll;
+	overflow-x: hidden;
+	overflow-y: auto;
 	border-top: 1px solid $core-grey-light-500;
 	border-bottom: 1px solid $core-grey-light-500;
 


### PR DESCRIPTION
Fixes #187 – Prevents the scrollbar along the bottom of the category list, and only show the vertical scrollbar if the container is scrollable. 

### Screenshots

<img width="451" alt="screen shot 2018-12-03 at 12 09 36 pm" src="https://user-images.githubusercontent.com/541093/49389496-76c6e700-f6f4-11e8-8f6b-c5856a9b8433.png">

### How to test the changes in this Pull Request:

1. On mac, you can turn on visible scrollbars by going to System Preferences > General > Show scrollbars, select "Always"
2. View the category selection in edit mode or in the block sidebar
3. There should only be a vertical sidebar, and only if there are more categories than space in the box.
