### PR TITLE
Reviews: only save wrapper element to post

### DIFF
--- a/assets/js/blocks/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews-by-product/index.js
@@ -12,7 +12,6 @@ import './style.scss';
 import './editor.scss';
 import Editor from './edit';
 import { IconReviewsByProduct } from '../../components/icons';
-import { renderReview } from './utils';
 
 /**
  * Register and run the "Reviews by Product" block.
@@ -155,11 +154,7 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 		};
 
 		return (
-			<div className={ classes } { ...data }>
-				<ul className="wc-block-reviews-by-product__list">
-					{ renderReview( attributes ) }
-				</ul>
-			</div>
+			<div className={ classes } { ...data } />
 		);
 	},
 } );


### PR DESCRIPTION
Part of #658.

This should prevent reviews blocks being invalidated when the review markup changes.

### How to test the changes in this Pull Request:

1. Create a post with a _Reviews by Product_ block.
2. Reload the post.
3. Verify the block is still there and without errors.
4. Preview the post and verify it renders correctly there too.