### PR TITLE
Fix misleading comment in src/Assets.php

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -126,7 +126,7 @@ class Assets {
 	}
 
 	/**
-	 * Returns block-related data for enqueued wc-shared-settings script.
+	 * Returns block-related data for enqueued wc-block-settings script.
 	 *
 	 * This is used to map site settings & data into JS-accessible variables.
 	 *


### PR DESCRIPTION
I think it refers to `wc-block-settings` instead of `wc-shared-settings`.