### PR TITLE
Remove constants and unhook old blocks plugin

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -158,9 +158,9 @@ class Assets {
 	protected static function get_file_version( $file ) {
 		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 			$file = trim( $file, '/' );
-			return filemtime( WGPB_ABSPATH . $file );
+			return filemtime( \Automattic\WooCommerce\Blocks\Package::get_path() . '/' . $file );
 		}
-		return WGPB_VERSION;
+		return \Automattic\WooCommerce\Blocks\Package::get_version();
 	}
 
 	/**

--- a/src/Package.php
+++ b/src/Package.php
@@ -35,14 +35,14 @@ class Package {
 		if ( true === self::$did_init || ! self::has_dependencies() ) {
 			return;
 		}
+
 		self::$did_init = true;
+		self::remove_core_blocks();
 
 		if ( ! self::is_built() ) {
 			return self::add_build_notice();
 		}
 
-		self::define_constants();
-		self::remove_core_blocks();
 		Library::init();
 		Assets::init();
 		RestApi::init();
@@ -105,14 +105,6 @@ class Package {
 	}
 
 	/**
-	 * Define plugin constants.
-	 */
-	protected static function define_constants() {
-		define( 'WGPB_VERSION', self::VERSION );
-		define( 'WGPB_ABSPATH', self::get_path() . '/' );
-	}
-
-	/**
 	 * Remove core blocks (for 3.6 and below).
 	 */
 	protected static function remove_core_blocks() {
@@ -121,6 +113,7 @@ class Package {
 		remove_action( 'init', array( 'WC_Block_Library', 'register_assets' ) );
 		remove_filter( 'block_categories', array( 'WC_Block_Library', 'add_block_category' ) );
 		remove_action( 'admin_print_footer_scripts', array( 'WC_Block_Library', 'print_script_settings' ), 1 );
+		remove_action( 'init', array( 'WGPB_Block_Library', 'init' ) );
 	}
 
 }


### PR DESCRIPTION
- Removes use of constants to avoid conflicts with the old blocks plugin
- Unhooks the old blocks plugin registration of blocks methods

Fixes #744

This will need cherry picking to the release branch.

### How to test the changes in this Pull Request:

You need to be running new code (this branch) and the old blocks plugin. #744 explains. I did the following.

1. Checked out woo master. Ran build scripts. Applied the changes in this PR to the /packages/woocommerce-gutenberg-products-block directory
2. In this repo, `git checkout v2.2.1` 
3. Check for error notices

<!-- If you can, add the appropriate labels -->