### PR TITLE
Remove the edit-blocks dependency from front-end styles

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -204,7 +204,7 @@ function wgpb_register_scripts() {
 	wp_register_style(
 		'wc-block-style',
 		plugins_url( 'build/style.css', __FILE__ ),
-		array( 'wp-edit-blocks' ),
+		array(),
 		wgpb_get_file_version( '/build/style.css' )
 	);
 


### PR DESCRIPTION
In #439, the front-end styles were accidentally registered with `wp-edit-blocks` as a style dependency, so it was loaded on the frontend of the site - same as happened in #335. Ironically, I referenced this issue in that PR, but still made the mistake 🙃 

This PR removes the unnecessary dependency, `wp-edit-blocks` should only be loaded in the editor.

### How to test the changes in this Pull Request:

1. Add a columns block with some content (doesn't need to be our blocks)
2. View on the front end of the site
3. Expect: They should be columns next to each other, not stacked.