### PR TITLE
Product Categories List: add a placeholder on save

### DIFF
--- a/assets/js/blocks/product-categories/frontend.js
+++ b/assets/js/blocks/product-categories/frontend.js
@@ -22,6 +22,7 @@ if ( containers.length ) {
 			isDropdown: data.isDropdown === 'true',
 			isHierarchical: data.isHierarchical === 'true',
 		};
+		el.className = el.className.replace( 'is-loading', '' );
 
 		render( <Block attributes={ attributes } />, el );
 	} );

--- a/assets/js/blocks/product-categories/frontend.js
+++ b/assets/js/blocks/product-categories/frontend.js
@@ -22,7 +22,7 @@ if ( containers.length ) {
 			isDropdown: data.isDropdown === 'true',
 			isHierarchical: data.isHierarchical === 'true',
 		};
-		el.className = el.className.replace( 'is-loading', '' );
+		el.classList.remove( 'is-loading' );
 
 		render( <Block attributes={ attributes } />, el );
 	} );

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -81,19 +81,31 @@ registerBlockType( 'woocommerce/product-categories', {
 	 */
 	save( { attributes } ) {
 		const { hasCount, hasEmpty, isDropdown, isHierarchical } = attributes;
-		const props = {};
+		const data = {};
 		if ( hasCount ) {
-			props[ 'data-has-count' ] = true;
+			data[ 'data-has-count' ] = true;
 		}
 		if ( hasEmpty ) {
-			props[ 'data-has-empty' ] = true;
+			data[ 'data-has-empty' ] = true;
 		}
 		if ( isDropdown ) {
-			props[ 'data-is-dropdown' ] = true;
+			data[ 'data-is-dropdown' ] = true;
 		}
 		if ( isHierarchical ) {
-			props[ 'data-is-hierarchical' ] = true;
+			data[ 'data-is-hierarchical' ] = true;
 		}
-		return <div { ...props }>LOADING</div>;
+		return (
+			<div className="is-loading" { ...data }>
+				{ isDropdown ? (
+					<span aria-hidden className="wc-block-product-categories__placeholder" />
+				) : (
+					<ul aria-hidden>
+						<li><span className="wc-block-product-categories__placeholder" /></li>
+						<li><span className="wc-block-product-categories__placeholder" /></li>
+						<li><span className="wc-block-product-categories__placeholder" /></li>
+					</ul>
+				) }
+			</div>
+		);
 	},
 } );

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -9,3 +9,12 @@
 		margin-right: 0.5em;
 	}
 }
+
+.wp-block-woocommerce-product-categories.is-loading .wc-block-product-categories__placeholder {
+	display: inline-block;
+	height: 1em;
+	width: 50%;
+	min-width: 200px;
+	background: currentColor;
+	opacity: 0.2;
+}


### PR DESCRIPTION
This is saved to the database so that we have a placeholder view while waiting for the categories component to render.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

A simple grey placeholder box to to take up some space while the content renders. List view gets a fake list (bottom), while the dropdown just gets a single box. Both are hidden from screen readers so users don't hear about an empty list. There is no animation, since this loads very quickly.

![Screen Shot 2019-06-25 at 4 36 25 PM](https://user-images.githubusercontent.com/541093/60131691-f4714380-9767-11e9-92a1-100c4ec83abf.png)

### How to test the changes in this Pull Request:

1. Add a Product Categories List block to your site (the new `save` response will invalidate any existing  Product Categories List blocks, this is expected)
2. View on the frontend, you should see the grey boxes before the content loads in
3. You might want to disable JS to see it, it loads pretty quickly.

@jwold I still can't request reviews from you, but I'd appreciate feedback– a quick look of the screenshot should be enough?
