### PR TITLE
Add ProductAttributeControl for selecting product attributes

### DIFF
--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import { Component } from '@wordpress/element';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import SearchListControl from '../search-list-control';
+import SearchListItem from '../search-list-control/item';
+
+class ProductAttributeControl extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			list: [],
+			loading: true,
+		};
+	}
+
+	componentDidMount() {
+		apiFetch( {
+			path: addQueryArgs( '/wc-pb/v3/products/attributes', { per_page: -1 } ),
+		} )
+			.then( ( attributes ) => {
+				Promise.all(
+					attributes.map( ( attribute ) =>
+						apiFetch( {
+							path: addQueryArgs(
+								`/wc-pb/v3/products/attributes/${ attribute.id }/terms`,
+								{
+									per_page: -1,
+								}
+							),
+						} ).then( ( terms ) =>
+							terms.map( ( t ) => ( { ...t, parent: attribute.id } ) )
+						)
+					)
+				).then( ( results ) => {
+					const list = attributes.map( ( a ) => ( { ...a, parent: 0 } ) );
+					results.forEach( ( terms ) => {
+						list.push( ...terms );
+					} );
+					this.setState( { list, loading: false } );
+				} );
+			} )
+			.catch( () => {
+				this.setState( { list: [], loading: false } );
+			} );
+	}
+
+	renderItem( args ) {
+		const { item, search, depth = 0 } = args;
+		const classes = [ 'woocommerce-product-attributes__item' ];
+		if ( search.length ) {
+			classes.push( 'is-searching' );
+		}
+		if ( depth === 0 && item.parent !== 0 ) {
+			classes.push( 'is-skip-level' );
+		}
+
+		const accessibleName = ! item.breadcrumbs.length ?
+			item.name :
+			`${ item.breadcrumbs[ 0 ] }: ${ item.name }`;
+
+		return (
+			<SearchListItem
+				className={ classes.join( ' ' ) }
+				{ ...args }
+				aria-label={ accessibleName }
+			/>
+		);
+	}
+
+	render() {
+		const { list, loading } = this.state;
+		const { selected, onChange } = this.props;
+
+		const messages = {
+			clear: __( 'Clear all product attributes', 'woo-gutenberg-products-block' ),
+			list: __( 'Product Attributes', 'woo-gutenberg-products-block' ),
+			noItems: __(
+				"Your store doesn't have any product attributes.",
+				'woo-gutenberg-products-block'
+			),
+			search: __(
+				'Search for product attributes',
+				'woo-gutenberg-products-block'
+			),
+			selected: ( n ) =>
+				sprintf(
+					_n(
+						'%d attribute selected',
+						'%d attributes selected',
+						n,
+						'woo-gutenberg-products-block'
+					),
+					n
+				),
+			updated: __(
+				'Product attribute search results updated.',
+				'woo-gutenberg-products-block'
+			),
+		};
+
+		return (
+			<SearchListControl
+				className="woocommerce-product-attributes"
+				list={ list }
+				isLoading={ loading }
+				selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
+				onChange={ onChange }
+				renderItem={ this.renderItem }
+				messages={ messages }
+				isHierarchical
+			/>
+		);
+	}
+}
+
+ProductAttributeControl.propTypes = {
+	/**
+	 * Callback to update the selected product categories.
+	 */
+	onChange: PropTypes.func.isRequired,
+	/**
+	 * The list of currently selected category IDs.
+	 */
+	selected: PropTypes.array.isRequired,
+};
+
+export default ProductAttributeControl;

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -124,7 +124,7 @@ class ProductAttributeControl extends Component {
 				className="woocommerce-product-attributes"
 				list={ list }
 				isLoading={ loading }
-				selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
+				selected={ selected.map( ( { id } ) => find( list, { id } ) ).filter( Boolean ) }
 				onChange={ onChange }
 				renderItem={ this.renderItem }
 				messages={ messages }

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -136,11 +136,11 @@ class ProductAttributeControl extends Component {
 
 ProductAttributeControl.propTypes = {
 	/**
-	 * Callback to update the selected product categories.
+	 * Callback to update the selected product attributes.
 	 */
 	onChange: PropTypes.func.isRequired,
 	/**
-	 * The list of currently selected category IDs.
+	 * The list of currently selected attribute slug/ID pairs.
 	 */
 	selected: PropTypes.array.isRequired,
 };

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -57,7 +57,7 @@ class ProductAttributeControl extends Component {
 
 	renderItem( args ) {
 		const { item, search, depth = 0 } = args;
-		const classes = [ 'woocommerce-product-attributes__item' ];
+		const classes = [ 'woocommerce-product-attributes__item', 'woocommerce-search-list__item' ];
 		if ( search.length ) {
 			classes.push( 'is-searching' );
 		}
@@ -65,15 +65,25 @@ class ProductAttributeControl extends Component {
 			classes.push( 'is-skip-level' );
 		}
 
-		const accessibleName = ! item.breadcrumbs.length ?
-			item.name :
-			`${ item.breadcrumbs[ 0 ] }: ${ item.name }`;
+		if ( ! item.breadcrumbs.length ) {
+			classes.push( 'is-not-active' );
+			return (
+				<div className={ classes.join( ' ' ) }>
+					<span className="woocommerce-search-list__item-label">
+						<span className="woocommerce-search-list__item-name">
+							{ item.name }
+						</span>
+					</span>
+				</div>
+			);
+		}
 
 		return (
 			<SearchListItem
 				className={ classes.join( ' ' ) }
 				{ ...args }
-				aria-label={ accessibleName }
+				showCount
+				aria-label={ `${ item.breadcrumbs[ 0 ] }: ${ item.name }` }
 			/>
 		);
 	}

--- a/assets/js/components/product-attribute-control/style.scss
+++ b/assets/js/components/product-attribute-control/style.scss
@@ -5,4 +5,10 @@
 			content: ":";
 		}
 	}
+
+	&.is-not-active {
+		@include hover-state {
+			background: transparent;
+		}
+	}
 }

