### PR TITLE
Fix increment bug in withComponentId

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 useTabs: true
-tabWidth: 2
+tabWidth: 4
 printWidth: 80
 singleQuote: true
 trailingComma: es5

--- a/assets/js/base/hocs/test/with-component-id.js
+++ b/assets/js/base/hocs/test/with-component-id.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+import withComponentId from '../with-component-id';
+
+const TestComponent = withComponentId( ( props ) => {
+	return <div componentId={ props.componentId } />;
+} );
+
+const render = () => {
+	return TestRenderer.create( <TestComponent /> );
+};
+
+describe( 'withComponentId Component', () => {
+	let renderer;
+	it( 'initializes with expected id on initial render', () => {
+		renderer = render();
+		const props = renderer.root.findByType( 'div' ).props;
+		expect( props.componentId ).toBe( 0 );
+	} );
+	it( 'does not increment on re-render', () => {
+		renderer.update( <TestComponent someValue={ 3 } /> );
+		const props = renderer.root.findByType( 'div' ).props;
+		expect( props.componentId ).toBe( 0 );
+	} );
+	it( 'increments on a new component instance', () => {
+		renderer.update( <TestComponent key={ 42 } /> );
+		const props = renderer.root.findByType( 'div' ).props;
+		expect( props.componentId ).toBe( 1 );
+	} );
+} );

--- a/assets/js/base/hocs/with-component-id.js
+++ b/assets/js/base/hocs/with-component-id.js
@@ -14,7 +14,10 @@ const withComponentId = ( OriginalComponent ) => {
 
 		render() {
 			return (
-				<OriginalComponent { ...this.props } componentId={ this.instanceId } />
+				<OriginalComponent
+					{ ...this.props }
+					componentId={ this.instanceId }
+				/>
 			);
 		}
 	}

--- a/assets/js/base/hocs/with-component-id.js
+++ b/assets/js/base/hocs/with-component-id.js
@@ -1,34 +1,24 @@
 import { Component } from 'react';
 
-const ids = [];
-
 /**
  * HOC that gives a component a unique ID.
  *
  * This is an alternative for withInstanceId from @wordpress/compose to avoid using that dependency on the frontend.
  */
 const withComponentId = ( OriginalComponent ) => {
-	return class WrappedComponent extends Component {
-		generateUniqueID() {
-			const group = WrappedComponent.name;
+	let instances = 0;
 
-			if ( ! ids[ group ] ) {
-				ids[ group ] = 0;
-			}
-
-			ids[ group ]++;
-
-			return ids[ group ];
-		}
+	class WrappedComponent extends Component {
+		instanceId = instances++;
 
 		render() {
-			const componentId = this.generateUniqueID();
-
 			return (
-				<OriginalComponent { ...this.props } componentId={ componentId } />
+				<OriginalComponent { ...this.props } componentId={ this.instanceId } />
 			);
 		}
-	};
+	}
+	WrappedComponent.displayName = 'withComponentId';
+	return WrappedComponent;
 };
 
 export default withComponentId;

--- a/assets/js/base/hocs/with-component-id.js
+++ b/assets/js/base/hocs/with-component-id.js
@@ -3,7 +3,8 @@ import { Component } from 'react';
 /**
  * HOC that gives a component a unique ID.
  *
- * This is an alternative for withInstanceId from @wordpress/compose to avoid using that dependency on the frontend.
+ * This is an alternative for withInstanceId from @wordpress/compose to avoid
+ * using that dependency on the frontend.
  */
 const withComponentId = ( OriginalComponent ) => {
 	let instances = 0;


### PR DESCRIPTION
This fixes a bug in the `withComponentId` component discovered by @mikejolley while him and I were troubleshooting some things in the new `AllProducts` block he is working on.  The bug was that `withComponentId` was incrementing the `componentId` prop on every render.  It should _only_ be incrementing on new instances.

In this pull:

- added test demonstrating bug (and verifying fix)
- fixed incrementation bug
- implemented `Component.displayName` so the name of the hoc shows up with debug tools.

## Testing

- This is covered by the new unit tests.
- smoke test blocks using `withComponentId` wrapping components to ensure there's no funkiness.