### PR TITLE
Add `menu_order` as a valid orderby value

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -369,7 +369,7 @@ class WGPB_Block_Library {
 	protected static function get_schema_orderby() {
 		return array(
 			'type'    => 'string',
-			'enum'    => array( 'date', 'popularity', 'price_asc', 'price_desc', 'rating', 'title' ),
+			'enum'    => array( 'date', 'popularity', 'price_asc', 'price_desc', 'rating', 'title', 'menu_order' ),
 			'default' => 'date',
 		);
 	}


### PR DESCRIPTION
Fixes #624.

### How to test the changes in this Pull Request:

1. Add any block that supports ordering (so not Newest, but Products by Category, Products by Attribute, On Sale…)
2. In the sidebar, set Order by to Menu order
3. Expect: It should render the block using "menu order" (set on a product under the "Advanced" tab, lower value comes first)
