### PR TITLE
Fix the chunking in webpack to always extract shared code to `vendors`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,8 +5,8 @@ const path = require( 'path' );
 const MergeExtractFilesPlugin = require( './bin/merge-extract-files-webpack-plugin' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const CleanWebpackPlugin = require( 'clean-webpack-plugin' );
-const ProgressBarPlugin = require('progress-bar-webpack-plugin');
-const chalk = require('chalk');
+const ProgressBarPlugin = require( 'progress-bar-webpack-plugin' );
+const chalk = require( 'chalk' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
 const externals = {
@@ -72,6 +72,7 @@ const GutenbergBlocksConfig = {
 					test: /[\\/]node_modules[\\/]/,
 					name: 'vendors',
 					chunks: 'all',
+					enforce: true,
 				},
 				editor: {
 					// Capture all `editor` stylesheets and the components stylesheets.


### PR DESCRIPTION
Fixes #571 – Previously, `optimization.splitChunks` wasn't splitting the shared code into the `vendors` chunk when building in production mode (but it was in development). Now we `enforce` the vendors chunk, which pulls all `node_modules` code into the separate `vendors` file. This prevents the duplicated `@woocommerce/components` etc in each block file.

| File | Before | After |
| ---- | ------ | ----- |
| featured-product.js | 2.2M | 12K |
| handpicked-products.js | 2.2M | 18K |
| product-best-sellers.js | 2.2M | 17K |
| product-category.js | 2.2M | 20K |
| product-new.js | 2.2M | 18K |
| product-on-sale.js | 2.2M | 18K |
| product-top-rated.js | 2.2M | 17K |
| products-attribute.js | 2.2M  | 21K |
| vendors.js | 7.6K | 2.1M |

I think this also speeds up the production build process 👍 

Note, the original issue says: "It seems that every WooCommerce block file contains gutenberg, momentjs, react, the source of the wc block and some smaller libraries." – this isn't exactly right– we do include momentjs (with/from `@woocommerce/components`), but `react` & the `@wordpess/*` packages are _not_ bundled with each block or in vendors.js, since these reference the versions of these libraries already loading in WordPress.

### How to test the changes in this Pull Request:

1. Build the project in production mode: `npm run build`
2. Check that each built block file is around 20KB
3. Spot-check the plugin, make sure each block still works