### PR TITLE
SearchListControl: Use the “radio” role for selecting just one item

### DIFF
--- a/assets/js/components/search-list-control/item.js
+++ b/assets/js/components/search-list-control/item.js
@@ -61,7 +61,7 @@ const SearchListItem = ( {
 
 	return (
 		<MenuItem
-			role="menuitemcheckbox"
+			role={ isSingle ? 'menuitemradio' : 'menuitemcheckbox' }
 			className={ classes.join( ' ' ) }
 			onClick={ onSelect( item ) }
 			isSelected={ isSelected }


### PR DESCRIPTION
A small change to make this more semantic for screen reader users– if you can only select a single item from a search list, the role of the item is now `menuitemradio`

### How to test the changes in this Pull Request:

1. Add a Featured Product block to the page
2. View the list of products
3. Inspect element on the items, each button should have `role="menuitemradio"`
4. Add any block with the category selector (Newest, etc)
5. View the list of product categories
6. Inspect element on the items, each button should have `role="menuitemcheckbox"`
