### PR TITLE
"Featured Product" Block: Add link to the product to the block

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -257,7 +257,7 @@ class FeaturedProduct extends Component {
 										dangerouslySetInnerHTML={ { __html: product.price_html } }
 									/>
 								) }
-								<div className="wc-block-featured-product__link">
+								<div className="wc-block-featured-product__link wp-block-button">
 									<RichText
 										value={ linkText }
 										onChange={ ( value ) => setAttributes( { linkText: value } ) }

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -8,6 +8,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	PanelColorSettings,
+	RichText,
 	withColors,
 } from '@wordpress/editor';
 import {
@@ -190,6 +191,7 @@ class FeaturedProduct extends Component {
 			contentAlign,
 			dimRatio,
 			editMode,
+			linkText,
 			showDesc,
 			showPrice,
 		} = attributes;
@@ -255,6 +257,15 @@ class FeaturedProduct extends Component {
 										dangerouslySetInnerHTML={ { __html: product.price_html } }
 									/>
 								) }
+								<div className="wc-block-featured-product__link">
+									<RichText
+										value={ linkText }
+										onChange={ ( value ) => setAttributes( { linkText: value } ) }
+										formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+										className="wp-block-button__link"
+										keepPlaceholderOnFocus
+									/>
+								</div>
 							</div>
 						) : (
 							<Placeholder

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -34,6 +34,7 @@ registerBlockType( 'woocommerce/featured-product', {
 			type: 'string',
 			default: 'center',
 		},
+
 		/**
 		 * Percentage opacity of overlay.
 		 */
@@ -62,6 +63,14 @@ registerBlockType( 'woocommerce/featured-product', {
 		 */
 		customOverlayColor: {
 			type: 'string',
+		},
+
+		/**
+		 * Text for the product link.
+		 */
+		linkText: {
+			type: 'string',
+			default: __( 'Shop now', 'woo-gutenberg-products-block' ),
 		},
 
 		/**

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -23,7 +23,8 @@
 
 		.wc-block-featured-product__title,
 		.wc-block-featured-product__description,
-		.wc-block-featured-product__price {
+		.wc-block-featured-product__price,
+		.wc-block-featured-product__link {
 			margin-left: 0;
 			text-align: left;
 		}
@@ -34,7 +35,8 @@
 
 		.wc-block-featured-product__title,
 		.wc-block-featured-product__description,
-		.wc-block-featured-product__price {
+		.wc-block-featured-product__price,
+		.wc-block-featured-product__link {
 			margin-right: 0;
 			text-align: right;
 		}

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -42,7 +42,8 @@
 
 	.wc-block-featured-product__title,
 	.wc-block-featured-product__description,
-	.wc-block-featured-product__price {
+	.wc-block-featured-product__price,
+	.wc-block-featured-product__link {
 		color: $white;
 		line-height: 1.25;
 		z-index: 1;

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -68,7 +68,7 @@ class WC_Block_Featured_Product {
 		);
 
 		$link_str = sprintf(
-			'<div class="wc-block-featured-product__link"><a class="wp-block-button__link" href="%1$s" aria-label="%2$s">%3$s</a></div>',
+			'<div class="wc-block-featured-product__link wp-block-button"><a class="wp-block-button__link" href="%1$s" aria-label="%2$s">%3$s</a></div>',
 			$product->get_permalink(),
 			/* translators: %s is product name */
 			sprintf( __( 'View product %s', 'woo-gutenberg-products-block' ), $product->get_name() ),

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -29,6 +29,7 @@ class WC_Block_Featured_Product {
 		'align'        => 'none',
 		'contentAlign' => 'center',
 		'dimRatio'     => 50,
+		'linkText'     => false,
 		'showDesc'     => true,
 		'showPrice'    => true,
 	);
@@ -47,6 +48,9 @@ class WC_Block_Featured_Product {
 			return '';
 		}
 		$attributes = wp_parse_args( $attributes, self::$defaults );
+		if ( ! $attributes['linkText'] ) {
+			$attributes['linkText'] = __( 'Shop now', 'woo-gutenberg-products-block' );
+		}
 
 		$title = sprintf(
 			'<h2 class="wc-block-featured-product__title">%s</h2>',
@@ -63,6 +67,12 @@ class WC_Block_Featured_Product {
 			$product->get_price_html()
 		);
 
+		$link_str = sprintf(
+			'<div class="wc-block-featured-product__link"><a class="wp-block-button__link" href="%1$s">%2$s</a></div>',
+			$product->get_permalink(),
+			$attributes['linkText']
+		);
+
 		$output = sprintf( '<div class="%1$s" style="%2$s">', self::get_classes( $attributes ), self::get_styles( $attributes, $product ) );
 
 		$output .= $title;
@@ -72,6 +82,7 @@ class WC_Block_Featured_Product {
 		if ( $attributes['showPrice'] ) {
 			$output .= $price_str;
 		}
+		$output .= $link_str;
 		$output .= '</div>';
 
 		return $output;

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -68,8 +68,10 @@ class WC_Block_Featured_Product {
 		);
 
 		$link_str = sprintf(
-			'<div class="wc-block-featured-product__link"><a class="wp-block-button__link" href="%1$s">%2$s</a></div>',
+			'<div class="wc-block-featured-product__link"><a class="wp-block-button__link" href="%1$s" aria-label="%2$s">%3$s</a></div>',
 			$product->get_permalink(),
+			/* translators: %s is product name */
+			sprintf( __( 'View product %s', 'woo-gutenberg-products-block' ), $product->get_name() ),
 			$attributes['linkText']
 		);
 


### PR DESCRIPTION
See #294 – This adds the link button to the product block (a link styled as a button). It uses the RichText component in the editor, so users can customize the link text. On the front end, it's a plain link with the user's custom text (if applicable). There's also a screen reader label reading "view product {name}", to avoid repeated/unclear link text.

The styling is pretty basic, using the same class as the core button - hopefully this way we can be consistent with themes that customize the button class.

### Screenshots

In the editor:

![screen shot 2019-01-11 at 7 06 05 pm](https://user-images.githubusercontent.com/541093/51065706-4d8f5580-15d4-11e9-92e0-97bdfa718dc2.png)

On the front end:

![screen shot 2019-01-11 at 7 05 35 pm](https://user-images.githubusercontent.com/541093/51065714-52eca000-15d4-11e9-863b-65976e932d9b.png)

### How to test the changes in this Pull Request:

1. Add a Featured Product block, select a product
2. Expect: The product preview should have a link with default text "Shop now"
3. Edit the link text
4. Save your post, view it
5. Expect: The product block should have a link using the text you entered.
