### PR TITLE
Load frontend scripts only when required

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -173,15 +173,20 @@ class Assets {
 	 * @param string $src       Full URL of the script, or path of the script relative to the WordPress root directory.
 	 * @param array  $deps      Optional. An array of registered script handles this script depends on. Default empty array.
 	 * @param bool   $has_i18n  Optional. Whether to add a script translation call to this file. Default 'true'.
+	 * @param bool   $enqueue   Optional. Whether the script should be enqueued instead of registered.
 	 */
-	protected static function register_script( $handle, $src, $deps = array(), $has_i18n = true ) {
+	protected static function register_script( $handle, $src, $deps = array(), $has_i18n = true, $enqueue = false ) {
 		$filename     = str_replace( plugins_url( '/', __DIR__ ), '', $src );
 		$ver          = self::get_file_version( $filename );
 		$deps_path    = dirname( __DIR__ ) . '/' . str_replace( '.js', '.deps.json', $filename );
 		$dependencies = file_exists( $deps_path ) ? json_decode( file_get_contents( $deps_path ) ) : array(); // phpcs:ignore WordPress.WP.AlternativeFunctions
 		$dependencies = array_merge( $dependencies, $deps );
 
-		wp_register_script( $handle, $src, $dependencies, $ver, true );
+		if ( $enqueue ) {
+			wp_enqueue_script( $handle, $src, $dependencies, $ver, true );
+		} else {
+			wp_register_script( $handle, $src, $dependencies, $ver, true );
+		}
 		if ( $has_i18n && function_exists( 'wp_set_script_translations' ) ) {
 			wp_set_script_translations( $handle, 'woo-gutenberg-products-block', dirname( __DIR__ ) . '/languages' );
 		}
@@ -196,8 +201,7 @@ class Assets {
 	 */
 	public static function load_script_as_required( $name ) {
 		$filename = 'build/' . $name . '.js';
-		$ver      = self::get_file_version( $filename );
-		wp_enqueue_script( $name, plugins_url( $filename, __DIR__ ), array( 'wc-vendors' ), $ver, true );
+		self::register_script( 'wc-' . $name, plugins_url( $filename, __DIR__ ), array( 'wc-vendors' ), true, true );
 	}
 
 	/**

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -36,7 +36,6 @@ class Assets {
 		self::register_script( 'wc-blocks', plugins_url( 'build/blocks.js', __DIR__ ), array(), false );
 		self::register_script( 'wc-vendors', plugins_url( 'build/vendors.js', __DIR__ ), array(), false );
 		self::register_script( 'wc-packages', plugins_url( 'build/packages.js', __DIR__ ), array(), false );
-		self::register_script( 'wc-frontend', plugins_url( 'build/frontend.js', __DIR__ ), array( 'wc-vendors' ) );
 
 		// Individual blocks.
 		self::register_script( 'wc-handpicked-products', plugins_url( 'build/handpicked-products.js', __DIR__ ), array( 'wc-vendors', 'wc-packages', 'wc-blocks' ) );
@@ -186,6 +185,19 @@ class Assets {
 		if ( $has_i18n && function_exists( 'wp_set_script_translations' ) ) {
 			wp_set_script_translations( $handle, 'woo-gutenberg-products-block', dirname( __DIR__ ) . '/languages' );
 		}
+	}
+
+	/**
+	 * Queues a scripts when required.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @param string $name Name of the script used to identify the file inside build folder.
+	 */
+	public static function load_script_as_required( $name ) {
+		$filename = 'build/' . $name . '.js';
+		$ver      = self::get_file_version( $filename );
+		wp_enqueue_script( $name, plugins_url( $filename, __DIR__ ), array( 'wc-vendors' ), $ver, true );
 	}
 
 	/**

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -188,7 +188,7 @@ class Assets {
 	}
 
 	/**
-	 * Queues a scripts when required.
+	 * Queues a script when required.
 	 *
 	 * @since 2.3.0
 	 *

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -38,7 +38,6 @@ abstract class AbstractBlock {
 				'editor_script' => 'wc-' . $this->block_name,
 				'editor_style'  => 'wc-block-editor',
 				'style'         => 'wc-block-style',
-				'script'        => 'wc-frontend',
 			)
 		);
 	}

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -20,4 +20,33 @@ class ProductCategories extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'product-categories';
+
+	/**
+	 * Registers the block type with WordPress.
+	 */
+	public function register_block_type() {
+		register_block_type(
+			$this->namespace . '/' . $this->block_name,
+			array(
+				'render_callback' => array( $this, 'render' ),
+				'editor_script'   => 'wc-' . $this->block_name,
+				'editor_style'    => 'wc-block-editor',
+				'style'           => 'wc-block-style',
+				'script'          => 'wc-frontend',
+			)
+		);
+	}
+
+	/**
+	 * Append frontend scripts when rendering the Product Categories List block.
+	 *
+	 * @param array  $attributes Block attributes. Default empty array.
+	 * @param string $content    Block content. Default empty string.
+	 * @return string Rendered block type output.
+	 */
+	public function render( $attributes = array(), $content = '' ) {
+		\Automattic\WooCommerce\Blocks\Assets::load_script_as_required( 'frontend' );
+
+		return $content;
+	}
 }


### PR DESCRIPTION
This PR makes it so we only load the block frontend files when a page contains a block.

### How to test the changes in this Pull Request:

1. Create a post and add a _Product Categories List_ block.
2. Open the post in the frontend and verify it works as expected.
3. Go to any other page where the post is not visible and in the _Network_ tab of the browser devtools, verify no `frontend.js` or `vendors.js` files are loaded.

### Changelog

Load frontend scripts dynamically only when the page contains a block that requires them
