### PR TITLE
Update and add documentation in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,19 @@ If you're just looking to use these blocks, update to WooCommerce 3.6! The block
 
 If you want to see what we're working on for future versions, or want to help out, read on.
 
-## Getting started with the stable version:
+## Table of Contents
+
+- [Installing the stable version](#installing-the-stable-version)
+- [Installing the development version](#installing-the-development-version)
+- [Getting started with block development](#getting-started-with-block-development)
+- [Contributing](CONTRIBUTING.md)
+  - [About the npm scripts](CONTRIBUTING.md#npm-scripts)
+  - [Publishing a release](CONTRIBUTING.md#publishing-woocommerceblock-library)
+- Code Documentation
+  - [Blocks](assets/js/blocks)
+  - [Components](assets/js/components)
+
+## Installing the stable version
 
 We release a new version of WooCommerce Blocks onto WordPress.org every few weeks, which can be used as an easier way to preview the features.
 
@@ -14,7 +26,7 @@ We release a new version of WooCommerce Blocks onto WordPress.org every few week
 2. The stable version is available on WordPress.org. [Download the stable version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
 3. Activate the plugin.
 
-## Getting started with the development version:
+## Installing the development version
 
 1. Make sure you have WordPress 5.0+ and WooCommerce 3.6+
 2. Get a copy of this plugin using the green "Clone or download" button on the right.
@@ -24,9 +36,17 @@ We release a new version of WooCommerce Blocks onto WordPress.org every few week
 
 The source code is in the `assets/` folder and the compiled code is built into `build/`.
 
-**Gutenberg Tutorial and Docs**: https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/introducing-attributes-and-editable-fields/
+## Getting started with block development
 
-**Using API in Gutenberg**: https://github.com/WordPress/gutenberg/tree/master/packages/api-fetch
+Run through the ["Writing Your First Block Type" tutorial](https://wordpress.org/gutenberg/handbook/designers-developers/developers/tutorials/block-tutorial/) for a quick course in block-building.
+
+For deeper dive, try looking at the [core blocks code,](https://github.com/WordPress/gutenberg/tree/master/packages/block-library/src) or see what [components are available.](https://github.com/WordPress/gutenberg/tree/master/packages/components/src)
+
+Other useful docs to explore:
+
+- [`InnerBlocks `](https://github.com/WordPress/gutenberg/blob/master/packages/block-editor/src/components/inner-blocks/README.md)
+- [`apiFetch`](https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-api-fetch/)
+- [`@wordpress/editor`](https://github.com/WordPress/gutenberg/blob/master/packages/editor/README.md)
 
 ## Vision for the Feature
 

--- a/assets/js/blocks/README.md
+++ b/assets/js/blocks/README.md
@@ -1,0 +1,30 @@
+# Blocks
+
+Our blocks are generally made up of up to 4 files:
+
+```
+|- block.js
+|- editor.scss
+|- index.js
+|- style.scss
+```
+
+The only required file is `index.js`, this sets up the block using [`registerBlockType`.](https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/) Each block has edit and save functions.
+
+The scss files are split so that things in `style` are added to the editor _and_ frontend, while styles in `editor` are only added to the editor. Most of our blocks should use core components that won't need CSS though.
+
+### Editing
+
+A simple edit function can live in `index.js`, but most blocks are a little more complicated, so the edit function instead returns a Block component, which lives in `block.js`. By using a component, we can use React lifecycle methods to fetch data or save state.
+
+The [Newest Products block](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5c9d587fcc0b9e652813a42b66eafa5520c7ac88/assets/js/blocks/product-new/block.js) is a good example to read over, this is a simple block that fetches the products and renders them using the ProductPreview component.
+
+We include settings in the sidebar, called the Inspector in gutenberg. [See an example of this.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5c9d587fcc0b9e652813a42b66eafa5520c7ac88/assets/js/blocks/product-new/block.js#L71)
+
+Other blocks have the concept of an "edit state", like when you need to pick a product in the Featured Product block, or [pick a category in the Products by Category block.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5c9d587fcc0b9e652813a42b66eafa5520c7ac88/assets/js/blocks/product-category/block.js#L140)
+
+### Saving
+
+Usually blocks can be converted to HTML in the save function, so that what's saved into the database is the same HTML that's rendered on the frontend. Our blocks are different since they need to show the latest products and reflect any changes to products.
+
+The grid blocks are saved as shortcodes using [`getShortcode`,](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5c9d587fcc0b9e652813a42b66eafa5520c7ac88/assets/js/utils/get-shortcode.js) but the Featured Product block is considered a "dynamic block", so we use PHP to build that each time the post is loaded on the frontend. The code for that is set up when [the block is registered in PHP](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5c9d587fcc0b9e652813a42b66eafa5520c7ac88/assets/php/class-wgpb-block-library.php#L216), and lives in [`WGPB_Block_Featured_Product`.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5c9d587fcc0b9e652813a42b66eafa5520c7ac88/assets/php/class-wgpb-block-featured-product.php)

--- a/assets/js/components/README.md
+++ b/assets/js/components/README.md
@@ -1,0 +1,45 @@
+# Components
+
+These are shared components used by the blocks. If there's a component that is more universally useful, it should go into [`@woocommerce/components`](https://github.com/woocommerce/woocommerce-admin/tree/master/packages/components)– these components are specific to the Gutenberg context.
+
+The `*-control` components here are designed to exist in the `InspectorControls` sidebar, or in a Placeholder component for the "edit state" of a block.
+
+## `GridContentControl`
+
+A combination of toggle controls for content visibility in product grids.
+
+## `GridLayoutControl`
+
+A combination of range controls for product grid layout settings.
+
+## `ProductOrderbyControl`
+
+A pre-configured SelectControl for product orderby settings.
+
+## `ProductPreview`
+
+Display a preview for a given product.
+
+## `ProductAttributeControl`
+
+A component using [`SearchListControl`](https://woocommerce.github.io/woocommerce-admin/#/components/packages/search-list-control) to show product attributes as selectable options. Only allows for selecting attribute terms from one attribute at a time (multiple terms can be selected).
+
+## `ProductCategoryControl`
+
+A component using [`SearchListControl`](https://woocommerce.github.io/woocommerce-admin/#/components/packages/search-list-control) to show product categories as selectable options. Options are displayed in hierarchy. Can select multiple categories.
+
+## `ProductControl`
+
+A component using [`SearchListControl`](https://woocommerce.github.io/woocommerce-admin/#/components/packages/search-list-control) to show products as selectable options. Only one product can be selected at a time.
+
+## `ProductsControl`
+
+A component using [`SearchListControl`](https://woocommerce.github.io/woocommerce-admin/#/components/packages/search-list-control) to show products as selectable options. Multiple products can be selected at once.
+
+## Icons
+
+These are a collection of custom icons used by the blocks or components, usually from Material.
+
+## Utilities
+
+There are some functions that work across components, these have been extracted into this utilities folder.

--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import { ToggleControl } from '@wordpress/components';
 
 /**
- * A combination of range controls for product grid layout settings.
+ * A combination of toggle controls for content visibility in product grids.
  */
 const GridContentControl = ( { onChange, settings } ) => {
 	const { button, price, rating, title } = settings;


### PR DESCRIPTION
This PR adds some docs and references for working on the blocks project, from how our blocks work to what the components are, and specific links to useful Gutenberg documentation.

### How to test the changes in this Pull Request:

View the [README on this branch,](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/update/readme-dev/README.md) and use the table of contents to explore the new docs– "Getting started with block development", "Code Documentation: Blocks", and "Code Documentation: Components".
