### PR TITLE
Left align stars

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -112,6 +112,7 @@
 		font-weight: 400;
 		display: inline-block;
 		margin: 0 auto;
+		text-align: left;
 
 		&::before {
 			content: "\53\53\53\53\53";


### PR DESCRIPTION
Fixes a storefront star rating style glitch @nerrad reported on slack.

To test, view top rated products in Storefront. Without this patch, sometimes the stars do not quite align correctly by a few px.