### PR TITLE
Try a transform from Featured Product to Cover

### DIFF
--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -91,14 +91,6 @@ registerBlockType( 'woocommerce/featured-product', {
 		},
 
 		/**
-		 * Text for the product link.
-		 */
-		linkText: {
-			type: 'string',
-			default: __( 'Shop now', 'woo-gutenberg-products-block' ),
-		},
-
-		/**
 		 * The product ID to display.
 		 */
 		productId: {


### PR DESCRIPTION
Fixes #295 – Gutenberg's updates to the Cover block have merged, and should be released in v 5.3 of Gutenberg. That update captures the work we wanted to do with the "Call to Action" block, so this PR adds a transform from our Featured Product into the new Cover block. All customizations except for height should be mapped over.

Currently this is blocked by a technical problem– how to get the data from the API? I can't use an async function because the way this is called, it doesn't wait around for the resolution. 

To do:

- [ ] Don't allow the transform if we're not at GB 5.3+
- [ ] Get real product data into the transform

### Screenshots

Before (Featured Product block)

<img width="699" alt="before" src="https://user-images.githubusercontent.com/541093/54377083-d3726000-465a-11e9-8b2f-38a4edfd272c.png">

Picking the transform:

<img width="465" alt="transform" src="https://user-images.githubusercontent.com/541093/54377084-d3726000-465a-11e9-8fa9-fd52ba1736e0.png">

After (Cover block)

<img width="706" alt="after" src="https://user-images.githubusercontent.com/541093/54377082-d3726000-465a-11e9-8b0f-434969f978cf.png">

("with links" text _is_ there ^ it's just blending into the background – you can see the non-link white period at the end of the line)

### How to test the changes in this Pull Request:

1. Add a Featured Product to you post/page
2. Click the block icon, this will give you the option to transform to the Cover block.
3. Click the cover icon to do the transform.
4. Expect: All your showing content should be included in the cover block. Now you can edit the text content as well as the button 👍 

Try the above flow a few times, with various customizations on Featured Product– custom image, background color, overlay opacity, button text, color, link…
