### PR TITLE
Grid blocks: Use a different theme option name for block column/row values

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -270,7 +270,7 @@ class WGPB_Block_Library {
 		$block_settings = array(
 			'min_columns'       => wc_get_theme_support( 'product_blocks::min_columns', 1 ),
 			'max_columns'       => wc_get_theme_support( 'product_blocks::max_columns', 6 ),
-			'default_columns'   => wc_get_theme_support( 'product_blocks::default_columns', 1 ),
+			'default_columns'   => wc_get_theme_support( 'product_blocks::default_columns', 3 ),
 			'min_rows'          => wc_get_theme_support( 'product_blocks::min_rows', 1 ),
 			'max_rows'          => wc_get_theme_support( 'product_blocks::max_rows', 6 ),
 			'default_rows'      => wc_get_theme_support( 'product_blocks::default_rows', 1 ),

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -268,12 +268,12 @@ class WGPB_Block_Library {
 
 		// Global settings used in each block.
 		$block_settings = array(
-			'min_columns'       => wc_get_theme_support( 'product_grid::min_columns', 1 ),
-			'max_columns'       => wc_get_theme_support( 'product_grid::max_columns', 6 ),
-			'default_columns'   => wc_get_default_products_per_row(),
-			'min_rows'          => wc_get_theme_support( 'product_grid::min_rows', 1 ),
-			'max_rows'          => wc_get_theme_support( 'product_grid::max_rows', 6 ),
-			'default_rows'      => wc_get_default_product_rows_per_page(),
+			'min_columns'       => wc_get_theme_support( 'product_blocks::min_columns', 1 ),
+			'max_columns'       => wc_get_theme_support( 'product_blocks::max_columns', 6 ),
+			'default_columns'   => wc_get_theme_support( 'product_blocks::default_columns', 1 ),
+			'min_rows'          => wc_get_theme_support( 'product_blocks::min_rows', 1 ),
+			'max_rows'          => wc_get_theme_support( 'product_blocks::max_rows', 6 ),
+			'default_rows'      => wc_get_theme_support( 'product_blocks::default_rows', 1 ),
 			'placeholderImgSrc' => wc_placeholder_img_src(),
 			'min_height'        => wc_get_theme_support( 'featured_block::min_height', 500 ),
 			'default_height'    => wc_get_theme_support( 'featured_block::default_height', 500 ),


### PR DESCRIPTION
Currently, the grid blocks use the same defaults as the product catalog, which means if a theme wants to change the blocks to default to one row, it also changes the product catalog to 1 row per page. This seemed unintuitive to me, so I've tried a "fix", but this can also be open to discussion.

This PR introduces a new theme option `product_blocks` with settings for min, max, and default rows and columns. It would be used the same way in a theme:

```php
function example_store_setup_theme() {
	add_theme_support( 'woocommerce', array(
		'product_blocks' => array(
			'min_columns' => 2,
			'max_columns' => 6,
			'default_columns' => 3,
			'min_rows' => 1,
			'max_rows' => 4,
			'default_rows' => 1,
		),
		'product_grid' => array(
			'default_columns' => 4,
			'default_rows' => 6,
		),
	) );
}
add_action( 'after_setup_theme', 'example_store_setup_theme' );
```

### How to test the changes in this Pull Request:

1. Add the above code to a theme
2. Switch to that theme, which resets the row/col defaults to the theme-defined defaults
3. Check your catalog page, it should show a 4 col, 6 row grid
4. Add a grid block to a post, it should show a 3 col, 1 row grid
5. You can also change the products per row / rows per page values in the customizer (Customizing ▸ WooCommerce ▸ Product Catalog) without changing the blocks settings.
