### PR TITLE
fix individual product block (legacy)

### DIFF
--- a/assets/js/legacy/views/specific-select.jsx
+++ b/assets/js/legacy/views/specific-select.jsx
@@ -348,13 +348,15 @@ class ProductSpecificSearchResultsDropdownElement extends Component {
 	render() {
 		const product = this.props.product;
 		const icon = this.props.selected ? <Dashicon icon="yes" /> : null;
+		const productImage = product.images.length !== 0 ? 
+			(<img src={ product.images[ 0 ].src } alt={ product.name } />) : null;
 
 		/* eslint-disable jsx-a11y/click-events-have-key-events */
 		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		/* reason: This interface will be deprecated, the new component is accessible. */
 		return (
 			<div className={ 'wc-products-list-card__content' + ( this.props.selected ? ' wc-products-list-card__content--added' : '' ) } onClick={ this.handleClick }>
-				<img src={ product.images[ 0 ].src } alt="" />
+				{ productImage }
 				<span className="wc-products-list-card__content-item-name">{ product.name }</span>
 				{ icon }
 			</div>
@@ -458,11 +460,13 @@ class ProductSpecificSelectedProducts extends Component {
 			}
 
 			const productData = PRODUCT_DATA[ productId ];
+			const productImage = productData.images.length !== 0 ? 
+				(<img src={ productData.images[ 0 ].src } alt={ productData.name } />) : null;
 
 			productElements.push(
 				<li className="wc-products-list-card__item" key={ productData.id + '-specific-select-edit' } >
 					<div className="wc-products-list-card__content">
-						<img src={ productData.images[ 0 ].src } alt="" />
+						{ productImage }
 						<span className="wc-products-list-card__content-item-name">{ productData.name }</span>
 						<button
 							type="button"


### PR DESCRIPTION
prior to this commit, an 'individual product' block would produce
an error if associated with a product with no image.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #226 

<!-- Don't forget to update the title with something descriptive. -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

see issue.

<!-- If you can, add the appropriate labels -->
