### PR TITLE
New Block: Add "Top Rated Products" block

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -179,13 +179,15 @@ registerBlockType( 'woocommerce/product-on-sale', {
 		},
 	},
 	getEditWrapperProps,
- 	/**
+
+	/**
 	 * Renders and manages the block.
 	 */
 	edit( props ) {
 		return <ProductOnSaleBlock { ...props } />;
 	},
- 	/**
+
+	/**
 	 * Save the block content in the post content. Block content is saved as a products shortcode.
 	 *
 	 * @return string

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -13,6 +13,7 @@ import '../css/product-category-block.scss';
 import getShortcode from './utils/get-shortcode';
 import ProductBestSellersBlock from './product-best-sellers';
 import ProductByCategoryBlock from './product-category-block';
+import ProductTopRatedBlock from './product-top-rated';
 import sharedAttributes from './utils/shared-attributes';
 
 const validAlignments = [ 'wide', 'full' ];
@@ -114,6 +115,44 @@ registerBlockType( 'woocommerce/product-best-sellers', {
 		return (
 			<RawHTML className={ align ? `align${ align }` : '' }>
 				{ getShortcode( props, 'woocommerce/product-best-sellers' ) }
+			</RawHTML>
+		);
+	},
+} );
+
+registerBlockType( 'woocommerce/product-top-rated', {
+	title: __( 'Top Rated Products', 'woo-gutenberg-products-block' ),
+	icon: <Gridicon icon="trophy" />,
+	category: 'widgets',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a grid of your top rated products.',
+		'woo-gutenberg-products-block'
+	),
+	attributes: {
+		...sharedAttributes,
+	},
+	getEditWrapperProps,
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <ProductTopRatedBlock { ...props } />;
+	},
+
+	/**
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
+	 */
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props, 'woocommerce/product-top-rated' ) }
 			</RawHTML>
 		);
 	},

