### PR TITLE
Fix "products by all categories" not finding products in parent-categories

### DIFF
--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -244,7 +244,8 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 		if ( $cat_operator && isset( $args['tax_query'] ) ) {
 			foreach ( $args['tax_query'] as $i => $tax_query ) {
 				if ( 'product_cat' === $tax_query['taxonomy'] ) {
-					$args['tax_query'][ $i ]['operator'] = $cat_operator;
+					$args['tax_query'][ $i ]['operator']         = $cat_operator;
+					$args['tax_query'][ $i ]['include_children'] = 'AND' === $cat_operator ? false : true;
 				}
 			}
 		}

--- a/tests/api/products-categories.php
+++ b/tests/api/products-categories.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Product Controller "products by categories" REST API Test
+ *
+ * @since 1.2.0
+ */
+class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-pb/v3';
+
+	/**
+	 * Setup test products data. Called before every test.
+	 *
+	 * @since 1.2.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		// Create 3 product categories.
+		$parent           = wp_insert_term( 'Parent Category', 'product_cat' );
+		$child            = wp_insert_term(
+			'Child Category',
+			'product_cat',
+			array( 'parent' => $parent['term_id'] )
+		);
+		$single           = wp_insert_term( 'Standalone Category', 'product_cat' );
+		$this->categories = array(
+			'parent' => $parent,
+			'child'  => $child,
+			'single' => $single,
+		);
+
+		// Create two products, one with 'parent', and one with 'single'.
+		$this->products    = array();
+		$this->products[0] = WC_Helper_Product::create_simple_product( false );
+		$this->products[0]->set_category_ids( array( $parent['term_id'] ) );
+		$this->products[0]->save();
+
+		$this->products[1] = WC_Helper_Product::create_simple_product( false );
+		$this->products[1]->set_category_ids( array( $single['term_id'] ) );
+		$this->products[1]->save();
+
+		$this->products[2] = WC_Helper_Product::create_simple_product( false );
+		$this->products[2]->set_category_ids( array( $child['term_id'], $single['term_id'] ) );
+		$this->products[2]->save();
+
+		$this->products[3] = WC_Helper_Product::create_simple_product( false );
+		$this->products[3]->set_category_ids( array( $parent['term_id'], $single['term_id'] ) );
+		$this->products[3]->save();
+	}
+
+	/**
+	 * Test product category intersection: Any product in either Single or Parent (4).
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_products_in_any_categories_parent() {
+		wp_set_current_user( $this->user );
+
+		$cats = $this->categories['parent']['term_id'] . ',' . $this->categories['single']['term_id'];
+
+		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request->set_param( 'category', $cats );
+		$request->set_param( 'cat_operator', 'IN' );
+
+		$response          = $this->server->dispatch( $request );
+		$response_products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 4, count( $response_products ) );
+	}
+
+	/**
+	 * Test product category intersection: Any product in either Single or Child (3).
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_products_in_any_categories_child() {
+		wp_set_current_user( $this->user );
+
+		$cats = $this->categories['child']['term_id'] . ',' . $this->categories['single']['term_id'];
+
+		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request->set_param( 'category', $cats );
+		$request->set_param( 'cat_operator', 'IN' );
+
+		$response          = $this->server->dispatch( $request );
+		$response_products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 3, count( $response_products ) );
+	}
+
+	/**
+	 * Test product category intersection: Any product in both Single and Child (1).
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_products_in_all_categories_child() {
+		wp_set_current_user( $this->user );
+
+		$cats = $this->categories['child']['term_id'] . ',' . $this->categories['single']['term_id'];
+
+		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request->set_param( 'category', $cats );
+		$request->set_param( 'cat_operator', 'AND' );
+
+		$response          = $this->server->dispatch( $request );
+		$response_products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $response_products ) );
+	}
+
+	/**
+	 * Test product category intersection: Any product in both Single and Parent (1).
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_products_in_all_categories_parent() {
+		wp_set_current_user( $this->user );
+
+		$cats = $this->categories['parent']['term_id'] . ',' . $this->categories['single']['term_id'];
+
+		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request->set_param( 'category', $cats );
+		$request->set_param( 'cat_operator', 'AND' );
+
+		$response          = $this->server->dispatch( $request );
+		$response_products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $response_products ) );
+	}
+}

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -251,10 +251,13 @@ function wgpb_extra_shortcode_features( $args, $attributes, $type ) {
 			$field      = 'term_id';
 		}
 		$args['tax_query'][] = array(
-			'taxonomy' => 'product_cat',
-			'terms'    => $categories,
-			'field'    => $field,
-			'operator' => $attributes['cat_operator'],
+			'taxonomy'         => 'product_cat',
+			'terms'            => $categories,
+			'field'            => $field,
+			'operator'         => $attributes['cat_operator'],
+
+			// See https://github.com/woocommerce/woocommerce/pull/20207/files#diff-9982e2749834d5232f1ed411b6c20312.
+			'include_children' => 'AND' === $attributes['cat_operator'] ? false : true,
 		);
 	}
 


### PR DESCRIPTION
Fixes #269 – For some reason, getting products with "all categories" when one category is a parent fails and returns no items. Looking at https://github.com/woocommerce/woocommerce/pull/20207/, it seems we need to add `include_children=false` when using the "all categories" setting, so this PR adds that to the API and shortcode.

I've also added a test suite to check that requesting products by different categories works as expected.

### How to test the changes in this Pull Request:

1. Create at least 3 categories, two top-level categories, one of those with a child category (and one with no children).
2. Add products to these categories, with a few overlapping the two top-level categories.
2. View the Products By Category block, select both top-level categories
3. Set "Display products matching" to all categories
4. Click Done
5. Expect: You should see the products that have both categories.
