### PR TITLE
Add key prop to dropdown elements

### DIFF
--- a/assets/js/legacy/views/specific-select.jsx
+++ b/assets/js/legacy/views/specific-select.jsx
@@ -307,6 +307,7 @@ class ProductSpecificSearchResultsDropdown extends Component {
 					product={ product }
 					addOrRemoveProductCallback={ addOrRemoveProductCallback }
 					selected={ selectedProducts.includes( product.id ) }
+					key={ product.id }
 				/>
 			);
 		}


### PR DESCRIPTION
Adds a key prop to `ProductSpecificSearchResultsDropdownElement`.

Fixes #228 

### Screenshots

<img width="630" alt="screen shot 2018-12-10 at 2 51 03 pm" src="https://user-images.githubusercontent.com/10561050/49715406-3682de00-fc8b-11e8-8218-817ba70ed796.png">

### How to test the changes in this Pull Request:

1.  Visit a page editor with Gutenberg.
2.  Add a product block and select "Individual products."
3.  Check that no console error is thrown for a missing key prop after typing a search query.