### PR TITLE
WordPress org release script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,8 @@
 /.* export-ignore
+/*.md export-ignore
 /node_modules* export-ignore
 /tests export-ignore
-/vendor export-ignore
 /bin export-ignore
-/CONTRIBUTING.md export-ignore
-/README.md export-ignore
 /phpcs.xml export-ignore
 /phpunit.* export-ignore
 /renovate.json export-ignore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,73 +2,90 @@
 
 Thanks for your interest in contributing to WooCommerce Blocks! Below are some developer docs for working with the project.
 
-To get started, first run `npm install` and `composer install`.
+To get started run `npm install` and `composer install` in the plugin directory to install all required dependencies.
 
-## npm scripts
+## Building assets
 
 We have a set of scripts in npm to handle repeated developer tasks.
 
-### `build` & `start`
+### `$ npm run build` & `$ npm start`
 
-These scripts compile the code using `webpack`. Run `build` to build the production build, `start` to build the development build and then keep watching for changes. You can also run `npx webpack` to run the development build and not keep watching.
+These scripts compile the code using `webpack`. 
 
-### `lint`
+- Run `$ npm run build` to build all assets for production.
+- Run `$ npm start` to build assets and watch for changes (useful for development). 
 
-This script runs 3 sub-commands: `lint:php`, `lint:css`, `lint:js`. Use these to run linters across the codebase.
+You can also run `$ npx webpack` to run the development build and not keep watching.
+
+### `$ npm run lint`
+
+This script runs 3 sub-commands: `lint:php`, `lint:css`, `lint:js`. Use these to run linters across the codebase (linters check for valid syntax).
 
 - `lint:php` runs phpcs via composer, which uses the [phpcs.xml](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/phpcs.xml) ruleset.
 - `lint:css` runs stylelint over all the scss code in `assets/css`, using the rules in [.stylelintrc.json.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/.stylelintrc.json)
 - `lint:js` runs eslint over all the JavaScript, using the rules in [.eslintrc.js.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/.eslintrc.js)
 
-### `test`
+### `$ npm run test`
 
 The test scripts use [wp-scripts](https://github.com/WordPress/gutenberg/tree/master/packages/scripts) to run jest for component and unit testing.
 
 - `test:update` updates the snapshot tests for components, used if you change a component that has tests attached.
 - Use `test:watch` to keep watch of files and automatically re-run tests.
 
-### `prepack`
+### `$ npm run prepack`
 
-This script is run automatically when `npm pack` or `npm publish` is run. It installs packages, runs the linters, runs the tests, and then builds the files from the source once more.
+This script is run automatically when `$ npm pack` or `$ npm publish` is run. It installs packages, runs the linters, runs the tests, and then builds assets from source once more.
 
-## Publishing @woocommerce/block-library
+## Tagging new releases on GitHub
+
+If you have commit access, tagging a new version on GitHub can be done by running the following script:
+
+```shell
+$ npm run deploy
+```
+
+This will trigger a build and then run the release script (found in `/bin/github-deploy.sh`). This tags a new version and creates the GitHub release from your current branch.
+
+__Important:__ Before running the deploy script ensure you have committed all changes to GitHub and that you have the correct branch checked out that you wish to release.
+
+If you want to add additional details or a binary file to the release after deployment, [you can edit the release here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases).
+
+## Pushing new releases to WordPress.org
+
+If you have SVN commit access to the WordPress.org plugin repository you can run the following script to prepare a new version:
+
+```shell
+$ npm run release
+```
+
+This will ask for a tagged version number, check it out from GitHub, check out the SVN repository, and prepare all files. It will give you a command when it's finished to do the actual commit; you have a chance to test/check the files before pushing to WordPress.org.
+
+__Important:__ Before running the release script ensure you have already pushed a new release to GitHub.
+
+## Publishing `@woocommerce/block-library`
 
 We publish the blocks to npm at [@woocommerce/block-library,](https://www.npmjs.com/package/@woocommerce/block-library) and then import them into WooCommerce core via [a grunt script.](https://github.com/woocommerce/woocommerce/blob/741bd5ba6d193e21893ef3af3d4f3f030a79c099/Gruntfile.js#L347) 
 
 To release a new version, there are 3 basic steps. Prepare and test the release, publish the version, then import into WooCommerce core.
 
-### Prepare and test the release
+### 1. Prepare and test the release
 
 - Manually change the versions in `package.json` and `woocommerce-gutenberg-products-block.php` (once in the plugin header, and `WGPB_VERSION`). [See an example PR with these changes.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/478/commits/725c43fe0362044c953728cb3391095a43e66bb5)
 - Run `npm pack` to prep a `.tgz` file.
 - Optionally test the package by uploading this onto a test site.
 
-### Publish this version
-
-On GitHub…
-
-- go to [Releases](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases) and click "Draft a new release"
-- The Tag version should start with `v`, and use [semver](https://semver.org/) formatting, ex `v2.0.0-rc`, or `v1.4.1`
-- The Release title should be the human-readable version, ex "2.0.0 Release Candidate" or "2.0.0 alpha release"
-- Add the changelog to the description (TBD, maybe not for every release?)
-- Upload the `.tgz` from `npm pack` in the previous step as an attached binary
-
-On npm…
+### 2. Publish this version
 
 - Run `npm publish --access public`, which will push the version up to npm.
 - Check [@woocommerce/block-library](https://www.npmjs.com/package/@woocommerce/block-library) for your update
 
-### Pull into WooCommerce core
+### 3. Pull into WooCommerce core
 
 - Manually update the @woocommerce/block-library version in `package.json`
 - In the woocommerce folder, run `npm install` to download the version you just specified
 - Run the copy command, `npx grunt blocks`, to copy the build files from node_modules into their destinations in WC core
 - Check that the changes imported look correct
 - Make a PR on WooCommerce to import the new version
-
-## Publishing the WooCommerce Blocks plugin
-
-TBD
 
 ## How to test `@woocommerce/block-library` without publishing to npm
 

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -53,7 +53,7 @@ echo "Before proceeding:"
 echo " • Ensure you have checked out the branch you wish to release"
 echo " • Ensure you have committed/pushed all local changes"
 echo " • Did you remember to update versions, changelogs, and stable tags in the readme and plugin files?"
-echo " • If you are running this script directory instead of via`$ npm run deploy`, ensure you have built assets."
+echo " • If you are running this script directory instead of via '$ npm run deploy', ensure you have built assets."
 echo
 output 3 "Do you want to continue? [y/N]: "
 read -r PROCEED

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -53,6 +53,7 @@ echo "Before proceeding:"
 echo " • Ensure you have checked out the branch you wish to release"
 echo " • Ensure you have committed/pushed all local changes"
 echo " • Did you remember to update versions, changelogs, and stable tags in the readme and plugin files?"
+echo " • If you are running this script directory instead of via`$ npm run deploy`, ensure you have built assets."
 echo
 output 3 "Do you want to continue? [y/N]: "
 read -r PROCEED

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -108,7 +108,7 @@ git push origin $BRANCH
 if [ $IS_PRE_RELEASE = true ]; then
 	hub release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH --prerelease "v${VERSION}"
 else
-	hub release create -m $MESSAGE -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH "v${VERSION}"
+	hub release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH "v${VERSION}"
 fi
 
 git checkout $CURRENTBRANCH

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -40,17 +40,19 @@ fi
 
 # Release script
 echo
-output 2 "BLOCKS RELEASE SCRIPT"
-output 2 "====================="
+output 5 "BLOCKS->GitHub RELEASE SCRIPT"
+output 5 "============================="
 echo
 printf "This script will build files and create a tag on GitHub based on your local branch."
 echo
 echo
-printf "The /build/ directory will also be pushed to the tag."
+printf "The /build/ directory will also be pushed to the tagged release."
 echo
 echo
-printf "Before proceeding, ensure you have checked out the correct branch you wish to release, and have committed/pushed all local changes."
-echo
+echo "Before proceeding:"
+echo " • Ensure you have checked out the branch you wish to release"
+echo " • Ensure you have committed/pushed all local changes"
+echo " • Did you remember to update versions, changelogs, and stable tags in the readme and plugin files?"
 echo
 output 3 "Do you want to continue? [y/N]: "
 read -r PROCEED

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -105,7 +105,7 @@ git commit -m "Adding /build directory to release"
 git push origin $BRANCH
 
 # Create the new release.
-if [ $IS_PRE_RELEASE ]; then
+if [ $IS_PRE_RELEASE = true ]; then
 	hub release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH --prerelease "v${VERSION}"
 else
 	hub release create -m $MESSAGE -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH "v${VERSION}"

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -48,7 +48,7 @@ printf "This script prepares a GitHub tag/release for WordPress.org SVN."
 echo
 echo
 echo "Before proceeding:"
-echo " • Ensure you have already created the release on GitHub using the ./bin/github-deploy.sh script."
+echo " • Ensure you have already created the release on GitHub. You can use `$ npm run deploy`."
 echo
 output 3 "Do you want to continue? [y/N]: "
 read -r PROCEED
@@ -153,7 +153,7 @@ output 2 "Copying project files to SVN trunk..."
 copy_dest_files "trunk" "$GIT_PATH" "$SVN_PATH"
 
 # Update stable tag on trunk/readme.txt
-if ! $IS_PRE_RELEASE; then
+if [ $IS_PRE_RELEASE = false ]; then
 	output 2 "Updating \"Stable tag\" to ${VERSION} on trunk/readme.txt..."
 	perl -i -pe"s/Stable tag: .*/Stable tag: ${VERSION}/" trunk/readme.txt
 fi

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -48,7 +48,7 @@ printf "This script prepares a GitHub tag/release for WordPress.org SVN."
 echo
 echo
 echo "Before proceeding:"
