### PR TITLE
Featured Product: Remove ability to change source product

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -126,18 +126,6 @@ class FeaturedProduct extends Component {
 
 		return (
 			<InspectorControls key="inspector">
-				<PanelBody
-					title={ __( 'Product', 'woo-gutenberg-products-block' ) }
-					initialOpen={ false }
-				>
-					<ProductControl
-						selected={ attributes.productId || 0 }
-						onChange={ ( value = [] ) => {
-							const id = value[ 0 ] ? value[ 0 ].id : 0;
-							setAttributes( { productId: id, mediaId: 0, mediaSrc: '' } );
-						} }
-					/>
-				</PanelBody>
 				<PanelBody title={ __( 'Content', 'woo-gutenberg-products-block' ) }>
 					<ToggleControl
 						label={ __( 'Show description', 'woo-gutenberg-products-block' ) }
@@ -254,16 +242,6 @@ class FeaturedProduct extends Component {
 						onChange={ ( nextAlign ) => {
 							setAttributes( { contentAlign: nextAlign } );
 						} }
-					/>
-					<Toolbar
-						controls={ [
-							{
-								icon: 'edit',
-								title: __( 'Edit' ),
-								onClick: () => setAttributes( { editMode: ! editMode } ),
-								isActive: editMode,
-							},
-						] }
 					/>
 					<MediaUploadCheck>
 						<Toolbar>


### PR DESCRIPTION
In #398, we [switched to using the Button block directly](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/398#pullrequestreview-200007773) in the Featured Product block. Due to the way `InnerBlocks` works, we can't update the product link once it's inserted into the page. We'd rather keep the button block functionality, so instead we'll remove the ability to change the product once inserted.

### How to test the changes in this Pull Request:

1. Add a Featured Product block
2. Expect: you should see the button block, with the product URL in the link field.
3. Expect: you can't change the source product anymore.
