### PR TITLE
Products by Attribute: Update block to use API, shortcode rendering

### DIFF
--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import Gridicon from 'gridicons';
+import { RawHTML } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -10,6 +11,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './style.scss';
 import Block from './block';
+import getShortcode from '../../utils/get-shortcode';
 
 registerBlockType( 'woocommerce/products-by-attribute', {
 	title: __( 'Products by Attribute', 'woo-gutenberg-products-block' ),
@@ -81,9 +83,18 @@ registerBlockType( 'woocommerce/products-by-attribute', {
 	},
 
 	/**
-	 * Block content is rendered in PHP, not via save function.
+	 * Save the block content in the post content. Block content is saved as a products shortcode.
+	 *
+	 * @return string
 	 */
-	save() {
-		return null;
+	save( props ) {
+		const {
+			align,
+		} = props.attributes; /* eslint-disable-line react/prop-types */
+		return (
+			<RawHTML className={ align ? `align${ align }` : '' }>
+				{ getShortcode( props, 'woocommerce/products-by-attribute' ) }
+			</RawHTML>
+		);
 	},
 } );

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -111,6 +111,19 @@
 			flex: 1;
 		}
 
+		&.depth-0 + .depth-1 {
+			// Hide the border on the preceding list item
+			margin-top: -1px;
+		}
+
+		&:not(.depth-0) {
+			border-bottom: 0 !important;
+		}
+
+		&:not(.depth-0) + .depth-0 {
+			border-top: 1px solid $core-grey-light-500;
+		}
+
 		// Anything deeper than 5 levels will use this fallback depth
 		&[class*="depth-"] .woocommerce-search-list__item-label:before {
 			margin-right: $gap-smallest;

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -40,19 +40,12 @@ export default function getQuery( blockAttributes, name ) {
 		}
 	}
 
-	if ( attributes ) {
-		query.attributes = attributes.reduce( ( accumulator, { attr_slug, id } ) => { // eslint-disable-line camelcase
-			if ( accumulator[ attr_slug ] ) {
-				accumulator[ attr_slug ].push( id );
-			} else {
-				accumulator[ attr_slug ] = [ id ];
-			}
-			return accumulator;
-		}, {} );
+	if ( attributes && attributes.length > 0 ) {
+		query.attribute_term = attributes.map( ( { id } ) => id ).join( ',' );
+		query.attribute = attributes[ 0 ].attr_slug;
 
 		if ( attrOperator ) {
 			query.attr_operator = 'all' === attrOperator ? 'AND' : 'IN';
-			query.tax_relation = 'all' === attrOperator ? 'AND' : 'OR';
 		}
 	}
 

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -1,12 +1,15 @@
-export default function getShortcode( { attributes }, name ) {
+export default function getShortcode( props, name ) {
+	const blockAttributes = props.attributes;
 	const {
+		attributes,
+		attrOperator,
 		categories,
 		catOperator,
 		orderby,
 		products,
-	} = attributes;
-	const columns = attributes.columns || wc_product_block_data.default_columns;
-	const rows = attributes.rows || wc_product_block_data.default_rows;
+	} = blockAttributes;
+	const columns = blockAttributes.columns || wc_product_block_data.default_columns;
+	const rows = blockAttributes.rows || wc_product_block_data.default_rows;
 
 	const shortcodeAtts = new Map();
 	shortcodeAtts.set( 'limit', rows * columns );
@@ -16,6 +19,14 @@ export default function getShortcode( { attributes }, name ) {
 		shortcodeAtts.set( 'category', categories.join( ',' ) );
 		if ( catOperator && 'all' === catOperator ) {
 			shortcodeAtts.set( 'cat_operator', 'AND' );
+		}
+	}
+
+	if ( attributes && attributes.length ) {
+		shortcodeAtts.set( 'terms', attributes.map( ( { id } ) => id ).join( ',' ) );
+		shortcodeAtts.set( 'attribute', attributes[ 0 ].attr_slug );
+		if ( attrOperator && 'all' === attrOperator ) {
+			shortcodeAtts.set( 'terms_operator', 'AND' );
 		}
 	}
 
@@ -58,6 +69,11 @@ export default function getShortcode( { attributes }, name ) {
 			break;
 		case 'woocommerce/product-category':
 			if ( ! categories || ! categories.length ) {
+				return '';
+			}
+			break;
+		case 'woocommerce/products-by-attribute':
+			if ( ! attributes || ! attributes.length ) {
 				return '';
 			}
 			break;


### PR DESCRIPTION
Fixes #361 – Uses the new design to load attribute types, then once selected it will load the terms in that attribute for selection. Once selected, the block uses the updated API to pull just the products matching those attribute terms, and on save it converts that to the shortcode.

#### Accessibility

Functionally this works, but I want to tweak the screen reader experience some more.

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

Note: I know the design isn't quite there, I'll put in a follow-up PR to fix the CSS & screen reader issues. This is just to make sure the functionality works as expected. I'm not tagging this as design review, but I would appreciate a "flow review" from @jameskoster 🙂 

![screen shot 2019-02-06 at 6 34 34 pm](https://user-images.githubusercontent.com/541093/52381008-e8494b80-2a3d-11e9-9f06-8c1698181b24.png)

### How to test the changes in this Pull Request:

1. Add a Products by Attribute block
2. Select different sets of attributes
3. Expect: The products that display should match the selected attributes
