### PR TITLE
Display the "Featured Product" block on the frontend

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -8,6 +8,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	PanelColorSettings,
+	RichText,
 	withColors,
 } from '@wordpress/editor';
 import {
@@ -190,6 +191,7 @@ class FeaturedProduct extends Component {
 			contentAlign,
 			dimRatio,
 			editMode,
+			linkText,
 			showDesc,
 			showPrice,
 		} = attributes;
@@ -255,6 +257,15 @@ class FeaturedProduct extends Component {
 										dangerouslySetInnerHTML={ { __html: product.price_html } }
 									/>
 								) }
+								<div className="wc-block-featured-product__link wp-block-button">
+									<RichText
+										value={ linkText }
+										onChange={ ( value ) => setAttributes( { linkText: value } ) }
+										formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+										className="wp-block-button__link"
+										keepPlaceholderOnFocus
+									/>
+								</div>
 							</div>
 						) : (
 							<Placeholder

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -34,6 +34,7 @@ registerBlockType( 'woocommerce/featured-product', {
 			type: 'string',
 			default: 'center',
 		},
+
 		/**
 		 * Percentage opacity of overlay.
 		 */
@@ -62,6 +63,14 @@ registerBlockType( 'woocommerce/featured-product', {
 		 */
 		customOverlayColor: {
 			type: 'string',
+		},
+
+		/**
+		 * Text for the product link.
+		 */
+		linkText: {
+			type: 'string',
+			default: __( 'Shop now', 'woo-gutenberg-products-block' ),
 		},
 
 		/**

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -71,6 +71,10 @@
 		}
 	}
 
+	.wc-block-featured-product__description p {
+		@include font-size( 18 );
+	}
+
 	&.has-background-dim::before {
 		content: "";
 		position: absolute;

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -23,7 +23,8 @@
 
 		.wc-block-featured-product__title,
 		.wc-block-featured-product__description,
-		.wc-block-featured-product__price {
+		.wc-block-featured-product__price,
+		.wc-block-featured-product__link {
 			margin-left: 0;
 			text-align: left;
 		}
@@ -34,7 +35,8 @@
 
 		.wc-block-featured-product__title,
 		.wc-block-featured-product__description,
-		.wc-block-featured-product__price {
+		.wc-block-featured-product__price,
+		.wc-block-featured-product__link {
 			margin-right: 0;
 			text-align: right;
 		}
@@ -42,7 +44,8 @@
 
 	.wc-block-featured-product__title,
 	.wc-block-featured-product__description,
-	.wc-block-featured-product__price {
+	.wc-block-featured-product__price,
+	.wc-block-featured-product__link {
 		color: $white;
 		line-height: 1.25;
 		z-index: 1;

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -1,5 +1,6 @@
 .wc-block-featured-product {
 	position: relative;
+	background-color: $black;
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
@@ -12,8 +13,9 @@
 	flex-wrap: wrap;
 	align-content: center;
 
-	&.has-background-dim {
-		background-color: $black;
+	&.components-placeholder {
+		// Reset the background for the placeholders.
+		background-color: rgba( 139, 139, 150, .1 );
 	}
 
 	&.has-left-content {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -73,10 +73,6 @@
 		}
 	}
 
-	.wc-block-featured-product__description p {
-		@include font-size( 18 );
-	}
-
 	&.has-background-dim::before {
 		content: "";
 		position: absolute;

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -108,12 +108,11 @@ class WC_Block_Featured_Product {
 			$classes[] = "align{$attributes['align']}";
 		}
 
-		if ( isset( $attributes['dimRatio'] ) ) {
-			if ( 0 !== $attributes['dimRatio'] ) {
-				$classes[] = 'has-background-dim';
-				if ( 50 !== $attributes['dimRatio'] ) {
-					$classes[] = 'has-background-dim-' . 10 * round( $attributes['dimRatio'] / 10 );
-				}
+		if ( isset( $attributes['dimRatio'] ) && ( 0 !== $attributes['dimRatio'] ) ) {
+			$classes[] = 'has-background-dim';
+
+			if ( 50 !== $attributes['dimRatio'] ) {
+				$classes[] = 'has-background-dim-' . 10 * round( $attributes['dimRatio'] / 10 );
 			}
 		}
 

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Display the featured product block in the content.
+ *
+ * @package WooCommerce\Blocks
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Wrapper class for Featured Product callback.
+ */
+class WC_Block_Featured_Product {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected static $block_name = 'featured-product';
+
+	/**
+	 * Default attribute values, should match what's set in JS `registerBlockType`.
+	 *
+	 * @var array
+	 */
+	protected static $defaults = array(
+		'align'        => 'none',
+		'contentAlign' => 'center',
+		'dimRatio'     => 50,
+		'showDesc'     => true,
+		'showPrice'    => true,
+	);
+
+	/**
+	 * Render the Featured Product block.
+	 *
+	 * @param array  $attributes Block attributes. Default empty array.
+	 * @param string $content    Block content. Default empty string.
+	 * @return string Rendered block type output.
+	 */
+	public static function render( $attributes, $content ) {
+		$id      = (int) $attributes['productId'];
+		$product = wc_get_product( $id );
+		if ( ! $product ) {
+			return '';
+		}
+		$attributes = wp_parse_args( $attributes, self::$defaults );
+
+		$title = sprintf(
+			'<h2 class="wc-block-featured-product__title">%s</h2>',
+			esc_html( $product->get_title() )
+		);
+
+		$desc_str = sprintf(
+			'<div class="wc-block-featured-product__description">%s</div>',
+			apply_filters( 'woocommerce_short_description', $product->get_short_description() )
+		);
+
+		$price_str = sprintf(
+			'<div class="wc-block-featured-product__price">%s</div>',
+			$product->get_price_html()
+		);
+
+		$output = sprintf( '<div class="%1$s" style="%2$s">', self::get_classes( $attributes ), self::get_styles( $attributes, $product ) );
+
+		$output .= $title;
+		if ( $attributes['showDesc'] ) {
+			$output .= $desc_str;
+		}
+		if ( $attributes['showPrice'] ) {
+			$output .= $price_str;
+		}
+		$output .= '</div>';
+
+		return $output;
+	}
+
+	/**
+	 * Get the styles for the wrapper element (background image, color).
+	 *
+	 * @param array      $attributes Block attributes. Default empty array.
+	 * @param WC_Product $product Product object.
+	 * @return string
+	 */
+	public static function get_styles( $attributes, $product ) {
+		$image = self::get_image( $product, ( 'none' !== $attributes['align'] ) ? 'large' : 'full' );
+		$style = sprintf( 'background-image:url(%s);', esc_url( $image ) );
+
+		if ( isset( $attributes['customOverlayColor'] ) ) {
+			$style .= sprintf( 'background-color:%s;', esc_attr( $attributes['customOverlayColor'] ) );
+		}
+
+		return $style;
+	}
+
+	/**
+	 * Get class names for the block container.
+	 *
+	 * @param array $attributes Block attributes. Default empty array.
+	 * @return string
+	 */
+	public static function get_classes( $attributes ) {
+		$classes = array( 'wc-block-' . self::$block_name );
+
+		if ( isset( $attributes['align'] ) ) {
+			$classes[] = "align{$attributes['align']}";
+		}
+
+		if ( isset( $attributes['dimRatio'] ) ) {
+			if ( 0 !== $attributes['dimRatio'] ) {
+				$classes[] = 'has-background-dim';
+				if ( 50 !== $attributes['dimRatio'] ) {
+					$classes[] = 'has-background-dim-' . 10 * round( $attributes['dimRatio'] / 10 );
+				}
+			}
+		}
+
+		if ( isset( $attributes['contentAlign'] ) && 'center' !== $attributes['contentAlign'] ) {
+			$classes[] = "has-{$attributes['contentAlign']}-content";
+		}
+
+		if ( isset( $attributes['overlayColor'] ) ) {
+			$classes[] = "has-{$attributes['overlayColor']}-background-color";
+		}
+
+		return implode( $classes, ' ' );
+	}
+
+	/**
+	 * Returns the main product image URL.
+	 *
+	 * @param WC_Product $product Product object.
+	 * @param string     $size    Image size, defaults to 'full'.
+	 * @return string
+	 */
+	public static function get_image( $product, $size = 'full' ) {
+		$image = '';
+		if ( $product->get_image_id() ) {
+			$image = wp_get_attachment_image_url( $product->get_image_id(), $size );
+		} elseif ( $product->get_parent_id() ) {
+			$parent_product = wc_get_product( $product->get_parent_id() );
+			if ( $parent_product ) {
+				$image = wp_get_attachment_image_url( $parent_product->get_image_id(), $size );
+			}
+		}
+
+		if ( ! $image && $placeholder ) {
+			$image = wc_placeholder_img( $size );
+		}
+
+		return $image;
+	}
+}

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -146,10 +146,6 @@ class WC_Block_Featured_Product {
 			}
 		}
 
-		if ( ! $image && $placeholder ) {
-			$image = wc_placeholder_img( $size );
-		}
-
 		return $image;
 	}
 }

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -29,6 +29,7 @@ class WC_Block_Featured_Product {
 		'align'        => 'none',
 		'contentAlign' => 'center',
 		'dimRatio'     => 50,
+		'linkText'     => false,
 		'showDesc'     => true,
 		'showPrice'    => true,
 	);
@@ -47,6 +48,9 @@ class WC_Block_Featured_Product {
 			return '';
 		}
 		$attributes = wp_parse_args( $attributes, self::$defaults );
+		if ( ! $attributes['linkText'] ) {
+			$attributes['linkText'] = __( 'Shop now', 'woo-gutenberg-products-block' );
+		}
 
 		$title = sprintf(
 			'<h2 class="wc-block-featured-product__title">%s</h2>',
@@ -63,6 +67,14 @@ class WC_Block_Featured_Product {
 			$product->get_price_html()
 		);
 
+		$link_str = sprintf(
+			'<div class="wc-block-featured-product__link wp-block-button"><a class="wp-block-button__link" href="%1$s" aria-label="%2$s">%3$s</a></div>',
+			$product->get_permalink(),
+			/* translators: %s is product name */
+			sprintf( __( 'View product %s', 'woo-gutenberg-products-block' ), $product->get_name() ),
+			$attributes['linkText']
+		);
+
 		$output = sprintf( '<div class="%1$s" style="%2$s">', self::get_classes( $attributes ), self::get_styles( $attributes, $product ) );
 
 		$output .= $title;
@@ -72,6 +84,7 @@ class WC_Block_Featured_Product {
 		if ( $attributes['showPrice'] ) {
 			$output .= $price_str;
 		}
+		$output .= $link_str;
 		$output .= '</div>';
 
 		return $output;

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -77,6 +77,8 @@ function wgpb_add_block_category( $categories ) {
  * Register the Products block and its scripts.
  */
 function wgpb_register_blocks() {
+	include_once dirname( __FILE__ ) . '/includes/blocks/class-wc-block-featured-product.php';
+
 	// Legacy block.
 	register_block_type(
 		'woocommerce/products',
@@ -131,8 +133,9 @@ function wgpb_register_blocks() {
 	register_block_type(
 		'woocommerce/featured-product',
 		array(
-			'editor_script' => 'wc-featured-product',
-			'editor_style'  => 'wc-featured-product-editor',
+			'render_callback' => array( 'WC_Block_Featured_Product', 'render' ),
+			'editor_script'   => 'wc-featured-product',
+			'style'           => 'wc-featured-product-editor',
 		)
 	);
 }


### PR DESCRIPTION
See #294; This is built on top of #308. This adds the front-end render function for the Featured Product block. 

### Screenshots

On Storefront, in a post:
![storefront-post](https://user-images.githubusercontent.com/541093/51064903-0d2dd880-15d0-11e9-8ca4-ce12e96540f3.png)

On Storefront, in a full-width page:
![storefront-page](https://user-images.githubusercontent.com/541093/51064904-0d2dd880-15d0-11e9-9335-22bb59dbaca6.png)

Same page as above, on Twenty Nineteen:
![2019](https://user-images.githubusercontent.com/541093/51064905-0d2dd880-15d0-11e9-890f-da6deb0b95af.png)

### How to test the changes in this Pull Request:

1. Add Featured Product block to a page/post
2. Play with the content & display settings
3. Publish the page/post, view it
4. Expect: The block should appear like it did in the editor (some theme styles might be different – let me know if you encounter anything awkward).
