### PR TITLE
Fix 3.6 conflict with 1.4: Move conflict check to init action

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -37,17 +37,24 @@ class WGPB_Block_Library {
 	 * Constructor.
 	 */
 	public function __construct() {
+		if ( function_exists( 'register_block_type' ) ) {
+			add_action( 'init', array( 'WGPB_Block_Library', 'init' ) );
+		}
+	}
+
+	/**
+	 * Initialize block library features.
+	 */
+	public static function init() {
 		// Shortcut out if we see the feature plugin, v1.4 or below.
 		// note: `FP_VERSION` is transformed to `WGPB_VERSION` in the grunt copy task.
 		if ( defined( 'FP_VERSION' ) && version_compare( FP_VERSION, '1.4.0', '<=' ) ) {
 			return;
 		}
-		if ( function_exists( 'register_block_type' ) ) {
-			add_action( 'init', array( 'WGPB_Block_Library', 'register_blocks' ) );
-			add_action( 'init', array( 'WGPB_Block_Library', 'register_assets' ) );
-			add_filter( 'block_categories', array( 'WGPB_Block_Library', 'add_block_category' ) );
-			add_action( 'admin_print_footer_scripts', array( 'WGPB_Block_Library', 'print_script_settings' ), 1 );
-		}
+		self::register_blocks();
+		self::register_assets();
+		add_filter( 'block_categories', array( 'WGPB_Block_Library', 'add_block_category' ) );
+		add_action( 'admin_print_footer_scripts', array( 'WGPB_Block_Library', 'print_script_settings' ), 1 );
 	}
 
 	/**

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -25,11 +25,8 @@ define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 function wgpb_initialize() {
 	require_once plugin_dir_path( __FILE__ ) . 'assets/php/class-wgpb-block-library.php';
 
-	// Remove core hooks in favor of our local feature plugin handlers.
-	remove_action( 'init', array( 'WC_Block_Library', 'register_blocks' ) );
-	remove_action( 'init', array( 'WC_Block_Library', 'register_assets' ) );
-	remove_filter( 'block_categories', array( 'WC_Block_Library', 'add_block_category' ) );
-	remove_action( 'admin_print_footer_scripts', array( 'WC_Block_Library', 'print_script_settings' ), 1 );
+	// Remove core hook in favor of our local feature plugin handler.
+	remove_action( 'init', array( 'WC_Block_Library', 'init' ) );
 
 	$files_exist = file_exists( plugin_dir_path( __FILE__ ) . '/build/featured-product.js' );
 	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && ! $files_exist ) {


### PR DESCRIPTION
In #502, we added a check for the feature plugin version to prevent a fatal error. If for some reason the feature plugin is loaded after WooCommerce core, the check fails, and it all fatal errors anyway 🙁   Checking the feature plugin version on `init` ensures the constant is defined before we get to it, which was not guaranteed in `__construct`.

Fixes #533 

### How to test the changes in this Pull Request:

Set up a test site with WooCommerce 3.6 (or master), WooCommerce Blocks 1.4.0 ([can download from here](https://wordpress.org/plugins/woo-gutenberg-products-block/advanced/)). Rename the WooCommerce Blocks directory to something alphabetically later than woocommerce core (ie `zwoo-blocks`). You'll want this branch somewhere too, but leave it inactive.

1. Activate both plugins, you should get a fatal error.
2. In this folder, run `npm pack` to generate a `.tgz` file
3. Move the `.tgz` file to the woocommerce directory
4. Update `package.json` in woocommerce to use the `.tgz` from the last step [(like this example)](https://github.com/woocommerce/woocommerce/compare/fix/blocks-1.4-conflict#diff-b9cfc7f2cdf78a7f4b91a753d10865a2)
5. In `woocommerce`, run `npm install && npx grunt blocks`
6. Go back to your site, there should be no more fatal error.

Additionally, you can test this version of the plugin with WooCommerce core (3.6).
