### PR TITLE
Create OrderSelect and Label components

### DIFF
--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import elementType from 'prop-types-elementtype';
+import { Fragment } from 'react';
+import classNames from 'classnames';
+
+const Label = ( { label, screenReaderLabel, wrapperElement: Wrapper, wrapperProps } ) => {
+	if ( label && screenReaderLabel && label !== screenReaderLabel ) {
+		return (
+			<Wrapper { ...wrapperProps }>
+				<span aria-hidden>
+					{ label }
+				</span>
+				<span className="screen-reader-text">
+					{ screenReaderLabel }
+				</span>
+			</Wrapper>
+		);
+	}
+
+	if ( ! label && screenReaderLabel ) {
+		if ( typeof Wrapper === 'symbol' && Symbol.keyFor( Wrapper ) === 'react.fragment' ) {
+			Wrapper = 'span';
+		}
+		wrapperProps = {
+			...wrapperProps,
+			className: classNames( wrapperProps.className, 'screen-reader-text' ),
+		};
+
+		return (
+			<Wrapper { ...wrapperProps }>
+				{ screenReaderLabel }
+			</Wrapper>
+		);
+	}
+
+	return (
+		<Wrapper { ...wrapperProps }>
+			{ label }
+		</Wrapper>
+	);
+};
+
+Label.propTypes = {
+	label: PropTypes.string,
+	screenReaderLabel: PropTypes.string,
+	wrapperElement: PropTypes.oneOfType( [
+		PropTypes.string,
+		elementType,
+	] ),
+	wrapperProps: PropTypes.object,
+};
+
+Label.defaultProps = {
+	wrapperElement: Fragment,
+	wrapperProps: {},
+};
+
+export default Label;

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -6,6 +6,11 @@ import elementType from 'prop-types-elementtype';
 import { Fragment } from 'react';
 import classNames from 'classnames';
 
+/**
+ * Component used to render an accessible text given a label and/or a
+ * screenReaderLabel. The wrapper element and wrapper props can also be
+ * specified via props.
+ */
 const Label = ( { label, screenReaderLabel, wrapperElement, wrapperProps } ) => {
 	let Wrapper;
 

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import elementType from 'prop-types-elementtype';
 import { Fragment } from 'react';
 import classNames from 'classnames';
 
@@ -55,7 +54,7 @@ Label.propTypes = {
 	screenReaderLabel: PropTypes.string,
 	wrapperElement: PropTypes.oneOfType( [
 		PropTypes.string,
-		elementType,
+		PropTypes.elementType,
 	] ),
 	wrapperProps: PropTypes.object,
 };

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -52,10 +52,7 @@ const Label = ( { label, screenReaderLabel, wrapperElement, wrapperProps } ) => 
 Label.propTypes = {
 	label: PropTypes.string,
 	screenReaderLabel: PropTypes.string,
-	wrapperElement: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.elementType,
-	] ),
+	wrapperElement: PropTypes.elementType,
 	wrapperProps: PropTypes.object,
 };
 

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -6,7 +6,25 @@ import elementType from 'prop-types-elementtype';
 import { Fragment } from 'react';
 import classNames from 'classnames';
 
