### PR TITLE
Experiment: Proof of concept for Blocks in content controlled outside the block.

### DIFF
--- a/assets/js/blocks/product-category-server-side/block.js
+++ b/assets/js/blocks/product-category-server-side/block.js
@@ -1,0 +1,275 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	BlockControls,
+	InspectorControls,
+	ServerSideRender,
+} from '@wordpress/editor';
+import {
+	Button,
+	Disabled,
+	PanelBody,
+	Placeholder,
+	Toolbar,
+	withSpokenMessages,
+} from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import GridContentControl from '../../components/grid-content-control';
+import GridLayoutControl from '../../components/grid-layout-control';
+import ProductCategoryControl from '../../components/product-category-control';
+import ProductOrderbyControl from '../../components/product-orderby-control';
+
+/**
+ * Component to handle edit mode of "Products by Category".
+ */
+class ProductByCategorySSRBlock extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			changedAttributes: {},
+			isEditing: false,
+		};
+		this.startEditing = this.startEditing.bind( this );
+		this.stopEditing = this.stopEditing.bind( this );
+		this.setChangedAttributes = this.setChangedAttributes.bind( this );
+		this.save = this.save.bind( this );
+	}
+
+	componentDidMount() {
+		const { attributes } = this.props;
+
+		if ( ! attributes.categories.length ) {
+			// We've removed all selected categories, or no categories have been selected yet.
+			this.setState( { isEditing: true } );
+		}
+	}
+
+	startEditing() {
+		this.setState( {
+			isEditing: true,
+			changedAttributes: {},
+		} );
+	}
+
+	stopEditing() {
+		this.setState( {
+			isEditing: false,
+			changedAttributes: {},
+		} );
+	}
+
+	setChangedAttributes( attributes ) {
+		this.setState( ( prevState ) => {
+			return { changedAttributes: { ...prevState.changedAttributes, ...attributes } };
+		} );
+	}
+
+	save() {
+		const { changedAttributes } = this.state;
+		const { setAttributes } = this.props;
+
+		setAttributes( changedAttributes );
+		this.stopEditing();
+	}
+
+	getInspectorControls() {
+		const { attributes, setAttributes } = this.props;
+		const { isEditing } = this.state;
+		const {
+			columns,
+			catOperator,
+			contentVisibility,
+			orderby,
+			rows,
+			alignButtons,
+		} = attributes;
+
+		return (
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Product Category', 'woo-gutenberg-products-block' ) }
+					initialOpen={ ! attributes.categories.length && ! isEditing }
+				>
+					<ProductCategoryControl
+						selected={ attributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							const changes = { categories: ids };
+
+							// Changes in the sidebar save instantly and overwrite any unsaved changes.
+							setAttributes( changes );
+							this.setChangedAttributes( changes );
+						} }
+						operator={ catOperator }
+						onOperatorChange={ ( value = 'any' ) => {
+							const changes = { catOperator: value };
+							setAttributes( changes );
+							this.setChangedAttributes( changes );
+						} }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridLayoutControl
+						columns={ columns }
+						rows={ rows }
+						alignButtons={ alignButtons }
+						setAttributes={ setAttributes }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<GridContentControl
+						settings={ contentVisibility }
+						onChange={ ( value ) => setAttributes( { contentVisibility: value } ) }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+					initialOpen={ false }
+				>
+					<ProductOrderbyControl
+						setAttributes={ setAttributes }
+						value={ orderby }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		);
+	}
+
+	renderEditMode() {
+		const { attributes, debouncedSpeak } = this.props;
+		const { changedAttributes } = this.state;
+		const currentAttributes = { ...attributes, ...changedAttributes };
+		const onDone = () => {
+			this.save();
+			debouncedSpeak(
+				__(
+					'Showing Products by Category block preview.',
+					'woo-gutenberg-products-block'
+				)
+			);
+		};
+		const onCancel = () => {
+			this.stopEditing();
+			debouncedSpeak(
+				__(
+					'Showing Products by Category block preview.',
+					'woo-gutenberg-products-block'
+				)
+			);
+		};
+
+		return (
+			<Placeholder
+				icon="category"
+				label={ __( 'Products by Category Server Side', 'woo-gutenberg-products-block' ) }
+				className="wc-block-products-grid wc-block-products-category"
+			>
+				{ __(
+					'Display a grid of products from your selected categories.',
+					'woo-gutenberg-products-block'
+				) }
+				<div className="wc-block-products-category__selection">
+					<ProductCategoryControl
+						selected={ currentAttributes.categories }
+						onChange={ ( value = [] ) => {
+							const ids = value.map( ( { id } ) => id );
+							this.setChangedAttributes( { categories: ids } );
+						} }
+						operator={ currentAttributes.catOperator }
+						onOperatorChange={ ( value = 'any' ) =>
+							this.setChangedAttributes( { catOperator: value } )
+						}
+					/>
+					<Button isDefault onClick={ onDone }>
+						{ __( 'Done', 'woo-gutenberg-products-block' ) }
+					</Button>
+					<Button
+						className="wc-block-products-category__cancel-button"
+						isTertiary
+						onClick={ onCancel }
+					>
+						{ __( 'Cancel', 'woo-gutenberg-products-block' ) }
+					</Button>
+				</div>
+			</Placeholder>
+		);
+	}
+
+	renderViewMode() {
+		const { attributes, name } = this.props;
+		const hasCategories = attributes.categories.length;
+
+		return (
+			<Disabled>
+				{ hasCategories ? (
+					<ServerSideRender block={ name } attributes={ attributes } />
+				) : (
+					__(
+						'Select at least one category to display its products.',
+						'woo-gutenberg-products-block'
+					)
+				) }
+			</Disabled>
+		);
+	}
+
+	render() {
+		const { isEditing } = this.state;
+
+		return (
+			<Fragment>
+				<BlockControls>
+					<Toolbar
+						controls={ [
+							{
+								icon: 'edit',
+								title: __( 'Edit' ),
+								onClick: () => isEditing ? this.stopEditing() : this.startEditing(),
+								isActive: isEditing,
+							},
+						] }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				{ isEditing ? (
+					this.renderEditMode()
+				) : (
+					this.renderViewMode()
+				) }
+			</Fragment>
+		);
+	}
+}
+
+ProductByCategorySSRBlock.propTypes = {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * The register block name.
+	 */
+	name: PropTypes.string.isRequired,
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: PropTypes.func.isRequired,
+
+	// from withSpokenMessages
+	debouncedSpeak: PropTypes.func.isRequired,
+};
+
+export default withSpokenMessages( ProductByCategorySSRBlock );

