### PR TITLE
Allow additional CSS classes to SSR blocks

### DIFF
--- a/assets/php/class-wgpb-block-grid-base.php
+++ b/assets/php/class-wgpb-block-grid-base.php
@@ -224,6 +224,10 @@ abstract class WGPB_Block_Grid_Base {
 			$classes[] = "align{$this->attributes['align']}";
 		}
 
+		if ( ! empty( $this->attributes['className'] ) ) {
+			$classes[] = $this->attributes['className'];
+		}
+
 		return implode( ' ', $classes );
 	}
 

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -242,6 +242,7 @@ class WGPB_Block_Library {
 				'style'           => 'wc-block-style',
 				'attributes'      => array(
 					'align'             => self::get_schema_align(),
+					'className'         => self::get_schema_string(),
 					'columns'           => self::get_schema_number( wc_get_theme_support( 'product_blocks::default_columns', 3 ) ),
 					'editMode'          => self::get_schema_boolean( true ),
 					'orderby'           => self::get_schema_orderby(),
@@ -270,8 +271,9 @@ class WGPB_Block_Library {
 				'attributes'      => array_merge(
 					self::get_shared_attributes(),
 					array(
-						'orderby'  => self::get_schema_orderby(),
-						'editMode' => self::get_schema_boolean( true ),
+						'className' => self::get_schema_string(),
+						'orderby'   => self::get_schema_orderby(),
+						'editMode'  => self::get_schema_boolean( true ),
 					)
 				),
 			)
@@ -296,7 +298,8 @@ class WGPB_Block_Library {
 				'attributes'      => array_merge(
 					self::get_shared_attributes(),
 					array(
-						'orderby' => self::get_schema_orderby(),
+						'className' => self::get_schema_string(),
+						'orderby'   => self::get_schema_orderby(),
 					)
 				),
 			)
@@ -339,6 +342,7 @@ class WGPB_Block_Library {
 						'type'    => 'string',
 						'default' => 'any',
 					),
+					'className'         => self::get_schema_string(),
 					'columns'           => self::get_schema_number( wc_get_theme_support( 'product_blocks::default_columns', 3 ) ),
 					'contentVisibility' => self::get_schema_content_visibility(),
 					'editMode'          => self::get_schema_boolean( true ),
@@ -451,12 +455,26 @@ class WGPB_Block_Library {
 	}
 
 	/**
+	 * Get the schema for a string value.
+	 *
+	 * @param  string $default  The default value.
+	 * @return array Property definition.
+	 */
+	protected static function get_schema_string( $default = '' ) {
+		return array(
+			'type'    => 'string',
+			'default' => $default,
+		);
+	}
+
+	/**
 	 * Get a set of attributes shared across most of the grid blocks.
 	 *
 	 * @return array List of block attributes with type and defaults.
 	 */
 	protected static function get_shared_attributes() {
 		return array(
+			'className'         => self::get_schema_string(),
 			'columns'           => self::get_schema_number( wc_get_theme_support( 'product_blocks::default_columns', 3 ) ),
 			'rows'              => self::get_schema_number( wc_get_theme_support( 'product_blocks::default_rows', 1 ) ),
 			'categories'        => self::get_schema_list_ids(),


### PR DESCRIPTION
Fixes #659.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/60352242-ae1a1f80-99c7-11e9-9b3d-2c93765d3c63.png)

### How to test the changes in this Pull Request:

1. Add a _Hand-picked Products_ block to a post or page.
2. In the sidebar, add an _Additional CSS Class_.
3. Verify the block doesn't crash.
4. Publish or preview the post/page.
5. Verify the block has the correct class applied.

Repeat the test above with all other SSR blocks:

* _Hand-picked Products_
* _Best Selling Products_
* _Products by Category_
* _Newest Products_
* _On Sale Products_
* _Top Rated Products_
* _Products by Attribute_