### PR TITLE
Fix fatal with 1.x versions of the feature plugin

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -37,6 +37,11 @@ class WGPB_Block_Library {
 	 * Constructor.
 	 */
 	public function __construct() {
+		// Shortcut out if we see the feature plugin, v1.4 or below.
+		// note: `FP_VERSION` is transformed to `WGPB_VERSION` in the grunt copy task.
+		if ( defined( 'FP_VERSION' ) && version_compare( FP_VERSION, '1.4.0', '<=' ) ) {
+			return;
+		}
 		if ( function_exists( 'register_block_type' ) ) {
 			add_action( 'init', array( 'WGPB_Block_Library', 'register_blocks' ) );
 			add_action( 'init', array( 'WGPB_Block_Library', 'register_assets' ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.0.0-rc1",
+  "version": "2.0.0-rc2",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.0.0-rc1
+ * Version: 2.0.0-rc2
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.0.0-rc1' );
+define( 'WGPB_VERSION', '2.0.0-rc2' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
See https://github.com/woocommerce/woocommerce/pull/23080 – this issue will fix the woocommerce core issue of the duplicate `WC_Block_Featured_Product` class, by not loading the core functionality if we detect 1.x of the feature plugin. Ideally everyone will update to 2.0 when it's released 😁

### How to test the changes in this Pull Request:

1. Build & make sure nothing changes with the plugin itself
2. Run `npm pack` to create the .tgz file, move this into the woocommerce directory
3. Check out the branch in https://github.com/woocommerce/woocommerce/pull/23080
4. Run `npm install` in `woocommerce`
5. Run `npx grunt blocks` to copy over the blocks file
6. Now try activating WooCommerce Blocks v 1.4.0
7. Expect: No fatal error
