### PR TITLE
Ensure register_block_type exists

### DIFF
--- a/src/Package.php
+++ b/src/Package.php
@@ -72,7 +72,7 @@ class Package {
 	 * @return boolean
 	 */
 	protected static function has_dependencies() {
-		return class_exists( 'WooCommerce' );
+		return class_exists( 'WooCommerce' ) && function_exists( 'register_block_type' );
 	}
 
 	/**


### PR DESCRIPTION
Prevent errors if `register_block_type` is not defined. This prevents breakage on WP 4.9.

Closes #778 

To test, run blocks alongside 4.9. There should be no errors.

Also test with 5.0+. Ensure blocks still exist.