### PR TITLE
Create Pagination and ProductOrderSelect components

### DIFF
--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -32,7 +32,7 @@ const Label = ( { label, screenReaderLabel, wrapperElement, wrapperProps } ) => 
 	if ( label && screenReaderLabel && label !== screenReaderLabel ) {
 		return (
 			<Wrapper { ...wrapperProps }>
-				<span aria-hidden>
+				<span aria-hidden="true">
 					{ label }
 				</span>
 				<span className="screen-reader-text">

--- a/assets/js/base/components/label/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/label/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`Label with wrapperElement should render both label and screen reader la
   data-foo="bar"
 >
   <span
-    aria-hidden={true}
+    aria-hidden="true"
   >
     Lorem
   </span>
@@ -39,7 +39,7 @@ exports[`Label with wrapperElement should render only the screen reader label 1`
 exports[`Label without wrapperElement should render both label and screen reader label 1`] = `
 Array [
   <span
-    aria-hidden={true}
+    aria-hidden="true"
   >
     Lorem
   </span>,

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -33,7 +33,7 @@ const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } )
 					title={ __( 'First page', 'woo-gutenberg-products-block' ) }
 				>
 					<Label
-						label="←"
+						label="<"
 						screenReaderLabel={ __( 'First page', 'woo-gutenberg-products-block' ) }
 					/>
 				</button>
@@ -58,7 +58,7 @@ const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } )
 					title={ __( 'Last page', 'woo-gutenberg-products-block' ) }
 				>
 					<Label
-						label="→"
+						label=">"
 						screenReaderLabel={ __( 'Last page', 'woo-gutenberg-products-block' ) }
 					/>
 				</button>

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -43,7 +43,7 @@ const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } )
 					<button
 						key={ page }
 						className={ classNames( 'wc-block-pagination-page', {
-							'is-active': currentPage === page,
+							'wc-block-pagination-page--active': currentPage === page,
 						} ) }
 						onClick={ currentPage === page ? null : () => onPageChange( page ) }
 					>

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Label from '../label';
+import { getIndexes } from './utils.js';
+import './style.scss';
+
+const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } ) => {
+	const { minIndex, maxIndex } = getIndexes( pagesToDisplay, currentPage, totalPages );
+	const pages = [];
+	for ( let i = minIndex; i <= maxIndex; i++ ) {
+		pages.push( i );
+	}
+	const showPreviousArrow = minIndex !== 1;
+	const showNextArrow = maxIndex !== totalPages;
+
+	return (
+		<div className="wc-block-pagination">
+			<Label
+				screenReaderLabel={ __( 'Navigate to another page', 'woo-gutenberg-products-block' ) }
+			/>
+			{ showPreviousArrow && (
+				<button
+					className="wc-block-pagination-page"
+					onClick={ () => onPageChange( 1 ) }
+					title={ __( 'First page', 'woo-gutenberg-products-block' ) }
+				>
+					<Label
+						label="←"
+						screenReaderLabel={ __( 'First page', 'woo-gutenberg-products-block' ) }
+					/>
+				</button>
+			) }
+			{ pages.map( ( page ) => {
+				return (
+					<button
+						key={ page }
+						className={ classNames( 'wc-block-pagination-page', {
+							'is-active': currentPage === page,
+						} ) }
+						onClick={ currentPage === page ? null : () => onPageChange( page ) }
+					>
+						{ page }
+					</button>
+				);
+			} ) }
+			{ showNextArrow && (
+				<button
+					className="wc-block-pagination-page"
+					onClick={ () => onPageChange( totalPages ) }
+					title={ __( 'Last page', 'woo-gutenberg-products-block' ) }
+				>
+					<Label
+						label="→"
+						screenReaderLabel={ __( 'Last page', 'woo-gutenberg-products-block' ) }
+					/>
+				</button>
+			) }
+		</div>
+	);
+};
+
+Pagination.propTypes = {
+	currentPage: PropTypes.number.isRequired,
+	totalPages: PropTypes.number.isRequired,
+	onPageChange: PropTypes.func,
+	pagesToDisplay: PropTypes.number,
+};
+
+Pagination.defaultProps = {
+	pagesToDisplay: 3,
+};
+
+export default Pagination;

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -68,9 +68,22 @@ const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } )
 };
 
 Pagination.propTypes = {
+	/**
+	 * Number of the page currently being displayed.
+	 */
 	currentPage: PropTypes.number.isRequired,
+	/**
+	 * Total number of pages.
+	 */
 	totalPages: PropTypes.number.isRequired,
+	/**
+	 * Callback function called when the user triggers a page change.
+	 */
 	onPageChange: PropTypes.func,
+	/**
+	 * Number of pages to display at the same time, including the active page
+	 * and the pages displayed before and after it.
+	 */
 	pagesToDisplay: PropTypes.number,
 };
 

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -12,14 +12,18 @@ import Label from '../label';
 import { getIndexes } from './utils.js';
 import './style.scss';
 
