### PR TITLE
Featured Product Block: Use real product short description

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -246,8 +246,7 @@ class FeaturedProduct extends Component {
 									<div
 										className="wc-block-featured-product__description"
 										dangerouslySetInnerHTML={ {
-											__html:
-												'<p>Black cotton top with matching striped skirt. </p>\n',
+											__html: product.short_description,
 										} }
 									/>
 								) }


### PR DESCRIPTION
Now that #309 is merged, we can use the real short description in the block preview.

### How to test the changes in this Pull Request:

1. Add a Featured Product block to a post/page
2. Select a product with a short description
3. Expect: The preview should show the correct short description
4. Change to a product without a short description
5. Expect: No description is visible
