### PR TITLE
updates and typos on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# WooCommerce Product Blocks
+# WooCommerce Products block
 
-Feature plugin for the Gutenberg Products block.
+Feature plugin for the WooCommerce Products block.
 
 ## Getting started with the stable version:
 
-1. The stable version is available on WordPress.org. [Download the stable version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
-2. Activate the plugin.
-3. On Gutenberg posts you should now have a Products block available.
+1. Make sure you have WordPress 5.0+ and WooCommerce 3.5.1+
+2. The stable version is available on WordPress.org. [Download the stable version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
+3. Activate the plugin.
+4. You should now have a "Products" block available.
 
 ## Getting started with the development version:
-1. Make sure you have:
-  - the latest version of the Gutenberg plugin and WooCommerce 3.3.1+ installed and active
-  - ***OR*** WordPress 5.0 (beta) and WooCommerce 3.5.1+
+
+1. Make sure you have WordPress 5.0+ and WooCommerce 3.5.1+
 2. Get a copy of this plugin using the green "Clone or download" button on the right.
 3. `npm install` to install the dependencies.
 4. `npm run build` (build once) or `npm start` (keep watching for changes) to compile the code.
 5. Activate the plugin.
-6. On Gutenberg posts & pages you should now have a "Products" block available.
+6. You should now have a "Products" block available.
 
 The source code is in the `assets/js/products-block.jsx` file and the compiled code is in `build/products-block.js`.
 
-**Gutenberg Tutorial and Docs**: https://wordpress.org/gutenberg/handbook/blocks/
+**Tutorial and Docs**: https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields/
 
-**Using API in Gutenberg**: https://github.com/WordPress/gutenberg/tree/master/packages/api-fetch
+**Using API**: https://github.com/WordPress/gutenberg/tree/master/packages/api-fetch
 
 ## Vision for the Feature
 
-Users should be able to insert a variety of products from their store (specific products, products in a category, with assorted layouts and visual styles, etc.) into their post content using a simple and powerful visual editor.
+Users should be able to insert a variety of products from their WooCommerce store (specific products, products in a category, with assorted layouts and visual styles, etc.) into their page/post content using a simple and powerful visual editor.


### PR DESCRIPTION
updates and typos on readme.md

- remove references to Gutenberg, since WordPress 5.0 is released
- update links to eliminate redirects
- misc typos