### PR TITLE
Products by Category: don't show products if no category is selected, better message

### DIFF
--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -207,6 +207,18 @@ class ProductByCategoryBlock extends Component {
 			}
 		}
 
+		const nothingFound = ! categories.length ?
+			__(
+				'Select at least one category to display its products.',
+				'woo-gutenberg-products-block'
+			) :
+			_n(
+				'No products in this category.',
+				'No products in these categories.',
+				categories.length,
+				'woo-gutenberg-products-block'
+			);
+
 		return (
 			<Fragment>
 				<BlockControls>
@@ -243,16 +255,7 @@ class ProductByCategoryBlock extends Component {
 									'woo-gutenberg-products-block'
 								) }
 							>
-								{ ! loaded ? (
-									<Spinner />
-								) : (
-									_n(
-										'No products in this category.',
-										'No products in these categories.',
-										categories.length,
-										'woo-gutenberg-products-block'
-									)
-								) }
+								{ ! loaded ? <Spinner /> : nothingFound }
 							</Placeholder>
 						) }
 					</div>

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -67,6 +67,11 @@ class ProductByCategoryBlock extends Component {
 	}
 
 	getProducts() {
+		if ( ! this.props.attributes.categories.length ) {
+			// We've removed all selected categories, or no categories have been selected yet.
+			this.setState( { products: [], loaded: true } );
+			return;
+		}
 		apiFetch( {
 			path: addQueryArgs(
 				'/wc-pb/v3/products',

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -184,7 +184,7 @@ class ProductByCategoryBlock extends Component {
 						}
 					/>
 					<Button isDefault onClick={ onDone }>
-						{ __( 'Insert Block', 'woo-gutenberg-products-block' ) }
+						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>
 			</Placeholder>

--- a/assets/js/product-category-block.js
+++ b/assets/js/product-category-block.js
@@ -184,7 +184,7 @@ class ProductByCategoryBlock extends Component {
 						}
 					/>
 					<Button isDefault onClick={ onDone }>
-						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+						{ __( 'Insert Block', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>
 			</Placeholder>

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -49,6 +49,11 @@ export default function getShortcode( { attributes }, name ) {
 			shortcodeAtts.set( 'ids', products.join( ',' ) );
 			shortcodeAtts.set( 'limit', products.length );
 			break;
+		case 'woocommerce/product-category':
+			if ( ! categories || ! categories.length ) {
+				return '';
+			}
+			break;
 	}
 
 	// Build the shortcode string out of the set shortcode attributes.


### PR DESCRIPTION
Fixes #274, builds on #276 – this PR prevents the block from showing "all products" if no category is selected - both in the editor and on the front end. This also adds a new message shown to users when no categories are selected, "Select at least one category to display its products." 

It also changes the "Done" button to read "Insert Block", as that was requested in #274, but I think that should be removed– technically, the block is already inserted, it's just in "edit mode". If you click a category with products, then save the post, your block will be there on the front end (this is basically what #172 is about). It's also confusing to see "Insert Block" if you've toggled into the edit mode from an existing block, since you know it's already inserted. @LevinMedia 

### Screenshots

![screen shot 2018-12-21 at 3 07 18 pm](https://user-images.githubusercontent.com/541093/50361597-217f3800-0532-11e9-9131-f66a7254c8f9.png)

### How to test the changes in this Pull Request:

1. Insert a product by category block
2. Click done without selecting categories
3. Expect: You should see the placeholder with the message above
4. Save the post, view it
5. Expect: you should not see any products in your post

