### PR TITLE
Add Order by and Load more controls in Reviews by Product frontend

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { Component } from '@wordpress/element';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -19,11 +21,17 @@ import { renderReview } from './utils';
 class ReviewsByProduct extends Component {
 	constructor() {
 		super( ...arguments );
+		const { attributes } = this.props;
 		this.state = {
+			order: attributes.orderby,
 			reviews: [],
+			totalReviews: 0,
 		};
 
 		this.debouncedGetReviews = debounce( this.getReviews.bind( this ), 200 );
+		this.onChangeOrderby = this.onChangeOrderby.bind( this );
+		this.getReviews = this.getReviews.bind( this );
+		this.appendReviews = this.appendReviews.bind( this );
 	}
 
 	componentDidMount() {
@@ -40,9 +48,18 @@ class ReviewsByProduct extends Component {
 		}
 	}
 
-	getReviews() {
+	onChangeOrderby( event ) {
+		this.setState( {
+			order: event.target.value,
+		} );
+		this.getReviews( event.target.value );
+	}
+
+	getReviews( order, page = 1 ) {
 		const { attributes } = this.props;
-		const { orderby, perPage, productId } = attributes;
+		const { perPage, productId } = attributes;
+		const { reviews } = this.state;
+		const orderby = order || this.state.order || attributes.orderby;
 
 		if ( ! productId ) {
 			// We've removed the selected product, or no product is selected yet.
@@ -52,21 +69,40 @@ class ReviewsByProduct extends Component {
 		apiFetch( {
 			path: addQueryArgs( `/wc/v3/products/reviews`, {
 				order_by: orderby,
+				page,
 				per_page: perPage,
 				product: productId,
 			} ),
-		} )
-			.then( ( reviews ) => {
-				this.setState( { reviews } );
-			} )
-			.catch( () => {
+			parse: false,
+		} ).then( ( response ) => {
+			if ( response.json ) {
+				response.json().then( ( newReviews ) => {
+					const totalReviews = parseInt( response.headers.get( 'x-wp-total' ), 10 );
+					if ( page === 1 ) {
+						this.setState( { reviews: newReviews, totalReviews } );
+					} else {
+						this.setState( { reviews: reviews.concat( newReviews ), totalReviews } );
+					}
+				} ).catch( () => {
+					this.setState( { reviews: [] } );
+				} );
+			} else {
 				this.setState( { reviews: [] } );
-			} );
+			}
+		} ).catch( () => {
+			this.setState( { reviews: [] } );
+		} );
+	}
+
+	appendReviews() {
+		const page = Math.round( this.state.reviews.length / this.props.attributes.perPage ) + 1;
+
+		this.getReviews( null, page );
 	}
 
 	render() {
-		const { attributes } = this.props;
-		const { reviews } = this.state;
+		const { attributes, instanceId, isPreview } = this.props;
+		const { order, reviews, totalReviews } = this.state;
 		const { className, showAvatar, showProductRating, showReviewDate, showReviewerName } = attributes;
 		const classes = classNames( 'wc-block-reviews-by-product', className, {
 			'has-avatar': showAvatar,
@@ -75,8 +111,33 @@ class ReviewsByProduct extends Component {
 			'has-rating': showProductRating,
 		} );
 
+		const selectId = `wc-block-reviews-by-product__orderby__select-${ instanceId }`;
+		const selectProps = isPreview ? {
+			readOnly: true,
+			value: attributes.orderby,
+		} : {
+			defaultValue: order,
+			onBlur: this.onChangeOrderby,
+		};
+
 		return (
 			<div className={ classes }>
+				<p className="wc-block-reviews-by-product__orderby">
+					<label className="wc-block-reviews-by-product__orderby__label" htmlFor={ selectId }>
+						{ __( 'Order by', 'woo-gutenberg-products-block' ) }
+					</label>
+					<select id={ selectId } className="wc-block-reviews-by-product__orderby__select" { ...selectProps }>
+						<option value="most-recent">
+							{ __( 'Most recent', 'woo-gutenberg-products-block' ) }
+						</option>
+						<option value="highest-rating">
+							{ __( 'Highest rating', 'woo-gutenberg-products-block' ) }
+						</option>
+						<option value="lowest-rating">
+							{ __( 'Lowest rating', 'woo-gutenberg-products-block' ) }
+						</option>
+					</select>
+				</p>
 				<ul className="wc-block-reviews-by-product__list">
 					{ reviews.length === 0 ?
 						(
@@ -86,6 +147,14 @@ class ReviewsByProduct extends Component {
 						)
 					}
 				</ul>
+				{ totalReviews > reviews.length && (
+					<button
+						className="wc-block-reviews-by-product__load-more"
+						onClick={ isPreview ? null : this.appendReviews }
+					>
+						{ __( 'Load more', 'woo-gutenberg-products-block' ) }
+					</button>
+				) }
 			</div>
 		);
 	}
@@ -96,6 +165,14 @@ ReviewsByProduct.propTypes = {
 	 * The attributes for this block.
 	 */
 	attributes: PropTypes.object.isRequired,
+	/**
+	 * A unique ID for identifying the label for the select dropdown.
+	 */
+	instanceId: PropTypes.number,
+	/**
+	 * Whether this is the block preview or frontend display.
+	 */
+	isPreview: PropTypes.bool,
 };
 
-export default ReviewsByProduct;
+export default withInstanceId( ReviewsByProduct );

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -147,7 +147,7 @@ class ReviewsByProductEditor extends Component {
 					<TextControl
 						label={ __( 'Reviews shown on page load', 'woo-gutenberg-products-block' ) }
 						value={ attributes.perPage }
-						onChange={ ( perPage ) => setAttributes( { perPage } ) }
+						onChange={ ( perPage ) => setAttributes( { perPage: parseInt( perPage, 10 ) } ) }
 						type="number"
 					/>
 				</PanelBody>
@@ -253,7 +253,7 @@ class ReviewsByProductEditor extends Component {
 				) : (
 					<Fragment>
 						{ product.rating_count > 0 ? (
-							<Block attributes={ attributes } />
+							<Block attributes={ attributes } isPreview />
 						) : (
 							<Placeholder
 								className="wc-block-reviews-by-product"

--- a/assets/js/blocks/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews-by-product/index.js
@@ -114,7 +114,7 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 		} );
 
 		return (
-			<div data-product-id={ productId } data-order-by={ orderby } data-per-page={ perPage } className={ classes }>
+			<div data-product-id={ productId } data-orderby={ orderby } data-per-page={ perPage } className={ classes }>
 				<ul className="wc-block-reviews-by-product__list">
 					{ renderReview( attributes ) }
 				</ul>

--- a/assets/js/blocks/reviews-by-product/style.scss
+++ b/assets/js/blocks/reviews-by-product/style.scss
@@ -33,6 +33,15 @@
 		}
 	}
 
+	.wc-block-reviews-by-product__orderby {
+		margin-bottom: $gap-larger;
+		text-align: right;
+	}
+
+	.wc-block-reviews-by-product__orderby__label {
+		margin-right: $gap-small;
+	}
+
 	.wc-block-reviews-by-product__list {
 		list-style: none;
 		margin: 0;
@@ -117,6 +126,11 @@
 			grid-column: 1;
 			grid-row: 1;
 		}
+	}
+
+	.wc-block-reviews-by-product__load-more {
+		display: block;
+		margin: 0 auto;
 	}
 
 	&.has-avatar {


### PR DESCRIPTION
Part of #658.

### Screenshots

![Peek 2019-07-10 15-54](https://user-images.githubusercontent.com/3616980/60974783-fcfe7800-a32a-11e9-8a3a-c6f56c0ef5b5.gif)

### How to test the changes in this Pull Request:

1. Add a _Reviews by Product_ block and select a product that has several reviews.
2. Verify an _Order by_ select appears in the editor.
3. Reduce the _Reviews shown on page load_ setting until a _Load more_ button appears below the list of reviews.
4. Publish the post.
5. In the frontend, press on _Load more_ and verify it loads more reviews.

Notice: the _Order by_ select doesn't work yet.