### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.0.0-rc3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.0.0-rc3",
+  "version": "2.0.0",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages!
 
-**NEW: Products by Attribute Block**
+**Products by Attribute Block**
 Display a grid of products from your selected attributes.
 
 **Featured Product Block**
@@ -43,7 +43,7 @@ We've also improved the category selection filter. If you select two or more cat
 = Minimum Requirements =
 
 * WordPress 5.0
-* WooCommerce 3.5.1 or greater
+* WooCommerce 3.6 or greater
 * PHP version 5.2.4 or greater (PHP 7.2 or greater is recommended)
 * MySQL version 5.0 or greater (MySQL 5.6 or greater is recommended)
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia
 Tags: gutenberg, woocommerce, woo commerce, products
 Requires at least: 5.0
-Tested up to: 5.1
+Tested up to: 5.2
 Requires PHP: 5.2
 Stable tag: 1.4.0
 License: GPLv3
@@ -83,9 +83,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
-= 2.0.0 - TBD =
+= 2.0.0 - 2019-04-18 =
 
-- **BREAKING:** Requires WordPress 5.0+, WooCommerce 3.5+
+- **BREAKING:** Requires WordPress 5.0+, WooCommerce 3.6+
 - **BREAKING:** Remove the legacy block entirely
 - **BREAKING:** Remove the `wc-pb/v3/*` endpoints in favor of new core `wc-blocks/v1/*` endpoints
 - Feature: Add content visibility settings to show/hide title, price, rating, button

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.0.0-rc3
+ * Version: 2.0.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.0.0-rc3' );
+define( 'WGPB_VERSION', '2.0.0' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
Everything's looking good, so let's release `@woocommerce/block-library` 2.0 officially. This bumps the version, then I'll run the publish command.

After the package is published, I'll make a PR for WooCommerce core to bump the version (or approve the renovate one, if that's faster 🙂). Then we'll release 2.0 on wp.org on Thursday, since it will require WC 3.6+

**To test**

Install the plugin & make sure the version reads `2.0.0`, no RC.