### PR TITLE
Add pre-commit CSS and JS linting

### DIFF
--- a/assets/js/blocks/featured-product/editor.scss
+++ b/assets/js/blocks/featured-product/editor.scss
@@ -1,7 +1,7 @@
 .wc-block-featured-product {
 	&.components-placeholder {
 		// Reset the background for the placeholders.
-		background-color: rgba( 139, 139, 150, .1 );
+		background-color: rgba(139, 139, 150, 0.1);
 	}
 
 	.components-resizable-box__handle {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -71,7 +71,7 @@
 	.wc-block-featured-product__title {
 		margin-top: 0;
 
-		&:before {
+		&::before {
 			display: none;
 		}
 	}

--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -70,6 +70,7 @@ GridContentControl.propTypes = {
 	settings: PropTypes.shape( {
 		button: PropTypes.bool.isRequired,
 		price: PropTypes.bool.isRequired,
+		rating: PropTypes.bool.isRequired,
 		title: PropTypes.bool.isRequired,
 	} ).isRequired,
 	/**

--- a/assets/js/components/product-attribute-control/style.scss
+++ b/assets/js/components/product-attribute-control/style.scss
@@ -18,7 +18,7 @@
 .woocommerce-search-list__item.woocommerce-product-attributes__item {
 	&.is-searching,
 	&.is-skip-level {
-		.woocommerce-search-list__item-prefix:after {
+		.woocommerce-search-list__item-prefix::after {
 			content: ":";
 		}
 	}
@@ -39,7 +39,7 @@
 
 	&.depth-0::after {
 		margin-left: $gap-smaller;
-		content: '';
+		content: "";
 		height: $gap-large;
 		width: $gap-large;
 		background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" fill="#{$core-grey-dark-300}" /></svg>');

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -81,6 +81,7 @@ ProductPreview.propTypes = {
 	 */
 	product: PropTypes.shape( {
 		id: PropTypes.number,
+		average_rating: PropTypes.oneOf( [ 'PropTypes.number', 'PropTypes.string' ] ),
 		images: PropTypes.array,
 		name: PropTypes.string,
 		price_html: PropTypes.string,

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "start": "cross-env BABEL_ENV=default webpack --watch --info-verbosity none",
     "lint": "npm run lint:php && npm run lint:css && npm run lint:js",
     "lint:php": "composer run-script phpcs .",
-    "lint:css": "stylelint assets/css",
+    "lint:css": "stylelint 'assets/**/*.scss'",
+    "lint:css-fix": "stylelint 'assets/**/*.scss' --fix",
     "lint:js": "eslint assets/js --ext=js,jsx",
+    "lint:js-fix": "eslint assets/js --ext=js,jsx --fix",
     "test": "wp-scripts test-unit-js --config tests/js/jest.config.json",
     "test:help": "wp-scripts test-unit-js --help",
     "test:update": "wp-scripts test-unit-js --updateSnapshot --config tests/js/jest.config.json",
@@ -94,6 +96,12 @@
     }
   },
   "lint-staged": {
+    "*.scss": [
+      "npm run lint:css"
+    ],
+    "*.js": [
+      "npm run lint:js"
+    ],
     "*.php": [
       "php -d display_errors=1 -l",
       "composer run-script phpcs"


### PR DESCRIPTION
This PR adds CSS and JS configuration to `lint-staged`, so files are linted before being committed. It also updates `npm run lint:css` so it includes all CSS files inside `assets`, not only the ones inside `assets/css`.

In addition, this PR fixes some linting errors that were now preventing me to make the commit. :slightly_smiling_face: (some fixes are duplicated from #693).

### How to test the changes in this Pull Request:

1. Modify a SCSS and a JS file and add some linting errors (you can undo the ones fixed in this PR, for example).
2. `git add . && git commit -m "Test"`
3. Verify you get an error indicating there are linting issues.
4. `npm run lint:css-fix && npm run lint:js-fix`
5. Verify the errors have been fixed automatically when possible.