### PR TITLE
Remove the edit-blocks dependency from featured product CSS file

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -318,7 +318,7 @@ function wgpb_register_scripts() {
 	wp_register_style(
 		'wc-featured-product-editor',
 		plugins_url( 'build/featured-product.css', __FILE__ ),
-		array( 'wc-vendors', 'wp-edit-blocks' ),
+		array( 'wc-vendors' ),
 		wgpb_get_file_version( '/build/featured-product.css' )
 	);
 


### PR DESCRIPTION
Fixes #335 – The dependency on `wp-edit-blocks` makes sense for an admin css file, but this is also used on the front end. Loading `wp-edit-blocks` on the frontend overrides some core column styling, causing the columns to break:

<img width="1144" alt="before" src="https://user-images.githubusercontent.com/541093/51330662-ed6e3880-1a45-11e9-8e5e-122088b1cc3b.png">

After removing the dependency, the columns work as expected:

<img width="1121" alt="after" src="https://user-images.githubusercontent.com/541093/51330661-ed6e3880-1a45-11e9-8eab-af7e728eb711.png">

### How to test the changes in this Pull Request:

1. Add some content with columns to your post (doesn't have to be our product blocks, any content works)
2. Publish/save and view the post
3. Expect: columns should appear next to each other, like in the editor.

(note that this PR was created on top of #339, since the enqueue functions moved around a little - thought it would save me a rebase 🙂 )