### PR TITLE
Category Selection: Add catOperator to remaining blocks

### DIFF
--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -44,7 +44,7 @@ class ProductNewestBlock extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const hasChange = [ 'rows', 'columns', 'categories' ].reduce( ( acc, key ) => {
+		const hasChange = [ 'rows', 'columns', 'categories', 'catOperator' ].reduce( ( acc, key ) => {
 			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
 		}, false );
 		if ( hasChange ) {
@@ -69,7 +69,7 @@ class ProductNewestBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, rows } = attributes;
+		const { categories, catOperator, columns, rows } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -100,11 +100,15 @@ class ProductNewestBlock extends Component {
 					initialOpen={ false }
 				>
 					<ProductCategoryControl
-						selected={ attributes.categories }
+						selected={ categories }
 						onChange={ ( value = [] ) => {
 							const ids = value.map( ( { id } ) => id );
 							setAttributes( { categories: ids } );
 						} }
+						operator={ catOperator }
+						onOperatorChange={ ( value = 'any' ) =>
+							setAttributes( { catOperator: value } )
+						}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -44,7 +44,7 @@ class ProductTopRatedBlock extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const hasChange = [ 'rows', 'columns', 'categories' ].reduce( ( acc, key ) => {
+		const hasChange = [ 'rows', 'columns', 'categories', 'catOperator' ].reduce( ( acc, key ) => {
 			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
 		}, false );
 		if ( hasChange ) {
@@ -69,7 +69,7 @@ class ProductTopRatedBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, rows } = attributes;
+		const { categories, catOperator, columns, rows } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -100,11 +100,15 @@ class ProductTopRatedBlock extends Component {
 					initialOpen={ false }
 				>
 					<ProductCategoryControl
-						selected={ attributes.categories }
+						selected={ categories }
 						onChange={ ( value = [] ) => {
 							const ids = value.map( ( { id } ) => id );
 							setAttributes( { categories: ids } );
 						} }
+						operator={ catOperator }
+						onOperatorChange={ ( value = 'any' ) =>
+							setAttributes( { catOperator: value } )
+						}
 					/>
 				</PanelBody>
 			</InspectorControls>


### PR DESCRIPTION
Fixes #326 – when the catOperator was added to the category selection, some blocks were missed – specifically Top Rated Products and Newest Products. This PR adds the category operator code into them.

### How to test the changes in this Pull Request:

1. Add a Top Rated Products block or a Newest Products block
2. Select at least two categories in the sidebar
3. You should see a dropdown appear to match "Any selected categories" or "All selected categories"
4. Changing that should update the preview
5. Publish the post, view it
6. The front end view should have the same products displayed as the preview.
