### PR TITLE
Bump version to 2.0.0-rc3 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.0.0-rc2",
+  "version": "2.0.0-rc3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8873,7 +8873,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.0.0-rc2",
+  "version": "2.0.0-rc3",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -94,6 +94,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Fix: Product titles render HTML correctly in preview
 - Fix: Icons are now aligned correctly in placeholders
 - Fix: Grid block preview column width now matches the front-end
+- Fix: Webpack now builds using a custom jsonp callback, fixing possible collisions with other projects
 - API: Change namespace, endpoints now accessed at `/wc-blocks/v1/*`
 - API: Add `catalog_visibility` parameter for fetching products
 - API: Update structure of attribute term endpoint to return `attribute.slug`, `attribute.name` etc

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Blocks ===
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia
 Tags: gutenberg, woocommerce, woo commerce, products
-Requires at least: 4.9
-Tested up to: 5.0
+Requires at least: 5.0
+Tested up to: 5.1
 Requires PHP: 5.2
 Stable tag: 1.4.0
 License: GPLv3

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * WC requires at least: 3.5
+ * WC requires at least: 3.6
  * WC tested up to: 3.6
  *
  * @package WooCommerce\Blocks

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.0.0-rc2
+ * Version: 2.0.0-rc3
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.0.0-rc2' );
+define( 'WGPB_VERSION', '2.0.0-rc3' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
This PR bumps the version for an RC3 release so we can get #520 into WooCommerce 3.6. Once merged, I'll run a release and make a PR to bump the package in woo core.

This also updates some meta info about required and tested WC/WP versions.

### How to test the changes in this Pull Request:

1. Build the project, and check that it shows as 2.0.0-rc3 in the plugins list
