### PR TITLE
Grid Blocks: Prevent invalid parameter passed to API

### DIFF
--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { min } from 'lodash';
+
 export default function getQuery( blockAttributes, name ) {
 	const {
 		attributes,
@@ -9,10 +14,11 @@ export default function getQuery( blockAttributes, name ) {
 	} = blockAttributes;
 	const columns = blockAttributes.columns || wc_product_block_data.default_columns;
 	const rows = blockAttributes.rows || wc_product_block_data.default_rows;
+	const apiMax = Math.floor( 100 / columns ) * columns; // Prevent uneven final row.
 
 	const query = {
 		status: 'publish',
-		per_page: rows * columns,
+		per_page: min( [ rows * columns, apiMax ] ),
 		catalog_visibility: 'visible',
 	};
 

--- a/assets/js/utils/test/get-query.js
+++ b/assets/js/utils/test/get-query.js
@@ -4,24 +4,40 @@
 import getQuery from '../get-query';
 
 describe( 'getQuery', () => {
-	test( 'should set per_page as a result of row * col', () => {
-		let query = getQuery( {
-			columns: 4,
-			rows: 3,
-		} );
-		expect( query.per_page ).toBe( 12 );
+	describe( 'per_page calculations', () => {
+		test( 'should set per_page as a result of row * col', () => {
+			let query = getQuery( {
+				columns: 4,
+				rows: 3,
+			} );
+			expect( query.per_page ).toBe( 12 );
 
-		query = getQuery( {
-			columns: 1,
-			rows: 3,
-		} );
-		expect( query.per_page ).toBe( 3 );
+			query = getQuery( {
+				columns: 1,
+				rows: 3,
+			} );
+			expect( query.per_page ).toBe( 3 );
 
-		query = getQuery( {
-			columns: 4,
-			rows: 1,
+			query = getQuery( {
+				columns: 4,
+				rows: 1,
+			} );
+			expect( query.per_page ).toBe( 4 );
 		} );
-		expect( query.per_page ).toBe( 4 );
+
+		test( 'should restrict per_page to under 100', () => {
+			let query = getQuery( {
+				columns: 4,
+				rows: 30,
+			} );
+			expect( query.per_page ).toBe( 100 );
+
+			query = getQuery( {
+				columns: 3,
+				rows: 87,
+			} );
+			expect( query.per_page ).toBe( 99 );
+		} );
 	} );
 
 	describe( 'for different query orders', () => {


### PR DESCRIPTION
Fixes #511 – When `per_page` is greater than 100, the API errors rather than returning products. We'll short-circuit that by always setting per_page to be less than 100 in the editor. On the frontend, the shortcode _does_ support a larger limit, so the correct number of products will be visible.

### How to test the changes in this Pull Request:

First, add the following code to your theme to allow for more rows, and make sure you have over 100 products on the site.

```php
add_theme_support( 'woocommerce', array(
	'product_blocks' => array(
		'max_rows' => 99,
	),
) );
```

1. Add any grid block, like Newest or Best Selling
2. Set your columns & rows to get more than 100 products, ex 4 x 30 or 3 x 50
3. Products should display in the block editor, but there will only be 100 max
4. Publish the post, and view it on the frontend.
5. You should see the full amount of products (assuming you have enough products)
