### PR TITLE
Add placeholder when no categories exist to list

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -4,8 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Component, createRef, Fragment } from '@wordpress/element';
-import { IconButton } from '@wordpress/components';
-import { repeat } from 'lodash';
+import { IconButton, Placeholder } from '@wordpress/components';
+import { repeat, isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
 
@@ -13,6 +13,7 @@ import { withInstanceId } from '@wordpress/compose';
  * Internal dependencies
  */
 import { buildTermsTree } from './hierarchy';
+import { IconFolder } from '../../components/icons';
 
 function getCategories( { hasEmpty, isHierarchical } ) {
 	const categories = wc_product_block_data.productCategories.filter(
@@ -98,30 +99,42 @@ class ProductCategoriesBlock extends Component {
 		const selectId = `prod-categories-${ instanceId }`;
 
 		return (
-			<div className={ classes }>
-				{ isDropdown ? (
-					<Fragment>
-						<div className="wc-block-product-categories__dropdown">
-							<label className="screen-reader-text" htmlFor={ selectId }>
-								{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
-							</label>
-							<select id={ selectId } ref={ this.select }>
-								<option value="false" hidden>
-									{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
-								</option>
-								{ this.renderOptions( categories ) }
-							</select>
-						</div>
-						<IconButton
-							icon="arrow-right-alt2"
-							label={ __( 'Go to category', 'woo-gutenberg-products-block' ) }
-							onClick={ this.onNavigate }
-						/>
-					</Fragment>
+			<Fragment>
+				{ ! isEmpty( categories ) ? (
+					<div className={ classes }>
+						{ isDropdown ? (
+							<Fragment>
+								<div className="wc-block-product-categories__dropdown">
+									<label className="screen-reader-text" htmlFor={ selectId }>
+										{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
+									</label>
+									<select id={ selectId } ref={ this.select }>
+										<option value="false" hidden>
+											{ __( 'Select a category', 'woo-gutenberg-products-block' ) }
+										</option>
+										{ this.renderOptions( categories ) }
+									</select>
+								</div>
+								<IconButton
+									icon="arrow-right-alt2"
+									label={ __( 'Go to category', 'woo-gutenberg-products-block' ) }
+									onClick={ this.onNavigate }
+								/>
+							</Fragment>
+						) : (
+							this.renderList( categories )
+						) }
+					</div>
 				) : (
-					this.renderList( categories )
+					<Placeholder
+						className="wc-block-product-categories"
+						icon={ <IconFolder /> }
+						label={ __( 'Product Categories List', 'woo-gutenberg-products-block' ) }
+					>
+						{ __( "This block shows product categories for your store. In order to preview this you'll first need to create a product and assign it to a category.", 'woo-gutenberg-products-block' ) }
+					</Placeholder>
 				) }
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Component, createRef, Fragment } from '@wordpress/element';
 import { IconButton, Placeholder } from '@wordpress/components';
-import { repeat, isEmpty } from 'lodash';
+import { repeat } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
 
@@ -100,7 +100,7 @@ class ProductCategoriesBlock extends Component {
 
 		return (
 			<Fragment>
-				{ ! isEmpty( categories ) ? (
+				{ categories.length > 0 ? (
 					<div className={ classes }>
 						{ isDropdown ? (
 							<Fragment>

--- a/assets/js/blocks/product-categories/editor.scss
+++ b/assets/js/blocks/product-categories/editor.scss
@@ -1,3 +1,13 @@
 .wc-block-product-categories.wc-block-product-categories ul {
 	margin-left: 20px;
 }
+.wc-block-product-categories {
+	&.components-placeholder {
+		// Reset the background for the placeholders.
+		background-color: rgba( 139, 139, 150, .1 );
+	}
+	svg {
+		margin-right: 1ch;
+		fill: currentColor;
+	}
+}

--- a/assets/js/blocks/product-categories/editor.scss
+++ b/assets/js/blocks/product-categories/editor.scss
@@ -2,10 +2,6 @@
 	margin-left: 20px;
 }
 .wc-block-product-categories {
-	&.components-placeholder {
-		// Reset the background for the placeholders.
-		background-color: rgba( 139, 139, 150, .1 );
-	}
 	svg {
 		margin-right: 1ch;
 		fill: currentColor;


### PR DESCRIPTION
When there are no categories or products yet in the store, the block shows an error. This fixes it by instead showing a placeholder.

Fixes #673 

### Screenshots

![Edit Post ‹ local wordpress test — WordPress 2019-07-03 13-44-34](https://user-images.githubusercontent.com/90977/60592604-e4291c00-9d98-11e9-969b-d7d0bf8dcb04.png)

### How to test the changes in this Pull Request:

1. Test on a clean install or (in my case) reset all content.
2. Build.
3. Add Category List block to editor. See placeholder.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add a placeholder in place of the Product Category List when used on a store with no categories.