--- a/assets/js/blocks/product-category-server-side/editor.scss
+++ b/assets/js/blocks/product-category-server-side/editor.scss
@@ -1,0 +1,9 @@
+.wc-block-products-category__selection {
+	width: 100%;
+}
+.wc-block-products-category__cancel-button.is-tertiary {
+	margin: 1em auto 0;
+	display: block;
+	text-align: center;
+	font-size: 1em;
+}

--- a/assets/js/blocks/product-category-server-side/frontend.js
+++ b/assets/js/blocks/product-category-server-side/frontend.js
@@ -1,0 +1,51 @@
+import { render, RawHTML } from '@wordpress/element';
+import ServerSideRender from '@wordpress/server-side-render';
+import { withSelect, dispatch } from '@wordpress/data';
+
+/**
+ * Frontend block
+ */
+const ProductCategoryBlock = ( { blockName, attributes, initialRenderContent = '' } ) => {
+	if ( initialRenderContent !== '' ) {
+		return <RawHTML>{ initialRenderContent }</RawHTML>;
+	}
+	return <ServerSideRender block={ blockName } attributes={ attributes } />;
+};
+
+/**
+ * Wrapped Block enhanced with withSelect
+ */
+const EnhancedProductCategoryBlock = withSelect(
+	( select, { blockName, attributes } ) => {
+		const store = select( 'wc-blocks/query-state' );
+		const newAttributes = store.getValueForQueryContext( blockName );
+
+		// if no change then avoid unnecessary render!
+		if ( JSON.stringify( attributes ) === JSON.stringify( newAttributes ) ) {
+			return {};
+		}
+		return {
+			attributes: newAttributes,
+			initialRenderContent: '',
+		};
+	}
+)( ProductCategoryBlock );
+
+const containers = document.querySelectorAll( '.wc-ssr-block' );
+
+if ( containers.length ) {
+	Array.prototype.forEach.call( containers, ( el ) => {
+		// note classList isn't supported by IE so this could be problematic
+		el.classList.remove( 'wc-ssr-block' );
+		const data = JSON.parse( JSON.stringify( el.dataset ) );
+		const { blockName: name, wcBlockattributes } = data;
+		const attributes = JSON.parse( wcBlockattributes );
+		const initialContent = el.outerHTML;
+		// hydrate the state for the data store with the attributes.
+		dispatch( 'wc-blocks/query-state' ).setValueForQueryContext(
+			name,
+			attributes
+		);
+		render( <EnhancedProductCategoryBlock attributes={ attributes } blockName={ name } initialRenderContent={ initialContent } />, el.parentElement );
+	} );
+}

