### PR TITLE
Replace stringifyQuery with addQueryArgs

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { Component } from '@wordpress/element';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
-import { stringifyQuery } from '@woocommerce/navigation';
 
 /**
  * Internal dependencies
@@ -49,10 +49,12 @@ class ReviewsByProduct extends Component {
 			return;
 		}
 
-		const payload = stringifyQuery( { order_by: orderby, per_page: perPage, product: productId } );
-
 		apiFetch( {
-			path: `/wc/v3/products/reviews${ payload }`,
+			path: addQueryArgs( `/wc/v3/products/reviews`, {
+				order_by: orderby,
+				per_page: perPage,
+				product: productId,
+			} ),
 		} )
 			.then( ( reviews ) => {
 				this.setState( { reviews } );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -36,7 +36,7 @@ class Assets {
 		self::register_script( 'wc-blocks', plugins_url( 'build/blocks.js', __DIR__ ), array(), false );
 		self::register_script( 'wc-vendors', plugins_url( 'build/vendors.js', __DIR__ ), array(), false );
 		self::register_script( 'wc-packages', plugins_url( 'build/packages.js', __DIR__ ), array(), false );
-		self::register_script( 'wc-frontend', plugins_url( 'build/frontend.js', __DIR__ ), array( 'wc-vendors', 'wc-packages' ) );
+		self::register_script( 'wc-frontend', plugins_url( 'build/frontend.js', __DIR__ ), array( 'wc-vendors' ) );
 
 		// Individual blocks.
 		self::register_script( 'wc-handpicked-products', plugins_url( 'build/handpicked-products.js', __DIR__ ), array( 'wc-vendors', 'wc-packages', 'wc-blocks' ) );


### PR DESCRIPTION
I just discovered about `addQueryArgs` in a previous PR. Considering we are broadly using it in this codebase, it makes sense to use this one instead of `stringifyQuery` from `@woocommerce/navigation` which requires another package.

### How to test the changes in this Pull Request:

1. Add a _Reviews by Product_ block and verify reviews are still correctly loaded.