### PR TITLE
Make ProductsControl potentially reusable

### DIFF
--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -41,6 +41,18 @@ class ProductsBlock extends Component {
 		this.debouncedGetProducts = debounce( this.getProducts.bind( this ), 200 );
 	}
 
+	productsMountHandler() {
+		apiFetch( {
+			path: addQueryArgs( '/wc-pb/v3/products', { per_page: -1, status: 'publish' } ),
+		} )
+			.then( ( list ) => {
+				this.setState( { list, loading: false } );
+			} )
+			.catch( () => {
+				this.setState( { list: [], loading: false } );
+			} );
+	}
+
 	componentDidMount() {
 		this.getProducts();
 	}
@@ -106,6 +118,7 @@ class ProductsBlock extends Component {
 					initialOpen={ false }
 				>
 					<ProductsControl
+						mountHandler={ this.productsMountHandler }
 						selected={ attributes.products }
 						onChange={ ( value = [] ) => {
 							const ids = value.map( ( { id } ) => id );
@@ -141,6 +154,7 @@ class ProductsBlock extends Component {
 				) }
 				<div className="wc-block-handpicked-products__selection">
 					<ProductsControl
+						mountHandler={ this.productsMountHandler }
 						selected={ attributes.products }
 						onChange={ ( value = [] ) => {
 							const ids = value.map( ( { id } ) => id );

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
@@ -23,15 +21,7 @@ class ProductsControl extends Component {
 	}
 
 	componentDidMount() {
-		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', { per_page: -1, status: 'publish' } ),
-		} )
-			.then( ( list ) => {
-				this.setState( { list, loading: false } );
-			} )
-			.catch( () => {
-				this.setState( { list: [], loading: false } );
-			} );
+		this.props.mountHandler.bind( this )();
 	}
 
 	render() {
@@ -89,6 +79,10 @@ ProductsControl.propTypes = {
 	 * The list of currently selected IDs.
 	 */
 	selected: PropTypes.array.isRequired,
+	/**
+	 * Mount handler usually intended to initialize 'list'.
+	 */
+	mountHandler: PropTypes.func.isRequired,
 };
 
 export default ProductsControl;


### PR DESCRIPTION
Make the `ProductsControl` component more abstract by allowing the list to be populated from elsewhere.