### PR TITLE
Improve Reviews by Product accessibility

### DIFF
--- a/assets/js/base/components/load-more-button/index.js
+++ b/assets/js/base/components/load-more-button/index.js
@@ -33,8 +33,8 @@ export const LoadMoreButton = ( { onClick, label, screenReaderLabel } ) => {
 };
 
 LoadMoreButton.propTypes = {
-	onClick: PropTypes.func.isRequired,
 	label: PropTypes.string,
+	onClick: PropTypes.func,
 	screenReaderLabel: PropTypes.string,
 };
 

--- a/assets/js/base/components/load-more-button/index.js
+++ b/assets/js/base/components/load-more-button/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -9,17 +10,36 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 
-export const LoadMoreButton = ( { onClick } ) => (
-	<button
-		className="wc-block-load-more"
-		onClick={ onClick }
-	>
-		{ __( 'Load more', 'woo-gutenberg-products-block' ) }
-	</button>
-);
+export const LoadMoreButton = ( { onClick, label, screenReaderLabel } ) => {
+	const labelNode = ( screenReaderLabel && label !== screenReaderLabel ) ? (
+		<Fragment>
+			<span aria-hidden>
+				{ label }
+			</span>
+			<span className="screen-reader-text">
+				{ screenReaderLabel }
+			</span>
+		</Fragment>
+	) : label;
+
+	return (
+		<button
+			className="wc-block-load-more"
+			onClick={ onClick }
+		>
+			{ labelNode }
+		</button>
+	);
+};
 
 LoadMoreButton.propTypes = {
-	onClick: PropTypes.func,
+	onClick: PropTypes.func.isRequired,
+	label: PropTypes.string,
+	screenReaderLabel: PropTypes.string,
+};
+
+LoadMoreButton.defaultProps = {
+	label: __( 'Load more', 'woo-gutenberg-products-block' ),
 };
 
 export default LoadMoreButton;

--- a/assets/js/base/components/review-order-select/index.js
+++ b/assets/js/base/components/review-order-select/index.js
@@ -15,7 +15,12 @@ const ReviewOrderSelect = ( { componentId, onChange, readOnly, value } ) => {
 	return (
 		<p className="wc-block-review-order-select">
 			<label className="wc-block-review-order-select__label" htmlFor={ selectId }>
-				{ __( 'Order by', 'woo-gutenberg-products-block' ) }
+				<span aria-hidden>
+					{ __( 'Order by', 'woo-gutenberg-products-block' ) }
+				</span>
+				<span className="screen-reader-text">
+					{ __( 'Order reviews by', 'woo-gutenberg-products-block' ) }
+				</span>
 			</label>
 			<select // eslint-disable-line jsx-a11y/no-onchange
 				id={ selectId }

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/editor';
 import {
 	Button,
+	Disabled,
 	Notice,
 	PanelBody,
 	Placeholder,
@@ -292,9 +293,11 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 						} } />
 					</Placeholder>
 				) : (
-					<div className={ classes }>
-						<EditorBlock attributes={ attributes } />
-					</div>
+					<Disabled>
+						<div className={ classes }>
+							<EditorBlock attributes={ attributes } />
+						</div>
+					</Disabled>
 				) }
 			</Fragment>
 		);

--- a/assets/js/blocks/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews-by-product/editor-block.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
@@ -85,7 +86,9 @@ class EditorBlock extends Component {
 					reviews={ reviews }
 				/>
 				{ ( attributes.showLoadMore && totalReviews > reviews.length ) && (
-					<LoadMoreButton />
+					<LoadMoreButton
+						screenReaderLabel={ __( 'Load more reviews', 'woo-gutenberg-products-block' ) }
+					/>
 				) }
 			</Fragment>
 		);

--- a/assets/js/blocks/reviews-by-product/frontend-block.js
+++ b/assets/js/blocks/reviews-by-product/frontend-block.js
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -55,6 +57,9 @@ class FrontendBlock extends Component {
 			this.setState( { reviews, totalReviews } );
 		} ).catch( () => {
 			this.setState( { reviews: [] } );
+			speak(
+				__( 'There was an error loading the reviews.', 'woo-gutenberg-products-block' )
+			);
 		} );
 	}
 
@@ -76,8 +81,21 @@ class FrontendBlock extends Component {
 				reviews: reviews.filter( ( review ) => Object.keys( review ).length ).concat( newReviews ),
 				totalReviews: newTotalReviews,
 			} );
+			speak(
+				sprintf(
+					_n(
+						'%d review loaded.',
+						'%d reviews loaded.',
+						'woo-gutenberg-products-block'
+					),
+					newReviews.length
+				)
+			);
 		} ).catch( () => {
 			this.setState( { reviews: [] } );
+			speak(
+				__( 'There was an error loading the reviews.', 'woo-gutenberg-products-block' )
+			);
 		} );
 	}
 
@@ -101,8 +119,12 @@ class FrontendBlock extends Component {
 		};
 		getReviews( args ).then( ( { reviews, totalReviews: newTotalReviews } ) => {
 			this.setState( { reviews, totalReviews: newTotalReviews } );
+			speak( __( 'Reviews order updated.', 'woo-gutenberg-products-block' ) );
 		} ).catch( () => {
 			this.setState( { reviews: [] } );
+			speak(
+				__( 'There was an error loading the reviews.', 'woo-gutenberg-products-block' )
+			);
 		} );
 	}
 
@@ -127,6 +149,7 @@ class FrontendBlock extends Component {
 				{ ( attributes.showLoadMore && totalReviews > reviews.length ) && (
 					<LoadMoreButton
 						onClick={ this.appendReviews }
+						screenReaderLabel={ __( 'Load more reviews', 'woo-gutenberg-products-block' ) }
 					/>
 				) }
 			</Fragment>


### PR DESCRIPTION
Part of #658.

This PR improves the _Reviews by Product_ block accessibility so it can be easily used with a screen reader. It implements the suggestion from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/841#discussion_r313509639 and adds some notices when the reviews list is updated.

This PR adds a new dependency to the frontend `@wordpress/a11y`. It's quite lightweight and wasn't easy to replace with vanilla JS.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### How to test the changes in this Pull Request:

1. Create a post with a _Reviews by Product_ block.
2. Using a screen reader, navigate the post.
3. Notice it reads _Order reviews by_ (instead of _Order by_) and _Load more reviews_ (intead of _Load more_), making it easy to know what the select and the button refer too.
4. Update the order and click on _Load more_ and verify it announces the list has been updated when the new reviews have been loaded.