### PR TITLE
Fix review block icons not having foreground color

### DIFF
--- a/assets/js/blocks/reviews/reviews-by-category/index.js
+++ b/assets/js/blocks/reviews/reviews-by-category/index.js
@@ -18,7 +18,10 @@ import save from '../save.js';
  */
 registerBlockType( 'woocommerce/reviews-by-category', {
 	title: __( 'Reviews by Category', 'woo-gutenberg-products-block' ),
-	icon: <IconReviewsByCategory />,
+	icon: {
+		src: <IconReviewsByCategory />,
+		foreground: '#96588a',
+	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(

--- a/assets/js/blocks/reviews/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews/reviews-by-product/index.js
@@ -18,7 +18,10 @@ import save from '../save.js';
  */
 registerBlockType( 'woocommerce/reviews-by-product', {
 	title: __( 'Reviews by Product', 'woo-gutenberg-products-block' ),
-	icon: <IconReviewsByProduct />,
+	icon: {
+		src: <IconReviewsByProduct />,
+		foreground: '#96588a',
+	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(


### PR DESCRIPTION
With the changes made in #949, we introduced an issue that made the _Reviews by Product_ and _Reviews by Category_ to appear gray in the inserter.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/64489794-6cbfaf00-d257-11e9-97b6-40cb10bed0c9.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/64489783-46017880-d257-11e9-8d88-3fe40b791e2d.png)

### How to test the changes in this Pull Request:

1. In a post, open the inserter and search for `reviews`.
2. Verify all icons are purple.