### PR TITLE
Disable HTML editing on dynamic blocks

### DIFF
--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -29,6 +29,7 @@ registerBlockType( 'woocommerce/featured-product', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		/**

--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -26,6 +26,7 @@ registerBlockType( 'woocommerce/handpicked-products', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		/**

--- a/assets/js/blocks/product-best-sellers/index.js
+++ b/assets/js/blocks/product-best-sellers/index.js
@@ -27,6 +27,7 @@ registerBlockType( 'woocommerce/product-best-sellers', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		...sharedAttributes,

--- a/assets/js/blocks/product-category/index.js
+++ b/assets/js/blocks/product-category/index.js
@@ -30,6 +30,7 @@ registerBlockType( 'woocommerce/product-category', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		...sharedAttributes,

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -93,7 +93,7 @@ class ProductSearchBlock extends Component {
 						className="wc-block-product-search__button"
 						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
 						onClick={ ( e ) => e.preventDefault() }
-						tabindex="-1"
+						tabIndex="-1"
 					>
 						<svg aria-hidden="true" role="img" focusable="false" className="dashicon dashicons-arrow-right-alt2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
 							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z"></path>

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -27,6 +27,7 @@ registerBlockType( 'woocommerce/product-tag', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		/**

--- a/assets/js/blocks/product-top-rated/index.js
+++ b/assets/js/blocks/product-top-rated/index.js
@@ -29,6 +29,7 @@ registerBlockType( blockTypeName, {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		...sharedAttributes,

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -28,6 +28,7 @@ registerBlockType( blockTypeName, {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		/**


### PR DESCRIPTION
Dynamic blocks have no content until they are rendered on the server side, therefore they should not be HTML editable. The use of shortcodes was dropped in 2.2.

Fixes #800 

Also fixes the case of `tabIndex` introduced in a previous merge.

To test,
- Add a product category and hand picked product block
- Click the more icon
- Confirm 'edit as html' is no longer shown