-echo " • Ensure you have already created the release on GitHub. You can use `$ npm run deploy`."
+echo " • Ensure you have already created the release on GitHub. You can use '$ npm run deploy'."
 echo
 output 3 "Do you want to continue? [y/N]: "
 read -r PROCEED

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -59,7 +59,7 @@ copy_dest_files() {
 	--exclude="*-config.js" \
 	--exclude=package.json \
     --exclude=package-lock.json \
-	--exclude=none \
+	--exclude=none
   output 2 "Done copying files!"
   cd "$3" || exit
 }
@@ -187,6 +187,8 @@ rm -rf "$GIT_PATH"
 
 # SVN commit messsage
 output 2 "Ready to commit into WordPress.org Plugin's Directory!"
-echo "Run the follow commads to commit:"
-echo "cd ${SVN_PATH}"
-echo "svn ci -m \"Release ${VERSION}, see readme.txt for changelog.\""
+echo
+echo "-------------------------------------------"
+echo
+output 3 "Run the following command to commit to SVN:"
+echo "cd ${SVN_PATH} && svn ci -m \"Release ${VERSION}, see readme.txt for changelog.\""

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -44,21 +44,21 @@ output_list() {
 copy_dest_files() {
   cd "$2" || exit
   rsync ./ "$3"/"$1"/ --recursive --delete --delete-excluded \
-    --exclude=".*/" \
-    --exclude="*.md" \
-    --exclude=".*" \
-    --exclude="composer.*" \
-    --exclude="*.lock" \
-    --exclude=bin/ \
+	--exclude=".*/" \
+	--exclude="*.md" \
+	--exclude=".*" \
+	--exclude="composer.*" \
+	--exclude="*.lock" \
+	--exclude=bin/ \
 	--exclude=node_modules/ \
 	--exclude=tests/ \
-    --exclude=phpcs.xml \
-    --exclude=phpunit.xml.dist \
+	--exclude=phpcs.xml \
+	--exclude=phpunit.xml.dist \
 	--exclude=renovate.json \
 	--exclude="*.config.js" \
 	--exclude="*-config.js" \
 	--exclude=package.json \
-    --exclude=package-lock.json \
+	--exclude=package-lock.json \
 	--exclude=none
   output 2 "Done copying files!"
   cd "$3" || exit

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+
+RELEASER_PATH=$(pwd)
+PLUGIN_SLUG="woocommerce-gutenberg-products-block"
+GITHUB_ORG="woocommerce"
+IS_PRE_RELEASE=false
+BUILD_PATH="${HOME}/blocks-deployment"
+
+# Functions
+# Check if string contains substring
+is_substring() {
+  case "$2" in
+    *$1*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# Output colorized strings
+#
+# Color codes:
+# 0 - black
+# 1 - red
+# 2 - green
+# 3 - yellow
+# 4 - blue
+# 5 - magenta
+# 6 - cian
+# 7 - white
+output() {
+  echo "$(tput setaf "$1")$2$(tput sgr0)"
+}
+
+# Output colorized list
+output_list() {
+  echo "$(tput setaf "$1") • $2:$(tput sgr0) \"$3\""
+}
+
+# Release script
+echo
+output 4 "BLOCKS->WordPress.org RELEASE SCRIPT"
+output 4 "===================================="
+echo
+printf "This script prepares a GitHub tag/release for WordPress.org SVN."
+echo
+echo
+echo "Before proceeding:"
+echo " • Ensure you have already created the release on GitHub using the ./bin/github-deploy.sh script."
+echo
+output 3 "Do you want to continue? [y/N]: "
+read -r PROCEED
+echo
+
+if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" != "y" ]; then
+  output 1 "Release cancelled!"
+  exit 1
+fi
+echo
+
+# Set deploy variables
+SVN_REPO="http://plugins.svn.wordpress.org/${PLUGIN_SLUG}/"
+GIT_REPO="https://github.com/${GITHUB_ORG}/${PLUGIN_SLUG}.git"
+SVN_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-svn"
+GIT_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-git"
+
+# Set deploy variables
+SVN_REPO="http://plugins.svn.wordpress.org/${PLUGIN_SLUG}/"
+GIT_REPO="https://github.com/${GITHUB_ORG}/${PLUGIN_SLUG}.git"
+SVN_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-svn"
+GIT_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-git"
+
+# Ask info
+output 2 "Starting release..."
+echo
+printf "VERSION: "
+read -r VERSION
+
+BRANCH="v$VERSION"
+
+# Check if is a pre-release.
+if is_substring "-" "${VERSION}"; then
+    IS_PRE_RELEASE=true
+	echo
+	output 2 "Detected pre-release version!"
+fi
+
+echo
+echo "-------------------------------------------"
+echo
+echo "Review all data before proceeding:"
+echo
+output_list 3 "Plugin slug" "${PLUGIN_SLUG}"
+output_list 3 "Version to release" "${VERSION}"
+output_list 3 "GIT tag to release" "${BRANCH}"
+output_list 3 "GIT repository" "${GIT_REPO}"
+output_list 3 "wp.org repository" "${SVN_REPO}"
+echo
+printf "Are you sure? [y/N]: "
+read -r PROCEED
+echo
+
+if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" != "y" ]; then
+  output 1 "Release cancelled!"
+  exit 1
+fi
+
+output 2 "Confirmed! Starting process..."
+
+# Create build directory if does not exists
+if [ ! -d "$BUILD_PATH" ]; then
+  mkdir -p "$BUILD_PATH"
+fi
+
+# Delete old GIT directory
+rm -rf "$GIT_PATH"
+
+# Clone GIT repository
+output 2 "Cloning GIT repository..."
+git clone "$GIT_REPO" "$GIT_PATH" --branch "$BRANCH" --single-branch || exit "$?"
+
+if [ ! -d "$GIT_PATH/build" ]; then
+	output 3 "Build directory not found in tag. Aborting."
+	exit 1
+fi
+
+# Checkout SVN repository if not exists
+if [ ! -d "$SVN_PATH" ]; then
+	output 2 "No SVN directory found, fetching files..."
+	# Checkout project without any file
+	svn co --depth=files "$SVN_REPO" "$SVN_PATH"
+
+	cd "$SVN_PATH" || exit
+
+	# Fetch main directories
+	svn up assets branches trunk
+
+	# Fetch tags directories without content
+	svn up --set-depth=immediates tags
+	# To fetch content for a tag, use:
+	# svn up --set-depth=infinity tags/<tag_number>
+else
+	# Update SVN
+	cd "$SVN_PATH" || exit
+	output 2 "Updating SVN..."
+	svn up
+fi
+
+# Copy GIT directory to trunk
+output 2 "Copying project files to SVN trunk..."
+copy_dest_files "trunk" "$GIT_PATH" "$SVN_PATH"
+
+# Update stable tag on trunk/readme.txt
+if ! $IS_PRE_RELEASE; then
+	output 2 "Updating \"Stable tag\" to ${VERSION} on trunk/readme.txt..."
+	perl -i -pe"s/Stable tag: .*/Stable tag: ${VERSION}/" trunk/readme.txt
+fi
+
+# Do the remove all deleted files
+svn st | grep -v "^.[ \t]*\..*" | grep "^\!" | awk '{print $2"@"}' | xargs svn rm
+
+# Do the add all not know files
+svn st | grep -v "^.[ \t]*\..*" | grep "^?" | awk '{print $2"@"}' | xargs svn add
+
+# Copy trunk to tag/$VERSION
+if [ ! -d "tags/${VERSION}" ]; then
+	output 2 "Creating SVN tags/${VERSION}..."
+	svn cp trunk tags/"${VERSION}"
+fi
+
+# Remove the GIT directory
+output 2 "Removing GIT directory..."
+rm -rf "$GIT_PATH"
+
+# SVN commit messsage
+output 2 "Ready to commit into WordPress.org Plugin's Directory!"
+echo "Run the follow commads to commit:"
+echo "cd ${SVN_PATH}"
+echo "svn ci -m \"Release ${VERSION}, see readme.txt for changelog.\""

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "GPL-3.0+",
   "scripts": {
     "deploy": "npm run build --loglevel error && sh ./bin/github-deploy.sh",
+    "release": "sh ./bin/wordpress-deploy.sh",
     "prepack": "npm install && npm run lint && npm run test && npm run build",
     "build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
     "start": "cross-env BABEL_ENV=default webpack --watch --info-verbosity none",


### PR DESCRIPTION
Adds a .org release script, updates the github script, and adds developer documentation.

I tested this today and it seems to work :)

To run you use:

```shell
$ npm run release
```

And then follow instructions. This is safe to test because the final commit won't happen without manual commands, so feel free to test against `2.2.1` version if you want to see it in action.