### PR TITLE
Reviews blocks: Fix warnings with components state

### DIFF
--- a/assets/js/base/hocs/with-reviews.js
+++ b/assets/js/base/hocs/with-reviews.js
@@ -17,7 +17,7 @@ const withReviews = ( OriginalComponent ) => {
 
 			this.state = {
 				error: null,
-				loading: false,
+				loading: true,
 				reviews: [],
 				totalReviews: 0,
 			};
@@ -50,6 +50,12 @@ const withReviews = ( OriginalComponent ) => {
 				prevProps.productId !== nextProps.productId ||
 				! isShallowEqual( prevProps.categoryIds, nextProps.categoryIds )
 			);
+		}
+
+		componentWillUnMount() {
+			if ( this.delayedAppendReviews.cancel ) {
+				this.delayedAppendReviews.cancel();
+			}
 		}
 
 		getArgs( reviewsToSkip ) {


### PR DESCRIPTION
When adding a _Reviews by product_ block, this warning was appearing in the console:
![image](https://user-images.githubusercontent.com/3616980/63678528-acb27b00-c7ef-11e9-8a4f-2c51e0bff231.png)

And if you deleted a reviews block before reviews were loaded (maybe you need to throttle you network speed via devtools), another `Can't perform a React state update on an unmounted component` warning was appearing too.

This PR fixes both.

### How to test the changes in this Pull Request:

1. Add a _Reviews by Product_ block and verify no JS errors appear in the console.
2. Set your Internet speed to the lowest using your browser devtools and add an _All Reviews_ block.
3. Then, delete it and verify there isn't any JS error either.
