### PR TITLE
Add error states to all components/blocks which use HOCs

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -35,17 +35,3 @@
 		}
 	}
 }
-
-.wc-block-api-error {
-	.components-placeholder__fieldset {
-		display: block;
-		margin: 0;
-		padding: 0;
-	}
-	.wc-block-error__message {
-		margin-bottom: 16px;
-	}
-	.components-spinner {
-		float: none;
-	}
-}

--- a/assets/js/base/hocs/with-reviews.js
+++ b/assets/js/base/hocs/with-reviews.js
@@ -9,6 +9,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  * Internal dependencies
  */
 import { getReviews } from '../../blocks/reviews/utils';
+import { formatError } from '../utils/errors.js';
 
 const withReviews = ( OriginalComponent ) => {
 	class WrappedComponent extends Component {
@@ -124,11 +125,7 @@ const withReviews = ( OriginalComponent ) => {
 		setError( errorResponse ) {
 			errorResponse.json().then( ( apiError ) => {
 				const { onReviewsLoadError } = this.props;
-				const error = typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
-					apiMessage: apiError.message,
-				} : {
-					apiMessage: null,
-				};
+				const error = formatError( apiError );
 
 				this.setState( { reviews: [], loading: false, error } );
 

--- a/assets/js/base/utils/errors.js
+++ b/assets/js/base/utils/errors.js
@@ -1,0 +1,9 @@
+export const formatError = ( apiError ) => {
+	return typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
+		apiMessage: apiError.message,
+	} : {
+		// If we can't get any message from the API, set it to null and
+		// let <ApiErrorPlaceholder /> handle the message to display.
+		apiMessage: null,
+	};
+};

--- a/assets/js/components/api-error-placeholder/error-message.js
+++ b/assets/js/components/api-error-placeholder/error-message.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+import { escapeHTML } from '@wordpress/escape-html';
+
+const getErrorMessage = ( { apiMessage, message } ) => {
+	if ( message ) {
+		return message;
+	}
+
+	if ( apiMessage ) {
+		return (
+			<span>
+				{ __( 'The following error was returned from the API', 'woo-gutenberg-products-block' ) }
+				<br />
+				<code>{ escapeHTML( apiMessage ) }</code>
+			</span>
+		);
+	}
+
+	return __( 'An unknown error occurred which prevented the block from being updated.', 'woo-gutenberg-products-block' );
+};
+
+const ErrorMessage = ( { error } ) => (
+	<div className="wc-block-error-message">
+		{ getErrorMessage( error ) }
+	</div>
+);
+
+ErrorMessage.propTypes = {
+	/**
+	 * The error object.
+	 */
+	error: PropTypes.shape( {
+		/**
+		 * API error message to display in case of a missing `message`.
+		 */
+		apiMessage: PropTypes.node,
+		/**
+		 * Human-readable error message to display.
+		 */
+		message: PropTypes.string,
+	} ),
+};
+
+export default ErrorMessage;

--- a/assets/js/components/api-error-placeholder/index.js
+++ b/assets/js/components/api-error-placeholder/index.js
@@ -6,30 +6,17 @@ import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
-import { escapeHTML } from '@wordpress/escape-html';
 import {
 	Button,
 	Placeholder,
 	Spinner,
 } from '@wordpress/components';
 
-const getErrorMessage = ( { apiMessage, message } ) => {
-	if ( message ) {
-		return message;
-	}
-
-	if ( apiMessage ) {
-		return (
-			<span>
-				{ __( 'The following error was returned from the API', 'woo-gutenberg-products-block' ) }
-				<br />
-				<code>{ escapeHTML( apiMessage ) }</code>
-			</span>
-		);
-	}
-
-	return __( 'An unknown error occurred which prevented the block from being updated.', 'woo-gutenberg-products-block' );
-};
+/**
+ * Internal dependencies
+ */
+import ErrorMessage from './error-message.js';
+import './style.scss';
 
 const ApiErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 	<Placeholder
@@ -37,9 +24,7 @@ const ApiErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 		label={ __( 'Sorry, an error occurred', 'woo-gutenberg-products-block' ) }
 		className={ classNames( 'wc-block-api-error', className ) }
 	>
-		<div className="wc-block-error__message">
-			{ getErrorMessage( error ) }
-		</div>
+		<ErrorMessage error={ error } />
 		{ onRetry && (
 			<Fragment>
 				{ isLoading ? (

--- a/assets/js/components/api-error-placeholder/style.scss
+++ b/assets/js/components/api-error-placeholder/style.scss
@@ -1,0 +1,18 @@
+.wc-block-error-message {
+	margin-bottom: 16px;
+	margin-top: 8px;
+}
+
+.wc-block-api-error {
+	.components-placeholder__fieldset {
+		display: block;
+	}
+
+	.wc-block-error-message {
+		margin-top: 0;
+	}
+
+	.components-spinner {
+		float: none;
+	}
+}

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { withSearchedProducts } from '../../hocs';
+import ErrorMessage from '../api-error-placeholder/error-message.js';
 
 /**
  * The products control exposes a custom selector for searching and selecting
@@ -24,6 +25,7 @@ import { withSearchedProducts } from '../../hocs';
  * @return {Function} A functional component.
  */
 const ProductsControl = ( {
+	error,
 	onChange,
 	onSearch,
 	selected,
@@ -56,6 +58,13 @@ const ProductsControl = ( {
 			'woo-gutenberg-products-block'
 		),
 	};
+
+	if ( error ) {
+		return (
+			<ErrorMessage error={ error } />
+		);
+	}
+
 	return (
 		<SearchListControl
 			className="woocommerce-products"

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -44,9 +44,11 @@ const getProductsRequests = ( { selected = [], search = '', queryArgs = [] } ) =
 export const getProducts = ( { selected = [], search = '', queryArgs = [] } ) => {
 	const requests = getProductsRequests( { selected, search, queryArgs } );
 
-	return Promise.all( requests.map( ( path ) => apiFetch( { path } ) ) ).then( ( data ) => {
-		return uniqBy( flatten( data ), 'id' );
-	} );
+	return Promise.all( requests.map( ( path ) => apiFetch( { path } ) ) )
+		.then( ( data ) => uniqBy( flatten( data ), 'id' ) )
+		.catch( ( e ) => {
+			throw e;
+		} );
 };
 
 /**

--- a/assets/js/hocs/with-category.js
+++ b/assets/js/hocs/with-category.js
@@ -8,6 +8,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * Internal dependencies
  */
 import { getCategory } from '../components/utils';
+import { formatError } from '../base/utils/errors.js';
 
 const withCategory = createHigherOrderComponent(
 	( OriginalComponent ) => {
@@ -45,13 +46,7 @@ const withCategory = createHigherOrderComponent(
 				getCategory( categoryId ).then( ( category ) => {
 					this.setState( { category, loading: false, error: null } );
 				} ).catch( ( apiError ) => {
-					const error = typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
-						apiMessage: apiError.message,
-					} : {
-						// If we can't get any message from the API, set it to null and
-						// let <ApiErrorPlaceholder /> handle the message to display.
-						apiMessage: null,
-					};
+					const error = formatError( apiError );
 
 					this.setState( { category: null, loading: false, error } );
 				} );

--- a/assets/js/hocs/with-product.js
+++ b/assets/js/hocs/with-product.js
@@ -8,6 +8,7 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  * Internal dependencies
  */
 import { getProduct } from '../components/utils';
+import { formatError } from '../base/utils/errors.js';
 
 const withProduct = createHigherOrderComponent(
 	( OriginalComponent ) => {
@@ -45,13 +46,7 @@ const withProduct = createHigherOrderComponent(
 				getProduct( productId ).then( ( product ) => {
 					this.setState( { product, loading: false, error: null } );
 				} ).catch( ( apiError ) => {
-					const error = typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
-						apiMessage: apiError.message,
-					} : {
-						// If we can't get any message from the API, set it to null and
-						// let <ApiErrorPlaceholder /> handle the message to display.
-						apiMessage: null,
-					};
+					const error = formatError( apiError );
 
 					this.setState( { product: null, loading: false, error } );
 				} );

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -11,6 +11,7 @@ import { IS_LARGE_CATALOG } from '@woocommerce/block-settings';
  * Internal dependencies
  */
 import { getProducts } from '../components/utils';
+import { formatError } from '../base/utils/errors.js';
 
 /**
  * A higher order component that enhances the provided component with products
@@ -58,13 +59,7 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 
 		setError( errorResponse ) {
 			errorResponse.json().then( ( apiError ) => {
-				const error = typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
-					apiMessage: apiError.message,
-				} : {
-					// If we can't get any message from the API, set it to null and
-					// let <ApiErrorPlaceholder /> handle the message to display.
-					apiMessage: null,
-				};
+				const error = formatError( apiError );
 
 				this.setState( { list: [], loading: false, error } );
 			} );

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -30,6 +30,7 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 				list: [],
 				loading: true,
 			};
+			this.setError = this.setError.bind( this );
 			this.debouncedOnSearch = debounce( this.onSearch.bind( this ), 400 );
 		}
 
@@ -39,9 +40,7 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 				.then( ( list ) => {
 					this.setState( { list, loading: false } );
 				} )
-				.catch( () => {
-					this.setState( { list: [], loading: false } );
-				} );
+				.catch( this.setError );
 		}
 
 		componentWillUnmount() {
@@ -54,17 +53,30 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 				.then( ( list ) => {
 					this.setState( { list, loading: false } );
 				} )
-				.catch( () => {
-					this.setState( { list: [], loading: false } );
-				} );
+				.catch( this.setError );
+		}
+
+		setError( errorResponse ) {
+			errorResponse.json().then( ( apiError ) => {
+				const error = typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
+					apiMessage: apiError.message,
+				} : {
+					// If we can't get any message from the API, set it to null and
+					// let <ApiErrorPlaceholder /> handle the message to display.
+					apiMessage: null,
+				};
+
+				this.setState( { list: [], loading: false, error } );
+			} );
 		}
 
 		render() {
-			const { list, loading } = this.state;
+			const { error, list, loading } = this.state;
 			const { selected } = this.props;
 			return (
 				<OriginalComponent
 					{ ...this.props }
+					error={ error }
 					products={ list }
 					isLoading={ loading }
 					selected={ list.filter(


### PR DESCRIPTION
Every once in a while we get reports in the support forums from users that get 0 products/categories/etc. when creating a new block. In those cases, there is probably an error but we are silently failing and displaying a no results message.

This PR adds error handling for all blocks/components that use HOCs. There are still other components that don't show error messages properly, but it might be worth refactoring them to use HOCs first, so I left that for a follow-up.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/63933071-d15d5b80-ca58-11e9-901e-303444a64f46.png)

### How to test the changes in this Pull Request:

1. Create a post with a _Featured Product_, a _Featured Category_ and _Hand-picked Products_ blocks.
2. For the featured blocks, select a product and a category for both. For the _Hand-picked Products_ block, leave it in the edit mode.
3. Modify [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/Controllers/Products.php#L88) like this:
```diff
-if ( ! \current_user_can( 'edit_posts' ) ) {
+if ( true ) {
```
4. Modify [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/Controllers/ProductCategories.php#L84) like this:
```diff
-if ( ! $taxonomy || ! \taxonomy_exists( $taxonomy ) ) {
+if ( true ) {
```
5. Reload the post you created and verify correct error messages are displayed to the user.

### Changelog

> Improve error visibility and messaging in the editor.
