### PR TITLE
Fix error appearing on Reviews by Product when there were no reviews

### DIFF
--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -10,23 +10,19 @@ import {
 	Button,
 	PanelBody,
 	Placeholder,
-	Spinner,
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/components';
 import { Fragment } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import ApiErrorPlaceholder from '../../../components/api-error-placeholder';
 import EditorBlock from './editor-block.js';
 import ProductControl from '../../../components/product-control';
 import { IconReviewsByProduct } from '../../../components/icons';
-import { withProduct } from '../../../hocs';
 import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '../../../constants';
 import { getSharedReviewContentControls, getSharedReviewListControls } from '../edit.js';
 import { getBlockClassName } from '../utils.js';
@@ -34,7 +30,7 @@ import { getBlockClassName } from '../utils.js';
 /**
  * Component to handle edit mode of "Reviews by Product".
  */
-const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct, isLoading, product, setAttributes } ) => {
+const ReviewsByProductEditor = ( { attributes, debouncedSpeak, setAttributes } ) => {
 	attributes.showReviewImage = ( SHOW_AVATARS || attributes.imageType === 'product' ) && attributes.showReviewImage;
 	attributes.showReviewRating = ENABLE_REVIEW_RATING && attributes.showReviewRating;
 
@@ -111,27 +107,6 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 		);
 	};
 
-	const renderApiError = () => (
-		<ApiErrorPlaceholder
-			className="wc-block-featured-product-error"
-			error={ error }
-			isLoading={ isLoading }
-			onRetry={ getProduct }
-		/>
-	);
-
-	const renderLoadingScreen = () => {
-		return (
-			<Placeholder
-				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
-				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
-				className="wc-block-reviews-by-product"
-			>
-				<Spinner />
-			</Placeholder>
-		);
-	};
-
 	const renderEditMode = () => {
 		const onDone = () => {
 			setAttributes( { editMode: false } );
@@ -198,16 +173,8 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 		);
 	};
 
-	if ( error ) {
-		return renderApiError();
-	}
-
 	if ( ! productId || editMode ) {
 		return renderEditMode();
-	}
-
-	if ( ! product || isLoading ) {
-		return renderLoadingScreen();
 	}
 
 	return (
@@ -232,19 +199,8 @@ ReviewsByProductEditor.propTypes = {
 	 * A callback to update attributes.
 	 */
 	setAttributes: PropTypes.func.isRequired,
-	// from withProduct
-	error: PropTypes.object,
-	getProduct: PropTypes.func,
-	isLoading: PropTypes.bool,
-	product: PropTypes.shape( {
-		name: PropTypes.node,
-		review_count: PropTypes.number,
-	} ),
 	// from withSpokenMessages
 	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-export default compose( [
-	withProduct,
-	withSpokenMessages,
-] )( ReviewsByProductEditor );
+export default withSpokenMessages( ReviewsByProductEditor );

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -17,6 +17,7 @@ import {
 import { SearchListItem } from '@woocommerce/components';
 import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
+import { escapeHTML } from '@wordpress/escape-html';
 import PropTypes from 'prop-types';
 
 /**
@@ -186,9 +187,31 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 		);
 	};
 
+	const renderNoReviews = () => (
+		<Placeholder
+			className="wc-block-reviews-by-product"
+			icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
+			label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
+		>
+			<div dangerouslySetInnerHTML={ {
+				__html: sprintf(
+					__(
+						"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
+						'woo-gutenberg-products-block'
+					),
+					'<strong>' + escapeHTML( product.name ) + '</strong>'
+				),
+			} } />
+		</Placeholder>
+	);
+
 	const renderViewMode = () => {
 		if ( ! showReviewContent && ! showReviewRating && ! showReviewDate && ! showReviewerName && ! showReviewImage ) {
 			return renderHiddenContentPlaceholder();
+		}
+
+		if ( product.review_count === 0 ) {
+			return renderNoReviews();
 		}
 
 		return (

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -10,19 +10,23 @@ import {
 	Button,
 	PanelBody,
 	Placeholder,
+	Spinner,
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/components';
 import { Fragment } from '@wordpress/element';
+import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
+import ApiErrorPlaceholder from '../../../components/api-error-placeholder';
 import EditorBlock from './editor-block.js';
 import ProductControl from '../../../components/product-control';
 import { IconReviewsByProduct } from '../../../components/icons';
+import { withProduct } from '../../../hocs';
 import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '../../../constants';
 import { getSharedReviewContentControls, getSharedReviewListControls } from '../edit.js';
 import { getBlockClassName } from '../utils.js';
@@ -30,7 +34,7 @@ import { getBlockClassName } from '../utils.js';
 /**
  * Component to handle edit mode of "Reviews by Product".
  */
-const ReviewsByProductEditor = ( { attributes, debouncedSpeak, setAttributes } ) => {
+const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct, isLoading, product, setAttributes } ) => {
 	attributes.showReviewImage = ( SHOW_AVATARS || attributes.imageType === 'product' ) && attributes.showReviewImage;
 	attributes.showReviewRating = ENABLE_REVIEW_RATING && attributes.showReviewRating;
 
@@ -107,6 +111,27 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, setAttributes } )
 		);
 	};
 
