### PR TITLE
Product Categories List: prevent importing all HOCs and import only withComponentId

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { withComponentId } from '../../hocs';
+import withComponentId from '../../hocs/with-component-id';
 
 /**
  * Component displaying the categories as dropdown or list.


### PR DESCRIPTION
Same as #811 for _Product Categories List_ block.

This PR fixes and issue that made the frontend of _Product Categories List_ to import the dependencies of all HOCs even though it was only using `withComponentId`.

### How to test the changes in this Pull Request:

Open `/build/frontend.deps.json` and verify we are not importing unnecessary dependencies.
```diff
-["lodash","react","react-dom","wp-api-fetch","wp-compose","wp-element","wp-i18n","wp-polyfill","wp-url"]
+["react","react-dom","wp-i18n","wp-polyfill"]
```