### PR TITLE
Category Selection: Add loading & no results states

### DIFF
--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -27,7 +27,6 @@ class ProductCategoryControl extends Component {
 	}
 
 	componentDidMount() {
-		this.setState( { loading: true } );
 		apiFetch( {
 			path: addQueryArgs( '/wc-pb/v3/products/categories', { per_page: -1 } ),
 		} )

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -21,19 +21,21 @@ class ProductCategoryControl extends Component {
 		super( ...arguments );
 		this.state = {
 			list: [],
+			loading: true,
 		};
 		this.renderItem = this.renderItem.bind( this );
 	}
 
 	componentDidMount() {
+		this.setState( { loading: true } );
 		apiFetch( {
 			path: addQueryArgs( '/wc-pb/v3/products/categories', { per_page: -1 } ),
 		} )
 			.then( ( list ) => {
-				this.setState( { list } );
+				this.setState( { list, loading: false } );
 			} )
 			.catch( () => {
-				this.setState( { list: [] } );
+				this.setState( { list: [], loading: false } );
 			} );
 	}
 
@@ -107,12 +109,13 @@ class ProductCategoryControl extends Component {
 	}
 
 	render() {
-		const { list } = this.state;
+		const { list, loading } = this.state;
 		const { selected, onChange } = this.props;
 
 		const messages = {
 			clear: __( 'Clear all product categories', 'woocommerce' ),
 			list: __( 'Product Categories', 'woocommerce' ),
+			noItems: __( 'Your store doesn\'t have any product categories.', 'woocommerce' ),
 			search: __( 'Search for product categories', 'woocommerce' ),
 			selected: ( n ) =>
 				sprintf(
@@ -131,6 +134,7 @@ class ProductCategoryControl extends Component {
 			<SearchListControl
 				className="woocommerce-product-categories"
 				list={ list }
+				isLoading={ loading }
 				selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
 				onChange={ onChange }
 				renderItem={ this.renderItem }

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -42,6 +42,36 @@
 	border-top: 1px solid $core-grey-light-500;
 	border-bottom: 1px solid $core-grey-light-500;
 
+	&.is-loading {
+		padding: $gap-small 0;
+		text-align: center;
+		border: none;
+	}
+
+	&.is-not-found {
+		padding: $gap-small 0;
+		text-align: center;
+		border: none;
+
+		.woocommerce-search-list__not-found-icon,
+		.woocommerce-search-list__not-found-text {
+			display: inline-block;
+		}
+
+		.woocommerce-search-list__not-found-icon {
+			margin-right: $gap;
+
+			.gridicon {
+				vertical-align: top;
+				margin-top: -1px;
+			}
+		}
+	}
+
+	.components-spinner {
+		float: none;
+	}
+
 	.components-menu-group__label {
 		@include visually-hidden;
 	}

--- a/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
+++ b/assets/js/components/search-list-control/test/__snapshots__/index.js.snap
@@ -1678,6 +1678,35 @@ exports[`SearchListControl should render a search box and no options 1`] = `
       </div>
     </div>
   </div>
+  <div
+    className="woocommerce-search-list__list is-not-found"
+  >
+    <span
+      className="woocommerce-search-list__not-found-icon"
+    >
+      <svg
+        aria-hidden="true"
+        className="gridicon gridicons-notice-outline"
+        focusable="false"
+        height={24}
+        role="img"
+        viewBox="0 0 24 24"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+          />
+        </g>
+      </svg>
+    </span>
+    <span
+      className="woocommerce-search-list__not-found-text"
+    >
+      No items found.
+    </span>
+  </div>
 </div>
 `;
 
@@ -1721,7 +1750,35 @@ exports[`SearchListControl should render a search box with a search term, and no
       </div>
     </div>
   </div>
-  No results for no matches
+  <div
+    className="woocommerce-search-list__list is-not-found"
+  >
+    <span
+      className="woocommerce-search-list__not-found-icon"
+    >
+      <svg
+        aria-hidden="true"
+        className="gridicon gridicons-notice-outline"
+        focusable="false"
+        height={24}
+        role="img"
+        viewBox="0 0 24 24"
+        width={24}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M12 4c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0-2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm1 13h-2v2h2v-2zm-2-2h2l.5-6h-3l.5 6z"
+          />
+        </g>
+      </svg>
+    </span>
+    <span
+      className="woocommerce-search-list__not-found-text"
+    >
+      No results for no matches
+    </span>
+  </div>
 </div>
 `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6305,14 +6305,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6327,20 +6325,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6457,8 +6452,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6470,7 +6464,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6485,7 +6478,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6493,14 +6485,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6519,7 +6509,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6600,8 +6589,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6613,7 +6601,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6735,7 +6722,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "npm": "6.4.1"
   },
   "dependencies": {
-    "@woocommerce/components": "1.2.0"
+    "@woocommerce/components": "1.2.0",
+    "gridicons": "^3.1.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
See #170 – this adds screens for transient states, like loading, no results, and no categories on the site.

### Screenshots

Loading from the server:

![loading-edit_mode](https://user-images.githubusercontent.com/541093/49404565-d38ac780-f71d-11e8-9450-0058d71af6ba.png)

![loading-sidebar](https://user-images.githubusercontent.com/541093/49404566-d38ac780-f71d-11e8-9576-837c42762c85.png)

If nothing is returned from the server, we assume the user has no product categories, and show this message:

![no-items](https://user-images.githubusercontent.com/541093/49404564-d38ac780-f71d-11e8-843e-272db0f69c9c.png)

If categories are returned, and the user searches for something that doesn't match, we show:

![no-results-edit_mode](https://user-images.githubusercontent.com/541093/49404563-d2f23100-f71d-11e8-9c0b-4f1cdbb35c88.png)

![no-results-sidebar](https://user-images.githubusercontent.com/541093/49404567-d38ac780-f71d-11e8-9a10-668446a84df0.png)

### How to test the changes in this Pull Request:

1. Add a Products by Category block
2. Expect: The loading spinner should show initially, then your categories will appear
3. Open the sidebar "Product Category" section
4. Expect: The loading spinner should show initially, then your categories will appear
5. Search in either location for something that won't match
6. Expect: You should see the "no results for [search]" message
7. Testing the empty response is harder, you can wipe all categories from your site, or just tweak line 34 in `assets/js/components/product-category-control/index.js` to be `list: [],` instead of `list,`
