### PR TITLE
Block: Add new "Best Selling Products" block

### DIFF
--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -7,7 +7,7 @@
 	overflow: hidden;
 }
 
-.wc-block-products-category {
+.wc-block-products-grid {
 	overflow: hidden;
 
 	&.components-placeholder {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -29,13 +29,22 @@ registerBlockType( 'woocommerce/product-category', {
 	),
 	attributes: {
 		...sharedAttributes,
+
+		/**
+		 * Toggle for edit mode in the block preview.
+		 */
 		editMode: {
 			type: 'boolean',
 			default: true,
 		},
-		categories: {
-			type: 'array',
-			default: [],
+
+		/**
+		 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
+		 */
+		orderby: {
+			type: 'string',
+			default: 'date',
+		},
 		},
 	},
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { RawHTML } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import '../css/product-category-block.scss';
+import getShortcode from './utils/get-shortcode';
+import ProductByCategoryBlock from './product-category-block.js';
+import sharedAttributes from './utils/shared-attributes';
+
+const validAlignments = [ 'wide', 'full' ];
+
+/**
+ * Register and run the "Products by Category" block.
+ */
+registerBlockType( 'woocommerce/product-category', {
+	title: __( 'Products by Category', 'woo-gutenberg-products-block' ),
+	icon: 'category',
+	category: 'widgets',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a grid of products from your selected categories.',
+		'woo-gutenberg-products-block'
+	),
+	attributes: {
+		...sharedAttributes,
+		editMode: {
+			type: 'boolean',
+			default: true,
+		},
+		categories: {
+			type: 'array',
+			default: [],
+		},
+	},
+
+	getEditWrapperProps( attributes ) {
+		const { align } = attributes;
+		if ( -1 !== validAlignments.indexOf( align ) ) {
+			return { 'data-align': align };
+		}
+	},
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <ProductByCategoryBlock { ...props } />;
+	},
+
+	/**
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
+	 */
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props ) }
+			</RawHTML>
+		);
+	},
+} );

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import Gridicon from 'gridicons';
 import { registerBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 
@@ -10,10 +11,18 @@ import { RawHTML } from '@wordpress/element';
  */
 import '../css/product-category-block.scss';
 import getShortcode from './utils/get-shortcode';
-import ProductByCategoryBlock from './product-category-block.js';
+import ProductBestSellersBlock from './product-best-sellers';
+import ProductByCategoryBlock from './product-category-block';
 import sharedAttributes from './utils/shared-attributes';
 
 const validAlignments = [ 'wide', 'full' ];
+
+const getEditWrapperProps = ( attributes ) => {
+	const { align } = attributes;
+	if ( -1 !== validAlignments.indexOf( align ) ) {
+		return { 'data-align': align };
+	}
+};
 
 /**
  * Register and run the "Products by Category" block.
@@ -45,15 +54,8 @@ registerBlockType( 'woocommerce/product-category', {
 			type: 'string',
 			default: 'date',
 		},
-		},
 	},
-
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( -1 !== validAlignments.indexOf( align ) ) {
-			return { 'data-align': align };
-		}
-	},
+	getEditWrapperProps,
 
 	/**
 	 * Renders and manages the block.
@@ -73,7 +75,45 @@ registerBlockType( 'woocommerce/product-category', {
 		} = props.attributes; /* eslint-disable-line react/prop-types */
 		return (
 			<RawHTML className={ align ? `align${ align }` : '' }>
-				{ getShortcode( props ) }
+				{ getShortcode( props, 'woocommerce/product-category' ) }
+			</RawHTML>
+		);
+	},
+} );
+
+registerBlockType( 'woocommerce/product-best-sellers', {
+	title: __( 'Best Selling Products', 'woo-gutenberg-products-block' ),
+	icon: <Gridicon icon="stats-up-alt" />,
+	category: 'widgets',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a grid of your all-time best selling products.',
+		'woo-gutenberg-products-block'
+	),
+	attributes: {
+		...sharedAttributes,
+	},
+	getEditWrapperProps,
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <ProductBestSellersBlock { ...props } />;
+	},
+
+	/**
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
+	 */
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props, 'woocommerce/product-best-sellers' ) }
 			</RawHTML>
 		);
 	},

