### PR TITLE
Reviews by Product: Set minimum to per page input field

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -74,7 +74,7 @@ class ReviewsByProduct extends Component {
 			path: addQueryArgs( `/wc/blocks/products/reviews`, {
 				order_by: orderby,
 				page,
-				per_page: perPage,
+				per_page: parseInt( perPage, 10 ) || 1,
 				product: productId,
 			} ),
 			parse: false,

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -80,6 +80,8 @@ class ReviewsByProductEditor extends Component {
 			attributes,
 			setAttributes,
 		} = this.props;
+		const minPerPage = 1;
+		const maxPerPage = 100;
 
 		return (
 			<InspectorControls key="inspector">
@@ -152,7 +154,11 @@ class ReviewsByProductEditor extends Component {
 					<TextControl
 						label={ __( 'Reviews shown on page load', 'woo-gutenberg-products-block' ) }
 						value={ attributes.perPage }
-						onChange={ ( perPage ) => setAttributes( { perPage: parseInt( perPage, 10 ) } ) }
+						onChange={ ( perPage ) => setAttributes( {
+							perPage: Math.max( Math.min( parseInt( perPage, 10 ), maxPerPage ), minPerPage ),
+						} ) }
+						max={ maxPerPage }
+						min={ minPerPage }
 						type="number"
 					/>
 				</PanelBody>


### PR DESCRIPTION
### Screenshots

![image](https://user-images.githubusercontent.com/3616980/61116083-140ca980-a494-11e9-9fa5-5ce039cf2af6.png)

### How to test the changes in this Pull Request:

1. Add a _Reviews by Product_ block.
2. Try changing the value of _Reviews shown on page load_ to `0`, `-1` and `101` and verify it always goes back to values between 1 and 100.
