### PR TITLE
Fix duplicated translatable string

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -219,7 +219,7 @@ class FeaturedCategory extends Component {
 				className="wc-block-featured-category"
 			>
 				{ __(
-					'Visually highlight a product category and encourage prompt action',
+					'Visually highlight a product category and encourage prompt action.',
 					'woo-gutenberg-products-block'
 				) }
 				<div className="wc-block-featured-category__selection">

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -119,7 +119,7 @@ class ProductsBlock extends Component {
 				className="wc-block-products-grid wc-block-handpicked-products"
 			>
 				{ __(
-					'Display a selection of hand-picked products in a grid',
+					'Display a selection of hand-picked products in a grid.',
 					'woo-gutenberg-products-block'
 				) }
 				<div className="wc-block-handpicked-products__selection">

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -178,7 +178,7 @@ class ProductByCategoryBlock extends Component {
 				className="wc-block-products-grid wc-block-products-category"
 			>
 				{ __(
-					'Display a grid of products from your selected categories',
+					'Display a grid of products from your selected categories.',
 					'woo-gutenberg-products-block'
 				) }
 				<div className="wc-block-products-category__selection">

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -174,7 +174,7 @@ class ProductsByTagBlock extends Component {
 				className="wc-block-products-grid wc-block-product-tag"
 			>
 				{ __(
-					'Display a grid of products from your selected tags',
+					'Display a grid of products from your selected tags.',
 					'woo-gutenberg-products-block'
 				) }
 				<div className="wc-block-product-tag__selection">

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -22,7 +22,7 @@ registerBlockType( 'woocommerce/product-tag', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a grid of products from selected tags.',
+		'Display a grid of products from your selected tags.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {


### PR DESCRIPTION
We need to avoid cases of duplicated translatable string like that:

![Screenshot from 2019-08-12 18-31-58](https://user-images.githubusercontent.com/1264099/62900048-7e349a80-bd2f-11e9-8425-6fae72027fa5.png)

Those cause gave more work for contributors to help, also may got different translations because of multiple contributors, what may be confusion. This is something that we do on WooCommerce core following efforts of the Polyglots community did for WordPress core.

Also some other blocks already uses `.` at the end of the descriptions, so probably easy to just make it as an standard, if not will require change in the `index.js` for each block.