### PR TITLE
REST API: Update usage of attributes/<id>/terms to match core.

### DIFF
--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -72,7 +72,7 @@ class ProductAttributeControl extends Component {
 			} ),
 		} )
 			.then( ( terms ) => {
-				terms = terms.map( ( term ) => ( { ...term, parent: attribute } ) );
+				terms = terms.map( ( term ) => ( { ...term, parent: attribute, attr_slug: term.attribute.slug } ) );
 				this.setState( ( prevState ) => ( {
 					termsList: { ...prevState.termsList, [ attribute ]: terms },
 					termsLoading: false,

--- a/includes/class-wgpb-product-attribute-terms-controller.php
+++ b/includes/class-wgpb-product-attribute-terms-controller.php
@@ -115,9 +115,9 @@ class WGPB_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_
 			'slug'      => $item->slug,
 			'count'     => (int) $item->count,
 			'attribute' => array(
-				'id'    => $attribute->id,
-				'name'  => $attribute->name,
-				'slug'  => $attribute->slug,
+				'id'   => $attribute->id,
+				'name' => $attribute->name,
+				'slug' => $attribute->slug,
 			),
 		);
 
@@ -155,8 +155,8 @@ class WGPB_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_
 			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
 			'readonly'    => true,
-			'properties' => array(
-				'id' => array(
+			'properties'  => array(
+				'id'   => array(
 					'description' => __( 'Attribute ID.', 'woo-gutenberg-products-block' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),

--- a/includes/class-wgpb-product-attribute-terms-controller.php
+++ b/includes/class-wgpb-product-attribute-terms-controller.php
@@ -114,8 +114,11 @@ class WGPB_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_
 			'name'      => $item->name,
 			'slug'      => $item->slug,
 			'count'     => (int) $item->count,
-			'attr_name' => $attribute->name,
-			'attr_slug' => $attribute->slug,
+			'attribute' => array(
+				'id'    => $attribute->id,
+				'name'  => $attribute->name,
+				'slug'  => $attribute->slug,
+			),
 		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -147,20 +150,30 @@ class WGPB_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_
 		$schema['properties']['name']      = $raw_schema['properties']['name'];
 		$schema['properties']['slug']      = $raw_schema['properties']['slug'];
 		$schema['properties']['count']     = $raw_schema['properties']['count'];
-		$schema['properties']['attr_name'] = array(
-			'description' => __( 'Attribute group name.', 'woo-gutenberg-products-block' ),
-			'type'        => 'string',
+		$schema['properties']['attribute'] = array(
+			'description' => __( 'Attribute.', 'woo-gutenberg-products-block' ),
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
-			'arg_options' => array(
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		);
-		$schema['properties']['attr_slug'] = array(
-			'description' => __( 'An alphanumeric identifier for the resource unique to its type.', 'woo-gutenberg-products-block' ),
-			'type'        => 'string',
-			'context'     => array( 'view', 'edit' ),
-			'arg_options' => array(
-				'sanitize_callback' => 'sanitize_title',
+			'readonly'    => true,
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Attribute ID.', 'woo-gutenberg-products-block' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'description' => __( 'Attribute name.', 'woo-gutenberg-products-block' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'slug' => array(
+					'description' => __( 'Attribute slug.', 'woo-gutenberg-products-block' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 			),
 		);
 


### PR DESCRIPTION
When the `wc-blocks/v1/attributes/<id>/terms` endpoint was added into Woo core ( https://github.com/woocommerce/woocommerce/pull/22809 ) the schema was updated a bit to nest the attribute as an object in the response instead of `attr_name` and `attr_slug`.

This PR seeks to implement the same REST API change, and update usage of that endpoint within the Products by Attributes block.

@ryelle I think I found the one place the endpoint is used, but let me know if I missed anything.

#### Accessibility

No UI/UX changes in this PR.

### How to test the changes in this Pull Request:

1. Create a Products by Attributes block
2. Verify it still works as expected.
