### PR TITLE
Fix Jest missing webpack config

### DIFF
--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -15,5 +15,8 @@
     "node_modules/(?!(simple-html-tokenizer)/)"
   ],
   "preset": "@wordpress/jest-preset-default",
+  "transform": {
+    "^.+\\.js$": "<rootDir>/tests/js/jestPreprocess.js"
+  },
   "verbose": true
 }

--- a/tests/js/jestPreprocess.js
+++ b/tests/js/jestPreprocess.js
@@ -1,0 +1,5 @@
+const babelOptions = {
+	presets: [ '@wordpress/babel-preset-default' ],
+};
+
+module.exports = require( 'babel-jest' ).createTransformer( babelOptions );


### PR DESCRIPTION
In a previous PR we removed `babel.config.js` so Jest was failing because of missing Babel configuration.

This PR adds a transform to the config which loads the Babel config, as described here: https://github.com/facebook/jest/issues/1468#issuecomment-276753756

### How to test the changes in this Pull Request:

1. Verify all tests pass when running `npm run test`.
2. Verify Travis is green in this PR.
3. Verify `frontend.deps.json` doesn't include `lodash`.