### PR TITLE
Remove unnecessary browserlist configuration from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,10 +114,6 @@
       "composer run-script phpcs"
     ]
   },
-  "browserslist": [
-    "last 1 version",
-    "not dead"
-  ],
   "files": [
     "assets/**/*.{js,scss,php}",
     "build/**/*.{js,json,css}",


### PR DESCRIPTION
The plugin targets the same browserlist configuration exposed by `@wordpress/browserlist` which we extend in the project webpack configuration directly for frontend bundles and via `@wordpress/babel-preset-default` for non-frontend bundles.  So it's unnecessary to have the current configuration as it exists in `package.json` which not only was never used, but also incorrect for the the targets :)

### How to test the changes in this Pull Request:

I tested this by doing a production build before the changes and after the changes and comparing file size.  No change, so should be fine.

<!-- If you can, add the appropriate labels -->

### Changelog

I don't think this requires a changelog engtry.
