### PR TITLE
Add pre-publishing script and bump version to 2.0.0-rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ jobs:
       php: 7.1
       script:
         - composer install
-        - composer run-script phpcs .
         - npm install
         - npm run lint
         - npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.0.0-beta",
+  "version": "2.0.0-rc1",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   },
   "license": "GPL-3.0+",
   "scripts": {
+    "prepack": "npm install && npm run lint && npm run test && npm run build",
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
     "start": "cross-env BABEL_ENV=default webpack --watch",
-    "lint": "npm run lint:css && npm run lint:js",
+    "lint": "npm run lint:php && npm run lint:css && npm run lint:js",
+    "lint:php": "composer run-script phpcs .",
     "lint:css": "stylelint assets/css",
     "lint:js": "eslint assets/js --ext=js,jsx",
     "test": "wp-scripts test-unit-js --config tests/js/jest.config.json",

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.0.0-beta
+ * Version: 2.0.0-rc1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.0.0-beta' );
+define( 'WGPB_VERSION', '2.0.0-rc1' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
This PR is technically doing two things for the sake of speed– version bumping for 2.0.0-rc1, and adding some publishing helpers.

The `prepack` script is called when `npm pack` and `npm publish` are run, and I've set it up to re-install dependencies, run linting on PHP, CSS, and JS, run the JS tests, and lastly build the production bundle. This basically checks everything one last time before making sure the build files are up to date. Then it builds the package to either a `.tgz` file (`pack`), or pushes it to npm (`publish`).

This means the only things needed to release a version is to do the version bump (manually, in `package.json` and `woocommerce-gutenberg-products-block.php`), and run `npm publish`

### How to test the changes in this Pull Request:

1. Run `npm pack`
2. Expect the steps above to run
3. You can also try introducing errors, and it will halt the packaging process with the error.
