### PR TITLE
Exclude bundlesize and composer files from being deployed ZIP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,8 @@
 /bin export-ignore
 /phpcs.xml export-ignore
 /phpunit.* export-ignore
+/composer.lock export-ignore
+/composer.json export-ignore
 /renovate.json export-ignore
 /webpack.config.js export-ignore
 /postcss.config.js export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /renovate.json export-ignore
 /webpack.config.js export-ignore
 /postcss.config.js export-ignore
+/bundlesize.config.json export-ignore
 /package.json export-ignore
 /package-lock.json export-ignore
 /babel-config.js export-ignore

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -53,7 +53,7 @@ echo "Before proceeding:"
 echo " • Ensure you have checked out the branch you wish to release"
 echo " • Ensure you have committed/pushed all local changes"
 echo " • Did you remember to update versions, changelogs, and stable tags in the readme and plugin files?"
-echo " • If you are running this script directory instead of via '$ npm run deploy', ensure you have built assets and installed composer in --no-dev mode."
+echo " • If you are running this script directly instead of via '$ npm run deploy', ensure you have built assets and installed composer in --no-dev mode."
 echo
 output 3 "Do you want to continue? [y/N]: "
 read -r PROCEED


### PR DESCRIPTION
### How to test the changes in this Pull Request:

1. Run `npm run deploy`.
2. Verify the zip uploaded to GitHub doesn't contain the bundlesize neither composer files.
3. Delete the release and tag from GitHub.

<!-- If you can, add the appropriate labels -->

### Changelog

> Prevent some config files from being included in GitHub release ZIP