### PR TITLE
Update Reviews styles so it looks the same in the editor and the frontend

### DIFF
--- a/assets/js/base/components/load-more-button/index.js
+++ b/assets/js/base/components/load-more-button/index.js
@@ -23,12 +23,14 @@ export const LoadMoreButton = ( { onClick, label, screenReaderLabel } ) => {
 	) : label;
 
 	return (
-		<button
-			className="wc-block-load-more"
-			onClick={ onClick }
-		>
-			{ labelNode }
-		</button>
+		<div className="wp-block-button wc-block-load-more">
+			<button
+				className="wp-block-button__link"
+				onClick={ onClick }
+			>
+				{ labelNode }
+			</button>
+		</div>
 	);
 };
 

--- a/assets/js/base/components/load-more-button/style.scss
+++ b/assets/js/base/components/load-more-button/style.scss
@@ -1,4 +1,4 @@
 .wc-block-load-more {
-	display: block;
-	margin: 0 auto;
+	text-align: center;
+	width: 100%;
 }

--- a/assets/js/base/components/review-list/style.scss
+++ b/assets/js/base/components/review-list/style.scss
@@ -1,3 +1,4 @@
-.wc-block-review-list {
+.wc-block-review-list,
+.editor-styles .wc-block-review-list {
 	margin: 0;
 }


### PR DESCRIPTION
This is an experiment coming from the discussion in #861.

I'm not 100% happy with this solution, since we have to add a class named `wp-block-button__link` to a button which is not a link, but still wanted to create the PR to get feedback.

### Screenshots

_Before:_
<img src="https://user-images.githubusercontent.com/3616980/63093450-97269100-bf65-11e9-8c49-31abe72aa1f4.png" alt="Screenshot" width="485" />

_After:_
<img src="https://user-images.githubusercontent.com/3616980/63093404-4a42ba80-bf65-11e9-94df-7559a14c93e3.png" alt="Screenshot" width="487" />

### How to test the changes in this Pull Request:

1. Create a post with a _Reviews by Product_ block and notice the _Load more_ button has the same styles as all other buttons in WooCommerce Blocks.
