### PR TITLE
Reviews by Product: prevent importing all HOCs and import only withComponentId

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { getReviews, renderReview } from './utils';
-import { withComponentId } from '../../hocs';
+import withComponentId from '../../hocs/with-component-id';
 
 /**
  * Component to handle edit mode of "Reviews by Product".


### PR DESCRIPTION
This PR fixes and issue that made the frontend of _Reviews by Product_ to import the dependencies of all HOCs even though it was only using `withComponentId`.

### How to test the changes in this Pull Request:

Open `/build/reviews-by-product-frontend.deps.json` and verify we are not importing unnecessary dependencies.
```diff
-["lodash","react","react-dom","wp-api-fetch","wp-compose","wp-element","wp-i18n","wp-polyfill","wp-url"]
+["react","react-dom","wp-api-fetch","wp-i18n","wp-polyfill"]
```