### PR TITLE
Featured Product: Allow to resize the block height

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -43,7 +43,7 @@ import {
 /**
  * The min-height for the block content.
  */
-const MIN_HEIGHT = 500;
+const MIN_HEIGHT = wc_product_block_data.min_height;
 
 /**
  * Generate a style object given either a product object or URL to an image.

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -19,6 +19,7 @@ import {
 	PanelBody,
 	Placeholder,
 	RangeControl,
+	ResizableBox,
 	Spinner,
 	ToggleControl,
 	Toolbar,
@@ -38,6 +39,11 @@ import {
 	getImageSrcFromProduct,
 	getImageIdFromProduct,
 } from '../../utils/products';
+
+/**
+ * The min-height for the block content.
+ */
+const MIN_HEIGHT = 500;
 
 /**
  * Generate a style object given either a product object or URL to an image.
@@ -206,11 +212,12 @@ class FeaturedProduct extends Component {
 	}
 
 	render() {
-		const { attributes, setAttributes, overlayColor } = this.props;
+		const { attributes, isSelected, overlayColor, setAttributes } = this.props;
 		const {
 			contentAlign,
 			dimRatio,
 			editMode,
+			height,
 			linkText,
 			showDesc,
 			showPrice,
@@ -219,6 +226,7 @@ class FeaturedProduct extends Component {
 		const classes = classnames(
 			'wc-block-featured-product',
 			{
+				'is-selected': isSelected,
 				'is-loading': ! product && ! loaded,
 				'is-not-found': ! product && loaded,
 				'has-background-dim': dimRatio !== 0,
@@ -234,6 +242,10 @@ class FeaturedProduct extends Component {
 		if ( overlayColor.color ) {
 			style.backgroundColor = overlayColor.color;
 		}
+
+		const onResizeStop = ( event, direction, elt ) => {
+			setAttributes( { height: parseInt( elt.style.height ) } );
+		};
 
 		return (
 			<Fragment>
@@ -280,7 +292,14 @@ class FeaturedProduct extends Component {
 				) : (
 					<Fragment>
 						{ !! product ? (
-							<div className={ classes } style={ style }>
+							<ResizableBox
+								className={ classes }
+								size={ { height } }
+								minHeight={ MIN_HEIGHT }
+								enable={ { bottom: true } }
+								onResizeStop={ onResizeStop }
+								style={ style }
+							>
 								<h2 className="wc-block-featured-product__title">
 									{ product.name }
 								</h2>
@@ -307,7 +326,7 @@ class FeaturedProduct extends Component {
 										keepPlaceholderOnFocus
 									/>
 								</div>
-							</div>
+							</ResizableBox>
 						) : (
 							<Placeholder
 								className="wc-block-featured-product"
@@ -330,15 +349,19 @@ class FeaturedProduct extends Component {
 
 FeaturedProduct.propTypes = {
 	/**
-	 * The attributes for this block
+	 * The attributes for this block.
 	 */
 	attributes: PropTypes.object.isRequired,
+	/**
+	 * Whether this block is currently active.
+	 */
+	isSelected: PropTypes.bool.isRequired,
 	/**
 	 * The register block name.
 	 */
 	name: PropTypes.string.isRequired,
 	/**
-	 * A callback to update attributes
+	 * A callback to update attributes.
 	 */
 	setAttributes: PropTypes.func.isRequired,
 	// from withColors

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -300,31 +300,33 @@ class FeaturedProduct extends Component {
 								onResizeStop={ onResizeStop }
 								style={ style }
 							>
-								<h2 className="wc-block-featured-product__title">
-									{ product.name }
-								</h2>
-								{ showDesc && (
-									<div
-										className="wc-block-featured-product__description"
-										dangerouslySetInnerHTML={ {
-											__html: product.short_description,
-										} }
-									/>
-								) }
-								{ showPrice && (
-									<div
-										className="wc-block-featured-product__price"
-										dangerouslySetInnerHTML={ { __html: product.price_html } }
-									/>
-								) }
-								<div className="wc-block-featured-product__link wp-block-button">
-									<RichText
-										value={ linkText }
-										onChange={ ( value ) => setAttributes( { linkText: value } ) }
-										formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-										className="wp-block-button__link"
-										keepPlaceholderOnFocus
-									/>
+								<div className="wc-block-featured-product__wrapper">
+									<h2 className="wc-block-featured-product__title">
+										{ product.name }
+									</h2>
+									{ showDesc && (
+										<div
+											className="wc-block-featured-product__description"
+											dangerouslySetInnerHTML={ {
+												__html: product.short_description,
+											} }
+										/>
+									) }
+									{ showPrice && (
+										<div
+											className="wc-block-featured-product__price"
+											dangerouslySetInnerHTML={ { __html: product.price_html } }
+										/>
+									) }
+									<div className="wc-block-featured-product__link wp-block-button">
+										<RichText
+											value={ linkText }
+											onChange={ ( value ) => setAttributes( { linkText: value } ) }
+											formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+											className="wp-block-button__link"
+											keepPlaceholderOnFocus
+										/>
+									</div>
 								</div>
 							</ResizableBox>
 						) : (

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -51,6 +51,14 @@ registerBlockType( 'woocommerce/featured-product', {
 		},
 
 		/**
+		 * A fixed height for the block.
+		 */
+		height: {
+			type: 'number',
+			default: 500,
+		},
+
+		/**
 		 * ID for a custom image, overriding the product's featured image.
 		 */
 		mediaId: {

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -55,7 +55,7 @@ registerBlockType( 'woocommerce/featured-product', {
 		 */
 		height: {
 			type: 'number',
-			default: 500,
+			default: wc_product_block_data.default_height,
 		},
 
 		/**

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -8,12 +8,17 @@
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	overflow: hidden;
 	flex-wrap: wrap;
 	align-content: center;
 
-	&.components-resizable-box__container {
-		overflow: visible;
+	.wc-block-featured-product__wrapper {
+		overflow: hidden;
+		height: 100%;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex-wrap: wrap;
+		align-content: center;
 	}
 
 	&.components-placeholder {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -13,9 +13,17 @@
 	flex-wrap: wrap;
 	align-content: center;
 
+	&.components-resizable-box__container {
+		overflow: visible;
+	}
+
 	&.components-placeholder {
 		// Reset the background for the placeholders.
 		background-color: rgba( 139, 139, 150, .1 );
+	}
+
+	.components-resizable-box__handle {
+		z-index: 10;
 	}
 
 	&.has-left-content {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -3,7 +3,6 @@
 	background-color: $black;
 	background-size: cover;
 	background-position: center center;
-	min-height: 500px;
 	width: 100%;
 	margin: 0 0 1.5em 0;
 	display: flex;

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -124,7 +124,7 @@ class WC_Block_Featured_Product {
 		}
 
 		if ( isset( $attributes['height'] ) ) {
-			$style .= sprintf( 'height:%dpx;', intval( $attributes['height'] ) );
+			$style .= sprintf( 'min-height:%dpx;', intval( $attributes['height'] ) );
 		}
 
 		return $style;

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -29,7 +29,7 @@ class WC_Block_Featured_Product {
 		'align'        => 'none',
 		'contentAlign' => 'center',
 		'dimRatio'     => 50,
-		'height'       => 500,
+		'height'       => false,
 		'linkText'     => false,
 		'mediaId'      => 0,
 		'mediaSrc'     => '',
@@ -53,6 +53,9 @@ class WC_Block_Featured_Product {
 		$attributes = wp_parse_args( $attributes, self::$defaults );
 		if ( ! $attributes['linkText'] ) {
 			$attributes['linkText'] = __( 'Shop now', 'woo-gutenberg-products-block' );
+		}
+		if ( ! $attributes['height'] ) {
+			$attributes['height'] = wc_get_theme_support( 'featured_block::default_height', 500 );
 		}
 
 		$title = sprintf(

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -29,6 +29,7 @@ class WC_Block_Featured_Product {
 		'align'        => 'none',
 		'contentAlign' => 'center',
 		'dimRatio'     => 50,
+		'height'       => 500,
 		'linkText'     => false,
 		'mediaId'      => 0,
 		'mediaSrc'     => '',
@@ -100,7 +101,11 @@ class WC_Block_Featured_Product {
 	 * @return string
 	 */
 	public static function get_styles( $attributes, $product ) {
-		$image_size = ( 'none' !== $attributes['align'] ) ? 'full' : 'large';
+		$image_size = 'large';
+		if ( 'none' !== $attributes['align'] || $attributes['height'] > 800 ) {
+			$image_size = 'full';
+		}
+
 		if ( $attributes['mediaId'] ) {
 			$image = wp_get_attachment_image_url( $attributes['mediaId'], $image_size );
 		} else {
@@ -113,6 +118,10 @@ class WC_Block_Featured_Product {
 
 		if ( isset( $attributes['customOverlayColor'] ) ) {
 			$style .= sprintf( 'background-color:%s;', esc_attr( $attributes['customOverlayColor'] ) );
+		}
+
+		if ( isset( $attributes['height'] ) ) {
+			$style .= sprintf( 'height:%dpx;', intval( $attributes['height'] ) );
 		}
 
 		return $style;

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -430,6 +430,8 @@ function wgpb_print_script_settings() {
 		'max_rows'          => wc_get_theme_support( 'product_grid::max_rows', 6 ),
 		'default_rows'      => wc_get_default_product_rows_per_page(),
 		'placeholderImgSrc' => wc_placeholder_img_src(),
+		'min_height'        => wc_get_theme_support( 'featured_block::min_height', 500 ),
+		'default_height'    => wc_get_theme_support( 'featured_block::default_height', 500 ),
 	);
 	?>
 	<script type="text/javascript">


### PR DESCRIPTION
Fixes #319 – This adds [the `ResizableBox` component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/resizable-box) around the featured product block, so that the block can be vertically resized by clicking & dragging a handle at the bottom of the block. This uses a min-height of 500px (the current min height), and has no upper limit.

Changing out the background image for a custom image will keep the customized height.

#### Accessibility

The resize handle doesn't appear to be keyboard-friendly, a problem in Gutenberg too: https://github.com/WordPress/gutenberg/issues/10595

### Screenshots

<img width="598" alt="screen shot 2019-02-04 at 2 12 51 pm" src="https://user-images.githubusercontent.com/541093/52231097-0a4c9d80-2887-11e9-81d0-181f29714cb4.png">

### How to test the changes in this Pull Request:

1. Add a Featured Product block
2. Pick a product with or without an image
3. Expect: You can grab the handle and make the block larger
4. Expect: Once larger, you can also grab the handle to make the block smaller again (but it will stop at 500px tall)
5. Leave the block taller than 500px
6. Change the image for a custom image
7. Expect: the block stays the same height
8. Expect: you can still drag to change the height
9. Save the post, view it
10. Expect: the block is using the correct, customized height