### PR TITLE
Fix webpack requestToExternal

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,7 +46,7 @@ const alias = {
 
 const requestToExternal = ( request ) => {
 	const wcDepMap = {
-		'@woocommerce/settings': { this: [ 'wc', 'wcSettings' ] },
+		'@woocommerce/settings': [ 'wc', 'wcSettings' ],
 	};
 	if ( wcDepMap[ request ] ) {
 		return wcDepMap[ request ];


### PR DESCRIPTION
It looks like a change introduced in #956 made WooCommerce Blocks not to load.

### How to test the changes in this Pull Request:

1. Create a post or page and verify you can add WooCommerce blocks.