### PR TITLE
Export IconReviewsByProduct

### DIFF
--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -29,7 +29,7 @@ import PropTypes from 'prop-types';
  */
 import Block from './block.js';
 import ProductControl from '../../components/product-control';
-import ReviewsByProductIcon from '../../components/icons/reviews-by-product';
+import { IconReviewsByProduct } from '../../components/icons';
 
 class ReviewsByProductEditor extends Component {
 	constructor() {
@@ -199,7 +199,7 @@ class ReviewsByProductEditor extends Component {
 
 		return (
 			<Placeholder
-				icon={ <ReviewsByProductIcon className="block-editor-block-icon" /> }
+				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
 				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
 				className="wc-block-reviews-by-product"
 			>
@@ -257,7 +257,7 @@ class ReviewsByProductEditor extends Component {
 						) : (
 							<Placeholder
 								className="wc-block-reviews-by-product"
-								icon={ <ReviewsByProductIcon className="block-editor-block-icon" /> }
+								icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
 								label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
 							>
 								<div dangerouslySetInnerHTML={ {

--- a/assets/js/blocks/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews-by-product/index.js
@@ -11,7 +11,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import './style.scss';
 import './editor.scss';
 import Editor from './edit';
-import ReviewsByProductIcon from '../../components/icons/reviews-by-product';
+import { IconReviewsByProduct } from '../../components/icons';
 import { renderReview } from './utils';
 
 /**
@@ -20,7 +20,7 @@ import { renderReview } from './utils';
 registerBlockType( 'woocommerce/reviews-by-product', {
 	title: __( 'Reviews by Product', 'woo-gutenberg-products-block' ),
 	icon: (
-		<ReviewsByProductIcon fillColor="#96588a" />
+		<IconReviewsByProduct fillColor="#96588a" />
 	),
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/components/icons/index.js
+++ b/assets/js/components/icons/index.js
@@ -6,5 +6,6 @@ export { default as IconFolderStar } from './folder-star';
 export { default as IconNewReleases } from './new-releases';
 export { default as IconRadioSelected } from './radio-selected';
 export { default as IconRadioUnselected } from './radio-unselected';
+export { default as IconReviewsByProduct } from './reviews-by-product';
 export { default as IconWidgets } from './widgets';
 export { default as IconWoo } from './woo';


### PR DESCRIPTION
Tiny PR that exports the _Reviews by Product_ icon from `components/icons/index.js`, which seems to be the common pattern for all other icons.

### How to test the changes in this Pull Request:

1. In the editor, add a _Reviews by Product_ block and verify the icon is loaded and there are no JS errors.