### PR TITLE
Fix multiple API calls returning out of order, causing set rows to be incorrect

### DIFF
--- a/assets/js/product-best-sellers.js
+++ b/assets/js/product-best-sellers.js
@@ -10,6 +10,7 @@ import {
 	InspectorControls,
 } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
+import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
 import {
 	PanelBody,
@@ -36,6 +37,8 @@ class ProductBestSellersBlock extends Component {
 			products: [],
 			loaded: false,
 		};
+
+		this.debouncedGetProducts = debounce( this.getProducts.bind( this ), 200 );
 	}
 
 	componentDidMount() {
@@ -50,7 +53,7 @@ class ProductBestSellersBlock extends Component {
 			false
 		);
 		if ( hasChange ) {
-			this.getProducts();
+			this.debouncedGetProducts();
 		}
 	}
 

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -4,7 +4,6 @@
 import { __, _n } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { Component, Fragment } from '@wordpress/element';
 import {
 	BlockAlignmentToolbar,
 	BlockControls,
@@ -19,6 +18,8 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -39,6 +40,8 @@ class ProductByCategoryBlock extends Component {
 			products: [],
 			loaded: false,
 		};
+
+		this.debouncedGetProducts = debounce( this.getProducts.bind( this ), 200 );
 	}
 
 	componentDidMount() {
@@ -48,20 +51,26 @@ class ProductByCategoryBlock extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const hasChange = [ 'categories', 'catOperator', 'columns', 'orderby', 'rows' ].reduce(
-			( acc, key ) => {
-				return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
-			},
-			false
-		);
+		const hasChange = [
+			'categories',
+			'catOperator',
+			'columns',
+			'orderby',
+			'rows',
+		].reduce( ( acc, key ) => {
+			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
+		}, false );
 		if ( hasChange ) {
-			this.getProducts();
+			this.debouncedGetProducts();
 		}
 	}
 
 	getProducts() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
+			path: addQueryArgs(
+				'/wc-pb/v3/products',
+				getQuery( this.props.attributes, this.props.name )
+			),
 		} )
 			.then( ( products ) => {
 				this.setState( { products, loaded: true } );
@@ -88,7 +97,9 @@ class ProductByCategoryBlock extends Component {
 							setAttributes( { categories: ids } );
 						} }
 						operator={ catOperator }
-						onOperatorChange={ ( value = 'any' ) => setAttributes( { catOperator: value } ) }
+						onOperatorChange={ ( value = 'any' ) =>
+							setAttributes( { catOperator: value } )
+						}
 					/>
 				</PanelBody>
 				<PanelBody
@@ -114,7 +125,10 @@ class ProductByCategoryBlock extends Component {
 					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
 					initialOpen={ false }
 				>
-					<ProductOrderbyControl setAttributes={ setAttributes } value={ orderby } />
+					<ProductOrderbyControl
+						setAttributes={ setAttributes }
+						value={ orderby }
+					/>
 				</PanelBody>
 			</InspectorControls>
 		);
@@ -147,7 +161,9 @@ class ProductByCategoryBlock extends Component {
 							setAttributes( { categories: ids } );
 						} }
 						operator={ attributes.catOperator }
-						onOperatorChange={ ( value = 'any' ) => setAttributes( { catOperator: value } ) }
+						onOperatorChange={ ( value = 'any' ) =>
+							setAttributes( { catOperator: value } )
+						}
 					/>
 					<Button isDefault onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
@@ -245,6 +261,4 @@ ProductByCategoryBlock.propTypes = {
 	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-export default withSpokenMessages(
-	ProductByCategoryBlock
-);
+export default withSpokenMessages( ProductByCategoryBlock );

--- a/assets/js/product-new.js
+++ b/assets/js/product-new.js
@@ -10,6 +10,7 @@ import {
 	InspectorControls,
 } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
+import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
 import {
 	PanelBody,
@@ -36,6 +37,8 @@ class ProductNewestBlock extends Component {
 			products: [],
 			loaded: false,
 		};
+
+		this.debouncedGetProducts = debounce( this.getProducts.bind( this ), 200 );
 	}
 
 	componentDidMount() {
@@ -49,13 +52,16 @@ class ProductNewestBlock extends Component {
 			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
 		}, false );
 		if ( hasChange ) {
-			this.getProducts();
+			this.debouncedGetProducts();
 		}
 	}
 
 	getProducts() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
