### PR TITLE
Add `package-plugin` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tests/cli/vendor
 # Built files
 /build/
 bin/languages
+woocommerce-gutenberg-products-block.zip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ We have a set of scripts in npm to handle repeated developer tasks.
 
 ### `$ npm run build` & `$ npm start`
 
-These scripts compile the code using `webpack`. 
+These scripts compile the code using `webpack`.
 
 - Run `$ npm run build` to build all assets for production.
-- Run `$ npm start` to build assets and watch for changes (useful for development). 
+- Run `$ npm start` to build assets and watch for changes (useful for development).
 
 You can also run `$ npx webpack` to run the development build and not keep watching.
 
@@ -35,6 +35,10 @@ The test scripts use [wp-scripts](https://github.com/WordPress/gutenberg/tree/ma
 ### `$ npm run prepack`
 
 This script is run automatically when `$ npm pack` or `$ npm publish` is run. It installs packages, runs the linters, runs the tests, and then builds assets from source once more.
+
+### `$ npm run package-plugin`
+
+This script run `npm install` and `npm run build` and then creates a zip file automatically for you which you can use to install WooCommerce Blocks through the WordPress admin.
 
 ## Tagging new releases on GitHub
 
@@ -64,7 +68,7 @@ __Important:__ Before running the release script ensure you have already pushed 
 
 ## Publishing `@woocommerce/block-library`
 
-We publish the blocks to npm at [@woocommerce/block-library,](https://www.npmjs.com/package/@woocommerce/block-library) and then import them into WooCommerce core via [a grunt script.](https://github.com/woocommerce/woocommerce/blob/741bd5ba6d193e21893ef3af3d4f3f030a79c099/Gruntfile.js#L347) 
+We publish the blocks to npm at [@woocommerce/block-library,](https://www.npmjs.com/package/@woocommerce/block-library) and then import them into WooCommerce core via [a grunt script.](https://github.com/woocommerce/woocommerce/blob/741bd5ba6d193e21893ef3af3d4f3f030a79c099/Gruntfile.js#L347)
 
 To release a new version, there are 3 basic steps. Prepare and test the release, publish the version, then import into WooCommerce core.
 

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -49,6 +49,7 @@ copy_dest_files() {
 		--exclude=package.json \
 		--exclude=package-lock.json \
 		--exclude=none \
+		--exclude=woocommerce-gutenberg-products-block.zip \
 		--exclude="zip-file/"
 	status "Done copying files!"
 	cd "$CURRENT_DIR" || exit

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Exit if any command fails.
+set -e
+
+# Change to the expected directory.
+cd "$(dirname "$0")"
+cd ..
+
+# Enable nicer messaging for build status.
+BLUE_BOLD='\033[1;34m';
+GREEN_BOLD='\033[1;32m';
+RED_BOLD='\033[1;31m';
+YELLOW_BOLD='\033[1;33m';
+COLOR_RESET='\033[0m';
+error () {
+	echo -e "\n${RED_BOLD}$1${COLOR_RESET}\n"
+}
+status () {
+	echo -e "\n${BLUE_BOLD}$1${COLOR_RESET}\n"
+}
+success () {
+	echo -e "\n${GREEN_BOLD}$1${COLOR_RESET}\n"
+}
+warning () {
+	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+}
+
+status "💃 Time to release WooCommerce Blocks 🕺"
+
+if [ -z "$NO_CHECKS" ]; then
+	# Make sure there are no changes in the working tree. Release builds should be
+	# traceable to a particular commit and reliably reproducible. (This is not
+	# totally true at the moment because we download nightly vendor scripts).
+	changed=
+	if ! git diff --exit-code > /dev/null; then
+		changed="file(s) modified"
+	elif ! git diff --cached --exit-code > /dev/null; then
+		changed="file(s) staged"
+	fi
+	if [ ! -z "$changed" ]; then
+		git status
+		error "ERROR: Cannot build plugin zip with dirty working tree. ☝️
+		Commit your changes and try again."
+		exit 1
+	fi
+
+	# Do a dry run of the repository reset. Prompting the user for a list of all
+	# files that will be removed should prevent them from losing important files!
+	status "Resetting the repository to pristine condition. ✨"
+	to_clean=$(git clean -xdf --dry-run)
+	if [ ! -z "$to_clean" ]; then
+		echo $to_clean
+		warning "🚨 About to delete everything above! Is this okay? 🚨"
+		echo -n "[y]es/[N]o: "
+		read answer
+		if [ "$answer" != "${answer#[Yy]}" ]; then
+			# Remove ignored files to reset repository to pristine condition. Previous
+			# test ensures that changed files abort the plugin build.
+			status "Cleaning working directory... 🛀"
+			git clean -xdf
+		else
+			error "Fair enough; aborting. Tidy up your repo and try again. 🙂"
+			exit 1
+		fi
+	fi
+fi
+
+# Run the build.
+status "Installing dependencies... 📦"
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
+status "==========================="
+npm list webpack
+status "Generating build... 👷‍♀️"
+status "==========================="
+npm list webpack
+npm run build
+status "==========================="
+npm list webpack
+
+build_files=$(ls build/*.{js,css})
+
+# Generate the plugin zip file.
+status "Creating archive... 🎁"
+zip -r woocommerce-gutenberg-products-block.zip \
+	$build_files \
+	languages/ \
+	images/ \
+	includes/ \
+	src/ \
+	readme.txt \
+	woocommerce-gutenberg-products-block.php
+
+# Reset `woocommerce-gutenberg-products-block.php`.
+git checkout woocommerce-gutenberg-products-block.php
+
+success "Done. You've built WooCommerce Blocks! 🎉 "

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -3,6 +3,9 @@
 # Exit if any command fails.
 set -e
 
+# Store paths
+SOURCE_PATH=$(pwd)
+
 # Change to the expected directory.
 cd "$(dirname "$0")"
 cd ..
@@ -24,6 +27,31 @@ success () {
 }
 warning () {
 	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+}
+
+copy_dest_files() {
+	CURRENT_DIR=$(pwd)
+	cd "$1" || exit
+	rsync ./ "$2"/ --recursive --delete --delete-excluded \
+		--exclude=".*/" \
+		--exclude="*.md" \
+		--exclude=".*" \
+		--exclude="composer.*" \
+		--exclude="*.lock" \
+		--exclude=bin/ \
+		--exclude=node_modules/ \
+		--exclude=tests/ \
+		--exclude=phpcs.xml \
+		--exclude=phpunit.xml.dist \
+		--exclude=renovate.json \
+		--exclude="*.config.js" \
+		--exclude="*-config.js" \
+		--exclude=package.json \
+		--exclude=package-lock.json \
+		--exclude=none \
+		--exclude="zip-file/"
+	status "Done copying files!"
+	cd "$CURRENT_DIR" || exit
 }
 
 status "💃 Time to release WooCommerce Blocks 🕺"
@@ -58,14 +86,11 @@ npm run build
 status "==========================="
 npm list webpack
 
-build_files=$(ls build/*.{js,css})
-
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
 mkdir zip-file
 mkdir zip-file/build
-cp -r $build_files zip-file/build
-cp -r {languages/,src/,vendor/,readme.txt,woocommerce-gutenberg-products-block.php} zip-file
+copy_dest_files $SOURCE_PATH "$SOURCE_PATH/zip-file"
 cd zip-file
 zip -r ../woocommerce-gutenberg-products-block.zip ./
 cd ..

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -44,26 +44,6 @@ if [ -z "$NO_CHECKS" ]; then
 		Commit your changes and try again."
 		exit 1
 	fi
-
-	# Do a dry run of the repository reset. Prompting the user for a list of all
-	# files that will be removed should prevent them from losing important files!
-	status "Resetting the repository to pristine condition. ✨"
-	to_clean=$(git clean -xdf --dry-run)
-	if [ ! -z "$to_clean" ]; then
-		echo $to_clean
-		warning "🚨 About to delete everything above! Is this okay? 🚨"
-		echo -n "[y]es/[N]o: "
-		read answer
-		if [ "$answer" != "${answer#[Yy]}" ]; then
-			# Remove ignored files to reset repository to pristine condition. Previous
-			# test ensures that changed files abort the plugin build.
-			status "Cleaning working directory... 🛀"
-			git clean -xdf
-		else
-			error "Fair enough; aborting. Tidy up your repo and try again. 🙂"
-			exit 1
-		fi
-	fi
 fi
 
 # Run the build.
@@ -82,16 +62,13 @@ build_files=$(ls build/*.{js,css})
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
-zip -r woocommerce-gutenberg-products-block.zip \
-	$build_files \
-	languages/ \
-	images/ \
-	includes/ \
-	src/ \
-	readme.txt \
-	woocommerce-gutenberg-products-block.php
+mkdir zip-file
+mkdir zip-file/build
+cp -r $build_files zip-file/build
+cp -r {languages/,src/,vendor/,readme.txt,woocommerce-gutenberg-products-block.php} zip-file
+cd zip-file
+zip -r ../woocommerce-gutenberg-products-block.zip ./
+cd ..
+rm -r zip-file
 
-# Reset `woocommerce-gutenberg-products-block.php`.
-git checkout woocommerce-gutenberg-products-block.php
-
-success "Done. You've built WooCommerce Blocks! 🎉 "
+success "Done. You've built WooCommerce Blocks! 🎉"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:php": "composer run-script phpcs .",
     "lint:css": "stylelint assets/css",
     "lint:js": "eslint assets/js --ext=js,jsx",
+    "package-plugin": "./bin/build-plugin-zip.sh",
     "test": "wp-scripts test-unit-js --config tests/js/jest.config.json",
     "test:help": "wp-scripts test-unit-js --help",
     "test:update": "wp-scripts test-unit-js --updateSnapshot --config tests/js/jest.config.json",


### PR DESCRIPTION
I needed to generate a ZIP when reviewing a prior PR, so I thought I would create a PR with the script.

It's based on the same script from Gutenberg, with some small modifications:

https://github.com/WordPress/gutenberg/blob/master/bin/build-plugin-zip.sh

### How to test the changes in this Pull Request:

1. Run `npm run package-plugin`.
2. Answer the questions and wait.
3. Install the zip plugin in a WordPress site and verify everything works as expected.