### PR TITLE
Show API errors in reviews editor block

### DIFF
--- a/assets/js/base/hocs/test/with-reviews.js
+++ b/assets/js/base/hocs/test/with-reviews.js
@@ -111,7 +111,9 @@ describe( 'withReviews Component', () => {
 	describe( 'when the API returns an error', () => {
 		beforeEach( () => {
 			mockUtils.getReviews.mockImplementation(
-				() => Promise.reject( { message: 'There was an error.' } )
+				() => Promise.reject( {
+					json: () => Promise.resolve( { message: 'There was an error.' } ),
+				} )
 			);
 			renderer = render();
 		} );

--- a/assets/js/base/hocs/with-reviews.js
+++ b/assets/js/base/hocs/with-reviews.js
@@ -115,17 +115,19 @@ const withReviews = ( OriginalComponent ) => {
 				.catch( this.setError );
 		}
 
-		setError( apiError ) {
-			const { onReviewsLoadError } = this.props;
-			const error = typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
-				apiMessage: apiError.message,
-			} : {
-				apiMessage: null,
-			};
+		setError( errorResponse ) {
+			errorResponse.json().then( ( apiError ) => {
+				const { onReviewsLoadError } = this.props;
+				const error = typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
+					apiMessage: apiError.message,
+				} : {
+					apiMessage: null,
+				};
 
-			this.setState( { reviews: [], loading: false, error } );
+				this.setState( { reviews: [], loading: false, error } );
 
-			onReviewsLoadError();
+				onReviewsLoadError();
+			} );
 		}
 
 		render() {

--- a/assets/js/blocks/reviews/editor-block.js
+++ b/assets/js/blocks/reviews/editor-block.js
@@ -10,6 +10,7 @@ import { ENABLE_REVIEW_RATING } from '@woocommerce/settings';
 /**
  * Internal dependencies
  */
+import ApiErrorPlaceholder from '../../components/api-error-placeholder';
 import LoadMoreButton from '../../base/components/load-more-button';
 import ReviewList from '../../base/components/review-list';
 import ReviewOrderSelect from '../../base/components/review-order-select';
@@ -33,7 +34,17 @@ class EditorBlock extends Component {
 	}
 
 	render() {
-		const { attributes, componentId, isLoading, noReviewsPlaceholder: NoReviewsPlaceholder, reviews, totalReviews } = this.props;
+		const { attributes, componentId, error, isLoading, noReviewsPlaceholder: NoReviewsPlaceholder, reviews, totalReviews } = this.props;
+
+		if ( error ) {
+			return (
+				<ApiErrorPlaceholder
+					className="wc-block-featured-product-error"
+					error={ error }
+					isLoading={ isLoading }
+				/>
+			);
+		}
 
 		if ( 0 === reviews.length && ! isLoading ) {
 			return <NoReviewsPlaceholder attributes={ attributes } />;

--- a/assets/js/components/api-error-placeholder/index.js
+++ b/assets/js/components/api-error-placeholder/index.js
@@ -56,10 +56,6 @@ const ApiErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 
 ApiErrorPlaceholder.propTypes = {
 	/**
-	 * Callback to retry an action.
-	 */
-	onRetry: PropTypes.func.isRequired,
-	/**
 	 * Classname to add to placeholder in addition to the defaults.
 	 */
 	className: PropTypes.string,
@@ -81,6 +77,10 @@ ApiErrorPlaceholder.propTypes = {
 	 * a spinner is shown instead.
 	 */
 	isLoading: PropTypes.bool,
+	/**
+	 * Callback to retry an action.
+	 */
+	onRetry: PropTypes.func,
 };
 
 export default ApiErrorPlaceholder;

--- a/src/RestApi/Controllers/ProductReviews.php
+++ b/src/RestApi/Controllers/ProductReviews.php
@@ -61,7 +61,7 @@ class ProductReviews extends WC_REST_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( 'edit' === $request['context'] ) {
-			return new WP_Error( 'rest_forbidden_context', __( 'Sorry, you are not allowed to edit resources.', 'woo-gutenberg-products-block' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'rest_forbidden_context', __( 'Sorry, you cannot list resources.', 'woo-gutenberg-products-block' ), array( 'status' => \rest_authorization_required_code() ) );
 		}
 		return true;
 	}


### PR DESCRIPTION
### Screenshots

![image](https://user-images.githubusercontent.com/3616980/63701882-29604c00-c826-11e9-9c96-7698c9d6b9bd.png)

### How to test the changes in this Pull Request:

1. Modify [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/Controllers/ProductReviews.php#L63) from `/src/RestApi/Controllers/ProductReviews.php` to:
```diff
-if ( 'edit' === $request['context'] ) {
+if ( true ) {
```
2. Create a post with a _Reviews by Product_ block.
3. Verify the error is displayed to the user.