### PR TITLE
Fix shared settings overwriting block settings

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,8 @@ const baseConfig = {
 
 const requestToExternal = ( request ) => {
 	const wcDepMap = {
-		'@woocommerce/block-settings': [ 'wc', 'blockSettings' ],
+		'@woocommerce/settings': [ 'wc', 'wc-shared-settings' ],
+		'@woocommerce/block-settings': [ 'wc', 'wc-block-settings' ],
 	};
 	if ( wcDepMap[ request ] ) {
 		return wcDepMap[ request ];
@@ -63,7 +64,7 @@ const CoreConfig = {
 	output: {
 		filename: '[name].js',
 		path: path.resolve( __dirname, './build/' ),
-		library: [ 'wc', 'blockSettings' ],
+		library: [ 'wc', '[name]' ],
 		libraryTarget: 'this',
 		// This fixes an issue with multiple webpack projects using chunking
 		// overwriting each other's chunk loader function.


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/916#pullrequestreview-280213489.

This PR splits the webpack output between `shared-settings` and `block-settings`.

### How to test the changes in this Pull Request:

* Add a _Reviews by Product_ to a post and verify it appears without problems.
