### PR TITLE
Version bump to 2.1.0-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.0.0-rc3",
+  "version": "2.1.0-dev",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.0.0-rc3
+ * Version: 2.1.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.0.0-rc3' );
+define( 'WGPB_VERSION', '2.1.0-dev' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
I've forked off a branch `branch/2.0.x` as of 2.0.0-RC3. `master` is a "development" branch, so we can start merging in 2.1 features (like #515). This version bump will make it clear which branch of the code you're using.

Any changes to `@woocommerce/block-library` that need to make WC 3.6 should be done in the 2.0.x branch, and that will be used for any point releases as needed. It will live parallel to master, and only bugfixes will be merged (no renovate PRs, for example, unless they're fixing a bug in the blocks). 

Note: I don't see us likely to _need_ the 2.0.x branch, since I think we can release `@woocommerce/block-library@2.1` with whatever WC version happens once it's released, whether that's a 3.6.x or 3.7, etc.

### How to test the changes in this Pull Request:

1. Verify the plugin version shows `2.1.0-dev`
