### PR TITLE
Fix html in preview of product titles

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -278,9 +278,12 @@ class FeaturedProduct extends Component {
 								style={ style }
 							>
 								<div className="wc-block-featured-product__wrapper">
-									<h2 className="wc-block-featured-product__title">
-										{ product.name }
-									</h2>
+									<h2
+										className="wc-block-featured-product__title"
+										dangerouslySetInnerHTML={ {
+											__html: product.name,
+										} }
+									/>
 									{ showDesc && (
 										<div
 											className="wc-block-featured-product__description"

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -25,7 +25,10 @@ const ProductPreview = ( { product } ) => {
 	return (
 		<div className="wc-product-preview">
 			{ image }
-			<div className="wc-product-preview__title">{ product.name }</div>
+			<div
+				className="wc-product-preview__title"
+				dangerouslySetInnerHTML={ { __html: product.name } }
+			/>
 			<div
 				className="wc-product-preview__price"
 				dangerouslySetInnerHTML={ { __html: product.price_html } }

--- a/assets/js/components/product-preview/test/__snapshots__/index.js.snap
+++ b/assets/js/components/product-preview/test/__snapshots__/index.js.snap
@@ -10,9 +10,12 @@ exports[`ProductPreview should render a single product preview with an image 1`]
   />
   <div
     className="wc-product-preview__title"
-  >
-    Winter Jacket
-  </div>
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Winter Jacket",
+      }
+    }
+  />
   <div
     className="wc-product-preview__price"
     dangerouslySetInnerHTML={
@@ -43,9 +46,12 @@ exports[`ProductPreview should render a single product preview without an image 
   />
   <div
     className="wc-product-preview__title"
-  >
-    Winter Jacket
-  </div>
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Winter Jacket",
+      }
+    }
+  />
   <div
     className="wc-product-preview__price"
     dangerouslySetInnerHTML={

--- a/includes/blocks/class-wc-block-featured-product.php
+++ b/includes/blocks/class-wc-block-featured-product.php
@@ -56,7 +56,7 @@ class WC_Block_Featured_Product {
 
 		$title = sprintf(
 			'<h2 class="wc-block-featured-product__title">%s</h2>',
-			esc_html( $product->get_title() )
+			wp_kses_post( $product->get_title() )
 		);
 
 		$desc_str = sprintf(


### PR DESCRIPTION
Fixes #347

Previously the html wasn't rendered in the preview for product titles.
This renders the html.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using a screen reader

### Screenshots

![html-marquee-product](https://user-images.githubusercontent.com/945228/53119000-13d73600-3514-11e9-97ed-d52a78d5d827.gif)

### How to test the changes in this Pull Request:

1. Add some HTML to a product title.
2. Preview it in any block
