### PR TITLE
Review ordering and placeholders

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -145,6 +145,10 @@ class ReviewsByProduct extends Component {
 							const id = value[ 0 ] ? value[ 0 ].id : 0;
 							setAttributes( { productId: id } );
 						} }
+						queryArgs={ {
+							orderby: 'comment_count',
+							order: 'desc',
+						} }
 					/>
 					<Button isDefault onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -224,7 +224,7 @@ class ReviewsByProduct extends Component {
 					this.renderEditMode()
 				) : (
 					<Fragment>
-						{ !! product.rating_count ? (
+						{ product.rating_count > 0 ? (
 							<Disabled>
 								<ServerSideRender block={ name } attributes={ attributes } className="wc-block-reviews-by-product" />
 							</Disabled>

--- a/assets/js/blocks/reviews-by-product/editor.scss
+++ b/assets/js/blocks/reviews-by-product/editor.scss
@@ -1,0 +1,3 @@
+.wc-block-reviews-by-product__selection {
+	width: 100%;
+}

--- a/assets/js/blocks/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews-by-product/index.js
@@ -8,6 +8,7 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import './style.scss';
+import './editor.scss';
 import Block from './block';
 import ReviewsByProductIcon from '../../components/icons/reviews-by-product';
 

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -24,9 +24,9 @@ class ProductControl extends Component {
 	}
 
 	componentDidMount() {
-		const { selected } = this.props;
+		const { selected, queryArgs } = this.props;
 
-		getProducts( { selected } )
+		getProducts( { selected, queryArgs } )
 			.then( ( list ) => {
 				this.setState( { list, loading: false } );
 			} )
@@ -36,8 +36,8 @@ class ProductControl extends Component {
 	}
 
 	onSearch( search ) {
-		const { selected } = this.props;
-		getProducts( { selected, search } )
+		const { selected, queryArgs } = this.props;
+		getProducts( { selected, search, queryArgs } )
 			.then( ( list ) => {
 				this.setState( { list, loading: false } );
 			} )
@@ -92,6 +92,10 @@ ProductControl.propTypes = {
 	 * The ID of the currently selected product.
 	 */
 	selected: PropTypes.number.isRequired,
+	/**
+	 * Query args to pass to getProducts.
+	 */
+	queryArgs: PropTypes.object,
 };
 
 export default ProductControl;

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -3,18 +3,24 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import { flatten, uniqBy } from 'lodash';
+import { flatten, uniqBy, merge } from 'lodash';
 
 export const isLargeCatalog = wc_product_block_data.isLargeCatalog || false;
 
-const getProductsRequests = ( { selected = [], search } ) => {
+const getProductsRequests = ( { selected = [], search = '', queryArgs = [] } ) => {
+	const defaultArgs = {
+		per_page: isLargeCatalog ? 100 : -1,
+		catalog_visibility: 'visible',
+		status: 'publish',
+		search,
+		orderby: 'title',
+		order: 'asc',
+	};
 	const requests = [
-		addQueryArgs( '/wc/blocks/products', {
-			per_page: isLargeCatalog ? 100 : -1,
-			catalog_visibility: 'visible',
-			status: 'publish',
-			search,
-		} ),
+		addQueryArgs(
+			'/wc/blocks/products',
+			merge( defaultArgs, queryArgs )
+		),
 	];
 
 	// If we have a large catalog, we might not get all selected products in the first page.
@@ -36,8 +42,8 @@ const getProductsRequests = ( { selected = [], search } ) => {
  *
  * @param {object} - A query object with the list of selected products and search term.
  */
-export const getProducts = ( { selected = [], search } ) => {
-	const requests = getProductsRequests( { selected, search } );
+export const getProducts = ( { selected = [], search = '', queryArgs = [] } ) => {
+	const requests = getProductsRequests( { selected, search, queryArgs } );
 
 	return Promise.all( requests.map( ( path ) => apiFetch( { path } ) ) ).then( ( data ) => {
 		return uniqBy( flatten( data ), 'id' );

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -19,7 +19,7 @@ const getProductsRequests = ( { selected = [], search = '', queryArgs = [] } ) =
 	const requests = [
 		addQueryArgs(
 			'/wc/blocks/products',
-			merge( defaultArgs, queryArgs )
+			{ ...defaultArgs, ...queryArgs }
 		),
 	];
 

--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -340,7 +340,7 @@ class Products extends WC_REST_Products_Controller {
 					'readonly'    => true,
 				),
 				'rating_count'      => array(
-					'description' => __( 'Amount of reviews that the product have.', 'woo-gutenberg-products-block' ),
+					'description' => __( 'Amount of reviews that the product has.', 'woo-gutenberg-products-block' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -240,7 +240,7 @@ class Products extends WC_REST_Products_Controller {
 	 */
 	public function get_collection_params() {
 		$params                       = parent::get_collection_params();
-		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
+		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'menu_order', 'comment_count' ) );
 		$params['category_operator']  = array(
 			'description'       => __( 'Operator to compare product category terms.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',

--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -186,6 +186,7 @@ class Products extends WC_REST_Products_Controller {
 		$data['price_html']        = $raw_data['price_html'];
 		$data['images']            = $raw_data['images'];
 		$data['average_rating']    = $raw_data['average_rating'];
+		$data['rating_count']      = $raw_data['rating_count'];
 
 		return $data;
 	}
@@ -335,6 +336,12 @@ class Products extends WC_REST_Products_Controller {
 				'average_rating'    => array(
 					'description' => __( 'Reviews average rating.', 'woo-gutenberg-products-block' ),
 					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'rating_count'      => array(
+					'description' => __( 'Amount of reviews that the product have.', 'woo-gutenberg-products-block' ),
+					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),


### PR DESCRIPTION
The tasks were originally:

- Hide products with no reviews from the Product Control. 
- Add placeholder to Product Control when no products have reviews. 

But instead decided to show all products, ordered by rating count, and then if no ratings exist simply show a placeholder. This allows review blocks to be added for products that may get reviews in the future.

This PR takes care of the backend view only. When frontend is done, as well as the SSR replacement, their will be a separate view for that.

## Screenshots

![Edit Post ‹ local wordpress test — WordPress 2019-07-04 15-58-04](https://user-images.githubusercontent.com/90977/60675538-879b2f00-9e74-11e9-986e-8aab033de44d.png)

## To test

- Create a reviews by product block for a product with no reviews. See the placeholder.
- Create a reviews by product block for a product with reviews. See SSR list.
- Confirm products are ordered by rating count in the product control. 