### PR TITLE
Make it possible to select variations in Featured Product block again

### DIFF
--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -272,7 +272,7 @@ class ProductControl extends Component {
 					isSingle
 					selected={ selectedListItems }
 					onChange={ onChange }
-					renderItem={ renderItem }
+					renderItem={ renderItem || this.renderItem }
 					onSearch={ IS_LARGE_CATALOG ? this.debouncedOnSearch : null }
 					messages={ messages }
 					isHierarchical


### PR DESCRIPTION
Fixes #963.

When we introduced the _Reviews by Product_ block, we made it so it overwrote the `renderItem` method of ProductControl, that broke the possibility to select variations in the _Featured Product_ block. This PR makes it so if no `renderItem` is passed through the props to ProductControls, it uses the default.

This code will probably be refactored soon when we implement the `withProduct()` HOC, so this PR is more like a quick-fix than a perfect solution.

### Screenshots

<img src="https://user-images.githubusercontent.com/3616980/64898363-2dde8e80-d687-11e9-8eee-feee2d34a81c.png" alt="Screenshot" width="494" />

### How to test the changes in this Pull Request:

1. Create a post or page and add a _Featured Product_ block.
2. Select a variable product.
3. Verify it expands and you can select its variations.

### Changelog

> Fix regression that prevented selecting product variations in the Featured Product block.