### PR TITLE
New Block: Add "On Sale Products" block

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,6 +13,7 @@ import '../css/product-category-block.scss';
 import getShortcode from './utils/get-shortcode';
 import ProductBestSellersBlock from './product-best-sellers';
 import ProductByCategoryBlock from './product-category-block';
+import ProductOnSaleBlock from './product-on-sale';
 import sharedAttributes from './utils/shared-attributes';
 
 const validAlignments = [ 'wide', 'full' ];
@@ -114,6 +115,51 @@ registerBlockType( 'woocommerce/product-best-sellers', {
 		return (
 			<RawHTML className={ align ? `align${ align }` : '' }>
 				{ getShortcode( props, 'woocommerce/product-best-sellers' ) }
+			</RawHTML>
+		);
+	},
+} );
+
+registerBlockType( 'woocommerce/product-on-sale', {
+	title: __( 'On Sale Products', 'woo-gutenberg-products-block' ),
+	icon: <Gridicon icon="tag" />,
+	category: 'widgets',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a grid of on sale products.',
+		'woo-gutenberg-products-block'
+	),
+	attributes: {
+		...sharedAttributes,
+		/**
+		 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
+		 */
+		orderby: {
+			type: 'string',
+			default: 'date',
+		},
+	},
+	getEditWrapperProps,
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <ProductOnSaleBlock { ...props } />;
+	},
+
+	/**
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
+	 */
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props, 'woocommerce/product-on-sale' ) }
 			</RawHTML>
 		);
 	},

--- a/assets/js/product-best-sellers.js
+++ b/assets/js/product-best-sellers.js
@@ -39,9 +39,7 @@ class ProductBestSellersBlock extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.attributes.categories ) {
-			this.getProducts();
-		}
+		this.getProducts();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -55,7 +53,10 @@ class ProductBestSellersBlock extends Component {
 
 	getProducts() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
+			path: addQueryArgs(
+				'/wc-pb/v3/products',
+				getQuery( this.props.attributes, this.props.name )
+			),
 		} )
 			.then( ( products ) => {
 				this.setState( { products, loaded: true } );
@@ -113,7 +114,10 @@ class ProductBestSellersBlock extends Component {
 		const { setAttributes } = this.props;
 		const { columns, align } = this.props.attributes;
 		const { loaded, products } = this.state;
-		const classes = [ 'wc-block-products-grid', 'wc-block-best-selling-products' ];
+		const classes = [
+			'wc-block-products-grid',
+			'wc-block-best-selling-products',
+		];
 		if ( columns ) {
 			classes.push( `cols-${ columns }` );
 		}

--- a/assets/js/product-on-sale.js
+++ b/assets/js/product-on-sale.js
@@ -1,0 +1,193 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	BlockAlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+} from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import Gridicon from 'gridicons';
+import {
+	PanelBody,
+	Placeholder,
+	RangeControl,
+	Spinner,
+} from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import getQuery from './utils/get-query';
+import ProductCategoryControl from './components/product-category-control';
+import ProductOrderbyControl from './components/product-orderby-control';
+import ProductPreview from './components/product-preview';
+
+/**
+ * Component to handle edit mode of "On Sale Products".
+ */
+class ProductOnSaleBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			products: [],
+			loaded: false,
+		};
+	}
+
+	componentDidMount() {
+		this.getProducts();
+	}
+
+	componentDidUpdate( prevProps ) {
+		const hasChange = [ 'rows', 'columns', 'orderby', 'categories' ].reduce(
+			( acc, key ) => {
+				return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
+			},
+			false
+		);
+		if ( hasChange ) {
+			this.getProducts();
+		}
+	}
+
+	getProducts() {
+		apiFetch( {
+			path: addQueryArgs(
+				'/wc-pb/v3/products',
+				getQuery( this.props.attributes, this.props.name )
+			),
+		} )
+			.then( ( products ) => {
+				this.setState( { products, loaded: true } );
+			} )
+			.catch( () => {
+				this.setState( { products: [], loaded: true } );
+			} );
+	}
+
+	getInspectorControls() {
+		const { attributes, setAttributes } = this.props;
+		const { columns, rows, orderby } = attributes;
+
+		return (
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<RangeControl
+						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+						value={ columns }
+						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						min={ wc_product_block_data.min_columns }
+						max={ wc_product_block_data.max_columns }
+					/>
+					<RangeControl
+						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
+						value={ rows }
+						onChange={ ( value ) => setAttributes( { rows: value } ) }
+						min={ wc_product_block_data.min_rows }
+						max={ wc_product_block_data.max_rows }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
+					<ProductOrderbyControl setAttributes={ setAttributes } value={ orderby } />
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Filter by Product Category',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductCategoryControl
+						selected={ attributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { categories: ids } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	render() {
+		const { setAttributes } = this.props;
+		const { columns, align } = this.props.attributes;
+		const { loaded, products } = this.state;
+		const classes = [
+			'wc-block-products-grid',
+			'wc-block-on-sale-products',
+		];
+		if ( columns ) {
+			classes.push( `cols-${ columns }` );
+		}
+		if ( products && ! products.length ) {
+			if ( ! loaded ) {
+				classes.push( 'is-loading' );
+			} else {
+				classes.push( 'is-not-found' );
+			}
+		}
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						controls={ [ 'wide', 'full' ] }
+						value={ align }
+						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				<div className={ classes.join( ' ' ) }>
+					{ products.length ? (
+						products.map( ( product ) => (
+							<ProductPreview product={ product } key={ product.id } />
+						) )
+					) : (
+						<Placeholder
+							icon={ <Gridicon icon="tag" /> }
+							label={ __(
+								'On Sale Products',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							{ ! loaded ? (
+								<Spinner />
+							) : (
+								__( 'No products found.', 'woo-gutenberg-products-block' )
+							) }
+						</Placeholder>
+					) }
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+ProductOnSaleBlock.propTypes = {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: PropTypes.func.isRequired,
+};
+
+export default ProductOnSaleBlock;

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -33,6 +33,9 @@ export default function getQuery( attributes, name ) {
 		case 'woocommerce/product-best-sellers':
 			query.orderby = 'popularity';
 			break;
+		case 'woocommerce/product-on-sale':
+			query.on_sale = 1;
+			break;
 	}
 
 	return query;

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -29,6 +29,9 @@ export default function getShortcode( { attributes }, name ) {
 		case 'woocommerce/product-best-sellers':
 			shortcodeAtts.set( 'best_selling', '1' );
 			break;
+		case 'woocommerce/product-on-sale':
+			shortcodeAtts.set( 'on_sale', '1' );
+			break;
 	}
 
 	// Build the shortcode string out of the set shortcode attributes.


### PR DESCRIPTION
This PR adds the new block, "On Sale Products". On Sale shows all products that are on sale in the preview, and generates a shortcode like `[products limit="9" columns="3" on_sale="1"]`.

You can also limit this block by category, or change the order of products, in the block sidebar.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="663" alt="screen shot 2018-12-13 at 2 01 34 pm" src="https://user-images.githubusercontent.com/541093/49961036-9ffb2a80-fedf-11e8-80f4-66dab3eebb73.png">

### How to test the changes in this Pull Request:

1. Open a new post
2. Add a new block, look for "On Sale Products"
3. Expect: The block should be in the list
4. Add the block
5. Expect: a preview of all on sale products should show up
6. Now you can change the layout, order, or filter by category
7. Expect: each of these should work
8. View the post on the front end, the block should have the same products, in the same order, as in gutenberg.