### PR TITLE
Add "FocalPointPicker" to Featured Product block

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -127,6 +127,7 @@ class FeaturedProduct extends Component {
 
 		const url =
 			attributes.mediaSrc || getImageSrcFromProduct( this.state.product );
+		const { focalPoint = { x: 0.5, y: 0.5 } } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -160,11 +161,11 @@ class FeaturedProduct extends Component {
 						max={ 100 }
 						step={ 10 }
 					/>
-					{ url &&
+					{ !! FocalPointPicker && !! url &&
 						<FocalPointPicker
 							label={ __( 'Focal Point Picker' ) }
 							url={ url }
-							value={ attributes.focalPoint }
+							value={ focalPoint }
 							onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
 						/>
 					}

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -15,6 +15,7 @@ import {
 } from '@wordpress/editor';
 import {
 	Button,
+	FocalPointPicker,
 	IconButton,
 	PanelBody,
 	Placeholder,
@@ -124,6 +125,9 @@ class FeaturedProduct extends Component {
 			setOverlayColor,
 		} = this.props;
 
+		const url =
+			attributes.mediaSrc || getImageSrcFromProduct( this.state.product );
+
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody title={ __( 'Content', 'woo-gutenberg-products-block' ) }>
@@ -156,6 +160,14 @@ class FeaturedProduct extends Component {
 						max={ 100 }
 						step={ 10 }
 					/>
+					{ url &&
+						<FocalPointPicker
+							label={ __( 'Focal Point Picker' ) }
+							url={ url }
+							value={ attributes.focalPoint }
+							onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
+						/>
+					}
 				</PanelColorSettings>
 			</InspectorControls>
 		);
@@ -205,6 +217,7 @@ class FeaturedProduct extends Component {
 			contentAlign,
 			dimRatio,
 			editMode,
+			focalPoint,
 			height,
 			showDesc,
 			showPrice,
@@ -228,6 +241,10 @@ class FeaturedProduct extends Component {
 			{};
 		if ( overlayColor.color ) {
 			style.backgroundColor = overlayColor.color;
+		}
+		if ( focalPoint ) {
+			style.backgroundPosition = `${ focalPoint.x * 100 }% ${ focalPoint.y *
+				100 }%`;
 		}
 
 		const onResizeStop = ( event, direction, elt ) => {
@@ -304,7 +321,10 @@ class FeaturedProduct extends Component {
 												[
 													'core/button',
 													{
-														text: __( 'Shop now', 'woo-gutenberg-products-block' ),
+														text: __(
+															'Shop now',
+															'woo-gutenberg-products-block'
+														),
 														url: product.permalink,
 														align: 'center',
 													},

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -274,6 +274,7 @@ class FeaturedProduct extends Component {
 										label={ __( 'Edit media' ) }
 										icon="format-image"
 										onClick={ open }
+										disabled={ ! this.state.product }
 									/>
 								) }
 							/>

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -53,6 +53,13 @@ registerBlockType( 'woocommerce/featured-product', {
 		},
 
 		/**
+		 * Focus point for the background image
+		 */
+		focalPoint: {
+			type: 'object',
+		},
+
+		/**
 		 * A fixed height for the block.
 		 */
 		height: {

--- a/assets/php/class-wgpb-block-featured-product.php
+++ b/assets/php/class-wgpb-block-featured-product.php
@@ -119,7 +119,7 @@ class WGPB_Block_Featured_Product {
 			$style .= sprintf( 'min-height:%dpx;', intval( $attributes['height'] ) );
 		}
 
-		if ( isset( $attributes['focalPoint'] ) && 2 === count( $attributes['focalPoint'] ) ) {
+		if ( is_array( $attributes['focalPoint'] ) && 2 === count( $attributes['focalPoint'] ) ) {
 			$style .= sprintf(
 				'background-position: %s%% %s%%',
 				$attributes['focalPoint']['x'] * 100,

--- a/assets/php/class-wgpb-block-featured-product.php
+++ b/assets/php/class-wgpb-block-featured-product.php
@@ -31,6 +31,7 @@ class WGPB_Block_Featured_Product {
 		'align'        => 'none',
 		'contentAlign' => 'center',
 		'dimRatio'     => 50,
+		'focalPoint'   => false,
 		'height'       => false,
 		'mediaId'      => 0,
 		'mediaSrc'     => '',
@@ -116,6 +117,14 @@ class WGPB_Block_Featured_Product {
 
 		if ( isset( $attributes['height'] ) ) {
 			$style .= sprintf( 'min-height:%dpx;', intval( $attributes['height'] ) );
+		}
+
+		if ( isset( $attributes['focalPoint'] ) && 2 === count( $attributes['focalPoint'] ) ) {
+			$style .= sprintf(
+				'background-position: %s%% %s%%',
+				$attributes['focalPoint']['x'] * 100,
+				$attributes['focalPoint']['y'] * 100
+			);
 		}
 
 		return $style;


### PR DESCRIPTION
Fixes #403 - Adds the FocalPointPicker to the Featured Product block, which lets you reposition the background image. For example, by default this person's head is cut off:

![before](https://user-images.githubusercontent.com/541093/56920670-d94cc500-6a91-11e9-80fb-7e48b4e20358.png)

But by using the focal point picker, we can move the "focus" up a bit and have this:

![after](https://user-images.githubusercontent.com/541093/56920671-d94cc500-6a91-11e9-9c36-f57b87b78c62.png)

#### Accessibility

FocalPointPicker is a core component, it has the 2 text inputs as accessible fallbacks from the image selection. There's a minor bug with the inputs, will be fixed with https://github.com/WordPress/gutenberg/pull/15255

### How to test the changes in this Pull Request:

1. Add a Featured Product block (most noticeable change when the image is tall)
2. Use the Focal Point Picker to change which part of the image is visible in the block
3. Publish the post, reload the page – it should keep that part of the image visible
4. View it on the frontend – it should look the same on the frontend