+	const renderApiError = () => (
+		<ApiErrorPlaceholder
+			className="wc-block-featured-product-error"
+			error={ error }
+			isLoading={ isLoading }
+			onRetry={ getProduct }
+		/>
+	);
+
+	const renderLoadingScreen = () => {
+		return (
+			<Placeholder
+				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
+				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
+				className="wc-block-reviews-by-product"
+			>
+				<Spinner />
+			</Placeholder>
+		);
+	};
+
 	const renderEditMode = () => {
 		const onDone = () => {
 			setAttributes( { editMode: false } );
@@ -173,8 +198,16 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, setAttributes } )
 		);
 	};
 
+	if ( error ) {
+		return renderApiError();
+	}
+
 	if ( ! productId || editMode ) {
 		return renderEditMode();
+	}
+
+	if ( ! product || isLoading ) {
+		return renderLoadingScreen();
 	}
 
 	return (
@@ -199,8 +232,19 @@ ReviewsByProductEditor.propTypes = {
 	 * A callback to update attributes.
 	 */
 	setAttributes: PropTypes.func.isRequired,
+	// from withProduct
+	error: PropTypes.object,
+	getProduct: PropTypes.func,
+	isLoading: PropTypes.bool,
+	product: PropTypes.shape( {
+		name: PropTypes.node,
+		review_count: PropTypes.number,
+	} ),
 	// from withSpokenMessages
 	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-export default withSpokenMessages( ReviewsByProductEditor );
+export default compose( [
+	withProduct,
+	withSpokenMessages,
+] )( ReviewsByProductEditor );

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -10,24 +10,19 @@ import {
 	Button,
 	PanelBody,
 	Placeholder,
-	Spinner,
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/components';
 import { Fragment } from '@wordpress/element';
-import { compose } from '@wordpress/compose';
-import { escapeHTML } from '@wordpress/escape-html';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import ApiErrorPlaceholder from '../../../components/api-error-placeholder';
 import EditorBlock from './editor-block.js';
 import ProductControl from '../../../components/product-control';
 import { IconReviewsByProduct } from '../../../components/icons';
-import { withProduct } from '../../../hocs';
 import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '../../../constants';
 import { getSharedReviewContentControls, getSharedReviewListControls } from '../edit.js';
 import { getBlockClassName } from '../utils.js';
@@ -35,7 +30,7 @@ import { getBlockClassName } from '../utils.js';
 /**
  * Component to handle edit mode of "Reviews by Product".
  */
-const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct, isLoading, product, setAttributes } ) => {
+const ReviewsByProductEditor = ( { attributes, debouncedSpeak, setAttributes } ) => {
 	attributes.showReviewImage = ( SHOW_AVATARS || attributes.imageType === 'product' ) && attributes.showReviewImage;
 	attributes.showReviewRating = ENABLE_REVIEW_RATING && attributes.showReviewRating;
 
@@ -112,27 +107,6 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 		);
 	};
 
-	const renderApiError = () => (
-		<ApiErrorPlaceholder
-			className="wc-block-featured-product-error"
-			error={ error }
-			isLoading={ isLoading }
-			onRetry={ getProduct }
-		/>
-	);
-
-	const renderLoadingScreen = () => {
-		return (
-			<Placeholder
-				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
-				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
-				className="wc-block-reviews-by-product"
-			>
-				<Spinner />
-			</Placeholder>
-		);
-	};
-
 	const renderEditMode = () => {
 		const onDone = () => {
 			setAttributes( { editMode: false } );
@@ -187,31 +161,9 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 		);
 	};
 
-	const renderNoReviews = () => (
-		<Placeholder
-			className="wc-block-reviews-by-product"
-			icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
-			label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
-		>
-			<div dangerouslySetInnerHTML={ {
-				__html: sprintf(
-					__(
-						"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
-						'woo-gutenberg-products-block'
-					),
-					'<strong>' + escapeHTML( product.name ) + '</strong>'
-				),
-			} } />
-		</Placeholder>
-	);
-
 	const renderViewMode = () => {
 		if ( ! showReviewContent && ! showReviewRating && ! showReviewDate && ! showReviewerName && ! showReviewImage ) {
 			return renderHiddenContentPlaceholder();
-		}
-
-		if ( product.review_count === 0 ) {
-			return renderNoReviews();
 		}
 
 		return (
@@ -221,16 +173,8 @@ const ReviewsByProductEditor = ( { attributes, debouncedSpeak, error, getProduct
 		);
 	};
 
-	if ( error ) {
-		return renderApiError();
-	}
-
 	if ( ! productId || editMode ) {
 		return renderEditMode();
-	}
-
-	if ( ! product || isLoading ) {
-		return renderLoadingScreen();
 	}
 
 	return (
@@ -255,19 +199,8 @@ ReviewsByProductEditor.propTypes = {
 	 * A callback to update attributes.
 	 */
 	setAttributes: PropTypes.func.isRequired,
-	// from withProduct
-	error: PropTypes.object,
-	getProduct: PropTypes.func,
-	isLoading: PropTypes.bool,
-	product: PropTypes.shape( {
-		name: PropTypes.node,
-		review_count: PropTypes.number,
-	} ),
 	// from withSpokenMessages
 	debouncedSpeak: PropTypes.func.isRequired,
 };
 
-export default compose( [
-	withProduct,
-	withSpokenMessages,
-] )( ReviewsByProductEditor );
+export default withSpokenMessages( ReviewsByProductEditor );

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -6,17 +6,20 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 import { escapeHTML } from '@wordpress/escape-html';
-import { Disabled, Placeholder } from '@wordpress/components';
+import { RawHTML } from '@wordpress/element';
+import { Disabled, Placeholder, Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import ApiErrorPlaceholder from '../../../components/api-error-placeholder';
 import { getOrderArgs, getReviews } from '../utils';
 import LoadMoreButton from '../../../base/components/load-more-button';
 import ReviewList from '../../../base/components/review-list';
 import ReviewOrderSelect from '../../../base/components/review-order-select';
 import withComponentId from '../../../base/hocs/with-component-id';
 import { IconReviewsByProduct } from '../../../components/icons';
+import { withProduct } from '../../../hocs';
 import { ENABLE_REVIEW_RATING } from '../../../constants';
 /**
  * Block rendered in the editor.
@@ -69,33 +72,67 @@ class EditorBlock extends Component {
 		} );
 	}
 
+	renderApiError() {
+		const { error, getProduct, isLoading } = this.props;
+
+		return (
+			<ApiErrorPlaceholder
+				className="wc-block-featured-product-error"
+				error={ error }
+				isLoading={ isLoading }
+				onRetry={ getProduct }
+			/>
+		);
+	}
+
+	renderLoadingScreen() {
+		return (
+			<Placeholder
+				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
+				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
+				className="wc-block-reviews-by-product"
+			>
+				<Spinner />
+			</Placeholder>
+		);
+	}
+
 	renderNoReviews() {
-		const { attributes } = this.props;
-		const { product } = attributes;
+		const { product } = this.props;
+
 		return (
 			<Placeholder
 				className="wc-block-reviews-by-product"
 				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
 				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
 			>
-				<div dangerouslySetInnerHTML={ {
-					__html: sprintf(
+				<RawHTML>
+					{ sprintf(
 						__(
 							"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
 							'woo-gutenberg-products-block'
 						),
 						'<strong>' + escapeHTML( product.name ) + '</strong>'
-					),
-				} } />
+					) }
+				</RawHTML>
 			</Placeholder>
 		);
 	}
 
 	render() {
-		const { attributes, componentId } = this.props;
-		const { reviews, totalReviews, isLoading } = this.state;
+		const { attributes, componentId, error, product } = this.props;
+		const { reviews, totalReviews } = this.state;
+		const isLoading = this.state.isLoading || this.props.isLoading;
 
-		if ( 0 === reviews.length && ! isLoading ) {
+		if ( error ) {
+			return this.renderApiError();
+		}
+
+		if ( isLoading || ! product ) {
+			return this.renderLoadingScreen();
+		}
+
+		if ( 0 === reviews.length ) {
 			return this.renderNoReviews();
 		}
 
@@ -128,8 +165,15 @@ EditorBlock.propTypes = {
 	 * The attributes for this block.
 	 */
 	attributes: PropTypes.object.isRequired,
+	// from withProduct
+	error: PropTypes.object,
+	getProduct: PropTypes.func,
+	isLoading: PropTypes.bool,
+	product: PropTypes.shape( {
+		name: PropTypes.node,
+	} ),
 	// from withComponentId
 	componentId: PropTypes.number,
 };
 
-export default withComponentId( EditorBlock );
+export default withComponentId( withProduct( EditorBlock ) );

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -1,12 +1,11 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
-import { escapeHTML } from '@wordpress/escape-html';
-import { Disabled, Placeholder } from '@wordpress/components';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,7 +15,6 @@ import LoadMoreButton from '../../../base/components/load-more-button';
 import ReviewList from '../../../base/components/review-list';
 import ReviewOrderSelect from '../../../base/components/review-order-select';
 import withComponentId from '../../../base/hocs/with-component-id';
-import { IconReviewsByProduct } from '../../../components/icons';
 import { ENABLE_REVIEW_RATING } from '../../../constants';
 /**
  * Block rendered in the editor.
@@ -67,28 +65,6 @@ class EditorBlock extends Component {
 		} ).catch( () => {
 			this.setState( { reviews: [], isLoading: false } );
 		} );
-	}
-
-	renderNoReviews() {
-		const { attributes } = this.props;
-		const { product } = attributes;
-		return (
-			<Placeholder
-				className="wc-block-reviews-by-product"
-				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
-				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
-			>
-				<div dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						__(
-							"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
-							'woo-gutenberg-products-block'
-						),
-						'<strong>' + escapeHTML( product.name ) + '</strong>'
-					),
-				} } />
-			</Placeholder>
-		);
 	}
 
 	render() {

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -6,20 +6,17 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
 import { escapeHTML } from '@wordpress/escape-html';
-import { RawHTML } from '@wordpress/element';
-import { Disabled, Placeholder, Spinner } from '@wordpress/components';
+import { Disabled, Placeholder } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import ApiErrorPlaceholder from '../../../components/api-error-placeholder';
 import { getOrderArgs, getReviews } from '../utils';
 import LoadMoreButton from '../../../base/components/load-more-button';
 import ReviewList from '../../../base/components/review-list';
 import ReviewOrderSelect from '../../../base/components/review-order-select';
 import withComponentId from '../../../base/hocs/with-component-id';
 import { IconReviewsByProduct } from '../../../components/icons';
-import { withProduct } from '../../../hocs';
 import { ENABLE_REVIEW_RATING } from '../../../constants';
 /**
  * Block rendered in the editor.
@@ -72,67 +69,33 @@ class EditorBlock extends Component {
 		} );
 	}
 
-	renderApiError() {
-		const { error, getProduct, isLoading } = this.props;
-
-		return (
-			<ApiErrorPlaceholder
-				className="wc-block-featured-product-error"
-				error={ error }
-				isLoading={ isLoading }
-				onRetry={ getProduct }
-			/>
-		);
-	}
-
-	renderLoadingScreen() {
-		return (
-			<Placeholder
-				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
-				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
-				className="wc-block-reviews-by-product"
-			>
-				<Spinner />
-			</Placeholder>
-		);
-	}
-
 	renderNoReviews() {
-		const { product } = this.props;
-
+		const { attributes } = this.props;
+		const { product } = attributes;
 		return (
 			<Placeholder
 				className="wc-block-reviews-by-product"
 				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
 				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
 			>
-				<RawHTML>
-					{ sprintf(
+				<div dangerouslySetInnerHTML={ {
+					__html: sprintf(
 						__(
 							"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
 							'woo-gutenberg-products-block'
 						),
 						'<strong>' + escapeHTML( product.name ) + '</strong>'
-					) }
-				</RawHTML>
+					),
+				} } />
 			</Placeholder>
 		);
 	}
 
 	render() {
-		const { attributes, componentId, error, product } = this.props;
-		const { reviews, totalReviews } = this.state;
-		const isLoading = this.state.isLoading || this.props.isLoading;
+		const { attributes, componentId } = this.props;
+		const { reviews, totalReviews, isLoading } = this.state;
 
-		if ( error ) {
-			return this.renderApiError();
-		}
-
-		if ( isLoading || ! product ) {
-			return this.renderLoadingScreen();
-		}
-
-		if ( 0 === reviews.length ) {
+		if ( 0 === reviews.length && ! isLoading ) {
 			return this.renderNoReviews();
 		}
 
@@ -165,15 +128,8 @@ EditorBlock.propTypes = {
 	 * The attributes for this block.
 	 */
 	attributes: PropTypes.object.isRequired,
-	// from withProduct
-	error: PropTypes.object,
-	getProduct: PropTypes.func,
-	isLoading: PropTypes.bool,
-	product: PropTypes.shape( {
-		name: PropTypes.node,
-	} ),
 	// from withComponentId
 	componentId: PropTypes.number,
 };
 
-export default withComponentId( withProduct( EditorBlock ) );
+export default withComponentId( EditorBlock );

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -15,6 +15,7 @@ import LoadMoreButton from '../../../base/components/load-more-button';
 import ReviewList from '../../../base/components/review-list';
 import ReviewOrderSelect from '../../../base/components/review-order-select';
 import withComponentId from '../../../base/hocs/with-component-id';
+import NoReviewsPlaceholder from './no-reviews-placeholder.js';
 import { ENABLE_REVIEW_RATING } from '../../../constants';
 /**
  * Block rendered in the editor.
@@ -72,7 +73,7 @@ class EditorBlock extends Component {
 		const { reviews, totalReviews, isLoading } = this.state;
 
 		if ( 0 === reviews.length && ! isLoading ) {
-			return this.renderNoReviews();
+			return <NoReviewsPlaceholder attributes={ attributes } />;
 		}
 
 		return (

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -1,10 +1,11 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
+import { escapeHTML } from '@wordpress/escape-html';
 import { Disabled, Placeholder } from '@wordpress/components';
 
 /**
@@ -69,13 +70,23 @@ class EditorBlock extends Component {
 	}
 
 	renderNoReviews() {
+		const { attributes } = this.props;
+		const { product } = attributes;
 		return (
 			<Placeholder
 				className="wc-block-reviews-by-product"
 				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
 				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
 			>
-				{ __( "This block lists reviews for a selected product. The selected product doesn't have any reviews yet, but they will show up here when it does.", 'woo-gutenberg-products-block' ) }
+				<div dangerouslySetInnerHTML={ {
+					__html: sprintf(
+						__(
+							"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
+							'woo-gutenberg-products-block'
+						),
+						'<strong>' + escapeHTML( product.name ) + '</strong>'
+					),
+				} } />
 			</Placeholder>
 		);
 	}

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
-import { escapeHTML } from '@wordpress/escape-html';
 import { Disabled, Placeholder } from '@wordpress/components';
 
 /**
@@ -70,23 +69,13 @@ class EditorBlock extends Component {
 	}
 
 	renderNoReviews() {
-		const { attributes } = this.props;
-		const { product } = attributes;
 		return (
 			<Placeholder
 				className="wc-block-reviews-by-product"
 				icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
 				label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
 			>
-				<div dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						__(
-							"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
-							'woo-gutenberg-products-block'
-						),
-						'<strong>' + escapeHTML( product.name ) + '</strong>'
-					),
-				} } />
+				{ __( "This block lists reviews for a selected product. The selected product doesn't have any reviews yet, but they will show up here when it does.", 'woo-gutenberg-products-block' ) }
 			</Placeholder>
 		);
 	}

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { escapeHTML } from '@wordpress/escape-html';
+import { Placeholder, Spinner } from '@wordpress/components';
+import { RawHTML } from '@wordpress/element';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import ApiErrorPlaceholder from '../../../components/api-error-placeholder';
+import { IconReviewsByProduct } from '../../../components/icons';
+import { withProduct } from '../../../hocs';
+
+const NoReviewsPlaceholder = ( { error, getProduct, isLoading, product } ) => {
+	const renderApiError = () => (
+		<ApiErrorPlaceholder
+			className="wc-block-featured-product-error"
+			error={ error }
+			isLoading={ isLoading }
+			onRetry={ getProduct }
+		/>
+	);
+
+	if ( error ) {
+		return renderApiError();
+	}
+
+	const content = ( ! product || isLoading ) ? <Spinner /> : (
+		<RawHTML>
+			{ sprintf(
+				__(
+					"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
+					'woo-gutenberg-products-block'
+				),
+				'<strong>' + escapeHTML( product.name ) + '</strong>'
+			) }
+		</RawHTML>
+	);
+
+	return (
+		<Placeholder
+			className="wc-block-reviews-by-product"
+			icon={ <IconReviewsByProduct className="block-editor-block-icon" /> }
+			label={ __( 'Reviews by Product', 'woo-gutenberg-products-block' ) }
+		>
+			{ content }
+		</Placeholder>
+	);
+};
+
+NoReviewsPlaceholder.propTypes = {
+};
+
+NoReviewsPlaceholder.defaultProps = {
+	// from withProduct
+	error: PropTypes.object,
+	isLoading: PropTypes.bool,
+	product: PropTypes.shape( {
+		name: PropTypes.node,
+		review_count: PropTypes.number,
+	} ),
+};
+
+export default withProduct( NoReviewsPlaceholder );

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -4,7 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { escapeHTML } from '@wordpress/escape-html';
 import { Placeholder, Spinner } from '@wordpress/components';
-import { RawHTML } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
@@ -28,17 +27,15 @@ const NoReviewsPlaceholder = ( { error, getProduct, isLoading, product } ) => {
 		return renderApiError();
 	}
 
-	const content = ( ! product || isLoading ) ? <Spinner /> : (
-		<RawHTML>
-			{ sprintf(
-				__(
-					"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
-					'woo-gutenberg-products-block'
-				),
-				'<strong>' + escapeHTML( product.name ) + '</strong>'
-			) }
-		</RawHTML>
-	);
+	const content = ( ! product || isLoading ) ?
+		<Spinner /> :
+		sprintf(
+			__(
+				"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
+				'woo-gutenberg-products-block'
+			),
+			escapeHTML( product.name )
+		);
 
 	return (
 		<Placeholder

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -49,9 +49,6 @@ const NoReviewsPlaceholder = ( { error, getProduct, isLoading, product } ) => {
 };
 
 NoReviewsPlaceholder.propTypes = {
-};
-
-NoReviewsPlaceholder.defaultProps = {
 	// from withProduct
 	error: PropTypes.object,
 	isLoading: PropTypes.bool,

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { escapeHTML } from '@wordpress/escape-html';
 import { Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
@@ -34,7 +33,7 @@ const NoReviewsPlaceholder = ( { error, getProduct, isLoading, product } ) => {
 				"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
 				'woo-gutenberg-products-block'
 			),
-			escapeHTML( product.name )
+			product.name
 		);
 
 	return (


### PR DESCRIPTION
Fixes a JavaScript error appearing in _Reviews by Product_ when a product with no reviews was selected. That's because we were using a `product` attribute that doesn't exist.

### How to test the changes in this Pull Request:

1. Create a post with a _Reviews by Product_ block.
2. Select a product with 0 reviews.
3. Verify there is no JS error.
