### PR TITLE
Add changelog script

### DIFF
--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+'use strict';
+/* eslint-disable */
+
+const requestPromise = require( 'request-promise' );
+const chalk = require( 'chalk' );
+const octokit = require( '@octokit/rest' )();
+const promptly = require( 'promptly' );
+
+const headers = {
+	'Content-Type': 'application/json;charset=UTF-8',
+	'Authorization': `token ${process.env.GH_API_TOKEN}`,
+	'Accept': 'application/vnd.github.inertia-preview+json',
+	'User-Agent': 'request'
+};
+
+const columnIds = [];
+
+const getPullRequestType = labels => {
+	const typeLabel = labels.find( label => label.name.includes( '[Type]' ) );
+	if ( ! typeLabel ) {
+		return 'Dev';
+	}
+	return typeLabel.name.replace( '[Type] ', '' );
+};
+
+const getLabels = labels => {
+	return labels
+		.filter( label => ! /\[.*\]/.test( label.name ) )
+		.map( label => label.name )
+		.join( ', ' );
+};
+
+const isCollaborator = async ( username ) => {
+	return requestPromise( {
+		url: `https://api.github.com/orgs/woocommerce/members/${ username }`,
+		headers,
+		resolveWithFullResponse: true
+	} ).then( response => {
+		return response.statusCode === 204;
+	} )
+		.catch( err => {
+			if ( err.statusCode !== 404 ) {
+				console.log( '🤯' );
+				console.log( err.message );
+			}
+		});
+}
+
+const isMergedPullRequest = async ( pullRequestUrl ) => {
+	const options = {
+		url: pullRequestUrl,
+		headers,
+		json: true,
+	};
+	return requestPromise( options )
+		.then( data => data.merged )
+		.catch( err => {
+			console.log( '🤯' );
+			console.log( err.message );
+		});
+}
+
+const writeEntry = async ( content_url ) => {
+	const options = {
+		url: content_url,
+		headers,
+		json: true
+	}
+	return requestPromise( options )
+		.then( async data => {
+			if ( data.pull_request ) {
+				const isMerged = await isMergedPullRequest( data.pull_request.url );
+				if ( isMerged ) {
+					const collaborator = await isCollaborator( data.user.login );
+					const type = getPullRequestType( data.labels );
+					const labels = getLabels( data.labels );
+					const labelTag = labels.length ? `(${ labels })` : '';
+					const authorTag = collaborator ? '' : `👏 @${ data.user.login }`;
+					let title;
+					if ( /### Changelog Note/.test( data.body ) ) {
+						const bodyParts = data.body.split( '### Changelog Note:' );
+						const note = bodyParts[ bodyParts.length - 1 ];
+						title = note
+							// Remove comment prompt
+							.replace( /<!---(.*)--->/gm, '' )
+							// Remove new lines and whitespace
+							.trim();
+						if ( ! title.length ) {
+							title = `${ type }: ${ data.title }`;
+						}
+					} else {
+						title = `${ type }: ${ data.title }`;
+					}
+					const entry = `- ${ title } #${ data.number } ${ labelTag } ${ authorTag }`;
+					console.log( entry );
+				}
+			}
+		} )
+		.catch( err => {
+			console.log( '🤯' );
+			console.log( err.message );
+		});
+};
+
+const makeChangelog = async column_id => {
+	octokit.paginate(
+		'GET /projects/columns/:column_id/cards',
+		{ headers, column_id },
+		response => response.data.forEach( async card => {
+			await writeEntry( card.content_url );
+		} )
+	).catch( err => {
+		console.log( '🤯' );
+		console.log( err.message );
+	})
+};
+
+const printProjectColumns = async () => {
+	const options = {
+		url: 'https://api.github.com/projects/1492664/columns',
+		headers,
+		json: true,
+	}
+
+	console.log( chalk.yellow( 'Gathering columns from the project board, https://github.com/orgs/woocommerce/projects/2' ) );
+
+	return requestPromise( options )
+		.then( data => {
+			console.log( ' ' );
+			console.log( chalk.yellow( 'The project board contains the following columns:' ) );
+			console.log( ' ' );
+			console.log( '+---------+-----------------------------' );
+			console.log( '| id      | sprint name ' );
+			console.log( '+---------+-----------------------------' );
+			data.forEach( column => {
+				columnIds.push( column.id.toString() );
+				console.log( '| ' + chalk.green( column.id ) + ' | ' + column.name );
+			} );
+			console.log( '+---------+-----------------------------' );
+			console.log( ' ' );
+		} ).catch( err => {
+			console.log( '🤯' );
+			console.log( err.message );
+			exit;
+		});
+}
+
+( async () => {
+	console.log( chalk.yellow( 'This program requires an api token. You can create one here: ' ) + 'https://github.com/settings/tokens' );
+	console.log( '' );
+	console.log( chalk.yellow( 'Token scope will require read permissions on public_repo, admin:org, and user.' ) );
+	console.log( '' );
+	console.log( chalk.yellow( 'Export the token as variable called GH_API_TOKEN from your bash profile.' ) );
+	console.log( '' );
+
+	const ready = await promptly.confirm( 'Are you ready to continue? ' );
+
+	if ( ready ) {
+		await printProjectColumns();
+		const id = await promptly.prompt( chalk.yellow( 'Enter a column id: ' ) );
+
+		if ( columnIds.includes( id ) ) {
+			console.log( '' );
+			console.log( chalk.green( 'Here is the generated changelog. Be sure to remove entries ' +
+				'not intended for a WooCommerce Admin release.' ) );
+			console.log( '' );
+			makeChangelog( id );
+		} else {
+			console.log( '' );
+			console.log( chalk.red( 'Invalid column id' ) );
+			console.log( '' );
+		}
+	} else {
+		console.log( '' );
+		console.log( chalk.yellow( 'Ok, see you soon.' ) );
+		console.log( '' );
+	}
+} )();

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "test:help": "wp-scripts test-unit-js --help",
     "test:update": "wp-scripts test-unit-js --updateSnapshot --config tests/js/jest.config.json",
     "test:watch": "npm run test -- --watch",
-    "size-check": "bundlesize"
+    "size-check": "bundlesize",
+    "changelog": "node ./bin/changelog.js "
   },
   "devDependencies": {
     "@babel/core": "7.5.5",
     "@woocommerce/navigation": "2.1.1",
+    "@octokit/rest": "^16.28.7",
     "@wordpress/babel-preset-default": "4.4.0",
     "@wordpress/blocks": "6.5.0",
     "@wordpress/browserslist-config": "2.6.0",
@@ -81,7 +83,9 @@
     "po2json": "1.0.0-alpha",
     "postcss-loader": "3.0.0",
     "progress-bar-webpack-plugin": "1.12.1",
+    "promptly": "^3.0.3",
     "react-test-renderer": "16.8.6",
+    "request-promise": "^4.2.4",
     "rimraf": "2.7.1",
     "sass-loader": "7.2.0",
     "style-loader": "1.0.0",


### PR DESCRIPTION
This PR takes the `changelog.js` script from WooCommerce Admin so we can easily generate changelogs without having to create them manually for each release.

I adapted the script from WooCommerce Admin so ours uses milestones instead of sprints. I also removed labels from changelog entries, since I think they are not really relevant for users in our project.

I also added a `skip-changelog` label so we can easily tag PRs that should not appear in the changelog without having to remove them manually later.

### How to test the changes in this Pull Request:

1. Run `npm run changelog` and follow the steps.
2. Test generating the changelog for 2.3.1 and 2.4.