### PR TITLE
Featured Product: Try using Button block for button

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -324,7 +324,7 @@ class FeaturedProduct extends Component {
 													'core/button',
 													{
 														text: __( 'Shop now', 'woo-gutenberg-products-block' ),
-														url: 'https://vagrant.local/marketplace/imageless-product/',
+														url: product.permalink,
 													},
 												],
 											] }

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -328,7 +328,7 @@ class FeaturedProduct extends Component {
 													},
 												],
 											] }
-											templateLock={ true }
+											templateLock="all"
 										/>
 									</div>
 								</div>

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -325,6 +325,7 @@ class FeaturedProduct extends Component {
 													{
 														text: __( 'Shop now', 'woo-gutenberg-products-block' ),
 														url: product.permalink,
+														align: 'center',
 													},
 												],
 											] }

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -6,11 +6,11 @@ import apiFetch from '@wordpress/api-fetch';
 import {
 	AlignmentToolbar,
 	BlockControls,
+	InnerBlocks,
 	InspectorControls,
 	MediaUpload,
 	MediaUploadCheck,
 	PanelColorSettings,
-	RichText,
 	withColors,
 } from '@wordpress/editor';
 import {
@@ -218,7 +218,6 @@ class FeaturedProduct extends Component {
 			dimRatio,
 			editMode,
 			height,
-			linkText,
 			showDesc,
 			showPrice,
 		} = attributes;
@@ -318,13 +317,18 @@ class FeaturedProduct extends Component {
 											dangerouslySetInnerHTML={ { __html: product.price_html } }
 										/>
 									) }
-									<div className="wc-block-featured-product__link wp-block-button">
-										<RichText
-											value={ linkText }
-											onChange={ ( value ) => setAttributes( { linkText: value } ) }
-											formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
-											className="wp-block-button__link"
-											keepPlaceholderOnFocus
+									<div className="wc-block-featured-product__link">
+										<InnerBlocks
+											template={ [
+												[
+													'core/button',
+													{
+														text: __( 'Shop now', 'woo-gutenberg-products-block' ),
+														url: 'https://vagrant.local/marketplace/imageless-product/',
+													},
+												],
+											] }
+											templateLock={ true }
 										/>
 									</div>
 								</div>

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/editor';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -131,6 +132,6 @@ registerBlockType( 'woocommerce/featured-product', {
 	 * Block content is rendered in PHP, not via save function.
 	 */
 	save() {
-		return null;
+		return <InnerBlocks.Content />;
 	},
 } );

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -35,8 +35,7 @@
 
 		.wc-block-featured-product__title,
 		.wc-block-featured-product__description,
