### PR TITLE
Create a constants.js file with the NAMESPACE value

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -36,6 +36,7 @@ import { IconFolderStar } from '../../components/icons';
 /**
  * Internal dependencies
  */
+import { NAMESPACE } from '../../constants';
 import ProductCategoryControl from '../../components/product-category-control';
 
 /**
@@ -130,7 +131,7 @@ class FeaturedCategory extends Component {
 			return;
 		}
 		apiFetch( {
-			path: `/wc/blocks/products/categories/${ categoryId }`,
+			path: `${ NAMESPACE }/categories/${ categoryId }`,
 		} )
 			.then( ( category ) => {
 				this.setState( { category, loaded: true } );

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -36,7 +36,7 @@ import { IconFolderStar } from '../../components/icons';
 /**
  * Internal dependencies
  */
-import { NAMESPACE } from '../../constants';
+import { ENDPOINTS } from '../../constants';
 import ProductCategoryControl from '../../components/product-category-control';
 
 /**
@@ -131,7 +131,7 @@ class FeaturedCategory extends Component {
 			return;
 		}
 		apiFetch( {
-			path: `${ NAMESPACE }/categories/${ categoryId }`,
+			path: `${ ENDPOINTS.products }/categories/${ categoryId }`,
 		} )
 			.then( ( category ) => {
 				this.setState( { category, loaded: true } );

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -13,7 +13,7 @@ import { SelectControl, Spinner } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { NAMESPACE } from '../../constants';
+import { ENDPOINTS } from '../../constants';
 import './style.scss';
 
 class ProductAttributeControl extends Component {
@@ -35,7 +35,7 @@ class ProductAttributeControl extends Component {
 	componentDidMount() {
 		const { selected } = this.props;
 		apiFetch( {
-			path: addQueryArgs( `${ NAMESPACE }/attributes`, { per_page: -1 } ),
+			path: addQueryArgs( `${ ENDPOINTS.products }/attributes`, { per_page: -1 } ),
 		} )
 			.then( ( list ) => {
 				list = list.map( ( item ) => ( { ...item, parent: 0 } ) );
@@ -72,7 +72,7 @@ class ProductAttributeControl extends Component {
 		}
 
 		apiFetch( {
-			path: addQueryArgs( `${ NAMESPACE }/attributes/${ attribute }/terms`, {
+			path: addQueryArgs( `${ ENDPOINTS.products }/attributes/${ attribute }/terms`, {
 				per_page: -1,
 			} ),
 		} )

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -13,6 +13,7 @@ import { SelectControl, Spinner } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import { NAMESPACE } from '../../constants';
 import './style.scss';
 
 class ProductAttributeControl extends Component {
@@ -34,7 +35,7 @@ class ProductAttributeControl extends Component {
 	componentDidMount() {
 		const { selected } = this.props;
 		apiFetch( {
-			path: addQueryArgs( '/wc/blocks/products/attributes', { per_page: -1 } ),
+			path: addQueryArgs( `${ NAMESPACE }/attributes`, { per_page: -1 } ),
 		} )
 			.then( ( list ) => {
 				list = list.map( ( item ) => ( { ...item, parent: 0 } ) );
@@ -71,7 +72,7 @@ class ProductAttributeControl extends Component {
 		}
 
 		apiFetch( {
-			path: addQueryArgs( `/wc/blocks/products/attributes/${ attribute }/terms`, {
+			path: addQueryArgs( `${ NAMESPACE }/attributes/${ attribute }/terms`, {
 				per_page: -1,
 			} ),
 		} )

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -13,6 +13,7 @@ import { SelectControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import { NAMESPACE } from '../../constants';
 import './style.scss';
 
 class ProductCategoryControl extends Component {
@@ -27,7 +28,7 @@ class ProductCategoryControl extends Component {
 
 	componentDidMount() {
 		apiFetch( {
-			path: addQueryArgs( '/wc/blocks/products/categories', { per_page: -1 } ),
+			path: addQueryArgs( `${ NAMESPACE }/categories`, { per_page: -1 } ),
 		} )
 			.then( ( list ) => {
 				this.setState( { list, loading: false } );

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -13,7 +13,7 @@ import { SelectControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
-import { NAMESPACE } from '../../constants';
+import { ENDPOINTS } from '../../constants';
 import './style.scss';
 
 class ProductCategoryControl extends Component {
@@ -28,7 +28,7 @@ class ProductCategoryControl extends Component {
 
 	componentDidMount() {
 		apiFetch( {
-			path: addQueryArgs( `${ NAMESPACE }/categories`, { per_page: -1 } ),
+			path: addQueryArgs( `${ ENDPOINTS.products }/categories`, { per_page: -1 } ),
 		} )
 			.then( ( list ) => {
 				this.setState( { list, loading: false } );

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -17,6 +17,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { NAMESPACE } from '../../constants';
 import { isLargeCatalog, getProducts } from '../utils';
 import {
 	IconRadioSelected,
@@ -101,7 +102,7 @@ class ProductControl extends Component {
 		}
 
 		apiFetch( {
-			path: addQueryArgs( `/wc/blocks/products/${ product }/variations`, {
+			path: addQueryArgs( `${ NAMESPACE }/${ product }/variations`, {
 				per_page: -1,
 			} ),
 		} )

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -17,7 +17,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { NAMESPACE } from '../../constants';
+import { ENDPOINTS } from '../../constants';
 import { isLargeCatalog, getProducts } from '../utils';
 import {
 	IconRadioSelected,
@@ -102,7 +102,7 @@ class ProductControl extends Component {
 		}
 
 		apiFetch( {
-			path: addQueryArgs( `${ NAMESPACE }/${ product }/variations`, {
+			path: addQueryArgs( `${ ENDPOINTS.products }/${ product }/variations`, {
 				per_page: -1,
 			} ),
 		} )

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -8,7 +8,7 @@ import { flatten, uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { NAMESPACE } from '../../constants';
+import { ENDPOINTS } from '../../constants';
 
 export const isLargeCatalog = wc_product_block_data.isLargeCatalog || false;
 export const limitTags = wc_product_block_data.limitTags || false;
@@ -16,7 +16,7 @@ export const hasTags = wc_product_block_data.hasTags || false;
 
 const getProductsRequests = ( { selected = [], search } ) => {
 	const requests = [
-		addQueryArgs( NAMESPACE, {
+		addQueryArgs( ENDPOINTS.products, {
 			per_page: isLargeCatalog ? 100 : -1,
 			catalog_visibility: 'visible',
 			status: 'publish',
@@ -27,7 +27,7 @@ const getProductsRequests = ( { selected = [], search } ) => {
 	// If we have a large catalog, we might not get all selected products in the first page.
 	if ( isLargeCatalog && selected.length ) {
 		requests.push(
-			addQueryArgs( NAMESPACE, {
+			addQueryArgs( ENDPOINTS.products, {
 				catalog_visibility: 'visible',
 				status: 'publish',
 				include: selected,
@@ -58,13 +58,13 @@ export const getProducts = ( { selected = [], search } ) => {
  */
 export const getProduct = ( productId ) => {
 	return apiFetch( {
-		path: `${ NAMESPACE }/${ productId }`,
+		path: `${ ENDPOINTS.products }/${ productId }`,
 	} );
 };
 
 const getProductTagsRequests = ( { selected = [], search } ) => {
 	const requests = [
-		addQueryArgs( `${ NAMESPACE }/tags`, {
+		addQueryArgs( `${ ENDPOINTS.products }/tags`, {
 			per_page: limitTags ? 100 : -1,
 			orderby: limitTags ? 'count' : 'name',
 			order: limitTags ? 'desc' : 'asc',
@@ -75,7 +75,7 @@ const getProductTagsRequests = ( { selected = [], search } ) => {
 	// If we have a large catalog, we might not get all selected products in the first page.
 	if ( limitTags && selected.length ) {
 		requests.push(
-			addQueryArgs( `${ NAMESPACE }/tags`, {
+			addQueryArgs( `${ ENDPOINTS.products }/tags`, {
 				include: selected,
 			} )
 		);

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -5,11 +5,14 @@ import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { flatten, uniqBy } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import { NAMESPACE } from '../../constants';
+
 export const isLargeCatalog = wc_product_block_data.isLargeCatalog || false;
 export const limitTags = wc_product_block_data.limitTags || false;
 export const hasTags = wc_product_block_data.hasTags || false;
-
-const NAMESPACE = '/wc/blocks/products';
 
 const getProductsRequests = ( { selected = [], search } ) => {
 	const requests = [

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -1,4 +1,5 @@
+const NAMESPACE = '/wc/blocks';
 export const ENDPOINTS = {
-	root: '/wc/blocks',
-	products: '/wc/blocks/products',
+	root: NAMESPACE,
+	products: `${ NAMESPACE }/products`,
 };

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -1,0 +1,1 @@
+export const NAMESPACE = '/wc/blocks/products';

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -1,1 +1,4 @@
-export const NAMESPACE = '/wc/blocks/products';
+export const ENDPOINTS = {
+	root: '/wc/blocks',
+	products: '/wc/blocks/products',
+};


### PR DESCRIPTION
This PR creates a `constants.js` file as discussed here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/779#discussion_r309950402.

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

Creating a new post, adding the affected blocks and verifying they still fetch information should be enough to test.

Affected blocks:
* _Featured Category_
* _Products by Attribute_
* _Products by Category_
* _Featured Product_

### Changelog

> Internal: create a `NAMESPACE` constant and export it from `assets/js/constant.js`.