### PR TITLE
Update/wc blocks/v1/products

### DIFF
--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -19,7 +19,7 @@ export default function getQuery( blockAttributes, name ) {
 	if ( categories && categories.length ) {
 		query.category = categories.join( ',' );
 		if ( catOperator && 'all' === catOperator ) {
-			query.cat_operator = 'AND';
+			query.category_operator = 'and';
 		}
 	}
 
@@ -46,7 +46,7 @@ export default function getQuery( blockAttributes, name ) {
 		query.attribute = attributes[ 0 ].attr_slug;
 
 		if ( attrOperator ) {
-			query.attr_operator = 'all' === attrOperator ? 'AND' : 'IN';
+			query.attribute_operator = 'all' === attrOperator ? 'and' : 'in';
 		}
 	}
 

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -228,7 +228,7 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 	 * @return array
 	 */
 	protected function prepare_objects_query( $request ) {
-		$args = parent::prepare_objects_query( $request );
+		$args             = parent::prepare_objects_query( $request );
 		$operator_mapping = array(
 			'in'     => 'IN',
 			'not_in' => 'NOT IN',

--- a/includes/class-wgpb-products-controller.php
+++ b/includes/class-wgpb-products-controller.php
@@ -229,11 +229,16 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 	 */
 	protected function prepare_objects_query( $request ) {
 		$args = parent::prepare_objects_query( $request );
+		$operator_mapping = array(
+			'in'     => 'IN',
+			'not_in' => 'NOT IN',
+			'and'    => 'AND',
+		);
 
 		$orderby            = $request->get_param( 'orderby' );
 		$order              = $request->get_param( 'order' );
-		$cat_operator       = $request->get_param( 'cat_operator' );
-		$attr_operator      = $request->get_param( 'attr_operator' );
+		$category_operator  = $operator_mapping[ $request->get_param( 'category_operator' ) ];
+		$attribute_operator = $operator_mapping[ $request->get_param( 'attribute_operator' ) ];
 		$catalog_visibility = $request->get_param( 'catalog_visibility' );
 
 		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
@@ -243,19 +248,19 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 			$args['meta_key'] = $ordering_args['meta_key']; // WPCS: slow query ok.
 		}
 
-		if ( $cat_operator && isset( $args['tax_query'] ) ) {
+		if ( $category_operator && isset( $args['tax_query'] ) ) {
 			foreach ( $args['tax_query'] as $i => $tax_query ) {
 				if ( 'product_cat' === $tax_query['taxonomy'] ) {
-					$args['tax_query'][ $i ]['operator']         = $cat_operator;
-					$args['tax_query'][ $i ]['include_children'] = 'AND' === $cat_operator ? false : true;
+					$args['tax_query'][ $i ]['operator']         = $category_operator;
+					$args['tax_query'][ $i ]['include_children'] = 'AND' === $category_operator ? false : true;
 				}
 			}
 		}
 
-		if ( $attr_operator && isset( $args['tax_query'] ) ) {
+		if ( $attribute_operator && isset( $args['tax_query'] ) ) {
 			foreach ( $args['tax_query'] as $i => $tax_query ) {
 				if ( in_array( $tax_query['taxonomy'], wc_get_attribute_taxonomy_names(), true ) ) {
-					$args['tax_query'][ $i ]['operator'] = $attr_operator;
+					$args['tax_query'][ $i ]['operator'] = $attribute_operator;
 				}
 			}
 		}
@@ -310,25 +315,27 @@ class WGPB_Products_Controller extends WC_REST_Products_Controller {
 	public function get_collection_params() {
 		$params                       = parent::get_collection_params();
 		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
-		$params['cat_operator']       = array(
+		$params['category_operator']  = array(
 			'description'       => __( 'Operator to compare product category terms.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
-			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
-			'sanitize_callback' => 'sanitize_text_field',
+			'enum'              => array( 'in', 'not_in', 'and' ),
+			'default'           => 'in',
+			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attr_operator']      = array(
+		$params['attribute_operator'] = array(
 			'description'       => __( 'Operator to compare product attribute terms.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
-			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
-			'sanitize_callback' => 'sanitize_text_field',
+			'enum'              => array( 'in', 'not_in', 'and' ),
+			'default'           => 'in',
+			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['catalog_visibility'] = array(
 			'description'       => __( 'Determines if hidden or visible catalog products are shown.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'enum'              => array( 'visible', 'catalog', 'search', 'hidden' ),
-			'sanitize_callback' => 'sanitize_text_field',
+			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/tests/api/products-attributes.php
+++ b/tests/api/products-attributes.php
@@ -136,7 +136,7 @@ class WC_Tests_API_Products_By_Attributes_Controller extends WC_REST_Unit_Test_C
 			// Terms list needs to be a string.
 			$this->attr_term_ids['medium'] . ',' . $this->attr_term_ids['large']
 		);
-		$request->set_param( 'attr_operator', 'AND' );
+		$request->set_param( 'attribute_operator', 'and' );
 
 		$response          = $this->server->dispatch( $request );
 		$response_products = $response->get_data();

--- a/tests/api/products-categories.php
+++ b/tests/api/products-categories.php
@@ -76,7 +76,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
-		$request->set_param( 'cat_operator', 'IN' );
+		$request->set_param( 'category_operator', 'in' );
 
 		$response          = $this->server->dispatch( $request );
 		$response_products = $response->get_data();

--- a/tests/api/products-categories.php
+++ b/tests/api/products-categories.php
@@ -97,7 +97,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
-		$request->set_param( 'cat_operator', 'IN' );
+		$request->set_param( 'category_operator', 'in' );
 
 		$response          = $this->server->dispatch( $request );
 		$response_products = $response->get_data();
@@ -118,7 +118,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
-		$request->set_param( 'cat_operator', 'AND' );
+		$request->set_param( 'category_operator', 'and' );
 
 		$response          = $this->server->dispatch( $request );
 		$response_products = $response->get_data();
@@ -139,7 +139,7 @@ class WC_Tests_API_Products_By_Categories_Controller extends WC_REST_Unit_Test_C
 
 		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
 		$request->set_param( 'category', $cats );
-		$request->set_param( 'cat_operator', 'AND' );
+		$request->set_param( 'category_operator', 'and' );
 
 		$response          = $this->server->dispatch( $request );
 		$response_products = $response->get_data();


### PR DESCRIPTION
This branch brings the copy of `wc-blocks/v1/products` up to date with what is going to be merged into Woo core ( https://github.com/woocommerce/woocommerce/pull/22856 ). The changes here are renaming the args `cat_operator` and `attr_operator` to `category_operator` and `attribute_operator`. The related API and test updates can be seen in 3501453 - and usage of these query args are updated in abc554e

#### Accessibility

No UI/UX changes

### How to test the changes in this Pull Request:

1. Test blocks which use the category and attribute operators
