### PR TITLE
Move product order control into a shared component

### DIFF
--- a/assets/js/components/product-orderby-control/index.js
+++ b/assets/js/components/product-orderby-control/index.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { SelectControl } from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+/**
+ * A pre-configured SelectControl for product orderby settings.
+ */
+const ProductOrderbyControl = ( { value, setAttributes } ) => {
+	return (
+		<SelectControl
+			label={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
+			value={ value }
+			options={ [
+				{
+					label: __( 'Newness - newest first', 'woo-gutenberg-products-block' ),
+					value: 'date',
+				},
+				{
+					label: __( 'Price - low to high', 'woo-gutenberg-products-block' ),
+					value: 'price_asc',
+				},
+				{
+					label: __( 'Price - high to low', 'woo-gutenberg-products-block' ),
+					value: 'price_desc',
+				},
+				{
+					label: __( 'Rating - highest first', 'woo-gutenberg-products-block' ),
+					value: 'rating',
+				},
+				{
+					label: __( 'Sales - most first', 'woo-gutenberg-products-block' ),
+					value: 'popularity',
+				},
+				{
+					label: __( 'Title - alphabetical', 'woo-gutenberg-products-block' ),
+					value: 'title',
+				},
+				{
+					label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
+					value: 'menu_order',
+				},
+			] }
+			onChange={ ( orderby ) => setAttributes( { orderby } ) }
+		/>
+	);
+};
+
+ProductOrderbyControl.propTypes = {
+	/**
+	 * Callback to update the order setting.
+	 */
+	setAttributes: PropTypes.func.isRequired,
+	/**
+	 * The selected order setting.
+	 */
+	value: PropTypes.string.isRequired,
+};
+
+export default ProductOrderbyControl;

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -15,7 +15,6 @@ import {
 	PanelBody,
 	Placeholder,
 	RangeControl,
-	SelectControl,
 	Spinner,
 	Toolbar,
 	withSpokenMessages,
@@ -27,6 +26,7 @@ import PropTypes from 'prop-types';
  */
 import getQuery from './utils/get-query';
 import ProductCategoryControl from './components/product-category-control';
+import ProductOrderbyControl from './components/product-orderby-control';
 import ProductPreview from './components/product-preview';
 
 /**
@@ -112,56 +112,7 @@ class ProductByCategoryBlock extends Component {
 					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
 					initialOpen={ false }
 				>
-					<SelectControl
-						label={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
-						value={ orderby }
-						options={ [
-							{
-								label: __(
-									'Newness - newest first',
-									'woo-gutenberg-products-block'
-								),
-								value: 'date',
-							},
-							{
-								label: __(
-									'Price - low to high',
-									'woo-gutenberg-products-block'
-								),
-								value: 'price_asc',
-							},
-							{
-								label: __(
-									'Price - high to low',
-									'woo-gutenberg-products-block'
-								),
-								value: 'price_desc',
-							},
-							{
-								label: __(
-									'Rating - highest first',
-									'woo-gutenberg-products-block'
-								),
-								value: 'rating',
-							},
-							{
-								label: __( 'Sales - most first', 'woo-gutenberg-products-block' ),
-								value: 'popularity',
-							},
-							{
-								label: __(
-									'Title - alphabetical',
-									'woo-gutenberg-products-block'
-								),
-								value: 'title',
-							},
-							{
-								label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
-								value: 'menu_order',
-							},
-						] }
-						onChange={ ( value ) => setAttributes( { orderby: value } ) }
-					/>
+					<ProductOrderbyControl setAttributes={ setAttributes } value={ orderby } />
 				</PanelBody>
 			</InspectorControls>
 		);


### PR DESCRIPTION
This PR moves the "Order By" select list into a shared control for all product blocks, so we don't need to duplicate order controls with each block. There should be no visual change. Right now, only the "Products by Category" block uses Order By, but On Sale will also use this (in a following PR).

### How to test the changes in this Pull Request:

1. Add a "Products by Category" block
2. Click into Order By
3. Expect: All the same ordering options: Newness - newest first, Price - low to high, Price - high to low, Rating - highest first, Sales - most first, Title - alphabetical, Menu Order
