### PR TITLE
Add styles for better reusable block preview

### DIFF
--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -3,7 +3,9 @@
 @import "../../node_modules/@woocommerce/components/build-style/style.css";
 
 // Hack to hide preview overflow.
-.editor-block-preview__content { overflow: hidden }
+.editor-block-preview__content {
+	overflow: hidden;
+}
 
 .wc-block-products-category {
 	overflow: hidden;
@@ -21,14 +23,26 @@
 			font-size: 0.6em;
 		}
 
-		&.cols-2 { min-width: 2 * 5em; }
-		&.cols-3 { min-width: 3 * 5em; }
-		&.cols-4 { min-width: 4 * 5em; }
-		&.cols-5 { min-width: 5 * 5em; }
-		&.cols-6 { min-width: 6 * 5em; }
+		&.cols-2 {
+			min-width: 2 * 5em;
+		}
+		&.cols-3 {
+			min-width: 3 * 5em;
+		}
+		&.cols-4 {
+			min-width: 4 * 5em;
+		}
+		&.cols-5 {
+			min-width: 5 * 5em;
+		}
+		&.cols-6 {
+			min-width: 6 * 5em;
+		}
 
 		&.is-loading,
-		&.is-not-found { min-width: auto; }
+		&.is-not-found {
+			min-width: auto;
+		}
 	}
 }
 

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -2,11 +2,33 @@
 // @todo Move this to a separate file so we can build a cacheable single stylesheet for all blocks.
 @import "../../node_modules/@woocommerce/components/build-style/style.css";
 
+// Hack to hide preview overflow.
+.editor-block-preview__content { overflow: hidden }
+
 .wc-block-products-category {
 	overflow: hidden;
 
 	&.components-placeholder {
 		padding: 2em 1em;
+	}
+
+	.editor-block-preview & {
+		min-width: 5em;
+
+		.wc-product-preview__title,
+		.wc-product-preview__price,
+		.wc-product-preview__add-to-cart {
+			font-size: 0.6em;
+		}
+
+		&.cols-2 { min-width: 2 * 5em; }
+		&.cols-3 { min-width: 3 * 5em; }
+		&.cols-4 { min-width: 4 * 5em; }
+		&.cols-5 { min-width: 5 * 5em; }
+		&.cols-6 { min-width: 6 * 5em; }
+
+		&.is-loading,
+		&.is-not-found { min-width: auto; }
 	}
 }
 

