### PR TITLE
Add withCategories and withAttributes HOCs

### DIFF
--- a/assets/js/base/hocs/test/with-reviews.js
+++ b/assets/js/base/hocs/test/with-reviews.js
@@ -116,7 +116,7 @@ describe( 'withReviews Component', () => {
 	describe( 'when the API returns an error', () => {
 		const error = { message: 'There was an error.' };
 		const getReviewsPromise = Promise.reject( error );
-		const formattedError = { apiMessage: 'There was an error.' };
+		const formattedError = { message: 'There was an error.', type: 'api' };
 
 		beforeEach( () => {
 			mockUtils.getReviews.mockImplementation(

--- a/assets/js/base/hocs/test/with-reviews.js
+++ b/assets/js/base/hocs/test/with-reviews.js
@@ -8,6 +8,7 @@ import TestRenderer from 'react-test-renderer';
  */
 import withReviews from '../with-reviews';
 import * as mockUtils from '../../../blocks/reviews/utils';
+import * as mockBaseUtils from '../../utils/errors';
 
 jest.mock( '../../../blocks/reviews/utils', () => ( {
 	getOrderArgs: () => ( {
@@ -15,6 +16,10 @@ jest.mock( '../../../blocks/reviews/utils', () => ( {
 		orderby: 'date_gmt',
 	} ),
 	getReviews: jest.fn(),
+} ) );
+
+jest.mock( '../../utils/errors', () => ( {
+	formatError: jest.fn(),
 } ) );
 
 const mockReviews = [
@@ -109,21 +114,33 @@ describe( 'withReviews Component', () => {
 	} );
 
 	describe( 'when the API returns an error', () => {
+		const error = { message: 'There was an error.' };
+		const getReviewsPromise = Promise.reject( error );
+		const formattedError = { apiMessage: 'There was an error.' };
+
 		beforeEach( () => {
 			mockUtils.getReviews.mockImplementation(
-				() => Promise.reject( {
-					json: () => Promise.resolve( { message: 'There was an error.' } ),
-				} )
+				() => getReviewsPromise,
+			);
+			mockBaseUtils.formatError.mockImplementation(
+				() => formattedError,
 			);
 			renderer = render();
 		} );
 
-		it( 'sets the error prop', () => {
-			const props = renderer.root.findByType( 'div' ).props;
+		it( 'sets the error prop', ( done ) => {
+			const { formatError } = mockBaseUtils;
+			getReviewsPromise.catch( () => {
+				const props = renderer.root.findByType( 'div' ).props;
 
-			expect( props.error ).toEqual( { apiMessage: 'There was an error.' } );
-			expect( props.isLoading ).toBe( false );
-			expect( props.reviews ).toEqual( [] );
+				expect( formatError ).toHaveBeenCalledWith( error );
+				expect( formatError ).toHaveBeenCalledTimes( 1 );
+				expect( props.error ).toEqual( formattedError );
+				expect( props.isLoading ).toBe( false );
+				expect( props.reviews ).toEqual( [] );
+
+				done();
+			} );
 		} );
 	} );
 } );

--- a/assets/js/base/hocs/with-reviews.js
+++ b/assets/js/base/hocs/with-reviews.js
@@ -122,15 +122,13 @@ const withReviews = ( OriginalComponent ) => {
 				.catch( this.setError );
 		}
 
-		setError( errorResponse ) {
-			errorResponse.json().then( ( apiError ) => {
-				const { onReviewsLoadError } = this.props;
-				const error = formatError( apiError );
+		async setError( e ) {
+			const { onReviewsLoadError } = this.props;
+			const error = await formatError( e );
 
-				this.setState( { reviews: [], loading: false, error } );
+			this.setState( { reviews: [], loading: false, error } );
 
-				onReviewsLoadError();
-			} );
+			onReviewsLoadError( error );
 		}
 
 		render() {

--- a/assets/js/base/utils/errors.js
+++ b/assets/js/base/utils/errors.js
@@ -1,11 +1,11 @@
 /**
  * Given a JS error or a fetch response error, parse and format it so it can be displayed to the user.
  *
- * @param {object} error Error object.
- * @param {function} [error.json] If a json method is specified, it will try parsing the error first.
- * @param {string} [error.message] If a message is specified, it will be shown to the user.
- * @param {string} [error.type] The type will be used to determine how the error is shown to the user.
- * @return {object} Error object containing a message and type.
+ * @param  {Object}   error           Error object.
+ * @param  {Function} [error.json]    If a json method is specified, it will try parsing the error first.
+ * @param  {string}   [error.message] If a message is specified, it will be shown to the user.
+ * @param  {string}   [error.type]    The context in which the error was triggered.
+ * @return {Object}   Error object containing a message and type.
  */
 export const formatError = async ( error ) => {
 	if ( typeof error.json === 'function' ) {

--- a/assets/js/base/utils/errors.js
+++ b/assets/js/base/utils/errors.js
@@ -1,22 +1,30 @@
-const formatErrorMessage = ( error, messageProperty = 'frontendMessage' ) => {
-	if ( typeof error === 'object' && error.hasOwnProperty( 'message' ) ) {
-		return {
-			[ messageProperty ]: error.message,
-		};
-	}
-
-	return error;
-};
-
+/**
+ * Given a JS error or a fetch response error, parse and format it so it can be displayed to the user.
+ *
+ * @param {object} error Error object.
+ * @param {function} [error.json] If a json method is specified, it will try parsing the error first.
+ * @param {string} [error.message] If a message is specified, it will be shown to the user.
+ * @param {string} [error.type] The type will be used to determine how the error is shown to the user.
+ * @return {object} Error object containing a message and type.
+ */
 export const formatError = async ( error ) => {
-	if ( error.json ) {
+	if ( typeof error.json === 'function' ) {
 		try {
 			const parsedError = await error.json();
-			return formatErrorMessage( parsedError, 'apiMessage' );
+			return {
+				message: parsedError.message,
+				type: parsedError.type || 'api',
+			};
 		} catch ( e ) {
-			return formatErrorMessage( e );
+			return {
+				message: e.message,
+				type: 'frontend',
+			};
 		}
 	}
 
-	return formatErrorMessage( error );
+	return {
+		message: error.message,
+		type: error.type || 'frontend',
+	};
 };

--- a/assets/js/base/utils/errors.js
+++ b/assets/js/base/utils/errors.js
@@ -1,9 +1,22 @@
-export const formatError = ( apiError ) => {
-	return typeof apiError === 'object' && apiError.hasOwnProperty( 'message' ) ? {
-		apiMessage: apiError.message,
-	} : {
-		// If we can't get any message from the API, set it to null and
-		// let <ApiErrorPlaceholder /> handle the message to display.
-		apiMessage: null,
-	};
+const formatErrorMessage = ( error, messageProperty = 'frontendMessage' ) => {
+	if ( typeof error === 'object' && error.hasOwnProperty( 'message' ) ) {
+		return {
+			[ messageProperty ]: error.message,
+		};
+	}
+
+	return error;
+};
+
+export const formatError = async ( error ) => {
+	if ( error.json ) {
+		try {
+			const parsedError = await error.json();
+			return formatErrorMessage( parsedError, 'apiMessage' );
+		} catch ( e ) {
+			return formatErrorMessage( e );
+		}
+	}
+
+	return formatErrorMessage( error );
 };

--- a/assets/js/base/utils/errors.js
+++ b/assets/js/base/utils/errors.js
@@ -18,13 +18,13 @@ export const formatError = async ( error ) => {
 		} catch ( e ) {
 			return {
 				message: e.message,
-				type: 'frontend',
+				type: 'general',
 			};
 		}
 	}
 
 	return {
 		message: error.message,
-		type: error.type || 'frontend',
+		type: error.type || 'general',
 	};
 };

--- a/assets/js/base/utils/test/errors.js
+++ b/assets/js/base/utils/test/errors.js
@@ -4,13 +4,13 @@
 import { formatError } from '../errors';
 
 describe( 'formatError', () => {
-	test( 'should format frontend errors', async () => {
+	test( 'should format general errors', async () => {
 		const error = await formatError( {
 			message: 'Lorem Ipsum',
 		} );
 		const expectedError = {
 			message: 'Lorem Ipsum',
-			type: 'frontend',
+			type: 'general',
 		};
 
 		expect( error ).toEqual( expectedError );
@@ -34,7 +34,7 @@ describe( 'formatError', () => {
 		} );
 		const expectedError = {
 			message: 'Lorem Ipsum',
-			type: 'frontend',
+			type: 'general',
 		};
 
 		expect( error ).toEqual( expectedError );

--- a/assets/js/base/utils/test/errors.js
+++ b/assets/js/base/utils/test/errors.js
@@ -9,7 +9,8 @@ describe( 'formatError', () => {
 			message: 'Lorem Ipsum',
 		} );
 		const expectedError = {
-			frontendMessage: 'Lorem Ipsum',
+			message: 'Lorem Ipsum',
+			type: 'frontend',
 		};
 
 		expect( error ).toEqual( expectedError );
@@ -20,7 +21,8 @@ describe( 'formatError', () => {
 			json: () => Promise.resolve( { message: 'Lorem Ipsum' } ),
 		} );
 		const expectedError = {
-			apiMessage: 'Lorem Ipsum',
+			message: 'Lorem Ipsum',
+			type: 'api',
 		};
 
 		expect( error ).toEqual( expectedError );
@@ -31,7 +33,8 @@ describe( 'formatError', () => {
 			json: () => Promise.reject( { message: 'Lorem Ipsum' } ),
 		} );
 		const expectedError = {
-			frontendMessage: 'Lorem Ipsum',
+			message: 'Lorem Ipsum',
+			type: 'frontend',
 		};
 
 		expect( error ).toEqual( expectedError );

--- a/assets/js/base/utils/test/errors.js
+++ b/assets/js/base/utils/test/errors.js
@@ -1,0 +1,39 @@
+/**
+ * Internal dependencies
+ */
+import { formatError } from '../errors';
+
+describe( 'formatError', () => {
+	test( 'should format frontend errors', async () => {
+		const error = await formatError( {
+			message: 'Lorem Ipsum',
+		} );
+		const expectedError = {
+			frontendMessage: 'Lorem Ipsum',
+		};
+
+		expect( error ).toEqual( expectedError );
+	} );
+
+	test( 'should format API errors', async () => {
+		const error = await formatError( {
+			json: () => Promise.resolve( { message: 'Lorem Ipsum' } ),
+		} );
+		const expectedError = {
+			apiMessage: 'Lorem Ipsum',
+		};
+
+		expect( error ).toEqual( expectedError );
+	} );
+
+	test( 'should format JSON parse errors', async () => {
+		const error = await formatError( {
+			json: () => Promise.reject( { message: 'Lorem Ipsum' } ),
+		} );
+		const expectedError = {
+			frontendMessage: 'Lorem Ipsum',
+		};
+
+		expect( error ).toEqual( expectedError );
+	} );
+} );

--- a/assets/js/components/api-error-placeholder/error-message.js
+++ b/assets/js/components/api-error-placeholder/error-message.js
@@ -10,7 +10,7 @@ const getErrorMessage = ( { message, type } ) => {
 		return __( 'An unknown error occurred which prevented the block from being updated.', 'woo-gutenberg-products-block' );
 	}
 
-	if ( type === 'frontend' ) {
+	if ( type === 'general' ) {
 		return (
 			<span>
 				{ __( 'The following error was returned', 'woo-gutenberg-products-block' ) }
@@ -49,9 +49,9 @@ ErrorMessage.propTypes = {
 		 */
 		message: PropTypes.node,
 		/**
-		 * Type of the error. That will determine how the error is displayed to the user.
+		 * Context in which the error was triggered. That will determine how the error is displayed to the user.
 		 */
-		type: PropTypes.oneOf( [ 'api', 'frontend' ] ),
+		type: PropTypes.oneOf( [ 'api', 'general' ] ),
 	} ),
 };
 

--- a/assets/js/components/api-error-placeholder/error-message.js
+++ b/assets/js/components/api-error-placeholder/error-message.js
@@ -5,32 +5,32 @@ import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { escapeHTML } from '@wordpress/escape-html';
 
-const getErrorMessage = ( { apiMessage, message, frontendMessage } ) => {
-	if ( message ) {
-		return message;
+const getErrorMessage = ( { message, type } ) => {
+	if ( ! message ) {
+		return __( 'An unknown error occurred which prevented the block from being updated.', 'woo-gutenberg-products-block' );
 	}
 
-	if ( frontendMessage ) {
+	if ( type === 'frontend' ) {
 		return (
 			<span>
 				{ __( 'The following error was returned', 'woo-gutenberg-products-block' ) }
 				<br />
-				<code>{ escapeHTML( frontendMessage ) }</code>
+				<code>{ escapeHTML( message ) }</code>
 			</span>
 		);
 	}
 
-	if ( apiMessage ) {
+	if ( type === 'api' ) {
 		return (
 			<span>
 				{ __( 'The following error was returned from the API', 'woo-gutenberg-products-block' ) }
 				<br />
-				<code>{ escapeHTML( apiMessage ) }</code>
+				<code>{ escapeHTML( message ) }</code>
 			</span>
 		);
 	}
 
-	return __( 'An unknown error occurred which prevented the block from being updated.', 'woo-gutenberg-products-block' );
+	return message;
 };
 
 const ErrorMessage = ( { error } ) => (
@@ -45,13 +45,13 @@ ErrorMessage.propTypes = {
 	 */
 	error: PropTypes.shape( {
 		/**
-		 * API error message to display in case of a missing `message`.
-		 */
-		apiMessage: PropTypes.node,
-		/**
 		 * Human-readable error message to display.
 		 */
-		message: PropTypes.string,
+		message: PropTypes.node,
+		/**
+		 * Type of the error. That will determine how the error is displayed to the user.
+		 */
+		type: PropTypes.oneOf( [ 'api', 'frontend' ] ),
 	} ),
 };
 

--- a/assets/js/components/api-error-placeholder/error-message.js
+++ b/assets/js/components/api-error-placeholder/error-message.js
@@ -5,9 +5,19 @@ import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { escapeHTML } from '@wordpress/escape-html';
 
-const getErrorMessage = ( { apiMessage, message } ) => {
+const getErrorMessage = ( { apiMessage, message, frontendMessage } ) => {
 	if ( message ) {
 		return message;
+	}
+
+	if ( frontendMessage ) {
+		return (
+			<span>
+				{ __( 'The following error was returned', 'woo-gutenberg-products-block' ) }
+				<br />
+				<code>{ escapeHTML( frontendMessage ) }</code>
+			</span>
+		);
 	}
 
 	if ( apiMessage ) {

--- a/assets/js/components/api-error-placeholder/index.js
+++ b/assets/js/components/api-error-placeholder/index.js
@@ -53,9 +53,9 @@ ApiErrorPlaceholder.propTypes = {
 		 */
 		message: PropTypes.node,
 		/**
-		 * Type of the error. That will determine how the error is displayed to the user.
+		 * Context in which the error was triggered. That will determine how the error is displayed to the user.
 		 */
-		type: PropTypes.oneOf( [ 'api', 'frontend' ] ),
+		type: PropTypes.oneOf( [ 'api', 'general' ] ),
 	} ),
 	/**
 	 * Whether there is a request running, so the 'Retry' button is hidden and

--- a/assets/js/components/api-error-placeholder/index.js
+++ b/assets/js/components/api-error-placeholder/index.js
@@ -49,13 +49,13 @@ ApiErrorPlaceholder.propTypes = {
 	 */
 	error: PropTypes.shape( {
 		/**
-		 * API error message to display in case of a missing `message`.
-		 */
-		apiMessage: PropTypes.node,
-		/**
 		 * Human-readable error message to display.
 		 */
-		message: PropTypes.string,
+		message: PropTypes.node,
+		/**
+		 * Type of the error. That will determine how the error is displayed to the user.
+		 */
+		type: PropTypes.oneOf( [ 'api', 'frontend' ] ),
 	} ),
 	/**
 	 * Whether there is a request running, so the 'Retry' button is hidden and

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -20,13 +20,13 @@ class ProductAttributeControl extends Component {
 		super();
 
 		this.renderItem = this.renderItem.bind( this );
-		this.onSelectAttribute = this.onSelectAttribute.bind( this );
+		this.onExpandAttribute = this.onExpandAttribute.bind( this );
 	}
 
-	onSelectAttribute( item ) {
+	onExpandAttribute( item ) {
 		return () => {
 			this.props.onChange( [] );
-			this.props.onSelectAttribute( item.id );
+			this.props.onExpandAttribute( item.id );
 		};
 	}
 
@@ -40,7 +40,7 @@ class ProductAttributeControl extends Component {
 		if ( search.length ) {
 			classes.push( 'is-searching' );
 		}
-		if ( depth === 0 && item.parent !== 0 ) {
+		if ( depth === 0 && item.parent ) {
 			classes.push( 'is-skip-level' );
 		}
 
@@ -51,7 +51,7 @@ class ProductAttributeControl extends Component {
 					{ ...args }
 					className={ classes.join( ' ' ) }
 					isSelected={ expandedAttribute === item.id }
-					onSelect={ this.onSelectAttribute }
+					onSelect={ this.onExpandAttribute }
 					isSingle
 					disabled={ '0' === item.count }
 					aria-expanded={ expandedAttribute === item.id }
@@ -201,7 +201,7 @@ ProductAttributeControl.propTypes = {
 	attributes: PropTypes.array,
 	error: PropTypes.object,
 	expandedAttribute: PropTypes.number,
-	onSelectAttribute: PropTypes.func,
+	onExpandAttribute: PropTypes.func,
 	isLoading: PropTypes.bool,
 	termsAreLoading: PropTypes.bool,
 	termsList: PropTypes.object,

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -15,24 +15,16 @@ import { withAttributes } from '../../hocs';
 import ErrorMessage from '../api-error-placeholder/error-message.js';
 import './style.scss';
 
-class ProductAttributeControl extends Component {
-	constructor() {
-		super();
-
-		this.renderItem = this.renderItem.bind( this );
-		this.onExpandAttribute = this.onExpandAttribute.bind( this );
-	}
-
-	onExpandAttribute( item ) {
+const ProductAttributeControl = ( { attributes, error, expandedAttribute, onChange, onOperatorChange, isLoading, operator, selected, termsAreLoading, termsList } ) => {
+	const onExpandAttribute = ( item ) => {
 		return () => {
-			this.props.onChange( [] );
-			this.props.onExpandAttribute( item.id );
+			onChange( [] );
+			onExpandAttribute( item.id );
 		};
-	}
+	};
 
-	renderItem( args ) {
+	const renderItem = ( args ) => {
 		const { item, search, depth = 0 } = args;
-		const { expandedAttribute, termsAreLoading } = this.props;
 		const classes = [
 			'woocommerce-product-attributes__item',
 			'woocommerce-search-list__item',
@@ -51,7 +43,7 @@ class ProductAttributeControl extends Component {
 					{ ...args }
 					className={ classes.join( ' ' ) }
 					isSelected={ expandedAttribute === item.id }
-					onSelect={ this.onExpandAttribute }
+					onSelect={ onExpandAttribute }
 					isSingle
 					disabled={ '0' === item.count }
 					aria-expanded={ expandedAttribute === item.id }
@@ -88,97 +80,94 @@ class ProductAttributeControl extends Component {
 				aria-label={ `${ item.breadcrumbs[ 0 ] }: ${ item.name }` }
 			/>
 		);
-	}
+	};
 
-	render() {
-		const { attributes, error, expandedAttribute, onChange, onOperatorChange, isLoading, operator, selected, termsList } = this.props;
-		const currentTerms = termsList[ expandedAttribute ] || [];
-		const currentList = [ ...attributes, ...currentTerms ];
+	const currentTerms = termsList[ expandedAttribute ] || [];
+	const currentList = [ ...attributes, ...currentTerms ];
 
-		const messages = {
-			clear: __( 'Clear all product attributes', 'woo-gutenberg-products-block' ),
-			list: __( 'Product Attributes', 'woo-gutenberg-products-block' ),
-			noItems: __(
-				"Your store doesn't have any product attributes.",
-				'woo-gutenberg-products-block'
-			),
-			search: __(
-				'Search for product attributes',
-				'woo-gutenberg-products-block'
-			),
-			selected: ( n ) =>
-				sprintf(
-					_n(
-						'%d attribute selected',
-						'%d attributes selected',
-						n,
-						'woo-gutenberg-products-block'
-					),
-					n
+	const messages = {
+		clear: __( 'Clear all product attributes', 'woo-gutenberg-products-block' ),
+		list: __( 'Product Attributes', 'woo-gutenberg-products-block' ),
+		noItems: __(
+			"Your store doesn't have any product attributes.",
+			'woo-gutenberg-products-block'
+		),
+		search: __(
+			'Search for product attributes',
+			'woo-gutenberg-products-block'
+		),
+		selected: ( n ) =>
+			sprintf(
+				_n(
+					'%d attribute selected',
+					'%d attributes selected',
+					n,
+					'woo-gutenberg-products-block'
 				),
-			updated: __(
-				'Product attribute search results updated.',
-				'woo-gutenberg-products-block'
+				n
 			),
-		};
+		updated: __(
+			'Product attribute search results updated.',
+			'woo-gutenberg-products-block'
+		),
+	};
 
-		if ( error ) {
-			return (
-				<ErrorMessage error={ error } />
-			);
-		}
-
+	if ( error ) {
 		return (
-			<Fragment>
-				<SearchListControl
-					className="woocommerce-product-attributes"
-					list={ currentList }
-					isLoading={ isLoading }
-					selected={ selected
-						.map( ( { id } ) => find( currentList, { id } ) )
-						.filter( Boolean ) }
-					onChange={ onChange }
-					renderItem={ this.renderItem }
-					messages={ messages }
-					isHierarchical
-				/>
-				{ !! onOperatorChange && (
-					<div className={ selected.length < 2 ? 'screen-reader-text' : '' }>
-						<SelectControl
-							className="woocommerce-product-attributes__operator"
-							label={ __(
-								'Display products matching',
-								'woo-gutenberg-products-block'
-							) }
-							help={ __(
-								'Pick at least two attributes to use this setting.',
-								'woo-gutenberg-products-block'
-							) }
-							value={ operator }
-							onChange={ onOperatorChange }
-							options={ [
-								{
-									label: __(
-										'Any selected attributes',
-										'woo-gutenberg-products-block'
-									),
-									value: 'any',
-								},
-								{
-									label: __(
-										'All selected attributes',
-										'woo-gutenberg-products-block'
-									),
-									value: 'all',
-								},
-							] }
-						/>
-					</div>
-				) }
-			</Fragment>
+			<ErrorMessage error={ error } />
 		);
 	}
-}
+
+	return (
+		<Fragment>
+			<SearchListControl
+				className="woocommerce-product-attributes"
+				list={ currentList }
+				isLoading={ isLoading }
+				selected={ selected
+					.map( ( { id } ) => find( currentList, { id } ) )
+					.filter( Boolean ) }
+				onChange={ onChange }
+				renderItem={ renderItem }
+				messages={ messages }
+				isHierarchical
+			/>
+			{ !! onOperatorChange && (
+				<div className={ selected.length < 2 ? 'screen-reader-text' : '' }>
+					<SelectControl
+						className="woocommerce-product-attributes__operator"
+						label={ __(
+							'Display products matching',
+							'woo-gutenberg-products-block'
+						) }
+						help={ __(
+							'Pick at least two attributes to use this setting.',
+							'woo-gutenberg-products-block'
+						) }
+						value={ operator }
+						onChange={ onOperatorChange }
+						options={ [
+							{
+								label: __(
+									'Any selected attributes',
+									'woo-gutenberg-products-block'
+								),
+								value: 'any',
+							},
+							{
+								label: __(
+									'All selected attributes',
+									'woo-gutenberg-products-block'
+								),
+								value: 'all',
+							},
+						] }
+					/>
+				</div>
+			) }
+		</Fragment>
+	);
+};
 
 ProductAttributeControl.propTypes = {
 	/**

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -15,14 +15,8 @@ import { withCategories } from '../../hocs';
 import ErrorMessage from '../api-error-placeholder/error-message.js';
 import './style.scss';
 
-class ProductCategoryControl extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.renderItem = this.renderItem.bind( this );
-	}
-
-	renderItem( args ) {
+const ProductCategoryControl = ( { categories, error, isLoading, onChange, onOperatorChange, operator, selected, isSingle } ) => {
+	const renderItem = ( args ) => {
 		const { item, search, depth = 0 } = args;
 		const classes = [
 			'woocommerce-product-categories__item',
@@ -55,82 +49,78 @@ class ProductCategoryControl extends Component {
 				) }
 			/>
 		);
-	}
+	};
 
-	render() {
-		const { categories, error, isLoading, onChange, onOperatorChange, operator, selected, isSingle } = this.props;
-
-		const messages = {
-			clear: __( 'Clear all product categories', 'woo-gutenberg-products-block' ),
-			list: __( 'Product Categories', 'woo-gutenberg-products-block' ),
-			noItems: __(
-				"Your store doesn't have any product categories.",
-				'woo-gutenberg-products-block'
-			),
-			search: __(
-				'Search for product categories',
-				'woo-gutenberg-products-block'
-			),
-			selected: ( n ) =>
-				sprintf(
-					_n(
-						'%d category selected',
-						'%d categories selected',
-						n,
-						'woo-gutenberg-products-block'
-					),
-					n
+	const messages = {
+		clear: __( 'Clear all product categories', 'woo-gutenberg-products-block' ),
+		list: __( 'Product Categories', 'woo-gutenberg-products-block' ),
+		noItems: __(
+			"Your store doesn't have any product categories.",
+			'woo-gutenberg-products-block'
+		),
+		search: __(
+			'Search for product categories',
+			'woo-gutenberg-products-block'
+		),
+		selected: ( n ) =>
+			sprintf(
+				_n(
+					'%d category selected',
+					'%d categories selected',
+					n,
+					'woo-gutenberg-products-block'
 				),
-			updated: __(
-				'Category search results updated.',
-				'woo-gutenberg-products-block'
+				n
 			),
-		};
+		updated: __(
+			'Category search results updated.',
+			'woo-gutenberg-products-block'
+		),
+	};
 
-		if ( error ) {
-			return (
-				<ErrorMessage error={ error } />
-			);
-		}
-
+	if ( error ) {
 		return (
-			<Fragment>
-				<SearchListControl
-					className="woocommerce-product-categories"
-					list={ categories }
-					isLoading={ isLoading }
-					selected={ selected.map( ( id ) => find( categories, { id } ) ).filter( Boolean ) }
-					onChange={ onChange }
-					renderItem={ this.renderItem }
-					messages={ messages }
-					isHierarchical
-					isSingle={ isSingle }
-				/>
-				{ ( !! onOperatorChange ) && (
-					<div className={ selected.length < 2 ? 'screen-reader-text' : '' }>
-						<SelectControl
-							className="woocommerce-product-categories__operator"
-							label={ __( 'Display products matching', 'woo-gutenberg-products-block' ) }
-							help={ __( 'Pick at least two categories to use this setting.', 'woo-gutenberg-products-block' ) }
-							value={ operator }
-							onChange={ onOperatorChange }
-							options={ [
-								{
-									label: __( 'Any selected categories', 'woo-gutenberg-products-block' ),
-									value: 'any',
-								},
-								{
-									label: __( 'All selected categories', 'woo-gutenberg-products-block' ),
-									value: 'all',
-								},
-							] }
-						/>
-					</div>
-				) }
-			</Fragment>
+			<ErrorMessage error={ error } />
 		);
 	}
-}
+
+	return (
+		<Fragment>
+			<SearchListControl
+				className="woocommerce-product-categories"
+				list={ categories }
+				isLoading={ isLoading }
+				selected={ selected.map( ( id ) => find( categories, { id } ) ).filter( Boolean ) }
+				onChange={ onChange }
+				renderItem={ renderItem }
+				messages={ messages }
+				isHierarchical
+				isSingle={ isSingle }
+			/>
+			{ ( !! onOperatorChange ) && (
+				<div className={ selected.length < 2 ? 'screen-reader-text' : '' }>
+					<SelectControl
+						className="woocommerce-product-categories__operator"
+						label={ __( 'Display products matching', 'woo-gutenberg-products-block' ) }
+						help={ __( 'Pick at least two categories to use this setting.', 'woo-gutenberg-products-block' ) }
+						value={ operator }
+						onChange={ onOperatorChange }
+						options={ [
+							{
+								label: __( 'Any selected categories', 'woo-gutenberg-products-block' ),
+								value: 'any',
+							},
+							{
+								label: __( 'All selected categories', 'woo-gutenberg-products-block' ),
+								value: 'all',
+							},
+						] }
+					/>
+				</div>
+			) }
+		</Fragment>
+	);
+};
 
 ProductCategoryControl.propTypes = {
 	/**

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -2,40 +2,24 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
-import apiFetch from '@wordpress/api-fetch';
 import { Component, Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
 import { SelectControl } from '@wordpress/components';
-import { ENDPOINTS } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
  */
+import { withCategories } from '../../hocs';
+import ErrorMessage from '../api-error-placeholder/error-message.js';
 import './style.scss';
 
 class ProductCategoryControl extends Component {
 	constructor() {
 		super( ...arguments );
-		this.state = {
-			list: [],
-			loading: true,
-		};
-		this.renderItem = this.renderItem.bind( this );
-	}
 
-	componentDidMount() {
-		apiFetch( {
-			path: addQueryArgs( `${ ENDPOINTS.products }/categories`, { per_page: -1 } ),
-		} )
-			.then( ( list ) => {
-				this.setState( { list, loading: false } );
-			} )
-			.catch( () => {
-				this.setState( { list: [], loading: false } );
-			} );
+		this.renderItem = this.renderItem.bind( this );
 	}
 
 	renderItem( args ) {
@@ -74,8 +58,7 @@ class ProductCategoryControl extends Component {
 	}
 
 	render() {
-		const { list, loading } = this.state;
-		const { onChange, onOperatorChange, operator, selected, isSingle } = this.props;
+		const { categories, error, isLoading, onChange, onOperatorChange, operator, selected, isSingle } = this.props;
 
 		const messages = {
 			clear: __( 'Clear all product categories', 'woo-gutenberg-products-block' ),
@@ -104,13 +87,19 @@ class ProductCategoryControl extends Component {
 			),
 		};
 
+		if ( error ) {
+			return (
+				<ErrorMessage error={ error } />
+			);
+		}
+
 		return (
 			<Fragment>
 				<SearchListControl
 					className="woocommerce-product-categories"
-					list={ list }
-					isLoading={ loading }
-					selected={ selected.map( ( id ) => find( list, { id } ) ).filter( Boolean ) }
+					list={ categories }
+					isLoading={ isLoading }
+					selected={ selected.map( ( id ) => find( categories, { id } ) ).filter( Boolean ) }
 					onChange={ onChange }
 					renderItem={ this.renderItem }
 					messages={ messages }
@@ -171,4 +160,4 @@ ProductCategoryControl.defaultProps = {
 	isSingle: false,
 };
 
-export default ProductCategoryControl;
+export default withCategories( ProductCategoryControl );

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -116,3 +116,15 @@ export const getCategories = () => {
 		path: addQueryArgs( `${ ENDPOINTS.products }/categories`, { per_page: -1 } ),
 	} );
 };
+
+export const getAttributes = () => {
+	return apiFetch( {
+		path: addQueryArgs( `${ ENDPOINTS.products }/attributes`, { per_page: -1 } ),
+	} );
+};
+
+export const getTerms = ( attribute ) => {
+	return apiFetch( {
+		path: addQueryArgs( `${ ENDPOINTS.products }/attributes/${ attribute }/terms`, { per_page: -1 } ),
+	} );
+};

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -107,3 +107,12 @@ export const getCategory = ( categoryId ) => {
 		path: `${ ENDPOINTS.categories }/${ categoryId }`,
 	} );
 };
+
+/**
+ * Get a promise that resolves to an array of category objects from the API.
+ */
+export const getCategories = () => {
+	return apiFetch( {
+		path: addQueryArgs( `${ ENDPOINTS.products }/categories`, { per_page: -1 } ),
+	} );
+};

--- a/assets/js/hocs/index.js
+++ b/assets/js/hocs/index.js
@@ -1,4 +1,5 @@
-export { default as withProduct } from './with-product';
+export { default as withAttributes } from './with-attributes';
 export { default as withCategories } from './with-categories';
 export { default as withCategory } from './with-category';
+export { default as withProduct } from './with-product';
 export { default as withSearchedProducts } from './with-searched-products';

--- a/assets/js/hocs/index.js
+++ b/assets/js/hocs/index.js
@@ -1,3 +1,4 @@
 export { default as withProduct } from './with-product';
+export { default as withCategories } from './with-categories';
 export { default as withCategory } from './with-category';
 export { default as withSearchedProducts } from './with-searched-products';

--- a/assets/js/hocs/test/with-attributes.js
+++ b/assets/js/hocs/test/with-attributes.js
@@ -117,7 +117,7 @@ describe( 'withAttributes Component', () => {
 	describe( 'when the API returns an error', () => {
 		const error = { message: 'There was an error.' };
 		const getAttributesPromise = Promise.reject( error );
-		const formattedError = { apiMessage: 'There was an error.' };
+		const formattedError = { message: 'There was an error.', type: 'api' };
 		let testComponent;
 
 		beforeEach( () => {

--- a/assets/js/hocs/test/with-attributes.js
+++ b/assets/js/hocs/test/with-attributes.js
@@ -1,0 +1,148 @@
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import withAttributes from '../with-attributes';
+import * as mockUtils from '../../components/utils';
+import * as mockBaseUtils from '../../base/utils/errors';
+
+jest.mock( '../../components/utils', () => ( {
+	getAttributes: jest.fn(),
+	getTerms: jest.fn(),
+} ) );
+
+jest.mock( '../../base/utils/errors', () => ( {
+	formatError: jest.fn(),
+} ) );
+
+jest.mock( 'lodash', () => ( {
+	...jest.requireActual( 'lodash' ),
+	debounce: ( func ) => func,
+} ) );
+
+const mockAttributes = [ { id: 1, name: 'Color', slug: 'color' }, { id: 2, name: 'Size', slug: 'size' } ];
+const mockAttributesWithParent = [ { id: 1, name: 'Color', slug: 'color', parent: 0 }, { id: 2, name: 'Size', slug: 'size', parent: 0 } ];
+const selected = [ { id: 11, attr_slug: 'color' } ];
+const TestComponent = withAttributes( ( props ) => {
+	return <div
+		attributes={ props.attributes }
+		error={ props.error }
+		expandedAttribute={ props.expandedAttribute }
+		onExpandAttribute={ props.onExpandAttribute }
+		isLoading={ props.isLoading }
+		termsAreLoading={ props.termsAreLoading }
+		termsList={ props.termsList }
+	/>;
+} );
+
+describe( 'withAttributes Component', () => {
+	afterEach( () => {
+		mockUtils.getAttributes.mockReset();
+		mockUtils.getTerms.mockReset();
+		mockBaseUtils.formatError.mockReset();
+	} );
+
+	describe( 'lifecycle events', () => {
+		let getAttributesPromise;
+		let testComponent;
+
+		beforeEach( () => {
+			getAttributesPromise = Promise.resolve( mockAttributes );
+			mockUtils.getAttributes.mockImplementation(
+				() => getAttributesPromise
+			);
+			mockUtils.getTerms.mockImplementation(
+				() => Promise.resolve()
+			);
+		} );
+
+		it( 'getAttributes is called on mount', () => {
+			testComponent = shallow( <TestComponent /> );
+			const { getAttributes } = mockUtils;
+
+			expect( getAttributes ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'getTerms is called on component update', () => {
+			testComponent = shallow( <TestComponent /> );
+			const { onExpandAttribute } = testComponent.props();
+
+			onExpandAttribute( 1 );
+
+			const element = testComponent.getElement();
+			const { getTerms } = mockUtils;
+
+			expect( getTerms ).toHaveBeenCalledWith( 1 );
+			expect( getTerms ).toHaveBeenCalledTimes( 1 );
+			expect( element.props.expandedAttribute ).toBe( 1 );
+		} );
+
+		it( 'getTerms is called on mount if there was an attribute selected', ( done ) => {
+			testComponent = shallow( <TestComponent selected={ selected } /> );
+
+			getAttributesPromise.then( () => {
+				const { getTerms } = mockUtils;
+
+				expect( getTerms ).toHaveBeenCalledWith( 1 );
+				expect( getTerms ).toHaveBeenCalledTimes( 1 );
+				expect( testComponent.state( 'expandedAttribute' ) ).toBe( 1 );
+				done();
+			} );
+		} );
+	} );
+
+	describe( 'when the API returns attributes data', () => {
+		let testComponent;
+
+		beforeEach( () => {
+			mockUtils.getAttributes.mockImplementation(
+				() => Promise.resolve( mockAttributes )
+			);
+			testComponent = shallow( <TestComponent /> );
+		} );
+
+		it( 'sets the attributes props', () => {
+			const element = testComponent.getElement();
+
+			expect( element.props.error ).toBeNull();
+			expect( element.props.isLoading ).toBe( false );
+			expect( element.props.attributes ).toEqual( mockAttributesWithParent );
+		} );
+	} );
+
+	describe( 'when the API returns an error', () => {
+		const error = { message: 'There was an error.' };
+		const getAttributesPromise = Promise.reject( error );
+		const formattedError = { apiMessage: 'There was an error.' };
+		let testComponent;
+
+		beforeEach( () => {
+			mockUtils.getAttributes.mockImplementation(
+				() => getAttributesPromise
+			);
+			mockBaseUtils.formatError.mockImplementation(
+				() => formattedError,
+			);
+			testComponent = shallow( <TestComponent /> );
+		} );
+
+		it( 'sets the error prop', ( done ) => {
+			const { formatError } = mockBaseUtils;
+			getAttributesPromise.catch( () => {
+				const element = testComponent.getElement();
+
+				expect( formatError ).toHaveBeenCalledWith( error );
+				expect( formatError ).toHaveBeenCalledTimes( 1 );
+				expect( element.props.error ).toEqual( formattedError );
+				expect( element.props.isLoading ).toBe( false );
+				expect( element.props.attributes ).toEqual( [] );
+
+				done();
+			} );
+		} );
+	} );
+} );

--- a/assets/js/hocs/test/with-categories.js
+++ b/assets/js/hocs/test/with-categories.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import withCategories from '../with-categories';
+import * as mockUtils from '../../components/utils';
+import * as mockBaseUtils from '../../base/utils/errors';
+
+jest.mock( '../../components/utils', () => ( {
+	getCategories: jest.fn(),
+} ) );
+
+jest.mock( '../../base/utils/errors', () => ( {
+	formatError: jest.fn(),
+} ) );
+
+const mockCategories = [ { id: 1, name: 'Clothing' }, { id: 2, name: 'Food' } ];
+const TestComponent = withCategories( ( props ) => {
+	return <div
+		error={ props.error }
+		isLoading={ props.isLoading }
+		categories={ props.categories }
+	/>;
+} );
+const render = () => {
+	return TestRenderer.create(
+		<TestComponent />
+	);
+};
+
+describe( 'withCategories Component', () => {
+	let renderer;
+	afterEach( () => {
+		mockUtils.getCategories.mockReset();
+	} );
+
+	describe( 'lifecycle events', () => {
+		beforeEach( () => {
+			mockUtils.getCategories.mockImplementation( () => Promise.resolve() );
+			renderer = render();
+		} );
+
+		it( 'getCategories is called on mount', () => {
+			const { getCategories } = mockUtils;
+
+			expect( getCategories ).toHaveBeenCalledWith();
+			expect( getCategories ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'when the API returns categories data', () => {
+		beforeEach( () => {
+			mockUtils.getCategories.mockImplementation(
+				() => Promise.resolve( mockCategories )
+			);
+			renderer = render();
+		} );
+
+		it( 'sets the categories props', () => {
+			const props = renderer.root.findByType( 'div' ).props;
+
+			expect( props.error ).toBeNull();
+			expect( props.isLoading ).toBe( false );
+			expect( props.categories ).toEqual( mockCategories );
+		} );
+	} );
+
+	describe( 'when the API returns an error', () => {
+		const error = { message: 'There was an error.' };
+		const getCategoriesPromise = Promise.reject( error );
+		const formattedError = { apiMessage: 'There was an error.' };
+
+		beforeEach( () => {
+			mockUtils.getCategories.mockImplementation(
+				() => getCategoriesPromise
+			);
+			mockBaseUtils.formatError.mockImplementation(
+				() => formattedError,
+			);
+			renderer = render();
+		} );
+
+		it( 'sets the error prop', ( done ) => {
+			const { formatError } = mockBaseUtils;
+			getCategoriesPromise.catch( () => {
+				const props = renderer.root.findByType( 'div' ).props;
+
+				expect( formatError ).toHaveBeenCalledWith( error );
+				expect( formatError ).toHaveBeenCalledTimes( 1 );
+				expect( props.error ).toEqual( formattedError );
+				expect( props.isLoading ).toBe( false );
+				expect( props.categories ).toBeNull();
+
+				done();
+			} );
+		} );
+	} );
+} );

--- a/assets/js/hocs/test/with-categories.js
+++ b/assets/js/hocs/test/with-categories.js
@@ -72,7 +72,7 @@ describe( 'withCategories Component', () => {
 	describe( 'when the API returns an error', () => {
 		const error = { message: 'There was an error.' };
 		const getCategoriesPromise = Promise.reject( error );
-		const formattedError = { apiMessage: 'There was an error.' };
+		const formattedError = { message: 'There was an error.', type: 'api' };
 
 		beforeEach( () => {
 			mockUtils.getCategories.mockImplementation(

--- a/assets/js/hocs/test/with-category.js
+++ b/assets/js/hocs/test/with-category.js
@@ -99,7 +99,7 @@ describe( 'withCategory Component', () => {
 	describe( 'when the API returns an error', () => {
 		const error = { message: 'There was an error.' };
 		const getCategoryPromise = Promise.reject( error );
-		const formattedError = { apiMessage: 'There was an error.' };
+		const formattedError = { message: 'There was an error.', type: 'api' };
 
 		beforeEach( () => {
 			mockUtils.getCategory.mockImplementation(

--- a/assets/js/hocs/test/with-category.js
+++ b/assets/js/hocs/test/with-category.js
@@ -6,26 +6,26 @@ import TestRenderer from 'react-test-renderer';
 /**
  * Internal dependencies
  */
-import withProduct from '../with-product';
+import withCategory from '../with-category';
 import * as mockUtils from '../../components/utils';
 import * as mockBaseUtils from '../../base/utils/errors';
 
 jest.mock( '../../components/utils', () => ( {
-	getProduct: jest.fn(),
+	getCategory: jest.fn(),
 } ) );
 
 jest.mock( '../../base/utils/errors', () => ( {
 	formatError: jest.fn(),
 } ) );
 
-const mockProduct = { name: 'T-Shirt' };
-const attributes = { productId: 1 };
-const TestComponent = withProduct( ( props ) => {
+const mockCategory = { name: 'Clothing' };
+const attributes = { categoryId: 1 };
+const TestComponent = withCategory( ( props ) => {
 	return <div
 		error={ props.error }
-		getProduct={ props.getProduct }
+		getCategory={ props.getCategory }
 		isLoading={ props.isLoading }
-		product={ props.product }
+		category={ props.category }
 	/>;
 } );
 const render = () => {
@@ -36,74 +36,74 @@ const render = () => {
 	);
 };
 
-describe( 'withProduct Component', () => {
+describe( 'withCategory Component', () => {
 	let renderer;
 	afterEach( () => {
-		mockUtils.getProduct.mockReset();
+		mockUtils.getCategory.mockReset();
 	} );
 
 	describe( 'lifecycle events', () => {
 		beforeEach( () => {
-			mockUtils.getProduct.mockImplementation( () => Promise.resolve() );
+			mockUtils.getCategory.mockImplementation( () => Promise.resolve() );
 			renderer = render();
 		} );
 
-		it( 'getProduct is called on mount with passed in product id', () => {
-			const { getProduct } = mockUtils;
+		it( 'getCategory is called on mount with passed in category id', () => {
+			const { getCategory } = mockUtils;
 
-			expect( getProduct ).toHaveBeenCalledWith( attributes.productId );
-			expect( getProduct ).toHaveBeenCalledTimes( 1 );
+			expect( getCategory ).toHaveBeenCalledWith( attributes.categoryId );
+			expect( getCategory ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'getProduct is called on component update', () => {
-			const { getProduct } = mockUtils;
-			const newAttributes = { ...attributes, productId: 2 };
+		it( 'getCategory is called on component update', () => {
+			const { getCategory } = mockUtils;
+			const newAttributes = { ...attributes, categoryId: 2 };
 			renderer.update(
 				<TestComponent
 					attributes={ newAttributes }
 				/>
 			);
 
-			expect( getProduct ).toHaveBeenNthCalledWith( 2, newAttributes.productId );
-			expect( getProduct ).toHaveBeenCalledTimes( 2 );
+			expect( getCategory ).toHaveBeenNthCalledWith( 2, newAttributes.categoryId );
+			expect( getCategory ).toHaveBeenCalledTimes( 2 );
 		} );
 
-		it( 'getProduct is hooked to the prop', () => {
-			const { getProduct } = mockUtils;
+		it( 'getCategory is hooked to the prop', () => {
+			const { getCategory } = mockUtils;
 			const props = renderer.root.findByType( 'div' ).props;
 
-			props.getProduct();
+			props.getCategory();
 
-			expect( getProduct ).toHaveBeenCalledTimes( 2 );
+			expect( getCategory ).toHaveBeenCalledTimes( 2 );
 		} );
 	} );
 
-	describe( 'when the API returns product data', () => {
+	describe( 'when the API returns category data', () => {
 		beforeEach( () => {
-			mockUtils.getProduct.mockImplementation(
-				( productId ) => Promise.resolve( { ...mockProduct, id: productId } )
+			mockUtils.getCategory.mockImplementation(
+				( categoryId ) => Promise.resolve( { ...mockCategory, id: categoryId } )
 			);
 			renderer = render();
 		} );
 
-		it( 'sets the product props', () => {
+		it( 'sets the category props', () => {
 			const props = renderer.root.findByType( 'div' ).props;
 
 			expect( props.error ).toBeNull();
-			expect( typeof props.getProduct ).toBe( 'function' );
+			expect( typeof props.getCategory ).toBe( 'function' );
 			expect( props.isLoading ).toBe( false );
-			expect( props.product ).toEqual( { ...mockProduct, id: attributes.productId } );
+			expect( props.category ).toEqual( { ...mockCategory, id: attributes.categoryId } );
 		} );
 	} );
 
 	describe( 'when the API returns an error', () => {
 		const error = { message: 'There was an error.' };
-		const getProductPromise = Promise.reject( error );
+		const getCategoryPromise = Promise.reject( error );
 		const formattedError = { apiMessage: 'There was an error.' };
 
 		beforeEach( () => {
-			mockUtils.getProduct.mockImplementation(
-				() => getProductPromise,
+			mockUtils.getCategory.mockImplementation(
+				() => getCategoryPromise
 			);
 			mockBaseUtils.formatError.mockImplementation(
 				() => formattedError,
@@ -113,15 +113,15 @@ describe( 'withProduct Component', () => {
 
 		it( 'sets the error prop', ( done ) => {
 			const { formatError } = mockBaseUtils;
-			getProductPromise.catch( () => {
+			getCategoryPromise.catch( () => {
 				const props = renderer.root.findByType( 'div' ).props;
 
 				expect( formatError ).toHaveBeenCalledWith( error );
 				expect( formatError ).toHaveBeenCalledTimes( 1 );
 				expect( props.error ).toEqual( formattedError );
-				expect( typeof props.getProduct ).toBe( 'function' );
+				expect( typeof props.getCategory ).toBe( 'function' );
 				expect( props.isLoading ).toBe( false );
-				expect( props.product ).toBeNull();
+				expect( props.category ).toBeNull();
 
 				done();
 			} );

--- a/assets/js/hocs/test/with-product.js
+++ b/assets/js/hocs/test/with-product.js
@@ -99,7 +99,7 @@ describe( 'withProduct Component', () => {
 	describe( 'when the API returns an error', () => {
 		const error = { message: 'There was an error.' };
 		const getProductPromise = Promise.reject( error );
-		const formattedError = { apiMessage: 'There was an error.' };
+		const formattedError = { message: 'There was an error.', type: 'api' };
 
 		beforeEach( () => {
 			mockUtils.getProduct.mockImplementation(

--- a/assets/js/hocs/with-attributes.js
+++ b/assets/js/hocs/with-attributes.js
@@ -61,8 +61,8 @@ const withAttributes = createHigherOrderComponent(
 						}
 					}
 					this.setState( { attributes, expandedAttribute: newExpandedAttribute, loading: false, error: null } );
-				} ).catch( ( e ) => {
-					const error = formatError( e );
+				} ).catch( async ( e ) => {
+					const error = await formatError( e );
 
 					this.setState( { attributes: [], expandedAttribute: null, loading: false, error } );
 				} );
@@ -85,8 +85,8 @@ const withAttributes = createHigherOrderComponent(
 							termsLoading: false,
 						} ) );
 					} )
-					.catch( ( apiError ) => {
-						const error = formatError( apiError );
+					.catch( async ( e ) => {
+						const error = await formatError( e );
 
 						this.setState( { termsList: {}, termsLoading: false, error } );
 					} );

--- a/assets/js/hocs/with-attributes.js
+++ b/assets/js/hocs/with-attributes.js
@@ -27,8 +27,7 @@ const withAttributes = createHigherOrderComponent(
 				};
 
 				this.loadAttributes = this.loadAttributes.bind( this );
-				this.loadTerms = this.loadTerms.bind( this );
-				this.onSelectAttribute = this.onSelectAttribute.bind( this );
+				this.onExpandAttribute = this.onExpandAttribute.bind( this );
 				this.debouncedLoadTerms = debounce( this.loadTerms.bind( this ), 200 );
 			}
 
@@ -92,7 +91,7 @@ const withAttributes = createHigherOrderComponent(
 					} );
 			}
 
-			onSelectAttribute( attributeId ) {
+			onExpandAttribute( attributeId ) {
 				const { expandedAttribute } = this.state;
 
 				this.setState( {
@@ -108,7 +107,7 @@ const withAttributes = createHigherOrderComponent(
 					attributes={ attributes }
 					error={ error }
 					expandedAttribute={ expandedAttribute }
-					onSelectAttribute={ this.onSelectAttribute }
+					onExpandAttribute={ this.onExpandAttribute }
 					isLoading={ loading }
 					termsAreLoading={ termsLoading }
 					termsList={ termsList }

--- a/assets/js/hocs/with-attributes.js
+++ b/assets/js/hocs/with-attributes.js
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import PropTypes from 'prop-types';
+import { debounce } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getAttributes, getTerms } from '../components/utils';
+import { formatError } from '../base/utils/errors.js';
+
+const withAttributes = createHigherOrderComponent(
+	( OriginalComponent ) => {
+		class WrappedComponent extends Component {
+			constructor() {
+				super( ...arguments );
+				this.state = {
+					attributes: [],
+					error: null,
+					expandedAttribute: null,
+					loading: false,
+					termsList: {},
+					termsLoading: false,
+				};
+
+				this.loadAttributes = this.loadAttributes.bind( this );
+				this.loadTerms = this.loadTerms.bind( this );
+				this.onSelectAttribute = this.onSelectAttribute.bind( this );
+				this.debouncedLoadTerms = debounce( this.loadTerms.bind( this ), 200 );
+			}
+
+			componentDidMount() {
+				this.loadAttributes();
+			}
+
+			componentWillUnmount() {
+				this.debouncedLoadTerms.cancel();
+			}
+
+			componentDidUpdate( prevProps, prevState ) {
+				if ( prevState.expandedAttribute !== this.state.expandedAttribute ) {
+					this.debouncedLoadTerms();
+				}
+			}
+
+			loadAttributes() {
+				const { selected } = this.props;
+				const { expandedAttribute } = this.state;
+				this.setState( { loading: true } );
+
+				getAttributes().then( ( attributes ) => {
+					attributes = attributes.map( ( item ) => ( { ...item, parent: 0 } ) );
+					let newExpandedAttribute = expandedAttribute;
+					if ( ! expandedAttribute && selected.length > 0 ) {
+						const attr = attributes.find( ( item ) => item.slug === selected[ 0 ].attr_slug );
+						if ( attr ) {
+							newExpandedAttribute = attr.id;
+						}
+					}
+					this.setState( { attributes, expandedAttribute: newExpandedAttribute, loading: false, error: null } );
+				} ).catch( ( e ) => {
+					const error = formatError( e );
+
+					this.setState( { attributes: [], expandedAttribute: null, loading: false, error } );
+				} );
+			}
+
+			loadTerms() {
+				const { expandedAttribute, termsList } = this.state;
+				if ( ! expandedAttribute ) {
+					return;
+				}
+				if ( ! termsList[ expandedAttribute ] ) {
+					this.setState( { termsLoading: true } );
+				}
+
+				getTerms( expandedAttribute )
+					.then( ( terms ) => {
+						terms = terms.map( ( term ) => ( { ...term, parent: expandedAttribute, attr_slug: term.attribute.slug } ) );
+						this.setState( ( prevState ) => ( {
+							termsList: { ...prevState.termsList, [ expandedAttribute ]: terms },
+							termsLoading: false,
+						} ) );
+					} )
+					.catch( ( apiError ) => {
+						const error = formatError( apiError );
+
+						this.setState( { termsList: {}, termsLoading: false, error } );
+					} );
+			}
+
+			onSelectAttribute( attributeId ) {
+				const { expandedAttribute } = this.state;
+
+				this.setState( {
+					expandedAttribute: attributeId === expandedAttribute ? null : attributeId,
+				} );
+			}
+
+			render() {
+				const { error, expandedAttribute, loading, attributes, termsList, termsLoading } = this.state;
+
+				return <OriginalComponent
+					{ ...this.props }
+					attributes={ attributes }
+					error={ error }
+					expandedAttribute={ expandedAttribute }
+					onSelectAttribute={ this.onSelectAttribute }
+					isLoading={ loading }
+					termsAreLoading={ termsLoading }
+					termsList={ termsList }
+				/>;
+			}
+		}
+		WrappedComponent.propTypes = {
+			selected: PropTypes.array,
+		};
+		WrappedComponent.defaultProps = {
+			selected: [],
+		};
+		return WrappedComponent;
+	},
+	'withAttributes'
+);
+
+export default withAttributes;

--- a/assets/js/hocs/with-categories.js
+++ b/assets/js/hocs/with-categories.js
@@ -47,7 +47,6 @@ const withCategories = createHigherOrderComponent(
 				return <OriginalComponent
 					{ ...this.props }
 					error={ error }
-					getCategories={ this.loadCategories }
 					isLoading={ loading }
 					categories={ categories }
 				/>;

--- a/assets/js/hocs/with-categories.js
+++ b/assets/js/hocs/with-categories.js
@@ -32,12 +32,10 @@ const withCategories = createHigherOrderComponent(
 
 				getCategories().then( ( categories ) => {
 					this.setState( { categories, loading: false, error: null } );
-				} ).catch( ( errorResponse ) => {
-					errorResponse.json().then( ( apiError ) => {
-						const error = formatError( apiError );
+				} ).catch( async ( e ) => {
+					const error = await formatError( e );
 
-						this.setState( { categories: null, loading: false, error } );
-					} );
+					this.setState( { categories: null, loading: false, error } );
 				} );
 			}
 

--- a/assets/js/hocs/with-categories.js
+++ b/assets/js/hocs/with-categories.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { Component } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { getCategories } from '../components/utils';
+import { formatError } from '../base/utils/errors.js';
+
+const withCategories = createHigherOrderComponent(
+	( OriginalComponent ) => {
+		return class WrappedComponent extends Component {
+			constructor() {
+				super( ...arguments );
+				this.state = {
+					error: null,
+					loading: false,
+					categories: null,
+				};
+				this.loadCategories = this.loadCategories.bind( this );
+			}
+
+			componentDidMount() {
+				this.loadCategories();
+			}
+
+			loadCategories() {
+				this.setState( { loading: true } );
+
+				getCategories().then( ( categories ) => {
+					this.setState( { categories, loading: false, error: null } );
+				} ).catch( ( errorResponse ) => {
+					errorResponse.json().then( ( apiError ) => {
+						const error = formatError( apiError );
+
+						this.setState( { categories: null, loading: false, error } );
+					} );
+				} );
+			}
+
+			render() {
+				const { error, loading, categories } = this.state;
+
+				return <OriginalComponent
+					{ ...this.props }
+					error={ error }
+					getCategories={ this.loadCategories }
+					isLoading={ loading }
+					categories={ categories }
+				/>;
+			}
+		};
+	},
+	'withCategories'
+);
+
+export default withCategories;

--- a/assets/js/hocs/with-category.js
+++ b/assets/js/hocs/with-category.js
@@ -45,8 +45,8 @@ const withCategory = createHigherOrderComponent(
 
 				getCategory( categoryId ).then( ( category ) => {
 					this.setState( { category, loading: false, error: null } );
-				} ).catch( ( apiError ) => {
-					const error = formatError( apiError );
+				} ).catch( async ( e ) => {
+					const error = await formatError( e );
 
 					this.setState( { category: null, loading: false, error } );
 				} );

--- a/assets/js/hocs/with-product.js
+++ b/assets/js/hocs/with-product.js
@@ -45,8 +45,8 @@ const withProduct = createHigherOrderComponent(
 
 				getProduct( productId ).then( ( product ) => {
 					this.setState( { product, loading: false, error: null } );
-				} ).catch( ( apiError ) => {
-					const error = formatError( apiError );
+				} ).catch( async ( e ) => {
+					const error = await formatError( e );
 
 					this.setState( { product: null, loading: false, error } );
 				} );

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -57,12 +57,10 @@ const withSearchedProducts = createHigherOrderComponent( ( OriginalComponent ) =
 				.catch( this.setError );
 		}
 
-		setError( errorResponse ) {
-			errorResponse.json().then( ( apiError ) => {
-				const error = formatError( apiError );
+		async setError( e ) {
+			const error = await formatError( e );
 
-				this.setState( { list: [], loading: false, error } );
-			} );
+			this.setState( { list: [], loading: false, error } );
 		}
 
 		render() {

--- a/src/RestApi/Controllers/ProductAttributes.php
+++ b/src/RestApi/Controllers/ProductAttributes.php
@@ -79,7 +79,7 @@ class ProductAttributes extends WC_REST_Product_Attributes_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! current_user_can( 'edit_posts' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woo-gutenberg-products-block' ), array( 'status' => rest_authorization_required_code() ) );
+			return new \WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woo-gutenberg-products-block' ), array( 'status' => \rest_authorization_required_code() ) );
 		}
 		return true;
 	}


### PR DESCRIPTION
This PR:
* Creates `withCategories` and `withAttributes` HOC.
* Makes it so Product Category Control and Product Attribute Control display API errors to the user.
* Refactors error handling in all HOCs so JS errors can be handled too.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/64109532-0bdc3680-cd80-11e9-85fc-aeb9a2077684.png)

### How to test the changes in this Pull Request:

1. Create a post with a _Products by Category_ and _Products by Attribute_ blocks.
2. In `src/RestApi/Controllers/ProductCategories.php` modify [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/Controllers/ProductCategories.php#L84) with:
```diff
-if ( ! $taxonomy || ! \taxonomy_exists( $taxonomy ) ) {
+if( true ) {
```
3. In `src/RestApi/Controllers/ProductAttributes.php` modify [this one](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/Controllers/ProductAttributes.php#L81) with:
```diff
-if ( ! current_user_can( 'edit_posts' ) ) {
+if ( true ) {
```
4. Reload the post and verify errors are displayed.
