### PR TITLE
RTL fixes

### DIFF
--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -36,6 +36,9 @@
 	svg {
 		fill: currentColor;
 		outline: none;
+		.rtl & {
+			transform: rotate(180deg);
+		}
 	}
 	&:active {
 		color: currentColor;

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -24,6 +24,9 @@
 		svg {
 			fill: currentColor;
 			outline: none;
+			.rtl & {
+				transform: rotate(180deg);
+			}
 		}
 		&:active {
 			color: currentColor;

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "stylelint-config-wordpress": "14.0.0",
     "webpack": "4.39.3",
     "webpack-cli": "3.3.7",
+    "webpack-rtl-plugin": "2.0.0",
     "yargs": "14.0.0"
   },
   "engines": {

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -32,7 +32,9 @@ class Assets {
 	 */
 	public static function register_assets() {
 		self::register_style( 'wc-block-editor', plugins_url( 'build/editor.css', __DIR__ ), array( 'wp-edit-blocks' ) );
+		wp_style_add_data( 'wc-block-editor', 'rtl', 'replace' );
 		self::register_style( 'wc-block-style', plugins_url( 'build/style.css', __DIR__ ), [] );
+		wp_style_add_data( 'wc-block-style', 'rtl', 'replace' );
 
 		// Shared libraries and components across all blocks.
 		self::register_script( 'wc-shared-settings', plugins_url( 'build/wc-shared-settings.js', __DIR__ ), [], false );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -199,6 +199,9 @@ const GutenbergBlocksConfig = {
 	plugins: [
 		new WebpackRTLPlugin( {
 			filename: '[name]-rtl.css',
+			minify: {
+				safe: true,
+			},
 		} ),
 		new MiniCssExtractPlugin( {
 			filename: '[name].css',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const ProgressBarPlugin = require( 'progress-bar-webpack-plugin' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const chalk = require( 'chalk' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
+const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 
 function findModuleMatch( module, match ) {
 	if ( module.request && match.test( module.request ) ) {
@@ -196,6 +197,9 @@ const GutenbergBlocksConfig = {
 		],
 	},
 	plugins: [
+		new WebpackRTLPlugin( {
+			filename: '[name]-rtl.css',
+		} ),
 		new MiniCssExtractPlugin( {
 			filename: '[name].css',
 		} ),


### PR DESCRIPTION
Install `webpack-rtl-plugin` to automatically generate RTL stylesheets. This is the same package we are using in WooCommerce Admin and the same one Gutenberg was using in the past.

In addition to that, this PR adds a couple of fixes to _Product Search_ and _Product Categories List_ arrow buttons, so they are rotated.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/64181248-651e9580-ce66-11e9-9ab2-644c3f81980e.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/64181139-428c7c80-ce66-11e9-9585-4e6694832b90.png)

### How to test the changes in this Pull Request:

1. Create a post with a _Product Search_, a _Product Categories List_ and a _Reviews by Product_ blocks.
2. Set your language to a RTL locale (Arabic, for example).
3. Verify those three blocks render correctly.

<!-- If you can, add the appropriate labels -->

### Changelog

> RTL fixes to several blocks.