### PR TITLE
Reviews by Product cleanup

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -4,8 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import classNames from 'classnames';
-import { Component } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@wordpress/compose';
@@ -182,9 +181,11 @@ class ReviewsByProduct extends Component {
 		);
 	}
 
-	renderReviewsList( showAvatar, showProductRating ) {
+	renderReviewsList() {
 		const { attributes } = this.props;
 		const { reviews } = this.state;
+		const showAvatar = wc_product_block_data.showAvatars && attributes.showAvatar;
+		const showProductRating = wc_product_block_data.enableReviewRating && attributes.showProductRating;
 		const attrs = {
 			...attributes,
 			showAvatar,
@@ -223,23 +224,12 @@ class ReviewsByProduct extends Component {
 	}
 
 	render() {
-		const { attributes } = this.props;
-		const { className, showReviewDate, showReviewerName } = attributes;
-		const showAvatar = wc_product_block_data.showAvatars && attributes.showAvatar;
-		const showProductRating = wc_product_block_data.enableReviewRating && attributes.showProductRating;
-		const classes = classNames( 'wc-block-reviews-by-product', className, {
-			'has-avatar': showAvatar,
-			'has-date': showReviewDate,
-			'has-name': showReviewerName,
-			'has-rating': showProductRating,
-		} );
-
 		return (
-			<div className={ classes }>
+			<Fragment>
 				{ this.renderOrderBySelect() }
-				{ this.renderReviewsList( showAvatar, showProductRating ) }
+				{ this.renderReviewsList() }
 				{ this.renderLoadMoreButton() }
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -17,6 +17,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
+import classNames from 'classnames';
 import { SearchListItem } from '@woocommerce/components';
 import { Component, Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
@@ -248,6 +249,16 @@ class ReviewsByProductEditor extends Component {
 		const { editMode, productId } = attributes;
 		const { product } = this.state;
 
+		const { className, showReviewDate, showReviewerName } = attributes;
+		const showAvatar = wc_product_block_data.showAvatars && attributes.showAvatar;
+		const showProductRating = wc_product_block_data.enableReviewRating && attributes.showProductRating;
+		const classes = classNames( 'wc-block-reviews-by-product', className, {
+			'has-avatar': showAvatar,
+			'has-date': showReviewDate,
+			'has-name': showReviewerName,
+			'has-rating': showProductRating,
+		} );
+
 		return (
 			<Fragment>
 				<BlockControls>
@@ -284,7 +295,9 @@ class ReviewsByProductEditor extends Component {
 								} } />
 							</Placeholder>
 						) : (
-							<Block attributes={ attributes } isPreview />
+							<div className={ classes }>
+								<Block attributes={ attributes } isPreview />
+							</div>
 						) }
 					</Fragment>
 				) }

--- a/assets/js/blocks/reviews-by-product/frontend.js
+++ b/assets/js/blocks/reviews-by-product/frontend.js
@@ -19,10 +19,10 @@ if ( containers.length ) {
 			orderby: el.dataset.orderby,
 			perPage: el.dataset.perPage,
 			productId: el.dataset.productId,
-			showAvatar: el.dataset.hasAvatar === 'true',
-			showProductRating: el.dataset.hasRating === 'true',
-			showReviewDate: el.dataset.hasReview === 'true',
-			showReviewerName: el.dataset.hasName === 'true',
+			showAvatar: el.classList.contains( 'has-avatar' ),
+			showProductRating: el.classList.contains( 'has-rating' ),
+			showReviewDate: el.classList.contains( 'has-date' ),
+			showReviewerName: el.classList.contains( 'has-name' ),
 		};
 
 		render( <Block attributes={ attributes } />, el );

--- a/assets/js/blocks/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews-by-product/index.js
@@ -106,12 +106,13 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 	save( { attributes } ) {
 		const { className, orderby, perPage, productId, showAvatar, showProductRating, showReviewDate, showReviewerName } = attributes;
 
-		const classes = classNames( 'wc-block-reviews-by-product', className );
+		const classes = classNames( 'wc-block-reviews-by-product', className, {
+			'has-avatar': showAvatar,
+			'has-date': showReviewDate,
+			'has-name': showReviewerName,
+			'has-rating': showProductRating,
+		} );
 		const data = {
-			'data-has-avatar': showAvatar,
-			'data-has-date': showReviewDate,
-			'data-has-name': showReviewerName,
-			'data-has-rating': showProductRating,
 			'data-orderby': orderby,
 			'data-per-page': perPage,
 			'data-product-id': productId,

--- a/assets/js/blocks/reviews-by-product/style.scss
+++ b/assets/js/blocks/reviews-by-product/style.scss
@@ -134,7 +134,7 @@
 		margin: 0 auto;
 	}
 
-	.has-avatar {
+	&.has-avatar {
 		.wc-block-reviews-by-product__info {
 			grid-template-columns: #{48px + $gap-small} 1fr;
 		}
@@ -145,8 +145,8 @@
 		}
 	}
 
-	.has-name,
-	.has-rating {
+	&.has-name,
+	&.has-rating {
 		.wc-block-reviews-by-product__published-date {
 			grid-row: 2;
 		}

--- a/assets/js/blocks/reviews-by-product/utils.js
+++ b/assets/js/blocks/reviews-by-product/utils.js
@@ -20,10 +20,6 @@ export function renderReview( attributes, review = {}, i = 0 ) {
 	const showProductRating = Number.isFinite( rating ) && showProductRatingAttr;
 
 	const classes = classNames( 'wc-block-reviews-by-product__item', {
-		'has-avatar': showAvatar,
-		'has-date': showReviewDate,
-		'has-name': showReviewerName,
-		'has-rating': showProductRating,
 		'is-loading': isLoading,
 	} );
 	const starStyle = {


### PR DESCRIPTION
This is a small PR with some improvements and fixes I found we could do while working on #770.

The only visible change is that before there was a double `<div>` around the block in the frontend:

_Before:_
![image](https://user-images.githubusercontent.com/3616980/62036727-a0d49880-b1f2-11e9-949f-11461bdc8cd4.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/62037003-396b1880-b1f3-11e9-8fd5-8157345270fc.png)

Everything else are internal changes.

### How to test the changes in this Pull Request:

1. Create a Post with a _Reviews by Product_ block.
2. Verify it renders correctly both in the editor and the frontend.
