### PR TITLE
Use correct parameter order for implode.

### DIFF
--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -152,7 +152,7 @@ class FeaturedCategory extends AbstractDynamicBlock {
 			$classes[] = $attributes['className'];
 		}
 
-		return implode( $classes, ' ' );
+		return implode( ' ', $classes );
 	}
 
 	/**

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -168,7 +168,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 			$classes[] = $attributes['className'];
 		}
 
-		return implode( $classes, ' ' );
+		return implode( ' ', $classes );
 	}
 
 	/**


### PR DESCRIPTION
Solves deprecation notice in PHP 7.4
See https://www.php.net/manual/en/function.implode.php
and https://wiki.php.net/rfc/deprecations_php_7_4

### How to test the changes in this Pull Request:

1. Install PHP 7.4
2. Add Featured product or category block
3. ensure no error happen

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix Deprecations notices with PHP 7.4


