### PR TITLE
Use withProduct HOC in ReviewsByProductEditor

### DIFF
--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -298,12 +298,12 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 		return renderApiError();
 	}
 
-	if ( ( productId && ! product ) || isLoading ) {
-		return renderLoadingScreen();
-	}
-
 	if ( ! productId || editMode ) {
 		return renderEditMode();
+	}
+
+	if ( ! product || isLoading ) {
+		return renderLoadingScreen();
 	}
 
 	return (

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -13,6 +13,7 @@ import {
 	Placeholder,
 	RangeControl,
 	SelectControl,
+	Spinner,
 	ToggleControl,
 	Toolbar,
 	withSpokenMessages,
@@ -28,13 +29,14 @@ import { getAdminLink } from '@woocommerce/navigation';
 /**
  * Internal dependencies
  */
+import ApiErrorPlaceholder from '../../components/api-error-placeholder';
 import Block from './block.js';
 import ProductControl from '../../components/product-control';
 import ToggleButtonControl from '../../components/toggle-button-control';
 import { IconReviewsByProduct } from '../../components/icons';
 import { withProduct } from '../../hocs';
 
-const ReviewsByProductEditor = ( { attributes, debouncedSpeak, product, setAttributes } ) => {
+const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct, isLoading, product, setAttributes } ) => {
 	const { className, editMode, productId, showReviewDate, showReviewerName } = attributes;
 
 	const getBlockControls = () => (
@@ -192,6 +194,27 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, product, setAttri
 		);
 	};
 
+	const renderApiError = () => (
+		<ApiErrorPlaceholder
+			className="wc-block-featured-product-error"
+			error={ error }
+			isLoading={ isLoading }
+			onRetry={ getProduct }
+		/>
+	);
+
+	const renderLoadingScreen = () => {
+		return (
+			<Placeholder
+				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
+				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
+				className="wc-block-reviews-by-product"
+			>
+				<Spinner />
+			</Placeholder>
+		);
+	};
+
 	const renderEditMode = () => {
 		const onDone = () => {
 			setAttributes( { editMode: false } );
@@ -270,6 +293,14 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, product, setAttri
 			</Fragment>
 		);
 	};
+
+	if ( error ) {
+		return renderApiError();
+	}
+
+	if ( ( productId && ! product ) || isLoading ) {
+		return renderLoadingScreen();
+	}
 
 	if ( ! productId || editMode ) {
 		return renderEditMode();


### PR DESCRIPTION
Part of #658.

This PR:
* Updates `<ReviewsByProductEditor>` so it uses the `withProduct()` HOC introduced in #779.
* Refactors `<ReviewsByProductEditor>` to a functional component.
* Adds a loading and error state to that block.

### How to test the changes in this Pull Request:

1. Create a post and add a _Reviews by Product_ block.
2. Select a product and verify everything works as usual.
3. Reload the page and verify a loading state is shown while loading product data.
4. Modify [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/Controllers/Products.php#L101) as follows:
```diff
-if ( ! \current_user_can( 'edit_posts' ) ) {
+if ( true ) {
```
5. Verify the block correctly displays the error.
