### PR TITLE
Category block: select categories when none selected

### DIFF
--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -85,13 +85,13 @@ class ProductByCategoryBlock extends Component {
 
 	getInspectorControls() {
 		const { attributes, setAttributes } = this.props;
-		const { columns, catOperator, contentVisibility, orderby, rows } = attributes;
+		const { columns, catOperator, contentVisibility, editMode, orderby, rows } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
 					title={ __( 'Product Category', 'woo-gutenberg-products-block' ) }
-					initialOpen={ ! attributes.categories.length }
+					initialOpen={ ! attributes.categories.length && ! editMode }
 				>
 					<ProductCategoryControl
 						selected={ attributes.categories }

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -91,7 +91,7 @@ class ProductByCategoryBlock extends Component {
 			<InspectorControls key="inspector">
 				<PanelBody
 					title={ __( 'Product Category', 'woo-gutenberg-products-block' ) }
-					initialOpen={ false }
+					initialOpen={ ! attributes.categories.length }
 				>
 					<ProductCategoryControl
 						selected={ attributes.categories }


### PR DESCRIPTION
Fixes #454 

This change opens the category panel on the right on initial render any time there are no categories selected for the block.

This shows when transforming from another block with no categories selected, and it also shows when all categories have been deselected and then the block is left and re-selected.

#### Accessibility

No changes to accessibility.

### How to test the changes in this Pull Request:

1. Create a Best Sellers, Top Rated, or New Products block, do not set a category.
2. Transform the block to a Category block. The block should show a placeholder as normal, but the product category panel on the right should be open.
3. Select a category, the block should show a preview as normal.
4. Deselect the category, the block shows the placeholder again. Close the product category panel.
5. Select another block on the post, or select the post itself (deselect this block)
7. Select this block again, and the product category panel on the right should be open once more.
