### PR TITLE
Fix the spacing around the “edit mode” of Products by Category

### DIFF
--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -133,7 +133,7 @@ class ProductByCategoryBlock extends Component {
 			<Placeholder
 				icon="category"
 				label={ __( 'Products by Category', 'woo-gutenberg-products-block' ) }
-				className="wc-block-products-category"
+				className="wc-block-products-grid wc-block-products-category"
 			>
 				{ __(
 					'Display a grid of products from your selected categories',


### PR DESCRIPTION
At some point, the class wrapper changed & the padding is no longer being applied to the "edit mode" of Products by Category. This PR adds the new shared class to to the edit mode placeholder.

Before:
<img width="584" alt="before" src="https://user-images.githubusercontent.com/541093/50237143-25705600-038a-11e9-8f83-b0080e20e2fd.png">

After:
<img width="584" alt="after" src="https://user-images.githubusercontent.com/541093/50237144-25705600-038a-11e9-87ef-dd8bb5a68a0f.png">

### How to test the changes in this Pull Request:

1. Add Products by Category block
2. Expect: There should be 2em of padding at the top/bottom of the grey box
