### PR TITLE
Add catalog_visibility param to products api

### DIFF
--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -26,6 +26,7 @@ class ProductControl extends Component {
 		apiFetch( {
 			path: addQueryArgs( '/wc-pb/v3/products', {
 				per_page: -1,
+				catalog_visibility: 'visible',
 				status: 'publish',
 			} ),
 		} )

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -24,7 +24,11 @@ class ProductsControl extends Component {
 
 	componentDidMount() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', { per_page: -1, status: 'publish' } ),
+			path: addQueryArgs( '/wc-pb/v3/products', {
+				per_page: -1,
+				catalog_visibility: 'visible',
+				status: 'publish',
+			} ),
 		} )
 			.then( ( list ) => {
 				this.setState( { list, loading: false } );

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -13,6 +13,7 @@ export default function getQuery( blockAttributes, name ) {
 	const query = {
 		status: 'publish',
 		per_page: rows * columns,
+		catalog_visibility: 'visible',
 	};
 
 	if ( categories && categories.length ) {
@@ -68,9 +69,6 @@ export default function getQuery( blockAttributes, name ) {
 			query.per_page = products.length;
 			break;
 	}
-
-	// Always only show visible products.
-	query.catalog_visibility = 'visible';
 
 	return query;
 }

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -69,5 +69,8 @@ export default function getQuery( blockAttributes, name ) {
 			break;
 	}
 
+	// Always only show visible products.
+	query.catalog_visibility = 'visible';
+
 	return query;
 }

--- a/assets/js/utils/test/get-query.js
+++ b/assets/js/utils/test/get-query.js
@@ -81,6 +81,7 @@ describe( 'getQuery', () => {
 		test( 'should return a general query with no category', () => {
 			const query = getQuery( attributes );
 			expect( query ).toEqual( {
+				catalog_visibility: 'visible',
 				orderby: 'date',
 				per_page: 12,
 				status: 'publish',
@@ -91,6 +92,7 @@ describe( 'getQuery', () => {
 			attributes.categories = [];
 			const query = getQuery( attributes );
 			expect( query ).toEqual( {
+				catalog_visibility: 'visible',
 				orderby: 'date',
 				per_page: 12,
 				status: 'publish',
@@ -101,6 +103,7 @@ describe( 'getQuery', () => {
 			attributes.categories = [ 1 ];
 			const query = getQuery( attributes );
 			expect( query ).toEqual( {
+				catalog_visibility: 'visible',
 				category: '1',
 				orderby: 'date',
 				per_page: 12,
@@ -112,6 +115,7 @@ describe( 'getQuery', () => {
 			attributes.categories = [ 1, 2 ];
 			const query = getQuery( attributes );
 			expect( query ).toEqual( {
+				catalog_visibility: 'visible',
 				category: '1,2',
 				orderby: 'date',
 				per_page: 12,

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -230,10 +230,13 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 	protected function prepare_objects_query( $request ) {
 		$args = parent::prepare_objects_query( $request );
 
-		$orderby       = $request->get_param( 'orderby' );
-		$order         = $request->get_param( 'order' );
-		$cat_operator  = $request->get_param( 'cat_operator' );
-		$attr_operator = $request->get_param( 'attr_operator' );
+		$orderby            = $request->get_param( 'orderby' );
+		$order              = $request->get_param( 'order' );
+		$cat_operator       = $request->get_param( 'cat_operator' );
+		$attr_operator      = $request->get_param( 'attr_operator' );
+		$attributes         = $request->get_param( 'attributes' );
+		$tax_relation       = $request->get_param( 'tax_relation' );
+		$catalog_visibility = $request->get_param( 'catalog_visibility' );
 
 		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
 		$args['orderby'] = $ordering_args['orderby'];
@@ -257,6 +260,15 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 					$args['tax_query'][ $i ]['operator'] = $attr_operator;
 				}
 			}
+		}
+
+		if ( 'visible' === $catalog_visibility ) {
+			$args['tax_query'][] = array(
+				'taxonomy' => 'product_visibility',
+				'field'    => 'term_id',
+				'terms'    => array( 'exclude-from-catalog' ),
+				'operator' => 'NOT IN',
+			);
 		}
 
 		return $args;

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -266,7 +266,7 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 			$args['tax_query'][] = array(
 				'taxonomy' => 'product_visibility',
 				'field'    => 'term_id',
-				'terms'    => array( 'exclude-from-catalog' ),
+				'terms'    => array( 'exclude-from-catalog', 'exclude-from-search' ),
 				'operator' => 'NOT IN',
 			);
 		}

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -307,19 +307,26 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params                    = parent::get_collection_params();
-		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
-		$params['cat_operator']    = array(
+		$params                       = parent::get_collection_params();
+		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
+		$params['cat_operator']       = array(
 			'description'       => __( 'Operator to compare product category terms.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attr_operator']   = array(
+		$params['attr_operator']      = array(
 			'description'       => __( 'Operator to compare product attribute terms.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['catalog_visibility'] = array(
+			'description'       => __( 'Determines if hidden or visible catalog products are shown.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'enum'              => array( 'visible', 'catalog', 'search', 'hidden' ),
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -234,8 +234,6 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 		$order              = $request->get_param( 'order' );
 		$cat_operator       = $request->get_param( 'cat_operator' );
 		$attr_operator      = $request->get_param( 'attr_operator' );
-		$attributes         = $request->get_param( 'attributes' );
-		$tax_relation       = $request->get_param( 'tax_relation' );
 		$catalog_visibility = $request->get_param( 'catalog_visibility' );
 
 		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
@@ -262,12 +260,15 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 			}
 		}
 
-		if ( 'visible' === $catalog_visibility ) {
+		if ( in_array( $catalog_visibility, array_keys( wc_get_product_visibility_options() ), true ) ) {
+			$exclude_from_catalog = 'search' === $catalog_visibility ? '' : 'exclude-from-catalog';
+			$exclude_from_search  = 'catalog' === $catalog_visibility ? '' : 'exclude-from-search';
+
 			$args['tax_query'][] = array(
 				'taxonomy' => 'product_visibility',
-				'field'    => 'term_id',
-				'terms'    => array( 'exclude-from-catalog', 'exclude-from-search' ),
-				'operator' => 'NOT IN',
+				'field'    => 'name',
+				'terms'    => array( $exclude_from_catalog, $exclude_from_search ),
+				'operator' => 'hidden' === $catalog_visibility ? 'AND' : 'NOT IN',
 			);
 		}
 


### PR DESCRIPTION
Fixes #252

This adds a catalog_visibility=visible option to the product api which
will filter out any products that are excluded from the catalog.

#### Accessibility

No accessibility changes, this only filters products out in the preview.

### How to test the changes in this Pull Request:

1. Exclude some products from the catalog.
2. Try out each of the blocks and ensure those products don't show up in the previews.
