### PR TITLE
Build: Compile all blocks into one file

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { RawHTML } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import '../css/product-category-block.scss';
+import getShortcode from './utils/get-shortcode';
+import ProductByCategoryBlock from './product-category-block.js';
+import sharedAttributes from './utils/shared-attributes';
+
+const validAlignments = [ 'wide', 'full' ];
+
+/**
+ * Register and run the "Products by Category" block.
+ */
+registerBlockType( 'woocommerce/product-category', {
+	title: __( 'Products by Category', 'woo-gutenberg-products-block' ),
+	icon: 'category',
+	category: 'widgets',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a grid of products from your selected categories.',
+		'woo-gutenberg-products-block'
+	),
+	attributes: {
+		...sharedAttributes,
+		editMode: {
+			type: 'boolean',
+			default: true,
+		},
+		categories: {
+			type: 'array',
+			default: [],
+		},
+	},
+
+	getEditWrapperProps( attributes ) {
+		const { align } = attributes;
+		if ( -1 !== validAlignments.indexOf( align ) ) {
+			return { 'data-align': align };
+		}
+	},
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <ProductByCategoryBlock { ...props } />;
+	},
+
+	/**
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
+	 */
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props ) }
+			</RawHTML>
+		);
+	},
+} );

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import {
 	BlockAlignmentToolbar,
 	BlockControls,
@@ -21,25 +21,18 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import PropTypes from 'prop-types';
-import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import '../css/product-category-block.scss';
 import getQuery from './utils/get-query';
-import getShortcode from './utils/get-shortcode';
 import ProductCategoryControl from './components/product-category-control';
 import ProductPreview from './components/product-preview';
-import sharedAttributes from './utils/shared-attributes';
-
-// Only enable wide and full alignments
-const validAlignments = [ 'wide', 'full' ];
 
 /**
  * Component to handle edit mode of "Products by Category".
  */
-export default class ProductByCategoryBlock extends Component {
+class ProductByCategoryBlock extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
@@ -230,7 +223,7 @@ export default class ProductByCategoryBlock extends Component {
 			<Fragment>
 				<BlockControls>
 					<BlockAlignmentToolbar
-						controls={ validAlignments }
+						controls={ [ 'wide', 'full' ] }
 						value={ align }
 						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
 					/>
@@ -292,61 +285,6 @@ ProductByCategoryBlock.propTypes = {
 	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-const WrappedProductByCategoryBlock = withSpokenMessages(
+export default withSpokenMessages(
 	ProductByCategoryBlock
 );
-
-/**
- * Register and run the "Products by Category" block.
- */
-registerBlockType( 'woocommerce/product-category', {
-	title: __( 'Products by Category', 'woo-gutenberg-products-block' ),
-	icon: 'category',
-	category: 'widgets',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
-	description: __(
-		'Display a grid of products from your selected categories.',
-		'woo-gutenberg-products-block'
-	),
-	attributes: {
-		...sharedAttributes,
-		editMode: {
-			type: 'boolean',
-			default: true,
-		},
-		categories: {
-			type: 'array',
-			default: [],
-		},
-	},
-
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( -1 !== validAlignments.indexOf( align ) ) {
-			return { 'data-align': align };
-		}
-	},
-
-	/**
-	 * Renders and manages the block.
-	 */
-	edit( props ) {
-		return <WrappedProductByCategoryBlock { ...props } />;
-	},
-
-	/**
-	 * Save the block content in the post content. Block content is saved as a products shortcode.
-	 *
-	 * @return string
-	 */
-	save( props ) {
-		const {
-			align,
-		} = props.attributes; /* eslint-disable-line react/prop-types */
-		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
-				{ getShortcode( props ) }
-			</RawHTML>
-		);
-	},
-} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const GutenbergBlocksConfig = {
 		// Legacy block
 		'products-block': './assets/js/legacy/products-block.jsx',
 		// New blocks
-		'product-category-block': './assets/js/product-category-block.js',
+		blocks: './assets/js/index.js',
 	},
 	output: {
 		path: path.resolve( __dirname, './build/' ),

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -51,13 +51,8 @@ function wgpb_plugins_notice() {
  * Register the Products block and its scripts.
  */
 function wgpb_register_products_block() {
-	register_block_type(
-		'woocommerce/products',
-		array(
-			'editor_script' => 'woocommerce-products-block-editor',
-			'editor_style'  => 'woocommerce-products-block-editor',
-		)
-	);
+	register_block_type( 'woocommerce/products' );
+	register_block_type( 'woocommerce/product-category' );
 }
 
 /**

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -78,8 +78,8 @@ function wgpb_extra_gutenberg_scripts() {
 	);
 
 	wp_register_script(
-		'woocommerce-products-category-block',
-		plugins_url( 'build/product-category-block.js', __FILE__ ),
+		'woocommerce-blocks',
+		plugins_url( 'build/blocks.js', __FILE__ ),
 		array(
 			'wp-api-fetch',
 			'wp-blocks',
@@ -92,7 +92,7 @@ function wgpb_extra_gutenberg_scripts() {
 			'wp-url',
 			'lodash',
 		),
-		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/product-category-block.js' ) : WGPB_VERSION,
+		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/blocks.js' ) : WGPB_VERSION,
 		true
 	);
 
@@ -115,11 +115,11 @@ function wgpb_extra_gutenberg_scripts() {
 	wp_localize_script( 'woocommerce-products-block-editor', 'wc_product_block_data', $product_block_data );
 
 	if ( function_exists( 'wp_set_script_translations' ) ) {
-		wp_set_script_translations( 'woocommerce-products-category-block', 'woo-gutenberg-products-block' );
+		wp_set_script_translations( 'woocommerce-blocks', 'woo-gutenberg-products-block' );
 	}
 
 	wp_enqueue_script( 'woocommerce-products-block-editor' );
-	wp_enqueue_script( 'woocommerce-products-category-block' );
+	wp_enqueue_script( 'woocommerce-blocks' );
 
 	wp_enqueue_style(
 		'woocommerce-products-block-editor',
@@ -129,10 +129,10 @@ function wgpb_extra_gutenberg_scripts() {
 	);
 
 	wp_enqueue_style(
-		'woocommerce-products-category-block',
-		plugins_url( 'build/product-category-block.css', __FILE__ ),
+		'woocommerce-blocks',
+		plugins_url( 'build/blocks.css', __FILE__ ),
 		array( 'wp-edit-blocks' ),
-		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/product-category-block.css' ) : WGPB_VERSION
+		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/blocks.css' ) : WGPB_VERSION
 	);
 }
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -104,16 +104,6 @@ function wgpb_extra_gutenberg_scripts() {
 		true
 	);
 
-	$product_block_data = array(
-		'min_columns'     => wc_get_theme_support( 'product_grid::min_columns', 1 ),
-		'max_columns'     => wc_get_theme_support( 'product_grid::max_columns', 6 ),
-		'default_columns' => wc_get_default_products_per_row(),
-		'min_rows'        => wc_get_theme_support( 'product_grid::min_rows', 1 ),
-		'max_rows'        => wc_get_theme_support( 'product_grid::max_rows', 6 ),
-		'default_rows'    => wc_get_default_product_rows_per_page(),
-	);
-	wp_localize_script( 'woocommerce-products-block-editor', 'wc_product_block_data', $product_block_data );
-
 	if ( function_exists( 'wp_set_script_translations' ) ) {
 		wp_set_script_translations( 'woocommerce-blocks', 'woo-gutenberg-products-block' );
 	}
@@ -134,6 +124,8 @@ function wgpb_extra_gutenberg_scripts() {
 		array( 'wp-edit-blocks' ),
 		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/blocks.css' ) : WGPB_VERSION
 	);
+
+	add_action( 'admin_print_footer_scripts', 'wgpb_print_script_settings', 1 );
 }
 
 /**
@@ -156,13 +148,23 @@ function wgpb_print_script_settings() {
 			'dow' => get_option( 'start_of_week', 0 ),
 		),
 	);
+
+	// Global settings used in each block.
+	$block_settings = array(
+		'min_columns'     => wc_get_theme_support( 'product_grid::min_columns', 1 ),
+		'max_columns'     => wc_get_theme_support( 'product_grid::max_columns', 6 ),
+		'default_columns' => wc_get_default_products_per_row(),
+		'min_rows'        => wc_get_theme_support( 'product_grid::min_rows', 1 ),
+		'max_rows'        => wc_get_theme_support( 'product_grid::max_rows', 6 ),
+		'default_rows'    => wc_get_default_product_rows_per_page(),
+	);
 	?>
 	<script type="text/javascript">
 		var wcSettings = <?php echo wp_json_encode( $settings ); ?>;
+		var wc_product_block_data = <?php echo wp_json_encode( $block_settings ); ?>;
 	</script>
 	<?php
 }
-add_action( 'admin_print_footer_scripts', 'wgpb_print_script_settings', 1 );
 
 /**
  * Register extra API routes with functionality specific for product blocks.


### PR DESCRIPTION
Built on #215 – Currently, each block is set up to register a new file per-block. This can end up causing a lot of duplicate code in each file, with shared components and libraries (like gridicons). This PR combines all block registration into one file– so webpack will only bundle the shared code into one file.

The downside here could be if someone wants to disable a specific block, they can't just un-enqueue a single file. If that's something we want to support, we can switch back and investigate splitting out the shared libraries.

**To test**

- Run `npm run build`
- Expect: `/build/` now contains `blocks.js`, `products-block.js`, and matching CSS files.
- Add/edit a post to check the Products by Category block
- Expect: block should work as expected, no changes.
- Test the legacy block, there should be no change there either.