### PR TITLE
Remove screen-reader-text css rules

### DIFF
--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -37,9 +37,6 @@
 		fill: currentColor;
 		outline: none;
 	}
-	.screen-reader-text {
-		height: auto;
-	}
 	&:active {
 		color: currentColor;
 	}

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -25,9 +25,6 @@
 			fill: currentColor;
 			outline: none;
 		}
-		.screen-reader-text {
-			height: auto;
-		}
 		&:active {
 			color: currentColor;
 		}


### PR DESCRIPTION
Removes screen reader text css rules for buttons.

Fixes #837

Confirmed these rules are unused. We don't show screen reader text in buttons.

### Changelog

> Removed unused screen-reader-text css styles for buttons which caused some theme conflicts.
