### PR TITLE
Read more component - change how clamped content is shown

### DIFF
--- a/assets/js/blocks/reviews-by-product/utils.js
+++ b/assets/js/blocks/reviews-by-product/utils.js
@@ -60,7 +60,14 @@ function getReviewContent( review ) {
 			lessText={ __( 'Hide full review', 'woo-gutenberg-products-block' ) }
 			className="wc-block-reviews-by-product__text"
 		>
-			{ review.review || '' }
+			<div
+				dangerouslySetInnerHTML={ {
+					// `content` is the `review` parameter returned by the `reviews` endpoint.
+					// It's filtered with `wp_filter_post_kses()`, which removes dangerous HTML tags,
+					// so using it inside `dangerouslySetInnerHTML` is safe.
+					__html: review.review || '',
+				} }
+			/>
 		</ReadMore>
 	);
 }

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -19,7 +19,7 @@ class ReadMore extends Component {
 			/**
 			 * True if we are clamping content. False if the review is short. Null during init.
 			 */
-			isClamped: null,
+			clampEnabled: null,
 			/**
 			 * Content is passed in via children.
 			 */
@@ -48,18 +48,18 @@ class ReadMore extends Component {
 			const lineHeight = this.reviewSummary.current.clientHeight + 1;
 			const reviewHeight = this.reviewContent.current.clientHeight + 1;
 			const maxHeight = ( lineHeight * maxLines ) + 1;
-			const isClamped = reviewHeight > maxHeight;
+			const clampEnabled = reviewHeight > maxHeight;
 
 			this.setState( {
 				maxHeight: maxHeight,
 				isExpanded: false,
-				isClamped: isClamped,
+				clampEnabled: clampEnabled,
 			} );
 		}
 	}
 
 	componentDidUpdate( prevProps, prevState ) {
-		if ( prevState.isClamped !== this.state.isClamped && this.state.isClamped ) {
+		if ( prevState.clampEnabled !== this.state.clampEnabled && this.state.clampEnabled ) {
 			this.clampLines();
 		}
 	}
@@ -141,13 +141,13 @@ class ReadMore extends Component {
 
 	render() {
 		const { className } = this.props;
-		const { content, summary, isClamped, isExpanded } = this.state;
+		const { content, summary, clampEnabled, isExpanded } = this.state;
 
 		if ( ! content ) {
 			return null;
 		}
 
-		if ( false === isClamped ) {
+		if ( false === clampEnabled ) {
 			return (
 				<div className={ className }>
 					<div ref={ this.reviewContent }>
@@ -163,7 +163,7 @@ class ReadMore extends Component {
 					ref={ this.reviewSummary }
 					aria-hidden={ isExpanded }
 					style={ {
-						display: isExpanded && null !== isClamped ? 'none' : 'inherit',
+						display: isExpanded && null !== clampEnabled ? 'none' : 'inherit',
 					} }
 					dangerouslySetInnerHTML={ {
 						__html: summary,
@@ -173,7 +173,7 @@ class ReadMore extends Component {
 					ref={ this.reviewContent }
 					aria-hidden={ ! isExpanded }
 					style={ {
-						display: ! isExpanded && null !== isClamped ? 'none' : 'inherit',
+						display: ! isExpanded && null !== clampEnabled ? 'none' : 'inherit',
 					} }
 				>
 					{ content }

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -25,6 +25,10 @@ class ReadMore extends Component {
 			 */
 			content: props.children,
 			/**
+			 * Summary content generated from content HTML.
+			 */
+			summary: '.',
+			/**
 			 * Max height for a review.
 			 */
 			maxHeight: 0,
@@ -51,10 +55,12 @@ class ReadMore extends Component {
 				isExpanded: false,
 				isClamped: isClamped,
 			} );
+		}
+	}
 
-			if ( isClamped ) {
-				this.clampLines();
-			}
+	componentDidUpdate( prevProps, prevState ) {
+		if ( prevState.isClamped !== this.state.isClamped && this.state.isClamped ) {
+			this.clampLines();
 		}
 	}
 
@@ -75,13 +81,15 @@ class ReadMore extends Component {
 
 		while ( markers.start <= markers.end ) {
 			markers.middle = Math.floor( ( markers.start + markers.end ) / 2 );
-
-			this.reviewSummary.current.innerHTML = originalContent.slice( 0, markers.middle );
-
 			markers = this.moveMarkers( maxHeight, markers );
+
+			// We set the innerHTML directly in the DOM here so we can reliably check the clientHeight later in moveMarkers.
+			this.reviewSummary.current.innerHTML = originalContent.slice( 0, markers.middle );
 		}
 
-		this.reviewSummary.current.innerHTML = originalContent.slice( 0, markers.middle - 5 ) + ellipsis;
+		this.setState( {
+			summary: originalContent.slice( 0, markers.middle - 5 ) + ellipsis,
+		} );
 	}
 
 	moveMarkers( maxHeight, markers ) {
@@ -133,7 +141,7 @@ class ReadMore extends Component {
 
 	render() {
 		const { className } = this.props;
-		const { content, isClamped, isExpanded } = this.state;
+		const { content, summary, isClamped, isExpanded } = this.state;
 
 		if ( ! content ) {
 			return null;
@@ -157,9 +165,10 @@ class ReadMore extends Component {
 					style={ {
 						display: isExpanded && null !== isClamped ? 'none' : 'inherit',
 					} }
-				>
-					.
-				</div>
+					dangerouslySetInnerHTML={ {
+						__html: summary,
+					} }
+				/>
 				<div
 					ref={ this.reviewContent }
 					aria-hidden={ ! isExpanded }

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -41,10 +41,6 @@ class ReadMore extends Component {
 
 	componentDidMount() {
 		if ( this.props.children ) {
-			// Force elements to be displayed so we can get measurements.
-			this.reviewSummary.current.style.display = 'block';
-			this.reviewContent.current.style.display = 'block';
-
 			const { maxLines } = this.props;
 			const lineHeight = this.reviewSummary.current.clientHeight + 1;
 			const reviewHeight = this.reviewContent.current.clientHeight + 1;
@@ -167,7 +163,7 @@ class ReadMore extends Component {
 					ref={ this.reviewSummary }
 					aria-hidden={ isExpanded }
 					style={ {
-						display: isExpanded ? 'none' : 'inherit',
+						display: isExpanded && null !== isClamped ? 'none' : 'inherit',
 					} }
 				>
 					.
@@ -176,7 +172,7 @@ class ReadMore extends Component {
 					ref={ this.reviewContent }
 					aria-hidden={ ! isExpanded }
 					style={ {
-						display: ! isExpanded ? 'none' : 'inherit',
+						display: ! isExpanded && null !== isClamped ? 'none' : 'inherit',
 					} }
 				>
 					{ content }

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -120,26 +120,23 @@ class ReadMore extends Component {
 
 		return (
 			<div className={ className }>
-				<div
-					ref={ this.reviewSummary }
-					aria-hidden={ isExpanded }
-					style={ {
-						display: isExpanded && null !== clampEnabled ? 'none' : 'inherit',
-					} }
-					dangerouslySetInnerHTML={ {
-						__html: summary,
-					} }
-					data-testid="summary"
-				/>
-				<div
-					ref={ this.reviewContent }
-					aria-hidden={ ! isExpanded }
-					style={ {
-						display: ! isExpanded && null !== clampEnabled ? 'none' : 'inherit',
-					} }
-				>
-					{ content }
-				</div>
+				{ ( ! isExpanded || null === clampEnabled ) && (
+					<div
+						ref={ this.reviewSummary }
+						aria-hidden={ isExpanded }
+						dangerouslySetInnerHTML={ {
+							__html: summary,
+						} }
+					/>
+				) }
+				{ ( isExpanded || null === clampEnabled ) && (
+					<div
+						ref={ this.reviewContent }
+						aria-hidden={ ! isExpanded }
+					>
+						{ content }
+					</div>
+				) }
 				{ this.getButton() }
 			</div>
 		);

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -28,10 +28,6 @@ class ReadMore extends Component {
 			 * Summary content generated from content HTML.
 			 */
 			summary: '.',
-			/**
-			 * Max height for a review.
-			 */
-			maxHeight: 0,
 		};
 
 		this.reviewSummary = createRef();
@@ -51,16 +47,12 @@ class ReadMore extends Component {
 			const clampEnabled = reviewHeight > maxHeight;
 
 			this.setState( {
-				maxHeight: maxHeight,
-				isExpanded: false,
-				clampEnabled: clampEnabled,
+				clampEnabled,
 			} );
-		}
-	}
 
-	componentDidUpdate( prevProps, prevState ) {
-		if ( prevState.clampEnabled !== this.state.clampEnabled && this.state.clampEnabled ) {
-			this.clampLines();
+			if ( clampEnabled ) {
+				this.clampLines( maxHeight );
+			}
 		}
 	}
 
@@ -68,9 +60,8 @@ class ReadMore extends Component {
 	 * Clamp lines calculates the height of a line of text and then limits it to the
 	 * value of the lines prop. Content is updated once limited.
 	 */
-	clampLines() {
+	clampLines( maxHeight ) {
 		const { ellipsis } = this.props;
-		const { maxHeight } = this.state;
 		const originalContent = this.reviewContent.current.innerHTML;
 
 		let markers = {

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -30,7 +30,6 @@ class ReadMore extends Component {
 			maxHeight: 0,
 		};
 
-		this.maxHeight = 0;
 		this.reviewSummary = createRef();
 		this.reviewContent = createRef();
 		this.getButton = this.getButton.bind( this );

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -44,18 +44,17 @@ class ReadMore extends Component {
 			const lineHeight = this.reviewSummary.current.clientHeight + 1;
 			const reviewHeight = this.reviewContent.current.clientHeight + 1;
 			const maxHeight = ( lineHeight * maxLines ) + 1;
+			const isClamped = reviewHeight > maxHeight;
 
 			this.setState( {
 				maxHeight: maxHeight,
 				isExpanded: false,
-				isClamped: reviewHeight > maxHeight,
+				isClamped: isClamped,
 			} );
-		}
-	}
 
-	componentDidUpdate( prevProps, prevState ) {
-		if ( prevState.isClamped !== this.state.isClamped && this.state.isClamped ) {
-			this.clampLines();
+			if ( isClamped ) {
+				this.clampLines();
+			}
 		}
 	}
 

--- a/assets/js/components/read-more/index.js
+++ b/assets/js/components/read-more/index.js
@@ -75,14 +75,8 @@ class ReadMore extends Component {
 
 		while ( markers.start <= markers.end ) {
 			markers.middle = Math.floor( ( markers.start + markers.end ) / 2 );
-			this.reviewSummary.current.innerHTML = originalContent.slice( 0, markers.middle );
 
-			if ( markers.middle === originalContent.length ) {
-				this.setState( {
-					isClamped: false,
-				} );
-				return;
-			}
+			this.reviewSummary.current.innerHTML = originalContent.slice( 0, markers.middle );
 
 			markers = this.moveMarkers( maxHeight, markers );
 		}

--- a/assets/js/components/read-more/test/index.js
+++ b/assets/js/components/read-more/test/index.js
@@ -8,18 +8,16 @@ const longContent =
 	'<p>Morbi tristique iaculis felis, sed porta urna tincidunt vitae. Etiam nisl sem, eleifend non varius quis, placerat a arcu. Donec consectetur nunc at orci fringilla pulvinar. Nam hendrerit tellus in est aliquet varius id in diam. Donec eu ullamcorper ante. Ut ultricies, felis vel sodales aliquet, nibh massa vestibulum ipsum, sed dignissim mi nunc eget lacus. Curabitur mattis placerat magna a aliquam. Nullam diam elit, cursus nec erat ullamcorper, tempor eleifend mauris. Nunc placerat nunc ut enim ornare tempus. Fusce porta molestie ante eget faucibus. Fusce eu lectus sit amet diam auctor lacinia et in diam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Mauris eu lacus lobortis, faucibus est vel, pulvinar odio. Duis feugiat tortor quis dui euismod varius.</p>';
 
 describe( 'ReadMore Component', () => {
-	describe( 'truncateHtml function', () => {
-		describe( 'test', () => {
-			it( 'Truncate long HTML content to length of 10', async () => {
-				const truncatedContent = truncateHtml( longContent, 10 );
+	describe( 'Test the truncateHtml function', () => {
+		it( 'Truncate long HTML content to length of 10', async () => {
+			const truncatedContent = truncateHtml( longContent, 10 );
 
-				expect( truncatedContent ).toEqual( '<p>Lorem ipsum...</p>' );
-			} );
-			it( 'Truncate long HTML content, but avoid cutting off HTML tags.', async () => {
-				const truncatedContent = truncateHtml( longContent, 40 );
+			expect( truncatedContent ).toEqual( '<p>Lorem ipsum...</p>' );
+		} );
+		it( 'Truncate long HTML content, but avoid cutting off HTML tags.', async () => {
+			const truncatedContent = truncateHtml( longContent, 40 );
 
-				expect( truncatedContent ).toEqual( '<p>Lorem ipsum dolor sit amet, <strong>consectetur...</strong></p>' );
-			} );
+			expect( truncatedContent ).toEqual( '<p>Lorem ipsum dolor sit amet, <strong>consectetur...</strong></p>' );
 		} );
 	} );
 } );

--- a/assets/js/components/read-more/test/index.js
+++ b/assets/js/components/read-more/test/index.js
@@ -2,6 +2,8 @@
  * Internal dependencies
  */
 import { truncateHtml } from '../utils';
+const shortContent =
+	'<p>Lorem ipsum dolor sit amet, <strong>consectetur.</strong>.</p>';
 
 const longContent =
 	'<p>Lorem ipsum dolor sit amet, <strong>consectetur adipiscing elit. Nullam a condimentum diam.</strong> Donec finibus enim eros, et lobortis magna varius quis. Nulla lacinia tellus ac neque aliquet, in porttitor metus interdum. Maecenas vestibulum nisi et auctor vestibulum. Maecenas vehicula, lacus et pellentesque tempor, orci nulla mattis purus, id porttitor augue magna et metus. Aenean hendrerit aliquet massa ac convallis. Mauris vestibulum neque in condimentum porttitor. Donec viverra, orci a accumsan vehicula, dui massa lobortis lorem, et cursus est purus pulvinar elit. Vestibulum vitae tincidunt ex, ut vulputate nisi.</p>' +
@@ -18,6 +20,11 @@ describe( 'ReadMore Component', () => {
 			const truncatedContent = truncateHtml( longContent, 40 );
 
 			expect( truncatedContent ).toEqual( '<p>Lorem ipsum dolor sit amet, <strong>consectetur...</strong></p>' );
+		} );
+		it( 'No need to truncate short HTML content.', async () => {
+			const truncatedContent = truncateHtml( shortContent, 100 );
+
+			expect( truncatedContent ).toEqual( '<p>Lorem ipsum dolor sit amet, <strong>consectetur.</strong>.</p>' );
 		} );
 	} );
 } );

--- a/assets/js/components/read-more/test/index.js
+++ b/assets/js/components/read-more/test/index.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { truncateHtml } from '../utils';
+
+const longContent =
+	'<p>Lorem ipsum dolor sit amet, <strong>consectetur adipiscing elit. Nullam a condimentum diam.</strong> Donec finibus enim eros, et lobortis magna varius quis. Nulla lacinia tellus ac neque aliquet, in porttitor metus interdum. Maecenas vestibulum nisi et auctor vestibulum. Maecenas vehicula, lacus et pellentesque tempor, orci nulla mattis purus, id porttitor augue magna et metus. Aenean hendrerit aliquet massa ac convallis. Mauris vestibulum neque in condimentum porttitor. Donec viverra, orci a accumsan vehicula, dui massa lobortis lorem, et cursus est purus pulvinar elit. Vestibulum vitae tincidunt ex, ut vulputate nisi.</p>' +
+	'<p>Morbi tristique iaculis felis, sed porta urna tincidunt vitae. Etiam nisl sem, eleifend non varius quis, placerat a arcu. Donec consectetur nunc at orci fringilla pulvinar. Nam hendrerit tellus in est aliquet varius id in diam. Donec eu ullamcorper ante. Ut ultricies, felis vel sodales aliquet, nibh massa vestibulum ipsum, sed dignissim mi nunc eget lacus. Curabitur mattis placerat magna a aliquam. Nullam diam elit, cursus nec erat ullamcorper, tempor eleifend mauris. Nunc placerat nunc ut enim ornare tempus. Fusce porta molestie ante eget faucibus. Fusce eu lectus sit amet diam auctor lacinia et in diam. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Mauris eu lacus lobortis, faucibus est vel, pulvinar odio. Duis feugiat tortor quis dui euismod varius.</p>';
+
+describe( 'ReadMore Component', () => {
+	describe( 'truncateHtml function', () => {
+		describe( 'test', () => {
+			it( 'Truncate long HTML content to length of 10', async () => {
+				const truncatedContent = truncateHtml( longContent, 10 );
+
+				expect( truncatedContent ).toEqual( '<p>Lorem i' );
+			} );
+			it( 'Truncate long HTML content, but avoid cutting off HTML tags.', async () => {
+				const truncatedContent = truncateHtml( longContent, 35 );
+
+				expect( truncatedContent ).toEqual( '<p>Lorem ipsum dolor sit amet, ' );
+			} );
+		} );
+	} );
+} );

--- a/assets/js/components/read-more/test/index.js
+++ b/assets/js/components/read-more/test/index.js
@@ -13,12 +13,12 @@ describe( 'ReadMore Component', () => {
 			it( 'Truncate long HTML content to length of 10', async () => {
 				const truncatedContent = truncateHtml( longContent, 10 );
 
-				expect( truncatedContent ).toEqual( '<p>Lorem i' );
+				expect( truncatedContent ).toEqual( '<p>Lorem ipsum...</p>' );
 			} );
 			it( 'Truncate long HTML content, but avoid cutting off HTML tags.', async () => {
-				const truncatedContent = truncateHtml( longContent, 35 );
+				const truncatedContent = truncateHtml( longContent, 40 );
 
-				expect( truncatedContent ).toEqual( '<p>Lorem ipsum dolor sit amet, ' );
+				expect( truncatedContent ).toEqual( '<p>Lorem ipsum dolor sit amet, <strong>consectetur...</strong></p>' );
 			} );
 		} );
 	} );

--- a/assets/js/components/read-more/utils.js
+++ b/assets/js/components/read-more/utils.js
@@ -1,11 +1,19 @@
+import trimHtml from 'trim-html';
+
 /**
  * Truncate some HTML content to a given length.
  *
  * @param {string} html HTML that will be truncated.
  * @param {int} length Legth to truncate the string to.
+ * @param {string} ellipsis Character to append to truncated content.
  */
-export const truncateHtml = ( html, length ) => {
-	return html.slice( 0, length );
+export const truncateHtml = ( html, length, ellipsis = '...' ) => {
+	const trimmed = trimHtml( html, {
+		suffix: ellipsis,
+		limit: length,
+	} );
+
+	return trimmed.html;
 };
 
 /**
@@ -18,10 +26,10 @@ export const truncateHtml = ( html, length ) => {
  * @param {string} ellipsis Character to append to clamped content.
  * @return {string} clamped content
  */
-export const clampLines = ( originalContent, targetElement, maxHeight, ellipsis = '&hellip;' ) => {
+export const clampLines = ( originalContent, targetElement, maxHeight, ellipsis ) => {
 	const length = calculateLength( originalContent, targetElement, maxHeight );
 
-	return truncateHtml( originalContent, ( length - ellipsis.length ) ) + ellipsis;
+	return truncateHtml( originalContent, length, ellipsis );
 };
 
 /**

--- a/assets/js/components/read-more/utils.js
+++ b/assets/js/components/read-more/utils.js
@@ -1,0 +1,68 @@
+/**
+ * Truncate some HTML content to a given length.
+ *
+ * @param {string} html HTML that will be truncated.
+ * @param {int} length Legth to truncate the string to.
+ */
+export const truncateHtml = ( html, length ) => {
+	return html.slice( 0, length );
+};
+
+/**
+ * Clamp lines calculates the height of a line of text and then limits it to the
+ * value of the lines prop. Content is updated once limited.
+ *
+ * @param {string} originalContent Content to be clamped.
+ * @param {object} targetElement Element which will contain the clamped content.
+ * @param {integer} maxHeight Max height of the clamped content.
+ * @param {string} ellipsis Character to append to clamped content.
+ * @return {string} clamped content
+ */
+export const clampLines = ( originalContent, targetElement, maxHeight, ellipsis = '&hellip;' ) => {
+	const length = calculateLength( originalContent, targetElement, maxHeight );
+
+	return truncateHtml( originalContent, ( length - ellipsis.length ) ) + ellipsis;
+};
+
+/**
+ * Calculate how long the content can be based on the maximum number of lines allowed, and client height.
+ *
+ * @param {string} originalContent Content to be clamped.
+ * @param {object} targetElement Element which will contain the clamped content.
+ * @param {integer} maxHeight Max height of the clamped content.
+ */
+const calculateLength = ( originalContent, targetElement, maxHeight ) => {
+	let markers = {
+		start: 0,
+		middle: 0,
+		end: originalContent.length,
+	};
+
+	while ( markers.start <= markers.end ) {
+		markers.middle = Math.floor( ( markers.start + markers.end ) / 2 );
+
+		// We set the innerHTML directly in the DOM here so we can reliably check the clientHeight later in moveMarkers.
+		targetElement.innerHTML = truncateHtml( originalContent, markers.middle );
+
+		markers = moveMarkers( markers, targetElement.clientHeight, maxHeight );
+	}
+
+	return markers.middle;
+};
+
+/**
+ * Move string markers. Used by calculateLength.
+ *
+ * @param {object} markers Markers for clamped content.
+ * @param {integer} currentHeight Current height of clamped content.
+ * @param {integer} maxHeight Max height of the clamped content.
+ */
+const moveMarkers = ( markers, currentHeight, maxHeight ) => {
+	if ( currentHeight <= maxHeight ) {
+		markers.start = markers.middle + 1;
+	} else {
+		markers.end = markers.middle - 1;
+	}
+
+	return markers;
+};

--- a/assets/js/components/read-more/utils.js
+++ b/assets/js/components/read-more/utils.js
@@ -29,7 +29,7 @@ export const truncateHtml = ( html, length, ellipsis = '...' ) => {
 export const clampLines = ( originalContent, targetElement, maxHeight, ellipsis ) => {
 	const length = calculateLength( originalContent, targetElement, maxHeight );
 
-	return truncateHtml( originalContent, length, ellipsis );
+	return truncateHtml( originalContent, length - ellipsis.length, ellipsis );
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -7526,8 +7526,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7548,14 +7547,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7570,20 +7567,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7700,8 +7694,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7713,7 +7706,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7728,7 +7720,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7736,14 +7727,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7762,7 +7751,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7843,8 +7831,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7856,7 +7843,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7942,8 +7928,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7979,7 +7964,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7999,7 +7983,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8043,14 +8026,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11361,8 +11342,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11383,14 +11363,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11405,20 +11383,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11535,8 +11510,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11548,7 +11522,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11563,7 +11536,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11571,14 +11543,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11597,7 +11567,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11685,8 +11654,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11698,7 +11666,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11784,8 +11751,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11821,7 +11787,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11841,7 +11806,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11885,14 +11849,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -21255,6 +21217,11 @@
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
       "dev": true
+    },
+    "trim-html": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/trim-html/-/trim-html-0.1.9.tgz",
+      "integrity": "sha1-puYK1yFeItozcOR7bDRTp8ydSz4="
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
   },
   "dependencies": {
     "@woocommerce/components": "3.1.0",
-    "gridicons": "3.3.1"
+    "gridicons": "3.3.1",
+    "trim-html": "^0.1.9"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Improves ReadMore in the following ways:

- Supports passing in nodes. In the case of reviews, it's down with dangerous set HTML outside the context of this component.
- Renders content and a summary div. Visibility is toggled.
- The summary is generated from the full content after rendering - this allows us to work with strings and append the elipses
- Clamping only needs to happen once, if the review is long, after the component is mounted