### PR TITLE
Move wc_product_block_data variables to constants file

### DIFF
--- a/assets/js/base/components/review-list/index.js
+++ b/assets/js/base/components/review-list/index.js
@@ -7,11 +7,12 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ReviewListItem from '../review-list-item';
+import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '../../../constants';
 import './style.scss';
 
 const ReviewList = ( { attributes, componentId, reviews } ) => {
-	const showReviewImage = ( wc_product_block_data.showAvatars || attributes.imageType === 'product' ) && attributes.showReviewImage;
-	const showReviewRating = wc_product_block_data.enableReviewRating && attributes.showReviewRating;
+	const showReviewImage = ( SHOW_AVATARS || attributes.imageType === 'product' ) && attributes.showReviewImage;
+	const showReviewRating = ENABLE_REVIEW_RATING && attributes.showReviewRating;
 	const attrs = {
 		...attributes,
 		showReviewImage,

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -34,6 +34,7 @@ import { IconFolderStar } from '../../components/icons';
 /**
  * Internal dependencies
  */
+import { MIN_HEIGHT } from '../../constants';
 import ProductCategoryControl from '../../components/product-category-control';
 import ApiErrorPlaceholder from '../../components/api-error-placeholder';
 import {
@@ -43,11 +44,6 @@ import {
 	getCategoryImageSrc,
 } from './utils';
 import { withCategory } from '../../hocs';
-
-/**
- * The min-height for the block content.
- */
-const MIN_HEIGHT = wc_product_block_data.min_height;
 
 /**
  * Component to handle edit mode of "Featured Category".

--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -12,6 +12,7 @@ import './style.scss';
 import './editor.scss';
 import Block from './block';
 import { IconFolderStar } from '../../components/icons';
+import { DEFAULT_HEIGHT } from '../../constants';
 
 /**
  * Register and run the "Featured Category" block.
@@ -69,7 +70,7 @@ registerBlockType( 'woocommerce/featured-category', {
 		 */
 		height: {
 			type: 'number',
-			default: wc_product_block_data.default_height,
+			default: DEFAULT_HEIGHT,
 		},
 
 		/**

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -45,11 +45,7 @@ import {
 	getImageIdFromProduct,
 } from '../../utils/products';
 import { withProduct } from '../../hocs';
-
-/**
- * The min-height for the block content.
- */
-const MIN_HEIGHT = wc_product_block_data.min_height;
+import { MIN_HEIGHT } from '../../constants';
 
 /**
  * Component to handle edit mode of "Featured Product".

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -11,6 +11,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import './style.scss';
 import './editor.scss';
 import Block from './block';
+import { DEFAULT_HEIGHT } from '../../constants';
 
 /**
  * Register and run the "Featured Product" block.
@@ -68,7 +69,7 @@ registerBlockType( 'woocommerce/featured-product', {
 		 */
 		height: {
 			type: 'number',
-			default: wc_product_block_data.default_height,
+			default: DEFAULT_HEIGHT,
 		},
 
 		/**

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -27,6 +27,7 @@ import GridContentControl from '../../components/grid-content-control';
 import { IconWidgets } from '../../components/icons';
 import ProductsControl from '../../components/products-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
+import { MAX_COLUMNS, MIN_COLUMNS } from '../../constants';
 
 /**
  * Component to handle edit mode of "Hand-picked Products".
@@ -46,8 +47,8 @@ class ProductsBlock extends Component {
 						label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
 						value={ columns }
 						onChange={ ( value ) => setAttributes( { columns: value } ) }
-						min={ wc_product_block_data.min_columns }
-						max={ wc_product_block_data.max_columns }
+						min={ MIN_COLUMNS }
+						max={ MAX_COLUMNS }
 					/>
 					<ToggleControl
 						label={ __( 'Align Add to Cart buttons', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -11,6 +11,7 @@ import './editor.scss';
 import Block from './block';
 import { deprecatedConvertToShortcode } from '../../utils/deprecations';
 import { IconWidgets } from '../../components/icons';
+import { DEFAULT_COLUMNS } from '../../constants';
 
 registerBlockType( 'woocommerce/handpicked-products', {
 	title: __( 'Hand-picked Products', 'woo-gutenberg-products-block' ),
@@ -41,7 +42,7 @@ registerBlockType( 'woocommerce/handpicked-products', {
 		 */
 		columns: {
 			type: 'number',
-			default: wc_product_block_data.default_columns,
+			default: DEFAULT_COLUMNS,
 		},
 
 		/**
@@ -99,7 +100,7 @@ registerBlockType( 'woocommerce/handpicked-products', {
 				},
 				columns: {
 					type: 'number',
-					default: wc_product_block_data.default_columns,
+					default: DEFAULT_COLUMNS,
 				},
 				editMode: {
 					type: 'boolean',

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -9,6 +9,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import withComponentId from '../../base/hocs/with-component-id';
+import { HOME_URL } from '../../constants';
 
 /**
  * Component displaying the categories as dropdown or list.
@@ -28,7 +29,7 @@ class ProductCategoriesBlock extends Component {
 		if ( 'false' === url ) {
 			return;
 		}
-		const home = wc_product_block_data.homeUrl;
+		const home = HOME_URL;
 
 		if ( ! isPreview && 0 === url.indexOf( home ) ) {
 			document.location.href = url;

--- a/assets/js/blocks/product-categories/get-categories.js
+++ b/assets/js/blocks/product-categories/get-categories.js
@@ -2,12 +2,13 @@
  * Internal dependencies
  */
 import { buildTermsTree } from './hierarchy';
+import { PRODUCT_CATEGORIES } from '../../constants';
 
 /**
  * Returns categories in tree form.
  */
 export default function( { hasEmpty, isHierarchical } ) {
-	const categories = wc_product_block_data.productCategories.filter(
+	const categories = PRODUCT_CATEGORIES.filter(
 		( cat ) => hasEmpty || !! cat.count
 	);
 	return isHierarchical ?

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -11,6 +11,7 @@ import { PlainText } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
+import { HOME_URL } from '../../constants';
 import './editor.scss';
 import './style.scss';
 
@@ -20,7 +21,6 @@ import './style.scss';
 class ProductSearchBlock extends Component {
 	renderView() {
 		const { attributes: { label, placeholder, formId, className, hasLabel, align } } = this.props;
-		const home = wc_product_block_data.homeUrl;
 		const classes = classnames(
 			'wc-block-product-search',
 			align ? 'align' + align : '',
@@ -29,7 +29,7 @@ class ProductSearchBlock extends Component {
 
 		return (
 			<div className={ classes }>
-				<form role="search" method="get" action={ home }>
+				<form role="search" method="get" action={ HOME_URL }>
 					<label
 						htmlFor={ formId }
 						className={ hasLabel ? 'wc-block-product-search__label' : 'wc-block-product-search__label screen-reader-text' }

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -25,7 +25,7 @@ import GridContentControl from '../../components/grid-content-control';
 import GridLayoutControl from '../../components/grid-layout-control';
 import ProductTagControl from '../../components/product-tag-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
-import { hasTags } from '../../components/utils';
+import { HAS_TAGS } from '../../constants';
 
 /**
  * Component to handle edit mode of "Products by Tag".
@@ -231,7 +231,7 @@ class ProductsByTagBlock extends Component {
 
 		return (
 			<Fragment>
-				{ hasTags ? (
+				{ HAS_TAGS ? (
 					<Fragment>
 						<BlockControls>
 							<Toolbar

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -9,6 +9,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import './editor.scss';
 import Block from './block';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../../constants';
 
 /**
  * Register and run the "Products by Tag" block.
@@ -35,7 +36,7 @@ registerBlockType( 'woocommerce/product-tag', {
 		 */
 		columns: {
 			type: 'number',
-			default: wc_product_block_data.default_columns,
+			default: DEFAULT_COLUMNS,
 		},
 
 		/**
@@ -43,7 +44,7 @@ registerBlockType( 'woocommerce/product-tag', {
 		 */
 		rows: {
 			type: 'number',
-			default: wc_product_block_data.default_rows,
+			default: DEFAULT_ROWS,
 		},
 
 		/**

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -11,6 +11,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import './editor.scss';
 import Block from './block';
 import { deprecatedConvertToShortcode } from '../../utils/deprecations';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../../constants';
 
 const blockTypeName = 'woocommerce/products-by-attribute';
 
@@ -52,7 +53,7 @@ registerBlockType( blockTypeName, {
 		 */
 		columns: {
 			type: 'number',
-			default: wc_product_block_data.default_columns,
+			default: DEFAULT_COLUMNS,
 		},
 
 		/**
@@ -89,7 +90,7 @@ registerBlockType( blockTypeName, {
 		 */
 		rows: {
 			type: 'number',
-			default: wc_product_block_data.default_rows,
+			default: DEFAULT_ROWS,
 		},
 
 		/**
@@ -115,7 +116,7 @@ registerBlockType( blockTypeName, {
 				},
 				columns: {
 					type: 'number',
-					default: wc_product_block_data.default_columns,
+					default: DEFAULT_COLUMNS,
 				},
 				editMode: {
 					type: 'boolean',
@@ -136,7 +137,7 @@ registerBlockType( blockTypeName, {
 				},
 				rows: {
 					type: 'number',
-					default: wc_product_block_data.default_rows,
+					default: DEFAULT_ROWS,
 				},
 			},
 			save: deprecatedConvertToShortcode( blockTypeName ),

--- a/assets/js/blocks/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews-by-product/edit.js
@@ -36,9 +36,7 @@ import ProductControl from '../../components/product-control';
 import ToggleButtonControl from '../../components/toggle-button-control';
 import { IconReviewsByProduct } from '../../components/icons';
 import { withProduct } from '../../hocs';
-
-const enableReviewRating = !! ( typeof wc_product_block_data !== 'undefined' && wc_product_block_data.enableReviewRating );
-const showAvatars = !! ( typeof wc_product_block_data !== 'undefined' && wc_product_block_data.showAvatars );
+import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '../../constants';
 
 /**
  * Component to handle edit mode of "Reviews by Product".
@@ -116,7 +114,7 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 						checked={ attributes.showReviewRating }
 						onChange={ () => setAttributes( { showReviewRating: ! attributes.showReviewRating } ) }
 					/>
-					{ ( attributes.showReviewRating && ! enableReviewRating ) && (
+					{ ( attributes.showReviewRating && ! ENABLE_REVIEW_RATING ) && (
 						<Notice className="wc-block-reviews-by-product__notice" isDismissible={ false }>
 							<RawHTML>
 								{ sprintf( __( 'Product rating is disabled in your %sstore settings%s.', 'woo-gutenberg-products-block' ), `<a href="${ getAdminLink( 'admin.php?page=wc-settings&tab=products' ) }" target="_blank">`, '</a>' ) }
@@ -149,7 +147,7 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 								] }
 								onChange={ ( value ) => setAttributes( { imageType: value } ) }
 							/>
-							{ ( attributes.imageType === 'reviewer' && ! showAvatars ) && (
+							{ ( attributes.imageType === 'reviewer' && ! SHOW_AVATARS ) && (
 								<Notice className="wc-block-reviews-by-product__notice" isDismissible={ false }>
 									<RawHTML>
 										{ sprintf( __( 'Reviewer photo is disabled in your %ssite settings%s.', 'woo-gutenberg-products-block' ), `<a href="${ getAdminLink( 'options-discussion.php' ) }" target="_blank">`, '</a>' ) }
@@ -265,8 +263,8 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 	};
 
 	const renderViewMode = () => {
-		const showReviewImage = ( showAvatars || attributes.imageType === 'product' ) && attributes.showReviewImage;
-		const showReviewRating = enableReviewRating && attributes.showReviewRating;
+		const showReviewImage = ( SHOW_AVATARS || attributes.imageType === 'product' ) && attributes.showReviewImage;
+		const showReviewRating = ENABLE_REVIEW_RATING && attributes.showReviewRating;
 		const classes = classNames( 'wc-block-reviews-by-product', className, {
 			'has-image': showReviewImage,
 			'has-name': showReviewerName,

--- a/assets/js/blocks/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews-by-product/editor-block.js
@@ -14,8 +14,7 @@ import LoadMoreButton from '../../base/components/load-more-button';
 import ReviewList from '../../base/components/review-list';
 import ReviewOrderSelect from '../../base/components/review-order-select';
 import withComponentId from '../../base/hocs/with-component-id';
-
-const enableReviewRating = !! ( typeof wc_product_block_data !== 'undefined' && wc_product_block_data.enableReviewRating );
+import { ENABLE_REVIEW_RATING } from '../../constants';
 
 /**
  * Block rendered in the editor.
@@ -73,7 +72,7 @@ class EditorBlock extends Component {
 
 		return (
 			<Fragment>
-				{ ( attributes.showOrderby && enableReviewRating ) && (
+				{ ( attributes.showOrderby && ENABLE_REVIEW_RATING ) && (
 					<ReviewOrderSelect
 						componentId={ componentId }
 						readOnly

--- a/assets/js/blocks/reviews-by-product/frontend-block.js
+++ b/assets/js/blocks/reviews-by-product/frontend-block.js
@@ -14,8 +14,7 @@ import LoadMoreButton from '../../base/components/load-more-button';
 import ReviewOrderSelect from '../../base/components/review-order-select';
 import ReviewList from '../../base/components/review-list';
 import withComponentId from '../../base/hocs/with-component-id';
-
-const enableReviewRating = !! ( typeof wc_product_block_data !== 'undefined' && wc_product_block_data.enableReviewRating );
+import { ENABLE_REVIEW_RATING } from '../../constants';
 
 /**
  * Block rendered in the frontend.
@@ -134,7 +133,7 @@ class FrontendBlock extends Component {
 
 		return (
 			<Fragment>
-				{ ( attributes.showOrderby && enableReviewRating ) && (
+				{ ( attributes.showOrderby && ENABLE_REVIEW_RATING ) && (
 					<ReviewOrderSelect
 						componentId={ componentId }
 						onChange={ this.onChangeOrderby }

--- a/assets/js/blocks/reviews-by-product/utils.js
+++ b/assets/js/blocks/reviews-by-product/utils.js
@@ -3,10 +3,13 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
-const enableReviewRating = !! ( typeof wc_product_block_data !== 'undefined' && wc_product_block_data.enableReviewRating );
+/**
+ * Internal dependencies
+ */
+import { ENABLE_REVIEW_RATING } from '../../constants';
 
 export const getOrderArgs = ( orderValue ) => {
-	if ( enableReviewRating ) {
+	if ( ENABLE_REVIEW_RATING ) {
 		if ( orderValue === 'lowest-rating' ) {
 			return {
 				order: 'asc',

--- a/assets/js/components/grid-layout-control/index.js
+++ b/assets/js/components/grid-layout-control/index.js
@@ -6,6 +6,7 @@ import { clamp, isNaN } from 'lodash';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { RangeControl, ToggleControl } from '@wordpress/components';
+import { MAX_COLUMNS, MIN_COLUMNS, MAX_ROWS, MIN_ROWS } from '../../constants';
 
 /**
  * A combination of range controls for product grid layout settings.
@@ -19,13 +20,13 @@ const GridLayoutControl = ( { columns, rows, setAttributes, alignButtons } ) => 
 				onChange={ ( value ) => {
 					const newValue = clamp(
 						value,
-						wc_product_block_data.min_columns,
-						wc_product_block_data.max_columns
+						MIN_COLUMNS,
+						MAX_COLUMNS
 					);
 					setAttributes( { columns: isNaN( newValue ) ? '' : newValue } );
 				} }
-				min={ wc_product_block_data.min_columns }
-				max={ wc_product_block_data.max_columns }
+				min={ MIN_COLUMNS }
+				max={ MAX_COLUMNS }
 			/>
 			<RangeControl
 				label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
@@ -33,13 +34,13 @@ const GridLayoutControl = ( { columns, rows, setAttributes, alignButtons } ) => 
 				onChange={ ( value ) => {
 					const newValue = clamp(
 						value,
-						wc_product_block_data.min_rows,
-						wc_product_block_data.max_rows
+						MIN_ROWS,
+						MAX_ROWS
 					);
 					setAttributes( { rows: isNaN( newValue ) ? '' : newValue } );
 				} }
-				min={ wc_product_block_data.min_rows }
-				max={ wc_product_block_data.max_rows }
+				min={ MIN_ROWS }
+				max={ MAX_ROWS }
 			/>
 			<ToggleControl
 				label={ __( 'Align Add to Cart buttons', 'woo-gutenberg-products-block' ) }

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -17,8 +17,8 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { ENDPOINTS } from '../../constants';
-import { isLargeCatalog, getProducts } from '../utils';
+import { ENDPOINTS, IS_LARGE_CATALOG } from '../../constants';
+import { getProducts } from '../utils';
 import {
 	IconRadioSelected,
 	IconRadioUnselected,
@@ -273,7 +273,7 @@ class ProductControl extends Component {
 					selected={ selectedListItems }
 					onChange={ onChange }
 					renderItem={ renderItem }
-					onSearch={ isLargeCatalog ? this.debouncedOnSearch : null }
+					onSearch={ IS_LARGE_CATALOG ? this.debouncedOnSearch : null }
 					messages={ messages }
 					isHierarchical
 				/>

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import { PLACEHOLDER_IMG_SRC, THUMBNAIL_SIZE } from '../../constants';
 
 /**
  * Internal dependencies
@@ -13,10 +14,6 @@ import './style.scss';
  * Display a preview for a given product.
  */
 const ProductPreview = ( { product } ) => {
-	const {
-		placeholderImgSrc,
-	} = wc_product_block_data; /* eslint-disable-line camelcase */
-
 	let image = null;
 	if ( product.images.length ) {
 		image = (
@@ -24,16 +21,16 @@ const ProductPreview = ( { product } ) => {
 				className="wc-product-preview__image"
 				src={ product.images[ 0 ].src }
 				alt=""
-				style={ { width: `${ wc_product_block_data.thumbnail_size }px` } }
+				style={ { width: `${ THUMBNAIL_SIZE }px` } }
 			/>
 		);
 	} else {
 		image = (
 			<img
 				className="wc-product-preview__image"
-				src={ placeholderImgSrc }
+				src={ PLACEHOLDER_IMG_SRC }
 				alt=""
-				style={ { width: `${ wc_product_block_data.thumbnail_size }px` } }
+				style={ { width: `${ THUMBNAIL_SIZE }px` } }
 			/>
 		);
 	}

--- a/assets/js/components/product-preview/test/index.js
+++ b/assets/js/components/product-preview/test/index.js
@@ -8,6 +8,11 @@ import TestRenderer from 'react-test-renderer';
  */
 import ProductPreview from '../';
 
+jest.mock( '../../../constants.js', () => ( {
+	PLACEHOLDER_IMG_SRC: 'placeholder.png',
+	THUMBNAIL_SIZE: 300,
+} ) );
+
 describe( 'ProductPreview', () => {
 	test( 'should render a single product preview with an image', () => {
 		const product = {

--- a/assets/js/components/product-tag-control/index.js
+++ b/assets/js/components/product-tag-control/index.js
@@ -11,8 +11,9 @@ import { SelectControl } from '@wordpress/components';
 /**
  * Internal dependencies
  */
+import { getProductTags } from '../utils';
+import { LIMIT_TAGS } from '../../constants';
 import './style.scss';
-import { limitTags, getProductTags } from '../utils';
 
 /**
  * Component to handle searching and selecting product tags.
@@ -127,7 +128,7 @@ class ProductTagControl extends Component {
 					isLoading={ loading }
 					selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
 					onChange={ onChange }
-					onSearch={ limitTags ? this.debouncedOnSearch : null }
+					onSearch={ LIMIT_TAGS ? this.debouncedOnSearch : null }
 					renderItem={ this.renderItem }
 					messages={ messages }
 					isHierarchical

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -8,15 +8,11 @@ import { flatten, uniqBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { ENDPOINTS } from '../../constants';
-
-export const isLargeCatalog = wc_product_block_data.isLargeCatalog || false;
-export const limitTags = wc_product_block_data.limitTags || false;
-export const hasTags = wc_product_block_data.hasTags || false;
+import { ENDPOINTS, IS_LARGE_CATALOG, LIMIT_TAGS } from '../../constants';
 
 const getProductsRequests = ( { selected = [], search = '', queryArgs = [] } ) => {
 	const defaultArgs = {
-		per_page: isLargeCatalog ? 100 : -1,
+		per_page: IS_LARGE_CATALOG ? 100 : -1,
 		catalog_visibility: 'any',
 		status: 'publish',
 		search,
@@ -31,7 +27,7 @@ const getProductsRequests = ( { selected = [], search = '', queryArgs = [] } ) =
 	];
 
 	// If we have a large catalog, we might not get all selected products in the first page.
-	if ( isLargeCatalog && selected.length ) {
+	if ( IS_LARGE_CATALOG && selected.length ) {
 		requests.push(
 			addQueryArgs( ENDPOINTS.products, {
 				catalog_visibility: 'any',
@@ -71,15 +67,15 @@ export const getProduct = ( productId ) => {
 const getProductTagsRequests = ( { selected = [], search } ) => {
 	const requests = [
 		addQueryArgs( `${ ENDPOINTS.products }/tags`, {
-			per_page: limitTags ? 100 : -1,
-			orderby: limitTags ? 'count' : 'name',
-			order: limitTags ? 'desc' : 'asc',
+			per_page: LIMIT_TAGS ? 100 : -1,
+			orderby: LIMIT_TAGS ? 'count' : 'name',
+			order: LIMIT_TAGS ? 'desc' : 'asc',
 			search,
 		} ),
 	];
 
 	// If we have a large catalog, we might not get all selected products in the first page.
-	if ( limitTags && selected.length ) {
+	if ( LIMIT_TAGS && selected.length ) {
 		requests.push(
 			addQueryArgs( `${ ENDPOINTS.products }/tags`, {
 				include: selected,

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -4,3 +4,28 @@ export const ENDPOINTS = {
 	products: `${ NAMESPACE }/products`,
 	categories: `${ NAMESPACE }/products/categories`,
 };
+
+const getConstantFromData = ( property, fallback = false ) => {
+	if ( typeof wc_product_block_data === 'object' && wc_product_block_data.hasOwnProperty( property ) ) {
+		return wc_product_block_data[ property ];
+	}
+	return fallback;
+};
+
+export const ENABLE_REVIEW_RATING = getConstantFromData( 'enableReviewRating', true );
+export const SHOW_AVATARS = getConstantFromData( 'showAvatars', true );
+export const MAX_COLUMNS = getConstantFromData( 'max_columns', 6 );
+export const MIN_COLUMNS = getConstantFromData( 'min_columns', 1 );
+export const DEFAULT_COLUMNS = getConstantFromData( 'default_columns', 3 );
+export const MAX_ROWS = getConstantFromData( 'max_rows', 6 );
+export const MIN_ROWS = getConstantFromData( 'min_rows', 1 );
+export const DEFAULT_ROWS = getConstantFromData( 'default_rows', 1 );
+export const MIN_HEIGHT = getConstantFromData( 'min_height', 500 );
+export const DEFAULT_HEIGHT = getConstantFromData( 'default_height', 500 );
+export const PLACEHOLDER_IMG_SRC = getConstantFromData( 'placeholderImgSrc ', '' );
+export const THUMBNAIL_SIZE = getConstantFromData( 'thumbnail_size', 300 );
+export const IS_LARGE_CATALOG = getConstantFromData( 'isLargeCatalog' );
+export const LIMIT_TAGS = getConstantFromData( 'limitTags' );
+export const HAS_TAGS = getConstantFromData( 'hasTags', true );
+export const HOME_URL = getConstantFromData( 'homeUrl ', '' );
+export const PRODUCT_CATEGORIES = getConstantFromData( 'productCategories', [] );

--- a/assets/js/hocs/test/with-searched-products.js
+++ b/assets/js/hocs/test/with-searched-products.js
@@ -10,13 +10,16 @@ import _ from 'lodash';
 import withSearchedProducts from '../with-searched-products';
 import * as mockedUtils from '../../components/utils';
 
+jest.mock( '../../constants.js', () => ( {
+	IS_LARGE_CATALOG: true,
+} ) );
+
 // Mock the getProducts and isLargeCatalog values for tests.
 mockedUtils.getProducts = jest.fn().mockImplementation(
 	() => Promise.resolve(
 		[ { id: 10, name: 'foo' }, { id: 20, name: 'bar' } ]
 	)
 );
-mockedUtils.isLargeCatalog = true;
 
 // Add a mock implementation of debounce for testing so we can spy on
 // the onSearch call.
@@ -38,7 +41,6 @@ describe( 'withSearchedProducts Component', () => {
 		debouncedCancel.mockClear();
 		debouncedAction.mockClear();
 		mockedUtils.getProducts.mockClear();
-		mockedUtils.isLargeCatalog = false;
 	} );
 	const TestComponent = withSearchedProducts( ( {
 		selected,

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -9,7 +9,8 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { isLargeCatalog, getProducts } from '../components/utils';
+import { IS_LARGE_CATALOG } from '../constants';
+import { getProducts } from '../components/utils';
 
 /**
  * A higher order component that enhances the provided component with products
@@ -69,7 +70,7 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 					selected={ list.filter(
 						( { id } ) => selected.includes( id )
 					) }
-					onSearch={ isLargeCatalog ? this.debouncedOnSearch : null }
+					onSearch={ IS_LARGE_CATALOG ? this.debouncedOnSearch : null }
 				/>
 			);
 		}

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { min } from 'lodash';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../constants';
 
 export default function getQuery( blockAttributes, name ) {
 	const {
@@ -14,8 +15,8 @@ export default function getQuery( blockAttributes, name ) {
 		orderby,
 		products,
 	} = blockAttributes;
-	const columns = blockAttributes.columns || wc_product_block_data.default_columns;
-	const rows = blockAttributes.rows || wc_product_block_data.default_rows;
+	const columns = blockAttributes.columns || DEFAULT_COLUMNS;
+	const rows = blockAttributes.rows || DEFAULT_ROWS;
 	const apiMax = Math.floor( 100 / columns ) * columns; // Prevent uneven final row.
 
 	const query = {

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../constants';
+
 export default function getShortcode( props, name ) {
 	const blockAttributes = props.attributes;
 	const {
@@ -8,8 +13,8 @@ export default function getShortcode( props, name ) {
 		orderby,
 		products,
 	} = blockAttributes;
-	const columns = blockAttributes.columns || wc_product_block_data.default_columns;
-	const rows = blockAttributes.rows || wc_product_block_data.default_rows;
+	const columns = blockAttributes.columns || DEFAULT_COLUMNS;
+	const rows = blockAttributes.rows || DEFAULT_ROWS;
 
 	const shortcodeAtts = new Map();
 	shortcodeAtts.set( 'limit', rows * columns );

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -1,3 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../constants';
 
 export const sharedAttributeBlockTypes = [
 	'woocommerce/product-best-sellers',
@@ -13,7 +17,7 @@ export default {
 	 */
 	columns: {
 		type: 'number',
-		default: wc_product_block_data.default_columns,
+		default: DEFAULT_COLUMNS,
 	},
 
 	/**
@@ -21,7 +25,7 @@ export default {
 	 */
 	rows: {
 		type: 'number',
-		default: wc_product_block_data.default_rows,
+		default: DEFAULT_ROWS,
 	},
 
 	/**

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -1,12 +1,6 @@
 // Set up `wp.*` aliases.  Doing this because any tests importing wp stuff will likely run into this.
 global.wp = {};
 
-// Set up our settings global.
-global.wc_product_block_data = {
-	placeholderImgSrc: 'placeholder.png',
-	thumbnail_size: '300',
-};
-
 // wcSettings is required by @woocommerce/* packages
 global.wcSettings = {
 	adminUrl: 'https://vagrant.local/wp/wp-admin/',


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/841#discussion_r313063761.

### How to test the changes in this Pull Request:

This PR modifies many files. Even though the changes are minimal, I think the only way to test is adding each block and testing it still works as usual.