### PR TITLE
Bump `@woocommerce/components` to v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1516,15 +1516,15 @@
       }
     },
     "@woocommerce/components": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-1.4.2.tgz",
-      "integrity": "sha512-OM0sV4frKmvUnXXY22/DTAz+u0cM4qEqJUNJR8QogPr6Hkyqbhga0wYVQmwBYbIRfcYkiAJMod8i7sGtSGv0Zg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-1.5.0.tgz",
+      "integrity": "sha512-YbxTkvscX7NgJPWv2ohcgYxAAfW7eB7wE7iMin+4OHs7wmOY2nYYpR+qzvplrPKgj/0kOAkoxtFewqWmvIu18g==",
       "requires": {
         "@babel/runtime-corejs2": "7.3.1",
         "@woocommerce/csv-export": "^1.0.3",
         "@woocommerce/currency": "^1.1.0",
         "@woocommerce/date": "^1.0.6",
-        "@woocommerce/navigation": "^1.1.1",
+        "@woocommerce/navigation": "^2.0.0",
         "@wordpress/components": "7.0.5",
         "@wordpress/compose": "3.0.0",
         "@wordpress/date": "3.0.1",
@@ -1657,9 +1657,9 @@
           }
         },
         "react-dates": {
-          "version": "18.4.1",
-          "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-18.4.1.tgz",
-          "integrity": "sha512-ew6HiORfbJkEGlJ+5SMC5GtgI87zj2BqNv8tRsdnPtgLMt5fY2Z9dUFxc+XATeRHs+wOm4ku0dlKWpuqBzYapQ==",
+          "version": "18.5.0",
+          "resolved": "https://registry.npmjs.org/react-dates/-/react-dates-18.5.0.tgz",
+          "integrity": "sha512-5zWR3+ekkRzf740omDkO+N0JifsGGOeyvWwQ/7dFxSb2CqHUsOfKgvpXOiwd3hBm4yr+lelESI3b458BEOU5og==",
           "requires": {
             "airbnb-prop-types": "^2.10.0",
             "consolidated-events": "^1.1.1 || ^2.0.0",
@@ -1743,9 +1743,9 @@
       }
     },
     "@woocommerce/navigation": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-1.1.1.tgz",
-      "integrity": "sha512-/yaZlc/GE8jhGsJktGX7MmFy6lhMa1XRfXt+Jmf05/t+6ZFCGG2iX9e47NHJ8o0icj69Yza2mIN8TBY5A3Ku9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-2.0.0.tgz",
+      "integrity": "sha512-FHF/Nv9cO2q2k+f3xL3oNozwhqgeIWJ+2sXYjaFR3XwXvupt9kqmXu1MH6CN2foJ6xNsywaf4uU/1xj95L7MSA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "history": "4.7.2",
@@ -4550,8 +4550,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4572,14 +4571,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4594,20 +4591,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4724,8 +4718,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4737,7 +4730,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4752,7 +4744,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -4760,14 +4751,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4786,7 +4775,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4867,8 +4855,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4880,7 +4867,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4966,8 +4952,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5003,7 +4988,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5023,7 +5007,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5067,14 +5050,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -5980,17 +5961,17 @@
       "integrity": "sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg=="
     },
     "d3-shape": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.3.tgz",
-      "integrity": "sha512-f7V9wHQCmv4s4N7EmD5i0mwJ5y09L8r1rWVrzH1Av0YfgBKJCnTJGho76rS4HNUIw6tTBbWfFcs4ntP/MKWF4A==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.4.tgz",
+      "integrity": "sha512-izaz4fOpOnY3CD17hkZWNxbaN70sIGagLR/5jb6RS96Y+6VqX+q1BQf1av6QSBRdfULi3Gb8Js4CzG4+KAPjMg==",
       "requires": {
         "d3-path": "1"
       }
     },
     "d3-time": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.10.tgz",
-      "integrity": "sha512-hF+NTLCaJHF/JqHN5hE8HVGAXPStEq6/omumPE/SxyHVrR7/qQxusFDo0t0c/44+sCGHthC7yNGFZIEgju0P8g=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz",
+      "integrity": "sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw=="
     },
     "d3-time-format": {
       "version": "2.1.3",
@@ -7894,8 +7875,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7916,14 +7896,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7938,20 +7916,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8068,8 +8043,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8081,7 +8055,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8096,7 +8069,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8104,14 +8076,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -8130,7 +8100,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8211,8 +8180,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8224,7 +8192,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8310,8 +8277,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8347,7 +8313,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8367,7 +8332,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8411,14 +8375,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "npm": "6.7.0"
   },
   "dependencies": {
-    "@woocommerce/components": "1.4.2",
+    "@woocommerce/components": "1.5.0",
     "gridicons": "^3.1.1"
   },
   "husky": {


### PR DESCRIPTION
Fixes #327 

This advances the version of woocommerce components for the primary
reason of fixing the navigation problem of adding #/ to any URLs we use.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### How to test the changes in this Pull Request:

1. Edit a post, any post with a WooCommerce block, and observe that there's no redirect to the same url with `#/` at the end.
2. Poke around the rest of the block components to make sure nothing is broken.
