### PR TITLE
Use defaultProps to set up the taxonomy control operators

### DIFF
--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -90,7 +90,7 @@ class ProductAttributeControl extends Component {
 
 	render() {
 		const { list, loading } = this.state;
-		const { onChange, onOperatorChange, operator = 'any', selected } = this.props;
+		const { onChange, onOperatorChange, operator, selected } = this.props;
 
 		const messages = {
 			clear: __( 'Clear all product attributes', 'woo-gutenberg-products-block' ),
@@ -174,6 +174,10 @@ ProductAttributeControl.propTypes = {
 	 * The list of currently selected attribute slug/ID pairs.
 	 */
 	selected: PropTypes.array.isRequired,
+};
+
+ProductAttributeControl.defaultProps = {
+	operator: 'any',
 };
 
 export default ProductAttributeControl;

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -75,7 +75,7 @@ class ProductCategoryControl extends Component {
 
 	render() {
 		const { list, loading } = this.state;
-		const { onChange, onOperatorChange, operator = 'any', selected } = this.props;
+		const { onChange, onOperatorChange, operator, selected } = this.props;
 
 		const messages = {
 			clear: __( 'Clear all product categories', 'woo-gutenberg-products-block' ),
@@ -159,6 +159,10 @@ ProductCategoryControl.propTypes = {
 	 * The list of currently selected category IDs.
 	 */
 	selected: PropTypes.array.isRequired,
+};
+
+ProductCategoryControl.defaultProps = {
+	operator: 'any',
 };
 
 export default ProductCategoryControl;


### PR DESCRIPTION
Addresses a comment in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/378#discussion_r252357000 – we should use `defaultProps` for defaults, so that eventually these can be picked up by component documentation.

### How to test the changes in this Pull Request:

1. Add a Products by Category block, pick some categories, and verify that the "Display products matching" options work.
2. Add a Products by Attributes block, pick some attributes, and verify that the "Display products matching" options work.
3. There should be no visual change.
