### PR TITLE
Reviews: fix reviews without rating not appearing when sorting by rating

### DIFF
--- a/src/RestApi/Controllers/ProductReviews.php
+++ b/src/RestApi/Controllers/ProductReviews.php
@@ -122,7 +122,17 @@ class ProductReviews extends WC_REST_Controller {
 
 		if ( isset( $registered['orderby'] ) ) {
 			if ( 'rating' === $request['orderby'] ) {
-				$prepared_args['meta_key'] = 'rating'; // phpcs:ignore
+				$prepared_args['meta_query'] = array( // phpcs:ignore
+					'relation' => 'OR',
+					array(
+						'key'     => 'rating',
+						'compare' => 'EXISTS',
+					),
+					array(
+						'key'     => 'rating',
+						'compare' => 'NOT EXISTS',
+					),
+				);
 			}
 			$prepared_args['orderby'] = $this->normalize_query_param( $request['orderby'] );
 		}


### PR DESCRIPTION
### Screenshots

<img src="https://user-images.githubusercontent.com/3616980/63023748-fd4bdf00-bea5-11e9-942b-a0774942f115.gif" width="416" alt="" />

### How to test the changes in this Pull Request:

1. Create a review without rating (you might need to modify your settings in _WooCommerce_ > _Settings_ > _Products_ > _General_ > _Product ratings_).
2. Create a post with a _Reviews by Product_ block.
3. Verify sorting by _Highest rating_ or _Lowest rating_ doesn't hide the reviews without rating.

Note: sorting by _Lowest rating_ shows reviews without rating first (see GIF above). I couldn't find any performant way to sort them after the other reviews, but it seems to me like an edge case. But suggestions are accepted. :slightly_smiling_face: 