### PR TITLE
Add `woocommerce` as a supported keyword for the block

### DIFF
--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -261,6 +261,7 @@ registerBlockType( 'woocommerce/product-category', {
 	title: __( 'Products by Category', 'woocommerce' ),
 	icon: 'category',
 	category: 'widgets',
+	keywords: [ 'woocommerce' ],
 	description: __(
 		'Display a grid of products from your selected categories.',
 		'woocommerce'


### PR DESCRIPTION
Fixes #195 – add `woocommerce` as keyword to improve discoverability. Now you can type any part of "Products by Category" or "woocommerce" (case insensitive) in either the block search box or as part of the `/` command.

### How to test the changes in this Pull Request:

1. Try inserting the block by clicking the `+` & searching for `woocommerce`, `products`, or `category`
2. Try inserting the block using the `/` command & searching for `woocommerce`, `products`, or `category` 
3. Expect: all of those should give you the Products by Category block.