### PR TITLE
Remove shortcode tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Feature plugin for the Gutenberg Products block.
 
 ## Getting started with the development version:
 
-1. Make sure you have:
-  - the latest version of the Gutenberg plugin and WooCommerce 3.3.1+ installed and active
-  - ***OR*** WordPress 5.0 (beta) and WooCommerce 3.5.1+
+1. Make sure you have WordPress 5.0+ and WooCommerce 3.5.1+
 2. Get a copy of this plugin using the green "Clone or download" button on the right.
 3. `npm install` to install the dependencies.
 4. `npm run build` (build once) or `npm start` (keep watching for changes) to compile the code.

--- a/readme.txt
+++ b/readme.txt
@@ -42,15 +42,7 @@ We've also improved the category selection filter. If you select two or more cat
 
 = Minimum Requirements =
 
-* WordPress 4.9.x
-* Gutenberg plugin 4.6 or greater
-* WooCommerce 3.3.1 or greater
-* PHP version 5.2.4 or greater (PHP 7.2 or greater is recommended)
-* MySQL version 5.0 or greater (MySQL 5.6 or greater is recommended)
-
-OR
-
-* WordPress 5.0.x
+* WordPress 5.0
 * WooCommerce 3.5.1 or greater
 * PHP version 5.2.4 or greater (PHP 7.2 or greater is recommended)
 * MySQL version 5.0 or greater (MySQL 5.6 or greater is recommended)


### PR DESCRIPTION
Fixes #432 – these shortcode changes were actually added to WC core in 3.5: https://github.com/woocommerce/woocommerce/pull/21560, so we can just remove this function & bump the required version of WC.

I've also removed the option to run this with WP 4.9.x, since we're at 5.1 now. This is a feature plugin, I think it's within reason to expect users to be at least on 5.0. I'm not sure we're testing much with 4.9.x, and should either commit to testing or drop the option.

### How to test the changes in this Pull Request:

1. Add the blocks to your site, specifically anything with a category filter
2. View the post on the front end
3. Expect: the products displayed should match the editor preview
4. Add a Products by Attribute block
5. View the post on the front end
6. Expect: the products displayed should match the editor preview
