### PR TITLE
Blocks: Add new content controls to grid blocks

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,25 @@
+.wp-block-woocommerce-handpicked-products,
+.wp-block-woocommerce-product-best-sellers,
+.wp-block-woocommerce-product-category,
+.wp-block-woocommerce-product-new,
+.wp-block-woocommerce-product-on-sale,
+.wp-block-woocommerce-product-top-rated,
+.wp-block-woocommerce-products-by-attribute {
+	&.is-hidden-title {
+		.woocommerce-loop-product__title {
+			display: none !important;
+		}
+	}
+
+	&.is-hidden-price {
+		.price {
+			display: none !important;
+		}
+	}
+
+	&.is-hidden-button {
+		.button[data-product_sku] {
+			display: none !important;
+		}
+	}
+}

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -14,6 +14,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
+import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
@@ -22,6 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import GridContentControl from '../../components/grid-content-control';
 import { IconWidgets } from '../../components/icons';
 import ProductsControl from '../../components/products-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
@@ -76,7 +78,7 @@ class ProductsBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, orderby } = attributes;
+		const { columns, contentVisibility, orderby } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -90,6 +92,15 @@ class ProductsBlock extends Component {
 						onChange={ ( value ) => setAttributes( { columns: value } ) }
 						min={ wc_product_block_data.min_columns }
 						max={ wc_product_block_data.max_columns }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridContentControl
+						settings={ contentVisibility }
+						onChange={ ( value ) => setAttributes( { contentVisibility: value } ) }
 					/>
 				</PanelBody>
 				<PanelBody
@@ -157,20 +168,19 @@ class ProductsBlock extends Component {
 
 	render() {
 		const { setAttributes } = this.props;
-		const { columns, editMode } = this.props.attributes;
-		const { loaded, products } = this.state;
-		const hasSelectedProducts = products && products.length;
-		const classes = [ 'wc-block-products-grid', 'wc-block-handpicked-products' ];
-		if ( columns ) {
-			classes.push( `cols-${ columns }` );
-		}
-		if ( ! hasSelectedProducts ) {
-			if ( ! loaded ) {
-				classes.push( 'is-loading' );
-			} else {
-				classes.push( 'is-not-found' );
-			}
-		}
+		const { columns, contentVisibility, editMode } = this.props.attributes;
+		const { loaded, products = [] } = this.state;
+		const hasSelectedProducts = products.length > 0;
+		const classes = classnames( {
+			'wc-block-products-grid': true,
+			'wc-block-handpicked-products': true,
+			[ `cols-${ columns }` ]: columns,
+			'is-loading': ! loaded,
+			'is-not-found': loaded && ! hasSelectedProducts,
+			'is-hidden-title': ! contentVisibility.title,
+			'is-hidden-price': ! contentVisibility.price,
+			'is-hidden-button': ! contentVisibility.button,
+		} );
 
 		return (
 			<Fragment>
@@ -190,7 +200,7 @@ class ProductsBlock extends Component {
 				{ editMode ? (
 					this.renderEditMode()
 				) : (
-					<div className={ classes.join( ' ' ) }>
+					<div className={ classes }>
 						{ hasSelectedProducts ? (
 							products.map( ( product ) => (
 								<ProductPreview product={ product } key={ product.id } />

--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { registerBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 
@@ -50,6 +51,18 @@ registerBlockType( 'woocommerce/handpicked-products', {
 		},
 
 		/**
+		 * Content visibility setting
+		 */
+		contentVisibility: {
+			type: 'object',
+			default: {
+				title: true,
+				price: true,
+				button: true,
+			},
+		},
+
+		/**
 		 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
 		 */
 		orderby: {
@@ -81,9 +94,18 @@ registerBlockType( 'woocommerce/handpicked-products', {
 	save( props ) {
 		const {
 			align,
+			contentVisibility,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
+		const classes = classnames(
+			align ? `align${ align }` : '',
+			{
+				'is-hidden-title': ! contentVisibility.title,
+				'is-hidden-price': ! contentVisibility.price,
+				'is-hidden-button': ! contentVisibility.button,
+			}
+		);
 		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
+			<RawHTML className={ classes }>
 				{ getShortcode( props, 'woocommerce/handpicked-products' ) }
 			</RawHTML>
 		);

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -4,10 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { InspectorControls } from '@wordpress/editor';
+import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
+import { InspectorControls } from '@wordpress/editor';
 import { PanelBody, Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -15,6 +16,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import GridContentControl from '../../components/grid-content-control';
 import GridLayoutControl from '../../components/grid-layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductPreview from '../../components/product-preview';
@@ -66,7 +68,13 @@ class ProductBestSellersBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { categories, catOperator, columns, rows } = attributes;
+		const {
+			categories,
+			catOperator,
+			columns,
+			contentVisibility,
+			rows,
+		} = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -78,6 +86,15 @@ class ProductBestSellersBlock extends Component {
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridContentControl
+						settings={ contentVisibility }
+						onChange={ ( value ) => setAttributes( { contentVisibility: value } ) }
 					/>
 				</PanelBody>
 				<PanelBody
@@ -104,27 +121,23 @@ class ProductBestSellersBlock extends Component {
 	}
 
 	render() {
-		const { columns } = this.props.attributes;
-		const { loaded, products } = this.state;
-		const classes = [
-			'wc-block-products-grid',
-			'wc-block-best-selling-products',
-		];
-		if ( columns ) {
-			classes.push( `cols-${ columns }` );
-		}
-		if ( products && ! products.length ) {
-			if ( ! loaded ) {
-				classes.push( 'is-loading' );
-			} else {
-				classes.push( 'is-not-found' );
-			}
-		}
+		const { columns, contentVisibility } = this.props.attributes;
+		const { loaded, products = [] } = this.state;
+		const classes = classnames( {
+			'wc-block-products-grid': true,
+			'wc-block-best-selling-products': true,
+			[ `cols-${ columns }` ]: columns,
+			'is-loading': ! loaded,
+			'is-not-found': loaded && ! products.length,
+			'is-hidden-title': ! contentVisibility.title,
+			'is-hidden-price': ! contentVisibility.price,
+			'is-hidden-button': ! contentVisibility.button,
+		} );
 
 		return (
 			<Fragment>
 				{ this.getInspectorControls() }
-				<div className={ classes.join( ' ' ) }>
+				<div className={ classes }>
 					{ products.length ? (
 						products.map( ( product ) => (
 							<ProductPreview product={ product } key={ product.id } />

--- a/assets/js/blocks/product-best-sellers/index.js
+++ b/assets/js/blocks/product-best-sellers/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { registerBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
@@ -44,9 +45,18 @@ registerBlockType( 'woocommerce/product-best-sellers', {
 	save( props ) {
 		const {
 			align,
+			contentVisibility,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
+		const classes = classnames(
+			align ? `align${ align }` : '',
+			{
+				'is-hidden-title': ! contentVisibility.title,
+				'is-hidden-price': ! contentVisibility.price,
+				'is-hidden-button': ! contentVisibility.button,
+			}
+		);
 		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
+			<RawHTML className={ classes }>
 				{ getShortcode( props, 'woocommerce/product-best-sellers' ) }
 			</RawHTML>
 		);

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -13,6 +13,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
+import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
@@ -21,6 +22,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import GridContentControl from '../../components/grid-content-control';
 import GridLayoutControl from '../../components/grid-layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
@@ -83,7 +85,7 @@ class ProductByCategoryBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, catOperator, orderby, rows } = attributes;
+		const { columns, catOperator, contentVisibility, orderby, rows } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -111,6 +113,15 @@ class ProductByCategoryBlock extends Component {
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridContentControl
+						settings={ contentVisibility }
+						onChange={ ( value ) => setAttributes( { contentVisibility: value } ) }
 					/>
 				</PanelBody>
 				<PanelBody
@@ -170,19 +181,23 @@ class ProductByCategoryBlock extends Component {
 
 	render() {
 		const { setAttributes } = this.props;
-		const { categories, columns, editMode } = this.props.attributes;
-		const { loaded, products } = this.state;
-		const classes = [ 'wc-block-products-grid', 'wc-block-products-category' ];
-		if ( columns ) {
-			classes.push( `cols-${ columns }` );
-		}
-		if ( products && ! products.length ) {
-			if ( ! loaded ) {
-				classes.push( 'is-loading' );
-			} else {
-				classes.push( 'is-not-found' );
-			}
-		}
+		const {
+			categories,
+			columns,
+			contentVisibility,
+			editMode,
+		} = this.props.attributes;
+		const { loaded, products = [] } = this.state;
+		const classes = classnames( {
+			'wc-block-products-grid': true,
+			'wc-block-products-category': true,
+			[ `cols-${ columns }` ]: columns,
+			'is-loading': ! loaded,
+			'is-not-found': loaded && ! products.length,
+			'is-hidden-title': ! contentVisibility.title,
+			'is-hidden-price': ! contentVisibility.price,
+			'is-hidden-button': ! contentVisibility.button,
+		} );
 
 		const nothingFound = ! categories.length ?
 			__(
@@ -214,7 +229,7 @@ class ProductByCategoryBlock extends Component {
 				{ editMode ? (
 					this.renderEditMode()
 				) : (
-					<div className={ classes.join( ' ' ) }>
+					<div className={ classes }>
 						{ products.length ? (
 							products.map( ( product ) => (
 								<ProductPreview product={ product } key={ product.id } />

--- a/assets/js/blocks/product-category/index.js
+++ b/assets/js/blocks/product-category/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { registerBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 
@@ -63,9 +64,18 @@ registerBlockType( 'woocommerce/product-category', {
 	save( props ) {
 		const {
 			align,
+			contentVisibility,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
+		const classes = classnames(
+			align ? `align${ align }` : '',
+			{
+				'is-hidden-title': ! contentVisibility.title,
+				'is-hidden-price': ! contentVisibility.price,
+				'is-hidden-button': ! contentVisibility.button,
+			}
+		);
 		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
+			<RawHTML className={ classes }>
 				{ getShortcode( props, 'woocommerce/product-category' ) }
 			</RawHTML>
 		);

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -4,9 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { InspectorControls } from '@wordpress/editor';
+import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
+import { InspectorControls } from '@wordpress/editor';
 import { PanelBody, Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -14,6 +15,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import GridContentControl from '../../components/grid-content-control';
 import GridLayoutControl from '../../components/grid-layout-control';
 import { IconNewReleases } from '../../components/icons';
 import ProductCategoryControl from '../../components/product-category-control';
@@ -40,9 +42,12 @@ class ProductNewestBlock extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const hasChange = [ 'rows', 'columns', 'categories', 'catOperator' ].reduce( ( acc, key ) => {
-			return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
-		}, false );
+		const hasChange = [ 'rows', 'columns', 'categories', 'catOperator' ].reduce(
+			( acc, key ) => {
+				return acc || prevProps.attributes[ key ] !== this.props.attributes[ key ];
+			},
+			false
+		);
 		if ( hasChange ) {
 			this.debouncedGetProducts();
 		}
@@ -65,7 +70,13 @@ class ProductNewestBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { categories, catOperator, columns, rows } = attributes;
+		const {
+			categories,
+			catOperator,
+			columns,
+			contentVisibility,
+			rows,
+		} = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -77,6 +88,15 @@ class ProductNewestBlock extends Component {
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridContentControl
+						settings={ contentVisibility }
+						onChange={ ( value ) => setAttributes( { contentVisibility: value } ) }
 					/>
 				</PanelBody>
 				<PanelBody
@@ -103,24 +123,23 @@ class ProductNewestBlock extends Component {
 	}
 
 	render() {
-		const { columns } = this.props.attributes;
-		const { loaded, products } = this.state;
-		const classes = [ 'wc-block-products-grid', 'wc-block-newest-products' ];
-		if ( columns ) {
-			classes.push( `cols-${ columns }` );
-		}
-		if ( products && ! products.length ) {
-			if ( ! loaded ) {
-				classes.push( 'is-loading' );
-			} else {
-				classes.push( 'is-not-found' );
-			}
-		}
+		const { columns, contentVisibility } = this.props.attributes;
+		const { loaded, products = [] } = this.state;
+		const classes = classnames( {
+			'wc-block-products-grid': true,
+			'wc-block-newest-products': true,
+			[ `cols-${ columns }` ]: columns,
+			'is-loading': ! loaded,
+			'is-not-found': loaded && ! products.length,
+			'is-hidden-title': ! contentVisibility.title,
+			'is-hidden-price': ! contentVisibility.price,
+			'is-hidden-button': ! contentVisibility.button,
+		} );
 
 		return (
 			<Fragment>
 				{ this.getInspectorControls() }
-				<div className={ classes.join( ' ' ) }>
+				<div className={ classes }>
 					{ products.length ? (
 						products.map( ( product ) => (
 							<ProductPreview product={ product } key={ product.id } />

--- a/assets/js/blocks/product-new/index.js
+++ b/assets/js/blocks/product-new/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { registerBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
 
@@ -44,9 +45,18 @@ registerBlockType( 'woocommerce/product-new', {
 	save( props ) {
 		const {
 			align,
+			contentVisibility,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
+		const classes = classnames(
+			align ? `align${ align }` : '',
+			{
+				'is-hidden-title': ! contentVisibility.title,
+				'is-hidden-price': ! contentVisibility.price,
+				'is-hidden-button': ! contentVisibility.button,
+			}
+		);
 		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
+			<RawHTML className={ classes }>
 				{ getShortcode( props, 'woocommerce/product-new' ) }
 			</RawHTML>
 		);

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -4,10 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { InspectorControls } from '@wordpress/editor';
+import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
+import { InspectorControls } from '@wordpress/editor';
 import { PanelBody, Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -15,6 +16,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import GridContentControl from '../../components/grid-content-control';
 import GridLayoutControl from '../../components/grid-layout-control';
 import ProductCategoryControl from '../../components/product-category-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
@@ -70,7 +72,14 @@ class ProductOnSaleBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { categories, catOperator, columns, rows, orderby } = attributes;
+		const {
+			categories,
+			catOperator,
+			columns,
+			contentVisibility,
+			rows,
+			orderby,
+		} = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -82,6 +91,15 @@ class ProductOnSaleBlock extends Component {
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridContentControl
+						settings={ contentVisibility }
+						onChange={ ( value ) => setAttributes( { contentVisibility: value } ) }
 					/>
 				</PanelBody>
 				<PanelBody
@@ -117,24 +135,23 @@ class ProductOnSaleBlock extends Component {
 	}
 
 	render() {
-		const { columns } = this.props.attributes;
-		const { loaded, products } = this.state;
-		const classes = [ 'wc-block-products-grid', 'wc-block-on-sale-products' ];
-		if ( columns ) {
-			classes.push( `cols-${ columns }` );
-		}
-		if ( products && ! products.length ) {
-			if ( ! loaded ) {
-				classes.push( 'is-loading' );
-			} else {
-				classes.push( 'is-not-found' );
-			}
-		}
+		const { columns, contentVisibility } = this.props.attributes;
+		const { loaded, products = [] } = this.state;
+		const classes = classnames( {
+			'wc-block-products-grid': true,
+			'wc-block-on-sale-products': true,
+			[ `cols-${ columns }` ]: columns,
+			'is-loading': ! loaded,
+			'is-not-found': loaded && ! products.length,
+			'is-hidden-title': ! contentVisibility.title,
+			'is-hidden-price': ! contentVisibility.price,
+			'is-hidden-button': ! contentVisibility.button,
+		} );
 
 		return (
 			<Fragment>
 				{ this.getInspectorControls() }
-				<div className={ classes.join( ' ' ) }>
+				<div className={ classes }>
 					{ products.length ? (
 						products.map( ( product ) => (
 							<ProductPreview product={ product } key={ product.id } />

--- a/assets/js/blocks/product-on-sale/index.js
+++ b/assets/js/blocks/product-on-sale/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { registerBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
@@ -52,9 +53,18 @@ registerBlockType( 'woocommerce/product-on-sale', {
 	save( props ) {
 		const {
 			align,
+			contentVisibility,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
+		const classes = classnames(
+			align ? `align${ align }` : '',
+			{
+				'is-hidden-title': ! contentVisibility.title,
+				'is-hidden-price': ! contentVisibility.price,
+				'is-hidden-button': ! contentVisibility.button,
+			}
+		);
 		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
+			<RawHTML className={ classes }>
 				{ getShortcode( props, 'woocommerce/product-on-sale' ) }
 			</RawHTML>
 		);

--- a/assets/js/blocks/product-top-rated/index.js
+++ b/assets/js/blocks/product-top-rated/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { registerBlockType } from '@wordpress/blocks';
 import { RawHTML } from '@wordpress/element';
@@ -44,9 +45,18 @@ registerBlockType( 'woocommerce/product-top-rated', {
 	save( props ) {
 		const {
 			align,
+			contentVisibility,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
+		const classes = classnames(
+			align ? `align${ align }` : '',
+			{
+				'is-hidden-title': ! contentVisibility.title,
+				'is-hidden-price': ! contentVisibility.price,
+				'is-hidden-button': ! contentVisibility.button,
+			}
+		);
 		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
+			<RawHTML className={ classes }>
 				{ getShortcode( props, 'woocommerce/product-top-rated' ) }
 			</RawHTML>
 		);

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -13,6 +13,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
+import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import Gridicon from 'gridicons';
@@ -22,6 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import getQuery from '../../utils/get-query';
+import GridContentControl from '../../components/grid-content-control';
 import GridLayoutControl from '../../components/grid-layout-control';
 import ProductAttributeControl from '../../components/product-attribute-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
@@ -85,7 +87,14 @@ class ProductsByAttributeBlock extends Component {
 
 	getInspectorControls() {
 		const { setAttributes } = this.props;
-		const { attributes, attrOperator, columns, orderby, rows } = this.props.attributes;
+		const {
+			attributes,
+			attrOperator,
+			columns,
+			contentVisibility,
+			orderby,
+			rows,
+		} = this.props.attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -97,6 +106,15 @@ class ProductsByAttributeBlock extends Component {
 						columns={ columns }
 						rows={ rows }
 						setAttributes={ setAttributes }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridContentControl
+						settings={ contentVisibility }
+						onChange={ ( value ) => setAttributes( { contentVisibility: value } ) }
 					/>
 				</PanelBody>
 				<PanelBody
@@ -182,19 +200,18 @@ class ProductsByAttributeBlock extends Component {
 
 	render() {
 		const { setAttributes } = this.props;
-		const { columns, editMode } = this.props.attributes;
-		const { loaded, products } = this.state;
-		const classes = [ 'wc-block-products-grid', 'wc-block-products-attribute' ];
-		if ( columns ) {
-			classes.push( `cols-${ columns }` );
-		}
-		if ( products && ! products.length ) {
-			if ( ! loaded ) {
-				classes.push( 'is-loading' );
-			} else {
-				classes.push( 'is-not-found' );
-			}
-		}
+		const { columns, editMode, contentVisibility } = this.props.attributes;
+		const { loaded, products = [] } = this.state;
+		const classes = classnames( {
+			'wc-block-products-grid': true,
+			'wc-block-products-attribute': true,
+			[ `cols-${ columns }` ]: columns,
+			'is-loading': ! loaded,
+			'is-not-found': loaded && ! products.length,
+			'is-hidden-title': ! contentVisibility.title,
+			'is-hidden-price': ! contentVisibility.price,
+			'is-hidden-button': ! contentVisibility.button,
+		} );
 
 		return (
 			<Fragment>
@@ -214,7 +231,7 @@ class ProductsByAttributeBlock extends Component {
 				{ editMode ? (
 					this.renderEditMode()
 				) : (
-					<div className={ classes.join( ' ' ) }>
+					<div className={ classes }>
 						{ products.length ? (
 							products.map( ( product ) => (
 								<ProductPreview product={ product } key={ product.id } />

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import Gridicon from 'gridicons';
 import { RawHTML } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
@@ -59,6 +60,18 @@ registerBlockType( 'woocommerce/products-by-attribute', {
 		},
 
 		/**
+		 * Content visibility setting
+		 */
+		contentVisibility: {
+			type: 'object',
+			default: {
+				title: true,
+				price: true,
+				button: true,
+			},
+		},
+
+		/**
 		 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
 		 */
 		orderby: {
@@ -90,9 +103,18 @@ registerBlockType( 'woocommerce/products-by-attribute', {
 	save( props ) {
 		const {
 			align,
+			contentVisibility,
 		} = props.attributes; /* eslint-disable-line react/prop-types */
+		const classes = classnames(
+			align ? `align${ align }` : '',
+			{
+				'is-hidden-title': ! contentVisibility.title,
+				'is-hidden-price': ! contentVisibility.price,
+				'is-hidden-button': ! contentVisibility.button,
+			}
+		);
 		return (
-			<RawHTML className={ align ? `align${ align }` : '' }>
+			<RawHTML className={ classes }>
 				{ getShortcode( props, 'woocommerce/products-by-attribute' ) }
 			</RawHTML>
 		);

--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -15,19 +15,19 @@ const GridContentControl = ( { onChange, settings } ) => {
 		<Fragment>
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
-				help={ title ? 'Product title is hidden.' : 'Product title is visible.' }
+				help={ title ? 'Product title is visible.' : 'Product title is hidden.' }
 				checked={ title }
 				onChange={ () => onChange( { ...settings, title: ! title } ) }
 			/>
 			<ToggleControl
 				label={ __( 'Product price', 'woo-gutenberg-products-block' ) }
-				help={ price ? 'Product price is hidden.' : 'Product price is visible.' }
+				help={ price ? 'Product price is visible.' : 'Product price is hidden.' }
 				checked={ price }
 				onChange={ () => onChange( { ...settings, price: ! price } ) }
 			/>
 			<ToggleControl
 				label={ __( 'Add to Cart button', 'woo-gutenberg-products-block' ) }
-				help={ button ? 'Add to Cart button is hidden.' : 'Add to Cart button is visible.' }
+				help={ button ? 'Add to Cart button is visible.' : 'Add to Cart button is hidden.' }
 				checked={ button }
 				onChange={ () => onChange( { ...settings, button: ! button } ) }
 			/>

--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -15,19 +15,37 @@ const GridContentControl = ( { onChange, settings } ) => {
 		<Fragment>
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
-				help={ title ? 'Product title is visible.' : 'Product title is hidden.' }
+				help={
+					title ?
+						__( 'Product title is visible.', 'woo-gutenberg-products-block' ) :
+						__( 'Product title is hidden.', 'woo-gutenberg-products-block' )
+				}
 				checked={ title }
 				onChange={ () => onChange( { ...settings, title: ! title } ) }
 			/>
 			<ToggleControl
 				label={ __( 'Product price', 'woo-gutenberg-products-block' ) }
-				help={ price ? 'Product price is visible.' : 'Product price is hidden.' }
+				help={
+					price ?
+						__( 'Product price is visible.', 'woo-gutenberg-products-block' ) :
+						__( 'Product price is hidden.', 'woo-gutenberg-products-block' )
+				}
 				checked={ price }
 				onChange={ () => onChange( { ...settings, price: ! price } ) }
 			/>
 			<ToggleControl
 				label={ __( 'Add to Cart button', 'woo-gutenberg-products-block' ) }
-				help={ button ? 'Add to Cart button is visible.' : 'Add to Cart button is hidden.' }
+				help={
+					button ?
+						__(
+							'Add to Cart button is visible.',
+							'woo-gutenberg-products-block'
+						) :
+						__(
+							'Add to Cart button is hidden.',
+							'woo-gutenberg-products-block'
+						)
+				}
 				checked={ button }
 				onChange={ () => onChange( { ...settings, button: ! button } ) }
 			/>

--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
+import { ToggleControl } from '@wordpress/components';
+
+/**
+ * A combination of range controls for product grid layout settings.
+ */
+const GridContentControl = ( { onChange, settings } ) => {
+	const { button, price, title } = settings;
+	return (
+		<Fragment>
+			<ToggleControl
+				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
+				help={ title ? 'Product title is hidden.' : 'Product title is visible.' }
+				checked={ title }
+				onChange={ () => onChange( { ...settings, title: ! title } ) }
+			/>
+			<ToggleControl
+				label={ __( 'Product price', 'woo-gutenberg-products-block' ) }
+				help={ price ? 'Product price is hidden.' : 'Product price is visible.' }
+				checked={ price }
+				onChange={ () => onChange( { ...settings, price: ! price } ) }
+			/>
+			<ToggleControl
+				label={ __( 'Add to Cart button', 'woo-gutenberg-products-block' ) }
+				help={ button ? 'Add to Cart button is hidden.' : 'Add to Cart button is visible.' }
+				checked={ button }
+				onChange={ () => onChange( { ...settings, button: ! button } ) }
+			/>
+		</Fragment>
+	);
+};
+
+GridContentControl.propTypes = {
+	/**
+	 * The current title visibility.
+	 */
+	settings: PropTypes.shape( {
+		button: PropTypes.bool.isRequired,
+		price: PropTypes.bool.isRequired,
+		title: PropTypes.bool.isRequired,
+	} ).isRequired,
+	/**
+	 * Callback to update the layout settings.
+	 */
+	onChange: PropTypes.func.isRequired,
+};
+
+export default GridContentControl;

--- a/assets/js/components/product-preview/style.scss
+++ b/assets/js/components/product-preview/style.scss
@@ -32,6 +32,24 @@
 		}
 	}
 
+	.is-hidden-title & {
+		.wc-product-preview__title {
+			display: none;
+		}
+	}
+
+	.is-hidden-price & {
+		.wc-product-preview__price {
+			display: none;
+		}
+	}
+
+	.is-hidden-button & {
+		.wp-block-button {
+			display: none;
+		}
+	}
+
 	.editor-block-preview & {
 		.wc-product-preview__title {
 			font-size: 0.7em;

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -30,4 +30,16 @@ export default {
 		type: 'string',
 		default: 'any',
 	},
+
+	/**
+	 * Content visibility setting
+	 */
+	contentVisibility: {
+		type: 'object',
+		default: {
+			title: true,
+			price: true,
+			button: true,
+		},
+	},
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ const GutenbergBlocksConfig = {
 		'products-attribute': './assets/js/blocks/products-by-attribute/index.js',
 		'featured-product': './assets/js/blocks/featured-product/index.js',
 		// Global styles
-		styles: [ './assets/css/editor.scss' ],
+		styles: [ './assets/css/style.scss', './assets/css/editor.scss' ],
 	},
 	output: {
 		path: path.resolve( __dirname, './build/' ),


### PR DESCRIPTION
Fixes #372, built on #439 – Adds 3 toggles to each grid block to control the visibility of title, price, and "add to cart" button. Hiding the content toggles a CSS class, `is-hidden-title` (etc), which adds `display:none` to the appropriate element in the preview and on the frontend.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

Each grid block has a Content panel now:

![screen shot 2019-02-18 at 3 35 48 pm](https://user-images.githubusercontent.com/541093/52975497-c7fd8300-3393-11e9-8574-54887c3b32e7.png)

### How to test the changes in this Pull Request:

1. Add any grid block
2. Try toggling the content on and off
3. Expect: The preview should update with your changes
4. Save your post, view it on the frontend
5. Expect: The correct fields should be hidden
6. Check an existing block, created before these settings existed
7. Expect: It should still be editable, not crash

Note: if you switch off this branch, blocks you created while on this branch will crash because it will have unexpected classes - this is fine, since it only happens in the "downgrade" direction.
