### PR TITLE
Set eslint version back to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "cross-env": "5.2.0",
     "css-loader": "3.2.0",
     "cssnano": "4.1.10",
-    "eslint": "6.2.1",
+    "eslint": "6.1.0",
     "eslint-plugin-jest": "22.15.1",
     "har-validator": "5.1.3",
     "husky": "2.4.1",


### PR DESCRIPTION
There seems to be a bug when updating eslint to 6.2.0 when it's used in combination with babel-eslint:

https://github.com/eslint/eslint/issues/12117

https://github.com/babel/babel-eslint/issues/791

Until there is an upstream fix, we should lock eslint version to 6.1.0.

### How to test the changes in this Pull Request:

1. Run `npm run lint` and see it pass.
2. Verify Travis is passing in this PR.