### PR TITLE
New Block: Add "Newest Products" Block

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -33,7 +33,7 @@ const getEditWrapperProps = ( attributes ) => {
 registerBlockType( 'woocommerce/product-category', {
 	title: __( 'Products by Category', 'woo-gutenberg-products-block' ),
 	icon: 'category',
-	category: 'widgets',
+	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
 		'Display a grid of products from your selected categories.',
@@ -87,7 +87,7 @@ registerBlockType( 'woocommerce/product-category', {
 registerBlockType( 'woocommerce/product-best-sellers', {
 	title: __( 'Best Selling Products', 'woo-gutenberg-products-block' ),
 	icon: <Gridicon icon="stats-up-alt" />,
-	category: 'widgets',
+	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
 		'Display a grid of your all-time best selling products.',
@@ -125,7 +125,7 @@ registerBlockType( 'woocommerce/product-best-sellers', {
 registerBlockType( 'woocommerce/product-top-rated', {
 	title: __( 'Top Rated Products', 'woo-gutenberg-products-block' ),
 	icon: <Gridicon icon="trophy" />,
-	category: 'widgets',
+	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
 		'Display a grid of your top rated products.',
@@ -163,7 +163,7 @@ registerBlockType( 'woocommerce/product-top-rated', {
 registerBlockType( 'woocommerce/product-on-sale', {
 	title: __( 'On Sale Products', 'woo-gutenberg-products-block' ),
 	icon: <Gridicon icon="tag" />,
-	category: 'widgets',
+	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
 		'Display a grid of on sale products.',
@@ -208,7 +208,7 @@ registerBlockType( 'woocommerce/product-on-sale', {
 registerBlockType( 'woocommerce/product-new', {
 	title: __( 'Newest Products', 'woo-gutenberg-products-block' ),
 	icon: <Gridicon icon="notice" />,
-	category: 'widgets',
+	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
 		'Display a grid of your newest products.',

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -15,6 +15,7 @@ import ProductBestSellersBlock from './product-best-sellers';
 import ProductByCategoryBlock from './product-category-block';
 import ProductTopRatedBlock from './product-top-rated';
 import ProductOnSaleBlock from './product-on-sale';
+import ProductNewestBlock from './product-new';
 import sharedAttributes from './utils/shared-attributes';
 
 const validAlignments = [ 'wide', 'full' ];
@@ -199,6 +200,44 @@ registerBlockType( 'woocommerce/product-on-sale', {
 		return (
 			<RawHTML className={ align ? `align${ align }` : '' }>
 				{ getShortcode( props, 'woocommerce/product-on-sale' ) }
+			</RawHTML>
+		);
+	},
+} );
+
+registerBlockType( 'woocommerce/product-new', {
+	title: __( 'Top Rated Products', 'woo-gutenberg-products-block' ),
+	icon: <Gridicon icon="notice-outline" />,
+	category: 'widgets',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a grid of your newest products.',
+		'woo-gutenberg-products-block'
+	),
+	attributes: {
+		...sharedAttributes,
+	},
+	getEditWrapperProps,
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <ProductTopRatedBlock { ...props } />;
+	},
+
+	/**
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
+	 */
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props, 'woocommerce/product-new' ) }
 			</RawHTML>
 		);
 	},

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -206,8 +206,8 @@ registerBlockType( 'woocommerce/product-on-sale', {
 } );
 
 registerBlockType( 'woocommerce/product-new', {
-	title: __( 'Top Rated Products', 'woo-gutenberg-products-block' ),
-	icon: <Gridicon icon="notice-outline" />,
+	title: __( 'Newest Products', 'woo-gutenberg-products-block' ),
+	icon: <Gridicon icon="notice" />,
 	category: 'widgets',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
@@ -223,7 +223,7 @@ registerBlockType( 'woocommerce/product-new', {
 	 * Renders and manages the block.
 	 */
 	edit( props ) {
-		return <ProductTopRatedBlock { ...props } />;
+		return <ProductNewestBlock { ...props } />;
 	},
 
 	/**

--- a/assets/js/legacy/products-block.jsx
+++ b/assets/js/legacy/products-block.jsx
@@ -903,7 +903,7 @@ class ProductsBlock extends Component {
 registerBlockType( 'woocommerce/products', {
 	title: __( 'Products' ),
 	icon: 'screenoptions',
-	category: 'widgets',
+	category: 'woocommerce',
 	description: __( 'Display a grid of products from a variety of sources.' ),
 
 	attributes: {

--- a/assets/js/product-new.js
+++ b/assets/js/product-new.js
@@ -29,7 +29,7 @@ import ProductPreview from './components/product-preview';
 /**
  * Component to handle edit mode of "Newest Products".
  */
-class ProductTopRatedBlock extends Component {
+class ProductNewestBlock extends Component {
 	constructor() {
 		super( ...arguments );
 		this.state = {

--- a/assets/js/product-new.js
+++ b/assets/js/product-new.js
@@ -1,0 +1,179 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	BlockAlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+} from '@wordpress/editor';
+import { Component, Fragment } from '@wordpress/element';
+import Gridicon from 'gridicons';
+import {
+	PanelBody,
+	Placeholder,
+	RangeControl,
+	Spinner,
+} from '@wordpress/components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import getQuery from './utils/get-query';
+import ProductCategoryControl from './components/product-category-control';
+import ProductPreview from './components/product-preview';
+
+/**
+ * Component to handle edit mode of "Newest Products".
+ */
+class ProductTopRatedBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			products: [],
+			loaded: false,
+		};
+	}
+
+	componentDidMount() {
+		if ( this.props.attributes.categories ) {
+			this.getProducts();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const hasChange = [ 'rows', 'columns', 'categories' ].reduce( ( acc, key ) => {
+			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
+		}, false );
+		if ( hasChange ) {
+			this.getProducts();
+		}
+	}
+
+	getProducts() {
+		apiFetch( {
+			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
+		} )
+			.then( ( products ) => {
+				this.setState( { products, loaded: true } );
+			} )
+			.catch( () => {
+				this.setState( { products: [], loaded: true } );
+			} );
+	}
+
+	getInspectorControls() {
+		const { attributes, setAttributes } = this.props;
+		const { columns, rows } = attributes;
+
+		return (
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<RangeControl
+						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+						value={ columns }
+						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						min={ wc_product_block_data.min_columns }
+						max={ wc_product_block_data.max_columns }
+					/>
+					<RangeControl
+						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
+						value={ rows }
+						onChange={ ( value ) => setAttributes( { rows: value } ) }
+						min={ wc_product_block_data.min_rows }
+						max={ wc_product_block_data.max_rows }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Filter by Product Category',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductCategoryControl
+						selected={ attributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { categories: ids } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	render() {
+		const { setAttributes } = this.props;
+		const { columns, align } = this.props.attributes;
+		const { loaded, products } = this.state;
+		const classes = [ 'wc-block-products-grid', 'wc-block-newest-products' ];
+		if ( columns ) {
+			classes.push( `cols-${ columns }` );
+		}
+		if ( products && ! products.length ) {
+			if ( ! loaded ) {
+				classes.push( 'is-loading' );
+			} else {
+				classes.push( 'is-not-found' );
+			}
+		}
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						controls={ [ 'wide', 'full' ] }
+						value={ align }
+						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				<div className={ classes.join( ' ' ) }>
+					{ products.length ? (
+						products.map( ( product ) => (
+							<ProductPreview product={ product } key={ product.id } />
+						) )
+					) : (
+						<Placeholder
+							icon={ <Gridicon icon="notice-outline" /> }
+							label={ __(
+								'Newest Products',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							{ ! loaded ? (
+								<Spinner />
+							) : (
+								__( 'No products found.', 'woo-gutenberg-products-block' )
+							) }
+						</Placeholder>
+					) }
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+ProductNewestBlock.propTypes = {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: PropTypes.func.isRequired,
+};
+
+export default ProductNewestBlock;

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -39,6 +39,9 @@ export default function getQuery( attributes, name ) {
 		case 'woocommerce/product-on-sale':
 			query.on_sale = 1;
 			break;
+		case 'woocommerce/product-new':
+			query.orderby = 'date';
+			break;
 	}
 
 	return query;

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -35,6 +35,9 @@ export default function getShortcode( { attributes }, name ) {
 		case 'woocommerce/product-on-sale':
 			shortcodeAtts.set( 'on_sale', '1' );
 			break;
+		case 'woocommerce/product-new':
+			shortcodeAtts.set( 'orderby', 'date' );
+			break;
 	}
 
 	// Build the shortcode string out of the set shortcode attributes.

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -37,6 +37,7 @@ export default function getShortcode( { attributes }, name ) {
 			break;
 		case 'woocommerce/product-new':
 			shortcodeAtts.set( 'orderby', 'date' );
+			shortcodeAtts.set( 'order', 'DESC' );
 			break;
 	}
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -54,6 +54,30 @@ function wgpb_plugins_notice() {
 }
 
 /**
+ * Adds a WooCommerce category to the block inserter
+ *
+ * @param array  $categories Array of categories.
+ * @param object $post WP_Post object.
+ */
+function woocommerce_block_categories( $categories, $post ) {
+	if ( 'post' !== $post->post_type && 'page' !== $post->post_type ) {
+		return $categories;
+	}
+	return array_merge(
+		$categories,
+		array(
+			array(
+				'slug'  => 'woocommerce',
+				'title' => __( 'WooCommerce', 'woo-gutenberg-products-block' ),
+				'icon'  => 'woocommerce',
+			),
+		)
+	);
+}
+add_filter( 'block_categories', 'woocommerce_block_categories', 10, 2 );
+
+
+/**
  * Register the Products block and its scripts.
  */
 function wgpb_register_products_block() {

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -54,15 +54,12 @@ function wgpb_plugins_notice() {
 }
 
 /**
- * Adds a WooCommerce category to the block inserter
+ * Adds a WooCommerce category to the block inserter.
  *
- * @param array  $categories Array of categories.
- * @param object $post WP_Post object.
+ * @param array $categories Array of categories.
+ * @return array Array of block categories.
  */
-function woocommerce_block_categories( $categories, $post ) {
-	if ( 'post' !== $post->post_type && 'page' !== $post->post_type ) {
-		return $categories;
-	}
+function wgpb_add_block_category( $categories ) {
 	return array_merge(
 		$categories,
 		array(
@@ -74,8 +71,7 @@ function woocommerce_block_categories( $categories, $post ) {
 		)
 	);
 }
-add_filter( 'block_categories', 'woocommerce_block_categories', 10, 2 );
-
+add_filter( 'block_categories', 'wgpb_add_block_category' );
 
 /**
  * Register the Products block and its scripts.


### PR DESCRIPTION
This PR adds a block: "Newest Products".

Newest Products shows all products ordered by the date they were added to the store in the preview.

You can also filter this block by category, in the block sidebar.

<img width="1573" alt="screen shot 2018-12-15 at 11 49 20 am" src="https://user-images.githubusercontent.com/4500952/50046901-1d4da900-0060-11e9-88d4-8449f162c373.png">


To test

Add/edit a post
Expect: A new block called "Newest Products" should appear (can also be found with woocommerce)
Add the block
Expect: a live preview of your newest products
You can edit layout settings, or restrict the category filtering in the sidebar
Save/publish the post
View the post
Expect: same ordering of products on the frontend of the site

Fixes #241