### PR TITLE
Remove the styles build target in webpack

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -7,6 +7,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import '../css/editor.scss';
+import '../css/style.scss';
 import { IconWoo } from './components/icons';
 
 setCategories( [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,8 +53,6 @@ const GutenbergBlocksConfig = {
 		'product-top-rated': './assets/js/blocks/product-top-rated/index.js',
 		'products-attribute': './assets/js/blocks/products-by-attribute/index.js',
 		'featured-product': './assets/js/blocks/featured-product/index.js',
-		// Global styles
-		styles: [ './assets/css/style.scss', './assets/css/editor.scss' ],
 	},
 	output: {
 		path: path.resolve( __dirname, './build/' ),
@@ -134,7 +132,6 @@ const GutenbergBlocksConfig = {
 		new MergeExtractFilesPlugin( [
 			'build/editor.js',
 			'build/style.js',
-			'build/styles.js',
 		], 'build/vendors.js' ),
 		new ProgressBarPlugin( {
 			format: chalk.blue( 'Build' ) + ' [:bar] ' + chalk.green( ':percent' ) + ' :msg (:elapsed seconds)',


### PR DESCRIPTION
It's technically not correct to use CSS files as entry points in webpack (it creates a fake .js file just to handle this), but we didn't have a shared JS file before. Now that we do, the CSS can be imported into the “global” JS file now.

### How to test the changes in this Pull Request:

1. Build the project
2. Check that `build/editor.css` contains the CSS from `assets/css/editor.scss`
3. Check that `build/style.css` contains the CSS from `assets/css/style.scss`
4. Spot check some blocks in the editor and on the frontend
