### PR TITLE
Avoid webpack conflict

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ const GutenbergBlocksConfig = {
 		path: path.resolve( __dirname, './build/' ),
 		filename: '[name].js',
 		libraryTarget: 'this',
+		jsonpFunction: 'wooJsonp',
 	},
 	externals,
 	optimization: {


### PR DESCRIPTION
Since this project uses some dependencies which create their own instances of React, webpack conflicts with other plugins that use react from Core, such as our Otter block. Ideally, your plugin should use react from WP core but even then it's a good idea to define a unique jsonp function.

This should fix: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/389

### How to test the changes in this Pull Request:

Now plugin shouldn't conflict with plugins that use React from WP core, such as https://wordpress.org/plugins/otter-blocks/
