### PR TITLE
Add PHPCS to travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
       env: WP_VERSION=latest WP_MULTISITE=0 WP_CORE_DIR=/tmp/wordpress
       php: 7.1
       script:
+        - composer install
+        - composer run-script phpcs .
         - npm install
         - npm run lint
         - npm run build

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "phpcs": [
-      "phpcs -s -p"
+      "phpcs --extensions=php -s -p"
     ],
     "phpcbf": [
       "phpcbf -p"


### PR DESCRIPTION
Fixes #231 – Adds composer install & phpcs to travis. This also updates the composer script to only run phpcs on .php files.

### How to test the changes in this Pull Request:

1. Check the travis logs for this PR
2. Expect: phpcs should have run, and passed.