### PR TITLE
Featured Product: hide background opacity control if there is no image

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -147,6 +147,9 @@ class FeaturedCategory extends Component {
 		const url =
 			attributes.mediaSrc || getCategoryImageSrc( this.state.category );
 		const { focalPoint = { x: 0.5, y: 0.5 } } = attributes;
+		// FocalPointPicker was introduced in Gutenberg 5.0 (WordPress 5.2),
+		// so we need to check if it exists before using it.
+		const focalPointPickerExists = typeof FocalPointPicker === 'function';
 
 		return (
 			<InspectorControls key="inspector">
@@ -177,7 +180,7 @@ class FeaturedCategory extends Component {
 								max={ 100 }
 								step={ 10 }
 							/>
-							{ !! FocalPointPicker &&
+							{ focalPointPickerExists &&
 								<FocalPointPicker
 									label={ __( 'Focal Point Picker' ) }
 									url={ url }

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -167,22 +167,26 @@ class FeaturedCategory extends Component {
 						},
 					] }
 				>
-					<RangeControl
-						label={ __( 'Background Opacity', 'woo-gutenberg-products-block' ) }
-						value={ attributes.dimRatio }
-						onChange={ ( ratio ) => setAttributes( { dimRatio: ratio } ) }
-						min={ 0 }
-						max={ 100 }
-						step={ 10 }
-					/>
-					{ !! FocalPointPicker && !! url &&
-						<FocalPointPicker
-							label={ __( 'Focal Point Picker' ) }
-							url={ url }
-							value={ focalPoint }
-							onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
-						/>
-					}
+					{ !! url && (
+						<Fragment>
+							<RangeControl
+								label={ __( 'Background Opacity', 'woo-gutenberg-products-block' ) }
+								value={ attributes.dimRatio }
+								onChange={ ( ratio ) => setAttributes( { dimRatio: ratio } ) }
+								min={ 0 }
+								max={ 100 }
+								step={ 10 }
+							/>
+							{ !! FocalPointPicker &&
+								<FocalPointPicker
+									label={ __( 'Focal Point Picker' ) }
+									url={ url }
+									value={ focalPoint }
+									onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
+								/>
+							}
+						</Fragment>
+					) }
 				</PanelColorSettings>
 			</InspectorControls>
 		);

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -128,6 +128,9 @@ class FeaturedProduct extends Component {
 		const url =
 			attributes.mediaSrc || getImageSrcFromProduct( this.state.product );
 		const { focalPoint = { x: 0.5, y: 0.5 } } = attributes;
+		// FocalPointPicker was introduced in Gutenberg 5.0 (WordPress 5.2),
+		// so we need to check if it exists before using it.
+		const focalPointPickerExists = typeof FocalPointPicker === 'function';
 
 		return (
 			<InspectorControls key="inspector">
@@ -163,7 +166,7 @@ class FeaturedProduct extends Component {
 								max={ 100 }
 								step={ 10 }
 							/>
-							{ !! FocalPointPicker &&
+							{ focalPointPickerExists &&
 								<FocalPointPicker
 									label={ __( 'Focal Point Picker' ) }
 									url={ url }

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -153,22 +153,26 @@ class FeaturedProduct extends Component {
 						},
 					] }
 				>
-					<RangeControl
-						label={ __( 'Background Opacity', 'woo-gutenberg-products-block' ) }
-						value={ attributes.dimRatio }
-						onChange={ ( ratio ) => setAttributes( { dimRatio: ratio } ) }
-						min={ 0 }
-						max={ 100 }
-						step={ 10 }
-					/>
-					{ !! FocalPointPicker && !! url &&
-						<FocalPointPicker
-							label={ __( 'Focal Point Picker' ) }
-							url={ url }
-							value={ focalPoint }
-							onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
-						/>
-					}
+					{ !! url && (
+						<Fragment>
+							<RangeControl
+								label={ __( 'Background Opacity', 'woo-gutenberg-products-block' ) }
+								value={ attributes.dimRatio }
+								onChange={ ( ratio ) => setAttributes( { dimRatio: ratio } ) }
+								min={ 0 }
+								max={ 100 }
+								step={ 10 }
+							/>
+							{ !! FocalPointPicker &&
+								<FocalPointPicker
+									label={ __( 'Focal Point Picker' ) }
+									url={ url }
+									value={ focalPoint }
+									onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
+								/>
+							}
+						</Fragment>
+					) }
 				</PanelColorSettings>
 			</InspectorControls>
 		);


### PR DESCRIPTION
Fixes #812.

This PR removes the _Background Opacity_ slider from _Featured Product_ and _Featured Category_ blocks when they have no background image. Having the sliders visible was confusing because it wasn't producing any visual effect on the block.

### Screenshots

![image](https://user-images.githubusercontent.com/3616980/62615683-0836ca80-b90e-11e9-97cd-bd523dbcdcb7.png)

### How to test the changes in this Pull Request:

1. Add a _Featured Product_ block selecting a product with an image. Repeat with a product without an image. Verify the background opacity control only appears when you select the product with image.
2. Repeat the process with the _Featured Category_ block.

### Changelog

> Hide background opacity range control from Featured Product and Featured Category blocks when it had no effect.