### PR TITLE
Search Lists: Hide the selected items section until the content is loaded

### DIFF
--- a/assets/js/components/search-list-control/index.js
+++ b/assets/js/components/search-list-control/index.js
@@ -158,35 +158,43 @@ export class SearchListControl extends Component {
 	}
 
 	render() {
-		const { className = '', search, selected, setState } = this.props;
+		const {
+			className = '',
+			isLoading,
+			search,
+			selected,
+			setState,
+		} = this.props;
 		const messages = { ...defaultMessages, ...this.props.messages };
 		const selectedCount = selected.length;
 
 		return (
 			<div className={ `woocommerce-search-list ${ className }` }>
-				<div className="woocommerce-search-list__selected">
-					<div className="woocommerce-search-list__selected-header">
-						<strong>{ messages.selected( selectedCount ) }</strong>
-						{ selectedCount > 0 ? (
-							<Button
-								isLink
-								isDestructive
-								onClick={ this.onClear }
-								aria-label={ messages.clear }
-							>
-								{ __( 'Clear all', 'woo-gutenberg-products-block' ) }
-							</Button>
-						) : null }
+				{ ! isLoading && (
+					<div className="woocommerce-search-list__selected">
+						<div className="woocommerce-search-list__selected-header">
+							<strong>{ messages.selected( selectedCount ) }</strong>
+							{ selectedCount > 0 ? (
+								<Button
+									isLink
+									isDestructive
+									onClick={ this.onClear }
+									aria-label={ messages.clear }
+								>
+									{ __( 'Clear all', 'woo-gutenberg-products-block' ) }
+								</Button>
+							) : null }
+						</div>
+						{ selected.map( ( item, i ) => (
+							<Tag
+								key={ i }
+								label={ item.name }
+								id={ item.id }
+								remove={ this.onRemove }
+							/>
+						) ) }
 					</div>
-					{ selected.map( ( item, i ) => (
-						<Tag
-							key={ i }
-							label={ item.name }
-							id={ item.id }
-							remove={ this.onRemove }
-						/>
-					) ) }
-				</div>
+				) }
 
 				<div className="woocommerce-search-list__search">
 					<TextControl


### PR DESCRIPTION
Fixes #277 – In the categories list and attributes list, "0 items selected" is shown while the categories are loading, even if there are selected categories. This fixes that issue by hiding the selected section until the categories load.

### Screenshots

![screen shot 2018-12-21 at 3 42 00 pm](https://user-images.githubusercontent.com/541093/50362766-fc40f880-0536-11e9-97e8-ff1c056a55b5.png)

### How to test the changes in this Pull Request:

1. Add a Products by Category block, select some categories and/or attributes
2. Open & close the Product Category or Filter by Attribute sidebar panels
3. Expect: The selected section is hidden, and when it appears it should show your selected categories/attributes.
