### PR TITLE
REST API: Add new parameter for relationship between multiple taxonomies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Feature plugin for the Gutenberg Products block.
 3. On Gutenberg posts you should now have a Products block available.
 
 ## Getting started with the development version:
+
 1. Make sure you have:
   - the latest version of the Gutenberg plugin and WooCommerce 3.3.1+ installed and active
   - ***OR*** WordPress 5.0 (beta) and WooCommerce 3.5.1+

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -235,6 +235,7 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 		$cat_operator  = $request->get_param( 'cat_operator' );
 		$attributes    = $request->get_param( 'attributes' );
 		$attr_operator = $request->get_param( 'attr_operator' );
+		$tax_relation  = $request->get_param( 'tax_relation' );
 
 		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
 		$args['orderby'] = $ordering_args['orderby'];
@@ -273,7 +274,9 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 			} else {
 				$args['tax_query'] = $tax_query; // WPCS: slow query ok.
 			}
-			$args['tax_query']['relation'] = 'AND' === $attr_operator ? 'AND' : 'OR';
+			if ( ! empty( $tax_relation ) && count( $tax_query ) > 1 ) {
+				$args['tax_query']['relation'] = 'AND' === $tax_relation ? 'AND' : 'OR';
+			}
 		}
 
 		return $args;
@@ -306,7 +309,8 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 	/**
 	 * Update the collection params.
 	 *
-	 * Adds new options for 'orderby', and new parameter 'cat_operator'.
+	 * Adds new options for 'orderby', and new parameters 'cat_operator', 'attributes',
+	 * 'attr_operator', and 'tax_relation'.
 	 *
 	 * @return array
 	 */
@@ -324,6 +328,13 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 			'description'       => __( 'Operator to compare product attribute terms.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'enum'              => array( 'IN', 'AND' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['tax_relation']    = array(
+			'description'       => __( 'The logical relationship between each inner taxonomy array when there is more than one.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'enum'              => array( 'AND', 'OR' ),
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/tests/api/products-attributes.php
+++ b/tests/api/products-attributes.php
@@ -163,6 +163,7 @@ class WC_Tests_API_Products_By_Attributes_Controller extends WC_REST_Unit_Test_C
 			)
 		);
 		$request->set_param( 'attr_operator', 'IN' );
+		$request->set_param( 'tax_relation', 'OR' );
 
 		$response          = $this->server->dispatch( $request );
 		$response_products = $response->get_data();
@@ -186,6 +187,7 @@ class WC_Tests_API_Products_By_Attributes_Controller extends WC_REST_Unit_Test_C
 			)
 		);
 		$request->set_param( 'attr_operator', 'AND' );
+		$request->set_param( 'tax_relation', 'AND' );
 
 		$response          = $this->server->dispatch( $request );
 		$response_products = $response->get_data();


### PR DESCRIPTION
Fixes #362 – Adds a `tax_relation` parameter to the REST API products endpoint. This pulls the logic out of the attr_operator parameter, so that it's more clear what each parameter does.

### How to test the changes in this Pull Request:

1. Try it in an API client. An example request with color & size attributes might look like this, but your attribute slugs and IDs will probably be different.

```
/wc-pb/v3/products?attributes[pa_color]=23,24&attributes[pa_size]=48&attr_operator=IN&tax_relation=OR
```

2. Expect `attr_operator=IN&tax_relation=OR` to return any products matching any attribute selected
3. Expect `attr_operator=AND&tax_relation=AND` to return only products matching all selected attributes
4. Check that the phpunit tests pass (do this manually, since travis is down for us ATM)
