### PR TITLE
Fix product grids overflowing in some themes

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -7,6 +7,7 @@
 }
 
 .wc-block-grid__product {
+	box-sizing: border-box;
 	padding: 0 $gap 0 0;
 	margin: 0 0 $gap-large 0;
 	float: none;


### PR DESCRIPTION
Fixes #965.

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. If you are using storefront, open `/wp-content/themes/storefront/style.css` and add this line at the end of the file:
```CSS
* { box-sizing: content-box; }
```
2. Create a post with a _Top Rated Products_ and preview it.
3. Verify the grid doesn't overflow.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix product grids overflowing in some themes