### PR TITLE
Update textdomain to plugin slug

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,15 +1,24 @@
 {
-	"presets": [ "@wordpress/babel-preset-default" ],
+	"presets": ["@wordpress/babel-preset-default"],
 	"plugins": [
-		[ "@babel/transform-react-jsx", {
-			"pragma": "createElement"
-		} ],
+		[
+			"@babel/transform-react-jsx",
+			{
+				"pragma": "createElement"
+			}
+		],
 		[
 			"@wordpress/babel-plugin-import-jsx-pragma",
 			{
 				"scopeVariable": "createElement",
 				"source": "@wordpress/element",
 				"isDefault": false
+			}
+		],
+		[
+			"@wordpress/babel-plugin-makepot",
+			{
+				"output": "languages/woo-gutenberg-products-block.pot"
 			}
 		]
 	]

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ tests/cli/vendor
 
 # Built files
 /build/
+languages/woo-gutenberg-products-block.pot

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -78,7 +78,7 @@ class ProductCategoryControl extends Component {
 						'%s, has %d product',
 						'%s, has %d products',
 						item.count,
-						'woocommerce'
+						'woo-gutenberg-products-block'
 					),
 					accessibleName,
 					item.count
@@ -112,21 +112,21 @@ class ProductCategoryControl extends Component {
 		const { selected, onChange } = this.props;
 
 		const messages = {
-			clear: __( 'Clear all product categories', 'woocommerce' ),
-			list: __( 'Product Categories', 'woocommerce' ),
-			noItems: __( 'Your store doesn\'t have any product categories.', 'woocommerce' ),
-			search: __( 'Search for product categories', 'woocommerce' ),
+			clear: __( 'Clear all product categories', 'woo-gutenberg-products-block' ),
+			list: __( 'Product Categories', 'woo-gutenberg-products-block' ),
+			noItems: __( 'Your store doesn\'t have any product categories.', 'woo-gutenberg-products-block' ),
+			search: __( 'Search for product categories', 'woo-gutenberg-products-block' ),
 			selected: ( n ) =>
 				sprintf(
 					_n(
 						'%d category selected',
 						'%d categories selected',
 						n,
-						'woocommerce'
+						'woo-gutenberg-products-block'
 					),
 					n
 				),
-			updated: __( 'Category search results updated.', 'woocommerce' ),
+			updated: __( 'Category search results updated.', 'woo-gutenberg-products-block' ),
 		};
 
 		return (

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -27,7 +27,7 @@ const ProductPreview = ( { product } ) => {
 				dangerouslySetInnerHTML={ { __html: product.price_html } }
 			/>
 			<span className="wc-product-preview__add-to-cart">
-				{ __( 'Add to cart', 'woocommerce' ) }
+				{ __( 'Add to cart', 'woo-gutenberg-products-block' ) }
 			</span>
 		</div>
 	);

--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -25,14 +25,14 @@ import { buildTermsTree } from './hierarchy';
 import { CheckedIcon, UncheckedIcon } from './icons';
 
 const defaultMessages = {
-	clear: __( 'Clear all selected items', 'woocommerce' ),
-	list: __( 'Results', 'woocommerce' ),
-	noItems: __( 'No items found.', 'woocommerce' ),
-	noResults: __( 'No results for %s', 'woocommerce' ),
-	search: __( 'Search for items', 'woocommerce' ),
+	clear: __( 'Clear all selected items', 'woo-gutenberg-products-block' ),
+	list: __( 'Results', 'woo-gutenberg-products-block' ),
+	noItems: __( 'No items found.', 'woo-gutenberg-products-block' ),
+	noResults: __( 'No results for %s', 'woo-gutenberg-products-block' ),
+	search: __( 'Search for items', 'woo-gutenberg-products-block' ),
 	selected: ( n ) =>
-		sprintf( _n( '%d item selected', '%d items selected', n, 'woocommerce' ), n ),
-	updated: __( 'Search results updated.', 'woocommerce' ),
+		sprintf( _n( '%d item selected', '%d items selected', n, 'woo-gutenberg-products-block' ), n ),
+	updated: __( 'Search results updated.', 'woo-gutenberg-products-block' ),
 };
 
 /**
@@ -212,7 +212,7 @@ export class SearchListControl extends Component {
 								onClick={ this.onClear }
 								aria-label={ messages.clear }
 							>
-								{ __( 'Clear all', 'woocommerce' ) }
+								{ __( 'Clear all', 'woo-gutenberg-products-block' ) }
 							</Button>
 						) : null }
 					</div>

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -85,7 +85,7 @@ export default class ProductByCategoryBlock extends Component {
 
 		return (
 			<InspectorControls key="inspector">
-				<PanelBody title={ __( 'Product Category', 'woocommerce' ) } initialOpen={ false }>
+				<PanelBody title={ __( 'Product Category', 'woo-gutenberg-products-block' ) } initialOpen={ false }>
 					<ProductCategoryControl
 						selected={ attributes.categories }
 						onChange={ ( value = [] ) => {
@@ -94,53 +94,53 @@ export default class ProductByCategoryBlock extends Component {
 						} }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Layout', 'woocommerce' ) } initialOpen>
+				<PanelBody title={ __( 'Layout', 'woo-gutenberg-products-block' ) } initialOpen>
 					<RangeControl
-						label={ __( 'Columns', 'woocommerce' ) }
+						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
 						value={ columns }
 						onChange={ ( value ) => setAttributes( { columns: value } ) }
 						min={ wc_product_block_data.min_columns }
 						max={ wc_product_block_data.max_columns }
 					/>
 					<RangeControl
-						label={ __( 'Rows', 'woocommerce' ) }
+						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
 						value={ rows }
 						onChange={ ( value ) => setAttributes( { rows: value } ) }
 						min={ wc_product_block_data.min_rows }
 						max={ wc_product_block_data.max_rows }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Order By', 'woocommerce' ) } initialOpen={ false }>
+				<PanelBody title={ __( 'Order By', 'woo-gutenberg-products-block' ) } initialOpen={ false }>
 					<SelectControl
-						label={ __( 'Order products by', 'woocommerce' ) }
+						label={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
 						value={ orderby }
 						options={ [
 							{
-								label: __( 'Newness - newest first', 'woocommerce' ),
+								label: __( 'Newness - newest first', 'woo-gutenberg-products-block' ),
 								value: 'date',
 							},
 							{
-								label: __( 'Price - low to high', 'woocommerce' ),
+								label: __( 'Price - low to high', 'woo-gutenberg-products-block' ),
 								value: 'price_asc',
 							},
 							{
-								label: __( 'Price - high to low', 'woocommerce' ),
+								label: __( 'Price - high to low', 'woo-gutenberg-products-block' ),
 								value: 'price_desc',
 							},
 							{
-								label: __( 'Rating - highest first', 'woocommerce' ),
+								label: __( 'Rating - highest first', 'woo-gutenberg-products-block' ),
 								value: 'rating',
 							},
 							{
-								label: __( 'Sales - most first', 'woocommerce' ),
+								label: __( 'Sales - most first', 'woo-gutenberg-products-block' ),
 								value: 'popularity',
 							},
 							{
-								label: __( 'Title - alphabetical', 'woocommerce' ),
+								label: __( 'Title - alphabetical', 'woo-gutenberg-products-block' ),
 								value: 'title',
 							},
 							{
-								label: __( 'Menu Order', 'woocommerce' ),
+								label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
 								value: 'menu_order',
 							},
 						] }
@@ -155,18 +155,18 @@ export default class ProductByCategoryBlock extends Component {
 		const { attributes, debouncedSpeak, setAttributes } = this.props;
 		const onDone = () => {
 			setAttributes( { editMode: false } );
-			debouncedSpeak( __( 'Showing product block preview.', 'woocommerce' ) );
+			debouncedSpeak( __( 'Showing product block preview.', 'woo-gutenberg-products-block' ) );
 		};
 
 		return (
 			<Placeholder
 				icon="category"
-				label={ __( 'Products by Category', 'woocommerce' ) }
+				label={ __( 'Products by Category', 'woo-gutenberg-products-block' ) }
 				className="wc-block-products-category"
 			>
 				{ __(
 					'Display a grid of products from your selected categories',
-					'woocommerce'
+					'woo-gutenberg-products-block'
 				) }
 				<div className="wc-block-products-category__selection">
 					<ProductCategoryControl
@@ -180,7 +180,7 @@ export default class ProductByCategoryBlock extends Component {
 						isDefault
 						onClick={ onDone }
 					>
-						{ __( 'Done', 'woocommerce' ) }
+						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>
 			</Placeholder>
@@ -223,12 +223,12 @@ export default class ProductByCategoryBlock extends Component {
 						) : (
 							<Placeholder
 								icon="category"
-								label={ __( 'Products by Category', 'woocommerce' ) }
+								label={ __( 'Products by Category', 'woo-gutenberg-products-block' ) }
 							>
 								{ ! loaded ? (
 									<Spinner />
 								) : (
-									__( 'No products in this category.', 'woocommerce' )
+									__( 'No products in this category.', 'woo-gutenberg-products-block' )
 								) }
 							</Placeholder>
 						) }
@@ -258,13 +258,13 @@ const WrappedProductByCategoryBlock = withSpokenMessages( ProductByCategoryBlock
  * Register and run the "Products by Category" block.
  */
 registerBlockType( 'woocommerce/product-category', {
-	title: __( 'Products by Category', 'woocommerce' ),
+	title: __( 'Products by Category', 'woo-gutenberg-products-block' ),
 	icon: 'category',
 	category: 'widgets',
-	keywords: [ 'woocommerce' ],
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
 		'Display a grid of products from your selected categories.',
-		'woocommerce'
+		'woo-gutenberg-products-block'
 	),
 	attributes: {
 		...sharedAttributes,

--- a/languages/woo-gutenberg-products-block.php
+++ b/languages/woo-gutenberg-products-block.php
@@ -1,0 +1,232 @@
+<?php
+/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
+$generated_i18n_strings = array(
+	// Reference: assets/js/components/product-category-control/index.js:114
+	__( 'Clear all product categories', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/product-category-control/index.js:115
+	__( 'Product Categories', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/product-category-control/index.js:116
+	__( 'Search for product categories', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/product-category-control/index.js:119
+	_n_noop( '%d category selected', '%d categories selected', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/product-category-control/index.js:127
+	__( 'Category search results updated.', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/product-category-control/index.js:76
+	_n_noop( '%s, has %d product', '%s, has %d products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/product-preview/index.js:30
+	// Reference: assets/js/legacy/products-block.jsx:365
+	__( 'Add to cart', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:173
+	__( 'Clear all', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:26
+	__( 'Clear all selected items', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:27
+	__( 'Results', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:28
+	__( 'No results for %s', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:29
+	__( 'Search for items', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:31
+	_n_noop( '%d item selected', '%d items selected', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:32
+	__( 'Search results updated.', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:194
+	__( 'Choose which products you\'d like to display:', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:24
+	__( 'Individual products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:25
+	__( 'Hand-pick which products to display', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:29
+	__( 'Product category', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:297
+	__( 'Display different products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:30
+	__( 'Display products from a specific category or multiple categories', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:304
+	__( 'Displaying ', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:317
+	__( 'Please select which products you\'d like to display', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:318
+	__( 'Please search for and select products to display', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:319
+	__( 'Please select at least one category to display', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:320
+	__( 'Please select an attribute', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:325
+	// Reference: assets/js/product-category-block.js:183
+	__( 'Done', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:34
+	__( 'Filter products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:35
+	__( 'E.g. featured products, or products with a specific attribute like size or color', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:40
+	__( 'Featured products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:45
+	__( 'On sale', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:485
+	// Reference: assets/js/legacy/views/attribute-select.jsx:420
+	// Reference: assets/js/legacy/views/category-select.jsx:199
+	__( 'Loading', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:489
+	// Reference: assets/js/legacy/views/specific-select.jsx:261
+	__( 'No products found', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:50
+	__( 'Best sellers', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:56
+	__( 'Top rated', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:62
+	__( 'Attribute', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:637
+	__( 'Product categories: ', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:651
+	__( 'Attribute: ', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:655
+	__( 'Terms: ', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:67
+	__( 'All products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:68
+	__( 'Display all products ordered chronologically, alphabetically, by price, by rating or by sales', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:703
+	// Reference: assets/js/product-category-block.js:99
+	__( 'Columns', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:716
+	__( 'Order Products By', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:720
+	// Reference: assets/js/product-category-block.js:119
+	__( 'Newness - newest first', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:724
+	// Reference: assets/js/product-category-block.js:123
+	__( 'Price - low to high', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:728
+	// Reference: assets/js/product-category-block.js:127
+	__( 'Price - high to low', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:732
+	// Reference: assets/js/product-category-block.js:131
+	__( 'Rating - highest first', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:736
+	// Reference: assets/js/product-category-block.js:135
+	__( 'Sales - most first', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:740
+	// Reference: assets/js/product-category-block.js:139
+	__( 'Title - alphabetical', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:754
+	// Reference: assets/js/product-category-block.js:106
+	__( 'Rows', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:766
+	// Reference: assets/js/product-category-block.js:97
+	__( 'Layout', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:828
+	// Reference: assets/js/product-category-block.js:207
+	__( 'Edit', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:836
+	__( 'Current Source', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:904
+	__( 'Products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/products-block.jsx:907
+	__( 'Display a grid of products from a variety of sources.', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/attribute-select.jsx:154
+	__( 'Search for attributes', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/attribute-select.jsx:237
+	__( 'No attributes found', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/attribute-select.jsx:424
+	__( 'No terms found', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/category-select.jsx:120
+	__( 'Search for categories', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/category-select.jsx:203
+	__( 'No categories found', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/specific-select.jsx:159
+	__( 'Search for products to display', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/specific-select.jsx:315
+	__( 'Products list', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/legacy/views/specific-select.jsx:483
+	__( 'Selected products', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:113
+	__( 'Order By', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:115
+	__( 'Order products by', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:143
+	__( 'Menu Order', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:158
+	__( 'Showing product block preview.', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:167
+	__( 'Display a grid of products from your selected categories', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:231
+	__( 'No products in this category.', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:261
+	__( 'Products by Category', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:264
+	__( 'Display a grid of products from your selected categories.', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:88
+	__( 'Product Category', 'woo-gutenberg-products-block' )
+);
+/* THIS IS THE END OF THE GENERATED FILE */

--- a/languages/woo-gutenberg-products-block.php
+++ b/languages/woo-gutenberg-products-block.php
@@ -1,47 +1,53 @@
 <?php
 /* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
 $generated_i18n_strings = array(
-	// Reference: assets/js/components/product-category-control/index.js:114
+	// Reference: assets/js/components/product-category-control/index.js:115
 	__( 'Clear all product categories', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/product-category-control/index.js:115
+	// Reference: assets/js/components/product-category-control/index.js:116
 	__( 'Product Categories', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/product-category-control/index.js:116
+	// Reference: assets/js/components/product-category-control/index.js:117
+	__( 'Your store doesn\'t have any product categories.', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/product-category-control/index.js:118
 	__( 'Search for product categories', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/product-category-control/index.js:119
+	// Reference: assets/js/components/product-category-control/index.js:121
 	_n_noop( '%d category selected', '%d categories selected', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/product-category-control/index.js:127
+	// Reference: assets/js/components/product-category-control/index.js:129
 	__( 'Category search results updated.', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/product-category-control/index.js:76
+	// Reference: assets/js/components/product-category-control/index.js:77
 	_n_noop( '%s, has %d product', '%s, has %d products', 'woo-gutenberg-products-block' ),
 
 	// Reference: assets/js/components/product-preview/index.js:30
 	// Reference: assets/js/legacy/products-block.jsx:365
 	__( 'Add to cart', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/search-list-control/index.js:173
+	// Reference: assets/js/components/search-list-control/index.js:215
 	__( 'Clear all', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/search-list-control/index.js:26
+	// Reference: assets/js/components/search-list-control/index.js:28
 	__( 'Clear all selected items', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/search-list-control/index.js:27
+	// Reference: assets/js/components/search-list-control/index.js:29
 	__( 'Results', 'woo-gutenberg-products-block' ),
 
-	// Reference: assets/js/components/search-list-control/index.js:28
-	__( 'No results for %s', 'woo-gutenberg-products-block' ),
-
-	// Reference: assets/js/components/search-list-control/index.js:29
-	__( 'Search for items', 'woo-gutenberg-products-block' ),
+	// Reference: assets/js/components/search-list-control/index.js:30
+	__( 'No items found.', 'woo-gutenberg-products-block' ),
 
 	// Reference: assets/js/components/search-list-control/index.js:31
-	_n_noop( '%d item selected', '%d items selected', 'woo-gutenberg-products-block' ),
+	__( 'No results for %s', 'woo-gutenberg-products-block' ),
 
 	// Reference: assets/js/components/search-list-control/index.js:32
+	__( 'Search for items', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:34
+	_n_noop( '%d item selected', '%d items selected', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/components/search-list-control/index.js:35
 	__( 'Search results updated.', 'woo-gutenberg-products-block' ),
 
 	// Reference: assets/js/legacy/products-block.jsx:194
@@ -224,6 +230,9 @@ $generated_i18n_strings = array(
 	__( 'Products by Category', 'woo-gutenberg-products-block' ),
 
 	// Reference: assets/js/product-category-block.js:264
+	__( 'WooCommerce', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/product-category-block.js:265
 	__( 'Display a grid of products from your selected categories.', 'woo-gutenberg-products-block' ),
 
 	// Reference: assets/js/product-category-block.js:88

--- a/package-lock.json
+++ b/package-lock.json
@@ -1697,6 +1697,17 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "@wordpress/babel-plugin-makepot": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-2.1.2.tgz",
+      "integrity": "sha512-YpQKaiqyvBrRuIBo9oAIESTxRSLDmL0q4ls7s4kUmqGEVifGUkgePF3yze3rmUVRTLP/Y4UoRSPqu1edLT3+Yg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "gettext-parser": "^1.3.1",
+        "lodash": "^4.17.10"
+      }
+    },
     "@wordpress/babel-preset-default": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-3.0.1.tgz",
@@ -6303,8 +6314,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6706,8 +6716,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6762,7 +6771,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6806,14 +6814,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
     "start": "cross-env BABEL_ENV=default webpack --watch",
+    "i18n:php": "pot-to-php ./languages/woo-gutenberg-products-block.pot ./languages/woo-gutenberg-products-block.php woo-gutenberg-products-block",
     "lint": "npm run lint:css && npm run lint:js",
     "lint:css": "stylelint assets/css",
     "lint:js": "eslint assets/js --ext=js,jsx",
@@ -23,6 +24,7 @@
   "devDependencies": {
     "@babel/core": "7.2.0",
     "@wordpress/babel-plugin-import-jsx-pragma": "1.1.2",
+    "@wordpress/babel-plugin-makepot": "2.1.2",
     "@wordpress/babel-preset-default": "3.0.1",
     "@wordpress/blocks": "5.3.1",
     "@wordpress/components": "6.0.2",

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -42,7 +42,7 @@ add_action( 'woocommerce_loaded', 'wgpb_initialize' );
  */
 function wgpb_plugins_notice() {
 	echo '<div class="error"><p>';
-	echo __( 'WooCommerce Product Blocks development mode requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm start</code> to build the files and watch for changes.', 'woocommerce' );
+	echo __( 'WooCommerce Product Blocks development mode requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm start</code> to build the files and watch for changes.', 'woo-gutenberg-products-block' );
 	echo '</p></div>';
 }
 
@@ -111,7 +111,7 @@ function wgpb_extra_gutenberg_scripts() {
 	wp_localize_script( 'woocommerce-products-block-editor', 'wc_product_block_data', $product_block_data );
 
 	if ( function_exists( 'wp_set_script_translations' ) ) {
-		wp_set_script_translations( 'woocommerce-products-category-block', 'woocommerce' );
+		wp_set_script_translations( 'woocommerce-products-category-block', 'woo-gutenberg-products-block' );
 	}
 
 	wp_enqueue_script( 'woocommerce-products-block-editor' );

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -6,8 +6,7 @@
  * Version: 1.1.2
  * Author: Automattic
  * Author URI: https://woocommerce.com
- * Text Domain:  woocommerce
- * Domain Path:  /languages
+ * Text Domain:  woo-gutenberg-products-block
  * WC requires at least: 3.3
  * WC tested up to: 3.5
  */


### PR DESCRIPTION
Currently all the i18n functions are using `woocommerce` as the textdomain. If we want this to be translated before merging into WC core, we should use `woo-gutenberg-products-block` to enable wp.org translations. There are already [some translations available on the legacy block,](https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block) though the legacy block is not calling the i18n functions correctly so they won't load.

This PR also introduces the babel makepot plugin, which along with the i18n `pot-to-php` generate a PHP file of the strings used in JS. This is used by the translation engine of wordpress.org to create [the translations page,](https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block) where community members can contribute back by translating our plugin. But wp.org only supports PHP files, hence the need for this generated `languages/woo-gutenberg-products-block.php` file.

### How to test the changes in this Pull Request:

1. Make sure all content shows up as expected, there are no visual changes in any text
