### PR TITLE
Add version string replacement script for deploy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,9 @@ These instructions cover new releases of the blocks plugin for those with commit
 
 **Before any release** ensure you update:
 
-- The `readme.txt` file supported versions, version number, changelog and list of blocks if the release includes new blocks.
-- The version number in `woocommerce-gutenberg-products-block.php`
-- The version number in `package.json`
-- The version number in `src/Package.php`
+- The `readme.txt` file supported versions, changelog and list of blocks if the release includes new blocks.
+
+> Note: version numbers will automatically be updated in files via the deploy script (see `bin/version-changes.sh`).
 
 ### Tagging new releases on GitHub
 

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -79,7 +79,7 @@ fi
 
 # Version changes
 output 2 "Updating version numbers in files..."
-source version-changes.sh
+source $RELEASER_PATH/bin/version-changes.sh
 
 output 2 "Committing version change..."
 echo

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -69,9 +69,17 @@ output 3 "Please enter the version number to tag, for example, 1.0.0:"
 read -r VERSION
 echo
 
+CURRENTBRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
 # Version changes
 output 2 "Updating version numbers in files..."
 source version-changes.sh
+
+output 2 "Committing version change..."
+echo
+
+git commit -am "Bumping version strings to new version." --no-verify
+git push origin $CURRENTBRANCH
 
 # Check if is a pre-release.
 if is_substring "-" "${VERSION}"; then
@@ -95,8 +103,6 @@ fi
 
 output 2 "Starting release to GitHub..."
 echo
-
-CURRENTBRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
 # Create a release branch.
 BRANCH="build/${VERSION}"

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -52,7 +52,8 @@ echo
 echo "Before proceeding:"
 echo " • Ensure you have checked out the branch you wish to release"
 echo " • Ensure you have committed/pushed all local changes"
-echo " • Did you remember to update versions, changelogs, and stable tags in the readme and plugin files?"
+echo " • Did you remember to update changelogs, the readme and plugin files?"
+echo " • Are there any changes needed to the readme file?"
 echo " • If you are running this script directly instead of via '$ npm run deploy', ensure you have built assets and installed composer in --no-dev mode."
 echo
 output 3 "Do you want to continue? [y/N]: "
@@ -67,6 +68,10 @@ echo
 output 3 "Please enter the version number to tag, for example, 1.0.0:"
 read -r VERSION
 echo
+
+# Version changes
+output 2 "Updating version numbers in files..."
+source version-changes.sh
 
 # Check if is a pre-release.
 if is_substring "-" "${VERSION}"; then

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -71,6 +71,12 @@ echo
 
 CURRENTBRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
+# Check if is a pre-release.
+if is_substring "-" "${VERSION}"; then
+    IS_PRE_RELEASE=true
+	output 2 "Detected pre-release version!"
+fi
+
 # Version changes
 output 2 "Updating version numbers in files..."
 source version-changes.sh
@@ -80,12 +86,6 @@ echo
 
 git commit -am "Bumping version strings to new version." --no-verify
 git push origin $CURRENTBRANCH
-
-# Check if is a pre-release.
-if is_substring "-" "${VERSION}"; then
-    IS_PRE_RELEASE=true
-	output 2 "Detected pre-release version!"
-fi
 
 if [ ! -d "build" ]; then
 	output 3 "Build directory not found. Aborting."

--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
+VERSION=${VERSION:=\$VID\:\$}
+IS_PRE_RELEASE=${IS_PRE_RELEASE:=false}
 
-# replace all instances of $VID:$ with the release version.
-find ./src -name "*.php" -print0 | xargs -0 sed -i '' 's/\$VID:\$/'${VERSION}'/g'
+# replace all instances of $VID:$ with the release version but only when not pre-release.
+if [ $IS_PRE_RELEASE = false ]; then
+	find ./src -name "*.php" -print0 | xargs -0 sed -i '' 's/\$VID:\$/'${VERSION}'/g'
+fi
 
 # Update version number in readme.txt
 sed -i '' -E 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt

--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -1,20 +1,40 @@
 #!/bin/sh
 VERSION=${VERSION:=\$VID\:\$}
 IS_PRE_RELEASE=${IS_PRE_RELEASE:=false}
+OS=`uname`
 
-# replace all instances of $VID:$ with the release version but only when not pre-release.
-if [ $IS_PRE_RELEASE = false ]; then
-	find ./src -name "*.php" -print0 | xargs -0 sed -i '' 's/\$VID:\$/'${VERSION}'/g'
+if [ $OS = "Darwin" ]; then
+	# replace all instances of $VID:$ with the release version but only when not pre-release.
+	if [ $IS_PRE_RELEASE = false ]; then
+		find ./src -name "*.php" -print0 | xargs -0 sed -i '' 's/\$VID:\$/'${VERSION}'/g'
+	fi
+
+	# Update version number in readme.txt
+	sed -i '' -E 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
+
+	# Update version in main plugin file
+	sed -i '' -E 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
+
+	# Update version in package.json
+	sed -i '' -E 's/"version":*.+/"version": "'${VERSION}'",/' package.json
+
+	# Update version in main file
+	sed -i '' -E "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php
+else
+	# replace all instances of $VID:$ with the release version but only when not pre-release.
+	if [ $IS_PRE_RELEASE = false ]; then
+		find ./src -name "*.php" -print0 | xargs -0 sed -i 's/\$VID:\$/'${VERSION}'/g'
+	fi
+
+	# Update version number in readme.txt
+	sed -i -E 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
+
+	# Update version in main plugin file
+	sed -i -E 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
+
+	# Update version in package.json
+	sed -i -E 's/"version":*.+/"version": "'${VERSION}'",/' package.json
+
+	# Update version in main file
+	sed -i -E "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php
 fi