-const Label = ( { label, screenReaderLabel, wrapperElement: Wrapper, wrapperProps } ) => {
+const Label = ( { label, screenReaderLabel, wrapperElement, wrapperProps } ) => {
+	let Wrapper;
+
+	if ( ! label && screenReaderLabel ) {
+		Wrapper = wrapperElement || 'span';
+		wrapperProps = {
+			...wrapperProps,
+			className: classNames( wrapperProps.className, 'screen-reader-text' ),
+		};
+
+		return (
+			<Wrapper { ...wrapperProps }>
+				{ screenReaderLabel }
+			</Wrapper>
+		);
+	}
+
+	Wrapper = wrapperElement || Fragment;
+
 	if ( label && screenReaderLabel && label !== screenReaderLabel ) {
 		return (
 			<Wrapper { ...wrapperProps }>
@@ -16,22 +34,6 @@ const Label = ( { label, screenReaderLabel, wrapperElement: Wrapper, wrapperProp
 				<span className="screen-reader-text">
 					{ screenReaderLabel }
 				</span>
-			</Wrapper>
-		);
-	}
-
-	if ( ! label && screenReaderLabel ) {
-		if ( typeof Wrapper === 'symbol' && Symbol.keyFor( Wrapper ) === 'react.fragment' ) {
-			Wrapper = 'span';
-		}
-		wrapperProps = {
-			...wrapperProps,
-			className: classNames( wrapperProps.className, 'screen-reader-text' ),
-		};
-
-		return (
-			<Wrapper { ...wrapperProps }>
-				{ screenReaderLabel }
 			</Wrapper>
 		);
 	}
@@ -54,7 +56,6 @@ Label.propTypes = {
 };
 
 Label.defaultProps = {
-	wrapperElement: Fragment,
 	wrapperProps: {},
 };
 

--- a/assets/js/base/components/label/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/label/test/__snapshots__/index.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Label with wrapperElement should render both label and screen reader label 1`] = `
+<label
+  className="foo-bar"
+  data-foo="bar"
+>
+  <span
+    aria-hidden={true}
+  >
+    Lorem
+  </span>
+  <span
+    className="screen-reader-text"
+  >
+    Ipsum
+  </span>
+</label>
+`;
+
+exports[`Label with wrapperElement should render only the label 1`] = `
+<label
+  className="foo-bar"
+  data-foo="bar"
+>
+  Lorem
+</label>
+`;
+
+exports[`Label with wrapperElement should render only the scree reader label 1`] = `
+<label
+  className="foo-bar screen-reader-text"
+  data-foo="bar"
+>
+  Ipsum
+</label>
+`;
+
+exports[`Label without wrapperElement should render both label and screen reader label 1`] = `
+Array [
+  <span
+    aria-hidden={true}
+  >
+    Lorem
+  </span>,
+  <span
+    className="screen-reader-text"
+  >
+    Ipsum
+  </span>,
+]
+`;
+
+exports[`Label without wrapperElement should render only the label 1`] = `"Lorem"`;
+
+exports[`Label without wrapperElement should render only the scree reader label 1`] = `
+<span
+  className="screen-reader-text"
+>
+  Ipsum
+</span>
+`;

--- a/assets/js/base/components/label/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/label/test/__snapshots__/index.js.snap
@@ -27,7 +27,7 @@ exports[`Label with wrapperElement should render only the label 1`] = `
 </label>
 `;
 
-exports[`Label with wrapperElement should render only the scree reader label 1`] = `
+exports[`Label with wrapperElement should render only the screen reader label 1`] = `
 <label
   className="foo-bar screen-reader-text"
   data-foo="bar"
@@ -53,7 +53,7 @@ Array [
 
 exports[`Label without wrapperElement should render only the label 1`] = `"Lorem"`;
 
-exports[`Label without wrapperElement should render only the scree reader label 1`] = `
+exports[`Label without wrapperElement should render only the screen reader label 1`] = `
 <span
   className="screen-reader-text"
 >

--- a/assets/js/base/components/label/test/index.js
+++ b/assets/js/base/components/label/test/index.js
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import Label from '../';
+
+describe( 'Label', () => {
+	describe( 'without wrapperElement', () => {
+		test( 'should render both label and screen reader label', () => {
+			const component = TestRenderer.create(
+				<Label label="Lorem" screenReaderLabel="Ipsum" />
+			);
+
+			expect( component.toJSON() ).toMatchSnapshot();
+		} );
+
+		test( 'should render only the label', () => {
+			const component = TestRenderer.create(
+				<Label label="Lorem" />
+			);
+
+			expect( component.toJSON() ).toMatchSnapshot();
+		} );
+
+		test( 'should render only the screen reader label', () => {
+			const component = TestRenderer.create(
+				<Label screenReaderLabel="Ipsum" />
+			);
+
+			expect( component.toJSON() ).toMatchSnapshot();
+		} );
+	} );
+
+	describe( 'with wrapperElement', () => {
+		test( 'should render both label and screen reader label', () => {
+			const component = TestRenderer.create(
+				<Label
+					label="Lorem"
+					screenReaderLabel="Ipsum"
+					wrapperElement="label"
+					wrapperProps={ {
+						className: 'foo-bar',
+						'data-foo': 'bar',
+					} }
+				/>
+			);
+
+			expect( component.toJSON() ).toMatchSnapshot();
+		} );
+
+		test( 'should render only the label', () => {
+			const component = TestRenderer.create(
+				<Label
+					label="Lorem"
+					wrapperElement="label"
+					wrapperProps={ {
+						className: 'foo-bar',
+						'data-foo': 'bar',
+					} }
+				/>
+			);
+
+			expect( component.toJSON() ).toMatchSnapshot();
+		} );
+
+		test( 'should render only the screen reader label', () => {
+			const component = TestRenderer.create(
+				<Label
+					screenReaderLabel="Ipsum"
+					wrapperElement="label"
+					wrapperProps={ {
+						className: 'foo-bar',
+						'data-foo': 'bar',
+					} }
+				/>
+			);
+
+			expect( component.toJSON() ).toMatchSnapshot();
+		} );
+	} );
+} );

--- a/assets/js/base/components/load-more-button/index.js
+++ b/assets/js/base/components/load-more-button/index.js
@@ -2,33 +2,25 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
+import Label from '../label';
 import './style.scss';
 
 export const LoadMoreButton = ( { onClick, label, screenReaderLabel } ) => {
-	const labelNode = ( screenReaderLabel && label !== screenReaderLabel ) ? (
-		<Fragment>
-			<span aria-hidden>
-				{ label }
-			</span>
-			<span className="screen-reader-text">
-				{ screenReaderLabel }
-			</span>
-		</Fragment>
-	) : label;
-
 	return (
 		<div className="wp-block-button wc-block-load-more">
 			<button
 				className="wp-block-button__link"
 				onClick={ onClick }
 			>
-				{ labelNode }
+				<Label
+					label={ label }
+					screenReaderLabel={ screenReaderLabel }
+				/>
 			</button>
 		</div>
 	);

--- a/assets/js/base/components/order-select/index.js
+++ b/assets/js/base/components/order-select/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -9,11 +10,11 @@ import PropTypes from 'prop-types';
 import Label from '../label';
 import './style.scss';
 
-const OrderSelect = ( { componentId, defaultValue, label, onChange, options, screenReaderLabel, readOnly, value } ) => {
+const OrderSelect = ( { className, componentId, defaultValue, label, onChange, options, screenReaderLabel, readOnly, value } ) => {
 	const selectId = `wc-block-order-select__select-${ componentId }`;
 
 	return (
-		<p className="wc-block-order-select">
+		<p className={ classNames( 'wc-block-order-select', className ) }>
 			<Label
 				label={ label }
 				screenReaderLabel={ screenReaderLabel }

--- a/assets/js/base/components/order-select/index.js
+++ b/assets/js/base/components/order-select/index.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Label from '../label';
+import './style.scss';
+
+const OrderSelect = ( { componentId, defaultValue, label, onChange, options, screenReaderLabel, readOnly, value } ) => {
+	const selectId = `wc-block-order-select__select-${ componentId }`;
+
+	return (
+		<p className="wc-block-order-select">
+			<Label
+				label={ label }
+				screenReaderLabel={ screenReaderLabel }
+				wrapperElement="label"
+				wrapperProps={ {
+					className: 'wc-block-order-select__label',
+					htmlFor: selectId,
+				} }
+			/>
+			<select // eslint-disable-line jsx-a11y/no-onchange
+				id={ selectId }
+				className="wc-block-order-select__select"
+				defaultValue={ defaultValue }
+				onChange={ onChange }
+				readOnly={ readOnly }
+				value={ value }
+			>
+				{ options.map( ( option ) => (
+					<option key={ option.key } value={ option.key }>
+						{ option.label }
+					</option>
+				) ) }
+			</select>
+		</p>
+	);
+};
+
+OrderSelect.propTypes = {
+	componentId: PropTypes.number.isRequired,
+	defaultValue: PropTypes.string,
+	label: PropTypes.string,
+	onChange: PropTypes.func,
+	options: PropTypes.arrayOf( PropTypes.shape( {
+		key: PropTypes.string.isRequired,
+		label: PropTypes.string.isRequired,
+	} ) ),
+	readOnly: PropTypes.bool,
+	screenReaderLabel: PropTypes.string,
+	value: PropTypes.string,
+};
+
+export default OrderSelect;

--- a/assets/js/base/components/order-select/index.js
+++ b/assets/js/base/components/order-select/index.js
@@ -10,6 +10,10 @@ import classNames from 'classnames';
 import Label from '../label';
 import './style.scss';
 
+/**
+ * Component used for 'Order by' selectors, which renders a label
+ * and a <select> with the options provided in the props.
+ */
 const OrderSelect = ( { className, componentId, defaultValue, label, onChange, options, screenReaderLabel, readOnly, value } ) => {
 	const selectId = `wc-block-order-select__select-${ componentId }`;
 

--- a/assets/js/base/components/order-select/style.scss
+++ b/assets/js/base/components/order-select/style.scss
@@ -1,9 +1,9 @@
-.wc-block-review-order-select {
+.wc-block-order-select {
 	margin-bottom: $gap-small;
 	text-align: right;
 }
 
-.wc-block-review-order-select__label {
+.wc-block-order-select__label {
 	margin-right: $gap-small;
 	display: inline-block;
 	font-weight: normal;

--- a/assets/js/base/components/order-select/style.scss
+++ b/assets/js/base/components/order-select/style.scss
@@ -1,6 +1,5 @@
 .wc-block-order-select {
 	margin-bottom: $gap-small;
-	text-align: right;
 }
 
 .wc-block-order-select__label {

--- a/assets/js/base/components/review-list-item/index.js
+++ b/assets/js/base/components/review-list-item/index.js
@@ -3,22 +3,13 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import ReadMore from '../read-more';
 import './style.scss';
-
-function getReviewClasses( isLoading ) {
-	const classArray = [ 'wc-block-review-list-item__item' ];
-
-	if ( isLoading ) {
-		classArray.push( 'is-loading' );
-	}
-
-	return classArray.join( ' ' );
-}
 
 function getReviewImage( review, imageType, isLoading ) {
 	if ( isLoading || ! review ) {
@@ -108,10 +99,12 @@ const ReviewListItem = ( { attributes, review = {} } ) => {
 	const { rating } = review;
 	const isLoading = ! Object.keys( review ).length > 0;
 	const showReviewRating = Number.isFinite( rating ) && showReviewRatingAttr;
-	const classes = getReviewClasses( isLoading );
 
 	return (
-		<li className={ classes } aria-hidden={ isLoading }>
+		<li
+			className={ classNames( 'wc-block-review-list-item__item', { 'is-loading': isLoading } ) }
+			aria-hidden={ isLoading }
+		>
 			{ ( showProductName || showReviewDate || showReviewerName || showReviewImage || showReviewRating ) && (
 				<div className="wc-block-review-list-item__info">
 					{ showReviewImage && getReviewImage( review, imageType, isLoading ) }

--- a/assets/js/base/components/review-order-select/index.js
+++ b/assets/js/base/components/review-order-select/index.js
@@ -7,45 +7,30 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import './style.scss';
+import OrderSelect from '../order-select';
 
 const ReviewOrderSelect = ( { componentId, defaultValue, onChange, readOnly, value } ) => {
-	const selectId = `wc-block-review-order-select__select-${ componentId }`;
-
 	return (
-		<p className="wc-block-review-order-select">
-			<label className="wc-block-review-order-select__label" htmlFor={ selectId }>
-				<span aria-hidden>
-					{ __( 'Order by', 'woo-gutenberg-products-block' ) }
-				</span>
-				<span className="screen-reader-text">
-					{ __( 'Order reviews by', 'woo-gutenberg-products-block' ) }
-				</span>
-			</label>
-			<select // eslint-disable-line jsx-a11y/no-onchange
-				id={ selectId }
-				className="wc-block-review-order-select__select"
-				defaultValue={ defaultValue }
-				onChange={ onChange }
-				readOnly={ readOnly }
-				value={ value }
-			>
-				<option value="most-recent">
-					{ __( 'Most recent', 'woo-gutenberg-products-block' ) }
-				</option>
-				<option value="highest-rating">
-					{ __( 'Highest rating', 'woo-gutenberg-products-block' ) }
-				</option>
-				<option value="lowest-rating">
-					{ __( 'Lowest rating', 'woo-gutenberg-products-block' ) }
-				</option>
-			</select>
-		</p>
+		<OrderSelect
+			componentId={ componentId }
+			defaultValue={ defaultValue }
+			label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
+			onChange={ onChange }
+			options={ [
+				{ key: 'most-recent', label: __( 'Most recent', 'woo-gutenberg-products-block' ) },
+				{ key: 'highest-rating', label: __( 'Highest rating', 'woo-gutenberg-products-block' ) },
+				{ key: 'lowest-rating', label: __( 'Lowest rating', 'woo-gutenberg-products-block' ) },
+			] }
+			readOnly={ readOnly }
+			screenReaderLabel={ __( 'Order reviews by', 'woo-gutenberg-products-block' ) }
+			value={ value }
+		/>
 	);
 };
 
 ReviewOrderSelect.propTypes = {
 	componentId: PropTypes.number.isRequired,
+	defaultValue: PropTypes.oneOf( [ 'most-recent', 'highest-rating', 'lowest-rating' ] ),
 	onChange: PropTypes.func,
 	readOnly: PropTypes.bool,
 	value: PropTypes.oneOf( [ 'most-recent', 'highest-rating', 'lowest-rating' ] ),

--- a/assets/js/base/components/review-order-select/index.js
+++ b/assets/js/base/components/review-order-select/index.js
@@ -8,10 +8,12 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import OrderSelect from '../order-select';
+import './style.scss';
 
 const ReviewOrderSelect = ( { componentId, defaultValue, onChange, readOnly, value } ) => {
 	return (
 		<OrderSelect
+			className="wc-block-review-order-select"
 			componentId={ componentId }
 			defaultValue={ defaultValue }
 			label={ __( 'Order by', 'woo-gutenberg-products-block' ) }

--- a/assets/js/base/components/review-order-select/style.scss
+++ b/assets/js/base/components/review-order-select/style.scss
@@ -1,0 +1,3 @@
+.wc-block-review-order-select {
+	text-align: right;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18323,12 +18323,13 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "prop-types-exact": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "postcss-loader": "3.0.0",
     "progress-bar-webpack-plugin": "1.12.1",
     "promptly": "3.0.3",
-    "prop-types-elementtype": "^1.0.0",
     "react-test-renderer": "16.8.6",
     "request-promise": "4.2.4",
     "rimraf": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "postcss-loader": "3.0.0",
     "progress-bar-webpack-plugin": "1.12.1",
     "promptly": "3.0.3",
+    "prop-types-elementtype": "^1.0.0",
     "react-test-renderer": "16.8.6",
     "request-promise": "4.2.4",
     "rimraf": "2.7.1",


### PR DESCRIPTION
This PR creates an `<OrderSelect />` component with most of the logic from `<ReviewOrderSelect />` so we have a generic component that can be used in _All Products_ block.

I also extracted some logic to display/hide label and screen reader labels into a `<Label />` component, this way it can be shared between `<OrderSelect />` and `<LoadMoreButton />`.

### Screenshots

_(this PR shouldn't produce any visible change)_

### How to test the changes in this Pull Request:

1. Add a _Reviews by Product_ block into a post and verify the _Order by_ select and the _Load more_ button still display the correct labels and work fine.
2. Inspecting them or using a screen reader verify they have the correct screen reader labels.
3. Look at the `assets/js/base/components/label/test/__snapshots__/index.js.snap` markup and verify it makes sense.

### Changelog

> Create new generic base components: `<OrderSelect />` and `<Label />` so they can be shared between different blocks.
