### PR TITLE
Fix best selling products block query

### DIFF
--- a/src/BlockTypes/ProductBestSellers.php
+++ b/src/BlockTypes/ProductBestSellers.php
@@ -27,8 +27,6 @@ class ProductBestSellers extends AbstractProductGrid {
 	 * @param array $query_args Query args.
 	 */
 	protected function set_block_query_args( &$query_args ) {
-		$query_args['meta_key'] = 'total_sales'; // phpcs:ignore WordPress.DB.SlowDBQuery
-		$query_args['order']    = 'DESC';
-		$query_args['orderby']  = 'meta_value_num';
+		$query_args['orderby'] = 'popularity';
 	}
 }


### PR DESCRIPTION
WC 3.6+ uses a custom table to track best sellers/sales. This updates the query to use that instead of meta.

Fixes #915

### How to test the changes in this Pull Request:

1. Create a best seller and newest product block on the same page
2. View the page
3. Confirm results are correct

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix best-sellers block results
