### PR TITLE
Fix order by and load more buttons not hidden in frontend review blocks

### DIFF
--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -26,7 +26,7 @@ const FrontendBlock = ( { attributes, onAppendReviews, onChangeOrderby, reviews,
 
 	return (
 		<Fragment>
-			{ ( attributes.showOrderby && ENABLE_REVIEW_RATING ) && (
+			{ ( attributes.showOrderby !== 'false' && ENABLE_REVIEW_RATING ) && (
 				<ReviewOrderSelect
 					defaultValue={ orderby }
 					onChange={ onChangeOrderby }
@@ -36,7 +36,7 @@ const FrontendBlock = ( { attributes, onAppendReviews, onChangeOrderby, reviews,
 				attributes={ attributes }
 				reviews={ reviews }
 			/>
-			{ ( attributes.showLoadMore && totalReviews > reviews.length ) && (
+			{ ( attributes.showLoadMore !== 'false' && totalReviews > reviews.length ) && (
 				<LoadMoreButton
 					onClick={ onAppendReviews }
 					screenReaderLabel={ __( 'Load more reviews', 'woo-gutenberg-products-block' ) }


### PR DESCRIPTION
Fixes an issue that was always displaying the _Order by_ select and the _Load more_ button in the frontend even when they were disabled in the editor. The issue was caused because we were assuming `showOrderby` and `showLoadMore` attributes were bools but in fact they were strings.

### How to test the changes in this Pull Request:

1. Create a _Reviews by Product_ block and disable the _Order by_ select and the _Load more_ button in the editor side bar.
2. Preview the post in the frontend.
3. Verify the _Order by_ select and the _Load more_ button are not displayed.