--- a/assets/css/products-block.scss
+++ b/assets/css/products-block.scss
@@ -107,9 +107,9 @@ $color__alt-background: #fdfdfd;
 	.editor-block-preview & {
 		min-width: 5em;
 
-		.wc-product-preview__title,
-		.wc-product-preview__price,
-		.wc-product-preview__add-to-cart {
+		.product-title,
+		.product-price,
+		.product-add-to-cart {
 			font-size: 0.6em !important;
 		}
 

--- a/assets/css/products-block.scss
+++ b/assets/css/products-block.scss
@@ -103,6 +103,22 @@ $color__alt-background: #fdfdfd;
 		margin-top: 0.5em;
 		margin-bottom: 1em;
 	}
+
+	.editor-block-preview & {
+		min-width: 5em;
+
+		.wc-product-preview__title,
+		.wc-product-preview__price,
+		.wc-product-preview__add-to-cart {
+			font-size: 0.6em !important;
+		}
+
+		&.cols-2 { min-width: 2 * 5em; }
+		&.cols-3 { min-width: 3 * 5em; }
+		&.cols-4 { min-width: 4 * 5em; }
+		&.cols-5 { min-width: 5 * 5em; }
+		&.cols-6 { min-width: 6 * 5em; }
+	}
 }
 
 /**

--- a/assets/css/products-block.scss
+++ b/assets/css/products-block.scss
@@ -31,7 +31,7 @@ $color__alt-background: #fdfdfd;
 			margin-right: 0;
 		}
 
-		&:nth-of-type(2n+1) {
+		&:nth-of-type(2n + 1) {
 			clear: both;
 		}
 	}
@@ -43,7 +43,7 @@ $color__alt-background: #fdfdfd;
 			margin-right: 0;
 		}
 
-		&:nth-of-type(3n+1) {
+		&:nth-of-type(3n + 1) {
 			clear: both;
 		}
 	}
@@ -55,7 +55,7 @@ $color__alt-background: #fdfdfd;
 			margin-right: 0;
 		}
 
-		&:nth-of-type(4n+1) {
+		&:nth-of-type(4n + 1) {
 			clear: both;
 		}
 	}
@@ -67,7 +67,7 @@ $color__alt-background: #fdfdfd;
 			margin-right: 0;
 		}
 
-		&:nth-of-type(5n+1) {
+		&:nth-of-type(5n + 1) {
 			clear: both;
 		}
 
@@ -83,7 +83,7 @@ $color__alt-background: #fdfdfd;
 			margin-right: 0;
 		}
 
-		&:nth-of-type(6n+1) {
+		&:nth-of-type(6n + 1) {
 			clear: both;
 		}
 
@@ -113,11 +113,21 @@ $color__alt-background: #fdfdfd;
 			font-size: 0.6em !important;
 		}
 
-		&.cols-2 { min-width: 2 * 5em; }
-		&.cols-3 { min-width: 3 * 5em; }
-		&.cols-4 { min-width: 4 * 5em; }
-		&.cols-5 { min-width: 5 * 5em; }
-		&.cols-6 { min-width: 6 * 5em; }
+		&.cols-2 {
+			min-width: 2 * 5em;
+		}
+		&.cols-3 {
+			min-width: 3 * 5em;
+		}
+		&.cols-4 {
+			min-width: 4 * 5em;
+		}
+		&.cols-5 {
+			min-width: 5 * 5em;
+		}
+		&.cols-6 {
+			min-width: 6 * 5em;
+		}
 	}
 }
 

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -218,7 +218,7 @@ export default class ProductByCategoryBlock extends Component {
 		if ( columns ) {
 			classes.push( `cols-${ columns }` );
 		}
-		if ( ! products.length ) {
+		if ( products && ! products.length ) {
 			if ( ! loaded ) {
 				classes.push( 'is-loading' );
 			} else {

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -85,7 +85,10 @@ export default class ProductByCategoryBlock extends Component {
 
 		return (
 			<InspectorControls key="inspector">
-				<PanelBody title={ __( 'Product Category', 'woo-gutenberg-products-block' ) } initialOpen={ false }>
+				<PanelBody
+					title={ __( 'Product Category', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
 					<ProductCategoryControl
 						selected={ attributes.categories }
 						onChange={ ( value = [] ) => {
@@ -94,7 +97,10 @@ export default class ProductByCategoryBlock extends Component {
 						} }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Layout', 'woo-gutenberg-products-block' ) } initialOpen>
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
 					<RangeControl
 						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
 						value={ columns }
@@ -110,25 +116,40 @@ export default class ProductByCategoryBlock extends Component {
 						max={ wc_product_block_data.max_rows }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Order By', 'woo-gutenberg-products-block' ) } initialOpen={ false }>
+				<PanelBody
+					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
 					<SelectControl
 						label={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
 						value={ orderby }
 						options={ [
 							{
-								label: __( 'Newness - newest first', 'woo-gutenberg-products-block' ),
+								label: __(
+									'Newness - newest first',
+									'woo-gutenberg-products-block'
+								),
 								value: 'date',
 							},
 							{
-								label: __( 'Price - low to high', 'woo-gutenberg-products-block' ),
+								label: __(
+									'Price - low to high',
+									'woo-gutenberg-products-block'
+								),
 								value: 'price_asc',
 							},
 							{
-								label: __( 'Price - high to low', 'woo-gutenberg-products-block' ),
+								label: __(
+									'Price - high to low',
+									'woo-gutenberg-products-block'
+								),
 								value: 'price_desc',
 							},
 							{
-								label: __( 'Rating - highest first', 'woo-gutenberg-products-block' ),
+								label: __(
+									'Rating - highest first',
+									'woo-gutenberg-products-block'
+								),
 								value: 'rating',
 							},
 							{
@@ -136,7 +157,10 @@ export default class ProductByCategoryBlock extends Component {
 								value: 'popularity',
 							},
 							{
-								label: __( 'Title - alphabetical', 'woo-gutenberg-products-block' ),
+								label: __(
+									'Title - alphabetical',
+									'woo-gutenberg-products-block'
+								),
 								value: 'title',
 							},
 							{
@@ -155,7 +179,9 @@ export default class ProductByCategoryBlock extends Component {
 		const { attributes, debouncedSpeak, setAttributes } = this.props;
 		const onDone = () => {
 			setAttributes( { editMode: false } );
-			debouncedSpeak( __( 'Showing product block preview.', 'woo-gutenberg-products-block' ) );
+			debouncedSpeak(
+				__( 'Showing product block preview.', 'woo-gutenberg-products-block' )
+			);
 		};
 
 		return (
@@ -176,10 +202,7 @@ export default class ProductByCategoryBlock extends Component {
 							setAttributes( { categories: ids } );
 						} }
 					/>
-					<Button
-						isDefault
-						onClick={ onDone }
-					>
+					<Button isDefault onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>
@@ -191,6 +214,17 @@ export default class ProductByCategoryBlock extends Component {
 		const { setAttributes } = this.props;
 		const { columns, align, editMode } = this.props.attributes;
 		const { loaded, products } = this.state;
+		const classes = [ 'wc-block-products-category' ];
+		if ( columns ) {
+			classes.push( `cols-${ columns }` );
+		}
+		if ( ! products.length ) {
+			if ( ! loaded ) {
+				classes.push( 'is-loading' );
+			} else {
+				classes.push( 'is-not-found' );
+			}
+		}
 
 		return (
 			<Fragment>
@@ -215,7 +249,7 @@ export default class ProductByCategoryBlock extends Component {
 				{ editMode ? (
 					this.renderEditMode()
 				) : (
-					<div className={ `wc-block-products-category cols-${ columns }` }>
+					<div className={ classes.join( ' ' ) }>
 						{ products.length ? (
 							products.map( ( product ) => (
 								<ProductPreview product={ product } key={ product.id } />
@@ -223,12 +257,18 @@ export default class ProductByCategoryBlock extends Component {
 						) : (
 							<Placeholder
 								icon="category"
-								label={ __( 'Products by Category', 'woo-gutenberg-products-block' ) }
+								label={ __(
+									'Products by Category',
+									'woo-gutenberg-products-block'
+								) }
 							>
 								{ ! loaded ? (
 									<Spinner />
 								) : (
-									__( 'No products in this category.', 'woo-gutenberg-products-block' )
+									__(
+										'No products in this category.',
+										'woo-gutenberg-products-block'
+									)
 								) }
 							</Placeholder>
 						) }
@@ -252,7 +292,9 @@ ProductByCategoryBlock.propTypes = {
 	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-const WrappedProductByCategoryBlock = withSpokenMessages( ProductByCategoryBlock );
+const WrappedProductByCategoryBlock = withSpokenMessages(
+	ProductByCategoryBlock
+);
 
 /**
  * Register and run the "Products by Category" block.
@@ -301,6 +343,10 @@ registerBlockType( 'woocommerce/product-category', {
 		const {
 			align,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
-		return <RawHTML className={ align ? `align${ align }` : '' }>{ getShortcode( props ) }</RawHTML>;
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props ) }
+			</RawHTML>
+		);
 	},
 } );


### PR DESCRIPTION
Shrinks font size and adds a min-width, so the items are not all squeezed into the small viewport.

![screen shot 2018-12-04 at 1 17 35 pm](https://user-images.githubusercontent.com/541093/49464191-3a64bb00-f7c8-11e8-816f-527e792ffd49.png)
![screen shot 2018-12-04 at 1 17 54 pm](https://user-images.githubusercontent.com/541093/49464192-3a64bb00-f7c8-11e8-8019-b788d6893048.png)

**To test**

- Create a reusable block
- Preview it in the block inserter, either by searching for the name or looking in the "Reusable blocks" section