--- a/assets/js/blocks/product-category-server-side/index.js
+++ b/assets/js/blocks/product-category-server-side/index.js
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
+import { without } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import Block from './block';
+import sharedAttributes, { sharedAttributeBlockTypes } from '../../utils/shared-attributes';
+
+/**
+ * Register and run the "Products by Category" block.
+ */
+registerBlockType( 'woocommerce/product-category-server-side', {
+	title: __( 'Products by Category SSR', 'woo-gutenberg-products-block' ),
+	icon: {
+		src: 'category',
+		foreground: '#96588a',
+	},
+	category: 'woocommerce',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Display a grid of products from your selected categories.',
+		'woo-gutenberg-products-block'
+	),
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+	},
+	attributes: {
+		...sharedAttributes,
+
+		/**
+		 * Toggle for edit mode in the block preview.
+		 */
+		editMode: {
+			type: 'boolean',
+			default: true,
+		},
+
+		/**
+		 * How to order the products: 'date', 'popularity', 'price_asc', 'price_desc' 'rating', 'title'.
+		 */
+		orderby: {
+			type: 'string',
+			default: 'date',
+		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: without( sharedAttributeBlockTypes, 'woocommerce/product-category-server-side' ),
+				transform: ( attributes ) => createBlock(
+					'woocommerce/product-category-server-side',
+					{ ...attributes, editMode: false }
+				),
+			},
+		],
+	},
+
+	/**
+	 * Renders and manages the block.
+	 */
+	edit( props ) {
+		return <Block { ...props } />;
+	},
+
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/data/index.js
+++ b/assets/js/data/index.js
@@ -1,0 +1,1 @@
+export { default as queryStateStoreConfig } from './query-state';