--- a/assets/js/product-top-rated.js
+++ b/assets/js/product-top-rated.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	BlockAlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+} from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import Gridicon from 'gridicons';
+import {
+	PanelBody,
+	Placeholder,
+	RangeControl,
+	Spinner,
+} from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import getQuery from './utils/get-query';
+import ProductCategoryControl from './components/product-category-control';
+import ProductPreview from './components/product-preview';
+
+/**
+ * Component to handle edit mode of "Top Rated Products".
+ */
+class ProductTopRatedBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			products: [],
+			loaded: false,
+		};
+	}
+
+	componentDidMount() {
+		if ( this.props.attributes.categories ) {
+			this.getProducts();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const hasChange = [ 'rows', 'columns', 'categories' ].reduce( ( acc, key ) => {
+			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
+		}, false );
+		if ( hasChange ) {
+			this.getProducts();
+		}
+	}
+
+	getProducts() {
+		apiFetch( {
+			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
+		} )
+			.then( ( products ) => {
+				this.setState( { products, loaded: true } );
+			} )
+			.catch( () => {
+				this.setState( { products: [], loaded: true } );
+			} );
+	}
+
+	getInspectorControls() {
+		const { attributes, setAttributes } = this.props;
+		const { columns, rows } = attributes;
+
+		return (
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<RangeControl
+						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+						value={ columns }
+						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						min={ wc_product_block_data.min_columns }
+						max={ wc_product_block_data.max_columns }
+					/>
+					<RangeControl
+						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
+						value={ rows }
+						onChange={ ( value ) => setAttributes( { rows: value } ) }
+						min={ wc_product_block_data.min_rows }
+						max={ wc_product_block_data.max_rows }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Filter by Product Category',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductCategoryControl
+						selected={ attributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { categories: ids } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	render() {
+		const { setAttributes } = this.props;
+		const { columns, align } = this.props.attributes;
+		const { loaded, products } = this.state;
+		const classes = [ 'wc-block-products-grid', 'wc-block-top-rated-products' ];
+		if ( columns ) {
+			classes.push( `cols-${ columns }` );
+		}
+		if ( products && ! products.length ) {
+			if ( ! loaded ) {
+				classes.push( 'is-loading' );
+			} else {
+				classes.push( 'is-not-found' );
+			}
+		}
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						controls={ [ 'wide', 'full' ] }
+						value={ align }
+						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				<div className={ classes.join( ' ' ) }>
+					{ products.length ? (
+						products.map( ( product ) => (
+							<ProductPreview product={ product } key={ product.id } />
+						) )
+					) : (
+						<Placeholder
+							icon={ <Gridicon icon="trophy" /> }
+							label={ __(
+								'Top Rated Products',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							{ ! loaded ? (
+								<Spinner />
+							) : (
+								__( 'No products found.', 'woo-gutenberg-products-block' )
+							) }
+						</Placeholder>
+					) }
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+ProductTopRatedBlock.propTypes = {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: PropTypes.func.isRequired,
+};
+
+export default ProductTopRatedBlock;

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -33,6 +33,9 @@ export default function getQuery( attributes, name ) {
 		case 'woocommerce/product-best-sellers':
 			query.orderby = 'popularity';
 			break;
+		case 'woocommerce/product-top-rated':
+		query.orderby = 'rating';
+		break;
 	}
 
 	return query;

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -34,8 +34,8 @@ export default function getQuery( attributes, name ) {
 			query.orderby = 'popularity';
 			break;
 		case 'woocommerce/product-top-rated':
-		query.orderby = 'rating';
-		break;
+			query.orderby = 'rating';
+			break;
 	}
 
 	return query;

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -33,13 +33,11 @@ export default function getQuery( attributes, name ) {
 		case 'woocommerce/product-best-sellers':
 			query.orderby = 'popularity';
 			break;
-<<<<<<< HEAD
 		case 'woocommerce/product-top-rated':
 			query.orderby = 'rating';
-=======
+			break;
 		case 'woocommerce/product-on-sale':
 			query.on_sale = 1;
->>>>>>> 75e957b33c668e2ef98500fab68ecfe8ca705ac4
 			break;
 	}
 

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -30,7 +30,7 @@ export default function getShortcode( { attributes }, name ) {
 			shortcodeAtts.set( 'best_selling', '1' );
 			break;
 		case 'woocommerce/product-top-rated':
-			shortcodeAtts.set( 'orderby', 'rating', '1' );
+			shortcodeAtts.set( 'orderby', 'rating');
 			break;
 	}
 

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -29,6 +29,9 @@ export default function getShortcode( { attributes }, name ) {
 		case 'woocommerce/product-best-sellers':
 			shortcodeAtts.set( 'best_selling', '1' );
 			break;
+		case 'woocommerce/product-top-rated':
+		shortcodeAtts.set( 'rating', '1' );
+		break;
 	}
 
 	// Build the shortcode string out of the set shortcode attributes.

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -30,7 +30,7 @@ export default function getShortcode( { attributes }, name ) {
 			shortcodeAtts.set( 'best_selling', '1' );
 			break;
 		case 'woocommerce/product-top-rated':
-			shortcodeAtts.set( 'orderby', 'rating', '1' );
+			shortcodeAtts.set( 'orderby', 'rating' );
 			break;
 	}
 

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -30,8 +30,8 @@ export default function getShortcode( { attributes }, name ) {
 			shortcodeAtts.set( 'best_selling', '1' );
 			break;
 		case 'woocommerce/product-top-rated':
-		shortcodeAtts.set( 'rating', '1' );
-		break;
+			shortcodeAtts.set( 'orderby', 'rating', '1' );
+			break;
 	}
 
 	// Build the shortcode string out of the set shortcode attributes.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -54,6 +54,7 @@ function wgpb_register_products_block() {
 	register_block_type( 'woocommerce/products' );
 	register_block_type( 'woocommerce/product-category' );
 	register_block_type( 'woocommerce/product-best-sellers' );
+	register_block_type( 'woocommerce/product-top-rated' );
 }
 
 /**


### PR DESCRIPTION
Fixes #242 

This PR adds the new block, "Top Rated Products". 

Top rated shows all products ordered by `rating` in the preview.

You can also filter this block by category, in the block sidebar.

<img width="1927" alt="screen shot 2018-12-14 at 1 07 48 pm" src="https://user-images.githubusercontent.com/4500952/50027538-6d196b00-ffa1-11e8-9bad-f4692185183c.png">


**To test**

- Add/edit a post
- Expect: A new block called "Top Rated Products" should appear (can also be found with `woocommerce`)
- Add the block
- Expect: a live preview of your top rated products
- You can edit layout settings, or restrict the category filtering in the sidebar
- Save/publish the post
- View the post
- Expect: same ordering of products on the frontend of the site
