### PR TITLE
Install @babel/plugin-proposal-class-properties.

### DIFF
--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -30,16 +30,27 @@ import ProductOrderbyControl from '../../components/product-orderby-control';
  * Component to handle edit mode of "Products by Category".
  */
 class ProductByCategoryBlock extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			changedAttributes: {},
-			isEditing: false,
-		};
-		this.startEditing = this.startEditing.bind( this );
-		this.stopEditing = this.stopEditing.bind( this );
-		this.setChangedAttributes = this.setChangedAttributes.bind( this );
-		this.save = this.save.bind( this );
+	static propTypes = {
+		/**
+		 * The attributes for this block
+		 */
+		attributes: PropTypes.object.isRequired,
+		/**
+		 * The register block name.
+		 */
+		name: PropTypes.string.isRequired,
+		/**
+		 * A callback to update attributes
+		 */
+		setAttributes: PropTypes.func.isRequired,
+
+		// from withSpokenMessages
+		debouncedSpeak: PropTypes.func.isRequired,
+	}
+
+	state = {
+		changedAttributes: {},
+		isEditing: false,
 	}
 
 	componentDidMount() {
@@ -51,27 +62,27 @@ class ProductByCategoryBlock extends Component {
 		}
 	}
 
-	startEditing() {
+	startEditing = () => {
 		this.setState( {
 			isEditing: true,
 			changedAttributes: {},
 		} );
 	}
 
-	stopEditing() {
+	stopEditing = () => {
 		this.setState( {
 			isEditing: false,
 			changedAttributes: {},
 		} );
 	}
 
-	setChangedAttributes( attributes ) {
+	setChangedAttributes = ( attributes ) => {
 		this.setState( ( prevState ) => {
 			return { changedAttributes: { ...prevState.changedAttributes, ...attributes } };
 		} );
 	}
 
-	save() {
+	save = () => {
 		const { changedAttributes } = this.state;
 		const { setAttributes } = this.props;
 
@@ -253,23 +264,5 @@ class ProductByCategoryBlock extends Component {
 		);
 	}
 }
-
-ProductByCategoryBlock.propTypes = {
-	/**
-	 * The attributes for this block
-	 */
-	attributes: PropTypes.object.isRequired,
-	/**
-	 * The register block name.
-	 */
-	name: PropTypes.string.isRequired,
-	/**
-	 * A callback to update attributes
-	 */
-	setAttributes: PropTypes.func.isRequired,
-
-	// from withSpokenMessages
-	debouncedSpeak: PropTypes.func.isRequired,
-};
 
 export default withSpokenMessages( ProductByCategoryBlock );

--- a/package-lock.json
+++ b/package-lock.json
@@ -317,6 +317,48 @@
         }
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
+      "integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.5.5",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.5.5",
+        "@babel/helper-split-export-declaration": "^7.4.4"
+      },
+      "dependencies": {
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+          "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.4"
+          }
+        },
+        "@babel/types": {
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
+          "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
     "@babel/helper-define-map": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.5.5.tgz",
@@ -842,6 +884,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.1.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
+      "integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.5.5",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
   },
   "devDependencies": {
     "@babel/core": "7.5.5",
-    "@woocommerce/navigation": "2.1.1",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@octokit/rest": "16.28.7",
+	"@woocommerce/navigation": "2.1.1",
     "@wordpress/babel-preset-default": "4.4.0",
     "@wordpress/blocks": "6.5.0",
     "@wordpress/browserslist-config": "2.6.0",

--- a/tests/js/jestPreprocess.js
+++ b/tests/js/jestPreprocess.js
@@ -1,5 +1,6 @@
 const babelOptions = {
 	presets: [ '@wordpress/babel-preset-default' ],
+	plugins: [ '@babel/plugin-proposal-class-properties' ],
 };
 
 module.exports = require( 'babel-jest' ).createTransformer( babelOptions );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,6 +113,7 @@ const GutenbergBlocksConfig = {
 						presets: [ '@wordpress/babel-preset-default' ],
 						plugins: [
 							NODE_ENV === 'production' ? require.resolve( 'babel-plugin-transform-react-remove-prop-types' ) : false,
+							require.resolve( '@babel/plugin-proposal-class-properties' ),
 						].filter( Boolean ),
 					},
 				},
@@ -190,6 +191,7 @@ const BlocksFrontendConfig = {
 							require.resolve( '@babel/plugin-transform-react-jsx' ),
 							require.resolve( '@babel/plugin-proposal-async-generator-functions' ),
 							require.resolve( '@babel/plugin-transform-runtime' ),
+							require.resolve( '@babel/plugin-proposal-class-properties' ),
 							NODE_ENV === 'production' ? require.resolve( 'babel-plugin-transform-react-remove-prop-types' ) : false,
 						].filter( Boolean ),
 					},


### PR DESCRIPTION
This pull adds the `@babel/plugin-proposal-class-properties` babel plugin so that we can write classes using the new class fields/properties syntax.  You can read an overview of this [here](https://codeburst.io/use-class-properties-to-clean-up-your-classes-and-react-components-93185879f688)

Some advantages:

- more concise code
- PropTypes can be declared as static fields inside the class. Scanning is thus quicker.
- Less worry about forgetting to bind class methods to ensure `this` is the right context within the method (just declare the method as a field property of the class).
- following this convention will help spot "no-nos" when/if side-effects are done inside the constructor.  Feasibly, implementing this convention means there should never be need for a constructor in react component classes.

As a part of this pull I refactored the `ProductByCategoryBlock` component so it uses the class properties syntax.  I don't think we need to go through and refactor all the components, we can just do them as we touch them.

I verified that this has no impact on build size.  The final `product-category.js` bundle is the same after implementation as before implementation.
### How to test the changes in this Pull Request:

1. Changes impact _Products by Category_ block so that should be smoke tested to ensure there are no errors and it works consistent as master.
2. Verify unit tests pass (should pass in travis).

### Changelog

> Implement `@babel/plugin-proposal-class-properties` babel plugin.  This allows for using the ES6 class property syntax for all classes.
