### PR TITLE
Release version 2.2.0

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -26,6 +26,8 @@
 
 				img {
 					vertical-align: middle;
+					margin-left: auto;
+					margin-right: auto;
 				}
 			}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.2.0-rc",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.2.0-dev",
+  "version": "2.2.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   ],
   "files": [
     "assets/**/*.{js,scss,php}",
-    "build/**/*.{js,css}",
+    "build/**/*.{js,json,css}",
     "includes/**/*.php",
     "languages/**/*.json",
     "license.txt",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.2.0-rc",
+  "version": "2.2.0",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.2.0-dev",
+  "version": "2.2.0-rc",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -83,6 +83,14 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 2.2.0 - 2019-06-26 =
+
+- Feature: Add Product Categories List navigation block for showing a list of categories on your site.
+- Enhancement: All grid blocks are now rendered directly by the blocks code, not using the shortcode.
+- Enhancement: Brand the WooCommerce Blocks for better discoverability in the block inserter.
+- Build: Update build process to dynamically generate required WordPress dependencies.
+- Build: Update packages.
+
 = 2.1.0 - 2019-05-14 =
 
 - Feature: Add focal point picker to the Featured Product block, so you can adjust the background image position (only available on WP 5.2+ or with Gutenberg plugin).

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.2.0-dev
+ * Version: 2.2.0-rc
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.2.0-dev' );
+define( 'WGPB_VERSION', '2.2.0-rc' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.2.0-rc
+ * Version: 2.2.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.2.0-rc' );
+define( 'WGPB_VERSION', '2.2.0' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
Bump the version to 2.2.0 for release, and add the changelog entries. This also fixes an issue with the product images not being centered in wide columns (ex: 2 column layout), and an issue where `npm pack` was not grabbing the dependency json files.

Once this is merged, I'll publish to npm and wp.org, and publish the release notes post 👍🏻

To test

- Install on a site - generate a built plugin using `npm pack`
- Try an assortment of blocks, focusing on the grid blocks & product categories list
- Everything should work as expected in the editor and on the frontend