### PR TITLE
API: Inject attribute group name & slug into API response

### DIFF
--- a/includes/class-wgpb-product-attribute-terms-controller.php
+++ b/includes/class-wgpb-product-attribute-terms-controller.php
@@ -105,14 +105,17 @@ class WGPB_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
-		// Get term order.
-		$menu_order = get_woocommerce_term_meta( $item->term_id, 'order_' . $this->taxonomy );
+		// Get the attribute slug.
+		$attribute_id = absint( $request->get_param( 'attribute_id' ) );
+		$attribute    = wc_get_attribute( $attribute_id );
 
 		$data = array(
-			'id'    => (int) $item->term_id,
-			'name'  => $item->name,
-			'slug'  => $item->slug,
-			'count' => (int) $item->count,
+			'id'        => (int) $item->term_id,
+			'name'      => $item->name,
+			'slug'      => $item->slug,
+			'count'     => (int) $item->count,
+			'attr_name' => $attribute->name,
+			'attr_slug' => $attribute->slug,
 		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -140,10 +143,26 @@ class WGPB_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_
 			'properties' => array(),
 		);
 
-		$schema['properties']['id']    = $raw_schema['properties']['id'];
-		$schema['properties']['name']  = $raw_schema['properties']['name'];
-		$schema['properties']['slug']  = $raw_schema['properties']['slug'];
-		$schema['properties']['count'] = $raw_schema['properties']['count'];
+		$schema['properties']['id']        = $raw_schema['properties']['id'];
+		$schema['properties']['name']      = $raw_schema['properties']['name'];
+		$schema['properties']['slug']      = $raw_schema['properties']['slug'];
+		$schema['properties']['count']     = $raw_schema['properties']['count'];
+		$schema['properties']['attr_name'] = array(
+			'description' => __( 'Attribute group name.', 'woo-gutenberg-products-block' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
+		$schema['properties']['attr_slug'] = array(
+			'description' => __( 'An alphanumeric identifier for the resource unique to its type.', 'woo-gutenberg-products-block' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_title',
+			),
+		);
 
 		return $this->add_additional_fields_schema( $schema );
 	}


### PR DESCRIPTION
For #240, I need the "parent" attribute group name & slug, so that we can query the products endpoint and create the shortcode (which each use the parent slug). Currently I can hack around this by merging the `/attribute` endpoint response, but this creates a lot of special case handling around the `ProductsAttributeControl` (PR to come). Adding these values to the API is more straightforward.

### How to test the changes in this Pull Request:

1. Find an attribute ID by fetching the list of attributes: GET `/wc-pb/v3/products/attributes`
2. Get the list of terms in that attribute: GET `/wc-pb/v3/products/attributes/<id>/terms` where ID is your attribute ID
3. Expect: You should see a list of items, each with id, name, count, slug, attr_name, attr_slug.
4. attr_name and attr_slug should match the attribute, ex: `Color`, `pa_color`.
