### PR TITLE
New block: add "Hand-picked Products" block

### DIFF
--- a/assets/css/product-category-block.scss
+++ b/assets/css/product-category-block.scss
@@ -52,7 +52,8 @@
 	}
 }
 
-.wc-block-products-category__selection {
+.wc-block-products-category__selection,
+.wc-block-handpicked-products__selection {
 	width: 100%;
 }
 

--- a/assets/js/components/icons/index.js
+++ b/assets/js/components/icons/index.js
@@ -70,3 +70,19 @@ export const IconNewReleases = () => (
 		}
 	/>
 );
+
+export const IconWidgets = () => (
+	<Icon
+		icon={
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+			>
+				<path d="M13 13v8h8v-8h-8zM3 21h8v-8H3v8zM3 3v8h8V3H3zm13.66-1.31L11 7.34 16.66 13l5.66-5.66-5.66-5.65z" />
+				<path d="M0 0h24v24H0z" fill="none" />
+			</svg>
+		}
+	/>
+);

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import { Component, Fragment } from '@wordpress/element';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import SearchListControl from '../search-list-control';
+
+class ProductsControl extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			list: [],
+			loading: true,
+		};
+	}
+
+	componentDidMount() {
+		apiFetch( {
+			path: addQueryArgs( '/wc-pb/v3/products', { per_page: -1, status: 'publish' } ),
+		} )
+			.then( ( list ) => {
+				this.setState( { list, loading: false } );
+			} )
+			.catch( () => {
+				this.setState( { list: [], loading: false } );
+			} );
+	}
+
+	render() {
+		const { list, loading } = this.state;
+		const { onChange, selected } = this.props;
+
+		const messages = {
+			clear: __( 'Clear all products', 'woo-gutenberg-products-block' ),
+			list: __( 'Products', 'woo-gutenberg-products-block' ),
+			noItems: __(
+				"Your store doesn't have any products.",
+				'woo-gutenberg-products-block'
+			),
+			search: __(
+				'Search for products to display',
+				'woo-gutenberg-products-block'
+			),
+			selected: ( n ) =>
+				sprintf(
+					_n(
+						'%d product selected',
+						'%d products selected',
+						n,
+						'woo-gutenberg-products-block'
+					),
+					n
+				),
+			updated: __(
+				'Product search results updated.',
+				'woo-gutenberg-products-block'
+			),
+		};
+
+		return (
+			<Fragment>
+				<SearchListControl
+					className="woocommerce-products"
+					list={ list }
+					isLoading={ loading }
+					selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
+					onChange={ onChange }
+					messages={ messages }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+ProductsControl.propTypes = {
+	/**
+	 * Callback to update the selected products.
+	 */
+	onChange: PropTypes.func.isRequired,
+	/**
+	 * The list of currently selected IDs.
+	 */
+	selected: PropTypes.array.isRequired,
+};
+
+export default ProductsControl;

--- a/assets/js/handpicked-products.js
+++ b/assets/js/handpicked-products.js
@@ -1,0 +1,251 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	BlockAlignmentToolbar,
+	BlockControls,
+	InspectorControls,
+} from '@wordpress/editor';
+import {
+	Button,
+	PanelBody,
+	Placeholder,
+	RangeControl,
+	Spinner,
+	Toolbar,
+	withSpokenMessages,
+} from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { debounce } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import getQuery from './utils/get-query';
+import ProductsControl from './components/products-control';
+import ProductOrderbyControl from './components/product-orderby-control';
+import ProductPreview from './components/product-preview';
+
+/**
+ * Component to handle edit mode of "Hand-picked Products".
+ */
+class ProductsBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			products: [],
+			loaded: false,
+		};
+
+		this.debouncedGetProducts = debounce( this.getProducts.bind( this ), 200 );
+	}
+
+	componentDidMount() {
+		if ( this.props.attributes.products ) {
+			this.getProducts();
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const hasChange = [ 'products', 'columns', 'orderby', 'rows' ].reduce(
+			( acc, key ) => {
+				return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
+			},
+			false
+		);
+		if ( hasChange ) {
+			this.debouncedGetProducts();
+		}
+	}
+
+	getProducts() {
+		apiFetch( {
+			path: addQueryArgs(
+				'/wc-pb/v3/products',
+				getQuery( this.props.attributes, this.props.name )
+			),
+		} )
+			.then( ( products ) => {
+				this.setState( { products, loaded: true } );
+			} )
+			.catch( () => {
+				this.setState( { products: [], loaded: true } );
+			} );
+	}
+
+	getInspectorControls() {
+		const { attributes, setAttributes } = this.props;
+		const { columns, orderby, rows } = attributes;
+
+		return (
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<RangeControl
+						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+						value={ columns }
+						onChange={ ( value ) => setAttributes( { columns: value } ) }
+						min={ wc_product_block_data.min_columns }
+						max={ wc_product_block_data.max_columns }
+					/>
+					<RangeControl
+						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
+						value={ rows }
+						onChange={ ( value ) => setAttributes( { rows: value } ) }
+						min={ wc_product_block_data.min_rows }
+						max={ wc_product_block_data.max_rows }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
+					<ProductOrderbyControl
+						setAttributes={ setAttributes }
+						value={ orderby }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Products', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
+					<ProductsControl
+						selected={ attributes.products }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { products: ids } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	renderEditMode() {
+		const { attributes, debouncedSpeak, setAttributes } = this.props;
+		const onDone = () => {
+			setAttributes( { editMode: false } );
+			debouncedSpeak(
+				__( 'Showing product block preview.', 'woo-gutenberg-products-block' )
+			);
+		};
+
+		return (
+			<Placeholder
+				icon="category"
+				label={ __( 'Hand-picked Products', 'woo-gutenberg-products-block' ) }
+				className="wc-block-products-grid wc-block-handpicked-products"
+			>
+				{ __(
+					'Display a selection of hand-picked products in a grid',
+					'woo-gutenberg-products-block'
+				) }
+				<div className="wc-block-handpicked-products__selection">
+					<ProductsControl
+						selected={ attributes.products }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							setAttributes( { products: ids } );
+						} }
+					/>
+					<Button isDefault onClick={ onDone }>
+						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+					</Button>
+				</div>
+			</Placeholder>
+		);
+	}
+
+	render() {
+		const { setAttributes } = this.props;
+		const { align, columns, editMode } = this.props.attributes;
+		const { loaded, products } = this.state;
+		const classes = [ 'wc-block-products-grid', 'wc-block-handpicked-products' ];
+		if ( columns ) {
+			classes.push( `cols-${ columns }` );
+		}
+		if ( products && ! products.length ) {
+			if ( ! loaded ) {
+				classes.push( 'is-loading' );
+			} else {
+				classes.push( 'is-not-found' );
+			}
+		}
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<BlockAlignmentToolbar
+						controls={ [ 'wide', 'full' ] }
+						value={ align }
+						onChange={ ( nextAlign ) => setAttributes( { align: nextAlign } ) }
+					/>
+					<Toolbar
+						controls={ [
+							{
+								icon: 'edit',
+								title: __( 'Edit' ),
+								onClick: () => setAttributes( { editMode: ! editMode } ),
+								isActive: editMode,
+							},
+						] }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				{ editMode ? (
+					this.renderEditMode()
+				) : (
+					<div className={ classes.join( ' ' ) }>
+						{ products.length ? (
+							products.map( ( product ) => (
+								<ProductPreview product={ product } key={ product.id } />
+							) )
+						) : (
+							<Placeholder
+								icon="category"
+								label={ __(
+									'Hand-picked Products',
+									'woo-gutenberg-products-block'
+								) }
+							>
+								{ ! loaded ? (
+									<Spinner />
+								) : (
+									__(
+										'No products are selected.',
+										'woo-gutenberg-products-block'
+									)
+								) }
+							</Placeholder>
+						) }
+					</div>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+ProductsBlock.propTypes = {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: PropTypes.func.isRequired,
+	// from withSpokenMessages
+	debouncedSpeak: PropTypes.func.isRequired,
+};
+
+export default withSpokenMessages( ProductsBlock );

--- a/assets/js/handpicked-products.js
+++ b/assets/js/handpicked-products.js
@@ -46,9 +46,7 @@ class ProductsBlock extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.attributes.products ) {
-			this.getProducts();
-		}
+		this.getProducts();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -64,6 +62,11 @@ class ProductsBlock extends Component {
 	}
 
 	getProducts() {
+		if ( ! this.props.attributes.products.length ) {
+			// We've removed all selected products, or products haven't been selected yet.
+			this.setState( { products: [], loaded: true } );
+			return;
+		}
 		apiFetch( {
 			path: addQueryArgs(
 				'/wc-pb/v3/products',

--- a/assets/js/handpicked-products.js
+++ b/assets/js/handpicked-products.js
@@ -129,7 +129,7 @@ class ProductsBlock extends Component {
 		const onDone = () => {
 			setAttributes( { editMode: false } );
 			debouncedSpeak(
-				__( 'Showing product block preview.', 'woo-gutenberg-products-block' )
+				__( 'Showing Hand-picked Products block preview.', 'woo-gutenberg-products-block' )
 			);
 		};
 

--- a/assets/js/handpicked-products.js
+++ b/assets/js/handpicked-products.js
@@ -50,7 +50,7 @@ class ProductsBlock extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const hasChange = [ 'products', 'columns', 'orderby', 'rows' ].reduce(
+		const hasChange = [ 'products', 'columns', 'orderby' ].reduce(
 			( acc, key ) => {
 				return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
 			},
@@ -83,7 +83,7 @@ class ProductsBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, orderby, rows } = attributes;
+		const { columns, orderby } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -97,13 +97,6 @@ class ProductsBlock extends Component {
 						onChange={ ( value ) => setAttributes( { columns: value } ) }
 						min={ wc_product_block_data.min_columns }
 						max={ wc_product_block_data.max_columns }
-					/>
-					<RangeControl
-						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
-						value={ rows }
-						onChange={ ( value ) => setAttributes( { rows: value } ) }
-						min={ wc_product_block_data.min_rows }
-						max={ wc_product_block_data.max_rows }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/handpicked-products.js
+++ b/assets/js/handpicked-products.js
@@ -163,11 +163,12 @@ class ProductsBlock extends Component {
 		const { setAttributes } = this.props;
 		const { align, columns, editMode } = this.props.attributes;
 		const { loaded, products } = this.state;
+		const hasSelectedProducts = products && products.length;
 		const classes = [ 'wc-block-products-grid', 'wc-block-handpicked-products' ];
 		if ( columns ) {
 			classes.push( `cols-${ columns }` );
 		}
-		if ( products && ! products.length ) {
+		if ( ! hasSelectedProducts ) {
 			if ( ! loaded ) {
 				classes.push( 'is-loading' );
 			} else {
@@ -199,7 +200,7 @@ class ProductsBlock extends Component {
 					this.renderEditMode()
 				) : (
 					<div className={ classes.join( ' ' ) }>
-						{ products.length ? (
+						{ hasSelectedProducts ? (
 							products.map( ( product ) => (
 								<ProductPreview product={ product } key={ product.id } />
 							) )

--- a/assets/js/handpicked-products.js
+++ b/assets/js/handpicked-products.js
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from './utils/get-query';
+import { IconWidgets } from './components/icons';
 import ProductsControl from './components/products-control';
 import ProductOrderbyControl from './components/product-orderby-control';
 import ProductPreview from './components/product-preview';
@@ -138,7 +139,7 @@ class ProductsBlock extends Component {
 
 		return (
 			<Placeholder
-				icon="category"
+				icon={ <IconWidgets /> }
 				label={ __( 'Hand-picked Products', 'woo-gutenberg-products-block' ) }
 				className="wc-block-products-grid wc-block-handpicked-products"
 			>
@@ -208,7 +209,7 @@ class ProductsBlock extends Component {
 							) )
 						) : (
 							<Placeholder
-								icon="category"
+								icon={ <IconWidgets /> }
 								label={ __(
 									'Hand-picked Products',
 									'woo-gutenberg-products-block'

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -246,7 +246,7 @@ registerBlockType( 'woocommerce/product-new', {
 } );
 
 /**
- * Register and run the "Products by Category" block.
+ * Register and run the "Hand-picked Products" block.
  */
 registerBlockType( 'woocommerce/handpicked-products', {
 	title: __( 'Hand-picked Products', 'woo-gutenberg-products-block' ),

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -16,6 +16,7 @@ import ProductByCategoryBlock from './product-category-block';
 import ProductTopRatedBlock from './product-top-rated';
 import ProductOnSaleBlock from './product-on-sale';
 import ProductNewestBlock from './product-new';
+import ProductsBlock from './handpicked-products';
 import sharedAttributes from './utils/shared-attributes';
 
 const validAlignments = [ 'wide', 'full' ];
@@ -238,6 +239,92 @@ registerBlockType( 'woocommerce/product-new', {
 		return (
 			<RawHTML className={ align ? `align${ align }` : '' }>
 				{ getShortcode( props, 'woocommerce/product-new' ) }
+			</RawHTML>
+		);
+	},
+} );
+
+/**
+ * Register and run the "Products by Category" block.
+ */
+registerBlockType( 'woocommerce/handpicked-products', {
+	title: __( 'Hand-picked Products', 'woo-gutenberg-products-block' ),
+	icon: 'category',
+	category: 'woocommerce',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a selection of hand-picked products in a grid.',
+		'woo-gutenberg-products-block'
+	),
+	attributes: {
+		/**
+		 * Alignment of product grid
+		 */
+		align: {
+			type: 'string',
+		},
+
+		/**
+		 * Number of columns.
+		 */
+		columns: {
+			type: 'number',
+			default: wc_product_block_data.default_columns,
+		},
+
+		/**
+		 * Number of rows.
+		 */
+		rows: {
+			type: 'number',
+			default: wc_product_block_data.default_rows,
+		},
+
+		/**
+		 * Toggle for edit mode in the block preview.
+		 */
+		editMode: {
+			type: 'boolean',
+			default: true,
+		},
+
+		/**
+		 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
+		 */
+		orderby: {
+			type: 'string',
+			default: 'date',
+		},
+
+		/**
+		 * The list of product IDs to display
+		 */
+		products: {
+			type: 'array',
+			default: [],
+		},
+	},
+	getEditWrapperProps,
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <ProductsBlock { ...props } />;
+	},
+
+	/**
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
+	 */
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props, 'woocommerce/handpicked-products' ) }
 			</RawHTML>
 		);
 	},

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -274,14 +274,6 @@ registerBlockType( 'woocommerce/handpicked-products', {
 		},
 
 		/**
-		 * Number of rows.
-		 */
-		rows: {
-			type: 'number',
-			default: wc_product_block_data.default_rows,
-		},
-
-		/**
 		 * Toggle for edit mode in the block preview.
 		 */
 		editMode: {

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -11,6 +11,7 @@ import { RawHTML } from '@wordpress/element';
  */
 import '../css/product-category-block.scss';
 import getShortcode from './utils/get-shortcode';
+import { IconNewReleases, IconWidgets } from './components/icons';
 import ProductBestSellersBlock from './product-best-sellers';
 import ProductByCategoryBlock from './product-category-block';
 import ProductTopRatedBlock from './product-top-rated';
@@ -208,7 +209,7 @@ registerBlockType( 'woocommerce/product-on-sale', {
 
 registerBlockType( 'woocommerce/product-new', {
 	title: __( 'Newest Products', 'woo-gutenberg-products-block' ),
-	icon: <Gridicon icon="notice" />,
+	icon: <IconNewReleases />,
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
@@ -249,7 +250,7 @@ registerBlockType( 'woocommerce/product-new', {
  */
 registerBlockType( 'woocommerce/handpicked-products', {
 	title: __( 'Hand-picked Products', 'woo-gutenberg-products-block' ),
-	icon: 'category',
+	icon: <IconWidgets />,
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -139,7 +139,7 @@ class ProductByCategoryBlock extends Component {
 		const onDone = () => {
 			setAttributes( { editMode: false } );
 			debouncedSpeak(
-				__( 'Showing product block preview.', 'woo-gutenberg-products-block' )
+				__( 'Showing Products by Category block preview.', 'woo-gutenberg-products-block' )
 			);
 		};
 

--- a/assets/js/product-new.js
+++ b/assets/js/product-new.js
@@ -11,7 +11,6 @@ import {
 } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
-import Gridicon from 'gridicons';
 import {
 	PanelBody,
 	Placeholder,
@@ -24,6 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from './utils/get-query';
+import { IconNewReleases } from './components/icons';
 import ProductCategoryControl from './components/product-category-control';
 import ProductPreview from './components/product-preview';
 
@@ -148,7 +148,7 @@ class ProductNewestBlock extends Component {
 						) )
 					) : (
 						<Placeholder
-							icon={ <Gridicon icon="notice-outline" /> }
+							icon={ <IconNewReleases /> }
 							label={ __( 'Newest Products', 'woo-gutenberg-products-block' ) }
 						>
 							{ ! loaded ? (

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -31,7 +31,7 @@ export default function getQuery( attributes, name ) {
 		}
 	}
 
-	// Toggle shortcode atts depending on block type.
+	// Toggle query parameters depending on block type.
 	switch ( name ) {
 		case 'woocommerce/product-best-sellers':
 			query.orderby = 'popularity';

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -1,5 +1,5 @@
 export default function getQuery( attributes, name ) {
-	const { categories, catOperator, columns, orderby, rows } = attributes;
+	const { categories, catOperator, columns, orderby, products, rows } = attributes;
 
 	const query = {
 		status: 'publish',
@@ -44,6 +44,10 @@ export default function getQuery( attributes, name ) {
 			break;
 		case 'woocommerce/product-new':
 			query.orderby = 'date';
+			break;
+		case 'woocommerce/handpicked-products':
+			query.include = products;
+			query.per_page = products.length;
 			break;
 	}
 

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -43,6 +43,9 @@ export default function getShortcode( { attributes }, name ) {
 			shortcodeAtts.set( 'order', 'DESC' );
 			break;
 		case 'woocommerce/handpicked-products':
+			if ( ! products.length ) {
+				return '';
+			}
 			shortcodeAtts.set( 'ids', products.join( ',' ) );
 			shortcodeAtts.set( 'limit', products.length );
 			break;

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -1,5 +1,5 @@
 export default function getShortcode( { attributes }, name ) {
-	const { categories, catOperator, columns, orderby, rows } = attributes;
+	const { categories, catOperator, columns, orderby, products, rows } = attributes;
 
 	const shortcodeAtts = new Map();
 	shortcodeAtts.set( 'limit', rows * columns );
@@ -41,6 +41,10 @@ export default function getShortcode( { attributes }, name ) {
 		case 'woocommerce/product-new':
 			shortcodeAtts.set( 'orderby', 'date' );
 			shortcodeAtts.set( 'order', 'DESC' );
+			break;
+		case 'woocommerce/handpicked-products':
+			shortcodeAtts.set( 'ids', products.join( ',' ) );
+			shortcodeAtts.set( 'limit', products.length );
 			break;
 	}
 


### PR DESCRIPTION
Fixes #244, #245 – This PR adds both the ProductsControl shared component, and the Hand-picked Products block which uses that.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader –  _VoiceOver isn't working for me_ 😕 _will test later, but it's using the same patterns as previously tested components_
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![screen shot 2018-12-20 at 11 24 06 am](https://user-images.githubusercontent.com/541093/50297401-b7d82e80-044a-11e9-86ac-a93d11eb47a3.png)
![screen shot 2018-12-20 at 11 23 24 am](https://user-images.githubusercontent.com/541093/50297402-b870c500-044a-11e9-914c-27e993f2855e.png)

Note: this is using the same "columns" slider as the other blocks, rather than the S/M/L column width in the mockup– we can move to the new layout controls once we're not using the shortcode method anymore.

### How to test the changes in this Pull Request:

1. Edit a post/page/etc
2. Try to add a "Hand-picked Products" block
3. Expect: It exists, adding it should bring up the placeholder "edit mode"
4. Your products should load in, search & select some
5. Click Done
6. Expect: The block should flip to a preview, with your products displayed
7. Change the ordering, columns value, or add/remove other products in the sidebar
8. Save the post, view it
9. Expect: The same products, in the same order as the preview.
