### PR TITLE
REST API: Change namespeace to reflect what will exist in Woo core.

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -106,7 +106,7 @@ class FeaturedProduct extends Component {
 			return;
 		}
 		apiFetch( {
-			path: `/wc-pb/v3/products/${ productId }`,
+			path: `/wc-blocks/v1/products/${ productId }`,
 		} )
 			.then( ( product ) => {
 				this.setState( { product, loaded: true } );

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -64,7 +64,7 @@ class ProductsBlock extends Component {
 		}
 		apiFetch( {
 			path: addQueryArgs(
-				'/wc-pb/v3/products',
+				'/wc-blocks/v1/products',
 				getQuery( this.props.attributes, this.props.name )
 			),
 		} )

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -54,7 +54,7 @@ class ProductBestSellersBlock extends Component {
 	getProducts() {
 		apiFetch( {
 			path: addQueryArgs(
-				'/wc-pb/v3/products',
+				'/wc-blocks/v1/products',
 				getQuery( this.props.attributes, this.props.name )
 			),
 		} )

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -71,7 +71,7 @@ class ProductByCategoryBlock extends Component {
 		}
 		apiFetch( {
 			path: addQueryArgs(
-				'/wc-pb/v3/products',
+				'/wc-blocks/v1/products',
 				getQuery( this.props.attributes, this.props.name )
 			),
 		} )

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -56,7 +56,7 @@ class ProductNewestBlock extends Component {
 	getProducts() {
 		apiFetch( {
 			path: addQueryArgs(
-				'/wc-pb/v3/products',
+				'/wc-blocks/v1/products',
 				getQuery( this.props.attributes, this.props.name )
 			),
 		} )

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -58,7 +58,7 @@ class ProductOnSaleBlock extends Component {
 	getProducts() {
 		apiFetch( {
 			path: addQueryArgs(
-				'/wc-pb/v3/products',
+				'/wc-blocks/v1/products',
 				getQuery( this.props.attributes, this.props.name )
 			),
 		} )

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -56,7 +56,7 @@ class ProductTopRatedBlock extends Component {
 	getProducts() {
 		apiFetch( {
 			path: addQueryArgs(
-				'/wc-pb/v3/products',
+				'/wc-blocks/v1/products',
 				getQuery( this.props.attributes, this.props.name )
 			),
 		} )

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -73,7 +73,7 @@ class ProductsByAttributeBlock extends Component {
 		}
 		apiFetch( {
 			path: addQueryArgs(
-				'/wc-pb/v3/products',
+				'/wc-blocks/v1/products',
 				getQuery( blockAttributes, this.props.name )
 			),
 		} )

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -34,7 +34,7 @@ class ProductAttributeControl extends Component {
 	componentDidMount() {
 		const { selected } = this.props;
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products/attributes', { per_page: -1 } ),
+			path: addQueryArgs( '/wc-blocks/v1/products/attributes', { per_page: -1 } ),
 		} )
 			.then( ( list ) => {
 				list = list.map( ( item ) => ( { ...item, parent: 0 } ) );
@@ -67,7 +67,7 @@ class ProductAttributeControl extends Component {
 		}
 
 		apiFetch( {
-			path: addQueryArgs( `/wc-pb/v3/products/attributes/${ attribute }/terms`, {
+			path: addQueryArgs( `/wc-blocks/v1/products/attributes/${ attribute }/terms`, {
 				per_page: -1,
 			} ),
 		} )

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -27,7 +27,7 @@ class ProductCategoryControl extends Component {
 
 	componentDidMount() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products/categories', { per_page: -1 } ),
+			path: addQueryArgs( '/wc-blocks/v1/products/categories', { per_page: -1 } ),
 		} )
 			.then( ( list ) => {
 				this.setState( { list, loading: false } );

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -20,7 +20,7 @@ class ProductControl extends Component {
 
 	componentDidMount() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', {
+			path: addQueryArgs( '/wc-blocks/v1/products', {
 				per_page: -1,
 				catalog_visibility: 'visible',
 				status: 'publish',

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -20,7 +20,7 @@ class ProductsControl extends Component {
 
 	componentDidMount() {
 		apiFetch( {
-			path: addQueryArgs( '/wc-pb/v3/products', {
+			path: addQueryArgs( '/wc-blocks/v1/products', {
 				per_page: -1,
 				catalog_visibility: 'visible',
 				status: 'publish',

--- a/assets/js/legacy/products-block.jsx
+++ b/assets/js/legacy/products-block.jsx
@@ -453,7 +453,7 @@ class ProductsBlockPreview extends Component {
 			query_string += key + '=' + query[ key ] + '&';
 		}
 
-		const endpoint = '/wc-pb/v3/products' + query_string;
+		const endpoint = '/wc-blocks/v1/products' + query_string;
 		return endpoint;
 	}
 
@@ -561,13 +561,13 @@ class ProductsBlockSidebarInfo extends Component {
 			const ID = getAttributeID( display_setting[ 0 ] );
 			const terms = display_setting.slice( 1 ).join( ', ' );
 
-			endpoints.attribute = '/wc-pb/v3/products/attributes/' + ID;
+			endpoints.attribute = '/wc-blocks/v1/products/attributes/' + ID;
 
 			if ( terms.length ) {
-				endpoints.terms = '/wc-pb/v3/products/attributes/' + ID + '/terms?include=' + terms;
+				endpoints.terms = '/wc-blocks/v1/products/attributes/' + ID + '/terms?include=' + terms;
 			}
 		} else if ( 'category' === display && display_setting.length ) {
-			endpoints.categories = '/wc-pb/v3/products/categories?include=' + display_setting.join( ',' );
+			endpoints.categories = '/wc-blocks/v1/products/categories?include=' + display_setting.join( ',' );
 		}
 
 		return endpoints;

--- a/assets/js/legacy/views/attribute-select.jsx
+++ b/assets/js/legacy/views/attribute-select.jsx
@@ -199,7 +199,7 @@ class ProductAttributeList extends Component {
 	 * @return string
 	 */
 	getQuery() {
-		const endpoint = '/wc-pb/v3/products/attributes';
+		const endpoint = '/wc-blocks/v1/products/attributes';
 		return endpoint;
 	}
 
@@ -386,7 +386,7 @@ class AttributeTerms extends Component {
 	 * @return string
 	 */
 	getQuery() {
-		const endpoint = '/wc-pb/v3/products/attributes/' + this.props.attribute.id + '/terms';
+		const endpoint = '/wc-blocks/v1/products/attributes/' + this.props.attribute.id + '/terms';
 		return endpoint;
 	}
 

--- a/assets/js/legacy/views/category-select.jsx
+++ b/assets/js/legacy/views/category-select.jsx
@@ -165,7 +165,7 @@ class ProductCategoryList extends Component {
 	 * @return string
 	 */
 	getQuery() {
-		const endpoint = '/wc-pb/v3/products/categories';
+		const endpoint = '/wc-blocks/v1/products/categories';
 		return endpoint;
 	}
 

--- a/assets/js/legacy/views/specific-select.jsx
+++ b/assets/js/legacy/views/specific-select.jsx
@@ -216,7 +216,7 @@ class ProductSpecificSearchResults extends Component {
 			return '';
 		}
 
-		return '/wc-pb/v3/products?per_page=10&status=publish&search=' + this.props.searchString;
+		return '/wc-blocks/v1/products?per_page=10&status=publish&search=' + this.props.searchString;
 	}
 
 	/**
@@ -415,7 +415,7 @@ class ProductSpecificSelectedProducts extends Component {
 			}
 		}
 
-		return uncachedProducts.length ? '/wc-pb/v3/products?include=' + uncachedProducts.join( ',' ) : '';
+		return uncachedProducts.length ? '/wc-blocks/v1/products?include=' + uncachedProducts.join( ',' ) : '';
 	}
 
 	/**

--- a/includes/class-wgpb-product-attribute-terms-controller.php
+++ b/includes/class-wgpb-product-attribute-terms-controller.php
@@ -23,7 +23,7 @@ class WGPB_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc-pb/v3';
+	protected $namespace = 'wc-blocks/v1';
 
 	/**
 	 * Register the routes for products.

--- a/includes/class-wgpb-product-attributes-controller.php
+++ b/includes/class-wgpb-product-attributes-controller.php
@@ -23,7 +23,7 @@ class WGPB_Product_Attributes_Controller extends WC_REST_Product_Attributes_Cont
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc-pb/v3';
+	protected $namespace = 'wc-blocks/v1';
 
 	/**
 	 * Register the routes for products.

--- a/includes/class-wgpb-product-categories-controller.php
+++ b/includes/class-wgpb-product-categories-controller.php
@@ -23,7 +23,7 @@ class WGPB_Product_Categories_Controller extends WC_REST_Product_Categories_Cont
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc-pb/v3';
+	protected $namespace = 'wc-blocks/v1';
 
 	/**
 	 * Register the routes for products.

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -23,7 +23,7 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 	 *
 	 * @var string
 	 */
-	protected $namespace = 'wc-pb/v3';
+	protected $namespace = 'wc-blocks/v1';
 
 	/**
 	 * Register the routes for products.

--- a/tests/api/products-attributes.php
+++ b/tests/api/products-attributes.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Products_By_Attributes_Controller extends WC_REST_Unit_Test_C
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc-pb/v3';
+	protected $endpoint = '/wc-blocks/v1';
 
 	/**
 	 * Setup test products data. Called before every test.

--- a/tests/api/products-categories.php
+++ b/tests/api/products-categories.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc-pb/v3';
+	protected $endpoint = '/wc-blocks/v1';
 
 	/**
 	 * Setup test products data. Called before every test.
@@ -74,7 +74,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$cats = $this->categories['parent']['term_id'] . ',' . $this->categories['single']['term_id'];
 
-		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
 		$request->set_param( 'cat_operator', 'IN' );
 
@@ -95,7 +95,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$cats = $this->categories['child']['term_id'] . ',' . $this->categories['single']['term_id'];
 
-		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
 		$request->set_param( 'cat_operator', 'IN' );
 
@@ -116,7 +116,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$cats = $this->categories['child']['term_id'] . ',' . $this->categories['single']['term_id'];
 
-		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
 		$request->set_param( 'cat_operator', 'AND' );
 
@@ -137,7 +137,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$cats = $this->categories['parent']['term_id'] . ',' . $this->categories['single']['term_id'];
 
-		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
 		$request->set_param( 'cat_operator', 'AND' );
 

--- a/tests/api/products-extra.php
+++ b/tests/api/products-extra.php
@@ -15,7 +15,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 	 *
 	 * @var string
 	 */
-	protected $endpoint = '/wc-pb/v3';
+	protected $endpoint = '/wc-blocks/v1';
 
 	/**
 	 * Setup test products data. Called before every test.
@@ -50,8 +50,8 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
 
-		$this->assertArrayHasKey( '/wc-pb/v3/products', $routes );
-		$this->assertArrayHasKey( '/wc-pb/v3/products/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wc-blocks/v1/products', $routes );
+		$this->assertArrayHasKey( '/wc-blocks/v1/products/(?P<id>[\d]+)', $routes );
 	}
 
 	/**
@@ -64,7 +64,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 		WC_Helper_Product::create_external_product();
 		sleep( 1 ); // So both products have different timestamps.
 		$product  = WC_Helper_Product::create_simple_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-pb/v3/products' ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-blocks/v1/products' ) );
 		$products = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -84,7 +84,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 	public function test_get_products_as_contributor() {
 		wp_set_current_user( $this->contributor );
 		WC_Helper_Product::create_simple_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-pb/v3/products' ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-blocks/v1/products' ) );
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
@@ -96,7 +96,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 	public function test_get_products_as_subscriber() {
 		wp_set_current_user( $this->subscriber );
 		WC_Helper_Product::create_simple_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-pb/v3/products' ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-blocks/v1/products' ) );
 		$this->assertEquals( 403, $response->get_status() );
 	}
 
@@ -119,7 +119,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 		);
 		$product->save();
 
-		$request = new WP_REST_Request( 'GET', '/wc-pb/v3/products' );
+		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'orderby', 'price' );
 		$request->set_param( 'order', 'asc' );
 		$response = $this->server->dispatch( $request );
@@ -165,7 +165,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 		$query_params = array(
 			'catalog_visibility' => 'visible',
 		);
-		$request      = new WP_REST_REQUEST( 'GET', '/wc-pb/v3/products' );
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
 		$request->set_query_params( $query_params );
 		$response = $this->server->dispatch( $request );
 		$products = $response->get_data();
@@ -179,7 +179,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 			'orderby'            => 'id',
 			'order'              => 'asc',
 		);
-		$request      = new WP_REST_REQUEST( 'GET', '/wc-pb/v3/products' );
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
 		$request->set_query_params( $query_params );
 		$response = $this->server->dispatch( $request );
 		$products = $response->get_data();
@@ -194,7 +194,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 			'orderby'            => 'id',
 			'order'              => 'asc',
 		);
-		$request      = new WP_REST_REQUEST( 'GET', '/wc-pb/v3/products' );
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
 		$request->set_query_params( $query_params );
 		$response = $this->server->dispatch( $request );
 		$products = $response->get_data();
@@ -207,7 +207,7 @@ class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
 		$query_params = array(
 			'catalog_visibility' => 'hidden',
 		);
-		$request      = new WP_REST_REQUEST( 'GET', '/wc-pb/v3/products' );
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
 		$request->set_query_params( $query_params );
 		$response = $this->server->dispatch( $request );
 		$products = $response->get_data();


### PR DESCRIPTION
To prep for the core merge, this PR updates all instances of the old `wc-pb/v3` namespace to the new `wc-blocks/v1` which will be used in core.

I will do a follow-up PR to address the changes we made to the attributes/<id>/terms endpoint which should bring the plugin and the new endpoints in core in-line with eachother.

#### Accessibility

No UI/visual changes.

### How to test the changes in this Pull Request:

1. Essentially all blocks are touched here, so test them all out
2. Verify PHP test suite runs.