### PR TITLE
Add placeholder animation

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -15,6 +15,18 @@
 	}
 }
 
+@keyframes loading-fade {
+	0% {
+		opacity: 0.7;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0.7;
+	}
+}
+
 // Adds animation to placeholder section
 @mixin placeholder( $lighten-percentage: 30% ) {
 	animation: loading-fade 1.6s ease-in-out infinite;
@@ -23,6 +35,10 @@
 
 	&::after {
 		content: "\00a0";
+	}
+
+	@media screen and (prefers-reduced-motion: reduce) {
+		animation: none;
 	}
 }
 


### PR DESCRIPTION
This PR copies the placeholder animation from WooCommerce Admin.

### Screenshots

![Peek 2019-07-12 15-42](https://user-images.githubusercontent.com/3616980/61132448-ab392780-a4bb-11e9-91a1-acfd2e8d41a4.gif)

### How to test the changes in this Pull Request:

1. To make it easy to see the placeholder, modify this line:
https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/8200d22164b0e725c1155708d1b324012a9df4a0/assets/js/blocks/reviews-by-product/block.js#L155
with:
```ES6
reviews.map( () => renderReview( attrs ) )
```
2. Publish a post with a _Reviews by Product_ block.
3. Verify the placeholder's opacity is animated.
