### PR TITLE
Bump version to 1.3.0-dev

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 1.2.0
+ * Version: 1.3.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
Quick update to bump our dev plugin's version to 1.3.0-dev (mostly prevent accidentally updating the git checkout plugin), now that 1.2.0 is released. We can fork off the [1.2.0 tag](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/1.2.0) if we need to do a point release.

<img width="624" alt="screen shot 2018-12-04 at 4 11 17 pm" src="https://user-images.githubusercontent.com/541093/49473158-4314bb80-f7df-11e8-95d1-98324b3f2ec9.png">

### How to test the changes in this Pull Request:

1. View the plugin in your list of plugins
2. Expect: This should say `Version 1.3.0-dev`