### PR TITLE
Introduce withSearchedProducts higher order component and refactor ProductsControl Component

### DIFF
--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { SearchListControl } from '@woocommerce/components';
 import PropTypes from 'prop-types';
 
@@ -59,17 +58,15 @@ const ProductsControl = ( {
 		),
 	};
 	return (
-		<Fragment>
-			<SearchListControl
-				className="woocommerce-products"
-				list={ products }
-				isLoading={ isLoading }
-				selected={ selected }
-				onSearch={ onSearch }
-				onChange={ onChange }
-				messages={ messages }
-			/>
-		</Fragment>
+		<SearchListControl
+			className="woocommerce-products"
+			list={ products }
+			isLoading={ isLoading }
+			selected={ selected }
+			onSearch={ onSearch }
+			onChange={ onChange }
+			messages={ messages }
+		/>
 	);
 };
 

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -78,7 +78,7 @@ ProductsControl.propTypes = {
 	onSearch: PropTypes.func,
 	selected: PropTypes.array,
 	products: PropTypes.array,
-	isLoading: PropTypes.boolean,
+	isLoading: PropTypes.bool,
 };
 
 ProductsControl.defaultProps = {

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -71,7 +71,7 @@ const ProductsControl = ( {
 };
 
 ProductsControl.propTypes = {
-	onChange: PropTypes.func,
+	onChange: PropTypes.func.isRequired,
 	onSearch: PropTypes.func,
 	selected: PropTypes.array,
 	products: PropTypes.array,
@@ -79,8 +79,6 @@ ProductsControl.propTypes = {
 };
 
 ProductsControl.defaultProps = {
-	onChange: () => undefined,
-	onSearch: () => undefined,
 	selected: [],
 	products: [],
 	isLoading: true,

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -2,110 +2,91 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
-import { debounce, find } from 'lodash';
-import PropTypes from 'prop-types';
+import { Fragment } from '@wordpress/element';
 import { SearchListControl } from '@woocommerce/components';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import { isLargeCatalog, getProducts } from '../utils';
+import { withSearchedProducts } from '../../hocs/with-searched-products';
 
-class ProductsControl extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			list: [],
-			loading: true,
-		};
-
-		this.debouncedOnSearch = debounce( this.onSearch.bind( this ), 400 );
-	}
-
-	componentDidMount() {
-		const { selected } = this.props;
-
-		getProducts( { selected } )
-			.then( ( list ) => {
-				this.setState( { list, loading: false } );
-			} )
-			.catch( () => {
-				this.setState( { list: [], loading: false } );
-			} );
-	}
-
-	componentWillUnmount() {
-		this.debouncedOnSearch.cancel();
-	}
-
-	onSearch( search ) {
-		const { selected } = this.props;
-		getProducts( { selected, search } )
-			.then( ( list ) => {
-				this.setState( { list, loading: false } );
-			} )
-			.catch( () => {
-				this.setState( { list: [], loading: false } );
-			} );
-	}
-
-	render() {
-		const { list, loading } = this.state;
-		const { onChange, selected } = this.props;
-
-		const messages = {
-			clear: __( 'Clear all products', 'woo-gutenberg-products-block' ),
-			list: __( 'Products', 'woo-gutenberg-products-block' ),
-			noItems: __(
-				"Your store doesn't have any products.",
-				'woo-gutenberg-products-block'
-			),
-			search: __(
-				'Search for products to display',
-				'woo-gutenberg-products-block'
-			),
-			selected: ( n ) =>
-				sprintf(
-					_n(
-						'%d product selected',
-						'%d products selected',
-						n,
-						'woo-gutenberg-products-block'
-					),
-					n
+/**
+ * The products control exposes a custom selector for searching and selecting
+ * products.
+ *
+ * @param {function} props.onChange  Callback fired when the selected item
+ *                                   changes
+ * @param {function} props.onSearch  Callback fired when a search is triggered
+ * @param {array}    props.selected  An array of selected products.
+ * @param {array}    props.products  An array of products to select from.
+ * @param {boolean}  props.isLoading Whether or not the products are being
+ *                                   loaded.
+ *
+ * @return {function} A functional component.
+ */
+const ProductsControl = ( {
+	onChange,
+	onSearch,
+	selected,
+	products,
+	isLoading,
+} ) => {
+	const messages = {
+		clear: __( 'Clear all products', 'woo-gutenberg-products-block' ),
+		list: __( 'Products', 'woo-gutenberg-products-block' ),
+		noItems: __(
+			"Your store doesn't have any products.",
+			'woo-gutenberg-products-block'
+		),
+		search: __(
+			'Search for products to display',
+			'woo-gutenberg-products-block'
+		),
+		selected: ( n ) =>
+			sprintf(
+				_n(
+					'%d product selected',
+					'%d products selected',
+					n,
+					'woo-gutenberg-products-block'
 				),
-			updated: __(
-				'Product search results updated.',
-				'woo-gutenberg-products-block'
+				n
 			),
-		};
-
-		return (
-			<Fragment>
-				<SearchListControl
-					className="woocommerce-products"
-					list={ list }
-					isLoading={ loading }
-					selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
-					onSearch={ isLargeCatalog ? this.debouncedOnSearch : null }
-					onChange={ onChange }
-					messages={ messages }
-				/>
-			</Fragment>
-		);
-	}
-}
-
-ProductsControl.propTypes = {
-	/**
-	 * Callback to update the selected products.
-	 */
-	onChange: PropTypes.func.isRequired,
-	/**
-	 * The list of currently selected IDs.
-	 */
-	selected: PropTypes.array.isRequired,
+		updated: __(
+			'Product search results updated.',
+			'woo-gutenberg-products-block'
+		),
+	};
+	return (
+		<Fragment>
+			<SearchListControl
+				className="woocommerce-products"
+				list={ products }
+				isLoading={ isLoading }
+				selected={ selected }
+				onSearch={ onSearch }
+				onChange={ onChange }
+				messages={ messages }
+			/>
+		</Fragment>
+	);
 };
 
-export default ProductsControl;
+ProductsControl.propTypes = {
+	onChange: PropTypes.func,
+	onSearch: PropTypes.func,
+	selected: PropTypes.array,
+	products: PropTypes.array,
+	isLoading: PropTypes.boolean,
+};
+
+ProductsControl.defaultProps = {
+	onChange: () => undefined,
+	onSearch: () => undefined,
+	selected: [],
+	products: [],
+	isLoading: true,
+};
+
+export default withSearchedProducts( ProductsControl );

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { withSearchedProducts } from '../../hocs/with-searched-products';
+import { withSearchedProducts } from '../../hocs';
 
 /**
  * The products control exposes a custom selector for searching and selecting

--- a/assets/js/hocs/index.js
+++ b/assets/js/hocs/index.js
@@ -1,2 +1,3 @@
 export { default as withComponentId } from './with-component-id';
 export { default as withProduct } from './with-product';
+export { default as withSearchedProducts } from './with-searched-products';

--- a/assets/js/hocs/test/with-searched-products.js
+++ b/assets/js/hocs/test/with-searched-products.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+import _ from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import withSearchedProducts from '../with-searched-products';
+import * as mockedUtils from '../../components/utils';
+
+// Mock the getProducts and isLargeCatalog values for tests.
+mockedUtils.getProducts = jest.fn().mockImplementation(
+	( { selected } ) => Promise.resolve( selected )
+);
+mockedUtils.isLargeCatalog = true;
+
+// Add a mock implementation of debounce for testing so we can spy on
+// the onSearch call.
+const debouncedCancel = jest.fn();
+const debouncedAction = jest.fn();
+_.debounce = ( onSearch ) => {
+	const debounced = debouncedAction.mockImplementation(
+		() => {
+			onSearch();
+		}
+	);
+	debounced.cancel = debouncedCancel;
+	return debounced;
+};
+
+describe( 'withSearchedProducts Component', () => {
+	const { getProducts } = mockedUtils;
+	afterEach( () => {
+		debouncedCancel.mockClear();
+		debouncedAction.mockClear();
+		mockedUtils.getProducts.mockClear();
+		mockedUtils.isLargeCatalog = false;
+	} );
+	const TestComponent = withSearchedProducts( ( {
+		selected,
+		products,
+		isLoading,
+		onSearch,
+	} ) => {
+		return <div
+			products={ products }
+			selected={ selected }
+			isLoading={ isLoading }
+			onSearch={ onSearch }
+		/>;
+	} );
+	describe( 'lifecycle tests', () => {
+		const selected = [ { id: 10, name: 'foo' } ];
+		const renderer = TestRenderer.create(
+			<TestComponent
+				selected={ selected }
+			/>
+		);
+		let props;
+		it( 'getProducts is called on mount with passed in selected ' +
+			'values', () => {
+			expect( getProducts ).toHaveBeenCalledWith( { selected } );
+			expect( getProducts ).toHaveBeenCalledTimes( 1 );
+		} );
+		it( 'has expected values for props', () => {
+			props = renderer.root.findByType( 'div' ).props;
+			expect( props.selected ).toEqual( selected );
+			expect( props.products ).toEqual( selected );
+		} );
+		it( 'debounce and getProducts is called on search event', () => {
+			props.onSearch();
+			expect( debouncedAction ).toHaveBeenCalled();
+			expect( getProducts ).toHaveBeenCalledTimes( 1 );
+		} );
+		it( 'debounce is cancelled on unmount', () => {
+			renderer.unmount();
+			expect( debouncedCancel ).toHaveBeenCalled();
+			expect( getProducts ).toHaveBeenCalledTimes( 0 );
+		} );
+	} );
+} );

--- a/assets/js/hocs/test/with-searched-products.js
+++ b/assets/js/hocs/test/with-searched-products.js
@@ -70,6 +70,7 @@ describe( 'withSearchedProducts Component', () => {
 			expect( props.products ).toEqual( selected );
 		} );
 		it( 'debounce and getProducts is called on search event', () => {
+			props = renderer.root.findByType( 'div' ).props;
 			props.onSearch();
 			expect( debouncedAction ).toHaveBeenCalled();
 			expect( getProducts ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/hocs/test/with-searched-products.js
+++ b/assets/js/hocs/test/with-searched-products.js
@@ -12,7 +12,9 @@ import * as mockedUtils from '../../components/utils';
 
 // Mock the getProducts and isLargeCatalog values for tests.
 mockedUtils.getProducts = jest.fn().mockImplementation(
-	( { selected } ) => Promise.resolve( selected )
+	() => Promise.resolve(
+		[ { id: 10, name: 'foo' }, { id: 20, name: 'bar' } ]
+	)
 );
 mockedUtils.isLargeCatalog = true;
 
@@ -52,7 +54,7 @@ describe( 'withSearchedProducts Component', () => {
 		/>;
 	} );
 	describe( 'lifecycle tests', () => {
-		const selected = [ { id: 10, name: 'foo' } ];
+		const selected = [ 10 ];
 		const renderer = TestRenderer.create(
 			<TestComponent
 				selected={ selected }
@@ -66,8 +68,10 @@ describe( 'withSearchedProducts Component', () => {
 		} );
 		it( 'has expected values for props', () => {
 			props = renderer.root.findByType( 'div' ).props;
-			expect( props.selected ).toEqual( selected );
-			expect( props.products ).toEqual( selected );
+			expect( props.selected ).toEqual( [ { id: 10, name: 'foo' } ] );
+			expect( props.products ).toEqual(
+				[ { id: 10, name: 'foo' }, { id: 20, name: 'bar' } ]
+			);
 		} );
 		it( 'debounce and getProducts is called on search event', () => {
 			props = renderer.root.findByType( 'div' ).props;

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { debounce, find } from 'lodash';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { isLargeCatalog, getProducts } from '../components/utils';
+
+/**
+ * A higher order component that enhances the provided component with products
+ * from a search query.
+ */
+const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) => {
+	/**
+	 * A Component wrapping the passed in component.
+	 *
+	 * @class WrappedComponent
+	 * @extends {Component}
+	 */
+	class WrappedComponent extends Component {
+		constructor() {
+			super( ...arguments );
+			this.state = {
+				list: [],
+				loading: true,
+			};
+			this.debouncedOnSearch = debounce( this.onSearch.bind( this ), 400 );
+		}
+
+		componentDidMount() {
+			const { selected } = this.props;
+			getProducts( { selected } )
+				.then( ( list ) => {
+					this.setState( { list, loading: false } );
+				} )
+				.catch( () => {
+					this.setState( { list: [], loading: false } );
+				} );
+		}
+
+		componentWillUnmount() {
+			this.debouncedOnSearch.cancel();
+		}
+
+		onSearch( search ) {
+			const { selected } = this.props;
+			getProducts( { selected, search } )
+				.then( ( list ) => {
+					this.setState( { list, loading: false } );
+				} )
+				.catch( () => {
+					this.setState( { list: [], loading: false } );
+				} );
+		}
+
+		render() {
+			const { list, loading } = this.state;
+			const { selected } = this.props;
+			return (
+				<OriginalComponent
+					{ ...this.props }
+					products={ list }
+					isLoading={ loading }
+					selected={ selected
+						.map( ( { id } ) => find( list, { id } ) )
+						.filter( Boolean ) }
+					onSearch={ isLargeCatalog ? this.debouncedOnSearch : null }
+				/>
+			);
+		}
+	}
+	WrappedComponent.propTypes = {
+		selected: PropTypes.array,
+	};
+	WrappedComponent.defaultProps = {
+		selected: [],
+	};
+	return WrappedComponent;
+}, 'withSearchedProducts' );
+
+export default withSearchedProducts;

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Component } from '@wordpress/element';
-import { debounce, find } from 'lodash';
+import { debounce } from 'lodash';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 
@@ -66,9 +66,9 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 					{ ...this.props }
 					products={ list }
 					isLoading={ loading }
-					selected={ selected
-						.map( ( id ) => find( list, { id } ) )
-						.filter( Boolean ) }
+					selected={ list.filter(
+						( { id } ) => selected.includes( id )
+					) }
 					onSearch={ isLargeCatalog ? this.debouncedOnSearch : null }
 				/>
 			);

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -67,7 +67,7 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 					products={ list }
 					isLoading={ loading }
 					selected={ selected
-						.map( ( { id } ) => find( list, { id } ) )
+						.map( ( id ) => find( list, { id } ) )
 						.filter( Boolean ) }
 					onSearch={ isLargeCatalog ? this.debouncedOnSearch : null }
 				/>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

As outlined in p90Yrv-1an-p2, this pull refactors the `ProductsControl` component so that data/logic is kept separate from presentation.  So with this pull:

- introduction of new `withSearchedProducts` higher order component handling the logic related to getting products (and updating `onSearch`).
- adds unit tests for the new hoc.
- refactoring `ProductsControl` component so that it now is solely presentation and receives data via the hoc.

### How to test the changes in this Pull Request:

This should have no impact to behaviour of the block for end users as this is solely a internal change.  With that said, the following covers tests:

* [ ] Unit tests should pass (including the new tests for the hoc).
* [ ] Existing functionality of the "Hand Picked Products" block should continue to work as expected (specifically make sure that the search functionality works and multiple blocks in the same view work with different selected products).
* [ ] Verify there are no console errors introduced by work in this branch.

### Changelog

> Internal: Introduce new `withSearchedProducts` higher order component and refactor `ProductsControl` component to use it.
