### PR TITLE
Update SearchListControl hierarchical items style

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -57,3 +57,15 @@
 	margin: unset;
 	overflow: hidden;
 }
+
+// Create a string-repeat function
+@function repeat($character, $n) {
+	@if $n == 0 {
+		@return "";
+	}
+	$c: "";
+	@for $i from 1 through $n {
+		$c: $c + $character;
+	}
+	@return $c;
+}

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -110,13 +110,19 @@
 		}
 
 		// Anything deeper than 5 levels will use this fallback depth
-		&[class*="depth-"] .woocommerce-search-list__item-label {
-			padding-left: $gap-small * 5;
+		&[class*="depth-"] .woocommerce-search-list__item-label:before {
+			margin-right: $gap-smallest;
+			content: repeat( '— ', 5 );
 		}
 
-		@for $i from 0 to 5 {
-			&.depth-#{$i} .woocommerce-search-list__item-label {
-				padding-left: $gap-small * $i;
+		&.depth-0 .woocommerce-search-list__item-label:before {
+			margin-right: 0;
+			content: '';
+		}
+
+		@for $i from 1 to 5 {
+			&.depth-#{$i} .woocommerce-search-list__item-label:before {
+				content: repeat( '— ', $i );
 			}
 		}
 
@@ -131,11 +137,16 @@
 
 		&.is-searching,
 		&.is-skip-level {
-			.woocommerce-search-list__item-prefix {
+			.woocommerce-search-list__item-label {
+				// Un-flex the label, so the prefix (breadcrumbs) and name are aligned.
 				display: inline-block;
-				margin-right: $gap-smallest;
+			}
+
+			.woocommerce-search-list__item-prefix {
+				display: inline;
 
 				&:after {
+					margin-right: $gap-smallest;
 					content: " ›";
 				}
 			}


### PR DESCRIPTION
Fixes #237– use em-dashes to indent hierarchical items in the search list.

### Screenshots

Items now look like this:

![screen shot 2018-12-18 at 6 21 18 pm](https://user-images.githubusercontent.com/541093/50189054-cced7a00-02f1-11e9-9172-52904b507c92.png)

When searching, we switch back to no indentation & display the parent items ghosted out slightly:

![screen shot 2018-12-18 at 6 21 27 pm](https://user-images.githubusercontent.com/541093/50189053-cced7a00-02f1-11e9-81ac-7132ae833600.png)

This also fixes a display issue when searching in the inspector

![screen shot 2018-12-18 at 6 22 44 pm](https://user-images.githubusercontent.com/541093/50189131-0c1bcb00-02f2-11e9-831e-f42ce667c3d4.png)

### How to test the changes in this Pull Request:

1. Add Products By Category, or any other block that allows filtering by category
2. View the category selection in either edit mode or the sidebar
3. Expect: child categories should be indented under the parent category with up to 5 `—`s
4. Expect: searching and selecting categories should still work
