### PR TITLE
Products by Tag(s) block supporting changes

### DIFF
--- a/assets/php/api/class-wc-rest-blocks-products-controller-v2.php
+++ b/assets/php/api/class-wc-rest-blocks-products-controller-v2.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * REST API Products controller customized for Products Block.
+ *
+ * Handles requests to the /products endpoint.
+ *
+ * @internal These overrides need rolling into core when releasing a new version.
+ *
+ * @package WooCommerce\Blocks\Products\Rest\Controller
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Products controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_REST_Blocks_Products_Controller_V2 extends WC_REST_Blocks_Products_Controller {
+
+	/**
+	 * Register the routes for products.
+	 *
+	 * Only difference here is the override property.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
+			true
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param(
+							array(
+								'default' => 'view',
+							)
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			),
+			true
+		);
+	}
+
+	/**
+	 * Update the collection params.
+	 *
+	 * Adds new options for 'orderby', and new parameters 'category_operator', 'attribute_operator'.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                 = parent::get_collection_params();
+		$params['tag_operator'] = array(
+			'description'       => __( 'Operator to compare product tags.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'enum'              => array( 'in', 'not_in', 'and' ),
+			'default'           => 'in',
+			'sanitize_callback' => 'sanitize_key',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		return $params;
+	}
+
+	/**
+	 * Make extra product orderby features supported by WooCommerce available to the WC API.
+	 * This includes 'price', 'popularity', and 'rating'.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		$args             = parent::prepare_objects_query( $request );
+		$operator_mapping = array(
+			'in'     => 'IN',
+			'not_in' => 'NOT IN',
+			'and'    => 'AND',
+		);
+
+		// New handling for tags.
+		$tag_operator = $operator_mapping[ $request->get_param( 'tag_operator' ) ];
+
+		if ( $tag_operator && isset( $args['tax_query'] ) ) {
+			foreach ( $args['tax_query'] as $i => $tax_query ) {
+				if ( 'product_tag' === $tax_query['taxonomy'] ) {
+					$args['tax_query'][ $i ]['operator'] = $tag_operator;
+				}
+			}
+		}
+
+		return $args;
+	}
+}

--- a/assets/php/class-wgpb-extend-core.php
+++ b/assets/php/class-wgpb-extend-core.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Extend core/WC Rest API with new functionality.
+ *
+ * Changes here should be moved to core before merging blocks into a core release.
+ *
+ * @package WooCommerce\Blocks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WGPB_Extend_Core Class.
+ */
+class WGPB_Extend_Core {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WGPB_Rest_API instance
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return WGPB_Extend_Core instance.
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Init - register hooks.
+	 */
+	public function init() {
+		add_action( 'rest_api_init', array( $this, 'override_product_api_controller' ), 20 );
+		add_filter( 'shortcode_atts_products', array( $this, 'products_shortcode_allow_unregistered_atts' ), 10, 3 );
+		add_filter( 'woocommerce_shortcode_products_query', array( $this, 'products_shortcode_support_tag_ids' ), 10, 2 );
+	}
+
+	/**
+	 * On rest API Init, replace core endpoints with custom ones.
+	 */
+	public function override_product_api_controller() {
+		require_once WGPB_ABSPATH . 'assets/php/api/class-wc-rest-blocks-products-controller-v2.php';
+
+		// Replace the products controller in woo core.
+		wc()->api->WC_REST_Blocks_Products_Controller = new WC_REST_Blocks_Products_Controller_V2();
+		wc()->api->WC_REST_Blocks_Products_Controller->register_routes();
+	}
+
+	/**
+	 * Prevent shotrcode_atts from removing the custom tag_ids and tag_operator parameters.
+	 *
+	 * @internal This code won't be needed when these parameters are added to core WC_Shortcode_Products::parse_attributes.
+	 *
+	 * @param array $out   The output array of shortcode attributes.
+	 * @param array $pairs The supported attributes and their defaults.
+	 * @param array $atts  The user defined shortcode attributes.
+	 * @return array
+	 */
+	public function products_shortcode_allow_unregistered_atts( $out, $pairs, $atts ) {
+		$out['tag_ids']      = isset( $atts['tag_ids'] ) ? $atts['tag_ids'] : null;
+		$out['tag_operator'] = isset( $atts['tag_operator'] ) ? $atts['tag_operator'] : null;
+		return $out;
+	}
+
+	/**
+	 * Add support for tag IDs to the products shortcode.
+	 *
+	 * @param array $query_args Array of query args for WordPress.
+	 * @param array $attributes Array of options for the shortcode.
+	 * @return array Modified query args.
+	 */
+	public function products_shortcode_support_tag_ids( $query_args, $attributes ) {
+		if ( isset( $attributes['tag_ids'] ) ) {
+			$query_args['tax_query'][] = array(
+				'taxonomy' => 'product_tag',
+				'terms'    => array_map( 'absint', explode( ',', $attributes['tag_ids'] ) ),
+				'field'    => 'id',
+				'operator' => isset( $attributes['tag_operator'] ) ? $attributes['tag_operator'] : 'IN',
+			);
+		}
+		return $query_args;
+	}
+}
+WGPB_Extend_Core::get_instance();

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -24,6 +24,7 @@ define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
  */
 function wgpb_initialize() {
 	require_once plugin_dir_path( __FILE__ ) . 'assets/php/class-wgpb-block-library.php';
+	require_once plugin_dir_path( __FILE__ ) . 'assets/php/class-wgpb-extend-core.php';
 
 	// Remove core hook in favor of our local feature plugin handler.
 	remove_action( 'init', array( 'WC_Block_Library', 'init' ) );


### PR DESCRIPTION
Part of #554 

This introduces a class to extend WooCommerce core via hooks, changes the wc-blocks API to support `tag_operator`, and the `[products]` shortcode to support `tag_ids` and `tag_operator`. Without these changes, products by tag is not possible.

To test the shortcode, you can add a shortcode to a post manually using `[products tag_ids="x"]` replacing x with a valid tag ID. You should see only products with that tag displayed.

To test the API you can do a request to the blocks API and include both the tag param and the tag_operator param (valid values IN and AND) `wc-blocks/v1/products?tag=32&tag_operator=IN`. Only tag_operator is new.