### PR TITLE
Release 1.3.1

### DIFF
--- a/languages/woo-gutenberg-products-block.php
+++ b/languages/woo-gutenberg-products-block.php
@@ -7,6 +7,12 @@ $generated_i18n_strings = array(
 	// Reference: assets/js/blocks/featured-product/block.js:135
 	__( 'Content', 'woo-gutenberg-products-block' ),
 
+	// Reference: assets/js/blocks/featured-product/block.js:137
+	__( 'Show description', 'woo-gutenberg-products-block' ),
+
+	// Reference: assets/js/blocks/featured-product/block.js:142
+	__( 'Show price', 'woo-gutenberg-products-block' ),
+
 	// Reference: assets/js/blocks/featured-product/block.js:148
 	__( 'Overlay', 'woo-gutenberg-products-block' ),
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products
 Requires at least: 4.9
 Tested up to: 5.0
 Requires PHP: 5.2
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,12 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+== 1.3.1 - 2019-01-17 =
+
+- Fix: A CSS conflict was causing the core columns style to reset, this has been fixed and columns will display as expected now.
+- Fix: A version conflict with a JS package was causing the blocks to be broken in non-English locales. The package was updated.
+- Fix: Translations were not being loaded correctly for the JS files. We now bundle the Danish, Spanish, and French translations so that these can be used.
+
 == 1.3.0 - 2019-01-15 =
 
 - Feature: Added new blocks: "Featured Product", "Hand-picked Products", "Best Selling Products", "Newest Products", "On Sale Products", "Top Rated Products"

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This PR bumps the version & adds the changelog for the 1.3.1 release. Note that we need to merge #344 before release, as this changelog mentions the Spanish translations.

### How to test the changes in this Pull Request:

1. Make sure the changelog makes sense.
2. Check that the version number is 1.3.1 in wp-admin