-
-# Update version number in readme.txt
-sed -i '' -E 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
-
-# Update version in main plugin file
-sed -i '' -E 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
-
-# Update version in package.json
-sed -i '' -E 's/"version":*.+/"version": "'${VERSION}'",/' package.json
-
-# Update version in main file
-sed -i '' -E "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php

--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -1,40 +1,20 @@
 #!/bin/sh
 VERSION=${VERSION:=\$VID\:\$}
 IS_PRE_RELEASE=${IS_PRE_RELEASE:=false}
-OS=`uname`
 
-if [ $OS = "Darwin" ]; then
-	# replace all instances of $VID:$ with the release version but only when not pre-release.
-	if [ $IS_PRE_RELEASE = false ]; then
-		find ./src -name "*.php" -print0 | xargs -0 sed -i '' 's/\$VID:\$/'${VERSION}'/g'
-	fi
-
-	# Update version number in readme.txt
-	sed -i '' -E 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
-
-	# Update version in main plugin file
-	sed -i '' -E 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
-
-	# Update version in package.json
-	sed -i '' -E 's/"version":*.+/"version": "'${VERSION}'",/' package.json
-
-	# Update version in main file
-	sed -i '' -E "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php
-else
-	# replace all instances of $VID:$ with the release version but only when not pre-release.
-	if [ $IS_PRE_RELEASE = false ]; then
-		find ./src -name "*.php" -print0 | xargs -0 sed -i 's/\$VID:\$/'${VERSION}'/g'
-	fi
-
-	# Update version number in readme.txt
-	sed -i -E 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
-
-	# Update version in main plugin file
-	sed -i -E 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
-
-	# Update version in package.json
-	sed -i -E 's/"version":*.+/"version": "'${VERSION}'",/' package.json
-
-	# Update version in main file
-	sed -i -E "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php
+# replace all instances of $VID:$ with the release version but only when not pre-release.
+if [ $IS_PRE_RELEASE = false ]; then
+	find ./src -name "*.php" -print0 | xargs -0 perl -i -pe 's/\$VID:\$/'${VERSION}'/g'
 fi
+
+# Update version number in readme.txt
+perl -i -pe 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
+
+# Update version in main plugin file
+perl -i -pe 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
+
+# Update version in package.json
+perl -i -pe 's/"version":*.+/"version": "'${VERSION}'",/' package.json
+
+# Update version in main file
+perl -i -pe "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php

--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# replace all instances of $VID:$ with the release version.
+find ./src -name "*.php" -print0 | xargs -0 sed -i '' 's/\$VID:\$/'${VERSION}'/g'
+
+# Update version number in readme.txt
+sed -i '' -E 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
+
+# Update version in main plugin file
+sed -i '' -E 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
+
+# Update version in package.json
+sed -i '' -E 's/"version":*.+/"version": "'${VERSION}'",/' package.json
+
+# Update version in main file
+sed -i '' -E "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php


### PR DESCRIPTION
Closes: #901 

This pull adds a couple features for our deploy process:

- Removes the need to manually change the version string in `readme.txt`, `package.json`, `woocommerce-gutenberg-products-block.php` and `src/Package.php`.  It will automatically update the version strings using whatever is provided via the `github-deploy.sh` script process.
- Will replace any instances of `$VID:$` in any `*.php` files within the `src` directory.  This comes in really handy when adding `@since $VID:$` comment blocks in the code.  However, also handy any place else you want to have updated with the correct version for a release.  **Note:** $VID:$ will not be updated on a pre-release.

## Rationale

- Automating as much as possible helps eliminate human error and bloopers.  There's a number of files that need updated with version changes, this removes the need to remember to do that.
- I'm doing some refactoring of php files which will result in a number of `@since` updates, so this makes it easier to ensure the correct version is updated for those whenever that work is released.
- Related to the above, no more having to think about what version to use for `@since` :)

## To test

You can test the version script in isolation by doing the following:

- in some php file add a `$VID:$` string anywhere.  Then in the root folder of the plugin in a bash shell, execute this:

```bash
VERSION=5.6 ./bin/version-changes.sh
```

The above should change:

- wherever there is `$VID:$` to `5.6`
- update `package.json` to have the given value for it's version item (in this case `5.6`)
- update `readme.txt` to have the given value for it's `Stable Tag:` value
- update `woocommerce-gutenberg-blocks.php` file to have the given value for the version.
- update `src/Package.php` version constant to be the given value.

Nothing else should be changed.  You can discard the changes once you've verified it work.

We'll also verify this on the next run of github deploy (I'm going to test this in a fork before I merge).

**Update:** I tested running `github-deploy.sh` on a fork and other than having to fix the path to the `version-script.sh`, it worked.  So after review this is ready to go,.