### PR TITLE
Fix incorrectly escaped HTML in build notice

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -43,7 +43,13 @@ add_action( 'woocommerce_loaded', 'wgpb_initialize' );
  */
 function wgpb_plugins_notice() {
 	echo '<div class="error"><p>';
-	esc_html_e( 'WooCommerce Product Blocks development mode requires files to be built. From the plugin directory, run <code>npm install</code> to install dependencies, <code>npm run build</code> to build the files or <code>npm start</code> to build the files and watch for changes.', 'woo-gutenberg-products-block' );
+	printf(
+		/* Translators: %1$s is the install command, %2$s is the build command, %3$s is the watch command. */
+		esc_html__( 'WooCommerce Blocks development mode requires files to be built. From the plugin directory, run %1$s to install dependencies, %2$s to build the files or %3$s to build the files and watch for changes.', 'woo-gutenberg-products-block' ),
+		'<code>npm install</code>',
+		'<code>npm run build</code>',
+		'<code>npm start</code>'
+	);
 	echo '</p></div>';
 }
 


### PR DESCRIPTION
This PR updates the notice displayed when running in development mode (which is true if the plugin is pulled from github), but the build files do not exist. In a previous change, escaping was added to the translation function, so the `<code>` tags were escaped, rather than rendered. This moves the code + commands into placeholders, so translators don't have to worry about translating npm commands, and we can keep the `esc_html` on the translated string.

<img width="646" alt="screen shot 2018-12-13 at 12 34 28 pm" src="https://user-images.githubusercontent.com/541093/49956597-91a71180-fed3-11e8-8c2c-2e718173371e.png">

### How to test the changes in this Pull Request:

1. Delete the `build` folder
2. View any page in wp-admin, Dashboard, Plugins, etc
3. Expect: the notice with npm commands correctly wrapped in `code` tags.
