### PR TITLE
Add "contributor" docs for developer tools, release processes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To release a new version, there are 3 basic steps. Prepare and test the release,
 
 ### Prepare and test the release
 
-- Manually change the versions in `package.json` and `woocommerce-gutenberg-products-block.php` (once in the plugin header, and `WGPB_VERSION`).
+- Manually change the versions in `package.json` and `woocommerce-gutenberg-products-block.php` (once in the plugin header, and `WGPB_VERSION`). [See an example PR with these changes.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/478/commits/725c43fe0362044c953728cb3391095a43e66bb5)
 - Run `npm pack` to prep a `.tgz` file.
 - Optionally test the package by uploading this onto a test site.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing to WooCommerce Blocks! Below are some developer docs for working with the project.
 
+To get started, first run `npm install` and `composer install`.
+
 ## npm scripts
 
 We have a set of scripts in npm to handle repeated developer tasks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing
+
+Thanks for your interest in contributing to WooCommerce Blocks! Below are some developer docs for working with the project.
+
+## npm scripts
+
+We have a set of scripts in npm to handle repeated developer tasks.
+
+### `build` & `start`
+
+These scripts compile the code using `webpack`. Run `build` to build the production build, `start` to build the development build and then keep watching for changes. You can also run `npx webpack` to run the development build and not keep watching.
+
+### `lint`
+
+This script runs 3 sub-commands: `lint:php`, `lint:css`, `lint:js`. Use these to run linters across the codebase.
+
+- `lint:php` runs phpcs via composer, which uses the [phpcs.xml](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/phpcs.xml) ruleset.
+- `lint:css` runs stylelint over all the scss code in `assets/css`, using the rules in [.stylelintrc.json.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/.stylelintrc.json)
+- `lint:js` runs eslint over all the JavaScript, using the rules in [.eslintrc.js.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/.eslintrc.js)
+
+### `test`
+
+The test scripts use [wp-scripts](https://github.com/WordPress/gutenberg/tree/master/packages/scripts) to run jest for component and unit testing.
+
+- `test:update` updates the snapshot tests for components, used if you change a component that has tests attached.
+- Use `test:watch` to keep watch of files and automatically re-run tests.
+
+### `prepack`
+
+This script is run automatically when `npm pack` or `npm publish` is run. It installs packages, runs the linters, runs the tests, and then builds the files from the source once more.
+
+## Publishing @woocommerce/block-library
+
+We publish the blocks to npm at [@woocommerce/block-library,](https://www.npmjs.com/package/@woocommerce/block-library) and then import them into WooCommerce core via [a grunt script.](https://github.com/woocommerce/woocommerce/blob/741bd5ba6d193e21893ef3af3d4f3f030a79c099/Gruntfile.js#L347) 
+
+To release a new version, there are 3 basic steps. Prepare and test the release, publish the version, then import into WooCommerce core.
+
+### Prepare and test the release
+
+- Manually change the versions in `package.json` and `woocommerce-gutenberg-products-block.php` (once in the plugin header, and `WGPB_VERSION`).
+- Run `npm pack` to prep a `.tgz` file.
+- Optionally test the package by uploading this onto a test site.
+
+### Publish this version
+
+On GitHub…
+
+- go to [Releases](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases) and click "Draft a new release"
+- The Tag version should start with `v`, and use [semver](https://semver.org/) formatting, ex `v2.0.0-rc`, or `v1.4.1`
+- The Release title should be the human-readable version, ex "2.0.0 Release Candidate" or "2.0.0 alpha release"
+- Add the changelog to the description (TBD, maybe not for every release?)
+- Upload the `.tgz` from `npm pack` in the previous step as an attached binary
+
+On npm…
+
+- Run `npm publish --access public`, which will push the version up to npm.
+- Check [@woocommerce/block-library](https://www.npmjs.com/package/@woocommerce/block-library) for your update
+
+### Pull into WooCommerce core
+
+- Manually update the @woocommerce/block-library version in `package.json`
+- In the woocommerce folder, run `npm install` to download the version you just specified
+- Run the copy command, `npx grunt blocks`, to copy the build files from node_modules into their destinations in WC core
+- Check that the changes imported look correct
+- Make a PR on WooCommerce to import the new version
+
+## Publishing the WooCommerce Blocks plugin
+
+TBD

--- a/README.md
+++ b/README.md
@@ -1,23 +1,28 @@
 # WooCommerce Product Blocks
 
-Feature plugin for the Gutenberg Products block.
+Feature plugin for WooCoomerce + Gutenberg. Now that the product blocks have been merged into WooCommerce 3.6, this plugin serves as a space to iterate and explore how else WooCommerce might work with the block editor. 
+
+If you're just looking to use these blocks, update to WooCommerce 3.6! The blocks are bundled into WooCommerce, and can be added from the "WooCommerce" section in the block inserter.
+
+If you want to see what we're working on for future versions, or want to help out, read on.
 
 ## Getting started with the stable version:
 
-1. The stable version is available on WordPress.org. [Download the stable version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
-2. Activate the plugin.
-3. On Gutenberg posts you should now have a Products block available.
+We release a new version of WooCommerce Blocks onto WordPress.org every few weeks, which can be used as an easier way to preview the features.
+
+1. Make sure you have WordPress 5.0+ and WooCommerce 3.6+
+2. The stable version is available on WordPress.org. [Download the stable version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
+3. Activate the plugin.
 
 ## Getting started with the development version:
 
-1. Make sure you have WordPress 5.0+ and WooCommerce 3.5.1+
+1. Make sure you have WordPress 5.0+ and WooCommerce 3.6+
 2. Get a copy of this plugin using the green "Clone or download" button on the right.
 3. `npm install` to install the dependencies.
 4. `npm run build` (build once) or `npm start` (keep watching for changes) to compile the code.
 5. Activate the plugin.
-6. On Gutenberg posts & pages you should now have a "Products" block available.
 
-The source code is in the `assets/js/products-block.jsx` file and the compiled code is in `build/products-block.js`.
+The source code is in the `assets/` folder and the compiled code is built into `build/`.
 
 **Gutenberg Tutorial and Docs**: https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields/
 


### PR DESCRIPTION
This adds a new [CONTRIBUTING.md](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/74917d196e999b67263ffe8469bcef2fc9d236ab/CONTRIBUTING.md) file with documentation on the npm scripts, and release process for npm (+ eventually wp.org).

I've also updated the README to reflect the current project a little better.

**To test**

- Check that the updates make sense, and the release process is understandable.
