### PR TITLE
Category Selection: Always show "selected" section

### DIFF
--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -22,6 +22,8 @@
 		margin: 0 0 $gap;
 		padding: 0;
 		border-top: none;
+		// 54px is the height of 1 row of tags in the sidebar.
+		min-height: 54px;
 	}
 	.woocommerce-search-list__search {
 		margin: 0 0 $gap;

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -163,14 +163,16 @@ export class SearchListControl extends Component {
 				<div className="woocommerce-search-list__selected">
 					<div className="woocommerce-search-list__selected-header">
 						<strong>{ messages.selected( selectedCount ) }</strong>
-						<Button
-							isLink
-							isDestructive
-							onClick={ this.onClear }
-							aria-label={ messages.clear }
-						>
-							{ __( 'Clear all', 'woocommerce' ) }
-						</Button>
+						{ selectedCount > 0 ? (
+							<Button
+								isLink
+								isDestructive
+								onClick={ this.onClear }
+								aria-label={ messages.clear }
+							>
+								{ __( 'Clear all', 'woocommerce' ) }
+							</Button>
+						) : null }
 					</div>
 					{ selected.map( ( item, i ) => (
 						<Tag

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -160,29 +160,27 @@ export class SearchListControl extends Component {
 
 		return (
 			<div className={ `woocommerce-search-list ${ className }` }>
-				{ selectedCount > 0 ? (
-					<div className="woocommerce-search-list__selected">
-						<div className="woocommerce-search-list__selected-header">
-							<strong>{ messages.selected( selectedCount ) }</strong>
-							<Button
-								isLink
-								isDestructive
-								onClick={ this.onClear }
-								aria-label={ messages.clear }
-							>
-								{ __( 'Clear all', 'woocommerce' ) }
-							</Button>
-						</div>
-						{ selected.map( ( item, i ) => (
-							<Tag
-								key={ i }
-								label={ item.name }
-								id={ item.id }
-								remove={ this.onRemove }
-							/>
-						) ) }
+				<div className="woocommerce-search-list__selected">
+					<div className="woocommerce-search-list__selected-header">
+						<strong>{ messages.selected( selectedCount ) }</strong>
+						<Button
+							isLink
+							isDestructive
+							onClick={ this.onClear }
+							aria-label={ messages.clear }
+						>
+							{ __( 'Clear all', 'woocommerce' ) }
+						</Button>
 					</div>
-				) : null }
+					{ selected.map( ( item, i ) => (
+						<Tag
+							key={ i }
+							label={ item.name }
+							id={ item.id }
+							remove={ this.onRemove }
+						/>
+					) ) }
+				</div>
 
 				<div className="woocommerce-search-list__search">
 					<TextControl

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -7,6 +7,8 @@
 .woocommerce-search-list__selected {
 	margin: $gap 0;
 	padding: $gap 0 0;
+	// 76px is the height of 1 row of tags.
+	min-height: 76px;
 	border-top: 1px solid $core-grey-light-500;
 
 	.woocommerce-search-list__selected-header {

--- a/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
+++ b/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
@@ -5,6 +5,17 @@ exports[`SearchListControl should render a search box and list of hierarchical o
   className="woocommerce-search-list "
 >
   <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
+  <div
     className="woocommerce-search-list__search"
   >
     <div
@@ -382,6 +393,17 @@ exports[`SearchListControl should render a search box and list of options 1`] = 
 <div
   className="woocommerce-search-list "
 >
+  <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
   <div
     className="woocommerce-search-list__search"
   >
@@ -761,6 +783,17 @@ exports[`SearchListControl should render a search box and list of options with a
   className="woocommerce-search-list test-search"
 >
   <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
+  <div
     className="woocommerce-search-list__search"
   >
     <div
@@ -1139,6 +1172,17 @@ exports[`SearchListControl should render a search box and list of options, with 
   className="woocommerce-search-list "
 >
   <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
+  <div
     className="woocommerce-search-list__search"
   >
     <div
@@ -1210,6 +1254,17 @@ exports[`SearchListControl should render a search box and list of options, with 
 <div
   className="woocommerce-search-list "
 >
+  <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
   <div
     className="woocommerce-search-list__search"
   >
@@ -1589,6 +1644,17 @@ exports[`SearchListControl should render a search box and no options 1`] = `
   className="woocommerce-search-list "
 >
   <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
+  <div
     className="woocommerce-search-list__search"
   >
     <div
@@ -1619,6 +1685,17 @@ exports[`SearchListControl should render a search box with a search term, and no
 <div
   className="woocommerce-search-list "
 >
+  <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
   <div
     className="woocommerce-search-list__search"
   >
@@ -1652,6 +1729,17 @@ exports[`SearchListControl should render a search box with a search term, and on
 <div
   className="woocommerce-search-list "
 >
+  <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
   <div
     className="woocommerce-search-list__search"
   >
@@ -1811,6 +1899,17 @@ exports[`SearchListControl should render a search box with a search term, and on
 <div
   className="woocommerce-search-list "
 >
+  <div
+    className="woocommerce-search-list__selected"
+  >
+    <div
+      className="woocommerce-search-list__selected-header"
+    >
+      <strong>
+        0 items selected
+      </strong>
+    </div>
+  </div>
   <div
     className="woocommerce-search-list__search"
   >


### PR DESCRIPTION
Fixes #183 – Selecting a category caused this section to appear, and push the category list down abruptly. Now we're always showing the section, even if it's empty, at the min-height of one row of categories – this way, selecting your first couple categories does not move the category list (though if you add enough categories to wrap to a second line, it will).

### Screenshots

<img width="455" alt="screen shot 2018-12-03 at 12 52 26 pm" src="https://user-images.githubusercontent.com/541093/49391673-5437cc80-f6fa-11e8-9ead-d141aaca00b8.png">

### How to test the changes in this Pull Request:

1. Add a Products by Category block
2. View the empty "0 categories selected" section
3. Select a category
4. Expect: The category list should not move down