### PR TITLE
Release 1.2.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== WooCommerce Product Blocks ===
+=== WooCommerce Blocks ===
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia
 Tags: gutenberg, woocommerce, woo commerce, products
 Requires at least: 4.9
@@ -10,7 +10,7 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 == Description ==
 
-WooCommerce Product Blocks are the easiest, most flexible way to display your products on posts and pages! Using the original "Products Block", your displayed products can be filtered by category, sale status, or a variety of other fields. You can even make a custom list of hand-picked products to display.
+WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages! Using the original "Products Block", your displayed products can be filtered by category, sale status, or a variety of other fields. You can even make a custom list of hand-picked products to display.
 
 New for 1.2.0: We've added a stand-alone Product Category block to simplify the experience and improve the category search and selection UI. Be on the lookout for additional stand-alone blocks in future releases. 
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Product Blocks ===
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia
 Tags: gutenberg, woocommerce, woo commerce, products
-Requires at least: 4.7
+Requires at least: 4.9
 Tested up to: 5.0
 Requires PHP: 5.2
 Stable tag: 1.2.0

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Plugin Name: WooCommerce Gutenberg Product Blocks
+ * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
- * Description: WooCommerce Products block for the Gutenberg editor.
+ * Description: WooCommerce blocks for the Gutenberg editor.
  * Version: 1.2.0
  * Author: Automattic
  * Author URI: https://woocommerce.com

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || die();
 
 define( 'WGPB_VERSION', '1.2.0' );
 
-define( 'WGPB_DEVELOPMENT_MODE', false );
+define( 'WGPB_DEVELOPMENT_MODE', true );
 
 /**
  * Load up the assets if Gutenberg is active.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: WooCommerce Gutenberg Products Block
+ * Plugin Name: WooCommerce Gutenberg Product Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce Products block for the Gutenberg editor.
  * Version: 1.1.2

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -13,7 +13,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '1.1.2' );
+define( 'WGPB_VERSION', '1.2.0' );
 
 define( 'WGPB_DEVELOPMENT_MODE', false );
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Gutenberg Product Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce Products block for the Gutenberg editor.
- * Version: 1.1.2
+ * Version: 1.2.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || die();
 
 define( 'WGPB_VERSION', '1.1.2' );
 
-define( 'WGPB_DEVELOPMENT_MODE', true );
+define( 'WGPB_DEVELOPMENT_MODE', false );
 
 /**
  * Load up the assets if Gutenberg is active.


### PR DESCRIPTION
Prepare for releasing 1.2.0.

- Version bump in the plugin header
- Update the plugin's display name
- ~Disable "dev mode"~ doing this locally, so this repo never gets stuck in a non-dev-mode state

In the future we can [automate this](https://github.com/woocommerce/woocommerce-core-to-wordpress-org), including bumping versions & disabling `WGPB_DEVELOPMENT_MODE` for release to wp.org.

