### PR TITLE
Fix travis config causing failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ before_script:
     fi
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
-      composer install
+      composer install --no-dev
       # also installs woocommerce plugin
       bash tests/bin/install-wp-tests.sh wgpb_admin root '' localhost $WP_VERSION
       composer global require "phpunit/phpunit=4.8.*|5.7.*"
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
-      composer install --no-dev
+      composer install
     fi
 jobs:
     fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,14 +25,14 @@ before_script:
     fi
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
-      composer install --no-dev
+      composer install
       # also installs woocommerce plugin
       bash tests/bin/install-wp-tests.sh wgpb_admin root '' localhost $WP_VERSION
       composer global require "phpunit/phpunit=4.8.*|5.7.*"
     fi
   - |
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
-      composer install
+      composer install --no-dev
     fi
 jobs:
     fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,15 @@
 	"license": "GPL-3.0-or-later",
 	"prefer-stable": true,
 	"minimum-stability": "dev",
+	"repositories": [
+	  {
+	    "type": "vcs",
+	    "url": "https://github.com/nerrad/jetpack-autoloader"
+	  }
+	],
 	"require": {
 		"composer/installers": "1.7.0",
-		"automattic/jetpack-autoloader": "1.3.1"
+		"automattic/jetpack-autoloader": "dev-test-autoloader_files-fix"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "6.5.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d8f1e958e216000e60535652daa35b4",
+    "content-hash": "bd25bac8c86f4ec55583ce019ab22912",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.3.1",
+            "version": "dev-test-autoloader_files-fix",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "531dc0541d873b1d54e9facb2732a09019184095"
+                "url": "https://github.com/nerrad/jetpack-autoloader.git",
+                "reference": "5310f86715242c4384cacee2969cd4428c00d524"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/531dc0541d873b1d54e9facb2732a09019184095",
-                "reference": "531dc0541d873b1d54e9facb2732a09019184095",
+                "url": "https://api.github.com/repos/nerrad/jetpack-autoloader/zipball/5310f86715242c4384cacee2969cd4428c00d524",
+                "reference": "5310f86715242c4384cacee2969cd4428c00d524",
                 "shasum": ""
             },
             "require": {
@@ -35,12 +35,20 @@
                     "Automattic\\Jetpack\\Autoloader\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "phpunit": [
+                    "@composer install",
+                    "./vendor/phpunit/phpunit/phpunit --colors=always"
+                ]
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2019-09-16T22:34:52+00:00"
+            "support": {
+                "source": "https://github.com/nerrad/jetpack-autoloader/tree/test-autoloader_files-fix"
+            },
+            "time": "2019-09-20T19:22:25+00:00"
         },
         {
             "name": "composer/installers",
@@ -600,35 +608,33 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -650,30 +656,30 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2018-08-07T13:53:10+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.3.1",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
-                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
+                "reference": "b83ff7cfcfee7827e1e78b637a5904fe6a96698e",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
+                "phpdocumentor/reflection-common": "^1.0.0 || ^2.0.0",
+                "phpdocumentor/type-resolver": "~0.4 || ^1.0.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "doctrine/instantiator": "~1.0.5",
+                "doctrine/instantiator": "^1.0.5",
                 "mockery/mockery": "^1.0",
                 "phpunit/phpunit": "^6.4"
             },
@@ -701,41 +707,40 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2019-04-30T17:48:53+00:00"
+            "time": "2019-09-12T14:27:41+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
+                "reference": "2e32a6d48972b2c1976ed5d8967145b6cec4a4a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
+                "php": "^7.1",
+                "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "ext-tokenizer": "^7.1",
+                "mockery/mockery": "~1",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -748,7 +753,8 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2019-08-22T18:11:29+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1419,16 +1425,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687"
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/06a9a5947f47b3029d76118eb5c22802e5869687",
-                "reference": "06a9a5947f47b3029d76118eb5c22802e5869687",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
                 "shasum": ""
             },
             "require": {
@@ -1482,7 +1488,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-08-11T12:43:14+00:00"
+            "time": "2019-09-14T09:02:43+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -2052,7 +2058,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "automattic/jetpack-autoloader": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -164,7 +164,6 @@ install_deps() {
 	git clone --depth 1 "https://github.com/woocommerce/woocommerce.git"
 	# install dependencies
 	cd woocommerce
-	npm install
 	composer install --no-dev
 
 	# Back to original dir


### PR DESCRIPTION
PHP tests on travis started failing all of a sudden for different branches/pulls.

The error is:

> HP Warning:  require(/home/travis/build/woocommerce/woocommerce-gutenberg-products-block/vendor/composer/autoload_files.php): failed to open stream: No such file or directory in /home/travis/build/woocommerce/woocommerce-gutenberg-products-block/vendor/autoload_packages.php on line 131
> Warning: require(/home/travis/build/woocommerce/woocommerce-gutenberg-products-block/vendor/composer/autoload_files.php): failed to open stream: No such file or directory in /home/travis/build/woocommerce/woocommerce-gutenberg-products-block/vendor/autoload_packages.php on line 131
> PHP Fatal error:  require(): Failed opening required '/home/travis/build/woocommerce/woocommerce-gutenberg-products-block/vendor/composer/autoload_files.php' (include_path='.:/home/travis/.phpenv/versions/7.1.11/share/pear') in /home/travis/build/woocommerce/woocommerce-gutenberg-products-block/vendor/autoload_packages.php on line 131

I'm not exactly sure what the cause is, however locally when I run `composer install` the expected files are generated just fine.  On a hunch and based on the install logs in travis, it looks like it may be because for the failing builds, `composer install --no-dev` is being run and this is preventing the necessary file from being generated.

So this pull is to test that hunch.