### PR TITLE
Fix Reviews by Product order by select not honoring default setting

### DIFF
--- a/assets/js/blocks/reviews-by-product/block.js
+++ b/assets/js/blocks/reviews-by-product/block.js
@@ -18,11 +18,9 @@ class ReviewsByProduct extends Component {
 	constructor() {
 		super( ...arguments );
 		const { attributes } = this.props;
-		const { order, orderby } = this.getOrderArgs( attributes.orderby );
 
 		this.state = {
-			order,
-			orderby,
+			orderby: attributes.orderby,
 			reviews: [],
 			totalReviews: 0,
 		};
@@ -54,7 +52,7 @@ class ReviewsByProduct extends Component {
 
 	getDefaultArgs() {
 		const { attributes, isPreview } = this.props;
-		const { order, orderby } = isPreview ? this.getOrderArgs( attributes.orderby ) : this.state;
+		const { order, orderby } = this.getOrderArgs( isPreview ? attributes.orderby : this.state.orderby );
 		const { productId, reviewsOnPageLoad } = attributes;
 
 		return {
@@ -132,8 +130,7 @@ class ReviewsByProduct extends Component {
 
 		this.setState( {
 			reviews: Array( newReviews ).fill( {} ),
-			order,
-			orderby,
+			orderby: event.target.value,
 		} );
 
 		const args = {


### PR DESCRIPTION
Part of #588.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/62695488-bc9c2380-b9d6-11e9-8f6a-f470e65b96d6.png)

### How to test the changes in this Pull Request:

1. Create a post with a _Reviews by Product_ block and set the default order to something different than the default option, for example, _Highest Rating_.
2. Preview the post and verify the _Order by_ select shows the correct option (_Highest Rating_) instead of the default one (_Most Recent_).