### PR TITLE
Make react-test-renderer import name consistent between tests

### DIFF
--- a/assets/js/components/product-preview/test/index.js
+++ b/assets/js/components/product-preview/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
+import TestRenderer from 'react-test-renderer';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ describe( 'ProductPreview', () => {
 				},
 			],
 		};
-		const component = renderer.create( <ProductPreview product={ product } /> );
+		const component = TestRenderer.create( <ProductPreview product={ product } /> );
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
@@ -33,7 +33,7 @@ describe( 'ProductPreview', () => {
 				'<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">&#36;</span>65.00</span>',
 			images: [],
 		};
-		const component = renderer.create( <ProductPreview product={ product } /> );
+		const component = TestRenderer.create( <ProductPreview product={ product } /> );
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
Tiny improvement I found while debugging #823. In some places we were importing `react-test-renderer` as `TestRenderer` and in another one as `renderer`.

Considering [in the docs they use `TestRenderer`](https://reactjs.org/docs/test-renderer.html), I think it makes sense unifying all imports to that name.

### How to test the changes in this Pull Request:

1. Run `npm run test` and verify all tests pass.