### PR TITLE
Fix ComponentId camelCase

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -70,7 +70,7 @@ class ProductCategoriesBlock extends Component {
 	}
 
 	render() {
-		const { attributes, categories, ComponentId } = this.props;
+		const { attributes, categories, componentId } = this.props;
 		const { className, isDropdown } = attributes;
 		const classes = classnames(
 			'wc-block-product-categories',
@@ -81,7 +81,7 @@ class ProductCategoriesBlock extends Component {
 			}
 		);
 
-		const selectId = `prod-categories-${ ComponentId }`;
+		const selectId = `prod-categories-${ componentId }`;
 
 		return (
 			<Fragment>

--- a/assets/js/utils/with-component-id.js
+++ b/assets/js/utils/with-component-id.js
@@ -22,11 +22,11 @@ const withComponentId = ( OriginalComponent ) => {
 		}
 
 		render() {
-			const ComponentId = this.generateUniqueID();
+			const componentId = this.generateUniqueID();
 
 			return <OriginalComponent
 				{ ...this.props }
-				ComponentId={ ComponentId }
+				componentId={ componentId }
 			/>;
 		}
 	};


### PR DESCRIPTION
While working on #774 I noticed `ComponentId` was not using camelCase. This PR should fix that.
