### PR TITLE
Fix Featured Product block using a Handpicked Products block CSS class

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -196,7 +196,7 @@ class FeaturedProduct extends Component {
 					'Visually highlight a product and encourage prompt action',
 					'woo-gutenberg-products-block'
 				) }
-				<div className="wc-block-handpicked-products__selection">
+				<div className="wc-block-featured-product__selection">
 					<ProductControl
 						selected={ attributes.productId || 0 }
 						onChange={ ( value = [] ) => {

--- a/assets/js/blocks/featured-product/editor.scss
+++ b/assets/js/blocks/featured-product/editor.scss
@@ -8,3 +8,7 @@
 		z-index: 10;
 	}
 }
+
+.wc-block-featured-product__selection {
+    width: 100%;
+}


### PR DESCRIPTION
Small fix: the _Featured Product_ block was using a CSS class from the _Handpicked Products_ block.

### How to test the changes in this Pull Request:

1. Add a _Featured Product_ block.
2. Verify the Product Control still looks good.
