### PR TITLE
Fix PHP Notice: Check for the existence of `productId` before using it

### DIFF
--- a/assets/php/class-wgpb-block-featured-product.php
+++ b/assets/php/class-wgpb-block-featured-product.php
@@ -46,7 +46,7 @@ class WGPB_Block_Featured_Product {
 	 * @return string Rendered block type output.
 	 */
 	public static function render( $attributes, $content ) {
-		$id      = (int) $attributes['productId'];
+		$id      = isset( $attributes['productId'] ) ? (int) $attributes['productId'] : 0;
 		$product = wc_get_product( $id );
 		if ( ! $product ) {
 			return '';


### PR DESCRIPTION
Fixes the following PHP notice

> PHP Notice:  Undefined index: productId in …/woocommerce-gutenberg-products-block/assets/php/class-wgpb-block-featured-product.php on line 49

### How to test the changes in this Pull Request:

Set up errors to track to `wp-content/debug.log` by setting `define( 'WP_DEBUG_LOG', true );` in wp-config.

1. Create a new post
2. Add a title
3. Add a featured product block, but don't select a product
4. Save the draft, or let it autosave
5. You should not see a notice in the debug.log file
