### PR TITLE
Add ProductControl, update SearchListControl to pick a "single item"

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -1,0 +1,197 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { BlockControls, InspectorControls } from '@wordpress/editor';
+import {
+	Button,
+	PanelBody,
+	Placeholder,
+	Spinner,
+	Toolbar,
+	withSpokenMessages,
+} from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { debounce } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { IconStar } from '../../components/icons';
+import ProductControl from '../../components/product-control';
+import ProductPreview from '../../components/product-preview';
+
+/**
+ * Component to handle edit mode of "Featured Product".
+ */
+class FeaturedProduct extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			product: false,
+			loaded: false,
+		};
+
+		this.debouncedGetProduct = debounce( this.getProduct.bind( this ), 200 );
+	}
+
+	componentDidMount() {
+		this.getProduct();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.attributes.productId !== this.props.attributes.productId ) {
+			this.debouncedGetProduct();
+		}
+	}
+
+	getProduct() {
+		const { productId } = this.props.attributes;
+		if ( ! productId ) {
+			// We've removed the selected product, or no product is selected yet.
+			this.setState( { product: false, loaded: true } );
+			return;
+		}
+		apiFetch( {
+			path: `/wc-pb/v3/products/${ productId }`,
+		} )
+			.then( ( product ) => {
+				this.setState( { product, loaded: true } );
+			} )
+			.catch( () => {
+				this.setState( { product: false, loaded: true } );
+			} );
+	}
+
+	getInspectorControls() {
+		const { attributes, setAttributes } = this.props;
+
+		return (
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Product', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
+					<ProductControl
+						selected={ attributes.productId || 0 }
+						onChange={ ( value = [] ) => {
+							const id = value[ 0 ] ? value[ 0 ].id : 0;
+							setAttributes( { productId: id } );
+						} }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	renderEditMode() {
+		const { attributes, debouncedSpeak, setAttributes } = this.props;
+		const onDone = () => {
+			setAttributes( { editMode: false } );
+			debouncedSpeak(
+				__(
+					'Showing Featured Product block preview.',
+					'woo-gutenberg-products-block'
+				)
+			);
+		};
+
+		return (
+			<Placeholder
+				icon={ <IconStar /> }
+				label={ __( 'Featured Product', 'woo-gutenberg-products-block' ) }
+				className="wc-block-featured-product"
+			>
+				{ __(
+					'Visually highlight a product and encourage promt action',
+					'woo-gutenberg-products-block'
+				) }
+				<div className="wc-block-handpicked-products__selection">
+					<ProductControl
+						selected={ attributes.productId || 0 }
+						onChange={ ( value = [] ) => {
+							const id = value[ 0 ] ? value[ 0 ].id : 0;
+							setAttributes( { productId: id } );
+						} }
+					/>
+					<Button isDefault onClick={ onDone }>
+						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+					</Button>
+				</div>
+			</Placeholder>
+		);
+	}
+
+	render() {
+		const { attributes, setAttributes } = this.props;
+		const { editMode } = attributes;
+		const { loaded, product } = this.state;
+		const classes = [ 'wc-block-featured-product' ];
+		if ( ! product ) {
+			if ( ! loaded ) {
+				classes.push( 'is-loading' );
+			} else {
+				classes.push( 'is-not-found' );
+			}
+		}
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<Toolbar
+						controls={ [
+							{
+								icon: 'edit',
+								title: __( 'Edit' ),
+								onClick: () => setAttributes( { editMode: ! editMode } ),
+								isActive: editMode,
+							},
+						] }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				{ editMode ? (
+					this.renderEditMode()
+				) : (
+					<div className={ classes.join( ' ' ) }>
+						{ !! product ? (
+							<ProductPreview product={ product } key={ product.id } />
+						) : (
+							<Placeholder
+								icon={ <IconStar /> }
+								label={ __( 'Featured Product', 'woo-gutenberg-products-block' ) }
+							>
+								{ ! loaded ? (
+									<Spinner />
+								) : (
+									__( 'No product is selected.', 'woo-gutenberg-products-block' )
+								) }
+							</Placeholder>
+						) }
+					</div>
+				) }
+			</Fragment>
+		);
+	}
+}
+
+FeaturedProduct.propTypes = {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: PropTypes.func.isRequired,
+	// from withSpokenMessages
+	debouncedSpeak: PropTypes.func.isRequired,
+};
+
+export default withSpokenMessages( FeaturedProduct );

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -105,7 +105,7 @@ class FeaturedProduct extends Component {
 				className="wc-block-featured-product"
 			>
 				{ __(
-					'Visually highlight a product and encourage promt action',
+					'Visually highlight a product and encourage prompt action',
 					'woo-gutenberg-products-block'
 				) }
 				<div className="wc-block-handpicked-products__selection">

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import { IconStar } from '../../components/icons';
+
+/**
+ * Register and run the "Featured Product" block.
+ */
+registerBlockType( 'woocommerce/featured-product', {
+	title: __( 'Featured Product', 'woo-gutenberg-products-block' ),
+	icon: <IconStar />,
+	category: 'woocommerce',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a selection of hand-picked products in a grid.',
+		'woo-gutenberg-products-block'
+	),
+	supports: {
+		align: [ 'wide', 'full' ],
+	},
+	attributes: {
+		/**
+		 * Toggle for edit mode in the block preview.
+		 */
+		editMode: {
+			type: 'boolean',
+			default: true,
+		},
+
+		/**
+		 * The product ID to display
+		 */
+		productId: {
+			type: 'number',
+		},
+	},
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <Block { ...props } />;
+	},
+
+	/**
+	 * Block content is rendered in PHP, not via save function.
+	 */
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -19,7 +19,7 @@ registerBlockType( 'woocommerce/featured-product', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a selection of hand-picked products in a grid.',
+		'Visually highlight a product and encourage prompt action.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -139,10 +139,10 @@ class ProductByCategoryBlock extends Component {
 					<ProductAttributeControl
 						selected={ attributes.attributes }
 						onChange={ ( value = [] ) => {
-							const selected = value.map( ( { id, attr_slug } ) => ( {
+							const selected = value.map( ( { id, attr_slug } ) => ( { // eslint-disable-line camelcase
 								id,
 								attr_slug,
-							} ) ); // eslint-disable-line camelcase
+							} ) );
 							setAttributes( { attributes: selected } );
 						} }
 					/>

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import apiFetch from '@wordpress/api-fetch';
+import { Component, Fragment } from '@wordpress/element';
+import { find } from 'lodash';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import SearchListControl from '../search-list-control';
+
+class ProductControl extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			list: [],
+			loading: true,
+		};
+	}
+
+	componentDidMount() {
+		apiFetch( {
+			path: addQueryArgs( '/wc-pb/v3/products', {
+				per_page: -1,
+				status: 'publish',
+			} ),
+		} )
+			.then( ( list ) => {
+				this.setState( { list, loading: false } );
+			} )
+			.catch( () => {
+				this.setState( { list: [], loading: false } );
+			} );
+	}
+
+	render() {
+		const { list, loading } = this.state;
+		const { onChange, selected } = this.props;
+		const messages = {
+			list: __( 'Products', 'woo-gutenberg-products-block' ),
+			noItems: __(
+				"Your store doesn't have any products.",
+				'woo-gutenberg-products-block'
+			),
+			search: __(
+				'Search for a product to display',
+				'woo-gutenberg-products-block'
+			),
+			updated: __(
+				'Product search results updated.',
+				'woo-gutenberg-products-block'
+			),
+		};
+
+		// Note: selected prop still needs to be array for SearchListControl.
+		return (
+			<Fragment>
+				<SearchListControl
+					className="woocommerce-products"
+					list={ list }
+					isLoading={ loading }
+					isSingle
+					selected={ [ find( list, { id: selected } ) ] }
+					onChange={ onChange }
+					messages={ messages }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+ProductControl.propTypes = {
+	/**
+	 * Callback to update the selected products.
+	 */
+	onChange: PropTypes.func.isRequired,
+	/**
+	 * The ID of the currently selected product.
+	 */
+	selected: PropTypes.number.isRequired,
+};
+
+export default ProductControl;

--- a/assets/js/components/search-list-control/item.js
+++ b/assets/js/components/search-list-control/item.js
@@ -8,7 +8,12 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { IconCheckChecked, IconCheckUnchecked } from '../icons';
+import {
+	IconCheckChecked,
+	IconCheckUnchecked,
+	IconRadioSelected,
+	IconRadioUnselected,
+} from '../icons';
 
 function getHighlightedName( name, search ) {
 	if ( ! search ) {
@@ -29,11 +34,19 @@ function getBreadcrumbsForDisplay( breadcrumbs ) {
 	return first( breadcrumbs ) + ' … ' + last( breadcrumbs );
 }
 
+const getInteractionIcon = ( isSingle = false, isSelected = false ) => {
+	if ( isSingle ) {
+		return isSelected ? <IconRadioSelected /> : <IconRadioUnselected />;
+	}
+	return isSelected ? <IconCheckChecked /> : <IconCheckUnchecked />;
+};
+
 const SearchListItem = ( {
 	className,
 	depth = 0,
 	item,
 	isSelected,
+	isSingle,
 	onSelect,
 	search = '',
 	showCount = false,
@@ -41,7 +54,9 @@ const SearchListItem = ( {
 } ) => {
 	const classes = [ className, 'woocommerce-search-list__item' ];
 	classes.push( `depth-${ depth }` );
-
+	if ( isSingle ) {
+		classes.push( 'is-radio-button' );
+	}
 	const hasBreadcrumbs = item.breadcrumbs && item.breadcrumbs.length;
 
 	return (
@@ -53,7 +68,7 @@ const SearchListItem = ( {
 			{ ...props }
 		>
 			<span className="woocommerce-search-list__item-state">
-				{ isSelected ? <IconCheckChecked /> : <IconCheckUnchecked /> }
+				{ getInteractionIcon( isSingle, isSelected ) }
 			</span>
 
 			<span className="woocommerce-search-list__item-label">
@@ -96,6 +111,10 @@ SearchListItem.propTypes = {
 	 * Whether this item is selected.
 	 */
 	isSelected: PropTypes.bool,
+	/**
+	 * Whether this should only display a single item (controls radio vs checkbox icon).
+	 */
+	isSingle: PropTypes.bool,
 	/**
 	 * Callback for selecting the item.
 	 */

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -1,12 +1,5 @@
 export default {
 	/**
-	 * Alignment of product grid
-	 */
-	align: {
-		type: 'string',
-	},
-
-	/**
 	 * Number of columns.
 	 */
 	columns: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ const GutenbergBlocksConfig = {
 		'product-new': './assets/js/blocks/product-new/index.js',
 		'product-on-sale': './assets/js/blocks/product-on-sale/index.js',
 		'product-top-rated': './assets/js/blocks/product-top-rated/index.js',
+		'featured-product': './assets/js/blocks/featured-product/index.js',
 		'products-grid': './assets/css/products-grid.scss',
 	},
 	output: {

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -128,6 +128,13 @@ function wgpb_register_blocks() {
 			'editor_style'  => 'wc-product-top-rated-editor',
 		)
 	);
+	register_block_type(
+		'woocommerce/featured-product',
+		array(
+			'editor_script' => 'wc-featured-product',
+			'editor_style'  => 'wc-featured-product-editor',
+		)
+	);
 }
 
 /**
@@ -209,6 +216,14 @@ function wgpb_register_scripts() {
 	);
 
 	wp_register_script(
+		'wc-featured-product',
+		plugins_url( 'build/featured-product.js', __FILE__ ),
+		$block_dependencies,
+		wgpb_get_file_version( '/build/featured-product.js' ),
+		true
+	);
+
+	wp_register_script(
 		'woocommerce-products-block-editor',
 		plugins_url( 'build/products-block.js', __FILE__ ),
 		array( 'wp-api-fetch', 'wp-element', 'wp-components', 'wp-blocks', 'wp-editor', 'wp-i18n', 'react-transition-group' ),
@@ -274,6 +289,13 @@ function wgpb_register_scripts() {
 		plugins_url( 'build/products-block.css', __FILE__ ),
 		array( 'wp-edit-blocks' ),
 		wgpb_get_file_version( '/build/products-block.css' )
+	);
+
+	wp_register_style(
+		'wc-featured-product-editor',
+		plugins_url( 'build/featured-product.css', __FILE__ ),
+		array( 'wp-edit-blocks' ),
+		wgpb_get_file_version( '/build/featured-product.css' )
 	);
 
 	add_action( 'admin_print_footer_scripts', 'wgpb_print_script_settings', 1 );


### PR DESCRIPTION
This PR adds a new control, `ProductControl`, which is very similar to `ProductsControl` except that it only allows for selecting one product at a time. There are updates to `SearchListControl` to handle selecting one item at a time, though `selected` is still always an array. Finally, this adds a very basic Featured Product block so the `ProductControl` can be tested.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

![screen shot 2019-01-09 at 2 19 14 pm](https://user-images.githubusercontent.com/541093/50927287-4ece5000-1425-11e9-9be8-761b9ed44c9c.png)

### How to test the changes in this Pull Request:

1. Add a featured product to a post
2. Try selecting a product, or searching then selecting
3. Click "Done"
4. Expect: you should see a basic preview of the selected product
4. Click into the Product panel in the sidebar
5. Expect: You should be able to pick a different product, and it will update the preview

Note: publishing won't do anything, there is no "save" function for this block yet.