-		.wc-block-featured-product__price,
-		.wc-block-featured-product__link {
+		.wc-block-featured-product__price {
 			margin-left: 0;
 			text-align: left;
 		}
@@ -47,8 +46,7 @@
 
 		.wc-block-featured-product__title,
 		.wc-block-featured-product__description,
-		.wc-block-featured-product__price,
-		.wc-block-featured-product__link {
+		.wc-block-featured-product__price {
 			margin-right: 0;
 			text-align: right;
 		}
@@ -56,14 +54,10 @@
 
 	.wc-block-featured-product__title,
 	.wc-block-featured-product__description,
-	.wc-block-featured-product__price,
-	.wc-block-featured-product__link {
+	.wc-block-featured-product__price {
 		color: $white;
 		line-height: 1.25;
-		z-index: 1;
 		margin-bottom: 0;
-		width: 100%;
-		padding: 0 48px 16px 48px;
 		text-align: center;
 
 		a,
@@ -72,6 +66,15 @@
 		a:active {
 			color: $white;
 		}
+	}
+
+	.wc-block-featured-product__title,
+	.wc-block-featured-product__description,
+	.wc-block-featured-product__price,
+	.wc-block-featured-product__link {
+		width: 100%;
+		padding: 0 48px 16px 48px;
+		z-index: 1;
 	}
 
 	.wc-block-featured-product__title {

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -30,7 +30,6 @@ class WC_Block_Featured_Product {
 		'contentAlign' => 'center',
 		'dimRatio'     => 50,
 		'height'       => false,
-		'linkText'     => false,
 		'mediaId'      => 0,
 		'mediaSrc'     => '',
 		'showDesc'     => true,
@@ -51,9 +50,6 @@ class WC_Block_Featured_Product {
 			return '';
 		}
 		$attributes = wp_parse_args( $attributes, self::$defaults );
-		if ( ! $attributes['linkText'] ) {
-			$attributes['linkText'] = __( 'Shop now', 'woo-gutenberg-products-block' );
-		}
 		if ( ! $attributes['height'] ) {
 			$attributes['height'] = wc_get_theme_support( 'featured_block::default_height', 500 );
 		}
@@ -73,14 +69,6 @@ class WC_Block_Featured_Product {
 			$product->get_price_html()
 		);
 
-		$link_str = sprintf(
-			'<div class="wc-block-featured-product__link wp-block-button"><a class="wp-block-button__link" href="%1$s" aria-label="%2$s">%3$s</a></div>',
-			$product->get_permalink(),
-			/* translators: %s is product name */
-			sprintf( __( 'View product %s', 'woo-gutenberg-products-block' ), $product->get_name() ),
-			$attributes['linkText']
-		);
-
 		$output = sprintf( '<div class="%1$s" style="%2$s">', self::get_classes( $attributes ), self::get_styles( $attributes, $product ) );
 
 		$output .= $title;
@@ -90,7 +78,7 @@ class WC_Block_Featured_Product {
 		if ( $attributes['showPrice'] ) {
 			$output .= $price_str;
 		}
-		$output .= $link_str;
+		$output .= '<div class="wc-block-featured-product__link">' . $content . '</div>';
 		$output .= '</div>';
 
 		return $output;

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -276,6 +276,7 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 
 		$data['id']                = $raw_data['id'];
 		$data['name']              = $raw_data['name'];
+		$data['permalink']         = $raw_data['permalink'];
 		$data['sku']               = $raw_data['sku'];
 		$data['description']       = $raw_data['description'];
 		$data['short_description'] = $raw_data['short_description'];
@@ -330,6 +331,7 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 
 		$schema['properties']['id']                = $raw_schema['properties']['id'];
 		$schema['properties']['name']              = $raw_schema['properties']['name'];
+		$schema['properties']['permalink']         = $raw_schema['properties']['permalink'];
 		$schema['properties']['sku']               = $raw_schema['properties']['sku'];
 		$schema['properties']['description']       = $raw_schema['properties']['description'];
 		$schema['properties']['short_description'] = $raw_schema['properties']['short_description'];


### PR DESCRIPTION
See #368 – Use the Button block to render the featured product's call to action button. We set up the block to use a template with the only button block. There are a few gotchas by using the template, though.

- The template is set once when the block loads, and does not reset if the product is changed - so if you pick Product A, the button sets up with the link to Product A; if you then change it to Product B, the link URL stays Product A. Any customized button text also sticks (but that's expected, IMO).
- There's no way to pass settings into the block, so we can't disable editing of the link
- We also can't disable the alignment options, so in this PR you need to align the text inside the block and then the button itself separately.

Bonuses we get from using the Button block:

- Text & background colors, along with the contrast checker
- The different Button styles are supported
- The toolbar for the button text styles (bold, italic, etc) is only shown at the button level

### Screenshots

It looks the same when inserted by default:

<img width="610" alt="default" src="https://user-images.githubusercontent.com/541093/52240178-3d4e5b80-289e-11e9-8f35-a23712a199d8.png" />

Since it's the button block, we can also use the different button styles:

<img width="593" alt="styled" src="https://user-images.githubusercontent.com/541093/52240177-3d4e5b80-289e-11e9-8c1b-0fb848767a82.png" />

### How to test the changes in this Pull Request:

1. Add a Featured Product block
2. Click around the button
3. Expect: Should work like a button 🙂

Given the issues above (and the fact that some were explicitly called out as "don't do this" in #368) I'm looking more for design feedback than dev feedback ATM.