### PR TITLE
Add bundlesize configuration for css

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -7,6 +7,10 @@
     {
       "path": "./build/frontend*.js",
       "maxSize": "130 kB"
+    },
+    {
+      "path": "./build/*.css",
+      "maxSize": "100kB"
     }
   ]
 }


### PR DESCRIPTION
This pull is a test/build environment update only.  It adds configuration to report the bundle size of built css files in pulls.