### PR TITLE
Remove Gutenberg requirement from phpunit tests

### DIFF
--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -146,9 +146,6 @@ install_deps() {
 	php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wptests_
 	php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
 
-	# Install Gutenberg
-	php wp-cli.phar plugin install gutenberg --activate
-
 	# Install WooCommerce
 	cd "wp-content/plugins/"
 	# As zip file does not include tests, we have to get it from git repo.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -89,9 +89,6 @@ function wgpb_test_includes() {
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
-	echo esc_html( 'Loading Gutenberg' . PHP_EOL );
-	require dirname( dirname( dirname( __FILE__ ) ) ) . '/gutenberg/gutenberg.php';
-
 	echo esc_html( 'Loading WooCommerce' . PHP_EOL );
 	define( 'WC_TAX_ROUNDING_MODE', 'auto' );
 	define( 'WC_USE_TRANSACTIONS', false );


### PR DESCRIPTION
If you try to run the phpunit tests without the Gutenberg plugin installed on a site, you get a Fatal Error:

> Warning: require(…/wp-content/plugins/gutenberg/gutenberg.php): failed to open stream: No such file or directory in …/wp-content/plugins/woocommerce-gutenberg-products-block/tests/bootstrap.php on line 93
> PHP Fatal error:  require(): Failed opening required '…/wp-content/plugins/gutenberg/gutenberg.php' (include_path='.:/usr/share/php') in …/wp-content/plugins/woocommerce-gutenberg-products-block/tests/bootstrap.php on line 93

This PR removes the call to load the gutenberg file, and removes GB from the installer step; since we don't actually need GB to run the tests.

**To test**

- Wipe out your unit test install (vagrant halt/vagrant up usually does this for me)
- Run the installer to set up the database & test WP install
- Run the phpunit tests