### PR TITLE
Use the wcSettings object from wc-admin if present

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -342,19 +342,24 @@ function wgpb_print_script_settings() {
 	$code = get_woocommerce_currency();
 
 	// Settings and variables can be passed here for access in the app.
+	// Will need `wcAdminAssetUrl` if the ImageAsset component is used.
+	// Will need `dataEndpoints.countries` if Search component is used with 'country' type.
+	// Will need `orderStatuses` if the OrderStatus component is used.
+	// Deliberately excluding: `embedBreadcrumbs`, `trackingEnabled`.
 	$settings = array(
-		'adminUrl'   => admin_url(),
-		'wcAssetUrl' => plugins_url( 'assets/', WC_PLUGIN_FILE ),
-		'siteLocale' => esc_attr( get_bloginfo( 'language' ) ),
-		'currency'   => array(
+		'adminUrl'      => admin_url(),
+		'wcAssetUrl'    => plugins_url( 'assets/', WC_PLUGIN_FILE ),
+		'siteLocale'    => esc_attr( get_bloginfo( 'language' ) ),
+		'currency'      => array(
 			'code'      => $code,
 			'precision' => wc_get_price_decimals(),
 			'symbol'    => get_woocommerce_currency_symbol( $code ),
+			'position'  => get_option( 'woocommerce_currency_pos' ),
 		),
-		'date'       => array(
-			'dow' => get_option( 'start_of_week', 0 ),
-		),
-		'l10n'       => array(
+		'stockStatuses' => wc_get_product_stock_status_options(),
+		'siteTitle'     => get_bloginfo( 'name' ),
+		'dataEndpoints' => array(),
+		'l10n'          => array(
 			'userLocale'    => get_user_locale(),
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
@@ -371,7 +376,8 @@ function wgpb_print_script_settings() {
 	);
 	?>
 	<script type="text/javascript">
-		var wcSettings = <?php echo wp_json_encode( $settings ); ?>;
+		<?php // Use the wcSettings from wc-admin if already present. ?>
+		var wcSettings = wcSettings || <?php echo wp_json_encode( $settings ); ?>;
 		var wc_product_block_data = <?php echo wp_json_encode( $block_settings ); ?>;
 	</script>
 	<?php


### PR DESCRIPTION
 Use the `wcSettings` object from `wc-admin` if present and update it to more closely match the latest from `wc-admin`.

Supplants work done in https://github.com/woocommerce/wc-admin/pull/1302.

This PR fixes the `wcSettings` object collision when the `wc-admin` plugin is active.

### How to test the changes in this Pull Request:

1. Enable `wc-admin` plugin
2. Verify that WooCommerce > Dashboard renders
3. Verify that all product blocks work as expected