### PR TITLE
Layout: Remove “center” alignment option

### DIFF
--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -33,8 +33,8 @@ import ProductCategoryControl from './components/product-category-control';
 import ProductPreview from './components/product-preview';
 import sharedAttributes from './utils/shared-attributes';
 
-// Only enable center, wide, and full alignments
-const validAlignments = [ 'center', 'wide', 'full' ];
+// Only enable wide and full alignments
+const validAlignments = [ 'wide', 'full' ];
 
 /**
  * Component to handle edit mode of "Products by Category".


### PR DESCRIPTION
Fixes #208 – Since we don't do anything for the "center" alignment option, we should remove it. This means we now only show "align wide" and "align full" in the toolbar layout settings.

<img width="216" alt="screen shot 2018-12-05 at 11 03 09 am" src="https://user-images.githubusercontent.com/541093/49526222-6130f900-f87d-11e8-9628-e3ec81c4f00d.png">

If the theme does not specifically support the wide/full settings, we don't show any layout options:

<img width="153" alt="screen shot 2018-12-05 at 11 01 06 am" src="https://user-images.githubusercontent.com/541093/49526223-6130f900-f87d-11e8-8afc-aa179a39fc93.png">

### How to test the changes in this Pull Request:

1. Use a theme that supports wide/full, like Twenty Nineteen
2. Add the Products by Category block
3. Expect: The toolbar should have both wide & full, but no "center" alignment
4. Switch to another theme without wide/full support, like Twenty Seventeen
5. View the products block again
6. Expect: The toolbar should not have any layout options