### PR TITLE
Build: Add a custom jsonpFunction to prevent collisions with other projects

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,12 @@ const GutenbergBlocksConfig = {
 	output: {
 		path: path.resolve( __dirname, './build/' ),
 		filename: '[name].js',
+		library: [ 'wc', 'blocks', '[name]' ],
 		libraryTarget: 'this',
+		// This fixes an issue with multiple webpack projects using chunking
+		// overwriting each other's chunk loader function.
+		// See https://webpack.js.org/configuration/output/#outputjsonpfunction
+		jsonpFunction: 'webpackWcBlocksJsonp',
 	},
 	externals,
 	optimization: {


### PR DESCRIPTION
Fixes #389 – As noted in [the webpack docs:](https://webpack.js.org/configuration/output/#outputjsonpfunction)

> A JSONP function name used to asynchronously load chunks or join multiple initial chunks (SplitChunksPlugin, AggressiveSplittingPlugin).  **This needs to be changed if multiple webpack runtimes (from different compilation) are used on the same webpage.**

This means any project using SplitChunks (etc) attempts to use the same function name `window.webpackJsonp` - and they clobber each other when loaded onto one page. For example, using the Woo Blocks with Otter Blocks enabled.

### How to test the changes in this Pull Request:

1. Download & activate [Otter Blocks](https://wordpress.org/plugins/otter-blocks/)
2. Edit a post or page, open the block inserter
3. You should see the WooCommerce section and the Otter section
4. You can add blocks from either section, and they work as expected
3. Open the console, there should be no big red warnings (at least, none about undefined functions, you might see "Unsafe lifecycle methods…" but that's OK)

FYI @timmyc We'll want to get this into WooCommerce 3.6 to prevent these collisions with any other plugins.