### PR TITLE
Product preview: Update "Add to cart" button to inherit theme's button styles 

### DIFF
--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -9,34 +9,36 @@
 
 .wc-block-products-category {
 	overflow: hidden;
+	display: grid;
+	grid-gap: $gap;
+	align-items: flex-start;
+
+	&.is-loading,
+	&.is-not-found,
+	&.cols-1 {
+		display: block;
+	}
+
+	@for $i from 2 to 7 {
+		&.cols-#{$i} {
+			grid-template-columns: repeat($i, 1fr);
+		}
+	}
 
 	&.components-placeholder {
+		// Reset from the grid of the preview.
+		display: flex;
+		align-items: center;
 		padding: 2em 1em;
 	}
 
 	.editor-block-preview & {
 		min-width: 5em;
 
-		.wc-product-preview__title,
-		.wc-product-preview__price,
-		.wc-product-preview__add-to-cart {
-			font-size: 0.6em;
-		}
-
-		&.cols-2 {
-			min-width: 2 * 5em;
-		}
-		&.cols-3 {
-			min-width: 3 * 5em;
-		}
-		&.cols-4 {
-			min-width: 4 * 5em;
-		}
-		&.cols-5 {
-			min-width: 5 * 5em;
-		}
-		&.cols-6 {
-			min-width: 6 * 5em;
+		@for $i from 1 to 7 {
+			&.cols-#{$i} {
+				min-width: $i * 5em;
+			}
 		}
 
 		&.is-loading,

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -11,7 +11,7 @@
 	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: space-between;
+	justify-content: flex-start;
 
 	&.is-loading,
 	&.is-not-found,
@@ -21,13 +21,14 @@
 
 	.wc-product-preview {
 		flex: 1;
-		margin-bottom: $gap-large;
+		padding: $gap/2;
 	}
 
 	@for $i from 2 to 7 {
 		&.cols-#{$i} .wc-product-preview {
-			max-width: calc( #{ 100% / $i } - #{$gap} );
-			flex: 1 0 calc( #{ 100% / $i } - #{$gap} );
+			max-width: calc( #{ 100% / $i } );
+			min-width: calc( #{ 100% / $i } );
+			flex: 1;
 		}
 	}
 

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -33,8 +33,6 @@
 	}
 
 	&.components-placeholder {
-		// Reset from the grid of the preview.
-		display: flex;
 		padding: 2em 1em;
 	}
 

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -26,8 +26,8 @@
 
 	@for $i from 2 to 7 {
 		&.cols-#{$i} .wc-product-preview {
-			max-width: calc( #{ 100% / $i } );
-			min-width: calc( #{ 100% / $i } );
+			max-width: calc(#{ 100% / $i });
+			min-width: calc(#{ 100% / $i });
 			flex: 1;
 		}
 	}

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -9,9 +9,9 @@
 
 .wc-block-products-category {
 	overflow: hidden;
-	display: grid;
-	grid-template: 1fr / auto;
-	grid-gap: $gap;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
 
 	&.is-loading,
 	&.is-not-found,
@@ -19,9 +19,15 @@
 		display: block;
 	}
 
+	.wc-product-preview {
+		flex: 1;
+		margin-bottom: $gap-large;
+	}
+
 	@for $i from 2 to 7 {
-		&.cols-#{$i} {
-			grid-template-columns: repeat($i, 1fr);
+		&.cols-#{$i} .wc-product-preview {
+			max-width: calc( #{ 100% / $i } - #{$gap} );
+			flex: 1 0 calc( #{ 100% / $i } - #{$gap} );
 		}
 	}
 

--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -10,8 +10,8 @@
 .wc-block-products-category {
 	overflow: hidden;
 	display: grid;
+	grid-template: 1fr / auto;
 	grid-gap: $gap;
-	align-items: flex-start;
 
 	&.is-loading,
 	&.is-not-found,
@@ -28,7 +28,6 @@
 	&.components-placeholder {
 		// Reset from the grid of the preview.
 		display: flex;
-		align-items: center;
 		padding: 2em 1em;
 	}
 

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -26,8 +26,10 @@ const ProductPreview = ( { product } ) => {
 				className="wc-product-preview__price"
 				dangerouslySetInnerHTML={ { __html: product.price_html } }
 			/>
-			<span className="wc-product-preview__add-to-cart">
-				{ __( 'Add to cart', 'woo-gutenberg-products-block' ) }
+			<span className="wp-block-button">
+				<span className="wc-product-preview__add-to-cart wp-block-button__link">
+					{ __( 'Add to cart', 'woo-gutenberg-products-block' ) }
+				</span>
 			</span>
 		</div>
 	);

--- a/assets/js/components/product-preview/style.scss
+++ b/assets/js/components/product-preview/style.scss
@@ -1,12 +1,19 @@
 .wc-product-preview {
 	text-align: center;
+	margin-bottom: $gap;
 
-	// wc-product-preview__title
-	// wc-product-preview__price
+	.wc-product-preview__title,
+	.wc-product-preview__price {
+		margin-top: $gap-smallest;
+	}
+
+	.wp-block-button {
+		margin-bottom: 0;
+	}
 
 	.wc-product-preview__add-to-cart {
 		cursor: text;
-		margin: 0.5em 0 1em;
+		margin: $gap-small 0 0;
 	}
 
 	.cols-4 &,

--- a/assets/js/components/product-preview/style.scss
+++ b/assets/js/components/product-preview/style.scss
@@ -76,15 +76,3 @@
 		}
 	}
 }
-
-.wc-product-preview__add-to-cart {
-	display: inline-block;
-	background: #ababab;
-	border-radius: 1.5em;
-	color: #fff;
-	cursor: pointer;
-	padding: 0.75em 1.25em;
-	line-height: 1.2em;
-	margin-top: 0.5em;
-	margin-bottom: 1em;
-}

--- a/assets/js/components/product-preview/style.scss
+++ b/assets/js/components/product-preview/style.scss
@@ -1,78 +1,40 @@
 .wc-product-preview {
-	float: left;
 	text-align: center;
-	margin-right: 3.8%;
 
-	.cols-1 & {
-		float: none;
-		margin-right: 0;
+	// wc-product-preview__title
+	// wc-product-preview__price
+
+	.wc-product-preview__add-to-cart {
+		cursor: text;
+		margin: 0.5em 0 1em;
 	}
 
-	.cols-2 & {
-		width: 48%;
-
-		&:nth-of-type(2n) {
-			margin-right: 0;
-		}
-
-		&:nth-of-type(2n+1) {
-			clear: both;
-		}
-	}
-
-	.cols-3 & {
-		width: 30.75%;
-
-		&:nth-of-type(3n) {
-			margin-right: 0;
-		}
-
-		&:nth-of-type(3n+1) {
-			clear: both;
-		}
-	}
-
-	.cols-4 & {
-		width: 22.05%;
-
-		&:nth-of-type(4n) {
-			margin-right: 0;
-		}
-
-		&:nth-of-type(4n+1) {
-			clear: both;
-		}
-	}
-
-	.cols-5 & {
-		width: 16.9%;
-
-		&:nth-of-type(5n) {
-			margin-right: 0;
-		}
-
-		&:nth-of-type(5n+1) {
-			clear: both;
-		}
-
-		.wc-product-preview__add-to-cart {
-			font-size: 0.75em;
-		}
-	}
-
+	.cols-4 &,
+	.cols-5 &,
 	.cols-6 & {
-		width: 13.5%;
-
-		&:nth-of-type(6n) {
-			margin-right: 0;
+		.wc-product-preview__title {
+			font-size: 0.9em;
+			line-height: 1.2;
 		}
-
-		&:nth-of-type(6n+1) {
-			clear: both;
+		.wc-product-preview__price {
+			font-size: 0.8em;
 		}
-
 		.wc-product-preview__add-to-cart {
-			font-size: 0.75em;
+			font-size: 0.7em !important;
+			line-height: 1.4 !important;
+		}
+	}
+
+	.editor-block-preview & {
+		.wc-product-preview__title {
+			font-size: 0.7em;
+			line-height: 1.2;
+		}
+		.wc-product-preview__price {
+			font-size: 0.6em;
+		}
+		.wc-product-preview__add-to-cart {
+			font-size: 0.6em !important;
 		}
 	}
 }

--- a/assets/js/components/product-preview/test/__snapshots__/index.js.snap
+++ b/assets/js/components/product-preview/test/__snapshots__/index.js.snap
@@ -22,9 +22,13 @@ exports[`ProductPreview should render a single product preview with an image 1`]
     }
   />
   <span
-    className="wc-product-preview__add-to-cart"
+    className="wp-block-button"
   >
-    Add to cart
+    <span
+      className="wc-product-preview__add-to-cart wp-block-button__link"
+    >
+      Add to cart
+    </span>
   </span>
 </div>
 `;
@@ -47,9 +51,13 @@ exports[`ProductPreview should render a single product preview without an image 
     }
   />
   <span
-    className="wc-product-preview__add-to-cart"
+    className="wp-block-button"
   >
-    Add to cart
+    <span
+      className="wc-product-preview__add-to-cart wp-block-button__link"
+    >
+      Add to cart
+    </span>
   </span>
 </div>
 `;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-	plugins: [
-		require( 'autoprefixer' )( { grid: true } ),
-	]
-}
+	plugins: [ require( 'autoprefixer' )( { browsers: [ '>1%' ] } ) ],
+};


### PR DESCRIPTION
Fixes #209 - by removing the custom button styling & instead switching to markup matching the button component, we can inherit the button styling that matches the theme.

This PR also cleans up the grid CSS by switching it from floats to flexbox (can't use css grid because IE11 doesn't support autoplacement, ugh). This shouldn't change the preview much, but now the SCSS is a little easier to manage.

### Screenshots

Twenty Nineteen:

<img width="656" alt="twentynineteen" src="https://user-images.githubusercontent.com/541093/49677115-8e7ad400-fa42-11e8-9a6b-b3d3f267cf2e.png">

Storefront:

<img width="670" alt="twentyseventeen" src="https://user-images.githubusercontent.com/541093/49677116-8e7ad400-fa42-11e8-860c-45c81bc5949e.png">

Twenty Seventeen

<img width="817" alt="storefront" src="https://user-images.githubusercontent.com/541093/49677117-8e7ad400-fa42-11e8-8f54-33251861a017.png">

### How to test the changes in this Pull Request:

1. Add/edit a post with the Products by Category block
2. Adjust the number of columns
3. Expect: the display should match the columns you've selected
3. Add a Button block to the post
4. Expect: the button and "Add to cart" button looks the same as the button created by the button block

Note: The front end might not look the same, since that is more dependent on the theme styling our shortcode's markup.