### PR TITLE
Add reviews endpoint

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -52,7 +52,7 @@ class ReviewsByProduct extends Component {
 		const payload = stringifyQuery( { order_by: orderby, per_page: perPage, product: productId } );
 
 		apiFetch( {
-			path: `/wc/v3/products/reviews${ payload }`,
+			path: `/wc/blocks/products/reviews${ payload }`,
 		} )
 			.then( ( reviews ) => {
 				this.setState( { reviews } );

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -45,6 +45,7 @@ class RestApi {
 			'product-categories'      => __NAMESPACE__ . '\RestApi\Controllers\ProductCategories',
 			'products'                => __NAMESPACE__ . '\RestApi\Controllers\Products',
 			'variations'              => __NAMESPACE__ . '\RestApi\Controllers\Variations',
+			'product-reviews'         => __NAMESPACE__ . '\RestApi\Controllers\ProductReviews',
 		];
 	}
 }

--- a/src/RestApi/ProductReviews.php
+++ b/src/RestApi/ProductReviews.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * REST API Reviews controller customized for Blocks.
+ *
+ * Handles requests to the /products/reviews endpoint. These endpoints allow read-only access to editors.
+ *
+ * @internal This API is used internally by the block post editor--it is still in flux. It should not be used outside of wc-blocks.
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\Controllers;
+
+defined( 'ABSPATH' ) || exit;
+
+use \WC_REST_Product_Reviews_Controller;
+
+/**
+ * REST API Product Reviews controller class.
+ */
+class ProductReviews extends WC_REST_Product_Reviews_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/blocks';
+
+	/**
+	 * Register the routes for product reviews.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => \WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to read the attributes.
+	 *
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woo-gutenberg-products-block' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+}


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/658

Extents the Reviews rest API including only READ methods and checking for `edit_posts` permissions so authors have access when reading review data.

To test, ensure the block can still read reviews.