### PR TITLE
Bump version to 2.3.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/block-library",
-  "version": "2.2.0",
+  "version": "2.3.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/block-library",
   "title": "WooCommerce Blocks",
   "author": "Automattic",
-  "version": "2.2.0",
+  "version": "2.3.0-dev",
   "description": "WooCommerce blocks for the Gutenberg editor.",
   "homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
   "keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products
 Requires at least: 5.0
 Tested up to: 5.2
 Requires PHP: 5.2
-Stable tag: 2.1.0
+Stable tag: 2.2.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.2.0
+ * Version: 2.3.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || die();
 
-define( 'WGPB_VERSION', '2.2.0' );
+define( 'WGPB_VERSION', '2.3.0-dev' );
 define( 'WGPB_PLUGIN_FILE', __FILE__ );
 define( 'WGPB_ABSPATH', dirname( WGPB_PLUGIN_FILE ) . '/' );
 


### PR DESCRIPTION
Update version to 2.3.0-dev to prevent any issues with point releases off [branch/2.2.x](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/branch/2.2.x).

To test

- Install plugin, check in the plugins list that the version is `2.3.0-dev`.