### PR TITLE
Refactor: Introduce `wc-block-settings` bundle serving as `@woocommerce/settings` external.

### DIFF
--- a/assets/js/base/components/review-list/index.js
+++ b/assets/js/base/components/review-list/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import ReviewListItem from '../review-list-item';
-import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '../../../constants';
 import './style.scss';
 
 const ReviewList = ( { attributes, componentId, reviews } ) => {

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -29,12 +29,12 @@ import classnames from 'classnames';
 import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
-import { IconFolderStar } from '../../components/icons';
+import { MIN_HEIGHT } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { MIN_HEIGHT } from '../../constants';
+import { IconFolderStar } from '../../components/icons';
 import ProductCategoryControl from '../../components/product-category-control';
 import ApiErrorPlaceholder from '../../components/api-error-placeholder';
 import {

--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/editor';
 import { registerBlockType } from '@wordpress/blocks';
+import { DEFAULT_HEIGHT } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import './style.scss';
 import './editor.scss';
 import Block from './block';
 import { IconFolderStar } from '../../components/icons';
-import { DEFAULT_HEIGHT } from '../../constants';
 
 /**
  * Register and run the "Featured Category" block.

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -30,6 +30,7 @@ import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
+import { MIN_HEIGHT } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -45,7 +46,6 @@ import {
 	getImageIdFromProduct,
 } from '../../utils/products';
 import { withProduct } from '../../hocs';
-import { MIN_HEIGHT } from '../../constants';
 
 /**
  * Component to handle edit mode of "Featured Product".

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/editor';
 import { registerBlockType } from '@wordpress/blocks';
+import { DEFAULT_HEIGHT } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -11,7 +12,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import './style.scss';
 import './editor.scss';
 import Block from './block';
-import { DEFAULT_HEIGHT } from '../../constants';
 
 /**
  * Register and run the "Featured Product" block.

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -19,6 +19,7 @@ import {
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { MAX_COLUMNS, MIN_COLUMNS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -27,7 +28,6 @@ import GridContentControl from '../../components/grid-content-control';
 import { IconWidgets } from '../../components/icons';
 import ProductsControl from '../../components/products-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
-import { MAX_COLUMNS, MIN_COLUMNS } from '../../constants';
 
 /**
  * Component to handle edit mode of "Hand-picked Products".

--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { DEFAULT_COLUMNS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -11,7 +12,6 @@ import './editor.scss';
 import Block from './block';
 import { deprecatedConvertToShortcode } from '../../utils/deprecations';
 import { IconWidgets } from '../../components/icons';
-import { DEFAULT_COLUMNS } from '../../constants';
 
 registerBlockType( 'woocommerce/handpicked-products', {
 	title: __( 'Hand-picked Products', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -4,12 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { Component, createRef, Fragment } from 'react';
 import classnames from 'classnames';
+import { HOME_URL } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import withComponentId from '../../base/hocs/with-component-id';
-import { HOME_URL } from '../../constants';
 
 /**
  * Component displaying the categories as dropdown or list.

--- a/assets/js/blocks/product-categories/get-categories.js
+++ b/assets/js/blocks/product-categories/get-categories.js
@@ -2,7 +2,11 @@
  * Internal dependencies
  */
 import { buildTermsTree } from './hierarchy';
-import { PRODUCT_CATEGORIES } from '../../constants';
+
+/**
+ * External dependencies
+ */
+import { PRODUCT_CATEGORIES } from '@woocommerce/settings';
 
 /**
  * Returns categories in tree form.

--- a/assets/js/blocks/product-categories/get-categories.js
+++ b/assets/js/blocks/product-categories/get-categories.js
@@ -1,12 +1,12 @@
 /**
- * Internal dependencies
- */
-import { buildTermsTree } from './hierarchy';
-
-/**
  * External dependencies
  */
 import { PRODUCT_CATEGORIES } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import { buildTermsTree } from './hierarchy';
 
 /**
  * Returns categories in tree form.

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -7,11 +7,11 @@ import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { PlainText } from '@wordpress/editor';
+import { HOME_URL } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { HOME_URL } from '../../constants';
 import './editor.scss';
 import './style.scss';
 

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { HAS_TAGS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -25,7 +26,6 @@ import GridContentControl from '../../components/grid-content-control';
 import GridLayoutControl from '../../components/grid-layout-control';
 import ProductTagControl from '../../components/product-tag-control';
 import ProductOrderbyControl from '../../components/product-orderby-control';
-import { HAS_TAGS } from '../../constants';
 
 /**
  * Component to handle edit mode of "Products by Tag".

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -3,13 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
 import Block from './block';
-import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../../constants';
 
 /**
  * Register and run the "Products by Tag" block.

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import Gridicon from 'gridicons';
 import { registerBlockType } from '@wordpress/blocks';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -11,7 +12,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import './editor.scss';
 import Block from './block';
 import { deprecatedConvertToShortcode } from '../../utils/deprecations';
-import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../../constants';
 
 const blockTypeName = 'woocommerce/products-by-attribute';
 

--- a/assets/js/blocks/reviews/edit.js
+++ b/assets/js/blocks/reviews/edit.js
@@ -7,12 +7,12 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { getAdminLink } from '@woocommerce/navigation';
+import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import ToggleButtonControl from '../../components/toggle-button-control';
-import { ENABLE_REVIEW_RATING, SHOW_AVATARS } from '../../constants';
 
 export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 	return (

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import { ENABLE_REVIEW_RATING } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import ReviewOrderSelect from '../../base/components/review-order-select';
 import ReviewList from '../../base/components/review-list';
 import withComponentId from '../../base/hocs/with-component-id';
 import withReviews from '../../base/hocs/with-reviews';
-import { ENABLE_REVIEW_RATING } from '../../constants';
 
 /**
  * Block rendered in the frontend.

--- a/assets/js/blocks/reviews/reviews-by-category/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-category/editor-block.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Disabled, Placeholder } from '@wordpress/components';
+import { ENABLE_REVIEW_RATING } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -15,7 +16,6 @@ import ReviewOrderSelect from '../../../base/components/review-order-select';
 import withComponentId from '../../../base/hocs/with-component-id';
 import withReviews from '../../../base/hocs/with-reviews';
 import { IconReviewsByCategory } from '../../../components/icons';
-import { ENABLE_REVIEW_RATING } from '../../../constants';
 
 /**
  * Block rendered in the editor.

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -5,6 +5,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Disabled, Placeholder } from '@wordpress/components';
+import { ENABLE_REVIEW_RATING } from '@woocommerce/settings';
+import { escapeHTML } from '@wordpress/escape-html';
 
 /**
  * Internal dependencies
@@ -15,11 +17,7 @@ import ReviewOrderSelect from '../../../base/components/review-order-select';
 import withComponentId from '../../../base/hocs/with-component-id';
 import withReviews from '../../../base/hocs/with-reviews';
 import { IconReviewsByProduct } from '../../../components/icons';
-import NoReviewsPlaceholder from './no-reviews-placeholder.js';
-import { ENABLE_REVIEW_RATING } from '../../../constants';
-import { escapeHTML } from '@wordpress/escape-html';
-
-/**
+import NoReviewsPlaceholder from './no-reviews-placeholder.js';/**
  * Block rendered in the editor.
  */
 class EditorBlock extends Component {

--- a/assets/js/blocks/reviews/reviews-by-product/editor-block.js
+++ b/assets/js/blocks/reviews/reviews-by-product/editor-block.js
@@ -17,7 +17,9 @@ import ReviewOrderSelect from '../../../base/components/review-order-select';
 import withComponentId from '../../../base/hocs/with-component-id';
 import withReviews from '../../../base/hocs/with-reviews';
 import { IconReviewsByProduct } from '../../../components/icons';
-import NoReviewsPlaceholder from './no-reviews-placeholder.js';/**
+import NoReviewsPlaceholder from './no-reviews-placeholder.js';
+
+/**
  * Block rendered in the editor.
  */
 class EditorBlock extends Component {

--- a/assets/js/blocks/reviews/utils.js
+++ b/assets/js/blocks/reviews/utils.js
@@ -3,11 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-import { ENABLE_REVIEW_RATING } from '../../constants';
+import { ENABLE_REVIEW_RATING } from '@woocommerce/settings';
 
 export const getOrderArgs = ( orderValue ) => {
 	if ( ENABLE_REVIEW_RATING ) {

--- a/assets/js/components/grid-layout-control/index.js
+++ b/assets/js/components/grid-layout-control/index.js
@@ -6,7 +6,7 @@ import { clamp, isNaN } from 'lodash';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { RangeControl, ToggleControl } from '@wordpress/components';
-import { MAX_COLUMNS, MIN_COLUMNS, MAX_ROWS, MIN_ROWS } from '../../constants';
+import { MAX_COLUMNS, MIN_COLUMNS, MAX_ROWS, MIN_ROWS } from '@woocommerce/settings';
 
 /**
  * A combination of range controls for product grid layout settings.

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -9,11 +9,11 @@ import { debounce, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
 import { SelectControl, Spinner } from '@wordpress/components';
+import { ENDPOINTS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { ENDPOINTS } from '../../constants';
 import './style.scss';
 
 class ProductAttributeControl extends Component {

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -9,11 +9,11 @@ import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
 import { SelectControl } from '@wordpress/components';
+import { ENDPOINTS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { ENDPOINTS } from '../../constants';
 import './style.scss';
 
 class ProductCategoryControl extends Component {

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -13,11 +13,11 @@ import {
 } from '@woocommerce/components';
 import { Spinner, MenuItem } from '@wordpress/components';
 import classnames from 'classnames';
+import { ENDPOINTS, IS_LARGE_CATALOG } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { ENDPOINTS, IS_LARGE_CATALOG } from '../../constants';
 import { getProducts } from '../utils';
 import {
 	IconRadioSelected,

--- a/assets/js/components/product-preview/index.js
+++ b/assets/js/components/product-preview/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
-import { PLACEHOLDER_IMG_SRC, THUMBNAIL_SIZE } from '../../constants';
+import { PLACEHOLDER_IMG_SRC, THUMBNAIL_SIZE } from '@woocommerce/settings';
 
 /**
  * Internal dependencies

--- a/assets/js/components/product-preview/test/index.js
+++ b/assets/js/components/product-preview/test/index.js
@@ -8,7 +8,7 @@ import TestRenderer from 'react-test-renderer';
  */
 import ProductPreview from '../';
 
-jest.mock( '../../../constants.js', () => ( {
+jest.mock( '@woocommerce/settings', () => ( {
 	PLACEHOLDER_IMG_SRC: 'placeholder.png',
 	THUMBNAIL_SIZE: 300,
 } ) );

--- a/assets/js/components/product-tag-control/index.js
+++ b/assets/js/components/product-tag-control/index.js
@@ -7,12 +7,12 @@ import { debounce, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
 import { SelectControl } from '@wordpress/components';
+import { LIMIT_TAGS } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import { getProductTags } from '../utils';
-import { LIMIT_TAGS } from '../../constants';
 import './style.scss';
 
 /**

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -4,11 +4,7 @@
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { flatten, uniqBy } from 'lodash';
-
-/**
- * Internal dependencies
- */
-import { ENDPOINTS, IS_LARGE_CATALOG, LIMIT_TAGS } from '../../constants';
+import { ENDPOINTS, IS_LARGE_CATALOG, LIMIT_TAGS } from '@woocommerce/settings';
 
 const getProductsRequests = ( { selected = [], search = '', queryArgs = [] } ) => {
 	const defaultArgs = {

--- a/assets/js/hocs/test/with-searched-products.js
+++ b/assets/js/hocs/test/with-searched-products.js
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import withSearchedProducts from '../with-searched-products';
 import * as mockedUtils from '../../components/utils';
 
-jest.mock( '../../constants.js', () => ( {
+jest.mock( '@woocommerce/settings', () => ( {
 	IS_LARGE_CATALOG: true,
 } ) );
 

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -5,11 +5,11 @@ import { Component } from '@wordpress/element';
 import { debounce } from 'lodash';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import PropTypes from 'prop-types';
+import { IS_LARGE_CATALOG } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
-import { IS_LARGE_CATALOG } from '../constants';
 import { getProducts } from '../components/utils';
 
 /**

--- a/assets/js/settings/endpoints.js
+++ b/assets/js/settings/endpoints.js
@@ -1,0 +1,6 @@
+const NAMESPACE = '/wc/blocks';
+export const ENDPOINTS = {
+	root: NAMESPACE,
+	products: `${ NAMESPACE }/products`,
+	categories: `${ NAMESPACE }/products/categories`,
+};

--- a/assets/js/settings/index.js
+++ b/assets/js/settings/index.js
@@ -1,1 +1,3 @@
 export { default as currency } from './currency';
+export { ENDPOINTS } from './endpoints';
+export * from './product-block-data';

--- a/assets/js/settings/product-block-data.js
+++ b/assets/js/settings/product-block-data.js
@@ -1,10 +1,3 @@
-const NAMESPACE = '/wc/blocks';
-export const ENDPOINTS = {
-	root: NAMESPACE,
-	products: `${ NAMESPACE }/products`,
-	categories: `${ NAMESPACE }/products/categories`,
-};
-
 const getConstantFromData = ( property, fallback = false ) => {
 	if ( typeof wc_product_block_data === 'object' && wc_product_block_data.hasOwnProperty( property ) ) {
 		return wc_product_block_data[ property ];

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { min } from 'lodash';
-import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../constants';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '@woocommerce/settings';
 
 export default function getQuery( blockAttributes, name ) {
 	const {

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../constants';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '@woocommerce/settings';
 
 export default function getShortcode( props, name ) {
 	const blockAttributes = props.attributes;

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '../constants';
+import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '@woocommerce/settings';
 
 export const sharedAttributeBlockTypes = [
 	'woocommerce/product-best-sellers',

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -20,10 +20,6 @@ class Assets {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_assets' ) );
 		add_action( 'body_class', array( __CLASS__, 'add_theme_body_class' ), 1 );
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'print_script_wc_settings' ), 1 );
-		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'print_script_wc_settings' ), 1 );
-		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'print_script_block_data' ), 1 );
-		add_action( 'wp_print_footer_scripts', array( __CLASS__, 'print_script_block_data' ), 1 );
 	}
 
 	/**
@@ -34,6 +30,7 @@ class Assets {
 		self::register_style( 'wc-block-style', plugins_url( 'build/style.css', __DIR__ ), array() );
 
 		// Shared libraries and components across all blocks.
+		self::register_script( 'wc-block-settings', plugins_url( 'build/wc-blocks-settings.js', __DIR__ ), [], false );
 		self::register_script( 'wc-blocks', plugins_url( 'build/blocks.js', __DIR__ ), array(), false );
 		self::register_script( 'wc-vendors', plugins_url( 'build/vendors.js', __DIR__ ), array(), false );
 
@@ -52,6 +49,13 @@ class Assets {
 		self::register_script( 'wc-reviews-by-product', plugins_url( 'build/reviews-by-product.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
 		self::register_script( 'wc-reviews-by-category', plugins_url( 'build/reviews-by-category.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
 		self::register_script( 'wc-product-search', plugins_url( 'build/product-search.js', __DIR__ ), array( 'wc-vendors', 'wc-blocks' ) );
+
+		// attach data to wc-blocks-settings.
+		wp_add_inline_script(
+			'wc-block-settings',
+			self::wc_settings_data() . "\n" . self::wc_block_data(),
+			'before'
+		);
 	}
 
 	/**
@@ -66,10 +70,12 @@ class Assets {
 	}
 
 	/**
-	 * These are used by @woocommerce/components and the block library to set up defaults
-	 * based on user-controlled settings from WordPress. Only use this in wp-admin.
+	 * Returns javascript to inject as data for enqueued wc-blocks-settings script.
+	 *
+	 * @return string;
+	 * @since 2.4.0
 	 */
-	public static function print_script_wc_settings() {
+	protected static function wc_settings_data() {
 		global $wp_locale;
 		$code     = get_woocommerce_currency();
 		$settings = apply_filters(
@@ -96,21 +102,18 @@ class Assets {
 				),
 			)
 		);
-		?>
-		<script type="text/javascript">
-			var wcSettings = wcSettings || JSON.parse( decodeURIComponent( '<?php echo rawurlencode( wp_json_encode( $settings ) ); ?>' ) );
-		</script>
-		<?php
+		$settings = rawurlencode( wp_json_encode( $settings ) );
+		return "var wcSettings = wcSettings || JSON.parse( decodeURIComponent( '" . $settings . "' ) );";
 	}
 
 	/**
-	 * Output block-related data on a global object.
+	 * Returns block-related data for enqueued wc-blocks-settings script.
 	 *
 	 * This is used to map site settings & data into JS-accessible variables.
 	 *
-	 * @since 2.0.0
+	 * @since 2.4.0
 	 */
-	public static function print_script_block_data() {
+	protected static function wc_block_data() {
 		$tag_count          = wp_count_terms( 'product_tag' );
 		$product_counts     = wp_count_posts( 'product' );
 		$product_categories = get_terms(
@@ -144,11 +147,8 @@ class Assets {
 			'showAvatars'        => '1' === get_option( 'show_avatars' ),
 			'enableReviewRating' => 'yes' === get_option( 'woocommerce_enable_review_rating' ),
 		);
-		?>
-		<script type="text/javascript">
-			var wc_product_block_data = JSON.parse( decodeURIComponent( '<?php echo rawurlencode( wp_json_encode( $block_settings ) ); ?>' ) );
-		</script>
-		<?php
+		$block_settings = rawurlencode( wp_json_encode( $block_settings ) );
+		return "var wc_product_block_data = JSON.parse( decodeURIComponent( '" . $block_settings . "' ) );";
 	}
 
 	/**

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -53,7 +53,7 @@ class Assets {
 		// attach data to wc-blocks-settings.
 		wp_add_inline_script(
 			'wc-block-settings',
-			self::wc_settings_data() . "\n" . self::wc_block_data(),
+			self::get_wc_settings_data() . "\n" . self::get_wc_block_data(),
 			'before'
 		);
 	}
@@ -75,7 +75,7 @@ class Assets {
 	 * @return string;
 	 * @since 2.4.0
 	 */
-	protected static function wc_settings_data() {
+	protected static function get_wc_settings_data() {
 		global $wp_locale;
 		$code     = get_woocommerce_currency();
 		$settings = apply_filters(
@@ -113,7 +113,7 @@ class Assets {
 	 *
 	 * @since 2.4.0
 	 */
-	protected static function wc_block_data() {
+	protected static function get_wc_block_data() {
 		$tag_count          = wp_count_terms( 'product_tag' );
 		$product_counts     = wp_count_posts( 'product' );
 		$product_categories = get_terms(

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -7,6 +7,9 @@
     "!**/test/**"
   ],
   "moduleDirectories": ["node_modules"],
+  "moduleNameMapper": {
+    "@woocommerce/settings": "assets/js/settings"
+  },
   "setupFiles": [
     "<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/setup-globals.js",
     "<rootDir>/tests/js/setup-globals"


### PR DESCRIPTION
Fixes #897 
Closes #897

## In this pull:

- data from server is initialized to a `wc.blockSettings` global exposed via a script registered to the `wc-block-settings` handle.
- inline data is enqueued with the `wc-block-settings` handle using `wp_add_inline_script`.
- webpack configuration has been modified to export the new script, register it as an external (aliased to `@woocommerce/settings`) and ensuring bundles dependent on the external have it correctly registered to the dependency map.
- All scripts referencing this data (currently only what is in `constants.js` is now referencing the `@woocommerce/settings` external for imports.

### Rationale

Currently in master, data from the server is being loaded on every route.  Mostly to ensure it's always available for any dependent scripts using it and partially because there's no reliable way to know for sure what script would need it.  The problem with this approach is that the amount of data being passed along for usage in blocks is and will increase over time (especially as we start implementing [passing through data need for initial load](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/898)). 

In #870 and #848 some work was done to move variable initialization using global objects passed from the server to a `settings` folder (along with aliasing it to `@woocommerce/settings`) so that scripts could more safely use the globals (and fail more gracefully if the globals weren't present).  This pull continues on that work by explicitly exporting a bundle registering the data values from the server to a single `wc.blockSettings` global.  While there's some duplication here, benefits are:

- Woo Extensions extending or creating their own blocks with woo data can use what is exposed on this global (they could also use the `@woocommerce/settings` as an external if they are using a build config).  They simply have to enqueue the `wc-block-settings` handle as a dependency for their scripts.
- This fixes the issue in #897.  Server transferred data will now only be output in the dom if the route is loading a script requiring it.
- We have a canonical place to register settings being passed through.
- The size of the bundle (currently) is 14.7KiB (dev build) and 2.51 KiB (production build). So it's very low weight.

## How to test the changes in this Pull Request:

This impacts any block/component that imported from `constants.js` directly (which is pretty much every block).  So what I did to test was create a post and insert every block and smoke tested each block by adjusting settings etc.  I watched the console for any errors triggered by the blocks.  Any issues should surface fairly immediately.

I also verified that the data only loads when needed in the dom (load a post/page without any blocks, or load an admin route without any blocks)

You can also smoke test that the global is initialized correctly by calling `wc.blockSettings` in the browser console and checking the properties.

### Changelog

> Fixes block settings output on every route.  Now they are only needed when the route has blocks requiring them.
> Export block settings to an external global `wc.blockSettings` that can be reliably used by extensions by enqueuing their script with the `wc-block-settings` as the handle.
