### PR TITLE
Use radio buttons instead of checkboxes in Featured Category control

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -217,7 +217,7 @@ class FeaturedCategory extends Component {
 							const id = value[ 0 ] ? value[ 0 ].id : 0;
 							setAttributes( { categoryId: id, mediaId: 0, mediaSrc: '' } );
 						} }
-						multiple={ false }
+						isSingle
 					/>
 					<Button isDefault onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }


### PR DESCRIPTION
Fixes #743. I'm targeting 2.3 since it's a very small PR and this is a new block for WooCommerce 3.7, so I think it makes sense fixing it before release.

### Screenshots

_Before:_
![image](https://user-images.githubusercontent.com/3616980/61627206-7a0ce400-ac7f-11e9-9a7d-48d1f572734d.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/61627244-8ee97780-ac7f-11e9-8753-fc1c1e9b89d6.png)

### How to test the changes in this Pull Request:

1. Create a new block and add a _Featured Category_ block.
2. Verify the control shows radio buttons (circles) instead of checkboxes (squares).

### Changelog

Fix _Featured Category_ block using radio buttons instead of checkboxes.
