### PR TITLE
Add placeholder image for product preview

### DIFF
--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -13,16 +13,13 @@ import './style.scss';
  * Display a preview for a given product.
  */
 const ProductPreview = ( { product } ) => {
-	const { placeholderImgSrc } = window.wcSettings;
+	const { placeholderImgSrc } = wc_product_block_data; /* eslint-disable-line camelcase */
 
 	let image = null;
 	if ( product.images.length ) {
 		image = <img src={ product.images[ 0 ].src } alt="" />;
 	} else {
-		image = <img
-			src={ placeholderImgSrc }
-			alt={ __( 'Placeholder Image', 'woo-gutenberg-products-block' ) }
-		/>;
+		image = <img src={ placeholderImgSrc } alt="" />;
 	}
 
 	return (

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -13,9 +13,16 @@ import './style.scss';
  * Display a preview for a given product.
  */
 const ProductPreview = ( { product } ) => {
+	const { placeholderImgSrc } = window.wcSettings;
+
 	let image = null;
 	if ( product.images.length ) {
 		image = <img src={ product.images[ 0 ].src } alt="" />;
+	} else {
+		image = <img
+			src={ placeholderImgSrc }
+			alt={ __( 'Placeholder Image', 'woo-gutenberg-products-block' ) }
+		/>;
 	}
 
 	return (

--- a/assets/js/components/product-preview/test/__snapshots__/index.js.snap
+++ b/assets/js/components/product-preview/test/__snapshots__/index.js.snap
@@ -37,6 +37,9 @@ exports[`ProductPreview should render a single product preview without an image 
 <div
   className="wc-product-preview"
 >
+  <img
+    alt=""
+  />
   <div
     className="wc-product-preview__title"
   >

--- a/assets/js/components/product-preview/test/__snapshots__/index.js.snap
+++ b/assets/js/components/product-preview/test/__snapshots__/index.js.snap
@@ -39,6 +39,7 @@ exports[`ProductPreview should render a single product preview without an image 
 >
   <img
     alt=""
+    src="placeholder.png"
   />
   <div
     className="wc-product-preview__title"

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -2,7 +2,9 @@
 global.wp = {};
 
 // Set up our settings global.
-global.wc_product_block_data = {};
+global.wc_product_block_data = {
+	placeholderImgSrc: 'placeholder.png',
+};
 
 // wcSettings is required by @woocommerce/* packages
 global.wcSettings = {

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -395,26 +395,27 @@ function wgpb_print_script_settings() {
 	global $wp_locale;
 	$code = get_woocommerce_currency();
 
+	// NOTE: wcSettings is not used directly, it's only for @woocommerce/components
+	//
 	// Settings and variables can be passed here for access in the app.
 	// Will need `wcAdminAssetUrl` if the ImageAsset component is used.
 	// Will need `dataEndpoints.countries` if Search component is used with 'country' type.
 	// Will need `orderStatuses` if the OrderStatus component is used.
 	// Deliberately excluding: `embedBreadcrumbs`, `trackingEnabled`.
 	$settings = array(
-		'adminUrl'          => admin_url(),
-		'wcAssetUrl'        => plugins_url( 'assets/', WC_PLUGIN_FILE ),
-		'siteLocale'        => esc_attr( get_bloginfo( 'language' ) ),
-		'currency'          => array(
+		'adminUrl'      => admin_url(),
+		'wcAssetUrl'    => plugins_url( 'assets/', WC_PLUGIN_FILE ),
+		'siteLocale'    => esc_attr( get_bloginfo( 'language' ) ),
+		'currency'      => array(
 			'code'      => $code,
 			'precision' => wc_get_price_decimals(),
 			'symbol'    => get_woocommerce_currency_symbol( $code ),
 			'position'  => get_option( 'woocommerce_currency_pos' ),
 		),
-		'stockStatuses'     => wc_get_product_stock_status_options(),
-		'siteTitle'         => get_bloginfo( 'name' ),
-		'placeholderImgSrc' => wc_placeholder_img_src(),
-		'dataEndpoints'     => array(),
-		'l10n'              => array(
+		'stockStatuses' => wc_get_product_stock_status_options(),
+		'siteTitle'     => get_bloginfo( 'name' ),
+		'dataEndpoints' => array(),
+		'l10n'          => array(
 			'userLocale'    => get_user_locale(),
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),
@@ -422,12 +423,13 @@ function wgpb_print_script_settings() {
 
 	// Global settings used in each block.
 	$block_settings = array(
-		'min_columns'     => wc_get_theme_support( 'product_grid::min_columns', 1 ),
-		'max_columns'     => wc_get_theme_support( 'product_grid::max_columns', 6 ),
-		'default_columns' => wc_get_default_products_per_row(),
-		'min_rows'        => wc_get_theme_support( 'product_grid::min_rows', 1 ),
-		'max_rows'        => wc_get_theme_support( 'product_grid::max_rows', 6 ),
-		'default_rows'    => wc_get_default_product_rows_per_page(),
+		'min_columns'       => wc_get_theme_support( 'product_grid::min_columns', 1 ),
+		'max_columns'       => wc_get_theme_support( 'product_grid::max_columns', 6 ),
+		'default_columns'   => wc_get_default_products_per_row(),
+		'min_rows'          => wc_get_theme_support( 'product_grid::min_rows', 1 ),
+		'max_rows'          => wc_get_theme_support( 'product_grid::max_rows', 6 ),
+		'default_rows'      => wc_get_default_product_rows_per_page(),
+		'placeholderImgSrc' => wc_placeholder_img_src(),
 	);
 	?>
 	<script type="text/javascript">

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -401,19 +401,20 @@ function wgpb_print_script_settings() {
 	// Will need `orderStatuses` if the OrderStatus component is used.
 	// Deliberately excluding: `embedBreadcrumbs`, `trackingEnabled`.
 	$settings = array(
-		'adminUrl'      => admin_url(),
-		'wcAssetUrl'    => plugins_url( 'assets/', WC_PLUGIN_FILE ),
-		'siteLocale'    => esc_attr( get_bloginfo( 'language' ) ),
-		'currency'      => array(
+		'adminUrl'          => admin_url(),
+		'wcAssetUrl'        => plugins_url( 'assets/', WC_PLUGIN_FILE ),
+		'siteLocale'        => esc_attr( get_bloginfo( 'language' ) ),
+		'currency'          => array(
 			'code'      => $code,
 			'precision' => wc_get_price_decimals(),
 			'symbol'    => get_woocommerce_currency_symbol( $code ),
 			'position'  => get_option( 'woocommerce_currency_pos' ),
 		),
-		'stockStatuses' => wc_get_product_stock_status_options(),
-		'siteTitle'     => get_bloginfo( 'name' ),
-		'dataEndpoints' => array(),
-		'l10n'          => array(
+		'stockStatuses'     => wc_get_product_stock_status_options(),
+		'siteTitle'         => get_bloginfo( 'name' ),
+		'placeholderImgSrc' => wc_placeholder_img_src(),
+		'dataEndpoints'     => array(),
+		'l10n'              => array(
 			'userLocale'    => get_user_locale(),
 			'weekdaysShort' => array_values( $wp_locale->weekday_abbrev ),
 		),


### PR DESCRIPTION
This adds the designated placeholder image url from settings into the
wcSettings global for the blocks to use. Then uses the placeholder url
when a product doesn't have any images.

Fixes #349

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

![edit_post_ _two_wordpress_test_ _wordpress](https://user-images.githubusercontent.com/945228/52022974-e6710c80-24c0-11e9-9941-5d190f1daa52.png)

### How to test the changes in this Pull Request:

1. Ensure you have a placeholder set in WooCommerce -> Settings -> Products
2. Create a new block that has a product in it that you know doesn't have a product picture.
3. You should see the designated placeholder image.

<!-- If you can, add the appropriate labels -->