-const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } ) => {
+const Pagination = ( { currentPage, displayFirstAndLastPages, displayNextAndPreviousArrows, pagesToDisplay, onPageChange, totalPages } ) => {
 	const { minIndex, maxIndex } = getIndexes( pagesToDisplay, currentPage, totalPages );
 	const pages = [];
 	for ( let i = minIndex; i <= maxIndex; i++ ) {
 		pages.push( i );
 	}
-	const showPreviousArrow = minIndex !== 1;
-	const showNextArrow = maxIndex !== totalPages;
+	const showFirstPage = displayFirstAndLastPages && Boolean( minIndex !== 1 );
+	const showLastPage = displayFirstAndLastPages && Boolean( maxIndex !== totalPages );
+	const showFirstPageEllipsis = displayFirstAndLastPages && Boolean( minIndex > 2 );
+	const showLastPageEllipsis = displayFirstAndLastPages && Boolean( maxIndex < totalPages - 1 );
+	const showPreviousArrow = displayNextAndPreviousArrows && Boolean( currentPage !== 1 );
+	const showNextArrow = displayNextAndPreviousArrows && Boolean( currentPage !== totalPages );
 
 	return (
 		<div className="wc-block-pagination">
@@ -29,14 +33,27 @@ const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } )
 			{ showPreviousArrow && (
 				<button
 					className="wc-block-pagination-page"
-					onClick={ () => onPageChange( 1 ) }
-					title={ __( 'First page', 'woo-gutenberg-products-block' ) }
+					onClick={ () => onPageChange( currentPage - 1 ) }
+					title={ __( 'Previous page', 'woo-gutenberg-products-block' ) }
 				>
 					<Label
 						label="<"
-						screenReaderLabel={ __( 'First page', 'woo-gutenberg-products-block' ) }
+						screenReaderLabel={ __( 'Previous page', 'woo-gutenberg-products-block' ) }
 					/>
 				</button>
+			) }
+			{ showFirstPage && (
+				<button
+					className="wc-block-pagination-page"
+					onClick={ () => onPageChange( 1 ) }
+				>
+					1
+				</button>
+			) }
+			{ showFirstPageEllipsis && (
+				<span className="wc-block-pagination-ellipsis" aria-hidden="true">
+					{ __( '…', 'woo-gutenberg-products-block' ) }
+				</span>
 			) }
 			{ pages.map( ( page ) => {
 				return (
@@ -51,15 +68,28 @@ const Pagination = ( { currentPage, pagesToDisplay, onPageChange, totalPages } )
 					</button>
 				);
 			} ) }
-			{ showNextArrow && (
+			{ showLastPageEllipsis && (
+				<span className="wc-block-pagination-ellipsis" aria-hidden="true">
+					{ __( '…', 'woo-gutenberg-products-block' ) }
+				</span>
+			) }
+			{ showLastPage && (
 				<button
 					className="wc-block-pagination-page"
 					onClick={ () => onPageChange( totalPages ) }
-					title={ __( 'Last page', 'woo-gutenberg-products-block' ) }
+				>
+					{ totalPages }
+				</button>
+			) }
+			{ showNextArrow && (
+				<button
+					className="wc-block-pagination-page"
+					onClick={ () => onPageChange( currentPage + 1 ) }
+					title={ __( 'Next page', 'woo-gutenberg-products-block' ) }
 				>
 					<Label
 						label=">"
-						screenReaderLabel={ __( 'Last page', 'woo-gutenberg-products-block' ) }
+						screenReaderLabel={ __( 'Next page', 'woo-gutenberg-products-block' ) }
 					/>
 				</button>
 			) }
@@ -77,17 +107,28 @@ Pagination.propTypes = {
 	 */
 	totalPages: PropTypes.number.isRequired,
 	/**
+	 * Displays first and last pages if they are not in the current range of pages displayed.
+	 */
+	displayFirstAndLastPages: PropTypes.bool,
+	/**
+	 * Displays arrows to navigate to the previous and next pages.
+	 */
+	displayNextAndPreviousArrows: PropTypes.bool,
+	/**
 	 * Callback function called when the user triggers a page change.
 	 */
 	onPageChange: PropTypes.func,
 	/**
 	 * Number of pages to display at the same time, including the active page
-	 * and the pages displayed before and after it.
+	 * and the pages displayed before and after it. It doesn't include the first
+	 * and last pages.
 	 */
 	pagesToDisplay: PropTypes.number,
 };
 
 Pagination.defaultProps = {
+	displayFirstAndLastPages: true,
+	displayNextAndPreviousArrows: true,
 	pagesToDisplay: 3,
 };
 

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -1,11 +1,20 @@
+.wc-block-pagination-page,
+.wc-block-pagination-ellipsis {
+	color: #333;
+	display: inline-block;
+	font-size: 1em;
+	font-weight: normal;
+}
+
 .wc-block-pagination-page {
 	background-color: transparent;
 	border-color: transparent;
-	color: #333;
-	font-size: 1em;
-	font-weight: normal;
-	min-width: 2.2em;
 	padding: 0.3em 0.6em;
+	min-width: 2.2em;
+}
+
+.wc-block-pagination-ellipsis {
+	padding: 0.3em;
 }
 
 .wc-block-pagination-page--active {

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -1,0 +1,13 @@
+.wc-block-pagination-page {
+	background-color: transparent;
+	border-color: transparent;
+	color: #333;
+	font-size: 1em;
+	font-weight: normal;
+	min-width: 2.2em;
+	padding: 0.3em 0.6em;
+}
+
+.wc-block-pagination-page.is-active {
+	font-weight: bold;
+}

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -8,6 +8,6 @@
 	padding: 0.3em 0.6em;
 }
 
-.wc-block-pagination-page.is-active {
+.wc-block-pagination-page--active {
 	font-weight: bold;
 }

--- a/assets/js/base/components/pagination/test/index.js
+++ b/assets/js/base/components/pagination/test/index.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { getIndexes } from '../utils.js';
+
+describe( 'getIndexes', () => {
+	describe( 'when on the first page', () => {
+		test( 'indexes include the first pages available', () => {
+			expect( getIndexes( 5, 1, 100 ) ).toEqual( { minIndex: 1, maxIndex: 5 } );
+		} );
+
+		test( 'indexes include the only available page if there is only one', () => {
+			expect( getIndexes( 5, 1, 1 ) ).toEqual( { minIndex: 1, maxIndex: 1 } );
+		} );
+	} );
+
+	describe( 'when on a page in the middle', () => {
+		test( 'indexes include pages before and after the current page', () => {
+			expect( getIndexes( 5, 50, 100 ) ).toEqual( { minIndex: 48, maxIndex: 52 } );
+		} );
+	} );
+
+	describe( 'when on the last page', () => {
+		test( 'indexes include the last pages available', () => {
+			expect( getIndexes( 5, 100, 100 ) ).toEqual( { minIndex: 96, maxIndex: 100 } );
+		} );
+	} );
+} );

--- a/assets/js/base/components/pagination/utils.js
+++ b/assets/js/base/components/pagination/utils.js
@@ -1,0 +1,17 @@
+/**
+ * Given the number of pages to display, the current page and the total pages,
+ * returns the min and max index of the pages to display in the pagination component.
+ *
+ * @param {integer} pagesToDisplay Maximum number of pages to display in the pagination component.
+ * @param {integer} currentPage Page currently visible.
+ * @param {integer} totalPages Total pages available.
+ * @return {object} Object containing the min and max index to display in the pagination component.
+ */
+export const getIndexes = ( pagesToDisplay, currentPage, totalPages ) => {
+	const extraPagesToDisplay = pagesToDisplay - 1;
+	const tentativeMinIndex = Math.max( Math.floor( currentPage - ( extraPagesToDisplay / 2 ) ), 1 );
+	const maxIndex = Math.min( Math.ceil( currentPage + ( extraPagesToDisplay - ( currentPage - tentativeMinIndex ) ) ), totalPages );
+	const minIndex = Math.max( Math.floor( currentPage - ( extraPagesToDisplay - ( maxIndex - currentPage ) ) ), 1 );
+
+	return { minIndex, maxIndex };
+};

--- a/assets/js/base/components/product-order-select/index.js
+++ b/assets/js/base/components/product-order-select/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import OrderSelect from '../order-select';
+
+const ProductOrderSelect = ( { defaultValue, onChange, readOnly, value } ) => {
+	return (
+		<OrderSelect
+			className="wc-block-product-order-select"
+			defaultValue={ defaultValue }
+			onChange={ onChange }
+			options={ [
+				{ key: 'highest-rating', label: __( 'Highest rating', 'woo-gutenberg-products-block' ) },
+				{ key: 'alphabetical', label: __( 'Alphabetical', 'woo-gutenberg-products-block' ) },
+				{ key: 'highest-price', label: __( 'Highest price', 'woo-gutenberg-products-block' ) },
+				{ key: 'lowest-price', label: __( 'Lowest price', 'woo-gutenberg-products-block' ) },
+			] }
+			readOnly={ readOnly }
+			screenReaderLabel={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
+			value={ value }
+		/>
+	);
+};
+
+ProductOrderSelect.propTypes = {
+	defaultValue: PropTypes.oneOf( [ 'highest-rating', 'alphabetical', 'highest-price', 'lowest-price' ] ),
+	onChange: PropTypes.func,
+	readOnly: PropTypes.bool,
+	value: PropTypes.oneOf( [ 'highest-rating', 'alphabetical', 'highest-price', 'lowest-price' ] ),
+};
+
+export default ProductOrderSelect;

--- a/assets/js/base/components/product-order-select/index.js
+++ b/assets/js/base/components/product-order-select/index.js
@@ -14,12 +14,15 @@ const ProductOrderSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 		<OrderSelect
 			className="wc-block-product-order-select"
 			defaultValue={ defaultValue }
+			name="orderby"
 			onChange={ onChange }
 			options={ [
-				{ key: 'highest-rating', label: __( 'Highest rating', 'woo-gutenberg-products-block' ) },
-				{ key: 'alphabetical', label: __( 'Alphabetical', 'woo-gutenberg-products-block' ) },
-				{ key: 'highest-price', label: __( 'Highest price', 'woo-gutenberg-products-block' ) },
-				{ key: 'lowest-price', label: __( 'Lowest price', 'woo-gutenberg-products-block' ) },
+				{ key: 'menu_order', label: __( 'Default sorting', 'woo-gutenberg-products-block' ) },
+				{ key: 'popularity', label: __( 'Popularity', 'woo-gutenberg-products-block' ) },
+				{ key: 'rating', label: __( 'Average rating', 'woo-gutenberg-products-block' ) },
+				{ key: 'date', label: __( 'Latest', 'woo-gutenberg-products-block' ) },
+				{ key: 'price', label: __( 'Price: low to high', 'woo-gutenberg-products-block' ) },
+				{ key: 'price-desc', label: __( 'Price: high to low', 'woo-gutenberg-products-block' ) },
 			] }
 			readOnly={ readOnly }
 			screenReaderLabel={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
@@ -29,10 +32,10 @@ const ProductOrderSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 };
 
 ProductOrderSelect.propTypes = {
-	defaultValue: PropTypes.oneOf( [ 'highest-rating', 'alphabetical', 'highest-price', 'lowest-price' ] ),
+	defaultValue: PropTypes.oneOf( [ 'menu_order', 'popularity', 'rating', 'date', 'price', 'price-desc' ] ),
 	onChange: PropTypes.func,
 	readOnly: PropTypes.bool,
-	value: PropTypes.oneOf( [ 'highest-rating', 'alphabetical', 'highest-price', 'lowest-price' ] ),
+	value: PropTypes.oneOf( [ 'menu_order', 'popularity', 'rating', 'date', 'price', 'price-desc' ] ),
 };
 
 export default ProductOrderSelect;


### PR DESCRIPTION
Part of #898.

This PR creates a `<Pagination />` and a `<ProductOrderSelect />` components, which will be used in the _All Products_ block.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/63851708-e96ca680-c996-11e9-929c-71a6a83ba2f2.png)

### How to test the changes in this Pull Request:

1. You will need to add the components to some other component that you can see:
```ES6
import ProductOrderSelect from '../../base/components/product-order-select';
import Pagination from '../../base/components/pagination';
...
<ProductOrderSelect
	defaultValue="highest-price"
	onChange={ ( e ) => {
		console.log( e.target.value );
	} }
/>
<Pagination currentPage={ 1 } totalPages={ 10 } onPageChange={ ( page ) => {
	console.log( 'navigate to page', page );
} } />
```
2. Verify they look correctly and you can interact with them.
3. Try changing the value of `currentPage` prop and verify the expected pages show in the `<Pagination />` component.