### PR TITLE
Fix bundlesize config not picking frontend files

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -5,7 +5,7 @@
       "maxSize": "300 kB"
     },
     {
-      "path": "./build/frontend*.js",
+      "path": "./build/*frontend*.js",
       "maxSize": "130 kB"
     },
     {


### PR DESCRIPTION
In the reviews branch we didn't have a `frontend.js` file but `*-frontend.js`, this PR fixes bundlesize config so it picks those files correctly.

### How to test the changes in this Pull Request:

1. Run `npm run build && npm run size-check` and verify there are no error.
2. Notice Travis is green.