### PR TITLE
ProductAttributeControl: Polish style, screen reader interaction

### DIFF
--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -5,7 +5,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment } from '@wordpress/element';
-import { debounce, filter, find } from 'lodash';
+import { debounce, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SelectControl, Spinner } from '@wordpress/components';
 
@@ -86,17 +86,9 @@ class ProductAttributeControl extends Component {
 
 	onSelectAttribute( item ) {
 		return () => {
-			if ( item.id === this.state.attribute ) {
-				return;
-			}
 			this.props.onChange( [] );
-			this.setState( ( { list } ) => {
-				// Remove all other attribute terms from the list.
-				const updatedList = filter( list, { parent: 0 } );
-				return {
-					list: updatedList,
-					attribute: item.id,
-				};
+			this.setState( {
+				attribute: item.id === this.state.attribute ? 0 : item.id,
 			} );
 		};
 	}

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -117,7 +117,6 @@ class ProductAttributeControl extends Component {
 					onSelect={ this.onSelectAttribute }
 					isSingle
 					disabled={ '0' === item.count }
-					showCount
 					aria-expanded={ attribute === item.id }
 					aria-label={ sprintf(
 						_n(
@@ -148,6 +147,7 @@ class ProductAttributeControl extends Component {
 			<SearchListItem
 				className={ classes.join( ' ' ) }
 				{ ...args }
+				showCount
 				aria-label={ `${ item.breadcrumbs[ 0 ] }: ${ item.name }` }
 			/>
 		);

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -116,6 +116,7 @@ class ProductAttributeControl extends Component {
 					isSelected={ attribute === item.id }
 					onSelect={ this.onSelectAttribute }
 					isSingle
+					disabled={ '0' === item.count }
 					showCount
 					aria-expanded={ attribute === item.id }
 					aria-label={ sprintf(

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -124,6 +124,18 @@ class ProductAttributeControl extends Component {
 					isSelected={ attribute === item.id }
 					onSelect={ this.onSelectAttribute }
 					isSingle
+					showCount
+					aria-expanded={ attribute === item.id }
+					aria-label={ sprintf(
+						_n(
+							'%s, has %d term',
+							'%s, has %d terms',
+							item.count,
+							'woo-gutenberg-products-block'
+						),
+						item.name,
+						item.count
+					) }
 				/>,
 				attribute === item.id && termsLoading && (
 					<div
@@ -143,7 +155,6 @@ class ProductAttributeControl extends Component {
 			<SearchListItem
 				className={ classes.join( ' ' ) }
 				{ ...args }
-				showCount
 				aria-label={ `${ item.breadcrumbs[ 0 ] }: ${ item.name }` }
 			/>
 		);

--- a/assets/js/components/product-attribute-control/style.scss
+++ b/assets/js/components/product-attribute-control/style.scss
@@ -36,4 +36,25 @@
 			margin-bottom: $gap-small;
 		}
 	}
+
+	&.depth-0::after {
+		margin-left: $gap-smaller;
+		content: '';
+		height: $gap-large;
+		width: $gap-large;
+		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" fill="#{$core-grey-dark-300}" /></svg>');
+		background-repeat: no-repeat;
+		background-position: center right;
+		background-size: contain;
+	}
+
+	&.depth-0[aria-expanded="true"]::after {
+		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" fill="#{$core-grey-dark-300}" /></svg>');
+	}
+
+	&[disabled].depth-0::after {
+		margin-left: 0;
+		width: auto;
+		background: none;
+	}
 }

--- a/assets/js/components/product-attribute-control/style.scss
+++ b/assets/js/components/product-attribute-control/style.scss
@@ -25,7 +25,15 @@
 
 	&.is-not-active {
 		@include hover-state {
-			background: transparent;
+			background: $white;
+		}
+	}
+
+	&.is-loading {
+		justify-content: center;
+
+		.components-spinner {
+			margin-bottom: $gap-small;
 		}
 	}
 }

--- a/assets/js/components/search-list-control/style.scss
+++ b/assets/js/components/search-list-control/style.scss
@@ -70,6 +70,7 @@
 
 	.components-spinner {
 		float: none;
+		margin: 0 auto;
 	}
 
 	.components-menu-group__label {

--- a/includes/class-wgpb-product-attributes-controller.php
+++ b/includes/class-wgpb-product-attributes-controller.php
@@ -138,10 +138,12 @@ class WGPB_Product_Attributes_Controller extends WC_REST_Product_Attributes_Cont
 	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
-		$data = array(
-			'id'   => (int) $item->attribute_id,
-			'name' => $item->attribute_label,
-			'slug' => wc_attribute_taxonomy_name( $item->attribute_name ),
+		$taxonomy = wc_attribute_taxonomy_name( $item->attribute_name );
+		$data     = array(
+			'id'    => (int) $item->attribute_id,
+			'name'  => $item->attribute_label,
+			'slug'  => $taxonomy,
+			'count' => wp_count_terms( $taxonomy ),
 		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -169,9 +171,15 @@ class WGPB_Product_Attributes_Controller extends WC_REST_Product_Attributes_Cont
 			'properties' => array(),
 		);
 
-		$schema['properties']['id']   = $raw_schema['properties']['id'];
-		$schema['properties']['name'] = $raw_schema['properties']['name'];
-		$schema['properties']['slug'] = $raw_schema['properties']['slug'];
+		$schema['properties']['id']    = $raw_schema['properties']['id'];
+		$schema['properties']['name']  = $raw_schema['properties']['name'];
+		$schema['properties']['slug']  = $raw_schema['properties']['slug'];
+		$schema['properties']['count'] = array(
+			'description' => __( 'Number of terms in the attribute taxonomy.', 'woo-gutenberg-products-block' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
 
 		return $this->add_additional_fields_schema( $schema );
 	}


### PR DESCRIPTION
Following up from #405 - cleans up the styling to match the design & fix missing aria info for screen reader users.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

Example of an attribute with 2 terms selected

![screen shot 2019-02-07 at 5 30 44 pm](https://user-images.githubusercontent.com/541093/52447708-894c0b00-2aff-11e9-98d6-4970d8211103.png)

On the initial load, all attributes are collapsed. If an item has no terms, it's disabled (unclickable and dimmed)

![all-collapse](https://user-images.githubusercontent.com/541093/52447733-a4b71600-2aff-11e9-9c05-a79ac5eef650.png)

EDIT: forgot to add a "Before" - this is what it looks like on master now:

![screen shot 2019-02-07 at 5 44 53 pm](https://user-images.githubusercontent.com/541093/52447880-18f1b980-2b00-11e9-841d-618fe3bdace5.png)

### How to test the changes in this Pull Request:

1. Add Products By Attribute block
2. Click around selecting different attribute combos
3. Try navigating the block with a screen reader
4. Attributes should be flagged as "expanded" or "collapsed" depending on if they're selected
5. Selecting attributes & loading terms should work, and you should be able to select terms once they're loaded.
