### PR TITLE
Add reviews count to Reviews by Product controls

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	BlockControls,
 	InspectorControls,
@@ -21,6 +21,7 @@ import {
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
+import { SearchListItem } from '@woocommerce/components';
 
 /**
  * Internal dependencies
@@ -50,6 +51,7 @@ class ReviewsByProduct extends Component {
 							const id = value[ 0 ] ? value[ 0 ].id : 0;
 							setAttributes( { productId: id } );
 						} }
+						renderItem={ this.renderProductControlItem }
 					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Content', 'woo-gutenberg-products-block' ) }>
@@ -116,6 +118,28 @@ class ReviewsByProduct extends Component {
 		);
 	}
 
+	renderProductControlItem( args ) {
+		const { item = 0 } = args;
+		item.count = item.rating_count;
+
+		return (
+			<SearchListItem
+				{ ...args }
+				showCount
+				aria-label={ sprintf(
+					_n(
+						'%s, has %d review',
+						'%s, has %d reviews',
+						item.count,
+						'woo-gutenberg-products-block'
+					),
+					item.name,
+					item.count
+				) }
+			/>
+		);
+	}
+
 	renderEditMode() {
 		const { attributes, debouncedSpeak, setAttributes } = this.props;
 		const onDone = () => {
@@ -145,6 +169,7 @@ class ReviewsByProduct extends Component {
 							const id = value[ 0 ] ? value[ 0 ].id : 0;
 							setAttributes( { productId: id } );
 						} }
+						renderItem={ this.renderProductControlItem }
 					/>
 					<Button isDefault onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -48,7 +48,7 @@ class ProductControl extends Component {
 
 	render() {
 		const { list, loading } = this.state;
-		const { onChange, selected } = this.props;
+		const { onChange, renderItem, selected } = this.props;
 		const messages = {
 			list: __( 'Products', 'woo-gutenberg-products-block' ),
 			noItems: __(
@@ -75,6 +75,7 @@ class ProductControl extends Component {
 					isSingle
 					selected={ [ find( list, { id: selected } ) ] }
 					onChange={ onChange }
+					renderItem={ renderItem }
 					onSearch={ isLargeCatalog ? this.debouncedOnSearch : null }
 					messages={ messages }
 				/>
@@ -88,6 +89,10 @@ ProductControl.propTypes = {
 	 * Callback to update the selected products.
 	 */
 	onChange: PropTypes.func.isRequired,
+	/**
+	 * Callback to render each item in the selection list, allows any custom object-type rendering.
+	 */
+	renderItem: PropTypes.func.isRequired,
 	/**
 	 * The ID of the currently selected product.
 	 */

--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -186,6 +186,7 @@ class Products extends WC_REST_Products_Controller {
 		$data['price_html']        = $raw_data['price_html'];
 		$data['images']            = $raw_data['images'];
 		$data['average_rating']    = $raw_data['average_rating'];
+		$data['rating_count']      = $raw_data['rating_count'];
 
 		return $data;
 	}
@@ -335,6 +336,12 @@ class Products extends WC_REST_Products_Controller {
 				'average_rating'    => array(
 					'description' => __( 'Reviews average rating.', 'woo-gutenberg-products-block' ),
 					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'rating_count'      => array(
+					'description' => __( 'Number of ratings.', 'woo-gutenberg-products-block' ),
+					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
Part of #588.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![image](https://user-images.githubusercontent.com/3616980/60512135-17ee3e00-9cd4-11e9-8fb9-1afb852e9fac.png)

![image](https://user-images.githubusercontent.com/3616980/60512239-54219e80-9cd4-11e9-8fab-80d973b5c952.png)

### How to test the changes in this Pull Request:

1. In a new or existing post/page add a _Reviews by Product_ block.
2. Verify the product control shows the reviews count next to the product name (see screenshots above).