### PR TITLE
Update grid blocks preview to match width of products on the frontend

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -17,29 +17,31 @@
 	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: flex-start;
+	justify-content: space-between;
+
+	&.components-placeholder {
+		padding: 2em 1em;
+	}
 
 	&.is-loading,
-	&.is-not-found,
-	&.cols-1 {
+	&.is-not-found {
 		display: block;
 	}
 
-	.wc-product-preview {
-		flex: 1;
-		padding: $gap/2;
+	&.cols-1 {
+		justify-content: space-around;
 	}
 
 	@for $i from 2 to 7 {
 		&.cols-#{$i} .wc-product-preview {
-			max-width: calc(#{ 100% / $i });
-			min-width: calc(#{ 100% / $i });
-			flex: 1;
+			flex: 1 0 calc(#{ 100% / $i });
 		}
 	}
 
-	&.components-placeholder {
-		padding: 2em 1em;
+	.wc-product-preview {
+		flex: 1;
+		max-width: 300px;
+		padding: $gap/2;
 	}
 
 	// Styles for "resuable block" preview.

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -40,8 +40,6 @@
 
 	.wc-product-preview {
 		flex: 1;
-		max-width: 300px;
-		padding: $gap/2;
 	}
 
 	// Styles for "resuable block" preview.

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -17,7 +17,7 @@
 	overflow: hidden;
 	display: flex;
 	flex-wrap: wrap;
-	justify-content: space-between;
+	justify-content: flex-start;
 
 	&.components-placeholder {
 		padding: 2em 1em;
@@ -29,17 +29,19 @@
 	}
 
 	&.cols-1 {
-		justify-content: space-around;
+		display: block;
+
+		.wc-product-preview {
+			margin-left: auto;
+			margin-right: auto;
+		}
 	}
 
 	@for $i from 2 to 7 {
 		&.cols-#{$i} .wc-product-preview {
 			flex: 1 0 calc(#{ 100% / $i });
+			max-width: 100% / $i !important;
 		}
-	}
-
-	.wc-product-preview {
-		flex: 1;
 	}
 
 	// Styles for "resuable block" preview.

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -13,13 +13,29 @@ import './style.scss';
  * Display a preview for a given product.
  */
 const ProductPreview = ( { product } ) => {
-	const { placeholderImgSrc } = wc_product_block_data; /* eslint-disable-line camelcase */
+	const {
+		placeholderImgSrc,
+	} = wc_product_block_data; /* eslint-disable-line camelcase */
 
 	let image = null;
 	if ( product.images.length ) {
-		image = <img src={ product.images[ 0 ].src } alt="" />;
+		image = (
+			<img
+				className="wc-product-preview__image"
+				src={ product.images[ 0 ].src }
+				alt=""
+				style={ { width: `${ wc_product_block_data.thumbnail_size }px` } }
+			/>
+		);
 	} else {
-		image = <img src={ placeholderImgSrc } alt="" />;
+		image = (
+			<img
+				className="wc-product-preview__image"
+				src={ placeholderImgSrc }
+				alt=""
+				style={ { width: `${ wc_product_block_data.thumbnail_size }px` } }
+			/>
+		);
 	}
 
 	const rating = Number( product.average_rating );

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -29,7 +29,10 @@ const ProductPreview = ( { product } ) => {
 	}
 
 	return (
-		<div className="wc-product-preview">
+		<div
+			className="wc-product-preview"
+			style={ { maxWidth: `${ wc_product_block_data.thumbnail_size }px` } }
+		>
 			{ image }
 			<div
 				className="wc-product-preview__title"

--- a/assets/js/components/product-preview/style.scss
+++ b/assets/js/components/product-preview/style.scss
@@ -1,6 +1,7 @@
 .wc-product-preview {
-	text-align: center;
 	margin-bottom: $gap;
+	padding: $gap/2;
+	text-align: center;
 
 	.wc-product-preview__title,
 	.wc-product-preview__price,

--- a/assets/js/components/product-preview/style.scss
+++ b/assets/js/components/product-preview/style.scss
@@ -9,6 +9,11 @@
 		margin-top: $gap-smallest;
 	}
 
+	.wc-product-preview__image {
+		margin-left: auto;
+		margin-right: auto;
+	}
+
 	.star-rating {
 		overflow: hidden;
 		position: relative;

--- a/assets/js/components/product-preview/test/__snapshots__/index.js.snap
+++ b/assets/js/components/product-preview/test/__snapshots__/index.js.snap
@@ -3,10 +3,21 @@
 exports[`ProductPreview should render a single product preview with an image 1`] = `
 <div
   className="wc-product-preview"
+  style={
+    Object {
+      "maxWidth": "300px",
+    }
+  }
 >
   <img
     alt=""
+    className="wc-product-preview__image"
     src="https://example.local/product.jpg"
+    style={
+      Object {
+        "width": "300px",
+      }
+    }
   />
   <div
     className="wc-product-preview__title"
@@ -39,10 +50,21 @@ exports[`ProductPreview should render a single product preview with an image 1`]
 exports[`ProductPreview should render a single product preview without an image 1`] = `
 <div
   className="wc-product-preview"
+  style={
+    Object {
+      "maxWidth": "300px",
+    }
+  }
 >
   <img
     alt=""
+    className="wc-product-preview__image"
     src="placeholder.png"
+    style={
+      Object {
+        "width": "300px",
+      }
+    }
   />
   <div
     className="wc-product-preview__title"

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -274,6 +274,7 @@ class WGPB_Block_Library {
 			'min_rows'          => wc_get_theme_support( 'product_blocks::min_rows', 1 ),
 			'max_rows'          => wc_get_theme_support( 'product_blocks::max_rows', 6 ),
 			'default_rows'      => wc_get_theme_support( 'product_blocks::default_rows', 1 ),
+			'thumbnail_size'    => wc_get_theme_support( 'thumbnail_image_width', 300 ),
 			'placeholderImgSrc' => wc_placeholder_img_src(),
 			'min_height'        => wc_get_theme_support( 'featured_block::min_height', 500 ),
 			'default_height'    => wc_get_theme_support( 'featured_block::default_height', 500 ),

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -4,6 +4,7 @@ global.wp = {};
 // Set up our settings global.
 global.wc_product_block_data = {
 	placeholderImgSrc: 'placeholder.png',
+	thumbnail_size: '300',
 };
 
 // wcSettings is required by @woocommerce/* packages


### PR DESCRIPTION
Fixes #488 – from @jobthomas: 

> I'm fairly confident we'll get customers reaching out to us who are frustrated that they can use these blocks full width on the backend, but that it doesn't display frontend.

We can't update the style on the frontend, since the shortcode only renders a 300px image (and we don't want to/can't change all shortcodes). Instead, we can update the preview to match what actually happens on the frontend.

### Screenshots

Here's how some themes handle this 

| Twenty Nineteen | Storefront | Radcliff2 |
| ---------------- | ------------ | --------|
| <img width="655" alt="theme-2019" src="https://user-images.githubusercontent.com/541093/54366854-bbddac00-4647-11e9-95fa-bd30b9d0d779.png"> | <img width="760" alt="theme-storefront" src="https://user-images.githubusercontent.com/541093/54366855-bc764280-4647-11e9-83b7-960f5ffc90c6.png"> | <img width="928" alt="theme-radcliffe" src="https://user-images.githubusercontent.com/541093/54366853-bbddac00-4647-11e9-9ba4-ef57987816aa.png"> |

This PR updates the backend so it always display the single-column as max-width 300px. This number is picked because the 300px image is what's used on the frontend, so most themes restrict the width to 300.

<img width="714" alt="gb-one-col" src="https://user-images.githubusercontent.com/541093/54366955-f34c5880-4647-11e9-88d0-c94347403d57.png">

Two columns + still behaves the same way, though when the content-area is wide it's obvious they still have the 300px max-width:

<img width="938" alt="gb-wide-two-col" src="https://user-images.githubusercontent.com/541093/54367217-68b82900-4648-11e9-9f2b-08478da06cc4.png">

### How to test the changes in this Pull Request:

1. Add a grid block to a post
2. Set the columns down to 1
3. Expect: There should be one item per row, with a max-width of 300px
4. Publish the post, view it
5. Expect: The frontend should match the preview (with the exception of some alignment, as that can be theme dependent)
6. Play with setting columns to 2+, wide or full width, see if it still behaves as expected.