+			path: addQueryArgs(
+				'/wc-pb/v3/products',
+				getQuery( this.props.attributes, this.props.name )
+			),
 		} )
 			.then( ( products ) => {
 				this.setState( { products, loaded: true } );
@@ -143,10 +149,7 @@ class ProductNewestBlock extends Component {
 					) : (
 						<Placeholder
 							icon={ <Gridicon icon="notice-outline" /> }
-							label={ __(
-								'Newest Products',
-								'woo-gutenberg-products-block'
-							) }
+							label={ __( 'Newest Products', 'woo-gutenberg-products-block' ) }
 						>
 							{ ! loaded ? (
 								<Spinner />

--- a/assets/js/product-on-sale.js
+++ b/assets/js/product-on-sale.js
@@ -10,6 +10,7 @@ import {
 	InspectorControls,
 } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
+import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
 import {
 	PanelBody,
@@ -37,6 +38,8 @@ class ProductOnSaleBlock extends Component {
 			products: [],
 			loaded: false,
 		};
+
+		this.debouncedGetProducts = debounce( this.getProducts.bind( this ), 200 );
 	}
 
 	componentDidMount() {
@@ -54,7 +57,7 @@ class ProductOnSaleBlock extends Component {
 			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
 		}, false );
 		if ( hasChange ) {
-			this.getProducts();
+			this.debouncedGetProducts();
 		}
 	}
 

--- a/assets/js/product-top-rated.js
+++ b/assets/js/product-top-rated.js
@@ -10,6 +10,7 @@ import {
 	InspectorControls,
 } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
+import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
 import {
 	PanelBody,
@@ -36,6 +37,8 @@ class ProductTopRatedBlock extends Component {
 			products: [],
 			loaded: false,
 		};
+
+		this.debouncedGetProducts = debounce( this.getProducts.bind( this ), 200 );
 	}
 
 	componentDidMount() {
@@ -49,13 +52,16 @@ class ProductTopRatedBlock extends Component {
 			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
 		}, false );
 		if ( hasChange ) {
-			this.getProducts();
+			this.debouncedGetProducts();
 		}
 	}
 
 	getProducts() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', getQuery( this.props.attributes, this.props.name ) ),
+			path: addQueryArgs(
+				'/wc-pb/v3/products',
+				getQuery( this.props.attributes, this.props.name )
+			),
 		} )
 			.then( ( products ) => {
 				this.setState( { products, loaded: true } );
@@ -143,10 +149,7 @@ class ProductTopRatedBlock extends Component {
 					) : (
 						<Placeholder
 							icon={ <Gridicon icon="trophy" /> }
-							label={ __(
-								'Top Rated Products',
-								'woo-gutenberg-products-block'
-							) }
+							label={ __( 'Top Rated Products', 'woo-gutenberg-products-block' ) }
 						>
 							{ ! loaded ? (
 								<Spinner />


### PR DESCRIPTION
Fixes #222 – By click+dragging the columns slider from X to 1, you actually fire off API requests for each column interval between X to 1, but those responses don't necessarily come back in the right order. So with row = 1, if you drag down from col = 4 to col = 1, the API replies with 3 items, 2 items, and 1 item -- but if the 3 item response comes in last, that's what the preview will display, despite col = 1.

This PR adds a debounce wrapper around `getProducts` for each block, for just 200ms, which is enough to cancel out the intermediate steps when dragging the slider.

### How to test the changes in this Pull Request:

1. In any product block, set rows = 1 and columns = 6
2. Pull the column slider down to 1 with the mouse
3. Expect: The block preview should only show one item
4. Try again by setting rows = 6 and columns = 6
5. Pull the rows slider down to 1 with the mouse
6. Expect: 1 row of items