--- a/assets/js/product-best-sellers.js
+++ b/assets/js/product-best-sellers.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	BlockAlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+} from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import Gridicon from 'gridicons';
+import {
+	PanelBody,
+	Placeholder,
+	RangeControl,
+	Spinner,
+} from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import getQuery from './utils/get-query';
+import ProductCategoryControl from './components/product-category-control';
+import ProductPreview from './components/product-preview';
+
+/**
+ * Component to handle edit mode of "Best Selling Products".
+ */
+class ProductBestSellersBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			products: [],
+			loaded: false,
+		};
+	}
+
+	componentDidMount() {
+		if ( this.props.attributes.categories ) {
+			this.getProducts();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const hasChange = [ 'rows', 'columns', 'categories' ].reduce( ( acc, key ) => {
+			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
+		}, false );
+		if ( hasChange ) {
+			this.getProducts();
+		}
+	}
+
+	getProducts() {
+		apiFetch( {
+			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
+		} )
+			.then( ( products ) => {
+				this.setState( { products, loaded: true } );
+			} )
+			.catch( () => {
+				this.setState( { products: [], loaded: true } );
+			} );
+	}
+
+	getInspectorControls() {
+		const { attributes, setAttributes } = this.props;
+		const { columns, rows } = attributes;
+
+		return (
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<RangeControl
+						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+						value={ columns }
+						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						min={ wc_product_block_data.min_columns }
+						max={ wc_product_block_data.max_columns }
+					/>
+					<RangeControl
+						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
+						value={ rows }
+						onChange={ ( value ) => setAttributes( { rows: value } ) }
+						min={ wc_product_block_data.min_rows }
+						max={ wc_product_block_data.max_rows }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Filter by Product Category',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductCategoryControl
+						selected={ attributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { categories: ids } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	render() {
+		const { setAttributes } = this.props;
+		const { columns, align } = this.props.attributes;
+		const { loaded, products } = this.state;
+		const classes = [ 'wc-block-products-grid', 'wc-block-best-selling-products' ];
+		if ( columns ) {
+			classes.push( `cols-${ columns }` );
+		}
+		if ( products && ! products.length ) {
+			if ( ! loaded ) {
+				classes.push( 'is-loading' );
+			} else {
+				classes.push( 'is-not-found' );
+			}
+		}
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						controls={ [ 'wide', 'full' ] }
+						value={ align }
+						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				<div className={ classes.join( ' ' ) }>
+					{ products.length ? (
+						products.map( ( product ) => (
+							<ProductPreview product={ product } key={ product.id } />
+						) )
+					) : (
+						<Placeholder
+							icon={ <Gridicon icon="stats-up-alt" /> }
+							label={ __(
+								'Best Selling Products',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							{ ! loaded ? (
+								<Spinner />
+							) : (
+								__( 'No products found.', 'woo-gutenberg-products-block' )
+							) }
+						</Placeholder>
+					) }
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+ProductBestSellersBlock.propTypes = {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: PropTypes.func.isRequired,
+};
+
+export default ProductBestSellersBlock;

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -60,9 +60,8 @@ class ProductByCategoryBlock extends Component {
 	}
 
 	getProducts() {
-		this.setState( { products: [], loaded: false } );
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes ) ),
+			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
 		} )
 			.then( ( products ) => {
 				this.setState( { products, loaded: true } );
@@ -277,6 +276,10 @@ ProductByCategoryBlock.propTypes = {
 	 * The attributes for this block
 	 */
 	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
 	/**
 	 * A callback to update attributes
 	 */

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import {
 	BlockAlignmentToolbar,
 	BlockControls,
@@ -21,25 +21,18 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import PropTypes from 'prop-types';
-import { registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import '../css/product-category-block.scss';
 import getQuery from './utils/get-query';
-import getShortcode from './utils/get-shortcode';
 import ProductCategoryControl from './components/product-category-control';
 import ProductPreview from './components/product-preview';
-import sharedAttributes from './utils/shared-attributes';
-
-// Only enable wide and full alignments
-const validAlignments = [ 'wide', 'full' ];
 
 /**
  * Component to handle edit mode of "Products by Category".
  */
-export default class ProductByCategoryBlock extends Component {
+class ProductByCategoryBlock extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {
@@ -230,7 +223,7 @@ export default class ProductByCategoryBlock extends Component {
 			<Fragment>
 				<BlockControls>
 					<BlockAlignmentToolbar
-						controls={ validAlignments }
+						controls={ [ 'wide', 'full' ] }
 						value={ align }
 						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
 					/>
@@ -292,61 +285,6 @@ ProductByCategoryBlock.propTypes = {
 	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-const WrappedProductByCategoryBlock = withSpokenMessages(
+export default withSpokenMessages(
 	ProductByCategoryBlock
 );
-
-/**
- * Register and run the "Products by Category" block.
- */
-registerBlockType( 'woocommerce/product-category', {
-	title: __( 'Products by Category', 'woo-gutenberg-products-block' ),
-	icon: 'category',
-	category: 'widgets',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
-	description: __(
-		'Display a grid of products from your selected categories.',
-		'woo-gutenberg-products-block'
-	),
-	attributes: {
-		...sharedAttributes,
-		editMode: {
-			type: 'boolean',
-			default: true,
-		},
-		categories: {
-			type: 'array',
-			default: [],
-		},
-	},
-
-	getEditWrapperProps( attributes ) {
-		const { align } = attributes;
-		if ( -1 !== validAlignments.indexOf( align ) ) {
-			return { 'data-align': align };
-		}
-	},
-
-	/**
-	 * Renders and manages the block.
-	 */
-	edit( props ) {
-		return <WrappedProductByCategoryBlock { ...props } />;
-	},
-
-	/**
-	 * Save the block content in the post content. Block content is saved as a products shortcode.
-	 *
-	 * @return string
-	 */
-	save( props ) {
-		const {
-			align,
-		} = props.attributes; /* eslint-disable-line react/prop-types */
-		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
-				{ getShortcode( props ) }
-			</RawHTML>
-		);
-	},
-} );

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -206,7 +206,7 @@ class ProductByCategoryBlock extends Component {
 		const { setAttributes } = this.props;
 		const { columns, align, editMode } = this.props.attributes;
 		const { loaded, products } = this.state;
-		const classes = [ 'wc-block-products-category' ];
+		const classes = [ 'wc-block-products-grid', 'wc-block-products-category' ];
 		if ( columns ) {
 			classes.push( `cols-${ columns }` );
 		}

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -1,4 +1,4 @@
-export default function getQuery( attributes ) {
+export default function getQuery( attributes, name ) {
 	const { categories, columns, orderby, rows } = attributes;
 
 	const query = {
@@ -6,24 +6,33 @@ export default function getQuery( attributes ) {
 		per_page: rows * columns,
 	};
 
-	if ( categories ) {
+	if ( categories && categories.length ) {
 		query.category = categories.join( ',' );
 	}
 
-	if ( 'price_desc' === orderby ) {
-		query.orderby = 'price';
-		query.order = 'desc';
-	} else if ( 'price_asc' === orderby ) {
-		query.orderby = 'price';
-		query.order = 'asc';
-	} else if ( 'title' === orderby ) {
-		query.orderby = 'title';
-		query.order = 'asc';
-	} else if ( 'menu_order' === orderby ) {
-		query.orderby = 'menu_order';
-		query.order = 'asc';
-	} else {
-		query.orderby = orderby;
+	if ( orderby ) {
+		if ( 'price_desc' === orderby ) {
+			query.orderby = 'price';
+			query.order = 'desc';
+		} else if ( 'price_asc' === orderby ) {
+			query.orderby = 'price';
+			query.order = 'asc';
+		} else if ( 'title' === orderby ) {
+			query.orderby = 'title';
+			query.order = 'asc';
+		} else if ( 'menu_order' === orderby ) {
+			query.orderby = 'menu_order';
+			query.order = 'asc';
+		} else {
+			query.orderby = orderby;
+		}
+	}
+
+	// Toggle shortcode atts depending on block type.
+	switch ( name ) {
+		case 'woocommerce/product-best-sellers':
+			query.orderby = 'popularity';
+			break;
 	}
 
 	return query;

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -1,22 +1,34 @@
-export default function getShortcode( props ) {
-	const { rows, columns, categories, orderby } = props.attributes;
+export default function getShortcode( { attributes }, name ) {
+	const { rows, columns, categories, orderby } = attributes;
 
 	const shortcodeAtts = new Map();
 	shortcodeAtts.set( 'limit', rows * columns );
 	shortcodeAtts.set( 'columns', columns );
-	shortcodeAtts.set( 'category', categories.join( ',' ) );
 
-	if ( 'price_desc' === orderby ) {
-		shortcodeAtts.set( 'orderby', 'price' );
-		shortcodeAtts.set( 'order', 'DESC' );
-	} else if ( 'price_asc' === orderby ) {
-		shortcodeAtts.set( 'orderby', 'price' );
-		shortcodeAtts.set( 'order', 'ASC' );
-	} else if ( 'date' === orderby ) {
-		shortcodeAtts.set( 'orderby', 'date' );
-		shortcodeAtts.set( 'order', 'DESC' );
-	} else {
-		shortcodeAtts.set( 'orderby', orderby );
+	if ( categories && categories.length ) {
+		shortcodeAtts.set( 'category', categories.join( ',' ) );
+	}
+
+	if ( orderby ) {
+		if ( 'price_desc' === orderby ) {
+			shortcodeAtts.set( 'orderby', 'price' );
+			shortcodeAtts.set( 'order', 'DESC' );
+		} else if ( 'price_asc' === orderby ) {
+			shortcodeAtts.set( 'orderby', 'price' );
+			shortcodeAtts.set( 'order', 'ASC' );
+		} else if ( 'date' === orderby ) {
+			shortcodeAtts.set( 'orderby', 'date' );
+			shortcodeAtts.set( 'order', 'DESC' );
+		} else {
+			shortcodeAtts.set( 'orderby', orderby );
+		}
+	}
+
+	// Toggle shortcode atts depending on block type.
+	switch ( name ) {
+		case 'woocommerce/product-best-sellers':
+			shortcodeAtts.set( 'best_selling', '1' );
+			break;
 	}
 
 	// Build the shortcode string out of the set shortcode attributes.

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -23,10 +23,10 @@ export default {
 	},
 
 	/**
-	 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
+	 * Product category, used to display only products in the given categories.
 	 */
-	orderby: {
-		type: 'string',
-		default: 'date',
+	categories: {
+		type: 'array',
+		default: [],
 	},
 };

--- a/assets/js/utils/test/get-query.js
+++ b/assets/js/utils/test/get-query.js
@@ -91,7 +91,6 @@ describe( 'getQuery', () => {
 			attributes.categories = [];
 			const query = getQuery( attributes );
 			expect( query ).toEqual( {
-				category: '',
 				orderby: 'date',
 				per_page: 12,
 				status: 'publish',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const GutenbergBlocksConfig = {
 		// Legacy block
 		'products-block': './assets/js/legacy/products-block.jsx',
 		// New blocks
-		'product-category-block': './assets/js/product-category-block.js',
+		blocks: './assets/js/index.js',
 	},
 	output: {
 		path: path.resolve( __dirname, './build/' ),

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -51,13 +51,8 @@ function wgpb_plugins_notice() {
  * Register the Products block and its scripts.
  */
 function wgpb_register_products_block() {
-	register_block_type(
-		'woocommerce/products',
-		array(
-			'editor_script' => 'woocommerce-products-block-editor',
-			'editor_style'  => 'woocommerce-products-block-editor',
-		)
-	);
+	register_block_type( 'woocommerce/products' );
+	register_block_type( 'woocommerce/product-category' );
 }
 
 /**

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -78,8 +78,8 @@ function wgpb_extra_gutenberg_scripts() {
 	);
 
 	wp_register_script(
-		'woocommerce-products-category-block',
-		plugins_url( 'build/product-category-block.js', __FILE__ ),
+		'woocommerce-blocks',
+		plugins_url( 'build/blocks.js', __FILE__ ),
 		array(
 			'wp-api-fetch',
 			'wp-blocks',
@@ -92,7 +92,7 @@ function wgpb_extra_gutenberg_scripts() {
 			'wp-url',
 			'lodash',
 		),
-		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/product-category-block.js' ) : WGPB_VERSION,
+		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/blocks.js' ) : WGPB_VERSION,
 		true
 	);
 
@@ -115,11 +115,11 @@ function wgpb_extra_gutenberg_scripts() {
 	wp_localize_script( 'woocommerce-products-block-editor', 'wc_product_block_data', $product_block_data );
 
 	if ( function_exists( 'wp_set_script_translations' ) ) {
-		wp_set_script_translations( 'woocommerce-products-category-block', 'woo-gutenberg-products-block' );
+		wp_set_script_translations( 'woocommerce-blocks', 'woo-gutenberg-products-block' );
 	}
 
 	wp_enqueue_script( 'woocommerce-products-block-editor' );
-	wp_enqueue_script( 'woocommerce-products-category-block' );
+	wp_enqueue_script( 'woocommerce-blocks' );
 
 	wp_enqueue_style(
 		'woocommerce-products-block-editor',
@@ -129,10 +129,10 @@ function wgpb_extra_gutenberg_scripts() {
 	);
 
 	wp_enqueue_style(
-		'woocommerce-products-category-block',
-		plugins_url( 'build/product-category-block.css', __FILE__ ),
+		'woocommerce-blocks',
+		plugins_url( 'build/blocks.css', __FILE__ ),
 		array( 'wp-edit-blocks' ),
-		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/product-category-block.css' ) : WGPB_VERSION
+		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/blocks.css' ) : WGPB_VERSION
 	);
 }
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -104,16 +104,6 @@ function wgpb_extra_gutenberg_scripts() {
 		true
 	);
 
-	$product_block_data = array(
-		'min_columns'     => wc_get_theme_support( 'product_grid::min_columns', 1 ),
-		'max_columns'     => wc_get_theme_support( 'product_grid::max_columns', 6 ),
-		'default_columns' => wc_get_default_products_per_row(),
-		'min_rows'        => wc_get_theme_support( 'product_grid::min_rows', 1 ),
-		'max_rows'        => wc_get_theme_support( 'product_grid::max_rows', 6 ),
-		'default_rows'    => wc_get_default_product_rows_per_page(),
-	);
-	wp_localize_script( 'woocommerce-products-block-editor', 'wc_product_block_data', $product_block_data );
-
 	if ( function_exists( 'wp_set_script_translations' ) ) {
 		wp_set_script_translations( 'woocommerce-blocks', 'woo-gutenberg-products-block' );
 	}
@@ -134,6 +124,8 @@ function wgpb_extra_gutenberg_scripts() {
 		array( 'wp-edit-blocks' ),
 		defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( plugin_dir_path( __FILE__ ) . '/build/blocks.css' ) : WGPB_VERSION
 	);
+
+	add_action( 'admin_print_footer_scripts', 'wgpb_print_script_settings', 1 );
 }
 
 /**
@@ -156,13 +148,23 @@ function wgpb_print_script_settings() {
 			'dow' => get_option( 'start_of_week', 0 ),
 		),
 	);
+
+	// Global settings used in each block.
+	$block_settings = array(
+		'min_columns'     => wc_get_theme_support( 'product_grid::min_columns', 1 ),
+		'max_columns'     => wc_get_theme_support( 'product_grid::max_columns', 6 ),
+		'default_columns' => wc_get_default_products_per_row(),
+		'min_rows'        => wc_get_theme_support( 'product_grid::min_rows', 1 ),
+		'max_rows'        => wc_get_theme_support( 'product_grid::max_rows', 6 ),
+		'default_rows'    => wc_get_default_product_rows_per_page(),
+	);
 	?>
 	<script type="text/javascript">
 		var wcSettings = <?php echo wp_json_encode( $settings ); ?>;
+		var wc_product_block_data = <?php echo wp_json_encode( $block_settings ); ?>;
 	</script>
 	<?php
 }
-add_action( 'admin_print_footer_scripts', 'wgpb_print_script_settings', 1 );
 
 /**
  * Register extra API routes with functionality specific for product blocks.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -53,6 +53,7 @@ function wgpb_plugins_notice() {
 function wgpb_register_products_block() {
 	register_block_type( 'woocommerce/products' );
 	register_block_type( 'woocommerce/product-category' );
+	register_block_type( 'woocommerce/product-best-sellers' );
 }
 
 /**


### PR DESCRIPTION
This PR adds the new block, "Best Selling Products". It also makes some changes in the `getQuery` & `getShortcode` function to support reuse across different blocks.

Best Selling shows all products ordered by `popularity` in the preview, and generates a shortcode like `[products limit="9" columns="3" best_selling="1"]`.

You can also limit this block by category, in the block sidebar.

![best-sellers-block](https://user-images.githubusercontent.com/541093/49662241-e0a30180-fa10-11e8-9832-ed5960e0b157.png)

![best-sellers-sidebar](https://user-images.githubusercontent.com/541093/49662242-e0a30180-fa10-11e8-940b-e16e5c050274.png)

**To test**

- Add/edit a post
- Expect: A new block called "Best Selling Products" should appear (can also be found with `woocommerce`)
- Add the block
- Expect: a live preview of your most popular products
- You can edit layout settings, or restrict the category filtering in the sidebar
- Save/publish the post
- View the post
- Expect: same ordering of products on the frontend of the site