### PR TITLE
Product Categories List: Add the links into the rendered block

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -23,7 +23,7 @@ function getCategories( { hasEmpty, isDropdown, isHierarchical } ) {
 /**
  * Component displaying the categories as dropdown or list.
  */
-const ProductCategoriesBlock = ( { attributes } ) => {
+const ProductCategoriesBlock = ( { attributes, isPreview = false } ) => {
 	const { hasCount, isDropdown } = attributes;
 	const categories = getCategories( attributes );
 	const parentKey = 'parent-' + categories[ 0 ].term_id;
@@ -65,6 +65,10 @@ ProductCategoriesBlock.propTypes = {
 	 * The attributes for this block
 	 */
 	attributes: PropTypes.object.isRequired,
+	/**
+	 * Whether this is the block preview or frontend display.
+	 */
+	isPreview: PropTypes.bool,
 };
 
 export default ProductCategoriesBlock;

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -33,10 +33,10 @@ const ProductCategoriesBlock = ( { attributes, isPreview = false } ) => {
 			{ items.map( ( cat ) => {
 				const count = hasCount ? <span>({ cat.count })</span> : null;
 				return [
-					<li key={ cat.term_id }><a>{ cat.name }</a> { count }</li>, // eslint-disable-line
-					!! cat.children &&
-						!! cat.children.length &&
-						renderList( cat.children ),
+					<li key={ cat.term_id }>
+						<a href={ isPreview ? null : cat.link }>{ cat.name }</a> { count } { /* eslint-disable-line */ }
+					</li>,
+					!! cat.children && !! cat.children.length && renderList( cat.children ),
 				];
 			} ) }
 		</ul>

--- a/assets/js/blocks/product-categories/edit.js
+++ b/assets/js/blocks/product-categories/edit.js
@@ -66,7 +66,7 @@ export default function( { attributes, setAttributes } ) {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Block attributes={ attributes } />
+			<Block attributes={ attributes } isPreview />
 		</Fragment>
 	);
 }

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -197,6 +197,10 @@ class WGPB_Block_Library {
 				'pad_counts' => true,
 			)
 		);
+		foreach ( $product_categories as &$category ) {
+			$category->link = get_term_link( $category->term_id, 'product_cat' );
+		}
+
 		// Global settings used in each block.
 		$block_settings = array(
 			'min_columns'       => wc_get_theme_support( 'product_blocks::min_columns', 1 ),


### PR DESCRIPTION
In #613, we merged the Product Categories List block, but the link list preview didn't have links yet. This PR adds the links to the `a` on the frontend only, so that you can't accidentally click & navigate away in the editor.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### How to test the changes in this Pull Request:

1. Add the block to your post, view as list of links (not dropdown)
2. Expect: the editor preview should not have links, clicking the text doesn't do anything
3. View the frontend, the list should have links, clicking should navigate to the category
