### PR TITLE
Bump the version to 2.0.0-beta, update the changelog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.0.0-alpha",
+  "version": "2.0.0-beta",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,26 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 2.0.0 - TBD =
+
+- **BREAKING:** Requires WordPress 5.0+, WooCommerce 3.5+
+- **BREAKING:** Remove the legacy block entirely
+- **BREAKING:** Remove the `wc-pb/v3/*` endpoints in favor of new core `wc-blocks/v1/*` endpoints
+- Feature: Add content visibility settings to show/hide title, price, rating, button
+- Feature: Add transforms between basic product grid blocks
+- Fix: Add product rating display to preview, to better match front end
+- Fix: Product titles render HTML correctly in preview
+- Fix: Icons are now aligned correctly in placeholders
+- API: Change namespace, endpoints now accessed at `/wc-blocks/v1/*`
+- API: Add `catalog_visibility` parameter for fetching products
+- API: Update structure of attribute term endpoint to return `attribute.slug`, `attribute.name` etc
+- API: Update parameters to use full names, `category_operator`, `attribute_operator`
+- Components: Move SearchListControl to `@woocommerce/components` library
+- Components: Added new control component GridContentControl to manage content visibility
+- Build: Reorganize CSS into one file for editor preview, and one file for front-end styles
+- Build: Move registration code to a new class
+- Build: Update packages
+
 = 1.4.0 - 2019-02-12 =
 
 - Feature: Added new block: "Products by Attribute"

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.0.0-alpha
+ * Version: 2.0.0-beta
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.0.0-alpha' );
+define( 'WGPB_VERSION', '2.0.0-beta' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
Bump the version in preparation to tag and release a version 2.0.0-beta now that [the 2.0 milestone is cleared out](https://github.com/woocommerce/woocommerce-gutenberg-products-block/milestone/11) (well, except this PR). This also updates the changelog with [everything that's changed since 1.4.0.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/compare/cb30d3d3403945ab174222250ef9c268a7ad9773..master)

### How to test the changes in this Pull Request:

1. Check that the version in the plugins list is `2.0.0-beta`
2. Read over the changelog
