### PR TITLE
Hide avatars in Reviews by Products if 'show_avatars' setting is false

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -107,13 +107,18 @@ class ReviewsByProduct extends Component {
 	render() {
 		const { attributes, instanceId, isPreview } = this.props;
 		const { order, reviews, totalReviews } = this.state;
-		const { className, showAvatar, showProductRating, showReviewDate, showReviewerName } = attributes;
+		const { className, showProductRating, showReviewDate, showReviewerName } = attributes;
+		const showAvatar = wc_product_block_data.showAvatars && attributes.showAvatar;
 		const classes = classNames( 'wc-block-reviews-by-product', className, {
 			'has-avatar': showAvatar,
 			'has-date': showReviewDate,
 			'has-name': showReviewerName,
 			'has-rating': showProductRating,
 		} );
+		const attrs = {
+			...attributes,
+			showAvatar,
+		};
 
 		const selectId = `wc-block-reviews-by-product__orderby__select-${ instanceId }`;
 		const selectProps = isPreview ? {
@@ -145,9 +150,9 @@ class ReviewsByProduct extends Component {
 				<ul className="wc-block-reviews-by-product__list">
 					{ reviews.length === 0 ?
 						(
-							renderReview( attributes )
+							renderReview( attrs )
 						) : (
-							reviews.map( ( review ) => renderReview( attributes, review ) )
+							reviews.map( ( review ) => renderReview( attrs, review ) )
 						)
 					}
 				</ul>

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -117,16 +117,18 @@ class ReviewsByProductEditor extends Component {
 						checked={ attributes.showReviewerName }
 						onChange={ () => setAttributes( { showReviewerName: ! attributes.showReviewerName } ) }
 					/>
-					<ToggleControl
-						label={ __( 'Avatar', 'woo-gutenberg-products-block' ) }
-						help={
-							attributes.showAvatar ?
-								__( 'Avatar is visible.', 'woo-gutenberg-products-block' ) :
-								__( 'Avatar is hidden.', 'woo-gutenberg-products-block' )
-						}
-						checked={ attributes.showAvatar }
-						onChange={ () => setAttributes( { showAvatar: ! attributes.showAvatar } ) }
-					/>
+					{ wc_product_block_data.showAvatars && (
+						<ToggleControl
+							label={ __( 'Avatar', 'woo-gutenberg-products-block' ) }
+							help={
+								attributes.showAvatar ?
+									__( 'Avatar is visible.', 'woo-gutenberg-products-block' ) :
+									__( 'Avatar is hidden.', 'woo-gutenberg-products-block' )
+							}
+							checked={ attributes.showAvatar }
+							onChange={ () => setAttributes( { showAvatar: ! attributes.showAvatar } ) }
+						/>
+					) }
 					<ToggleControl
 						label={ __( 'Review date', 'woo-gutenberg-products-block' ) }
 						help={

--- a/assets/js/blocks/reviews-by-product/frontend.js
+++ b/assets/js/blocks/reviews-by-product/frontend.js
@@ -10,7 +10,7 @@ import { render } from '@wordpress/element';
 import Block from './block.js';
 
 const containers = document.querySelectorAll(
-	'.wc-block-reviews-by-product'
+	'.wp-block-woocommerce-reviews-by-product'
 );
 
 if ( containers.length ) {
@@ -19,10 +19,10 @@ if ( containers.length ) {
 			orderby: el.dataset.orderby,
 			perPage: el.dataset.perPage,
 			productId: el.dataset.productId,
-			showAvatar: el.classList.contains( 'has-avatar' ),
-			showProductRating: el.classList.contains( 'has-rating' ),
-			showReviewDate: el.classList.contains( 'has-date' ),
-			showReviewerName: el.classList.contains( 'has-name' ),
+			showAvatar: el.dataset.hasAvatar === 'true',
+			showProductRating: el.dataset.hasRating === 'true',
+			showReviewDate: el.dataset.hasReview === 'true',
+			showReviewerName: el.dataset.hasName === 'true',
 		};
 
 		render( <Block attributes={ attributes } />, el );

--- a/assets/js/blocks/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews-by-product/index.js
@@ -106,15 +106,19 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 	save( { attributes } ) {
 		const { className, orderby, perPage, productId, showAvatar, showProductRating, showReviewDate, showReviewerName } = attributes;
 
-		const classes = classNames( 'wc-block-reviews-by-product', className, {
-			'has-avatar': showAvatar,
-			'has-date': showReviewDate,
-			'has-name': showReviewerName,
-			'has-rating': showProductRating,
-		} );
+		const classes = classNames( 'wc-block-reviews-by-product', className );
+		const data = {
+			'data-has-avatar': showAvatar,
+			'data-has-date': showReviewDate,
+			'data-has-name': showReviewerName,
+			'data-has-rating': showProductRating,
+			'data-orderby': orderby,
+			'data-per-page': perPage,
+			'data-product-id': productId,
+		};
 
 		return (
-			<div data-product-id={ productId } data-orderby={ orderby } data-per-page={ perPage } className={ classes }>
+			<div className={ classes } { ...data }>
 				<ul className="wc-block-reviews-by-product__list">
 					{ renderReview( attributes ) }
 				</ul>

--- a/assets/js/blocks/reviews-by-product/style.scss
+++ b/assets/js/blocks/reviews-by-product/style.scss
@@ -134,7 +134,7 @@
 		margin: 0 auto;
 	}
 
-	&.has-avatar {
+	.has-avatar {
 		.wc-block-reviews-by-product__info {
 			grid-template-columns: #{48px + $gap-small} 1fr;
 		}
@@ -145,8 +145,8 @@
 		}
 	}
 
-	&.has-name,
-	&.has-rating {
+	.has-name,
+	.has-rating {
 		.wc-block-reviews-by-product__published-date {
 			grid-row: 2;
 		}

--- a/assets/js/blocks/reviews-by-product/utils.js
+++ b/assets/js/blocks/reviews-by-product/utils.js
@@ -19,6 +19,10 @@ export function renderReview( attributes, review = {} ) {
 	const isLoading = ! Object.keys( review ).length > 0;
 
 	const classes = classNames( 'wc-block-reviews-by-product__item', {
+		'has-avatar': showAvatar,
+		'has-date': showReviewDate,
+		'has-name': showReviewerName,
+		'has-rating': showProductRating,
 		'is-loading': isLoading,
 	} );
 	const starStyle = {

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -140,6 +140,7 @@ class Assets {
 			'isLargeCatalog'    => $product_counts->publish > 200,
 			'productCategories' => $product_categories,
 			'homeUrl'           => esc_js( home_url( '/' ) ),
+			'showAvatars'       => '1' === get_option( 'show_avatars' ),
 		);
 		?>
 		<script type="text/javascript">


### PR DESCRIPTION
### Screenshots

![image](https://user-images.githubusercontent.com/3616980/61114045-c726d400-a48f-11e9-8c59-8c438abce86e.png)

### How to test the changes in this Pull Request:

1. Create a post and add two _Reviews by Products_ blocks, in one of them disable avatars.
2. In another tab, go to _Settings_ > _Discussion_ > _Avatars_ and uncheck _Show Avatars_.
3. Reload the post and verify both _Reviews by Products_ blocks show no avatars.
4. Add a third _Reviews by Products_ block, verify you can't enable/disable avatars because the option is hidden.
5. In _Settings_ check _Show Avatars_ again.
6. Reload the post and verify the recently added block shows avatars and the previous two returned to their original state.
