### PR TITLE
Product Categories List: Update dropdown view

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -2,20 +2,21 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { noop } from 'lodash';
-import { SelectControl } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { noop, repeat } from 'lodash';
 import PropTypes from 'prop-types';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { buildTermsTree } from './hierarchy';
 
-function getCategories( { hasEmpty, isDropdown, isHierarchical } ) {
+function getCategories( { hasEmpty, isHierarchical } ) {
 	const categories = wc_product_block_data.productCategories.filter(
 		( cat ) => hasEmpty || !! cat.count
 	);
-	return ! isDropdown && isHierarchical ?
+	return isHierarchical ?
 		buildTermsTree( categories ) :
 		categories;
 }
@@ -23,52 +24,86 @@ function getCategories( { hasEmpty, isDropdown, isHierarchical } ) {
 /**
  * Component displaying the categories as dropdown or list.
  */
-const ProductCategoriesBlock = ( { attributes, isPreview = false } ) => {
-	const { hasCount, isDropdown } = attributes;
-	const categories = getCategories( attributes );
-	const parentKey = 'parent-' + categories[ 0 ].term_id;
+class ProductCategoriesBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.renderList = this.renderList.bind( this );
+		this.renderOptions = this.renderOptions.bind( this );
+	}
 
-	const renderList = ( items ) => (
-		<ul key={ parentKey }>
-			{ items.map( ( cat ) => {
-				const count = hasCount ? <span>({ cat.count })</span> : null;
-				return [
-					<li key={ cat.term_id }>
-						<a href={ isPreview ? null : cat.link }>{ cat.name }</a> { count } { /* eslint-disable-line */ }
-					</li>,
-					!! cat.children && !! cat.children.length && renderList( cat.children ),
-				];
-			} ) }
-		</ul>
-	);
+	renderList( items, depth = 0 ) {
+		const { isPreview = false } = this.props;
+		const { hasCount } = this.props.attributes;
+		const parentKey = 'parent-' + items[ 0 ].term_id;
 
-	return (
-		<div className="wc-block-product-categories">
-			{ isDropdown ? (
-				<SelectControl
-					label={ __( 'Select a category', 'woo-gutenberg-products-block' ) }
-					options={ categories.map( ( cat ) => ( {
-						label: hasCount ? `${ cat.name } (${ cat.count })` : cat.name,
-						value: cat.term_id,
-					} ) ) }
-					onChange={ noop }
-				/>
-			) : (
-				renderList( categories )
-			) }
-		</div>
-	);
-};
+		return (
+			<ul key={ parentKey }>
+				{ items.map( ( cat ) => {
+					const count = hasCount ? <span>({ cat.count })</span> : null;
+					return [
+						<li key={ cat.term_id }>
+							<a href={ isPreview ? null : cat.link }>{ cat.name }</a> { count } { /* eslint-disable-line */ }
+						</li>,
+						!! cat.children && !! cat.children.length && this.renderList( cat.children, depth + 1 ),
+					];
+				} ) }
+			</ul>
+		);
+	}
+
+	renderOptions( items, depth = 0 ) {
+		const { hasCount } = this.props.attributes;
+
+		return items.map( ( cat ) => {
+			const count = hasCount ? `(${ cat.count })` : null;
+			return [
+				<option key={ cat.term_id } value={ cat.term_id }>
+					{ repeat( '–', depth ) } { cat.name } { count }
+				</option>,
+				!! cat.children && !! cat.children.length && this.renderOptions( cat.children, depth + 1 ),
+			];
+		} );
+	}
+
+	render() {
+		const { attributes, instanceId } = this.props;
+		const { isDropdown } = attributes;
+		const categories = getCategories( attributes );
+
+		const selectId = `prod-categories-${ instanceId }`;
+
+		return (
+			<div className="wc-block-product-categories">
+				{ isDropdown ? (
+					<Fragment>
+						<label htmlFor={ selectId }>
+							{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
+						</label>
+						<select id={ selectId } onBlur={ noop }>
+							{ this.renderOptions( categories ) }
+						</select>
+					</Fragment>
+				) : (
+					this.renderList( categories )
+				) }
+			</div>
+		);
+	}
+}
 
 ProductCategoriesBlock.propTypes = {
 	/**
-	 * The attributes for this block
+	 * The attributes for this block.
 	 */
 	attributes: PropTypes.object.isRequired,
+	/**
+	 * A unique ID for identifying the label for the select dropdown.
+	 */
+	instanceId: PropTypes.number,
 	/**
 	 * Whether this is the block preview or frontend display.
 	 */
 	isPreview: PropTypes.bool,
 };
 
-export default ProductCategoriesBlock;
+export default withInstanceId( ProductCategoriesBlock );

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -2,7 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import classnames from 'classnames';
+import { Component, createRef, Fragment } from '@wordpress/element';
+import { IconButton } from '@wordpress/components';
 import { repeat } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
@@ -27,14 +29,18 @@ function getCategories( { hasEmpty, isHierarchical } ) {
 class ProductCategoriesBlock extends Component {
 	constructor() {
 		super( ...arguments );
+		this.select = createRef();
 		this.onNavigate = this.onNavigate.bind( this );
 		this.renderList = this.renderList.bind( this );
 		this.renderOptions = this.renderOptions.bind( this );
 	}
 
-	onNavigate( event ) {
+	onNavigate() {
 		const { isPreview = false } = this.props;
-		const url = event.target.value;
+		const url = this.select.current.value;
+		if ( 'false' === url ) {
+			return;
+		}
 		const home = wc_product_block_data.homeUrl;
 
 		if ( ! isPreview && 0 === url.indexOf( home ) ) {
@@ -80,19 +86,34 @@ class ProductCategoriesBlock extends Component {
 		const { attributes, instanceId } = this.props;
 		const { isDropdown } = attributes;
 		const categories = getCategories( attributes );
+		const classes = classnames( {
+			'wc-block-product-categories': true,
+			'is-dropdown': isDropdown,
+			'is-list': ! isDropdown,
+		} );
 
 		const selectId = `prod-categories-${ instanceId }`;
 
 		return (
-			<div className="wc-block-product-categories">
+			<div className={ classes }>
 				{ isDropdown ? (
 					<Fragment>
-						<label htmlFor={ selectId }>
-							{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
-						</label>
-						<select id={ selectId } onChange={ this.onNavigate }>
-							{ this.renderOptions( categories ) }
-						</select>
+						<div className="wc-block-product-categories__dropdown">
+							<label className="screen-reader-text" htmlFor={ selectId }>
+								{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
+							</label>
+							<select id={ selectId } ref={ this.select }>
+								<option value="false">
+									{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
+								</option>
+								{ this.renderOptions( categories ) }
+							</select>
+						</div>
+						<IconButton
+							icon="arrow-right-alt2"
+							label={ __( 'Go to category', 'woo-gutenberg-products-block' ) }
+							onClick={ this.onNavigate }
+						/>
 					</Fragment>
 				) : (
 					this.renderList( categories )

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { noop, repeat } from 'lodash';
+import { repeat } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
 
@@ -27,8 +27,19 @@ function getCategories( { hasEmpty, isHierarchical } ) {
 class ProductCategoriesBlock extends Component {
 	constructor() {
 		super( ...arguments );
+		this.onNavigate = this.onNavigate.bind( this );
 		this.renderList = this.renderList.bind( this );
 		this.renderOptions = this.renderOptions.bind( this );
+	}
+
+	onNavigate( event ) {
+		const { isPreview = false } = this.props;
+		const url = event.target.value;
+		const home = wc_product_block_data.homeUrl;
+
+		if ( ! isPreview && 0 === url.indexOf( home ) ) {
+			document.location.href = url;
+		}
 	}
 
 	renderList( items, depth = 0 ) {
@@ -57,7 +68,7 @@ class ProductCategoriesBlock extends Component {
 		return items.map( ( cat ) => {
 			const count = hasCount ? `(${ cat.count })` : null;
 			return [
-				<option key={ cat.term_id } value={ cat.term_id }>
+				<option key={ cat.term_id } value={ cat.link }>
 					{ repeat( '–', depth ) } { cat.name } { count }
 				</option>,
 				!! cat.children && !! cat.children.length && this.renderOptions( cat.children, depth + 1 ),
@@ -79,7 +90,7 @@ class ProductCategoriesBlock extends Component {
 						<label htmlFor={ selectId }>
 							{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
 						</label>
-						<select id={ selectId } onBlur={ noop }>
+						<select id={ selectId } onChange={ this.onNavigate }>
 							{ this.renderOptions( categories ) }
 						</select>
 					</Fragment>

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -103,7 +103,7 @@ class ProductCategoriesBlock extends Component {
 								{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
 							</label>
 							<select id={ selectId } ref={ this.select }>
-								<option value="false">
+								<option value="false" hidden>
 									{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
 								</option>
 								{ this.renderOptions( categories ) }

--- a/assets/js/blocks/product-categories/edit.js
+++ b/assets/js/blocks/product-categories/edit.js
@@ -42,18 +42,16 @@ export default function( { attributes, setAttributes } ) {
 						checked={ hasCount }
 						onChange={ () => setAttributes( { hasCount: ! hasCount } ) }
 					/>
-					{ ! isDropdown && (
-						<ToggleControl
-							label={ __( 'Show hierarchy', 'woo-gutenberg-products-block' ) }
-							help={
-								isHierarchical ?
-									__( 'Hierarchy is visible.', 'woo-gutenberg-products-block' ) :
-									__( 'Hierarchy is hidden.', 'woo-gutenberg-products-block' )
-							}
-							checked={ isHierarchical }
-							onChange={ () => setAttributes( { isHierarchical: ! isHierarchical } ) }
-						/>
-					) }
+					<ToggleControl
+						label={ __( 'Show hierarchy', 'woo-gutenberg-products-block' ) }
+						help={
+							isHierarchical ?
+								__( 'Hierarchy is visible.', 'woo-gutenberg-products-block' ) :
+								__( 'Hierarchy is hidden.', 'woo-gutenberg-products-block' )
+						}
+						checked={ isHierarchical }
+						onChange={ () => setAttributes( { isHierarchical: ! isHierarchical } ) }
+					/>
 					<ToggleControl
 						label={ __( 'Show empty categories', 'woo-gutenberg-products-block' ) }
 						help={

--- a/assets/js/blocks/product-categories/frontend.js
+++ b/assets/js/blocks/product-categories/frontend.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { forEach } from 'lodash';
 import { render } from '@wordpress/element';
 
 /**
@@ -13,7 +14,7 @@ const containers = document.querySelectorAll(
 );
 
 if ( containers.length ) {
-	containers.forEach( ( el ) => {
+	forEach( containers, ( el ) => {
 		const data = JSON.parse( JSON.stringify( el.dataset ) );
 		const attributes = {
 			hasCount: data.hasCount === 'true',

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -8,6 +8,7 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import './editor.scss';
+import './style.scss';
 import edit from './edit.js';
 import { IconFolder } from '../../components/icons';
 

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -1,0 +1,11 @@
+.wc-block-product-categories {
+	margin-bottom: 1em;
+
+	&.is-dropdown {
+		display: flex;
+	}
+
+	select {
+		margin-right: 0.5em;
+	}
+}

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -215,6 +215,7 @@ class WGPB_Block_Library {
 			'default_height'    => wc_get_theme_support( 'featured_block::default_height', 500 ),
 			'isLargeCatalog'    => $product_counts->publish > 200,
 			'productCategories' => $product_categories,
+			'homeUrl'           => esc_js( home_url( '/' ) ),
 		);
 		?>
 		<script type="text/javascript">

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -119,7 +119,7 @@ class WGPB_Block_Library {
 	 */
 	public static function register_assets() {
 		self::register_style( 'wc-block-editor', plugins_url( 'build/editor.css', WGPB_PLUGIN_FILE ), array( 'wp-edit-blocks' ) );
-		self::register_style( 'wc-block-style', plugins_url( 'build/style.css', WGPB_PLUGIN_FILE ), array() );
+		self::register_style( 'wc-block-style', plugins_url( 'build/style.css', WGPB_PLUGIN_FILE ), array( 'wp-components' ) );
 
 		// Shared libraries and components across all blocks.
 		self::register_script( 'wc-blocks', plugins_url( 'build/blocks.js', WGPB_PLUGIN_FILE ), array(), false );


### PR DESCRIPTION
This PR updates the Product Categories List block, dropdown view. It adds the hierarchy support back in, and enables navigation using the dropdown.

#### Accessibility

Note: I've had to add a button to trigger the navigation. The other options are `onBlur` or `onChange` on the `select` element. Both have issues– `onBlur` works better using a keyboard, you can select a category and the navigation triggers once you leave the element; but for a mouse user you need to click away from the select box and only then will it navigate. `onChange` works as expected for a mouse user, but on some browsers (IE11 is what I tested) any keyboard nav just scanning through the select options triggers the navigation, so it will always nav to the first item, never letting you get through the options.

Since both of those approaches have downsides, I decided to follow [the "best practice" outlined here:](http://cita.disability.uiuc.edu/html-best-practices/auto/onchange.php) use a button to trigger the navigation. A button also makes it clear that this is a navigation action, which might not be as clear with the dropdown alone.

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

**In the editor**, you see the dropdown preview + button, but clicking the button won't navigate.

![editor-dropdown](https://user-images.githubusercontent.com/541093/60037634-14c5d300-9680-11e9-8103-391da906c7f4.png)

You can open the dropdown, which helps you see the preview when, for example, hierarchy and product counts are enabled.

![editor-dropdown-open](https://user-images.githubusercontent.com/541093/60037633-142d3c80-9680-11e9-8d66-8eb3dc40c872.png)

**On the front end,** it looks pretty much the same.

![frontend-dropdown](https://user-images.githubusercontent.com/541093/60037636-14c5d300-9680-11e9-81e5-156daf4d9121.png)

If you select a category, you can click the button now to navigate to that archive.

![frontend-dropdown-active](https://user-images.githubusercontent.com/541093/60037635-14c5d300-9680-11e9-83a8-3339acb6d66b.png)

### How to test the changes in this Pull Request:

1. Add Product Categories List block to you post/page
2. Set it to show as a dropdown
3. Change any other settings as you want
4. It should behave as you expect
5. View the front end
6. It should look the same as the editor preview, and selecting a category should navigate you to that page.
