### PR TITLE
Add babel-loader to webpack CoreConfig

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,20 @@ const CoreConfig = {
 		// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 		jsonpFunction: 'webpackWcBlocksJsonp',
 	},
+	module: {
+		rules: [
+			{
+				test: /\.jsx?$/,
+				exclude: /node_modules/,
+				use: {
+					loader: 'babel-loader?cacheDirectory',
+					options: {
+						presets: [ '@wordpress/babel-preset-default' ],
+					},
+				},
+			},
+		],
+	},
 	plugins: [
 		new CleanWebpackPlugin(),
 		new ProgressBarPlugin( {


### PR DESCRIPTION
While testing #905 I noticed `master` is not working on IE11. This PR transpiles `wc-blocks-settings` with babel, so it it works again.

### How to test the changes in this Pull Request:

With IE 11:
1. Open any post with a WooCommerce Block and verify it doesn't crash with a JS error.
2. Open the editor and verify you can add WooCommerce Blocks without JS errors.

