### PR TITLE
Featured Product: Fix undefined variable notice

### DIFF
--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -104,6 +104,7 @@ class WC_Block_Featured_Product {
 	 * @return string
 	 */
 	public static function get_styles( $attributes, $product ) {
+		$style      = '';
 		$image_size = 'large';
 		if ( 'none' !== $attributes['align'] || $attributes['height'] > 800 ) {
 			$image_size = 'full';
@@ -116,7 +117,7 @@ class WC_Block_Featured_Product {
 		}
 
 		if ( ! empty( $image ) ) {
-			$style = sprintf( 'background-image:url(%s);', esc_url( $image ) );
+			$style .= sprintf( 'background-image:url(%s);', esc_url( $image ) );
 		}
 
 		if ( isset( $attributes['customOverlayColor'] ) ) {


### PR DESCRIPTION
If you have a Featured Product block with an imageless product, you get an `undefined variable` notice because `$style` is not created.

> PHP Notice:  Undefined variable: style in …/includes/blocks/class-wc-block-featured-product.php on line 128

### How to test the changes in this Pull Request:

1. Add a Featured Product block, select a product with no set image
2. View the product on the front end
3. Expect: No PHP notice
