### PR TITLE
Run `composer install` after packages install

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "GPL-3.0+",
   "main": "Gruntfile.js",
   "scripts": {
+    "postinstall": "composer install",
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack && npm run i18n:php",
     "start": "cross-env BABEL_ENV=default webpack --watch",
     "i18n:php": "pot-to-php ./languages/woo-gutenberg-products-block.pot ./languages/woo-gutenberg-products-block.php woo-gutenberg-products-block",


### PR DESCRIPTION
This PR adds a postinstall script to run `composer install` automatically after `npm install`, to make sure both npm and composer packages are up to date (without needing to remember a second command).

### How to test the changes in this Pull Request:

1. Run `npm install`
2. Expect: after the npm packages install, you should see composer packages install.
