### PR TITLE
Add babel-plugin-transform-remove-prop-types Babel plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6473,6 +6473,12 @@
         "babel-runtime": "^6.22.0"
       }
     },
+    "babel-plugin-transform-react-remove-prop-types": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+      "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
+      "dev": true
+    },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "babel-plugin-transform-async-generator-functions": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-plugin-transform-react-jsx": "6.24.1",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "babel-plugin-transform-runtime": "6.23.0",
     "babel-preset-env": "1.7.0",
     "bundlesize": "0.18.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,7 +105,7 @@ const GutenbergBlocksConfig = {
 				use: {
 					loader: 'babel-loader?cacheDirectory',
 					options: {
-						presets: [ '@wordpress/default' ],
+						presets: [ '@wordpress/babel-preset-default' ],
 					},
 				},
 			},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,9 @@ const GutenbergBlocksConfig = {
 					loader: 'babel-loader?cacheDirectory',
 					options: {
 						presets: [ '@wordpress/babel-preset-default' ],
+						plugins: [
+							NODE_ENV === 'production' ? require.resolve( 'babel-plugin-transform-react-remove-prop-types' ) : false,
+						].filter( Boolean ),
 					},
 				},
 			},
@@ -174,6 +177,7 @@ const BlocksFrontendConfig = {
 							require.resolve( '@babel/plugin-transform-react-jsx' ),
 							require.resolve( '@babel/plugin-proposal-async-generator-functions' ),
 							require.resolve( '@babel/plugin-transform-runtime' ),
+							NODE_ENV === 'production' ? require.resolve( 'babel-plugin-transform-react-remove-prop-types' ) : false,
 						].filter( Boolean ),
 					},
 				},


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This babel plugin will remove prop-types from production builds (prop-types remain in developer builds) bringing some file size savings.  The file-size savings are minimal but could add up over time.

Changes in file size on production builds:

| File Name | Before | After |
| ---- | ---- | ---- |
| blocks.js | 7.89KiB | 7.83KiB |
| editor.js | 77b | 77 |
| featured-category.js | 18.7 KiB | 18.3 |
| handpicked-products.js | 23.7 KiB | 23 |
| product-best-sellers.js | 15KiB |  14.3 |
| product-categories.js | 17.3 KiB | 17.2 |
| product-category.js | 19.7 KiB | 18.9 |
| product-new.js | 20.5 KiB | 19.7 |
| product-on-sale.js | 16.2 KiB | 15.4 |
| product-search.js | 6.51 KiB | 6.39 |
| product-tag.js | 18.5 KiB | 17.7 |
| product-top-rated.js | 14.9 KiB | 14.2 |
| products-by-attribute.js | 19.3 KiB | 18.5 |
| frontend.js | 8.93KiB | 8.93 |

### How to test the changes in this Pull Request:

This affects any production builds because the plugin does remove any prop-type definitions.  So there should be a run through of each block type inserted/edited in posts to ensure there's no console errors.  Any issues _should_ surface immediately as they would typically be syntax type errors.

<!-- If you can, add the appropriate labels -->

### Changelog

> Enhancement: Remove prop-type implemention on release builds to reduce bundle size.
