### PR TITLE
Fix Reviews by Product using rating count instead of review count

### DIFF
--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -70,21 +70,21 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 					_n(
 						'%d Review',
 						'%d Reviews',
-						item.rating_count,
+						item.review_count,
 						'woo-gutenberg-products-block'
 					),
-					item.rating_count
+					item.review_count
 				) }
 				showCount
 				aria-label={ sprintf(
 					_n(
 						'%s, has %d review',
 						'%s, has %d reviews',
-						item.rating_count,
+						item.review_count,
 						'woo-gutenberg-products-block'
 					),
 					item.name,
-					item.rating_count
+					item.review_count
 				) }
 			/>
 		);
@@ -275,7 +275,7 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 
 		return (
 			<Fragment>
-				{ product.rating_count === 0 ? (
+				{ product.review_count === 0 ? (
 					<Placeholder
 						className="wc-block-reviews-by-product"
 						icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
@@ -340,7 +340,7 @@ ReviewsByProductEditor.propTypes = {
 	isLoading: PropTypes.bool,
 	product: PropTypes.shape( {
 		name: PropTypes.node,
-		rating_count: PropTypes.number,
+		review_count: PropTypes.number,
 	} ),
 	// from withSpokenMessages
 	debouncedSpeak: PropTypes.func.isRequired,

--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -207,7 +207,7 @@ class Products extends WC_REST_Products_Controller {
 			'price_html'     => $product->get_price_html(),
 			'images'         => $this->get_images( $product ),
 			'average_rating' => $product->get_average_rating(),
-			'rating_count'   => $product->get_rating_count(),
+			'review_count'   => $product->get_review_count(),
 		);
 	}
 
@@ -359,7 +359,7 @@ class Products extends WC_REST_Products_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'rating_count'   => array(
+				'review_count'   => array(
 					'description' => __( 'Amount of reviews that the product has.', 'woo-gutenberg-products-block' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),


### PR DESCRIPTION
### Screenshots

<img src="https://user-images.githubusercontent.com/3616980/63008451-f069c400-be82-11e9-9143-d409c8dbed2c.png" width="439" alt="Screenshot" />

### How to test the changes in this Pull Request:

1. Create a review without rating (you might need to modify your settings in _WooCommerce_ > _Settings_ > _Products_ > _General_ > _Product ratings_).
2. Create a post with a _Reviews by Product_ block.
3. Verify the counters when selecting a product correctly show the number of reviews each product has.
