### PR TITLE
Blocks: Restrict row/column values to only valid values

### DIFF
--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -8,18 +8,14 @@ import { InspectorControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
-import {
-	PanelBody,
-	Placeholder,
-	RangeControl,
-	Spinner,
-} from '@wordpress/components';
+import { PanelBody, Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import LayoutControl from '../../components/layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductPreview from '../../components/product-preview';
 
@@ -78,19 +74,10 @@ class ProductBestSellersBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<RangeControl
-						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ wc_product_block_data.min_columns }
-						max={ wc_product_block_data.max_columns }
-					/>
-					<RangeControl
-						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
-						value={ rows }
-						onChange={ ( value ) => setAttributes( { rows: value } ) }
-						min={ wc_product_block_data.min_rows }
-						max={ wc_product_block_data.max_rows }
+					<LayoutControl
+						columns={ columns }
+						rows={ rows }
+						setAttributes={ setAttributes }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
-import LayoutControl from '../../components/layout-control';
+import GridLayoutControl from '../../components/grid-layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductPreview from '../../components/product-preview';
 
@@ -74,7 +74,7 @@ class ProductBestSellersBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<LayoutControl
+					<GridLayoutControl
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -9,7 +9,6 @@ import {
 	Button,
 	PanelBody,
 	Placeholder,
-	RangeControl,
 	Spinner,
 	Toolbar,
 	withSpokenMessages,
@@ -22,6 +21,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import LayoutControl from '../../components/layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
 import ProductPreview from '../../components/product-preview';
@@ -107,19 +107,10 @@ class ProductByCategoryBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<RangeControl
-						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ wc_product_block_data.min_columns }
-						max={ wc_product_block_data.max_columns }
-					/>
-					<RangeControl
-						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
-						value={ rows }
-						onChange={ ( value ) => setAttributes( { rows: value } ) }
-						min={ wc_product_block_data.min_rows }
-						max={ wc_product_block_data.max_rows }
+					<LayoutControl
+						columns={ columns }
+						rows={ rows }
+						setAttributes={ setAttributes }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
-import LayoutControl from '../../components/layout-control';
+import GridLayoutControl from '../../components/grid-layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
 import ProductPreview from '../../components/product-preview';
@@ -107,7 +107,7 @@ class ProductByCategoryBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<LayoutControl
+					<GridLayoutControl
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -14,8 +14,8 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import GridLayoutControl from '../../components/grid-layout-control';
 import { IconNewReleases } from '../../components/icons';
-import LayoutControl from '../../components/layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductPreview from '../../components/product-preview';
 
@@ -73,7 +73,7 @@ class ProductNewestBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<LayoutControl
+					<GridLayoutControl
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -7,12 +7,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { InspectorControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
-import {
-	PanelBody,
-	Placeholder,
-	RangeControl,
-	Spinner,
-} from '@wordpress/components';
+import { PanelBody, Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
@@ -20,6 +15,7 @@ import PropTypes from 'prop-types';
  */
 import getQuery from '../../utils/get-query';
 import { IconNewReleases } from '../../components/icons';
+import LayoutControl from '../../components/layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductPreview from '../../components/product-preview';
 
@@ -77,19 +73,10 @@ class ProductNewestBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<RangeControl
-						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ wc_product_block_data.min_columns }
-						max={ wc_product_block_data.max_columns }
-					/>
-					<RangeControl
-						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
-						value={ rows }
-						onChange={ ( value ) => setAttributes( { rows: value } ) }
-						min={ wc_product_block_data.min_rows }
-						max={ wc_product_block_data.max_rows }
+					<LayoutControl
+						columns={ columns }
+						rows={ rows }
+						setAttributes={ setAttributes }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
-import LayoutControl from '../../components/layout-control';
+import GridLayoutControl from '../../components/grid-layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
 import ProductPreview from '../../components/product-preview';
@@ -78,7 +78,7 @@ class ProductOnSaleBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<LayoutControl
+					<GridLayoutControl
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -8,18 +8,14 @@ import { InspectorControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
-import {
-	PanelBody,
-	Placeholder,
-	RangeControl,
-	Spinner,
-} from '@wordpress/components';
+import { PanelBody, Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import LayoutControl from '../../components/layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
 import ProductPreview from '../../components/product-preview';
@@ -82,19 +78,10 @@ class ProductOnSaleBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<RangeControl
-						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ wc_product_block_data.min_columns }
-						max={ wc_product_block_data.max_columns }
-					/>
-					<RangeControl
-						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
-						value={ rows }
-						onChange={ ( value ) => setAttributes( { rows: value } ) }
-						min={ wc_product_block_data.min_rows }
-						max={ wc_product_block_data.max_rows }
+					<LayoutControl
+						columns={ columns }
+						rows={ rows }
+						setAttributes={ setAttributes }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -8,18 +8,14 @@ import { InspectorControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
-import {
-	PanelBody,
-	Placeholder,
-	RangeControl,
-	Spinner,
-} from '@wordpress/components';
+import { PanelBody, Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import LayoutControl from '../../components/layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductPreview from '../../components/product-preview';
 
@@ -77,19 +73,10 @@ class ProductTopRatedBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<RangeControl
-						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ wc_product_block_data.min_columns }
-						max={ wc_product_block_data.max_columns }
-					/>
-					<RangeControl
-						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
-						value={ rows }
-						onChange={ ( value ) => setAttributes( { rows: value } ) }
-						min={ wc_product_block_data.min_rows }
-						max={ wc_product_block_data.max_rows }
+					<LayoutControl
+						columns={ columns }
+						rows={ rows }
+						setAttributes={ setAttributes }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
-import LayoutControl from '../../components/layout-control';
+import GridLayoutControl from '../../components/grid-layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductPreview from '../../components/product-preview';
 
@@ -73,7 +73,7 @@ class ProductTopRatedBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<LayoutControl
+					<GridLayoutControl
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
-import LayoutControl from '../../components/layout-control';
+import GridLayoutControl from '../../components/grid-layout-control';
 import ProductAttributeControl from '../../components/product-attribute-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
 import ProductPreview from '../../components/product-preview';
@@ -93,7 +93,7 @@ class ProductsByAttributeBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<LayoutControl
+					<GridLayoutControl
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -9,7 +9,6 @@ import {
 	Button,
 	PanelBody,
 	Placeholder,
-	RangeControl,
 	Spinner,
 	Toolbar,
 	withSpokenMessages,
@@ -23,6 +22,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import LayoutControl from '../../components/layout-control';
 import ProductAttributeControl from '../../components/product-attribute-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
 import ProductPreview from '../../components/product-preview';
@@ -93,19 +93,10 @@ class ProductsByAttributeBlock extends Component {
 					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
-					<RangeControl
-						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-						value={ columns }
-						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ wc_product_block_data.min_columns }
-						max={ wc_product_block_data.max_columns }
-					/>
-					<RangeControl
-						label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
-						value={ rows }
-						onChange={ ( value ) => setAttributes( { rows: value } ) }
-						min={ wc_product_block_data.min_rows }
-						max={ wc_product_block_data.max_rows }
+					<LayoutControl
+						columns={ columns }
+						rows={ rows }
+						setAttributes={ setAttributes }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/components/grid-layout-control/index.js
+++ b/assets/js/components/grid-layout-control/index.js
@@ -10,7 +10,7 @@ import { RangeControl } from '@wordpress/components';
 /**
  * A combination of range controls for product grid layout settings.
  */
-const LayoutControl = ( { columns, rows, setAttributes } ) => {
+const GridLayoutControl = ( { columns, rows, setAttributes } ) => {
 	return (
 		<Fragment>
 			<RangeControl
@@ -45,7 +45,7 @@ const LayoutControl = ( { columns, rows, setAttributes } ) => {
 	);
 };
 
-LayoutControl.propTypes = {
+GridLayoutControl.propTypes = {
 	/**
 	 * The current columns count.
 	 */
@@ -60,4 +60,4 @@ LayoutControl.propTypes = {
 	setAttributes: PropTypes.func.isRequired,
 };
 
-export default LayoutControl;
+export default GridLayoutControl;

--- a/assets/js/components/layout-control/index.js
+++ b/assets/js/components/layout-control/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { clamp, isNaN } from 'lodash';
+import { Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
+import { RangeControl } from '@wordpress/components';
+
+/**
+ * A combination of range controls for product grid layout settings.
+ */
+const LayoutControl = ( { columns, rows, setAttributes } ) => {
+	return (
+		<Fragment>
+			<RangeControl
+				label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
+				value={ columns }
+				onChange={ ( value ) => {
+					const newValue = clamp(
+						value,
+						wc_product_block_data.min_columns,
+						wc_product_block_data.max_columns
+					);
+					setAttributes( { columns: isNaN( newValue ) ? '' : newValue } );
+				} }
+				min={ wc_product_block_data.min_columns }
+				max={ wc_product_block_data.max_columns }
+			/>
+			<RangeControl
+				label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
+				value={ rows }
+				onChange={ ( value ) => {
+					const newValue = clamp(
+						value,
+						wc_product_block_data.min_rows,
+						wc_product_block_data.max_rows
+					);
+					setAttributes( { rows: isNaN( newValue ) ? '' : newValue } );
+				} }
+				min={ wc_product_block_data.min_rows }
+				max={ wc_product_block_data.max_rows }
+			/>
+		</Fragment>
+	);
+};
+
+LayoutControl.propTypes = {
+	/**
+	 * The current columns count.
+	 */
+	columns: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
+	/**
+	 * The current rows count.
+	 */
+	rows: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ).isRequired,
+	/**
+	 * Callback to update the layout settings.
+	 */
+	setAttributes: PropTypes.func.isRequired,
+};
+
+export default LayoutControl;

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -4,11 +4,11 @@ export default function getQuery( blockAttributes, name ) {
 		attrOperator,
 		categories,
 		catOperator,
-		columns,
 		orderby,
 		products,
-		rows,
 	} = blockAttributes;
+	const columns = blockAttributes.columns || wc_product_block_data.default_columns;
+	const rows = blockAttributes.rows || wc_product_block_data.default_rows;
 
 	const query = {
 		status: 'publish',

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -1,5 +1,12 @@
 export default function getShortcode( { attributes }, name ) {
-	const { categories, catOperator, columns, orderby, products, rows } = attributes;
+	const {
+		categories,
+		catOperator,
+		orderby,
+		products,
+	} = attributes;
+	const columns = attributes.columns || wc_product_block_data.default_columns;
+	const rows = attributes.rows || wc_product_block_data.default_rows;
 
 	const shortcodeAtts = new Map();
 	shortcodeAtts.set( 'limit', rows * columns );


### PR DESCRIPTION
Fixes #359 – It was possible to set the row/column values to numbers > 6, which in addition to not looking right, was not supported by the CSS. This PR adds a new control called `LayoutControl`, which wraps the two `RangeControl`s for row and column. It also adds a check to limit each value to the min/max set up by the site/theme settings.

### How to test the changes in this Pull Request:

There should be no visual changes.

1. Edit any block with row & col settings: Newest Products, Best Selling Products, Products by Category, etc
2. Attempt to change the rows or columns values to larger than 6 by entering text in the text box
3. Expect: you can't, it defaults to 6
