### PR TITLE
Prevent state updates on unmounted components

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -36,8 +36,12 @@ class ReviewsByProduct extends Component {
 			prevProps.attributes.perPage !== this.props.attributes.perPage ||
 			prevProps.attributes.productId !== this.props.attributes.productId
 		) {
-			this.getReviews();
+			this.debouncedGetReviews();
 		}
+	}
+
+	componentWillUnmount() {
+		this.debouncedGetReviews.cancel();
 	}
 
 	getReviews() {

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -36,10 +36,14 @@ class ReviewsByProductEditor extends Component {
 		super( ...arguments );
 		this.state = {
 			product: false,
-			loaded: false,
 		};
 
-		this.debouncedGetProduct = debounce( this.getProduct.bind( this ), 200 );
+		this.getProduct = this.getProduct.bind( this );
+		this.debouncedGetProduct = debounce( this.getProduct, 200 );
+	}
+
+	componentWillUnmount() {
+		this.debouncedGetProduct.cancel();
 	}
 
 	componentDidMount() {
@@ -54,19 +58,20 @@ class ReviewsByProductEditor extends Component {
 
 	getProduct() {
 		const { productId } = this.props.attributes;
+
 		if ( ! productId ) {
 			// We've removed the selected product, or no product is selected yet.
-			this.setState( { product: false, loaded: true } );
+			this.setState( { product: false } );
 			return;
 		}
 		apiFetch( {
 			path: `/wc/blocks/products/${ productId }`,
 		} )
 			.then( ( product ) => {
-				this.setState( { product, loaded: true } );
+				this.setState( { product } );
 			} )
 			.catch( () => {
-				this.setState( { product: false, loaded: true } );
+				this.setState( { product: false } );
 			} );
 	}
 
@@ -230,7 +235,7 @@ class ReviewsByProductEditor extends Component {
 
 	render() {
 		const { attributes, setAttributes } = this.props;
-		const { editMode } = attributes;
+		const { editMode, productId } = attributes;
 		const { product } = this.state;
 
 		return (
@@ -248,13 +253,11 @@ class ReviewsByProductEditor extends Component {
 					/>
 				</BlockControls>
 				{ this.getInspectorControls() }
-				{ ! product || editMode ? (
+				{ ! productId || editMode ? (
 					this.renderEditMode()
 				) : (
 					<Fragment>
-						{ product.rating_count > 0 ? (
-							<Block attributes={ attributes } />
-						) : (
+						{ product.rating_count === 0 ? (
 							<Placeholder
 								className="wc-block-reviews-by-product"
 								icon={ <ReviewsByProductIcon className="block-editor-block-icon" /> }
@@ -270,6 +273,8 @@ class ReviewsByProductEditor extends Component {
 									),
 								} } />
 							</Placeholder>
+						) : (
+							<Block attributes={ attributes } />
 						) }
 					</Fragment>
 				) }

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -53,6 +53,11 @@ class ProductControl extends Component {
 		this.onProductSelect = this.onProductSelect.bind( this );
 	}
 
+	componentWillUnmount() {
+		this.debouncedOnSearch.cancel();
+		this.debouncedGetVariations.cancel();
+	}
+
 	componentDidMount() {
 		const { selected, queryArgs } = this.props;
 
@@ -80,7 +85,7 @@ class ProductControl extends Component {
 	}
 
 	getVariations() {
-		const { product, variationsList } = this.state;
+		const { product, products, variationsList } = this.state;
 
 		if ( ! product ) {
 			this.setState( {
@@ -90,7 +95,7 @@ class ProductControl extends Component {
 			return;
 		}
 
-		const productDetails = this.state.products.find( ( findProduct ) => findProduct.id === product );
+		const productDetails = products.find( ( findProduct ) => findProduct.id === product );
 
 		if ( ! productDetails.variations || productDetails.variations.length === 0 ) {
 			return;


### PR DESCRIPTION
This PR contains several fixes here and there:
* In `reviews-by-product/block.js` we had a `this.debouncedGetReviews` method but were not using it.
* In `reviews-by-product/edit.js` it looks like we were not using the `loaded` state, so I completely removed it.
* In `reviews-by-product/edit.js` I updated the render logic so when we have a value in the `productId` attribute but the `product` value from the state is empty, it will load the placeholder instead of trying to load the editor UI. That also fixes a JS error that was appearing in the console.
* In all components that use a debounced function, we must cancel them when the component is unmounted. This PR fixes this issue in components related to the _Reviews by Product_ block, but I will check if there are other components affected by this in other parts of the codebase.

### How to test the changes in this Pull Request:

1. Add a _Reviews by Product_ block.
2. Verify products are loading in the Product Control and, once you select one product, verify it loads the reviews.
3. Save the post and reload it, verify everything loads properly.