### PR TITLE
Disable HTML editing on Featured Category

### DIFF
--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -30,6 +30,7 @@ registerBlockType( 'woocommerce/featured-category', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	attributes: {
 		/**


### PR DESCRIPTION
Fixes #814.

Follow-up of #801 includind _Featured Category_.

### How to test the changes in this Pull Request:

1. Add a _Featured Category_ block.
2. Click the _More options_ icon.
3. Confirm _Edit as HTML_ is no longer shown.

