### PR TITLE
Remove the “Filter by Attribute” panel from products by category block

### DIFF
--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -22,7 +22,6 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
-import ProductAttributeControl from '../../components/product-attribute-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
 import ProductPreview from '../../components/product-preview';
@@ -130,21 +129,6 @@ class ProductByCategoryBlock extends Component {
 					<ProductOrderbyControl
 						setAttributes={ setAttributes }
 						value={ orderby }
-					/>
-				</PanelBody>
-				<PanelBody
-					title={ __( 'Filter by Attribute', 'woo-gutenberg-products-block' ) }
-					initialOpen={ false }
-				>
-					<ProductAttributeControl
-						selected={ attributes.attributes }
-						onChange={ ( value = [] ) => {
-							const selected = value.map( ( { id, attr_slug } ) => ( { // eslint-disable-line camelcase
-								id,
-								attr_slug,
-							} ) );
-							setAttributes( { attributes: selected } );
-						} }
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
Fixes #318 – We aren't allowing the combination of attributes + category selection, so we should remove the "Filter by Attributes" panel in the Products by Category block.

### How to test the changes in this Pull Request:

1. Add a Products by Category block
2. Look at the sidebar options
3. Expect: There should be no "Filter by Attributes" panel.
