### PR TITLE
Add changelog & version bump to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "woocommerceproductsblock",
-  "version": "3.3.0",
+  "name": "woocommerce-product-blocks",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "woocommerceproductsblock",
-  "title": "WooCommerce Products Block",
-  "version": "3.3.0",
+  "name": "woocommerce-product-blocks",
+  "title": "WooCommerce Blocks",
+  "version": "1.3.0",
   "homepage": "https://woocommerce.com/",
   "repository": {
     "type": "git",
@@ -86,5 +86,14 @@
         "composer run-script phpcs"
       ]
     }
-  }
+  },
+  "files": [
+    "assets/**",
+    "build/**",
+    "includes/**",
+    "languages/**",
+    "license.txt",
+    "readme.txt",
+    "woocommerce-gutenberg-products-block.php"
+  ]
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products
 Requires at least: 4.9
 Tested up to: 5.0
 Requires PHP: 5.2
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -63,6 +63,23 @@ Yes you can! Join in on our [GitHub repository](https://github.com/woocommerce/w
 4. New: Stand-alone Product Category block
 
 == Changelog ==
+
+== 1.3.0 - 2019-01-15 =
+
+- Feature: Added new blocks: "Featured Product", "Hand-picked Products", "Best Selling Products", "Newest Products", "On Sale Products", "Top Rated Products"
+- Enhancement: Create new "WooCommerce" block category, all blocks are found there now
+- Enhancement: Added a control to "Products by Category" block to control whether products need to match any selected categories or all selected categories
+- Fix: Fixed a bug in "Products by Category" block where all products would display if no category was selected
+- Legacy block: Remove legacy "Products" block from being shown in the block inserter (still loading the block for an existing uses)
+- Legacy block: Fix an issue with imageless products in the legacy "Products" block.
+- Components: Add new Control components `ProductControl`, `ProductsControl`, `ProductOrderbyControl`
+- Components: Update `SearchListControl` to allow selecting a single item
+- API: Add `cat_operator` support to products endpoint
+- API: Add product `description` & `short_description` to each product
+- API: Add attribute group names to each attribute
+- Build: Update packages
+- Build: Add cssnano to minify CSS
+- Build: Split out node_modules code into separate vendors files
 
 == 1.2.0 - 2018-12-04 =
 * Feature - Stand-alone product category block with improved category selection interface.

--- a/readme.txt
+++ b/readme.txt
@@ -10,9 +10,30 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 == Description ==
 
-WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages! Using the original "Products Block", your displayed products can be filtered by category, sale status, or a variety of other fields. You can even make a custom list of hand-picked products to display.
+WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages! New for version 1.3.0: We've added six new blocks! 
 
-New for 1.2.0: We've added a stand-alone Product Category block to simplify the experience and improve the category search and selection UI. Be on the lookout for additional stand-alone blocks in future releases. 
+**NEW: Featured Product Block**
+Select and display a single product in a new, high impact fashion. Control text alignment, hide or show the price and description, add a color overlay, change the button call to action, and override the product photo. 
+
+**NEW: Hand-Picked products Block**
+Display a grid of hand picked products. Products can be ordred in various ways.
+
+**NEW: Best Selling Products Block**
+Display a grid of your best selling products, filterable by category.
+
+**NEW: Top Rated Products Block**
+Display a grid of your top rated products, filterable by category.
+
+**NEW: Newest Products Block**
+Display a grid of your newest products, filterable by category.
+
+**NEW: On Sale Products Block**
+Display a grid of on sale products, filterable by category.
+
+**Products by Category Block**
+Display a grid of products from your selected category, or categories. Products can be ordered in various ways.
+
+We've also improved the category selection filter. If you select two or more categories, you can now chose to show products that include ANY or ALL selected categories. 
 
 == Getting Started ==
 
@@ -57,10 +78,11 @@ Yes you can! Join in on our [GitHub repository](https://github.com/woocommerce/w
 
 == Screenshots ==
 
-1. The initial Products block.
-2. Selecting hand-picked products for the Products block.
-3. The completed Products block when inserted into a post.
-4. New: Stand-alone Product Category block
+1. The Featured Product Block
+2. Selecting a product for the Featured Product Block
+3. Selecting Products for the Hand-Picked Products Block
+4. Selecting categories in the Products By Category block
+5. WooCommerce Product Blocks in the block inserter menu
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -69,7 +69,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/woocommerce/w
 - Feature: Added new blocks: "Featured Product", "Hand-picked Products", "Best Selling Products", "Newest Products", "On Sale Products", "Top Rated Products"
 - Enhancement: Create new "WooCommerce" block category, all blocks are found there now
 - Enhancement: Added a control to "Products by Category" block to control whether products need to match any selected categories or all selected categories
-- Fix: Fixed a bug in "Products by Category" block where all products would display if no category was selected
+- Fix: A "Products by Category" block with no category selected will no longer show all products
 - Legacy block: Remove legacy "Products" block from being shown in the block inserter (still loading the block for an existing uses)
 - Legacy block: Fix an issue with imageless products in the legacy "Products" block.
 - Components: Add new Control components `ProductControl`, `ProductsControl`, `ProductOrderbyControl`

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 1.3.0-RC
+ * Version: 1.3.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 1.3.0-dev
+ * Version: 1.3.0-RC
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '1.2.0' );
+define( 'WGPB_VERSION', '1.3.0' );
 
 define( 'WGPB_DEVELOPMENT_MODE', true );
 


### PR DESCRIPTION
What it says. Currently this is incrementing to 1.3.0-RC, so I can use this branch to tag an RC release today. Tomorrow, we'll bump the version again, check over the readme, and merge this prior to tagging the official 1.3.0 release + pushing to wp.org.

### How to test the changes in this Pull Request:

1. Read over the readme.txt
2. View the plugin in your plugins list, it should read version 1.3.0
3. Expect: It shouldn't appear as version 1.2 anywhere
4. Expect: No other documentation is needed
