### PR TITLE
Bump stable tag & plugin dev version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products
 Requires at least: 4.9
 Tested up to: 5.0
 Requires PHP: 5.2
-Stable tag: 1.3.1
+Stable tag: 1.4.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 1.4.0
+ * Version: 1.5.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
Syncing up with the version on wp.org– the stable tag is now 1.4.0. This also updates the dev plugin's version to `1.5.0-dev`, just to differentiate it from a wp.org-installed version.

I've gone with 1.5.0 for now, as I think we've decided not to break the shortcode dependency, which means even pre-merge this won't merit a major version change.

### How to test the changes in this Pull Request:

1. Look at the plugin in the wp-admin plugins list
2. The version should say 1.5.0-dev
