### PR TITLE
Add missing fix to changelog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Fix: Add product rating display to preview, to better match front end
 - Fix: Product titles render HTML correctly in preview
 - Fix: Icons are now aligned correctly in placeholders
+- Fix: Grid block preview column width now matches the front-end
 - API: Change namespace, endpoints now accessed at `/wc-blocks/v1/*`
 - API: Add `catalog_visibility` parameter for fetching products
 - API: Update structure of attribute term endpoint to return `attribute.slug`, `attribute.name` etc


### PR DESCRIPTION
Looks like a change was missed when updating the readme for the last release, so this PR just adds the changelog line to readme.txt.