### PR TITLE
Visually hide the “any”/“all” categories selector when less than 2 categories are selected

### DIFF
--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -12,6 +12,7 @@ import { SelectControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import './style.scss';
 import SearchListControl from '../search-list-control';
 import SearchListItem from '../search-list-control/item';
 
@@ -116,22 +117,25 @@ class ProductCategoryControl extends Component {
 					isHierarchical
 				/>
 				{ ( !! onOperatorChange ) && (
-					<SelectControl
-						className="woocommerce-product-categories__operator"
-						label={ __( 'Display products matching', 'woo-gutenberg-products-block' ) }
-						value={ operator }
-						onChange={ onOperatorChange }
-						options={ [
-							{
-								label: __( 'Any selected categories', 'woo-gutenberg-products-block' ),
-								value: 'any',
-							},
-							{
-								label: __( 'All selected categories', 'woo-gutenberg-products-block' ),
-								value: 'all',
-							},
-						] }
-					/>
+					<div className={ selected.length < 2 ? 'screen-reader-text' : '' }>
+						<SelectControl
+							className="woocommerce-product-categories__operator"
+							label={ __( 'Display products matching', 'woo-gutenberg-products-block' ) }
+							help={ __( 'Pick at least two categories to use this setting.', 'woo-gutenberg-products-block' ) }
+							value={ operator }
+							onChange={ onOperatorChange }
+							options={ [
+								{
+									label: __( 'Any selected categories', 'woo-gutenberg-products-block' ),
+									value: 'any',
+								},
+								{
+									label: __( 'All selected categories', 'woo-gutenberg-products-block' ),
+									value: 'all',
+								},
+							] }
+						/>
+					</div>
 				) }
 			</Fragment>
 		);

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -1,0 +1,5 @@
+.woocommerce-product-categories__operator {
+	.components-base-control__help {
+		@include visually-hidden;
+	}
+}


### PR DESCRIPTION
Fixes #270 – If you have less than 2 categories selected, the "Display products matching" select is hidden. I've set it to be hidden from sighted users but left for screen reader users to avoid confusion with the form changing. I've also added screen-reader only help text that says "Pick at least two categories to use this setting."

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### How to test the changes in this Pull Request:

1. Add any block with the category filter (Products by Category, for example)
2. Select at least 2 categories, you should see a "Display products matching" field appear below the category list.
3. Deselect until you have just 1 category, the field should be hidden
4. Inspect the DOM, you'll see the field is still there, it's just wrapped in a div with `screen-reader-text`.
5. You should also see a help text item in the DOM, similarly hidden with CSS