--- a/assets/js/components/product-attribute-control/style.scss
+++ b/assets/js/components/product-attribute-control/style.scss
@@ -1,0 +1,8 @@
+.woocommerce-search-list__item.woocommerce-product-attributes__item {
+	&.is-searching,
+	&.is-skip-level {
+		.woocommerce-search-list__item-prefix:after {
+			content: ":";
+		}
+	}
+}

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -95,7 +95,7 @@
 			background: $core-grey-light-100;
 		}
 
-		&:last-of-type {
+		&:last-child {
 			border-bottom: none !important;
 		}
 

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from './utils/get-query';
+import ProductAttributeControl from './components/product-attribute-control';
 import ProductCategoryControl from './components/product-category-control';
 import ProductOrderbyControl from './components/product-orderby-control';
 import ProductPreview from './components/product-preview';
@@ -100,6 +101,18 @@ class ProductByCategoryBlock extends Component {
 						onOperatorChange={ ( value = 'any' ) =>
 							setAttributes( { catOperator: value } )
 						}
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Product Attributes', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
+					<ProductAttributeControl
+						selected={ attributes.attributes }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id, attr_slug } ) => ( { id, attr_slug } ) ); // eslint-disable-line camelcase
+							setAttributes( { attributes: ids } );
+						} }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -104,18 +104,6 @@ class ProductByCategoryBlock extends Component {
 					/>
 				</PanelBody>
 				<PanelBody
-					title={ __( 'Product Attributes', 'woo-gutenberg-products-block' ) }
-					initialOpen={ false }
-				>
-					<ProductAttributeControl
-						selected={ attributes.attributes }
-						onChange={ ( value = [] ) => {
-							const selected = value.map( ( { id, attr_slug } ) => ( { id, attr_slug } ) ); // eslint-disable-line camelcase
-							setAttributes( { attributes: selected } );
-						} }
-					/>
-				</PanelBody>
-				<PanelBody
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
@@ -141,6 +129,18 @@ class ProductByCategoryBlock extends Component {
 					<ProductOrderbyControl
 						setAttributes={ setAttributes }
 						value={ orderby }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Filter by Attribute', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
+					<ProductAttributeControl
+						selected={ attributes.attributes }
+						onChange={ ( value = [] ) => {
+							const selected = value.map( ( { id, attr_slug } ) => ( { id, attr_slug } ) ); // eslint-disable-line camelcase
+							setAttributes( { attributes: selected } );
+						} }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -110,8 +110,8 @@ class ProductByCategoryBlock extends Component {
 					<ProductAttributeControl
 						selected={ attributes.attributes }
 						onChange={ ( value = [] ) => {
-							const ids = value.map( ( { id, attr_slug } ) => ( { id, attr_slug } ) ); // eslint-disable-line camelcase
-							setAttributes( { attributes: ids } );
+							const selected = value.map( ( { id, attr_slug } ) => ( { id, attr_slug } ) ); // eslint-disable-line camelcase
+							setAttributes( { attributes: selected } );
 						} }
 					/>
 				</PanelBody>

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -37,4 +37,12 @@ export default {
 		type: 'string',
 		default: 'any',
 	},
+
+	/**
+	 * Product attributes, used to display only products with the given attributes.
+	 */
+	attributes: {
+		type: 'array',
+		default: [],
+	},
 };


### PR DESCRIPTION
Builds on #265, Fixes #240 – Add a new component for `ProductAttributeControl`, using the `SearchListControl` just like `ProductCategoryControl`. This PR adds the component, and sets it up on the Products By Category component– but it isn't hooked up to the API or saving method yet.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

![screen shot 2018-12-18 at 6 39 27 pm](https://user-images.githubusercontent.com/541093/50189686-4c7c4880-02f4-11e9-9660-5a7f12605a07.png)

### How to test the changes in this Pull Request:

1. Add a Products by Category block
2. Open the Product Attributes panel
3. Expect: Your product attributes should display in the list, with the terms selectable, and the "group names" not selectable.
4. Click an attribute
5. Expect: It should become selected, and show in the "1 attribute selected" section. You should be able to remove the attribute here.
6. With at least 1 attribute selected, save the post
7. Reload the edit page/navigate away and come back
8. Open the Product Attributes panel again
9. Expect: It should save your selected attributes