### PR TITLE
Documentation: Fix changelog headings

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
-== 1.4.0 - 2019-02-12 =
+= 1.4.0 - 2019-02-12 =
 
 - Feature: Added new block: "Products by Attribute"
 - Enhancement: Added the ability to resize the Featured Product block (a default and minimum height can be set by your theme)
@@ -106,13 +106,13 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Build: Update packages
 - Build: Remove unnecessary internationalization build step
 
-== 1.3.1 - 2019-01-17 =
+= 1.3.1 - 2019-01-17 =
 
 - Fix: A CSS conflict was causing the core columns style to reset, this has been fixed and columns will display as expected now.
 - Fix: A version conflict with a JS package was causing the blocks to be broken in non-English locales. The package was updated.
 - Fix: Translations were not being loaded correctly for the JS files. We now bundle the Danish, Spanish, and French translations so that these can be used.
 
-== 1.3.0 - 2019-01-15 =
+= 1.3.0 - 2019-01-15 =
 
 - Feature: Added new blocks: "Featured Product", "Hand-picked Products", "Best Selling Products", "Newest Products", "On Sale Products", "Top Rated Products"
 - Enhancement: Create new "WooCommerce" block category, all blocks are found there now
@@ -129,7 +129,8 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Build: Add cssnano to minify CSS
 - Build: Split out node_modules code into separate vendors files
 
-== 1.2.0 - 2018-12-04 =
+= 1.2.0 - 2018-12-04 =
+
 * Feature - Stand-alone product category block with improved category selection interface.
 * Fix - All users who can edit posts can now use these blocks thanks to a new set of API endpoints allowing view access to products, product categories, and product attributes.
 * Fix - Compatibility with WP 5.0, fixed error “Cannot read property Toolbar of undefined”.
@@ -137,14 +138,17 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 * Enhancement - Translations should now load into the block (for WP 5.0+).
 * Enhancement - Modernized build process and developer tools, and added tests for faster future development.
 
-== 1.1.2 - 2018-09-07 =
+= 1.1.2 - 2018-09-07 =
+
 * Fix - Refactor to remove withAPIData usage, as the class was removed in Gutenberg 3.7. 
 
-== 1.1.1 - 2018-08-22 =
+= 1.1.1 - 2018-08-22 =
+
 * Fix - Make Newness ordering order correctly on frontend.
 * Fix - Don't cause fatal errors if WooCommerce is not active.
 
 = 1.1.0 - 2018-06-06 =
+
 * Feature - Add "Best Selling" and "Top Rated" product scopes.
 * Fix - Only enqueue scripts and styles in the site backend.
 * Fix - Remove focus checks deprecated in latest Gutenberg version.
@@ -153,6 +157,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 * Performance - Refactored the way the attribute select works to prevent many concurrent API requests on sites with many attributes.
 
 = 1.0.0 - 2018-04-24 =
+
 * Initial implementation of the Gutenberg Products block.
 
 == Upgrade Notice ==


### PR DESCRIPTION
The headings were incorrectly formatted in readme.txt, so wp.org was not parsing it correctly. It thought the changelog was empty, and we had a bunch of custom sections for each version. The changelog headings are fixed, and is now correctly displayed on the Developers tab. This PR just syncs that change back over from SVN.

**To test**

- Make sure nothing looks off in the diff, we already know this works 🙂