### PR TITLE
Fix placeholder icon alignment

### DIFF
--- a/assets/css/products-grid.scss
+++ b/assets/css/products-grid.scss
@@ -6,6 +6,13 @@
 	overflow: hidden;
 }
 
+// Align the block icons in edit mode
+.components-placeholder__label .gridicon,
+.components-placeholder__label .material-icon {
+	margin-right: 1ch;
+	fill: currentColor;
+}
+
 .wc-block-products-grid {
 	overflow: hidden;
 	display: flex;

--- a/assets/js/components/icons/new-releases.js
+++ b/assets/js/components/icons/new-releases.js
@@ -5,6 +5,7 @@ import { Icon } from '@wordpress/components';
 
 export default () => (
 	<Icon
+		className="material-icon"
 		icon={
 			<svg
 				xmlns="http://www.w3.org/2000/svg"

--- a/assets/js/components/icons/widgets.js
+++ b/assets/js/components/icons/widgets.js
@@ -5,6 +5,7 @@ import { Icon } from '@wordpress/components';
 
 export default () => (
 	<Icon
+		className="material-icon"
 		icon={
 			<svg
 				xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Fixes #379 – Adds space between icon & title. This also adds a new class, `material-icon`, to our custom icon SVGs.

### Screenshots

The top block uses a dashicon, the next block uses a material icon, and the last block uses a gridicon. The alignment of all three should match.

![screen shot 2019-02-13 at 4 07 48 pm](https://user-images.githubusercontent.com/541093/52744100-affbbd00-2fa9-11e9-9b75-08f8ac9ba540.png)

### How to test the changes in this Pull Request:

Note: the blocks to pay attention to are: "Hand-picked Products", "Best Selling Products", "Newest Products", "On Sale Products", "Top Rated Products", and "Products by Attribute" (the other two use dashicons).

1. Add a block to your post
2. Check the alignment of the icon in the placeholders: loading states, "edit modes", or empty states