--- a/assets/js/data/query-state/index.js
+++ b/assets/js/data/query-state/index.js
@@ -1,0 +1,84 @@
+const DEFAULT_STATE = {};
+const SET_QUERY_KEY_VALUE = 'SET_QUERY_KEY_VALUE';
+const SET_QUERY_CONTEXT_VALUE = 'SET_QUERY_CONTEXT_VALUE';
+
+const getStateForContext = ( state, context ) => {
+	return typeof state[ context ] === 'undefined' ?
+		null :
+		state[ context ];
+};
+
+const queryStateReducer = ( state = DEFAULT_STATE, action ) => {
+	const { type, context, queryKey, value } = action;
+	if ( type === SET_QUERY_KEY_VALUE ) {
+		// this is just for POC, there will be some other mechanism we'd probably
+		// use (maybe use immutable.js as there will be different data types)
+		const prevState = getStateForContext( state, context );
+
+		const prevStateObject = prevState !== null ?
+			JSON.parse( prevState ) :
+			{};
+
+		// mutate it and JSON.stringify to compare
+		prevStateObject[ queryKey ] = value;
+		const newState = JSON.stringify( prevStateObject );
+
+		if ( prevState !== newState ) {
+			return {
+				...state,
+				[ context ]: newState,
+			};
+		}
+	}
+	if ( type === SET_QUERY_CONTEXT_VALUE ) {
+		const prevState = getStateForContext( state, context );
+		const newState = JSON.stringify( value );
+		if ( prevState !== newState ) {
+			return {
+				...state,
+				[ context ]: newState,
+			};
+		}
+	}
+	return state;
+};
+
+const setQueryValue = ( context, queryKey, value ) => {
+	return {
+		type: SET_QUERY_KEY_VALUE,
+		context,
+		queryKey,
+		value,
+	};
+};
+
+const setValueForQueryContext = ( context, value ) => {
+	return {
+		type: SET_QUERY_CONTEXT_VALUE,
+		context,
+		value,
+	};
+};
+
+const getValueForQueryKey = ( state, context, queryKey, defaultValue = {} ) => {
+	let stateContext = getStateForContext( state, context );
+	if ( stateContext === null ) {
+		return defaultValue;
+	}
+	stateContext = JSON.parse( stateContext );
+	return typeof stateContext[ queryKey ] !== 'undefined' ?
+		stateContext[ queryKey ] :
+		defaultValue;
+};
+
+const getValueForQueryContext = ( state, context, defaultValue = {} ) => {
+	const stateContext = getStateForContext( state, context );
+	return stateContext === null ? defaultValue : JSON.parse( stateContext );
+};
+
+const storeConfig = {
+	reducer: queryStateReducer,
+	actions: { setQueryValue, setValueForQueryContext },
+	selectors: { getValueForQueryKey, getValueForQueryContext },
+};
+export default storeConfig;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,6 +3,12 @@
  */
 import { getCategories, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { queryStateStoreConfig } from './data';
 
 /**
  * Internal dependencies
@@ -20,3 +26,5 @@ setCategories( [
 		icon: <IconWoo />,
 	},
 ] );
+
+registerStore( 'wc-blocks/query-state', queryStateStoreConfig );

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -5,6 +5,7 @@ export const sharedAttributeBlockTypes = [
 	'woocommerce/product-new',
 	'woocommerce/product-on-sale',
 	'woocommerce/product-top-rated',
+	'woocommerce/product-category-server-side',
 ];
 
 export default {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5136,6 +5136,131 @@
         }
       }
     },
+    "@wordpress/server-side-render": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.1.0.tgz",
+      "integrity": "sha512-bSRHXfJozVzZSbkDSmhfBO/EuwebSLNvuBi/S0XrPA7lIJgqysZVPjSd7Z21qMnlKasF1N21lL7Dn1z2W/sMVQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@wordpress/api-fetch": "^3.4.0",
+        "@wordpress/components": "^8.1.0",
+        "@wordpress/data": "^4.7.0",
+        "@wordpress/element": "^2.6.0",
+        "@wordpress/i18n": "^3.6.0",
+        "@wordpress/url": "^2.7.0",
+        "lodash": "^4.17.14"
+      },
+      "dependencies": {
+        "@wordpress/api-fetch": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
+          "integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/i18n": "^3.6.0",
+            "@wordpress/url": "^2.7.0"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+          "integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/element": "^2.6.0",
+            "@wordpress/is-shallow-equal": "^1.5.0",
+            "lodash": "^4.17.14"
+          }
+        },
+        "@wordpress/data": {
+          "version": "4.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
+          "integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/compose": "^3.5.0",
+            "@wordpress/deprecated": "^2.5.0",
+            "@wordpress/element": "^2.6.0",
+            "@wordpress/is-shallow-equal": "^1.5.0",
+            "@wordpress/priority-queue": "^1.3.0",
+            "@wordpress/redux-routine": "^3.5.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^2.1.0",
+            "lodash": "^4.17.14",
+            "redux": "^4.0.0",
+            "turbo-combine-reducers": "^1.0.2"
+          }
+        },
+        "@wordpress/deprecated": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
+          "integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/hooks": "^2.5.0"
+          }
+        },
+        "@wordpress/hooks": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
+          "integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4"
+          }
+        },
+        "@wordpress/is-shallow-equal": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.5.0.tgz",
+          "integrity": "sha512-6GjIDZlwcgLmnt1uexUgnIj3zbzCPCtqe5vTqmsQeexC4zCIzgFJgzilOuuW/4kdwF/XB3jex91L9EImc5HTcw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4"
+          }
+        },
+        "@wordpress/priority-queue": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.3.0.tgz",
+          "integrity": "sha512-HlhHZUCnKW56b2KFg2cZcn6fnGdi6mrmfOn2lE3cBOibjQLYfOY3pe3TCd+AxS4GdfkgXFA7BHfAinaWCBpAyg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4"
+          }
+        },
+        "@wordpress/redux-routine": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
+          "integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "is-promise": "^2.1.0",
+            "rungen": "^0.3.2"
+          }
+        },
+        "@wordpress/url": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+          "integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "qs": "^6.5.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        }
+      }
+    },
     "@wordpress/shortcode": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@wordpress/jest-preset-default": "4.3.0",
     "@wordpress/rich-text": "3.5.0",
     "@wordpress/scripts": "3.4.0",
+    "@wordpress/server-side-render": "^1.1.0",
     "autoprefixer": "9.6.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.2",

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -41,6 +41,7 @@ class Assets {
 		self::register_script( 'wc-handpicked-products', plugins_url( 'build/handpicked-products.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
 		self::register_script( 'wc-product-best-sellers', plugins_url( 'build/product-best-sellers.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
 		self::register_script( 'wc-product-category', plugins_url( 'build/product-category.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
+		self::register_script( 'wc-product-category-server-side', plugins_url( 'build/product-category-server-side.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
 		self::register_script( 'wc-product-new', plugins_url( 'build/product-new.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
 		self::register_script( 'wc-product-on-sale', plugins_url( 'build/product-on-sale.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
 		self::register_script( 'wc-product-top-rated', plugins_url( 'build/product-top-rated.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
@@ -180,11 +181,23 @@ class Assets {
 		$deps_path    = dirname( __DIR__ ) . '/' . str_replace( '.js', '.deps.json', $filename );
 		$dependencies = file_exists( $deps_path ) ? json_decode( file_get_contents( $deps_path ) ) : array(); // phpcs:ignore WordPress.WP.AlternativeFunctions
 		$dependencies = array_merge( $dependencies, $deps );
-
 		wp_register_script( $handle, $src, $dependencies, $ver, true );
 		if ( $has_i18n && function_exists( 'wp_set_script_translations' ) ) {
 			wp_set_script_translations( $handle, 'woo-gutenberg-products-block', dirname( __DIR__ ) . '/languages' );
 		}
+	}
+
+	/**
+	 * Temp access to protected function for registering frontend script.
+	 *
+	 * @param string $handle  The handle for the script.
+	 * @param string $file Path to the file from the plugin root.
+	 * @param array  $dependencies  An array of additional dependencies.
+	 * @return void
+	 */
+	public static function register_frontend_script( $handle, $file, $dependencies = [] ) {
+		$filepath = plugins_url( $file, __DIR__ );
+		self::register_script( $handle, $filepath, $dependencies );
 	}
 
 	/**

--- a/src/BlockTypes/ProductCategoryServerSide.php
+++ b/src/BlockTypes/ProductCategoryServerSide.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Product category SSR block.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * ProductCategory class.
+ */
+class ProductCategoryServerSide extends AbstractProductGrid {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-category-server-side';
+
+	/**
+	 * Set args specific to this block
+	 *
+	 * @param array $query_args Query args.
+	 */
+	protected function set_block_query_args( &$query_args ) {}
+
+	/**
+	 * Registers the block type
+	 *
+	 * @return void
+	 */
+	public function register_block_type() {
+		register_block_type(
+			$this->namespace . '/' . $this->block_name,
+			array(
+				'render_callback' => array( $this, 'render' ),
+				'editor_script'   => 'wc-' . $this->block_name,
+				'editor_style'    => 'wc-block-editor',
+				'style'           => 'wc-block-style',
+				'script'          => 'wc-product-category-server-side-frontend',
+				'attributes'      => $this->get_attributes(),
+			)
+		);
+	}
+
+
+	/**
+	 * Get block attributes.
+	 *
+	 * @return array
+	 */
+	protected function get_attributes() {
+		return array_merge(
+			parent::get_attributes(),
+			array(
+				'className' => $this->get_schema_string(),
+				'orderby'   => $this->get_schema_orderby(),
+				'editMode'  => $this->get_schema_boolean( true ),
+			)
+		);
+	}
+
+	/**
+	 * Get the data attributes for the rendered element.
+	 *
+	 * @param array $attributes  The attributes containing the data to embed.
+	 * @return string
+	 */
+	protected function get_data( $attributes ) {
+		return implode(
+			' ',
+			array(
+				"data-wc-blockattributes='" . wp_json_encode( $attributes ) . "'",
+				"data-block-name='" . $this->namespace . '/' . $this->block_name . "'",
+			)
+		);
+	}
+
+	/**
+	 * Render function for block
+	 *
+	 * @param array  $attributes  Attributes for block.
+	 * @param string $content    Content for block.
+	 * @return string
+	 */
+	public function render( $attributes = array(), $content = '' ) {
+		\Automattic\WooCommerce\Blocks\Assets::register_frontend_script(
+			'wc-product-category-server-side-frontend',
+			'build/product-category-server-side-frontend.js',
+			array( 'wc-vendors', 'wc-blocks' )
+		);
+		wp_enqueue_script( 'wc-product-category-server-side-frontend' );
+		$this->attributes = $this->parse_attributes( $attributes );
+		$this->content    = $content;
+		$this->query_args = $this->parse_query_args();
+		$products         = $this->get_products();
+		$classes          = $this->get_container_classes() . ' wc-ssr-block';
+		$data             = $this->get_data( $attributes );
+		$output           = implode( '', array_map( array( $this, 'render_product' ), $products ) );
+
+		return sprintf( '<div class="%s" %s><ul class="wc-block-grid__products">%s</ul></div>', esc_attr( $classes ), $data, $output );
+	}
+}

--- a/src/Library.php
+++ b/src/Library.php
@@ -31,6 +31,7 @@ class Library {
 			'HandpickedProducts',
 			'ProductBestSellers',
 			'ProductCategories',
+			'ProductCategoryServerSide',
 			'ProductCategory',
 			'ProductNew',
 			'ProductOnSale',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,6 +53,7 @@ const GutenbergBlocksConfig = {
 		'product-best-sellers': './assets/js/blocks/product-best-sellers/index.js',
 		'product-category': './assets/js/blocks/product-category/index.js',
 		'product-categories': './assets/js/blocks/product-categories/index.js',
+		'product-category-server-side': './assets/js/blocks/product-category-server-side/index.js',
 		'product-new': './assets/js/blocks/product-new/index.js',
 		'product-on-sale': './assets/js/blocks/product-on-sale/index.js',
 		'product-top-rated': './assets/js/blocks/product-top-rated/index.js',
@@ -158,6 +159,7 @@ const BlocksFrontendConfig = {
 	entry: {
 		'product-categories': './assets/js/blocks/product-categories/frontend.js',
 		'reviews-by-product': './assets/js/blocks/reviews-by-product/frontend.js',
+		'product-category-server-side': './assets/js/blocks/product-category-server-side/frontend.js'
 	},
 	output: {
 		path: path.resolve( __dirname, './build/' ),


### PR DESCRIPTION
> **Note**: See the task list [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/873#issuecomment-523557970) pulled out from this pull.

For the "Filter Products By..." feature for the store shop page, one of the challenges will be communicating the selections in the various filter blocks to the rendered shop product view.  This pull is a proof of concept demonstrating a way this can be achieved: 

- Shop product view is controlled via a block.  Store owners could configure the _defaults_ for the attributes used to query the products via the editor.
- A `wp.data` store is used for maintaining the query state of the block and is initialized on shop render on the frontend.
- (not in this pull) Filter blocks would dispatch actions to the registered store to update the query state and that will trigger re-rendering of the Shop product view.

Let's break these down:

### Shop product view is controlled via a block.

In the editor, the block is rendered ServerSideRender and default state for the block is (i.e. the attributes defining the query) are set up by the Store owner.  On save, these attributes are saved with the block.

When rendering on the frontend, the following happens:

- initial view is provided the same way as any dynamic block from PHP. It is enhanced by having the attributes and the block name embedded in the rendered container for the block.
- frontend javascript captures the html from the rendered view, parses the attributes and block name out of the html, and hydrates it as a react component attached to the parent element containing the block content.  To avoid any perceived change for the user, the component is populated with the grabbed content from the initial render.
- The component is enhanced (via `withSelect`) which subscribes it to the `wc-blocks/query-state` store.
- When attributes in the store state change, this switches the component to a `ServerSideRender` powered component which will update the view using the new attributes in the state.

### A `wp.data` store is used for maintaining the query state of the block

- registered on the frontend
- initially hydrated using the attributes parsed from the products element in the initial view.

### Filter blocks would dispatch actions to the registered store to update the query state and that will trigger re-rendering of the Shop product view.

While I did not wire up any filter blocks in this proof of concept, to simulate how it would work, I used direct `wp.data.dispatch` calls via the browser console.  This effectively demonstrates how the product list can be triggered via the store dispatch.  So effectively, any filter block enhanced by `withDispatch` on the frontend will be able to dispatch changes to the attribute controlled by the filter block and this will impact the main product block view.

Video demonstration: https://cl.ly/d2a6ccfae6b7

## Demonstration Setup

To try this out yourself:

- Gutenberg _must_ be active (I'm importing the `@wordpress/server-side-render` component which is only in it's own package in a later version of the plugin).
- Do the usual build stuff (`composer install`, `npm install`, `npm run start/build`).
- Create a page and add the "Products by Category SSR" block.  Configure how you wish.
- Save the page (or preview, doesn't matter).
- While viewing on the frontend, load the console.

Testing with the console you can do something like this:

```js
// grabs the actions that can be dispatched.
actions = wp.data.dispatch( 'wc-blocks/query-state' ); 
// first argument is the "context" in this case the block name
// second argument is the key of the attribute you wish to change (use any valid attribute key for the Product Category Block
// third argument is the value you wish to change to.
actions.setQueryValue( 'woocommerce/product-category-server-side', 'columns', 1 );
```

## Notes and Caveats

- This code is not polished and not production ready.  I didn't spend time optimizing or considering architectural concerns.  It's merely a _technical_ demonstration. Keep that in mind when reviewing.
- I'm aware, asset weight on the page is heavy, I'm going to continue to work on reducing that (I think it's due in part to the `wc-blocks` dependency which can be eliminated).  However things like `lodash` and `wp.element` will likely still be required. 
- There is currently a hard dependency on the Gutenberg plugin because with earlier versions of WordPress supported by Woo, `ServerSideRender` is embedded in `@wordpress/editor`.  I don't think that will change until WordPress 5.3 (I'll have to double check).  One thing we could do is extract ServerSideRender into our own package and version detect which we load.
- Feasibly, this removes the necessity for widget areas for the initial MVP.  We could simply use inner blocks (possibly along with a Block Template) to add the layout for the filter blocks and a main content area containing the `AllProducts` block.  The Inspector control would configure the defaults for the filters and the products in the AllProducts block in the editor context and then on the frontend user interaction with the filter blocks/components would trigger the products showing in the view.
- For the Shop page, since that is a page, we could have it be progressively enhanced.  In other words, if it has a `AllProducts` block in the content, don't show the product archive and instead use the content served from the block.
- The `block-renderer` endpoint (what `ServerSideRenderer` uses) is restricted.  So currently `ServerSideRenderer` can only be used via the edit context (and authed users).  We'll need a public solution (possibly a new endpoint and new component specifically for frontend use).

## Next Steps

- Is this a technical solution we want to try implementing for the initial iteration of the Shop view?
- If yes, then we can break down the things needing to happen into smaller tasks.
- As a part of this, while doing this work I noticed a number of areas both in php and js which can be refactored to make it easier to add new blocks.  Right now there seems to be a lot of different places needing updated with new blocks and it's easy to miss.  I'd like it to be more dynamic/drop-in (which I think is doable).
