### PR TITLE
Delete interpolate-components dependency and update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
 			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.0.0"
@@ -42,141 +42,18 @@
 				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-					"integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.6.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-					"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-					"integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
-				"json5": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.5.tgz",
-			"integrity": "sha512-IO31r62xfMI+wBJVmgx0JR9ZOHty8HkoYpQAjRWUGG9vykBTlGHdArZ8zoFtpUu2gs17K7qTl/TtPpiSi6t+MA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.2.tgz",
+			"integrity": "sha512-j8iHaIW4gGPnViaIHI7e9t/Hl8qLjERI6DcV9kEpAIDJsAOrcnXqRS7t+QbhL76pwbtqP+QCQLL0z1CyVmtjjQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.1.5",
+				"@babel/types": "^7.6.0",
 				"jsesc": "^2.5.1",
-				"lodash": "^4.17.10",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				}
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -206,25 +83,6 @@
 			"requires": {
 				"@babel/types": "^7.3.0",
 				"esutils": "^2.0.0"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-call-delegate": {
@@ -236,100 +94,12 @@
 				"@babel/helper-hoist-variables": "^7.4.4",
 				"@babel/traverse": "^7.4.4",
 				"@babel/types": "^7.4.4"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-					"integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.6.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				},
-				"@babel/traverse": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-					"integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
-			"integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.6.0.tgz",
+			"integrity": "sha512-O1QWBko4fzGju6VoVvrZg0RROCVifcLxiApnGP3OWfWzvxRZFCoBD81K5ur5e3bVY2Vf/5rIJm8cqPKn8HUJng==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
@@ -338,34 +108,6 @@
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-replace-supers": "^7.5.5",
 				"@babel/helper-split-export-declaration": "^7.4.4"
-			},
-			"dependencies": {
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/types": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-define-map": {
@@ -377,25 +119,6 @@
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/types": "^7.5.5",
 				"lodash": "^4.17.13"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -435,25 +158,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.4.4"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -463,25 +167,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.5.5"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -505,51 +190,6 @@
 				"@babel/template": "^7.4.4",
 				"@babel/types": "^7.5.5",
 				"lodash": "^4.17.13"
-			},
-			"dependencies": {
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-					"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0"
-					}
-				},
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -574,14 +214,6 @@
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.13"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -607,94 +239,6 @@
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/traverse": "^7.5.5",
 				"@babel/types": "^7.5.5"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-					"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "^7.0.0"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.5.5",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-					"dev": true
-				},
-				"@babel/traverse": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.5.5",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.5",
-						"@babel/types": "^7.5.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"@babel/types": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -708,12 +252,12 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"version": "7.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.4"
 			}
 		},
 		"@babel/helper-wrap-function": {
@@ -726,162 +270,34 @@
 				"@babel/template": "^7.1.0",
 				"@babel/traverse": "^7.1.0",
 				"@babel/types": "^7.2.0"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
-			"integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.2.tgz",
+			"integrity": "sha512-3/bAUL8zZxYs1cdX2ilEE0WobqbCmKWr/889lf2SS0PpDcpEIY8pb1CCyz0pEcX3pEb+MCbks1jIokz2xLtGTA==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.6.0",
-				"@babel/traverse": "^7.6.0",
+				"@babel/traverse": "^7.6.2",
 				"@babel/types": "^7.6.0"
-			},
-			"dependencies": {
-				"@babel/generator": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-					"integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.6.0",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-					"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-					"integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.0",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.6.0",
-						"@babel/types": "^7.6.0",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					},
-					"dependencies": {
-						"@babel/code-frame": {
-							"version": "7.5.5",
-							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-							"dev": true,
-							"requires": {
-								"@babel/highlight": "^7.0.0"
-							}
-						}
-					}
-				},
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
-			},
-			"dependencies": {
-				"js-tokens": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/parser": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.5.tgz",
-			"integrity": "sha512-WXKf5K5HT6X0kKiCOezJZFljsfxKV1FpU8Tf1A7ZpGvyd/Q4hlrJm2EwoH2onaUq3O4tLDp+4gk0hHPsMyxmOg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.2.tgz",
+			"integrity": "sha512-mdFqWrSPCmikBoaBYMuBulzTIKuXVPtEISFbRRVNwMWpCms/hmE2kRq0bblUHaNRKrjRlmVbx1sDHmjmRgD2Xg==",
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
@@ -926,9 +342,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-			"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
+			"integrity": "sha512-LDBXlmADCsMZV1Y9OQwMc0MyGZ8Ta/zlD9N67BfQT8uYwkRswiu2hU6nJKrjrt/58aH/vqfQlR/9yId/7A2gWw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -946,14 +362,14 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
-			"integrity": "sha512-j1NwnOqMG9mFUOH58JTFsA/+ZYzQLUZ/drqWUqxCYLGeu2JFZL8YrNC9hBxKmWtAuOCHPcRpgv7fhap09Fb4kA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.6.2.tgz",
+			"integrity": "sha512-NxHETdmpeSCtiatMRYWVJo7266rrvAC3DTeG5exQBIH/fMIUK7ejDNznBbn3HQl/o9peymRRg7Yqkx6PdUXmMw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -1040,21 +456,13 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.0.tgz",
-			"integrity": "sha512-tIt4E23+kw6TgL/edACZwP1OUKrjOTyMrFMLoT5IOFrfMRabCgekjqFd5o6PaAMildBu46oFkekIdMuGkkPEpA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.6.2.tgz",
+			"integrity": "sha512-zZT8ivau9LOQQaOGC7bQLQOT4XPkPXgN2ERfUgk1X8ql+mVkLc4E8eKk+FO3o0154kxzqenWCorfmEXpEZcrSQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"lodash": "^4.17.13"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-transform-classes": {
@@ -1071,34 +479,6 @@
 				"@babel/helper-replace-supers": "^7.5.5",
 				"@babel/helper-split-export-declaration": "^7.4.4",
 				"globals": "^11.1.0"
-			},
-			"dependencies": {
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/plugin-transform-computed-properties": {
@@ -1120,14 +500,14 @@
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.4.tgz",
-			"integrity": "sha512-P05YEhRc2h53lZDjRPk/OektxCVevFzZs2Gfjd545Wde3k+yFDbXORgl2e0xpbq8mLcKJ7Idss4fAg0zORN/zg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.6.2.tgz",
+			"integrity": "sha512-KGKT9aqKV+9YMZSkowzYoYEiHqgaDhGmPNZlZxX6UeHC4z30nC1J9IrZuGqbYFB1jaIGdv91ujpze0exiVK8bA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -1231,12 +611,12 @@
 			}
 		},
 		"@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.0.tgz",
-			"integrity": "sha512-jem7uytlmrRl3iCAuQyw8BpB4c4LWvSpvIeXKpMb+7j84lkx4m4mYr5ErAcmN5KM7B6BqrAvRGjBIbbzqCczew==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.6.2.tgz",
+			"integrity": "sha512-xBdB+XOs+lgbZc2/4F5BVDVcDNS4tcSKQc96KmlqLEAwz6tpYPEvPdmDfvVG0Ssn8lAhronaRs6Z6KSexIpK5g==",
 			"dev": true,
 			"requires": {
-				"regexp-tree": "^0.1.13"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/plugin-transform-new-target": {
@@ -1308,9 +688,9 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
-			"integrity": "sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+			"integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -1329,9 +709,9 @@
 			}
 		},
 		"@babel/plugin-transform-spread": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz",
-			"integrity": "sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.6.2.tgz",
+			"integrity": "sha512-DpSvPFryKdK1x+EDJYCy28nmAaIMdxmhot62jAXF/o99iA33Zj2Lmcp3vDmz+MUh0LNYVPvfj5iC3feb3/+PFg==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -1367,20 +747,20 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.4.tgz",
-			"integrity": "sha512-il+/XdNw01i93+M9J9u4T7/e/Ue/vWfNZE4IRUQjplu2Mqb/AFTDimkw2tdEdSH50wuQXZAbXSql0UphQke+vA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.6.2.tgz",
+			"integrity": "sha512-orZI6cWlR3nk2YmYdb0gImrgCUwb5cBUwjf6Ks6dvNVvXERkwtJWOQaEOjPiu0Gu1Tq6Yq/hruCZZOOi9F34Dw==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.4.4",
-				"regexpu-core": "^4.5.4"
+				"regexpu-core": "^4.6.0"
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
-			"integrity": "sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.2.tgz",
+			"integrity": "sha512-Ru7+mfzy9M1/YTEtlDS8CD45jd22ngb9tXnn64DvQK3ooyqSw9K4K9DUWmYknTTVk4TqygL9dqCrZgm1HMea/Q==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
@@ -1388,9 +768,9 @@
 				"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.5.0",
 				"@babel/plugin-proposal-json-strings": "^7.2.0",
-				"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+				"@babel/plugin-proposal-object-rest-spread": "^7.6.2",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.6.2",
 				"@babel/plugin-syntax-async-generators": "^7.2.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.2.0",
 				"@babel/plugin-syntax-json-strings": "^7.2.0",
@@ -1399,11 +779,11 @@
 				"@babel/plugin-transform-arrow-functions": "^7.2.0",
 				"@babel/plugin-transform-async-to-generator": "^7.5.0",
 				"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-				"@babel/plugin-transform-block-scoping": "^7.6.0",
+				"@babel/plugin-transform-block-scoping": "^7.6.2",
 				"@babel/plugin-transform-classes": "^7.5.5",
 				"@babel/plugin-transform-computed-properties": "^7.2.0",
 				"@babel/plugin-transform-destructuring": "^7.6.0",
-				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.6.2",
 				"@babel/plugin-transform-duplicate-keys": "^7.5.0",
 				"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
 				"@babel/plugin-transform-for-of": "^7.4.4",
@@ -1414,7 +794,7 @@
 				"@babel/plugin-transform-modules-commonjs": "^7.6.0",
 				"@babel/plugin-transform-modules-systemjs": "^7.5.0",
 				"@babel/plugin-transform-modules-umd": "^7.2.0",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.2",
 				"@babel/plugin-transform-new-target": "^7.4.4",
 				"@babel/plugin-transform-object-super": "^7.5.5",
 				"@babel/plugin-transform-parameters": "^7.4.4",
@@ -1422,42 +802,23 @@
 				"@babel/plugin-transform-regenerator": "^7.4.5",
 				"@babel/plugin-transform-reserved-words": "^7.2.0",
 				"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-				"@babel/plugin-transform-spread": "^7.2.0",
+				"@babel/plugin-transform-spread": "^7.6.2",
 				"@babel/plugin-transform-sticky-regex": "^7.2.0",
 				"@babel/plugin-transform-template-literals": "^7.4.4",
 				"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-				"@babel/plugin-transform-unicode-regex": "^7.4.4",
+				"@babel/plugin-transform-unicode-regex": "^7.6.2",
 				"@babel/types": "^7.6.0",
 				"browserslist": "^4.6.0",
 				"core-js-compat": "^3.1.1",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
 				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.6.1",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-					"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.2.tgz",
-			"integrity": "sha512-9M29wrrP7//JBGX70+IrDuD1w4iOYhUGpJNMQJVNAXue+cFeFlMTqBECouIziXPUphlgrfjcfiEpGX4t0WGK4g==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+			"integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -1466,7 +827,6 @@
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
 			"integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
-			"dev": true,
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
@@ -1475,64 +835,47 @@
 				"core-js": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
-					"dev": true
+					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
 				}
 			}
 		},
 		"@babel/template": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-			"integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.1.2",
-				"@babel/types": "^7.1.2"
+				"@babel/parser": "^7.6.0",
+				"@babel/types": "^7.6.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.5.tgz",
-			"integrity": "sha512-eU6XokWypl0MVJo+MTSPUtlfPePkrqsF26O+l1qFGlCKWwmiYAYy2Sy44Qw8m2u/LbPCsxYt90rghmqhYMGpPA==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
+			"integrity": "sha512-8fRE76xNwNttVEF2TwxJDGBLWthUkHWSldmfuBzVRmEDWOtu4XdINTgN7TDWzuLg4bbeIMLvfMFD9we5YcWkRQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.1.5",
+				"@babel/code-frame": "^7.5.5",
+				"@babel/generator": "^7.6.2",
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/parser": "^7.1.5",
-				"@babel/types": "^7.1.5",
-				"debug": "^3.1.0",
+				"@babel/helper-split-export-declaration": "^7.4.4",
+				"@babel/parser": "^7.6.2",
+				"@babel/types": "^7.6.0",
+				"debug": "^4.1.0",
 				"globals": "^11.1.0",
-				"lodash": "^4.17.10"
-			},
-			"dependencies": {
-				"globals": {
-					"version": "11.8.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-					"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
-					"dev": true
-				}
+				"lodash": "^4.17.13"
 			}
 		},
 		"@babel/types": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.5.tgz",
-			"integrity": "sha512-sJeqa/d9eM/bax8Ivg+fXF7FpN3E/ZmTrWbkk6r+g7biVYfALMnLin4dKijsaqEhpd2xvOGfQTkQkD31YCVV4A==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+			"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
-				"lodash": "^4.17.10",
+				"lodash": "^4.17.13",
 				"to-fast-properties": "^2.0.0"
-			},
-			"dependencies": {
-				"to-fast-properties": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-					"dev": true
-				}
 			}
 		},
 		"@cnakazawa/watch": {
@@ -1543,14 +886,6 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"@glimmer/interfaces": {
@@ -1598,50 +933,42 @@
 			}
 		},
 		"@hapi/address": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.0.0.tgz",
-			"integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.2.tgz",
+			"integrity": "sha512-O4QDrx+JoGKZc6aN64L04vqa7e41tIiLU+OvKdcYaEMP97UttL0f9GIi9/0A4WAMx0uBd6SidDIhktZhgOcN8Q==",
+			"dev": true
+		},
+		"@hapi/bourne": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
 			"dev": true
 		},
 		"@hapi/hoek": {
-			"version": "6.2.4",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-			"integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.4.tgz",
+			"integrity": "sha512-Ze5SDNt325yZvNO7s5C4fXDscjJ6dcqLFXJQ/M7dZRQCewuDj2iDUuBi6jLQt+APbW9RjjVEvLr35FXuOEqjow==",
 			"dev": true
 		},
 		"@hapi/joi": {
-			"version": "15.1.0",
-			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.0.tgz",
-			"integrity": "sha512-n6kaRQO8S+kepUTbXL9O/UOL788Odqs38/VOfoCrATDtTvyfiO3fgjlSRaNkHabpTLgM7qru9ifqXlXbXk8SeQ==",
+			"version": "15.1.1",
+			"resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+			"integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
 			"dev": true,
 			"requires": {
 				"@hapi/address": "2.x.x",
-				"@hapi/hoek": "6.x.x",
-				"@hapi/marker": "1.x.x",
+				"@hapi/bourne": "1.x.x",
+				"@hapi/hoek": "8.x.x",
 				"@hapi/topo": "3.x.x"
 			}
 		},
-		"@hapi/marker": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/marker/-/marker-1.0.0.tgz",
-			"integrity": "sha512-JOfdekTXnJexfE8PyhZFyHvHjt81rBFSAbTIRAhF2vv/2Y1JzoKsGqxH/GpZJoF7aEfYok8JVcAHmSz1gkBieA==",
-			"dev": true
-		},
 		"@hapi/topo": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.2.tgz",
-			"integrity": "sha512-r+aumOqJ5QbD6aLPJWqVjMAPsx5pZKz+F5yPqXZ/WWG9JTtHbQqlzrJoknJ0iJxLj9vlXtmpSdjlkszseeG8OA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.4.tgz",
+			"integrity": "sha512-aVWQTOI9wBD6zawmOr6f+tdEIxQC8JXfQVLTjgGe8YEStAWGn/GNNVTobKJhbWKveQj2RyYF3oYbO9SC8/eOCA==",
 			"dev": true,
 			"requires": {
 				"@hapi/hoek": "8.x.x"
-			},
-			"dependencies": {
-				"@hapi/hoek": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.1.0.tgz",
-					"integrity": "sha512-b1J4jxYnW+n6lC91V6Pqg9imP9BZq0HNCeM+3sbXg05rQsE9cGYrKFpZjyztVesGmNRE6R+QaEoWGATeIiUVjA==",
-					"dev": true
-				}
 			}
 		},
 		"@iarna/toml": {
@@ -1651,48 +978,49 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "24.7.1",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
-			"integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+			"integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
 			"dev": true,
 			"requires": {
-				"@jest/source-map": "^24.3.0",
+				"@jest/source-map": "^24.9.0",
 				"chalk": "^2.0.1",
 				"slash": "^2.0.0"
 			}
 		},
 		"@jest/core": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
-			"integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-24.9.0.tgz",
+			"integrity": "sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/reporters": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/reporters": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.15",
-				"jest-changed-files": "^24.8.0",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
+				"jest-changed-files": "^24.9.0",
+				"jest-config": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-message-util": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve-dependencies": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
-				"jest-watcher": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-resolve-dependencies": "^24.9.0",
+				"jest-runner": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
+				"jest-watcher": "^24.9.0",
 				"micromatch": "^3.1.10",
 				"p-each-series": "^1.0.0",
-				"pirates": "^4.0.1",
 				"realpath-native": "^1.1.0",
 				"rimraf": "^2.5.4",
+				"slash": "^2.0.0",
 				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
@@ -1723,38 +1051,38 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
-			"integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+			"integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
-			"integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+			"integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0"
+				"@jest/types": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-mock": "^24.9.0"
 			}
 		},
 		"@jest/reporters": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
-			"integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.9.0.tgz",
+			"integrity": "sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.2",
@@ -1762,13 +1090,13 @@
 				"istanbul-lib-instrument": "^3.0.1",
 				"istanbul-lib-report": "^2.0.4",
 				"istanbul-lib-source-maps": "^3.0.1",
-				"istanbul-reports": "^2.1.1",
-				"jest-haste-map": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"istanbul-reports": "^2.2.6",
+				"jest-haste-map": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jest-worker": "^24.6.0",
-				"node-notifier": "^5.2.1",
+				"node-notifier": "^5.4.2",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^2.0.0"
@@ -1783,9 +1111,9 @@
 			}
 		},
 		"@jest/source-map": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
-			"integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+			"integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0",
@@ -1802,45 +1130,46 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
-			"integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+			"integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/types": "^24.8.0",
+				"@jest/console": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/istanbul-lib-coverage": "^2.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
-			"integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.9.0.tgz",
+			"integrity": "sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-runner": "^24.8.0",
-				"jest-runtime": "^24.8.0"
+				"@jest/test-result": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-runner": "^24.9.0",
+				"jest-runtime": "^24.9.0"
 			}
 		},
 		"@jest/transform": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
-			"integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+			"integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"babel-plugin-istanbul": "^5.1.0",
 				"chalk": "^2.0.1",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.1.15",
-				"jest-haste-map": "^24.8.0",
-				"jest-regex-util": "^24.3.0",
-				"jest-util": "^24.8.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-regex-util": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"micromatch": "^3.1.10",
+				"pirates": "^4.0.1",
 				"realpath-native": "^1.1.0",
 				"slash": "^2.0.0",
 				"source-map": "^0.6.1",
@@ -1856,14 +1185,14 @@
 			}
 		},
 		"@jest/types": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
-			"integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^12.0.9"
+				"@types/yargs": "^13.0.0"
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -1877,19 +1206,19 @@
 			}
 		},
 		"@nodelib/fs.scandir": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.1.tgz",
-			"integrity": "sha512-NT/skIZjgotDSiXs0WqYhgcuBKhUMgfekCmCGtkUAiLqZdOnrdjmZr9wRl3ll64J9NF79uZ4fk16Dx0yMc/Xbg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
+			"integrity": "sha512-wrIBsjA5pl13f0RN4Zx4FNWmU71lv03meGKnqRUoCyan17s4V3WL92f3w3AIuWbNnpcrQyFBU5qMavJoB8d27w==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.stat": "2.0.1",
+				"@nodelib/fs.stat": "2.0.2",
 				"run-parallel": "^1.1.9"
 			},
 			"dependencies": {
 				"@nodelib/fs.stat": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz",
-					"integrity": "sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
+					"integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
 					"dev": true
 				}
 			}
@@ -1901,46 +1230,29 @@
 			"dev": true
 		},
 		"@nodelib/fs.walk": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.2.tgz",
-			"integrity": "sha512-J/DR3+W12uCzAJkw7niXDcqcKBg6+5G5Q/ZpThpGNzAUz70eOR6RV4XnnSN01qHZiVl0eavoxJsBypQoKsV2QQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.3.tgz",
+			"integrity": "sha512-l6t8xEhfK9Sa4YO5mIRdau7XSOADfmh3jCr0evNHdY+HNkW6xuQhgMH7D73VV6WpZOagrW0UludvMTiifiwTfA==",
 			"dev": true,
 			"requires": {
-				"@nodelib/fs.scandir": "2.1.1",
+				"@nodelib/fs.scandir": "2.1.2",
 				"fastq": "^1.6.0"
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "5.3.5",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.5.tgz",
-			"integrity": "sha512-f8KqzIrnzPLiezDsZZPB+K8v8YSv6aKFl7eOu59O46lmlW4HagWl1U6NWl6LmT8d1w7NsKBI3paVtzcnRGO1gw==",
+			"version": "5.3.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.3.6.tgz",
+			"integrity": "sha512-XuerByak8H+jW9J/rVMEdBXfI4UTsDWUwAKgIP/uhQjXIUVdPRwt2Zg+SmbWQ+WY7pRkw/hFVES8C4G/Kle7oA==",
 			"dev": true,
 			"requires": {
 				"is-plain-object": "^3.0.0",
 				"universal-user-agent": "^4.0.0"
-			},
-			"dependencies": {
-				"is-plain-object": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-					"dev": true,
-					"requires": {
-						"isobject": "^4.0.0"
-					}
-				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-					"dev": true
-				}
 			}
 		},
 		"@octokit/request": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.0.3.tgz",
-			"integrity": "sha512-4vRqNNf4lYqhpuiqimew2pxxwCvTShwENza25h+UMNBUvKm50K03LJ8PL7Iu6l9qboo1D0mI5DMrGwR0Tr/nKw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.1.0.tgz",
+			"integrity": "sha512-I15T9PwjFs4tbWyhtFU2Kq7WDPidYMvRB7spmxoQRZfxSmiqullG+Nz+KbSmpkfnlvHwTr1e31R5WReFRKMXjg==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^5.1.0",
@@ -1952,21 +1264,6 @@
 				"universal-user-agent": "^4.0.0"
 			},
 			"dependencies": {
-				"is-plain-object": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-					"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-					"dev": true,
-					"requires": {
-						"isobject": "^4.0.0"
-					}
-				},
-				"isobject": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
-					"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
-					"dev": true
-				},
 				"node-fetch": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -2015,6 +1312,12 @@
 				"postcss": "^5.0.21"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -2058,6 +1361,15 @@
 						"js-base64": "^2.1.9",
 						"source-map": "^0.5.6",
 						"supports-color": "^3.2.3"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -2114,9 +1426,9 @@
 			"dev": true
 		},
 		"@types/babel__core": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.2.tgz",
-			"integrity": "sha512-cfCCrFmiGY/yq0NuKNxIQvZFy9kY/1immpSpTngOnyIbD4+eJOG5mxphhHDv3CHL9GltO4GcKr54kGBg3RNdbg==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
+			"integrity": "sha512-8fBo0UR2CcwWxeX7WIIgJ7lXjasFxoYgRnFHUj+hRvKkpiBJbxhdAPTCY6/ZKM0uxANFVzt4yObSLuTiTnazDA==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -2152,25 +1464,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
-			},
-			"dependencies": {
-				"@babel/types": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@types/events": {
@@ -2228,9 +1521,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "10.12.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
-			"integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA==",
+			"version": "12.7.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
 			"dev": true
 		},
 		"@types/normalize-package-data": {
@@ -2240,15 +1533,21 @@
 			"dev": true
 		},
 		"@types/q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-			"integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
 			"dev": true
 		},
 		"@types/semver": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
 			"integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+			"dev": true
+		},
+		"@types/source-list-map": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+			"integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -2308,15 +1607,16 @@
 			}
 		},
 		"@types/webpack": {
-			"version": "4.4.32",
-			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.32.tgz",
-			"integrity": "sha512-mNARoaSJTzbiHxtZbf9NULFilu2frqD+g9Iyl9V2jPYJWXi+AC3Hz8lQWPZ5LLtgUm7iF4SDDMB/1bPrbRQgFw==",
+			"version": "4.39.1",
+			"resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.39.1.tgz",
+			"integrity": "sha512-rgO9ihNu/l72Sjx3shqwc9r6gi+tOMsqxhMEZhOEVIZt82GFOeUyEdpTk1BO2HqEHLS/XJW8ldUTIIfIMMyYFQ==",
 			"dev": true,
 			"requires": {
 				"@types/anymatch": "*",
 				"@types/node": "*",
 				"@types/tapable": "*",
 				"@types/uglify-js": "*",
+				"@types/webpack-sources": "*",
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
@@ -2328,10 +1628,38 @@
 				}
 			}
 		},
+		"@types/webpack-sources": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.5.tgz",
+			"integrity": "sha512-zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"@types/source-list-map": "*",
+				"source-map": "^0.6.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
 		"@types/yargs": {
-			"version": "12.0.12",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
-			"integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.2.tgz",
+			"integrity": "sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==",
+			"dev": true,
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+			"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
 			"dev": true
 		},
 		"@typescript-eslint/experimental-utils": {
@@ -2531,6 +1859,15 @@
 						"@webassemblyjs/wast-parser": "1.4.3",
 						"long": "^3.2.0"
 					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
 				}
 			}
 		},
@@ -2654,15 +1991,6 @@
 				"react-transition-group": "2.9.0"
 			},
 			"dependencies": {
-				"@babel/runtime-corejs2": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
-					"integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
-					"requires": {
-						"core-js": "^2.6.5",
-						"regenerator-runtime": "^0.13.2"
-					}
-				},
 				"@woocommerce/navigation": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-2.1.0.tgz",
@@ -2758,75 +2086,10 @@
 						"tannin": "^1.0.1"
 					}
 				},
-				"@wordpress/keycodes": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.3.0.tgz",
-					"integrity": "sha512-iutKSqHcvhxEvkV/QjgOXlWi/FLaOTtRumQtGxXd7eb8fDqs+8LmhExNn4dw6QJ+vvY+sjUnJh8121eTzCmPjw==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.4.0",
-						"lodash": "^4.17.11"
-					}
-				},
 				"core-js": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
 					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				},
-				"moment": {
-					"version": "2.22.1",
-					"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-					"integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
-				},
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-				},
-				"react": {
-					"version": "16.9.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-					"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2"
-					}
-				},
-				"react-dom": {
-					"version": "16.9.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-					"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.15.0"
-					}
-				},
-				"scheduler": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-					"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
 				}
 			}
 		},
@@ -2853,6 +2116,11 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
 					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+				},
+				"moment": {
+					"version": "2.22.2",
+					"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+					"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
 				}
 			}
 		},
@@ -2879,6 +2147,11 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
 					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 				}
 			}
 		},
@@ -2930,6 +2203,16 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
 					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+				},
+				"moment": {
+					"version": "2.22.2",
+					"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+					"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
 				}
 			}
 		},
@@ -2943,20 +2226,6 @@
 				"history": "4.9.0",
 				"lodash": "4.17.15",
 				"qs": "6.7.0"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
-				}
 			}
 		},
 		"@woocommerce/number": {
@@ -2982,6 +2251,11 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
 					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+				},
+				"lodash": {
+					"version": "4.17.11",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
 				}
 			}
 		},
@@ -2995,13 +2269,13 @@
 			}
 		},
 		"@wordpress/api-fetch": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
-			"integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.6.0.tgz",
+			"integrity": "sha512-xNn55LKJwFTY1pl98VU1eYhn5U0uFCS2RnqnIzjoDth747VNLSj0/OFD6FaMAIx3BSAd0XOjzXQmzsdDPr984Q==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/i18n": "^3.6.0",
-				"@wordpress/url": "^2.7.0"
+				"@wordpress/url": "^2.8.0"
 			}
 		},
 		"@wordpress/autop": {
@@ -3064,17 +2338,6 @@
 				"lodash": "^4.17.14"
 			},
 			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.6.0.tgz",
-					"integrity": "sha512-xNn55LKJwFTY1pl98VU1eYhn5U0uFCS2RnqnIzjoDth747VNLSj0/OFD6FaMAIx3BSAd0XOjzXQmzsdDPr984Q==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.6.0",
-						"@wordpress/url": "^2.8.0"
-					}
-				},
 				"@wordpress/compose": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
@@ -3086,73 +2349,6 @@
 						"@wordpress/is-shallow-equal": "^1.6.0",
 						"lodash": "^4.17.14"
 					}
-				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
-					"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
 				}
 			}
 		},
@@ -3207,79 +2403,6 @@
 						"@wordpress/element": "^2.8.0",
 						"@wordpress/is-shallow-equal": "^1.6.0",
 						"lodash": "^4.17.14"
-					},
-					"dependencies": {
-						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-							"dev": true
-						}
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					},
-					"dependencies": {
-						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-							"dev": true
-						}
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/dom": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.0.tgz",
-					"integrity": "sha512-nJUskVX/0RIskGgQBCXRrMMMxJcZ1UwQlpDBMNVPwMD9KPw13YnzCTzR6QgUMvCYF4pDUmxVIP+ao7CQzAL9lg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"lodash": "^4.17.14"
-					},
-					"dependencies": {
-						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-							"dev": true
-						}
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
 					}
 				},
 				"@wordpress/html-entities": {
@@ -3291,34 +2414,15 @@
 						"@babel/runtime": "^7.4.4"
 					}
 				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
+				"@wordpress/keycodes": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.0.tgz",
+					"integrity": "sha512-wWCyom/dHMBb2hmNbuZym30/6QrvW2RvIbQNu1LHNZvVqehMOQLdVMUf525aLVJVQfp9wfer/fz5TjphW43txA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					},
-					"dependencies": {
-						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-							"dev": true
-						}
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
-					"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
+						"@wordpress/i18n": "^3.6.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/viewport": {
@@ -3331,14 +2435,6 @@
 						"@wordpress/compose": "^3.7.0",
 						"@wordpress/data": "^4.9.0",
 						"lodash": "^4.17.14"
-					},
-					"dependencies": {
-						"lodash": {
-							"version": "4.17.15",
-							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-							"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-							"dev": true
-						}
 					}
 				}
 			}
@@ -3392,55 +2488,6 @@
 						"lodash": "^4.17.14"
 					}
 				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/dom": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.0.tgz",
-					"integrity": "sha512-nJUskVX/0RIskGgQBCXRrMMMxJcZ1UwQlpDBMNVPwMD9KPw13YnzCTzR6QgUMvCYF4pDUmxVIP+ao7CQzAL9lg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"lodash": "^4.17.14"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
 				"@wordpress/html-entities": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
@@ -3449,24 +2496,6 @@
 					"requires": {
 						"@babel/runtime": "^7.4.4"
 					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
 				}
 			}
 		},
@@ -3520,40 +2549,16 @@
 						"lodash": "^4.17.14"
 					}
 				},
-				"@wordpress/deprecated": {
+				"@wordpress/keycodes": {
 					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.0.tgz",
+					"integrity": "sha512-wWCyom/dHMBb2hmNbuZym30/6QrvW2RvIbQNu1LHNZvVqehMOQLdVMUf525aLVJVQfp9wfer/fz5TjphW43txA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/dom": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.0.tgz",
-					"integrity": "sha512-nJUskVX/0RIskGgQBCXRrMMMxJcZ1UwQlpDBMNVPwMD9KPw13YnzCTzR6QgUMvCYF4pDUmxVIP+ao7CQzAL9lg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
+						"@wordpress/i18n": "^3.6.0",
 						"lodash": "^4.17.14"
 					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
 				},
 				"re-resizable": {
 					"version": "6.0.0",
@@ -3592,112 +2597,20 @@
 				"equivalent-key-map": "^0.2.2",
 				"lodash": "^4.17.14",
 				"rememo": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.6.0.tgz",
-					"integrity": "sha512-xNn55LKJwFTY1pl98VU1eYhn5U0uFCS2RnqnIzjoDth747VNLSj0/OFD6FaMAIx3BSAd0XOjzXQmzsdDPr984Q==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.6.0",
-						"@wordpress/url": "^2.8.0"
-					}
-				},
-				"@wordpress/compose": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
-					"integrity": "sha512-DxwRCico4wVm8YnARaO7bZhcV6SoIjhVoNF7IPMvPnOXKfvp/w6QfcDl0qCtRqpofgZBCs93mRhFXHywQE0N6g==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"lodash": "^4.17.14"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
-					"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
-			"integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
+			"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.5.0",
-				"@wordpress/deprecated": "^2.5.0",
-				"@wordpress/element": "^2.6.0",
-				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/compose": "^3.7.0",
+				"@wordpress/deprecated": "^2.6.0",
+				"@wordpress/element": "^2.8.0",
+				"@wordpress/is-shallow-equal": "^1.6.0",
 				"@wordpress/priority-queue": "^1.3.0",
-				"@wordpress/redux-routine": "^3.5.0",
+				"@wordpress/redux-routine": "^3.6.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
 				"lodash": "^4.17.14",
@@ -3706,20 +2619,15 @@
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.5.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
-					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
+					"integrity": "sha512-DxwRCico4wVm8YnARaO7bZhcV6SoIjhVoNF7IPMvPnOXKfvp/w6QfcDl0qCtRqpofgZBCs93mRhFXHywQE0N6g==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.6.0",
-						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/element": "^2.8.0",
+						"@wordpress/is-shallow-equal": "^1.6.0",
 						"lodash": "^4.17.14"
 					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 				}
 			}
 		},
@@ -3731,98 +2639,6 @@
 			"requires": {
 				"@wordpress/api-fetch": "^3.6.0",
 				"@wordpress/data": "^4.9.0"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.6.0.tgz",
-					"integrity": "sha512-xNn55LKJwFTY1pl98VU1eYhn5U0uFCS2RnqnIzjoDth747VNLSj0/OFD6FaMAIx3BSAd0XOjzXQmzsdDPr984Q==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.6.0",
-						"@wordpress/url": "^2.8.0"
-					}
-				},
-				"@wordpress/compose": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
-					"integrity": "sha512-DxwRCico4wVm8YnARaO7bZhcV6SoIjhVoNF7IPMvPnOXKfvp/w6QfcDl0qCtRqpofgZBCs93mRhFXHywQE0N6g==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"lodash": "^4.17.14"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
-					"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/date": {
@@ -3847,28 +2663,21 @@
 			}
 		},
 		"@wordpress/deprecated": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
-			"integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
+			"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/hooks": "^2.5.0"
+				"@wordpress/hooks": "^2.6.0"
 			}
 		},
 		"@wordpress/dom": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.4.0.tgz",
-			"integrity": "sha512-8hcHi5iHgi1Z/1G6ti04bgsiYBDNlR05X7MiosjwP8U/iTmcRwKrmtA1X6qzsMlOgvJ3MetoLqGZb3lCjLtXmw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.0.tgz",
+			"integrity": "sha512-nJUskVX/0RIskGgQBCXRrMMMxJcZ1UwQlpDBMNVPwMD9KPw13YnzCTzR6QgUMvCYF4pDUmxVIP+ao7CQzAL9lg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				}
 			}
 		},
 		"@wordpress/dom-ready": {
@@ -3922,17 +2731,6 @@
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.6.0.tgz",
-					"integrity": "sha512-xNn55LKJwFTY1pl98VU1eYhn5U0uFCS2RnqnIzjoDth747VNLSj0/OFD6FaMAIx3BSAd0XOjzXQmzsdDPr984Q==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.6.0",
-						"@wordpress/url": "^2.8.0"
-					}
-				},
 				"@wordpress/compose": {
 					"version": "3.7.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
@@ -3945,45 +2743,6 @@
 						"lodash": "^4.17.14"
 					}
 				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
 				"@wordpress/html-entities": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
@@ -3993,26 +2752,15 @@
 						"@babel/runtime": "^7.4.4"
 					}
 				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
+				"@wordpress/keycodes": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.0.tgz",
+					"integrity": "sha512-wWCyom/dHMBb2hmNbuZym30/6QrvW2RvIbQNu1LHNZvVqehMOQLdVMUf525aLVJVQfp9wfer/fz5TjphW43txA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
-					"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
+						"@wordpress/i18n": "^3.6.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/viewport": {
@@ -4026,12 +2774,6 @@
 						"@wordpress/data": "^4.9.0",
 						"lodash": "^4.17.14"
 					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
 				}
 			}
 		},
@@ -4045,43 +2787,6 @@
 				"lodash": "^4.17.14",
 				"react": "^16.9.0",
 				"react-dom": "^16.9.0"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				},
-				"react": {
-					"version": "16.9.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
-					"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2"
-					}
-				},
-				"react-dom": {
-					"version": "16.9.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
-					"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.15.0"
-					}
-				},
-				"scheduler": {
-					"version": "0.15.0",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
-					"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
-				}
 			}
 		},
 		"@wordpress/escape-html": {
@@ -4106,9 +2811,9 @@
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
-			"integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
+			"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
@@ -4132,48 +2837,6 @@
 				"memize": "^1.0.5",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.1.0"
-			},
-			"dependencies": {
-				"@tannin/compile": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
-					"integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
-					"requires": {
-						"@tannin/evaluate": "^1.1.1",
-						"@tannin/postfix": "^1.0.2"
-					}
-				},
-				"@tannin/evaluate": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
-					"integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q=="
-				},
-				"@tannin/plural-forms": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
-					"integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
-					"requires": {
-						"@tannin/compile": "^1.0.3"
-					}
-				},
-				"@tannin/postfix": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
-					"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				},
-				"tannin": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
-					"integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
-					"requires": {
-						"@tannin/plural-forms": "^1.0.3"
-					}
-				}
 			}
 		},
 		"@wordpress/is-shallow-equal": {
@@ -4185,22 +2848,14 @@
 			}
 		},
 		"@wordpress/jest-console": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.2.0.tgz",
-			"integrity": "sha512-WZl2eJH9g+OSTrFPpAKSCT7Pl7rvwatPnBm1Z4kpPZdOQDbF3w2a6yzfpjtBBD2BVEqHsaLAxn0jC6xHkqbAxw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-3.3.0.tgz",
+			"integrity": "sha512-ga6KMvj81IclhT/3z7GYQZPdVYhBbasjYbCuzMwyFLMDGu3AZJVsxhTFufr2co3cSi03Z8dhWL2Mm9IEzQujdA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"jest-matcher-utils": "^24.7.0",
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/jest-preset-default": {
@@ -4217,20 +2872,13 @@
 			}
 		},
 		"@wordpress/keycodes": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.0.tgz",
-			"integrity": "sha512-wWCyom/dHMBb2hmNbuZym30/6QrvW2RvIbQNu1LHNZvVqehMOQLdVMUf525aLVJVQfp9wfer/fz5TjphW43txA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.3.0.tgz",
+			"integrity": "sha512-iutKSqHcvhxEvkV/QjgOXlWi/FLaOTtRumQtGxXd7eb8fDqs+8LmhExNn4dw6QJ+vvY+sjUnJh8121eTzCmPjw==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/i18n": "^3.6.0",
-				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-				}
+				"@wordpress/i18n": "^3.4.0",
+				"lodash": "^4.17.11"
 			}
 		},
 		"@wordpress/media-utils": {
@@ -4245,35 +2893,6 @@
 				"@wordpress/element": "^2.8.0",
 				"@wordpress/i18n": "^3.6.0",
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.6.0.tgz",
-					"integrity": "sha512-xNn55LKJwFTY1pl98VU1eYhn5U0uFCS2RnqnIzjoDth747VNLSj0/OFD6FaMAIx3BSAd0XOjzXQmzsdDPr984Q==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.6.0",
-						"@wordpress/url": "^2.8.0"
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
-					"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/notices": {
@@ -4286,77 +2905,6 @@
 				"@wordpress/a11y": "^2.5.0",
 				"@wordpress/data": "^4.9.0",
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"@wordpress/compose": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
-					"integrity": "sha512-DxwRCico4wVm8YnARaO7bZhcV6SoIjhVoNF7IPMvPnOXKfvp/w6QfcDl0qCtRqpofgZBCs93mRhFXHywQE0N6g==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"lodash": "^4.17.14"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/npm-package-json-lint-config": {
@@ -4392,63 +2940,6 @@
 						"@wordpress/is-shallow-equal": "^1.6.0",
 						"lodash": "^4.17.14"
 					}
-				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
 				}
 			}
 		},
@@ -4461,12 +2952,13 @@
 			}
 		},
 		"@wordpress/redux-routine": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
-			"integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
+			"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"is-promise": "^2.1.0",
+				"lodash": "^4.17.14",
 				"rungen": "^0.3.2"
 			}
 		},
@@ -4501,57 +2993,15 @@
 						"lodash": "^4.17.14"
 					}
 				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
+				"@wordpress/keycodes": {
 					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.0.tgz",
+					"integrity": "sha512-wWCyom/dHMBb2hmNbuZym30/6QrvW2RvIbQNu1LHNZvVqehMOQLdVMUf525aLVJVQfp9wfer/fz5TjphW43txA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
+						"@wordpress/i18n": "^3.6.0",
+						"lodash": "^4.17.14"
 					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 				}
 			}
 		},
@@ -4799,40 +3249,11 @@
 					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
 					"dev": true
 				},
-				"ajv": {
-					"version": "6.10.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0",
-						"map-obj": "^2.0.0",
-						"quick-lru": "^1.0.0"
-					}
 				},
 				"chrome-trace-event": {
 					"version": "0.1.3",
@@ -4849,15 +3270,6 @@
 						"lru-cache": "^4.0.1",
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
 					}
 				},
 				"doctrine": {
@@ -4928,190 +3340,109 @@
 						}
 					}
 				},
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				},
-				"globby": {
-					"version": "9.2.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
-					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^1.0.2",
-						"dir-glob": "^2.2.2",
-						"fast-glob": "^2.2.6",
-						"glob": "^7.1.3",
-						"ignore": "^4.0.3",
-						"pify": "^4.0.1",
-						"slash": "^2.0.0"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
+				"global-modules": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+					"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 					"dev": true,
 					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
+						"global-prefix": "^3.0.0"
 					}
+				},
+				"global-prefix": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+					"dev": true,
+					"requires": {
+						"ini": "^1.3.5",
+						"kind-of": "^6.0.2",
+						"which": "^1.3.1"
+					}
+				},
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+					"dev": true
 				},
 				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-							"dev": true
-						}
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
-				},
-				"map-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
-				},
-				"meow": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0",
-						"yargs-parser": "^10.0.0"
-					},
-					"dependencies": {
-						"read-pkg-up": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-							"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-							"dev": true,
-							"requires": {
-								"find-up": "^2.0.0",
-								"read-pkg": "^3.0.0"
-							}
-						}
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
 				},
 				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"pify": "^3.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-							"dev": true
-						}
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^4.0.0",
+						"load-json-file": "^1.0.0",
 						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
+						"path-type": "^1.0.0"
 					}
 				},
-				"redent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"indent-string": "^3.0.0",
-						"strip-indent": "^2.0.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"schema-utils": {
@@ -5123,12 +3454,6 @@
 						"ajv": "^6.1.0",
 						"ajv-keywords": "^3.1.0"
 					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
 				},
 				"string-width": {
 					"version": "3.1.0",
@@ -5168,16 +3493,13 @@
 					}
 				},
 				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				},
-				"strip-indent": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
 				},
 				"stylelint": {
 					"version": "9.10.1",
@@ -5244,9 +3566,15 @@
 							}
 						},
 						"ignore": {
-							"version": "5.1.2",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-							"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+							"version": "5.1.4",
+							"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+							"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+							"dev": true
+						},
+						"pify": {
+							"version": "4.0.1",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+							"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 							"dev": true
 						}
 					}
@@ -5261,21 +3589,6 @@
 						"stylelint-config-recommended-scss": "^3.2.0",
 						"stylelint-scss": "^3.3.0"
 					}
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
-				"trim-newlines": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
 				},
 				"webpack": {
 					"version": "4.8.3",
@@ -5318,15 +3631,6 @@
 							}
 						}
 					}
-				},
-				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
 				}
 			}
 		},
@@ -5345,98 +3649,6 @@
 				"@wordpress/i18n": "^3.6.0",
 				"@wordpress/url": "^2.8.0",
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.6.0.tgz",
-					"integrity": "sha512-xNn55LKJwFTY1pl98VU1eYhn5U0uFCS2RnqnIzjoDth747VNLSj0/OFD6FaMAIx3BSAd0XOjzXQmzsdDPr984Q==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.6.0",
-						"@wordpress/url": "^2.8.0"
-					}
-				},
-				"@wordpress/compose": {
-					"version": "3.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.0.tgz",
-					"integrity": "sha512-DxwRCico4wVm8YnARaO7bZhcV6SoIjhVoNF7IPMvPnOXKfvp/w6QfcDl0qCtRqpofgZBCs93mRhFXHywQE0N6g==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"lodash": "^4.17.14"
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.9.0.tgz",
-					"integrity": "sha512-wlaIXPU+vcKK+hoTsUMxdxU0WHlGSuqhJMmkLabNY5B/UTapajaeYROrFZ0Co/zS6eqgU5mXfqyVOam3/GDI9A==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.7.0",
-						"@wordpress/deprecated": "^2.6.0",
-						"@wordpress/element": "^2.8.0",
-						"@wordpress/is-shallow-equal": "^1.6.0",
-						"@wordpress/priority-queue": "^1.3.0",
-						"@wordpress/redux-routine": "^3.6.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.6.0.tgz",
-					"integrity": "sha512-DLYEhsG04V8qfm+k2hrHPExiC31+dgUGZBhIUq8ScvCIkqYOiWAgP0zTOjRgSuNk8Yp0/6XqSWbkXMC4ZQX03w==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.6.0"
-					}
-				},
-				"@wordpress/hooks": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.6.0.tgz",
-					"integrity": "sha512-93THIW9EklVkJLN3wr8PUdWqttRu/wGZgXUrM6fqqOGwm4uCL4S+jQe800kwZioRHvgW5moNLrvSdfanQ4QyEQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.6.0.tgz",
-					"integrity": "sha512-uZE6vA3XISS42aR2lx/5dUSPDXYLo1ETFPNzW1JN19NbwwpF/n2S1uUxICskNHe/Ku/bB8tZ+QRrd7AquyqhQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.14",
-						"rungen": "^0.3.2"
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
-					"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/shortcode": {
@@ -5448,14 +3660,6 @@
 				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.14",
 				"memize": "^1.0.5"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/token-list": {
@@ -5466,20 +3670,12 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@wordpress/url": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
-			"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.0.tgz",
+			"integrity": "sha512-TsQzHr1T8nNX31cMWIdCwAZmL9rkiDX5bOfBmeihthrykb1DhcxXL9unrZvZ7mcosQ+tD8dKPcySi/e79hOFEA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"qs": "^6.5.2"
@@ -5505,14 +3701,6 @@
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"@xtuc/ieee754": {
@@ -5528,9 +3716,9 @@
 			"dev": true
 		},
 		"abab": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-			"integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.1.tgz",
+			"integrity": "sha512-1zSbbCuoIjafKZ3mblY5ikvAb0ODUbqBnFuUb7f6uLeQhhGJ0vEV4ntmtxKLT2WgXCO94E07BjunsIw1jOMPZw==",
 			"dev": true
 		},
 		"abbrev": {
@@ -5547,29 +3735,12 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.40.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-					"dev": true
-				},
-				"mime-types": {
-					"version": "2.1.24",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-					"dev": true,
-					"requires": {
-						"mime-db": "1.40.0"
-					}
-				}
 			}
 		},
 		"acorn": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
-			"integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+			"integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
 			"dev": true
 		},
 		"acorn-dynamic-import": {
@@ -5590,9 +3761,9 @@
 			}
 		},
 		"acorn-globals": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
-			"integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -5600,9 +3771,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
+			"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -5628,36 +3799,29 @@
 			"requires": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^3.2.0"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				}
 			}
 		},
 		"airbnb-prop-types": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.11.0.tgz",
-			"integrity": "sha512-Y46/0gNVDy5gpedxIaoKjigdes+TouqVg7GTYQr73PBfE/lTSvOR/WIgUib0Zonm3Hyvlcax0mHr+v4K8DfGGw==",
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
+			"integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
 			"requires": {
-				"array.prototype.find": "^2.0.4",
-				"function.prototype.name": "^1.1.0",
+				"array.prototype.find": "^2.1.0",
+				"function.prototype.name": "^1.1.1",
 				"has": "^1.0.3",
 				"is-regex": "^1.0.4",
 				"object-is": "^1.0.1",
 				"object.assign": "^4.1.0",
-				"object.entries": "^1.0.4",
-				"prop-types": "^15.6.2",
-				"prop-types-exact": "^1.2.0"
+				"object.entries": "^1.1.0",
+				"prop-types": "^15.7.2",
+				"prop-types-exact": "^1.2.0",
+				"react-is": "^16.9.0"
 			}
 		},
 		"ajv": {
-			"version": "6.5.5",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
-			"integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
@@ -5667,15 +3831,15 @@
 			}
 		},
 		"ajv-errors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
-			"integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
 			"dev": true
 		},
 		"ajv-keywords": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-			"integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
 			"dev": true
 		},
 		"alphanum-sort": {
@@ -5710,16 +3874,15 @@
 			}
 		},
 		"ansi-escapes": {
-			"version": "3.1.0",
-			"resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-			"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+			"integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -5744,6 +3907,17 @@
 			"requires": {
 				"micromatch": "^3.1.4",
 				"normalize-path": "^2.1.1"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+					"dev": true,
+					"requires": {
+						"remove-trailing-separator": "^1.0.1"
+					}
+				}
 			}
 		},
 		"aproba": {
@@ -5863,12 +4037,12 @@
 			"dev": true
 		},
 		"array.prototype.find": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-			"integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+			"integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.7.0"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.13.0"
 			}
 		},
 		"array.prototype.flat": {
@@ -5913,11 +4087,12 @@
 			}
 		},
 		"assert": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+			"integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
 			"dev": true,
 			"requires": {
+				"object-assign": "^4.1.1",
 				"util": "0.10.3"
 			},
 			"dependencies": {
@@ -5929,7 +4104,7 @@
 				},
 				"util": {
 					"version": "0.10.3",
-					"resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+					"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 					"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 					"dev": true,
 					"requires": {
@@ -5969,20 +4144,12 @@
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.14"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
 		"async-foreach": {
@@ -6030,69 +4197,11 @@
 				"postcss-value-parser": "^4.0.0"
 			},
 			"dependencies": {
-				"browserslist": {
-					"version": "4.6.3",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-					"integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000975",
-						"electron-to-chromium": "^1.3.164",
-						"node-releases": "^1.1.23"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000980",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000980.tgz",
-					"integrity": "sha512-as0PRtWHaX3gl2gpC7qA7bX88lr+qLacMMXm1QKLLQtBCwT/Ljbgrv5EXKMNBoeEX6yFZ4vIsBb4Nh+PEwW2Rw==",
-					"dev": true
-				},
-				"electron-to-chromium": {
-					"version": "1.3.187",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.187.tgz",
-					"integrity": "sha512-XCEygaK7Fs35/RwS+67YbBWs/ydG+oUFPuy1wv558jC3Opd2DHwRyRqrCmhxpmPmCSVlZujYX4TOmOXuMz2GZA==",
-					"dev": true
-				},
-				"node-releases": {
-					"version": "1.1.25",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.25.tgz",
-					"integrity": "sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==",
-					"dev": true,
-					"requires": {
-						"semver": "^5.3.0"
-					}
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-value-parser": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.0.tgz",
-					"integrity": "sha512-ESPktioptiSUchCKgggAkzdmkgzKfmp0EU8jXH+5kbIUB+unr0Y4CY9SRMvibuvYUBjNh1ACLbxqYNpdTQOteQ==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -6152,6 +4261,12 @@
 				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -6169,6 +4284,21 @@
 						"has-ansi": "^2.0.0",
 						"strip-ansi": "^3.0.0",
 						"supports-color": "^2.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -6197,17 +4327,6 @@
 				"@babel/types": "^7.0.0",
 				"eslint-visitor-keys": "^1.0.0",
 				"resolve": "^1.12.0"
-			},
-			"dependencies": {
-				"resolve": {
-					"version": "1.12.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				}
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -6349,16 +4468,16 @@
 			}
 		},
 		"babel-jest": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
-			"integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
+			"integrity": "sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/babel__core": "^7.1.0",
 				"babel-plugin-istanbul": "^5.1.0",
-				"babel-preset-jest": "^24.6.0",
+				"babel-preset-jest": "^24.9.0",
 				"chalk": "^2.4.2",
 				"slash": "^2.0.0"
 			}
@@ -6373,14 +4492,6 @@
 				"loader-utils": "^1.0.2",
 				"mkdirp": "^0.5.1",
 				"pify": "^4.0.1"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				}
 			}
 		},
 		"babel-messages": {
@@ -6442,9 +4553,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -6468,9 +4579,9 @@
 			}
 		},
 		"babel-plugin-jest-hoist": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
-			"integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.9.0.tgz",
+			"integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
 			"dev": true,
 			"requires": {
 				"@types/babel__traverse": "^7.0.6"
@@ -6768,6 +4879,12 @@
 				"regexpu-core": "^2.0.0"
 			},
 			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
 				"regexpu-core": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
@@ -6926,13 +5043,13 @@
 			}
 		},
 		"babel-preset-jest": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
-			"integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.9.0.tgz",
+			"integrity": "sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-				"babel-plugin-jest-hoist": "^24.6.0"
+				"babel-plugin-jest-hoist": "^24.9.0"
 			}
 		},
 		"babel-runtime": {
@@ -7039,9 +5156,9 @@
 			"dev": true
 		},
 		"bail": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.3.tgz",
-			"integrity": "sha512-1X8CnjFVQ+a+KW36uBNMTU5s8+v5FzeqrP7hTG5aTb4aPreSbZJlhwPon9VKMuEVgV++JM+SQrALY3kr7eswdg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
+			"integrity": "sha512-S8vuDB4w6YpRhICUDET3guPlQpaJl7od94tpZ0Fvnyp+MKW/HyDTcRDck+29C9g+d/qQHnddRH3+94kZdrW0Ww==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -7112,9 +5229,9 @@
 			}
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -7145,25 +5262,37 @@
 			}
 		},
 		"big.js": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-			"integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
 			"dev": true
 		},
 		"binary-extensions": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
 		"bl": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-			"integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+			"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"readable-stream": "^3.0.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"block-stream": {
@@ -7255,12 +5384,6 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
-				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-					"dev": true
 				}
 			}
 		},
@@ -7306,6 +5429,12 @@
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
 			}
 		},
@@ -7360,7 +5489,7 @@
 		},
 		"browserify-aes": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {
@@ -7397,7 +5526,7 @@
 		},
 		"browserify-rsa": {
 			"version": "4.0.1",
-			"resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
@@ -7430,22 +5559,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.6.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.0.tgz",
+			"integrity": "sha512-9rGNDtnj+HaahxiVV38Gn8n8Lr8REKsel68v1sPFfIGEK6uSXTY3h9acgiT1dZVtOOUtifo/Dn8daDQ5dUgVsA==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30000984",
-				"electron-to-chromium": "^1.3.191",
-				"node-releases": "^1.1.25"
-			},
-			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30000985",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000985.tgz",
-					"integrity": "sha512-1ngiwkgqAYPG0JSSUp3PUDGPKKY59EK7NrGGX+VOxaKCNzRbNc7uXMny+c3VJfZxtoK3wSImTvG9T9sXiTw2+w==",
-					"dev": true
-				}
+				"caniuse-lite": "^1.0.30000989",
+				"electron-to-chromium": "^1.3.247",
+				"node-releases": "^1.1.29"
 			}
 		},
 		"bser": {
@@ -7465,36 +5586,22 @@
 		},
 		"buffer": {
 			"version": "4.9.1",
-			"resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4",
 				"isarray": "^1.0.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
+				}
 			}
-		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"dev": true
 		},
 		"buffer-from": {
 			"version": "1.1.1",
@@ -7506,12 +5613,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 			"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-			"dev": true
-		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
 		"builtin-status-codes": {
@@ -7538,38 +5639,6 @@
 				"prettycli": "^1.4.3"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"dev": true
-				},
-				"cosmiconfig": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-					"dev": true,
-					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.1",
-						"parse-json": "^4.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"gzip-size": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-4.1.0.tgz",
@@ -7580,25 +5649,11 @@
 						"pify": "^3.0.0"
 					}
 				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
 				}
 			}
 		},
@@ -7631,20 +5686,6 @@
 				"y18n": "^4.0.0"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"lru-cache": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -7719,32 +5760,42 @@
 			"dependencies": {
 				"callsites": {
 					"version": "2.0.0",
-					"resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
 					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
 					"dev": true
 				}
 			}
 		},
+		"caller-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+			"dev": true,
+			"requires": {
+				"caller-callsite": "^2.0.0"
+			}
+		},
 		"callsites": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
-			"integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
 		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+			"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 			"dev": true
 		},
 		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+			"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
+				"camelcase": "^4.1.0",
+				"map-obj": "^2.0.0",
+				"quick-lru": "^1.0.0"
 			}
 		},
 		"caniuse-api": {
@@ -7760,9 +5811,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000927",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000927.tgz",
-			"integrity": "sha512-ogq4NbUWf1uG/j66k0AmiO3GjqJAlQyF8n4w8a954cbCyFKmYGvRtgz6qkq2fWuduTXHibX7GyYL5Pg58Aks2g==",
+			"version": "1.0.30000997",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000997.tgz",
+			"integrity": "sha512-BQLFPIdj2ntgBNWp9Q64LGUIEmvhKkzzHhUHR3CD5A9Lb7ZKF20/+sgadhFap69lk5XmK1fTUleDclaRFvgVUA==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -7781,9 +5832,9 @@
 			"dev": true
 		},
 		"ccount": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.3.tgz",
-			"integrity": "sha512-Jt9tIBkRc9POUof7QA/VwWd+58fKkEEfI+/t1/eOlxKM7ZhrczNzMFefge7Ai+39y1pR/pP6cI19guHy3FSLmw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.4.tgz",
+			"integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
 			"dev": true
 		},
 		"chalk": {
@@ -7798,27 +5849,27 @@
 			}
 		},
 		"character-entities": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.2.tgz",
-			"integrity": "sha512-sMoHX6/nBiy3KKfC78dnEalnpn0Az0oSNvqUWYTtYrhRI5iUIYsROU48G+E+kMFQzqXaJ8kHJZ85n7y6/PHgwQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
+			"integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w==",
 			"dev": true
 		},
 		"character-entities-html4": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.2.tgz",
-			"integrity": "sha512-sIrXwyna2+5b0eB9W149izTPJk/KkJTg6mEzDGibwBUkyH1SbDa+nf515Ppdi3MaH35lW0JFJDWeq9Luzes1Iw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.3.tgz",
+			"integrity": "sha512-SwnyZ7jQBCRHELk9zf2CN5AnGEc2nA+uKMZLHvcqhpPprjkYhiLn0DywMHgN5ttFZuITMATbh68M6VIVKwJbcg==",
 			"dev": true
 		},
 		"character-entities-legacy": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz",
-			"integrity": "sha512-9NB2VbXtXYWdXzqrvAHykE/f0QJxzaKIpZ5QzNZrrgQ7Iyxr2vnfS8fCBNVW9nUEZE0lo57nxKRqnzY/dKrwlA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
+			"integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww==",
 			"dev": true
 		},
 		"character-reference-invalid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz",
-			"integrity": "sha512-7I/xceXfKyUJmSAn/jw8ve/9DyOP7XxufNYLI9Px7CmsKgEUaZLUTax6nZxGQtaoiZCjpu6cHPj20xC/vqRReQ==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
+			"integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==",
 			"dev": true
 		},
 		"chardet": {
@@ -7840,14 +5891,6 @@
 				"object.assign": "^4.0.4",
 				"run-parallel": "^1.1.4",
 				"semver": "^5.0.3"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"check-types": {
@@ -7868,24 +5911,12 @@
 				"htmlparser2": "^3.9.1",
 				"lodash": "^4.15.0",
 				"parse5": "^3.0.1"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-					"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-					"dev": true,
-					"requires": {
-						"domelementtype": "^1.3.0",
-						"entities": "^1.1.1"
-					}
-				}
 			}
 		},
 		"chokidar": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
-			"integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
@@ -7899,569 +5930,13 @@
 				"normalize-path": "^3.0.0",
 				"path-is-absolute": "^1.0.0",
 				"readdirp": "^2.2.1",
-				"upath": "^1.1.0"
-			},
-			"dependencies": {
-				"fsevents": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-					"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"nan": "^2.9.2",
-						"node-pre-gyp": "^0.10.0"
-					},
-					"dependencies": {
-						"abbrev": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ansi-regex": {
-							"version": "2.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"aproba": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"are-we-there-yet": {
-							"version": "1.1.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^2.0.6"
-							}
-						},
-						"balanced-match": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"brace-expansion": {
-							"version": "1.1.11",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"balanced-match": "^1.0.0",
-								"concat-map": "0.0.1"
-							}
-						},
-						"chownr": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"code-point-at": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"concat-map": {
-							"version": "0.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"console-control-strings": {
-							"version": "1.1.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"core-util-is": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"debug": {
-							"version": "2.6.9",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"deep-extend": {
-							"version": "0.6.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"delegates": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"detect-libc": {
-							"version": "1.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"fs-minipass": {
-							"version": "1.2.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"fs.realpath": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"gauge": {
-							"version": "2.7.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"aproba": "^1.0.3",
-								"console-control-strings": "^1.0.0",
-								"has-unicode": "^2.0.0",
-								"object-assign": "^4.1.0",
-								"signal-exit": "^3.0.0",
-								"string-width": "^1.0.1",
-								"strip-ansi": "^3.0.1",
-								"wide-align": "^1.1.0"
-							}
-						},
-						"glob": {
-							"version": "7.1.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"fs.realpath": "^1.0.0",
-								"inflight": "^1.0.4",
-								"inherits": "2",
-								"minimatch": "^3.0.4",
-								"once": "^1.3.0",
-								"path-is-absolute": "^1.0.0"
-							}
-						},
-						"has-unicode": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"iconv-lite": {
-							"version": "0.4.24",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safer-buffer": ">= 2.1.2 < 3"
-							}
-						},
-						"ignore-walk": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimatch": "^3.0.4"
-							}
-						},
-						"inflight": {
-							"version": "1.0.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"once": "^1.3.0",
-								"wrappy": "1"
-							}
-						},
-						"inherits": {
-							"version": "2.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"ini": {
-							"version": "1.3.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"is-fullwidth-code-point": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"number-is-nan": "^1.0.0"
-							}
-						},
-						"isarray": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minimatch": {
-							"version": "3.0.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"brace-expansion": "^1.1.7"
-							}
-						},
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"minipass": {
-							"version": "2.3.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.0"
-							}
-						},
-						"minizlib": {
-							"version": "1.2.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minipass": "^2.2.1"
-							}
-						},
-						"mkdirp": {
-							"version": "0.5.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"minimist": "0.0.8"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"needle": {
-							"version": "2.2.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"debug": "^2.1.2",
-								"iconv-lite": "^0.4.4",
-								"sax": "^1.2.4"
-							}
-						},
-						"node-pre-gyp": {
-							"version": "0.10.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"detect-libc": "^1.0.2",
-								"mkdirp": "^0.5.1",
-								"needle": "^2.2.1",
-								"nopt": "^4.0.1",
-								"npm-packlist": "^1.1.6",
-								"npmlog": "^4.0.2",
-								"rc": "^1.2.7",
-								"rimraf": "^2.6.1",
-								"semver": "^5.3.0",
-								"tar": "^4"
-							}
-						},
-						"nopt": {
-							"version": "4.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"abbrev": "1",
-								"osenv": "^0.1.4"
-							}
-						},
-						"npm-bundled": {
-							"version": "1.0.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"npm-packlist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ignore-walk": "^3.0.1",
-								"npm-bundled": "^1.0.1"
-							}
-						},
-						"npmlog": {
-							"version": "4.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"are-we-there-yet": "~1.1.2",
-								"console-control-strings": "~1.1.0",
-								"gauge": "~2.7.3",
-								"set-blocking": "~2.0.0"
-							}
-						},
-						"number-is-nan": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"object-assign": {
-							"version": "4.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"once": {
-							"version": "1.4.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"wrappy": "1"
-							}
-						},
-						"os-homedir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"os-tmpdir": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"osenv": {
-							"version": "0.1.5",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"os-homedir": "^1.0.0",
-								"os-tmpdir": "^1.0.0"
-							}
-						},
-						"path-is-absolute": {
-							"version": "1.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"process-nextick-args": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"rc": {
-							"version": "1.2.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"deep-extend": "^0.6.0",
-								"ini": "~1.3.0",
-								"minimist": "^1.2.0",
-								"strip-json-comments": "~2.0.1"
-							},
-							"dependencies": {
-								"minimist": {
-									"version": "1.2.0",
-									"bundled": true,
-									"dev": true,
-									"optional": true
-								}
-							}
-						},
-						"readable-stream": {
-							"version": "2.3.6",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"core-util-is": "~1.0.0",
-								"inherits": "~2.0.3",
-								"isarray": "~1.0.0",
-								"process-nextick-args": "~2.0.0",
-								"safe-buffer": "~5.1.1",
-								"string_decoder": "~1.1.1",
-								"util-deprecate": "~1.0.1"
-							}
-						},
-						"rimraf": {
-							"version": "2.6.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						},
-						"safe-buffer": {
-							"version": "5.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"safer-buffer": {
-							"version": "2.1.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"sax": {
-							"version": "1.2.4",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"semver": {
-							"version": "5.6.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"set-blocking": {
-							"version": "2.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"signal-exit": {
-							"version": "3.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"code-point-at": "^1.0.0",
-								"is-fullwidth-code-point": "^1.0.0",
-								"strip-ansi": "^3.0.0"
-							}
-						},
-						"string_decoder": {
-							"version": "1.1.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"safe-buffer": "~5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"ansi-regex": "^2.0.0"
-							}
-						},
-						"strip-json-comments": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"tar": {
-							"version": "4.4.8",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"chownr": "^1.1.1",
-								"fs-minipass": "^1.2.5",
-								"minipass": "^2.3.4",
-								"minizlib": "^1.1.1",
-								"mkdirp": "^0.5.0",
-								"safe-buffer": "^5.1.2",
-								"yallist": "^3.0.2"
-							}
-						},
-						"util-deprecate": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"wide-align": {
-							"version": "1.1.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true,
-							"requires": {
-								"string-width": "^1.0.2 || 2"
-							}
-						},
-						"wrappy": {
-							"version": "1.0.2",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						},
-						"yallist": {
-							"version": "3.0.3",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				}
+				"upath": "^1.1.1"
 			}
 		},
 		"chownr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
 			"dev": true
 		},
 		"chrome-trace-event": {
@@ -8474,9 +5949,9 @@
 			}
 		},
 		"ci-env": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.9.0.tgz",
-			"integrity": "sha512-GKMUVeOunoGplUXmIr3ss2OpYvp7JUwTTZ2wiVV8JtUy6U8r7MaDWuV1vjJdf7yxqs9AbELHXQGW4b/L60COdA==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/ci-env/-/ci-env-1.11.0.tgz",
+			"integrity": "sha512-UsrixXJWK5gzR+rCKZIoVdiIbXovqbbSyZSXC6DLsq/l7Zv3AIb7uWURZhgh+7ktt+Udoh/yujJBGkFZPJoTXQ==",
 			"dev": true
 		},
 		"ci-info": {
@@ -8553,70 +6028,6 @@
 			"requires": {
 				"@types/webpack": "^4.4.31",
 				"del": "^4.1.1"
-			},
-			"dependencies": {
-				"del": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-					"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-					"dev": true,
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"globby": "^6.1.0",
-						"is-path-cwd": "^2.0.0",
-						"is-path-in-cwd": "^2.0.0",
-						"p-map": "^2.0.0",
-						"pify": "^4.0.1",
-						"rimraf": "^2.6.3"
-					},
-					"dependencies": {
-						"rimraf": {
-							"version": "2.7.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						}
-					}
-				},
-				"is-path-cwd": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.1.0.tgz",
-					"integrity": "sha512-Sc5j3/YnM8tDeyCsVeKlm/0p95075DyLmDEIkSgQ7mXkrOX+uTCtmQFm0CYzVyJwcCCmO3k8qfJt17SxQwB5Zw==",
-					"dev": true
-				},
-				"is-path-in-cwd": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-					"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-					"dev": true,
-					"requires": {
-						"is-path-inside": "^2.1.0"
-					}
-				},
-				"is-path-inside": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-					"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-					"dev": true,
-					"requires": {
-						"path-is-inside": "^1.0.2"
-					}
-				},
-				"p-map": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-					"dev": true
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				}
 			}
 		},
 		"cli-cursor": {
@@ -8638,11 +6049,46 @@
 				"string-width": "^1.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
 				"slice-ansi": {
 					"version": "0.0.4",
 					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
 					"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 					"dev": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
 				}
 			}
 		},
@@ -8679,22 +6125,6 @@
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -8712,14 +6142,42 @@
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 		},
 		"clone-deep": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-			"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+			"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
 			"dev": true,
 			"requires": {
-				"is-plain-object": "^2.0.4",
-				"kind-of": "^6.0.2",
-				"shallow-clone": "^3.0.0"
+				"for-own": "^0.1.3",
+				"is-plain-object": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"lazy-cache": "^1.0.3",
+				"shallow-clone": "^0.1.2"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"clone-regexp": {
@@ -8756,9 +6214,9 @@
 			"dev": true
 		},
 		"collapse-white-space": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.4.tgz",
-			"integrity": "sha512-YfQ1tAUZm561vpYD+5eyWN8+UsceQbSrqqlc/6zDY2gtAE+uZLSdkkovhnGpmCThsvKBFakq4EdY/FF93E8XIw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.5.tgz",
+			"integrity": "sha512-703bOOmytCYAX9cXYqoikYIx6twmFCXsnzRQheBcTG3nzKYBR4P/+wkYeH+Mvj7qUz8zZDtdyzbxfnEi/kYzRQ==",
 			"dev": true
 		},
 		"collection-visit": {
@@ -8772,9 +6230,9 @@
 			}
 		},
 		"color": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
-			"integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+			"integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.1",
@@ -8819,36 +6277,21 @@
 			"requires": {
 				"strip-ansi": "^2.0.1",
 				"wcwidth": "^1.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-					"integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
-				},
-				"strip-ansi": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-					"integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-					"requires": {
-						"ansi-regex": "^1.0.0"
-					}
-				}
 			}
 		},
 		"combined-stream": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
 			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 			"dev": true
 		},
 		"commondir": {
@@ -8858,9 +6301,9 @@
 			"dev": true
 		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
 			"dev": true
 		},
 		"computed-style": {
@@ -8920,6 +6363,14 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "5.1.2"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"content-type": {
@@ -8941,6 +6392,14 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"cookie": {
@@ -9017,26 +6476,32 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
-			"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+			"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
 			"dev": true,
 			"requires": {
 				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
+				"js-yaml": "^3.13.1",
 				"parse-json": "^4.0.0"
 			},
 			"dependencies": {
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
 					}
+				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
 				}
 			}
 		},
@@ -9052,7 +6517,7 @@
 		},
 		"create-hash": {
 			"version": "1.2.0",
-			"resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"dev": true,
 			"requires": {
@@ -9065,7 +6530,7 @@
 		},
 		"create-hmac": {
 			"version": "1.1.7",
-			"resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+			"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"dev": true,
 			"requires": {
@@ -9084,30 +6549,18 @@
 			"dev": true,
 			"requires": {
 				"cross-spawn": "^6.0.5"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				}
 			}
 		},
 		"cross-spawn": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
 		},
@@ -9166,90 +6619,26 @@
 				"schema-utils": "^2.0.0"
 			},
 			"dependencies": {
-				"big.js": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-					"dev": true
-				},
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
-						"json5": "^1.0.1"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-value-parser": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.1.tgz",
-					"integrity": "sha512-3Jk+/CVH0HBfgSSFWALKm9Hyzf4kumPjZfUxkRYZNcqFztELb2APKxv0nlX8HCdc1/ymePmT/nFf1ST6fjWH2A==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
 				},
 				"schema-utils": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
-					"integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
+					"integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
 					}
 				}
 			}
@@ -9264,18 +6653,6 @@
 				"css-what": "2.1",
 				"domutils": "1.5.1",
 				"nth-check": "~1.0.1"
-			},
-			"dependencies": {
-				"domutils": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-					"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-					"dev": true,
-					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
-					}
-				}
 			}
 		},
 		"css-select-base-adapter": {
@@ -9285,12 +6662,12 @@
 			"dev": true
 		},
 		"css-tree": {
-			"version": "1.0.0-alpha.28",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-			"integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+			"version": "1.0.0-alpha.33",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+			"integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
 			"dev": true,
 			"requires": {
-				"mdn-data": "~1.1.0",
+				"mdn-data": "2.0.4",
 				"source-map": "^0.5.3"
 			}
 		},
@@ -9300,16 +6677,10 @@
 			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
 			"dev": true
 		},
-		"css-url-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-			"integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
-			"dev": true
-		},
 		"css-what": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.2.tgz",
-			"integrity": "sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
 			"dev": true
 		},
 		"cssesc": {
@@ -9413,6 +6784,12 @@
 						"mdn-data": "~1.1.0",
 						"source-map": "^0.5.3"
 					}
+				},
+				"mdn-data": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+					"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+					"dev": true
 				}
 			}
 		},
@@ -9451,9 +6828,9 @@
 			}
 		},
 		"cyclist": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-			"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
 		"d3-array": {
@@ -9477,9 +6854,9 @@
 			"integrity": "sha512-NHODMBlj59xPAwl2BDiO2Mog6V+PrGRtBfWKqKRrs9MCqlSkIEb0Z/SfY7jW29ReHTDC/j+vwXhnZcXI3+3fbg=="
 		},
 		"d3-format": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
-			"integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.1.tgz",
+			"integrity": "sha512-TUswGe6hfguUX1CtKxyG2nymO+1lyThbkS1ifLX0Sr+dOQtAD5gkrffpHnx+yHNKUZ0Bmg5T4AjUQwugPDrm0g=="
 		},
 		"d3-interpolate": {
 			"version": "1.3.2",
@@ -9508,9 +6885,9 @@
 			}
 		},
 		"d3-scale-chromatic": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.4.0.tgz",
-			"integrity": "sha512-0vyEt8ZqhdgzC+IvdkJZL7fc3k7UZyJvMxR3zvU312z/HilJ0N+WSY3099jAxdfhe99ak9VhcK1ChDVVGc8Q0Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
+			"integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
 			"requires": {
 				"d3-color": "1",
 				"d3-interpolate": "1"
@@ -9600,9 +6977,9 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "3.2.6",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-			"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
@@ -9622,6 +6999,14 @@
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
+			},
+			"dependencies": {
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
+				}
 			}
 		},
 		"decode-uri-component": {
@@ -9631,12 +7016,12 @@
 			"dev": true
 		},
 		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
 			"dev": true,
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "^2.0.0"
 			}
 		},
 		"dedent": {
@@ -9726,164 +7111,48 @@
 			}
 		},
 		"del": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
-			"integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+			"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
 			"dev": true,
 			"requires": {
-				"globby": "^10.0.1",
-				"graceful-fs": "^4.2.2",
-				"is-glob": "^4.0.1",
-				"is-path-cwd": "^2.2.0",
-				"is-path-inside": "^3.0.1",
-				"p-map": "^3.0.0",
-				"rimraf": "^3.0.0",
-				"slash": "^3.0.0"
+				"@types/glob": "^7.1.1",
+				"globby": "^6.1.0",
+				"is-path-cwd": "^2.0.0",
+				"is-path-in-cwd": "^2.0.0",
+				"p-map": "^2.0.0",
+				"pify": "^4.0.1",
+				"rimraf": "^2.6.3"
 			},
 			"dependencies": {
-				"@nodelib/fs.stat": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.1.tgz",
-					"integrity": "sha512-+RqhBlLn6YRBGOIoVYthsG0J9dfpO79eJyN7BYBkZJtfqrBwf2KK+rD/M/yjZR6WBmIhAgOV7S60eCgaSWtbFw==",
-					"dev": true
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
-					}
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"dev": true,
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"fast-glob": {
-					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
-					"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
-					"dev": true,
-					"requires": {
-						"@nodelib/fs.stat": "^2.0.1",
-						"@nodelib/fs.walk": "^1.2.1",
-						"glob-parent": "^5.0.0",
-						"is-glob": "^4.0.1",
-						"merge2": "^1.2.3",
-						"micromatch": "^4.0.2"
-					}
-				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
-				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
-					"dev": true,
-					"requires": {
-						"is-glob": "^4.0.1"
-					}
-				},
 				"globby": {
-					"version": "10.0.1",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
-					"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.0.3",
-						"glob": "^7.1.3",
-						"ignore": "^5.1.1",
-						"merge2": "^1.2.3",
-						"slash": "^3.0.0"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
+						}
 					}
-				},
-				"graceful-fs": {
-					"version": "4.2.2",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-					"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.1"
-					}
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"is-path-inside": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.1.tgz",
-					"integrity": "sha512-CKstxrctq1kUesU6WhtZDbYKzzYBuRH0UYInAVrkc/EYdB9ltbfE0gOoayG9nhohG6447sOOVGhHqsdmBvkbNg==",
-					"dev": true
-				},
-				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
 				},
 				"rimraf": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.0.tgz",
-					"integrity": "sha512-NDGVxTsjqfunkds7CqsOiEnxln4Bo7Nddl3XhS4pXg5OzwkLqJ971ZVAAnB+DDLnF76N+VnDEiBHaVV8I06SUg==",
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
-					}
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
 					}
 				}
 			}
@@ -9957,14 +7226,14 @@
 			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
 		},
 		"diff-sequences": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
-			"integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
 			"dev": true
 		},
 		"diffie-hellman": {
 			"version": "5.0.3",
-			"resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"dev": true,
 			"requires": {
@@ -9980,23 +7249,12 @@
 			"dev": true,
 			"requires": {
 				"path-type": "^3.0.0"
-			},
-			"dependencies": {
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				}
 			}
 		},
 		"direction": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.2.tgz",
-			"integrity": "sha512-hSKoz5FBn+zhP9vWKkVQaaxnRDg3/MoPdcg2au54HIUDR8MrP8Ah1jXSJwCXel6SV3Afh5DSzc8Uqv2r1UoQwQ=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.3.tgz",
+			"integrity": "sha512-8bHRqMt4w/kND19KBksE4NOJo+gIOPuiZfxQvbd6xikfKbuNBYBdLIw0hA/4lWzBaDpwpW+Olmg1BjD9+0LU2w=="
 		},
 		"discontinuous-range": {
 			"version": "1.0.0",
@@ -10013,6 +7271,14 @@
 				"esutils": "^2.0.2"
 			}
 		},
+		"document.contains": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.1.tgz",
+			"integrity": "sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==",
+			"requires": {
+				"define-properties": "^1.1.3"
+			}
+		},
 		"dom-helpers": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
@@ -10027,21 +7293,13 @@
 			"integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4="
 		},
 		"dom-serializer": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "~1.1.1",
-				"entities": "~1.1.1"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "1.1.3",
-					"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-					"dev": true
-				}
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
 			}
 		},
 		"domain-browser": {
@@ -10051,9 +7309,9 @@
 			"dev": true
 		},
 		"domelementtype": {
-			"version": "1.3.0",
-			"resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
 			"dev": true
 		},
 		"domexception": {
@@ -10075,9 +7333,9 @@
 			}
 		},
 		"domutils": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
 			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
@@ -10133,6 +7391,14 @@
 				"lru-cache": "^4.1.3",
 				"semver": "^5.6.0",
 				"sigmund": "^1.0.1"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "10.14.18",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
+					"integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==",
+					"dev": true
+				}
 			}
 		},
 		"editorconfig-to-prettier": {
@@ -10148,15 +7414,15 @@
 			"dev": true
 		},
 		"ejs": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.1.tgz",
+			"integrity": "sha512-kS/gEPzZs3Y1rRsbGX4UOSjtP/CeJP0CxSNZHYxGfVM/VgLcv0ZqM7C45YyTj2DI2g7+P9Dd24C+IMIg6D0nYQ==",
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.200",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.200.tgz",
-			"integrity": "sha512-PUurrpyDA74MuAjJRD+79ss5BqJlU3mdArRbuu4wO/dt6jc3Ic/6BDmFJxkdwbfq39cHf/XKm2vW98XSvut9Dg==",
+			"version": "1.3.265",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.265.tgz",
+			"integrity": "sha512-ypHt5Nv1Abr27QvJqk3VC4YDNqsrrWYMCmpmR7BNfCpcgYEwmCDoi3uJpp6kvj/MIjpScQoZMCQzLqfMQGmOsg==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -10166,9 +7432,9 @@
 			"dev": true
 		},
 		"elliptic": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+			"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -10216,9 +7482,9 @@
 			}
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.3.tgz",
+			"integrity": "sha512-cbNhPFS6MlYlWTGncSiDYbdqKhwWFy7kNeb1YSOG6K65i/wPTkLVCJQj0hXA4j0m5Da+hBWnqopEnu1FFelisQ==",
 			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
@@ -10284,43 +7550,6 @@
 				"react-is": "^16.8.6",
 				"react-test-renderer": "^16.0.0-0",
 				"semver": "^5.7.0"
-			},
-			"dependencies": {
-				"object.values": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-					"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.12.0",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3"
-					}
-				},
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				},
-				"react-is": {
-					"version": "16.8.6",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-					"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-					"dev": true
-				},
-				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-					"dev": true
-				}
 			}
 		},
 		"enzyme-adapter-utils": {
@@ -10335,93 +7564,6 @@
 				"object.fromentries": "^2.0.0",
 				"prop-types": "^15.7.2",
 				"semver": "^5.6.0"
-			},
-			"dependencies": {
-				"airbnb-prop-types": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.14.0.tgz",
-					"integrity": "sha512-Yb09vUkr3KP9r9NqfRuYtDYZG76wt8mhTUi2Vfzsghk+qkg01/gOc9NU8n63ZcMCLzpAdMEXyKjCHlxV62yN1A==",
-					"dev": true,
-					"requires": {
-						"array.prototype.find": "^2.1.0",
-						"function.prototype.name": "^1.1.1",
-						"has": "^1.0.3",
-						"is-regex": "^1.0.4",
-						"object-is": "^1.0.1",
-						"object.assign": "^4.1.0",
-						"object.entries": "^1.1.0",
-						"prop-types": "^15.7.2",
-						"prop-types-exact": "^1.2.0",
-						"react-is": "^16.8.6"
-					},
-					"dependencies": {
-						"function.prototype.name": {
-							"version": "1.1.1",
-							"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.1.tgz",
-							"integrity": "sha512-e1NzkiJuw6xqVH7YSdiW/qDHebcmMhPNe6w+4ZYYEg0VA+LaLzx37RimbPLuonHhYGFGPx1ME2nSi74JiaCr/Q==",
-							"dev": true,
-							"requires": {
-								"define-properties": "^1.1.3",
-								"function-bind": "^1.1.1",
-								"functions-have-names": "^1.1.1",
-								"is-callable": "^1.1.4"
-							}
-						}
-					}
-				},
-				"array.prototype.find": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
-					"integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.13.0"
-					}
-				},
-				"es-abstract": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-					"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.0",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"is-callable": "^1.1.4",
-						"is-regex": "^1.0.4",
-						"object-keys": "^1.0.12"
-					}
-				},
-				"object.entries": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-					"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.12.0",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3"
-					}
-				},
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				},
-				"react-is": {
-					"version": "16.8.6",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-					"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-					"dev": true
-				}
 			}
 		},
 		"enzyme-to-json": {
@@ -10431,14 +7573,6 @@
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.12"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				}
 			}
 		},
 		"equivalent-key-map": {
@@ -10456,13 +7590,12 @@
 			}
 		},
 		"error": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
-			"integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/error/-/error-7.2.0.tgz",
+			"integrity": "sha512-M6t3j3Vt3uDicrViMP5fLq2AeADNrCVFD8Oj4Qt2MHsX0mPYG7D5XdnEfSdRpaHQzjAJ19wu+I1mw9rQYMTAPg==",
 			"dev": true,
 			"requires": {
-				"string-template": "~0.2.1",
-				"xtend": "~4.0.0"
+				"string-template": "~0.2.1"
 			}
 		},
 		"error-ex": {
@@ -10475,15 +7608,20 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+			"integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
 			"requires": {
-				"es-to-primitive": "^1.1.1",
+				"es-to-primitive": "^1.2.0",
 				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.0",
+				"is-callable": "^1.1.4",
+				"is-regex": "^1.0.4",
+				"object-inspect": "^1.6.0",
+				"object-keys": "^1.1.1",
+				"string.prototype.trimleft": "^2.0.0",
+				"string.prototype.trimright": "^2.0.0"
 			}
 		},
 		"es-to-primitive": {
@@ -10524,9 +7662,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
-			"integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
+			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
 			"dev": true,
 			"requires": {
 				"esprima": "^3.1.3",
@@ -10597,64 +7735,16 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-					"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
 					"dev": true
-				},
-				"acorn-jsx": {
-					"version": "5.0.2",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-					"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
-					"dev": true
-				},
-				"ajv": {
-					"version": "6.10.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
 				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.1",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-							"dev": true
-						}
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
 				},
 				"doctrine": {
 					"version": "3.0.0",
@@ -10675,12 +7765,6 @@
 						"estraverse": "^4.1.1"
 					}
 				},
-				"eslint-visitor-keys": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-					"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-					"dev": true
-				},
 				"espree": {
 					"version": "6.1.1",
 					"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
@@ -10693,56 +7777,13 @@
 					}
 				},
 				"glob-parent": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-					"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
-					},
-					"dependencies": {
-						"is-glob": {
-							"version": "4.0.1",
-							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-							"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-							"dev": true,
-							"requires": {
-								"is-extglob": "^2.1.1"
-							}
-						}
 					}
-				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				},
-				"import-fresh": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
-					"dev": true,
-					"requires": {
-						"parent-module": "^1.0.0",
-						"resolve-from": "^4.0.0"
-					}
-				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
 				},
 				"semver": {
 					"version": "6.3.0",
@@ -10774,14 +7815,6 @@
 			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
-			},
-			"dependencies": {
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				}
 			}
 		},
 		"eslint-plugin-jest": {
@@ -10808,17 +7841,6 @@
 				"emoji-regex": "^7.0.2",
 				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.2.1"
-			},
-			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.4.5",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-					"integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
-					"dev": true,
-					"requires": {
-						"regenerator-runtime": "^0.13.2"
-					}
-				}
 			}
 		},
 		"eslint-plugin-react": {
@@ -10836,58 +7858,12 @@
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.2",
 				"resolve": "^1.10.1"
-			},
-			"dependencies": {
-				"object.entries": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-					"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.12.0",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3"
-					}
-				},
-				"object.values": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-					"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-					"dev": true,
-					"requires": {
-						"define-properties": "^1.1.3",
-						"es-abstract": "^1.12.0",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3"
-					}
-				},
-				"prop-types": {
-					"version": "15.7.2",
-					"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-					"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.4.0",
-						"object-assign": "^4.1.1",
-						"react-is": "^16.8.1"
-					}
-				},
-				"resolve": {
-					"version": "1.11.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-					"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				}
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
-			"integrity": "sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
+			"integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
 			"dev": true
 		},
 		"eslint-scope": {
@@ -10910,9 +7886,9 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
 			"dev": true
 		},
 		"espree": {
@@ -10951,15 +7927,15 @@
 			}
 		},
 		"estraverse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
 		"etag": {
@@ -11003,30 +7979,6 @@
 				"p-finally": "^1.0.0",
 				"signal-exit": "^3.0.0",
 				"strip-eof": "^1.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				}
 			}
 		},
 		"execall": {
@@ -11101,26 +8053,26 @@
 			"dev": true
 		},
 		"expand-tilde": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
 			"dev": true,
 			"requires": {
-				"homedir-polyfill": "^1.0.1"
+				"os-homedir": "^1.0.1"
 			}
 		},
 		"expect": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
-			"integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-24.9.0.tgz",
+			"integrity": "sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"ansi-styles": "^3.2.0",
-				"jest-get-type": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-regex-util": "^24.3.0"
+				"jest-get-type": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-regex-util": "^24.9.0"
 			}
 		},
 		"expect-puppeteer": {
@@ -11188,10 +8140,10 @@
 					"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
 					"dev": true
 				},
-				"qs": {
-					"version": "6.7.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true
 				}
 			}
@@ -11220,13 +8172,28 @@
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
 			}
 		},
 		"external-editor": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
 			"dev": true,
 			"requires": {
 				"chardet": "^0.7.0",
@@ -11341,9 +8308,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "2.2.6",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz",
-			"integrity": "sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==",
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+			"integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
 			"dev": true,
 			"requires": {
 				"@mrmlnc/readdir-enhanced": "^2.2.1",
@@ -11515,68 +8482,14 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-			"integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^1.0.0",
+				"make-dir": "^2.0.0",
 				"pkg-dir": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				}
 			}
 		},
 		"find-file-up": {
@@ -11587,55 +8500,6 @@
 			"requires": {
 				"fs-exists-sync": "^0.1.0",
 				"resolve-dir": "^0.1.0"
-			},
-			"dependencies": {
-				"expand-tilde": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-					"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.1"
-					}
-				},
-				"global-modules": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-					"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^0.1.4",
-						"is-windows": "^0.2.0"
-					}
-				},
-				"global-prefix": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-					"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-					"dev": true,
-					"requires": {
-						"homedir-polyfill": "^1.0.0",
-						"ini": "^1.3.4",
-						"is-windows": "^0.2.0",
-						"which": "^1.2.12"
-					}
-				},
-				"is-windows": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-					"dev": true
-				},
-				"resolve-dir": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-					"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-					"dev": true,
-					"requires": {
-						"expand-tilde": "^1.2.2",
-						"global-modules": "^0.2.3"
-					}
-				}
 			}
 		},
 		"find-parent-dir": {
@@ -11724,6 +8588,51 @@
 				"is-glob": "^4.0.0",
 				"micromatch": "^3.0.4",
 				"resolve-dir": "^1.0.1"
+			},
+			"dependencies": {
+				"expand-tilde": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+					"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+					"dev": true,
+					"requires": {
+						"homedir-polyfill": "^1.0.1"
+					}
+				},
+				"global-modules": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+					"dev": true,
+					"requires": {
+						"global-prefix": "^1.0.1",
+						"is-windows": "^1.0.1",
+						"resolve-dir": "^1.0.0"
+					}
+				},
+				"global-prefix": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+					"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+					"dev": true,
+					"requires": {
+						"expand-tilde": "^2.0.2",
+						"homedir-polyfill": "^1.0.1",
+						"ini": "^1.3.4",
+						"is-windows": "^1.0.1",
+						"which": "^1.2.14"
+					}
+				},
+				"resolve-dir": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+					"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+					"dev": true,
+					"requires": {
+						"expand-tilde": "^2.0.0",
+						"global-modules": "^1.0.0"
+					}
+				}
 			}
 		},
 		"flat-cache": {
@@ -11749,9 +8658,9 @@
 			}
 		},
 		"flatted": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
 			"dev": true
 		},
 		"flatten": {
@@ -12162,13 +9071,6 @@
 					"dev": true,
 					"optional": true
 				},
-				"nan": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-					"dev": true,
-					"optional": true
-				},
 				"needle": {
 					"version": "2.3.0",
 					"bundled": true,
@@ -12451,9 +9353,9 @@
 			}
 		},
 		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -12479,13 +9381,14 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
-			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.1.tgz",
+			"integrity": "sha512-e1NzkiJuw6xqVH7YSdiW/qDHebcmMhPNe6w+4ZYYEg0VA+LaLzx37RimbPLuonHhYGFGPx1ME2nSi74JiaCr/Q==",
 			"requires": {
-				"define-properties": "^1.1.2",
+				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1",
-				"is-callable": "^1.1.3"
+				"functions-have-names": "^1.1.1",
+				"is-callable": "^1.1.4"
 			}
 		},
 		"functional-red-black-tree": {
@@ -12497,8 +9400,7 @@
 		"functions-have-names": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.1.1.tgz",
-			"integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw==",
-			"dev": true
+			"integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw=="
 		},
 		"gauge": {
 			"version": "2.7.4",
@@ -12514,6 +9416,43 @@
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1",
 				"wide-align": "^1.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
 			}
 		},
 		"gaze": {
@@ -12538,16 +9477,19 @@
 			"dev": true
 		},
 		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 			"dev": true
 		},
 		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-			"dev": true
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
 		},
 		"get-value": {
 			"version": "2.0.6",
@@ -12566,7 +9508,7 @@
 		},
 		"gettext-parser": {
 			"version": "1.4.0",
-			"resolved": "http://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
 			"integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
 			"requires": {
 				"encoding": "^0.1.12",
@@ -12598,9 +9540,9 @@
 			"dev": true
 		},
 		"glob": {
-			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
 			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
@@ -12648,65 +9590,63 @@
 			}
 		},
 		"global-modules": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+			"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
 			"dev": true,
 			"requires": {
-				"global-prefix": "^3.0.0"
+				"global-prefix": "^0.1.4",
+				"is-windows": "^0.2.0"
 			},
 			"dependencies": {
-				"global-prefix": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-					"dev": true,
-					"requires": {
-						"ini": "^1.3.5",
-						"kind-of": "^6.0.2",
-						"which": "^1.3.1"
-					}
+				"is-windows": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+					"dev": true
 				}
 			}
 		},
 		"global-prefix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.2",
-				"homedir-polyfill": "^1.0.1",
+				"homedir-polyfill": "^1.0.0",
 				"ini": "^1.3.4",
-				"is-windows": "^1.0.1",
-				"which": "^1.2.14"
+				"is-windows": "^0.2.0",
+				"which": "^1.2.12"
+			},
+			"dependencies": {
+				"is-windows": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+					"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+					"dev": true
+				}
 			}
 		},
 		"globals": {
-			"version": "11.8.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-			"integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true
 		},
 		"globby": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+			"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
 			"dev": true,
 			"requires": {
-				"array-union": "^1.0.1",
-				"glob": "^7.0.3",
-				"object-assign": "^4.0.1",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-					"dev": true
-				}
+				"@types/glob": "^7.1.1",
+				"array-union": "^1.0.2",
+				"dir-glob": "^2.2.2",
+				"fast-glob": "^2.2.6",
+				"glob": "^7.1.3",
+				"ignore": "^4.0.3",
+				"pify": "^4.0.1",
+				"slash": "^2.0.0"
 			}
 		},
 		"globjoin": {
@@ -12752,9 +9692,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
 			"dev": true
 		},
 		"graphql": {
@@ -12793,20 +9733,12 @@
 			"requires": {
 				"duplexer": "^0.1.1",
 				"pify": "^4.0.1"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				}
 			}
 		},
 		"handlebars": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.0.tgz",
+			"integrity": "sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -12854,6 +9786,14 @@
 			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				}
 			}
 		},
 		"has-flag": {
@@ -12902,26 +9842,6 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -12989,9 +9909,9 @@
 			"integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
 		},
 		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
@@ -13004,9 +9924,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
 			"dev": true
 		},
 		"hpq": {
@@ -13076,23 +9996,23 @@
 			"dev": true
 		},
 		"htmlparser2": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
-			"integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "^1.3.0",
+				"domelementtype": "^1.3.1",
 				"domhandler": "^2.3.0",
 				"domutils": "^1.5.1",
 				"entities": "^1.1.1",
 				"inherits": "^2.0.1",
-				"readable-stream": "^3.0.6"
+				"readable-stream": "^3.1.1"
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.0.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-					"integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -13113,6 +10033,14 @@
 				"setprototypeof": "1.1.1",
 				"statuses": ">= 1.5.0 < 2",
 				"toidentifier": "1.0.0"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				}
 			}
 		},
 		"http-parser-js": {
@@ -13146,6 +10074,17 @@
 			"requires": {
 				"agent-base": "^4.3.0",
 				"debug": "^3.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
 			}
 		},
 		"husky": {
@@ -13166,18 +10105,6 @@
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"cosmiconfig": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-					"dev": true,
-					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.1",
-						"parse-json": "^4.0.0"
-					}
-				},
 				"find-up": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -13193,16 +10120,6 @@
 					"integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
 					"dev": true
 				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -13213,22 +10130,10 @@
 						"path-exists": "^3.0.0"
 					}
 				},
-				"normalize-package-data": {
-					"version": "2.5.0",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-					"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^2.1.4",
-						"resolve": "^1.10.0",
-						"semver": "2 || 3 || 4 || 5",
-						"validate-npm-package-license": "^3.0.1"
-					}
-				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -13250,13 +10155,15 @@
 					"dev": true
 				},
 				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
 					"dev": true,
 					"requires": {
+						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
 					}
 				},
 				"pkg-dir": {
@@ -13305,24 +10212,15 @@
 					}
 				},
 				"read-pkg": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
-					"integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 					"dev": true,
 					"requires": {
 						"@types/normalize-package-data": "^2.4.0",
 						"normalize-package-data": "^2.5.0",
-						"parse-json": "^4.0.0",
-						"type-fest": "^0.4.1"
-					}
-				},
-				"resolve": {
-					"version": "1.11.1",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-					"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
-					"dev": true,
-					"requires": {
-						"path-parse": "^1.0.6"
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
 					}
 				},
 				"slash": {
@@ -13348,40 +10246,12 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.14"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"ieee754": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-			"integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
 			"dev": true
 		},
 		"iferr": {
@@ -13391,9 +10261,9 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-			"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
 			"dev": true
 		},
 		"ignore-loader": {
@@ -13413,14 +10283,6 @@
 				"npmlog": "^4.1.2",
 				"prebuild-install": "^5.3.0",
 				"which-pm-runs": "^1.0.0"
-			},
-			"dependencies": {
-				"nan": {
-					"version": "2.14.0",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-					"dev": true
-				}
 			}
 		},
 		"import-cwd": {
@@ -13433,30 +10295,13 @@
 			}
 		},
 		"import-fresh": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+			"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
 			"dev": true,
 			"requires": {
-				"caller-path": "^2.0.0",
-				"resolve-from": "^3.0.0"
-			},
-			"dependencies": {
-				"caller-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-					"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-					"dev": true,
-					"requires": {
-						"caller-callsite": "^2.0.0"
-					}
-				},
-				"resolve-from": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-					"dev": true
-				}
+				"parent-module": "^1.0.0",
+				"resolve-from": "^4.0.0"
 			}
 		},
 		"import-from": {
@@ -13490,60 +10335,6 @@
 			"requires": {
 				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				}
 			}
 		},
 		"imurmurhash": {
@@ -13559,13 +10350,10 @@
 			"dev": true
 		},
 		"indent-string": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true,
-			"requires": {
-				"repeating": "^2.0.0"
-			}
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+			"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+			"dev": true
 		},
 		"indexes-of": {
 			"version": "1.0.1",
@@ -13590,9 +10378,9 @@
 			}
 		},
 		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true
 		},
 		"ini": {
@@ -13602,9 +10390,9 @@
 			"dev": true
 		},
 		"inquirer": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
-			"integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+			"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
 			"dev": true,
 			"requires": {
 				"ansi-escapes": "^3.2.0",
@@ -13613,7 +10401,7 @@
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^2.0.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.12",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
@@ -13622,44 +10410,11 @@
 				"through": "^2.3.6"
 			},
 			"dependencies": {
-				"ansi-escapes": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-					"dev": true
-				},
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
-					}
 				},
 				"strip-ansi": {
 					"version": "5.2.0",
@@ -13668,14 +10423,6 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-							"dev": true
-						}
 					}
 				}
 			}
@@ -13750,9 +10497,9 @@
 			}
 		},
 		"is-alphabetical": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.2.tgz",
-			"integrity": "sha512-V0xN4BYezDHcBSKb1QHUFMlR4as/XEuCZBzMJUU4n7+Cbt33SmUnSol+pnXFvLxSHNq2CemUXNdaXV6Flg7+xg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
+			"integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA==",
 			"dev": true
 		},
 		"is-alphanumeric": {
@@ -13762,9 +10509,9 @@
 			"dev": true
 		},
 		"is-alphanumerical": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
-			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
+			"integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
 			"dev": true,
 			"requires": {
 				"is-alphabetical": "^1.0.0",
@@ -13797,15 +10544,6 @@
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
-		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true,
-			"requires": {
-				"builtin-modules": "^1.0.0"
-			}
 		},
 		"is-callable": {
 			"version": "1.1.4",
@@ -13861,9 +10599,9 @@
 			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-decimal": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.2.tgz",
-			"integrity": "sha512-TRzl7mOCchnhchN+f3ICUCzYvL9ul7R+TYOsZ8xia++knyZAJfv/uA1FvQXsAnYIl1T3B2X5E/J7Wb1QXiIBXg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
+			"integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ==",
 			"dev": true
 		},
 		"is-descriptor": {
@@ -13913,13 +10651,10 @@
 			}
 		},
 		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
-			"requires": {
-				"number-is-nan": "^1.0.0"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -13928,18 +10663,18 @@
 			"dev": true
 		},
 		"is-glob": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
 		},
 		"is-hexadecimal": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz",
-			"integrity": "sha512-but/G3sapV3MNyqiDBLrOi4x8uCIw0RY3o/Vb5GT0sMFHrVV7731wFSVy41T5FO1og7G0gXLJh0MkgPRouko/A==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
+			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
 			"dev": true
 		},
 		"is-number": {
@@ -13970,7 +10705,7 @@
 		},
 		"is-obj": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
 			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 			"dev": true
 		},
@@ -13989,6 +10724,15 @@
 			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
 			"dev": true
 		},
+		"is-path-in-cwd": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+			"dev": true,
+			"requires": {
+				"is-path-inside": "^2.1.0"
+			}
+		},
 		"is-path-inside": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
@@ -14005,20 +10749,12 @@
 			"dev": true
 		},
 		"is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+			"integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
+				"isobject": "^4.0.0"
 			}
 		},
 		"is-promise": {
@@ -14104,9 +10840,9 @@
 			"dev": true
 		},
 		"is-whitespace-character": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz",
-			"integrity": "sha512-SzM+T5GKUCtLhlHFKt2SDAX2RFzfS6joT91F2/WSi9LxgFdsnhfPK/UIA+JhRR2xuyLdrCys2PiFDrtn1fU5hQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
+			"integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
 			"dev": true
 		},
 		"is-windows": {
@@ -14116,9 +10852,9 @@
 			"dev": true
 		},
 		"is-word-character": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.2.tgz",
-			"integrity": "sha512-T3FlsX8rCHAH8e7RE7PfOPZVFQlcV3XRF9eOOBQ1uf70OxO7CjjSOjeImMPCADBdYWcStAbVbYvJ1m2D3tb+EA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.3.tgz",
+			"integrity": "sha512-0wfcrFgOOOBdgRNT9H33xe6Zi6yhX/uoc4U8NBZGeQQB0ctU1dnlNTyL9JM2646bHDTpsDm1Brb3VPoCIMrd/A==",
 			"dev": true
 		},
 		"is-wsl": {
@@ -14128,10 +10864,9 @@
 			"dev": true
 		},
 		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -14140,9 +10875,9 @@
 			"dev": true
 		},
 		"isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+			"integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
 			"dev": true
 		},
 		"isomorphic-fetch": {
@@ -14181,105 +10916,6 @@
 				"semver": "^6.0.0"
 			},
 			"dependencies": {
-				"@babel/generator": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-					"integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.5.5",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0",
-						"trim-right": "^1.0.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-					"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-					"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
-					"dev": true
-				},
-				"@babel/template": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-					"integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"@babel/parser": "^7.4.4",
-						"@babel/types": "^7.4.4"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-					"integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.5.5",
-						"@babel/helper-function-name": "^7.1.0",
-						"@babel/helper-split-export-declaration": "^7.4.4",
-						"@babel/parser": "^7.5.5",
-						"@babel/types": "^7.5.5",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					},
-					"dependencies": {
-						"@babel/code-frame": {
-							"version": "7.5.5",
-							"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-							"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-							"dev": true,
-							"requires": {
-								"@babel/highlight": "^7.0.0"
-							}
-						}
-					}
-				},
-				"@babel/types": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-					"integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
-					"dev": true,
-					"requires": {
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"jsesc": {
-					"version": "2.5.2",
-					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-					"dev": true
-				},
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -14299,22 +10935,6 @@
 				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -14339,31 +10959,6 @@
 				"source-map": "^0.6.1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -14397,19 +10992,19 @@
 			"dev": true
 		},
 		"jest": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
-			"integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
+			"integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
 			"dev": true,
 			"requires": {
 				"import-local": "^2.0.0",
-				"jest-cli": "^24.8.0"
+				"jest-cli": "^24.9.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"camelcase": {
@@ -14417,6 +11012,17 @@
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
 				},
 				"find-up": {
 					"version": "3.0.0",
@@ -14427,31 +11033,31 @@
 						"locate-path": "^3.0.0"
 					}
 				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 					"dev": true
 				},
 				"jest-cli": {
-					"version": "24.8.0",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
-					"integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.9.0.tgz",
+					"integrity": "sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==",
 					"dev": true,
 					"requires": {
-						"@jest/core": "^24.8.0",
-						"@jest/test-result": "^24.8.0",
-						"@jest/types": "^24.8.0",
+						"@jest/core": "^24.9.0",
+						"@jest/test-result": "^24.9.0",
+						"@jest/types": "^24.9.0",
 						"chalk": "^2.0.1",
 						"exit": "^0.1.2",
 						"import-local": "^2.0.0",
 						"is-ci": "^2.0.0",
-						"jest-config": "^24.8.0",
-						"jest-util": "^24.8.0",
-						"jest-validate": "^24.8.0",
+						"jest-config": "^24.9.0",
+						"jest-util": "^24.9.0",
+						"jest-validate": "^24.9.0",
 						"prompts": "^2.0.1",
 						"realpath-native": "^1.1.0",
-						"yargs": "^12.0.2"
+						"yargs": "^13.3.0"
 					}
 				},
 				"locate-path": {
@@ -14465,9 +11071,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -14488,49 +11094,71 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
 				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
+						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"strip-ansi": "^5.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.3.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
+						"get-caller-file": "^2.0.1",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
+						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
 					}
 				},
 				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -14540,38 +11168,38 @@
 			}
 		},
 		"jest-changed-files": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
-			"integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.9.0.tgz",
+			"integrity": "sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"execa": "^1.0.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-config": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
-			"integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.9.0.tgz",
+			"integrity": "sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"babel-jest": "^24.8.0",
+				"@jest/test-sequencer": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"babel-jest": "^24.9.0",
 				"chalk": "^2.0.1",
 				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^24.8.0",
-				"jest-environment-node": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
+				"jest-environment-jsdom": "^24.9.0",
+				"jest-environment-node": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"jest-jasmine2": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
 				"micromatch": "^3.1.10",
-				"pretty-format": "^24.8.0",
+				"pretty-format": "^24.9.0",
 				"realpath-native": "^1.1.0"
 			}
 		},
@@ -14591,64 +11219,64 @@
 			}
 		},
 		"jest-diff": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
-			"integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+			"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"diff-sequences": "^24.3.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"diff-sequences": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-docblock": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
-			"integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.9.0.tgz",
+			"integrity": "sha512-F1DjdpDMJMA1cN6He0FNYNZlo3yYmOtRUnktrT9Q37njYzC5WEaDdmbynIgy0L/IvXvvgsG8OsqhLPXTpfmZAA==",
 			"dev": true,
 			"requires": {
 				"detect-newline": "^2.1.0"
 			}
 		},
 		"jest-each": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
-			"integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.9.0.tgz",
+			"integrity": "sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
-			"integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.9.0.tgz",
+			"integrity": "sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jsdom": "^11.5.1"
 			}
 		},
 		"jest-environment-node": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
-			"integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+			"integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^24.8.0",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"jest-mock": "^24.8.0",
-				"jest-util": "^24.8.0"
+				"@jest/environment": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"jest-mock": "^24.9.0",
+				"jest-util": "^24.9.0"
 			}
 		},
 		"jest-environment-puppeteer": {
@@ -14664,85 +11292,86 @@
 			}
 		},
 		"jest-get-type": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
-			"integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+			"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "24.8.1",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
-			"integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
 				"fsevents": "^1.2.7",
 				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
-				"jest-serializer": "^24.4.0",
-				"jest-util": "^24.8.0",
-				"jest-worker": "^24.6.0",
+				"jest-serializer": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-worker": "^24.9.0",
 				"micromatch": "^3.1.10",
 				"sane": "^4.0.3",
 				"walker": "^1.0.7"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
-			"integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.9.0.tgz",
+			"integrity": "sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
 				"co": "^4.6.0",
-				"expect": "^24.8.0",
+				"expect": "^24.9.0",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"pretty-format": "^24.8.0",
+				"jest-each": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"pretty-format": "^24.9.0",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
-			"integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
+			"integrity": "sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
-			"integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.9.0.tgz",
+			"integrity": "sha512-OZz2IXsu6eaiMAwe67c1T+5tUAtQyQx27/EMEkbFAGiw52tB9em+uGbzpcgYVpA8wl0hlxKPZxrly4CXU/GjHA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1",
-				"jest-diff": "^24.8.0",
-				"jest-get-type": "^24.8.0",
-				"pretty-format": "^24.8.0"
+				"jest-diff": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"pretty-format": "^24.9.0"
 			}
 		},
 		"jest-message-util": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
-			"integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+			"integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"@types/stack-utils": "^1.0.1",
 				"chalk": "^2.0.1",
 				"micromatch": "^3.1.10",
@@ -14751,12 +11380,12 @@
 			}
 		},
 		"jest-mock": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
-			"integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+			"integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0"
+				"@jest/types": "^24.9.0"
 			}
 		},
 		"jest-pnp-resolver": {
@@ -14776,18 +11405,18 @@
 			}
 		},
 		"jest-regex-util": {
-			"version": "24.3.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
-			"integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+			"integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
-			"integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.9.0.tgz",
+			"integrity": "sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"browser-resolve": "^1.11.3",
 				"chalk": "^2.0.1",
 				"jest-pnp-resolver": "^1.2.1",
@@ -14795,78 +11424,78 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
-			"integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.9.0.tgz",
+			"integrity": "sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-snapshot": "^24.8.0"
+				"jest-snapshot": "^24.9.0"
 			}
 		},
 		"jest-runner": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
-			"integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.9.0.tgz",
+			"integrity": "sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/environment": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.4.2",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
+				"jest-config": "^24.9.0",
 				"jest-docblock": "^24.3.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-jasmine2": "^24.8.0",
-				"jest-leak-detector": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
-				"jest-runtime": "^24.8.0",
-				"jest-util": "^24.8.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-jasmine2": "^24.9.0",
+				"jest-leak-detector": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-resolve": "^24.9.0",
+				"jest-runtime": "^24.9.0",
+				"jest-util": "^24.9.0",
 				"jest-worker": "^24.6.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^4.0.0"
 			}
 		},
 		"jest-runtime": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
-			"integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.9.0.tgz",
+			"integrity": "sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==",
 			"dev": true,
 			"requires": {
 				"@jest/console": "^24.7.1",
-				"@jest/environment": "^24.8.0",
+				"@jest/environment": "^24.9.0",
 				"@jest/source-map": "^24.3.0",
-				"@jest/transform": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.2",
+				"@jest/transform": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"@types/yargs": "^13.0.0",
 				"chalk": "^2.0.1",
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.1.15",
-				"jest-config": "^24.8.0",
-				"jest-haste-map": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-mock": "^24.8.0",
+				"jest-config": "^24.9.0",
+				"jest-haste-map": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-mock": "^24.9.0",
 				"jest-regex-util": "^24.3.0",
-				"jest-resolve": "^24.8.0",
-				"jest-snapshot": "^24.8.0",
-				"jest-util": "^24.8.0",
-				"jest-validate": "^24.8.0",
+				"jest-resolve": "^24.9.0",
+				"jest-snapshot": "^24.9.0",
+				"jest-util": "^24.9.0",
+				"jest-validate": "^24.9.0",
 				"realpath-native": "^1.1.0",
 				"slash": "^2.0.0",
 				"strip-bom": "^3.0.0",
-				"yargs": "^12.0.2"
+				"yargs": "^13.3.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"camelcase": {
@@ -14874,6 +11503,17 @@
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					}
 				},
 				"find-up": {
 					"version": "3.0.0",
@@ -14884,10 +11524,10 @@
 						"locate-path": "^3.0.0"
 					}
 				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 					"dev": true
 				},
 				"locate-path": {
@@ -14901,9 +11541,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -14924,55 +11564,71 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
 				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
+						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"strip-ansi": "^5.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},
 				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"version": "13.3.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+					"integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
+						"cliui": "^5.0.0",
 						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
+						"get-caller-file": "^2.0.1",
 						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
+						"require-main-filename": "^2.0.0",
 						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
+						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.1"
 					}
 				},
 				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -14982,42 +11638,51 @@
 			}
 		},
 		"jest-serializer": {
-			"version": "24.4.0",
-			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
-			"integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+			"integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
 			"dev": true
 		},
 		"jest-snapshot": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
-			"integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.9.0.tgz",
+			"integrity": "sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.0.0",
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"chalk": "^2.0.1",
-				"expect": "^24.8.0",
-				"jest-diff": "^24.8.0",
-				"jest-matcher-utils": "^24.8.0",
-				"jest-message-util": "^24.8.0",
-				"jest-resolve": "^24.8.0",
+				"expect": "^24.9.0",
+				"jest-diff": "^24.9.0",
+				"jest-get-type": "^24.9.0",
+				"jest-matcher-utils": "^24.9.0",
+				"jest-message-util": "^24.9.0",
+				"jest-resolve": "^24.9.0",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^24.8.0",
-				"semver": "^5.5.0"
+				"pretty-format": "^24.9.0",
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
 			}
 		},
 		"jest-util": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
-			"integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^24.7.1",
-				"@jest/fake-timers": "^24.8.0",
-				"@jest/source-map": "^24.3.0",
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
+				"@jest/console": "^24.9.0",
+				"@jest/fake-timers": "^24.9.0",
+				"@jest/source-map": "^24.9.0",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
 				"callsites": "^3.0.0",
 				"chalk": "^2.0.1",
 				"graceful-fs": "^4.1.15",
@@ -15036,17 +11701,17 @@
 			}
 		},
 		"jest-validate": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
-			"integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
+			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
-				"camelcase": "^5.0.0",
+				"@jest/types": "^24.9.0",
+				"camelcase": "^5.3.1",
 				"chalk": "^2.0.1",
-				"jest-get-type": "^24.8.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^24.8.0"
+				"jest-get-type": "^24.9.0",
+				"leven": "^3.1.0",
+				"pretty-format": "^24.9.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -15058,27 +11723,27 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
-			"integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.9.0.tgz",
+			"integrity": "sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^24.8.0",
-				"@jest/types": "^24.8.0",
-				"@types/yargs": "^12.0.9",
+				"@jest/test-result": "^24.9.0",
+				"@jest/types": "^24.9.0",
+				"@types/yargs": "^13.0.0",
 				"ansi-escapes": "^3.0.0",
 				"chalk": "^2.0.1",
-				"jest-util": "^24.8.0",
+				"jest-util": "^24.9.0",
 				"string-length": "^2.0.0"
 			}
 		},
 		"jest-worker": {
-			"version": "24.6.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
-			"integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+			"integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1",
+				"merge-stream": "^2.0.0",
 				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
@@ -15112,14 +11777,14 @@
 			"dev": true
 		},
 		"js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -15181,9 +11846,9 @@
 			}
 		},
 		"jsesc": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true
 		},
 		"json-parse-better-errors": {
@@ -15226,10 +11891,13 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.0"
+			}
 		},
 		"jsonify": {
 			"version": "0.0.0",
@@ -15305,9 +11973,9 @@
 			"dev": true
 		},
 		"leven": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true
 		},
 		"levn": {
@@ -15363,6 +12031,18 @@
 				"stringify-object": "^3.3.0"
 			},
 			"dependencies": {
+				"@nodelib/fs.stat": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.2.tgz",
+					"integrity": "sha512-z8+wGWV2dgUhLqrtRYa03yDx4HWMvXKi1z8g3m2JyxAx8F7xk74asqPk5LAETjqDSGLFML/6CDl0+yFunSYicw==",
+					"dev": true
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+					"dev": true
+				},
 				"braces": {
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
@@ -15372,44 +12052,29 @@
 						"fill-range": "^7.0.1"
 					}
 				},
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"dev": true
-				},
-				"cosmiconfig": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+				"del": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+					"integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
 					"dev": true,
 					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.1",
-						"parse-json": "^4.0.0"
+						"globby": "^10.0.1",
+						"graceful-fs": "^4.2.2",
+						"is-glob": "^4.0.1",
+						"is-path-cwd": "^2.2.0",
+						"is-path-inside": "^3.0.1",
+						"p-map": "^3.0.0",
+						"rimraf": "^3.0.0",
+						"slash": "^3.0.0"
 					}
 				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
+						"path-type": "^4.0.0"
 					}
 				},
 				"execa": {
@@ -15427,6 +12092,20 @@
 						"p-finally": "^2.0.0",
 						"signal-exit": "^3.0.2",
 						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"fast-glob": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.0.4.tgz",
+					"integrity": "sha512-wkIbV6qg37xTJwqSsdnIphL1e+LaGz4AIQqr00mIubMaEhv1/HEmJ0uuCGZRNRUkZZmOB5mJKO0ZUTVq+SxMQg==",
+					"dev": true,
+					"requires": {
+						"@nodelib/fs.stat": "^2.0.1",
+						"@nodelib/fs.walk": "^1.2.1",
+						"glob-parent": "^5.0.0",
+						"is-glob": "^4.0.1",
+						"merge2": "^1.2.3",
+						"micromatch": "^4.0.2"
 					}
 				},
 				"fill-range": {
@@ -15447,10 +12126,47 @@
 						"pump": "^3.0.0"
 					}
 				},
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globby": {
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.1.tgz",
+					"integrity": "sha512-sSs4inE1FB2YQiymcmTv6NWENryABjUNPeWhOvmn4SjtKybglsyPZxFB3U1/+L1bYi0rNZDqCLlHyLYDl1Pq5A==",
+					"dev": true,
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.0.3",
+						"glob": "^7.1.3",
+						"ignore": "^5.1.1",
+						"merge2": "^1.2.3",
+						"slash": "^3.0.0"
+					}
+				},
+				"ignore": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+					"dev": true
+				},
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-path-inside": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.1.tgz",
+					"integrity": "sha512-CKstxrctq1kUesU6WhtZDbYKzzYBuRH0UYInAVrkc/EYdB9ltbfE0gOoayG9nhohG6447sOOVGhHqsdmBvkbNg==",
 					"dev": true
 				},
 				"is-stream": {
@@ -15458,16 +12174,6 @@
 					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
 					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
 				},
 				"log-symbols": {
 					"version": "3.0.0",
@@ -15477,12 +12183,6 @@
 					"requires": {
 						"chalk": "^2.4.2"
 					}
-				},
-				"merge-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-					"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-					"dev": true
 				},
 				"micromatch": {
 					"version": "4.0.2",
@@ -15500,12 +12200,6 @@
 					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
 				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-					"dev": true
-				},
 				"npm-run-path": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
@@ -15513,14 +12207,6 @@
 					"dev": true,
 					"requires": {
 						"path-key": "^3.0.0"
-					},
-					"dependencies": {
-						"path-key": {
-							"version": "3.1.0",
-							"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-							"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
-							"dev": true
-						}
 					}
 				},
 				"onetime": {
@@ -15538,15 +12224,32 @@
 					"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
 					"dev": true
 				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"aggregate-error": "^3.0.0"
 					}
+				},
+				"path-key": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+					"integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+					"dev": true
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
 				},
 				"to-regex-range": {
 					"version": "5.0.1",
@@ -15574,14 +12277,6 @@
 				"listr-verbose-renderer": "^0.5.0",
 				"p-map": "^2.0.0",
 				"rxjs": "^6.3.3"
-			},
-			"dependencies": {
-				"p-map": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-					"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-					"dev": true
-				}
 			}
 		},
 		"listr-silent-renderer": {
@@ -15606,6 +12301,12 @@
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -15635,12 +12336,6 @@
 						"object-assign": "^4.1.0"
 					}
 				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				},
 				"log-symbols": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
@@ -15648,6 +12343,15 @@
 					"dev": true,
 					"requires": {
 						"chalk": "^1.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -15677,22 +12381,21 @@
 			"dev": true
 		},
 		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				}
 			}
@@ -15704,14 +12407,25 @@
 			"dev": true
 		},
 		"loader-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
 			"dev": true,
 			"requires": {
-				"big.js": "^3.1.3",
+				"big.js": "^5.2.2",
 				"emojis-list": "^2.0.0",
-				"json5": "^0.5.0"
+				"json5": "^1.0.1"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				}
 			}
 		},
 		"locate-path": {
@@ -15730,9 +12444,9 @@
 			"integrity": "sha512-AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ=="
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash._basecallback": {
 			"version": "3.3.1",
@@ -15921,22 +12635,6 @@
 					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 					"dev": true
 				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -15965,9 +12663,9 @@
 			"dev": true
 		},
 		"longest-streak": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
-			"integrity": "sha512-TmYTeEYxiAmSVdpbnQDXGtvYOIRsCMg89CVZzwzc2o7GFL1CjoiRPjH5ec0NFAVlAx3fVof9dX/t6KKRAo2OWA==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.3.tgz",
+			"integrity": "sha512-9lz5IVdpwsKLMzQi0MQ+oD9EA0mIGcWYP7jXMTZVXP8D42PwuAk+M/HBFYQoxt1G5OR8m7aSIgb1UymfWGBWEw==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -15989,9 +12687,9 @@
 			}
 		},
 		"lru-cache": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"dev": true,
 			"requires": {
 				"pseudomap": "^1.0.2",
@@ -16005,12 +12703,13 @@
 			"dev": true
 		},
 		"make-dir": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "^4.0.1",
+				"semver": "^5.6.0"
 			}
 		},
 		"makeerror": {
@@ -16044,9 +12743,9 @@
 			"dev": true
 		},
 		"map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+			"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
 			"dev": true
 		},
 		"map-values": {
@@ -16065,21 +12764,21 @@
 			}
 		},
 		"markdown-escapes": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.2.tgz",
-			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.3.tgz",
+			"integrity": "sha512-XUi5HJhhV5R74k8/0H2oCbCiYf/u4cO/rX8tnGkRvrqhsr5BRNU6Mg0yt/8UIx1iIS8220BNJsDb7XnILhLepw==",
 			"dev": true
 		},
 		"markdown-table": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
-			"integrity": "sha512-NcWuJFHDA8V3wkDgR/j4+gZx+YQwstPgfQDV8ndUeWWzta3dnDTBxpVzqS9lkmJAuV5YX35lmyojl6HO5JXAgw==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz",
+			"integrity": "sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==",
 			"dev": true
 		},
 		"mathml-tag-names": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz",
-			"integrity": "sha512-3Zs9P/0zzwTob2pdgT0CHZuMbnSUSp8MB1bddfm+HDmnFWHGT4jvEZRf+2RuPoa+cjdn/z25SEt5gFTqdhvJAg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.1.tgz",
+			"integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
 			"dev": true
 		},
 		"md5.js": {
@@ -16094,18 +12793,18 @@
 			}
 		},
 		"mdast-util-compact": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.2.tgz",
-			"integrity": "sha512-d2WS98JSDVbpSsBfVvD9TaDMlqPRz7ohM/11G0rp5jOBb5q96RJ6YLszQ/09AAixyzh23FeIpCGqfaamEADtWg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.3.tgz",
+			"integrity": "sha512-nRiU5GpNy62rZppDKbLwhhtw5DXoFMqw9UNZFmlPsNaQCZ//WLjGKUwWMdJrUH+Se7UvtO2gXtAMe0g/N+eI5w==",
 			"dev": true,
 			"requires": {
 				"unist-util-visit": "^1.1.0"
 			}
 		},
 		"mdn-data": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-			"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
 			"dev": true
 		},
 		"media-typer": {
@@ -16115,14 +12814,12 @@
 			"dev": true
 		},
 		"mem": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^1.0.0",
-				"p-is-promise": "^2.0.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"memize": {
@@ -16146,28 +12843,40 @@
 			}
 		},
 		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
+			"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
+				"camelcase-keys": "^4.0.0",
+				"decamelize-keys": "^1.0.0",
 				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
+				"minimist-options": "^3.0.1",
 				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
+				"read-pkg-up": "^3.0.0",
+				"redent": "^2.0.0",
+				"trim-newlines": "^2.0.0",
+				"yargs-parser": "^10.0.0"
 			},
 			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
+				"read-pkg-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^3.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^4.1.0"
+					}
 				}
 			}
 		},
@@ -16182,19 +12891,6 @@
 				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
-				"clone-deep": {
-					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-					"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
-					"dev": true,
-					"requires": {
-						"for-own": "^0.1.3",
-						"is-plain-object": "^2.0.1",
-						"kind-of": "^3.0.2",
-						"lazy-cache": "^1.0.3",
-						"shallow-clone": "^0.1.2"
-					}
-				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -16202,35 +12898,6 @@
 					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
-					}
-				},
-				"shallow-clone": {
-					"version": "0.1.2",
-					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-					"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.1",
-						"kind-of": "^2.0.1",
-						"lazy-cache": "^0.2.3",
-						"mixin-object": "^2.0.1"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "2.0.1",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-							"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.0.2"
-							}
-						},
-						"lazy-cache": {
-							"version": "0.2.7",
-							"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-							"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
-							"dev": true
-						}
 					}
 				}
 			}
@@ -16242,18 +12909,15 @@
 			"dev": true
 		},
 		"merge-stream": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "^2.0.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true
 		},
 		"merge2": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
 			"dev": true
 		},
 		"methods": {
@@ -16300,18 +12964,18 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-			"integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.21",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+			"version": "2.1.24",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.40.0"
 			}
 		},
 		"mimic-fn": {
@@ -16321,9 +12985,9 @@
 			"dev": true
 		},
 		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+			"integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
 			"dev": true
 		},
 		"mini-create-react-context": {
@@ -16384,9 +13048,9 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true
 		},
 		"minimist-options": {
@@ -16418,9 +13082,9 @@
 			}
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -16435,6 +13099,21 @@
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
 			}
 		},
@@ -16458,22 +13137,30 @@
 		},
 		"mkdirp": {
 			"version": "0.5.1",
-			"resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"dev": true,
 			"requires": {
 				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
 			}
 		},
 		"moment": {
-			"version": "2.22.2",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+			"integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ=="
 		},
 		"moment-timezone": {
-			"version": "0.5.23",
-			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
-			"integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
+			"version": "0.5.26",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+			"integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
 			"requires": {
 				"moment": ">= 2.9.0"
 			}
@@ -16515,9 +13202,9 @@
 			}
 		},
 		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
 		"mute-stream": {
@@ -16533,11 +13220,10 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-			"dev": true,
-			"optional": true
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+			"dev": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -16556,20 +13242,6 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				}
 			}
 		},
 		"napi-build-utils": {
@@ -16585,9 +13257,9 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.18.0.tgz",
-			"integrity": "sha512-/zQOMCeJcioI0xJtd5RpBiWw2WP7wLe6vq8/3Yu0rEwgus/G/+pViX80oA87JdVgjRt2895mZSv2VfZmy4W1uw==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.0.tgz",
+			"integrity": "sha512-2v52FTw7RPqieZr3Gth1luAXZR7Je6q3KaDHY5bjl/paDUdMu35fZ8ICNgiYJRr3tf3NMvIQQR1r27AvEr9CRA==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -16604,9 +13276,9 @@
 			"dev": true
 		},
 		"neo-async": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
 			"dev": true
 		},
 		"nice-try": {
@@ -16616,9 +13288,9 @@
 			"dev": true
 		},
 		"node-abi": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.10.0.tgz",
-			"integrity": "sha512-OT0WepUvYHXdki6DU8LWhEkuo3M44i2paWBYtH9qXtPb9YiKlYEKa5WUII20XEcOv7UJPzfB0kZfPZdW46zdkw==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.11.0.tgz",
+			"integrity": "sha512-kuy/aEg75u40v378WRllQ4ZexaXJiCvB68D2scDXclp/I4cRq6togpbOoKhmN07tns9Zldu51NNERo0wehfX9g==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.4.1"
@@ -16722,9 +13394,9 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.1.tgz",
-			"integrity": "sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.3.tgz",
+			"integrity": "sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
@@ -16735,9 +13407,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.26",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-			"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+			"version": "1.1.32",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.32.tgz",
+			"integrity": "sha512-VhVknkitq8dqtWoluagsGPn3dxTvN9fwgR59fV3D7sLBHe0JfDramsMI8n8mY//ccq/Kkrf8ZRHRpsyVZ3qw1A==",
 			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
@@ -16768,11 +13440,33 @@
 				"true-case-path": "^1.0.2"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
 					"dev": true
+				},
+				"camelcase": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+					"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+					"dev": true
+				},
+				"camelcase-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+					"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^2.0.0",
+						"map-obj": "^1.0.0"
+					}
 				},
 				"chalk": {
 					"version": "1.1.3",
@@ -16787,16 +13481,181 @@
 						"supports-color": "^2.0.0"
 					}
 				},
-				"nan": {
-					"version": "2.13.2",
-					"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-					"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+				"cross-spawn": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
+					}
+				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"get-stdin": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+					"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
 					"dev": true
+				},
+				"indent-string": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+					"dev": true,
+					"requires": {
+						"repeating": "^2.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
+				"map-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+					"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+					"dev": true
+				},
+				"meow": {
+					"version": "3.7.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+					"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+					"dev": true,
+					"requires": {
+						"camelcase-keys": "^2.0.0",
+						"decamelize": "^1.1.2",
+						"loud-rejection": "^1.0.0",
+						"map-obj": "^1.0.1",
+						"minimist": "^1.1.3",
+						"normalize-package-data": "^2.3.4",
+						"object-assign": "^4.0.1",
+						"read-pkg-up": "^1.0.1",
+						"redent": "^1.0.0",
+						"trim-newlines": "^1.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					}
+				},
+				"redent": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+					"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+					"dev": true,
+					"requires": {
+						"indent-string": "^2.1.0",
+						"strip-indent": "^1.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
+					}
+				},
+				"strip-indent": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+					"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+					"dev": true,
+					"requires": {
+						"get-stdin": "^4.0.1"
+					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
 					"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+					"dev": true
+				},
+				"trim-newlines": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
 					"dev": true
 				}
 			}
@@ -16817,25 +13676,22 @@
 			}
 		},
 		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
 			"dev": true,
 			"requires": {
 				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
+				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
-			"requires": {
-				"remove-trailing-separator": "^1.0.1"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true
 		},
 		"normalize-range": {
 			"version": "0.1.2",
@@ -16876,172 +13732,11 @@
 				"validator": "^10.11.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.10.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0",
-						"map-obj": "^2.0.0",
-						"quick-lru": "^1.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"ignore": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
 					"dev": true
-				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-					"dev": true
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"map-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
-				},
-				"meow": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0",
-						"yargs-parser": "^10.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"redent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^3.0.0",
-						"strip-indent": "^2.0.0"
-					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				},
-				"strip-indent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
-				},
-				"trim-newlines": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
-					}
 				}
 			}
 		},
@@ -17144,8 +13839,7 @@
 		"object-inspect": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
-			"dev": true
+			"integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
 		},
 		"object-is": {
 			"version": "1.0.1",
@@ -17153,9 +13847,9 @@
 			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
 		},
 		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
@@ -17186,14 +13880,14 @@
 			}
 		},
 		"object.entries": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-			"integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+			"integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
 			}
 		},
 		"object.fromentries": {
@@ -17236,14 +13930,14 @@
 			}
 		},
 		"object.values": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-			"integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
+			"integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.6.1",
-				"function-bind": "^1.1.0",
-				"has": "^1.0.1"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.12.0",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
 			}
 		},
 		"octokit-pagination-methods": {
@@ -17295,6 +13989,12 @@
 				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
+				"minimist": {
+					"version": "0.0.10",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+					"dev": true
+				},
 				"wordwrap": {
 					"version": "0.0.3",
 					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -17325,35 +14025,52 @@
 		},
 		"os-homedir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true
 		},
 		"os-locale": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "^1.0.0",
-				"lcid": "^2.0.0",
-				"mem": "^4.0.0"
+				"execa": "^0.7.0",
+				"lcid": "^1.0.0",
+				"mem": "^1.1.0"
 			},
 			"dependencies": {
-				"invert-kv": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-					"dev": true
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+				"cross-spawn": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"invert-kv": "^2.0.0"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
+				},
+				"execa": {
+					"version": "0.7.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"dev": true
 				}
 			}
 		},
@@ -17369,7 +14086,7 @@
 		},
 		"os-tmpdir": {
 			"version": "1.0.2",
-			"resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
@@ -17405,9 +14122,9 @@
 			"dev": true
 		},
 		"p-is-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true
 		},
 		"p-limit": {
@@ -17429,13 +14146,10 @@
 			}
 		},
 		"p-map": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-			"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-			"dev": true,
-			"requires": {
-				"aggregate-error": "^3.0.0"
-			}
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+			"dev": true
 		},
 		"p-reduce": {
 			"version": "1.0.0",
@@ -17450,18 +14164,18 @@
 			"dev": true
 		},
 		"pako": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
-			"integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
 			"dev": true
 		},
 		"parallel-transform": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+			"integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
 			"dev": true,
 			"requires": {
-				"cyclist": "~0.2.2",
+				"cyclist": "^1.0.1",
 				"inherits": "^2.0.3",
 				"readable-stream": "^2.1.5"
 			}
@@ -17476,9 +14190,9 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-			"integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
+			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
 			"dev": true,
 			"requires": {
 				"asn1.js": "^4.0.0",
@@ -17490,9 +14204,9 @@
 			}
 		},
 		"parse-entities": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.1.tgz",
-			"integrity": "sha512-NBWYLQm1KSoDKk7GAHyioLTvCZ5QjdH/ASBBQTD3iLiAWJXS5bg1jEWI8nIJ+vgVvsceBVBcDGRWSo0KVQBvvg==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
 			"dev": true,
 			"requires": {
 				"character-entities": "^1.0.0",
@@ -17504,12 +14218,13 @@
 			}
 		},
 		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
 			}
 		},
 		"parse-passwd": {
@@ -17564,7 +14279,7 @@
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true
 		},
@@ -17592,30 +14307,21 @@
 			"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
 			"requires": {
 				"isarray": "0.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				}
 			}
 		},
 		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
-					"version": "2.3.0",
-					"resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				}
 			}
@@ -17652,9 +14358,9 @@
 			"dev": true
 		},
 		"pify": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true
 		},
 		"pinkie": {
@@ -17682,18 +14388,63 @@
 			}
 		},
 		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				}
 			}
 		},
 		"please-upgrade-node": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
-			"integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
 			"dev": true,
 			"requires": {
 				"semver-compare": "^1.0.0"
@@ -17738,9 +14489,9 @@
 			}
 		},
 		"portfinder": {
-			"version": "1.0.21",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
-			"integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
+			"version": "1.0.24",
+			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.24.tgz",
+			"integrity": "sha512-ekRl7zD2qxYndYflwiryJwMioBI7LI7rVXg3EnLK3sjkouT5eOuhS3gS255XxBksa30VG8UPZYZCdgfGOfkSUg==",
 			"dev": true,
 			"requires": {
 				"async": "^1.5.2",
@@ -17778,14 +14529,14 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.5.tgz",
-			"integrity": "sha512-HBNpviAUFCKvEh7NZhw1e8MBPivRszIiUnhrJ+sBFVSYSqubrzwX3KG51mYgcRHX8j/cAgZJedONZcm5jTBdgQ==",
+			"version": "7.0.18",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+			"integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.1",
+				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
-				"supports-color": "^5.5.0"
+				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -17793,6 +14544,15 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
+				},
+				"supports-color": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -17911,106 +14671,16 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.14"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					},
-					"dependencies": {
-						"supports-color": {
-							"version": "5.5.0",
-							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						}
-					}
-				},
-				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-load-config": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+			"integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
 			"dev": true,
 			"requires": {
-				"cosmiconfig": "^4.0.0",
+				"cosmiconfig": "^5.0.0",
 				"import-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-					"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-					"dev": true,
-					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.9.0",
-						"parse-json": "^4.0.0",
-						"require-from-string": "^2.0.1"
-					}
-				},
-				"esprima": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
-				},
-				"js-yaml": {
-					"version": "3.12.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				}
 			}
 		},
 		"postcss-loader": {
@@ -18136,17 +14806,6 @@
 				"postcss-value-parser": "^4.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
@@ -18159,25 +14818,10 @@
 					}
 				},
 				"postcss-value-parser": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.1.tgz",
-					"integrity": "sha512-3Jk+/CVH0HBfgSSFWALKm9Hyzf4kumPjZfUxkRYZNcqFztELb2APKxv0nlX8HCdc1/ymePmT/nFf1ST6fjWH2A==",
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -18191,17 +14835,6 @@
 				"postcss-selector-parser": "^6.0.0"
 			},
 			"dependencies": {
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
 				"postcss-selector-parser": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
@@ -18211,21 +14844,6 @@
 						"cssesc": "^3.0.0",
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -18238,34 +14856,6 @@
 			"requires": {
 				"icss-utils": "^4.0.0",
 				"postcss": "^7.0.6"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-charset": {
@@ -18412,58 +15002,6 @@
 				"lodash": "^4.17.11",
 				"log-symbols": "^2.2.0",
 				"postcss": "^7.0.7"
-			},
-			"dependencies": {
-				"postcss": {
-					"version": "7.0.14",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.14.tgz",
-					"integrity": "sha512-NsbD6XUUMZvBxtQAJuWDJeeC4QFsmWsfozWxCJPWf3M55K9iu2iMDaKqyoOdTJ1R4usBXuxlVFAIo8rZPQD4Bg==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					},
-					"dependencies": {
-						"chalk": {
-							"version": "2.4.2",
-							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							},
-							"dependencies": {
-								"supports-color": {
-									"version": "5.5.0",
-									"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-									"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-									"dev": true,
-									"requires": {
-										"has-flag": "^3.0.0"
-									}
-								}
-							}
-						}
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-resolve-nested-selector": {
@@ -18558,9 +15096,9 @@
 			}
 		},
 		"prebuild-install": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
-			"integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.2.tgz",
+			"integrity": "sha512-INDfXzTPnhT+WYQemqnAXlP7SvfiFMopMozSgXCZ+RDLb279gKfIuLk4o7PgEawLp3WrMgIYGBpkxpraROHsSA==",
 			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3",
@@ -18572,31 +15110,12 @@
 				"node-abi": "^2.7.0",
 				"noop-logger": "^0.1.1",
 				"npmlog": "^4.0.1",
-				"os-homedir": "^1.0.1",
-				"pump": "^2.0.1",
+				"pump": "^3.0.0",
 				"rc": "^1.2.7",
-				"simple-get": "^2.7.0",
-				"tar-fs": "^1.13.0",
+				"simple-get": "^3.0.3",
+				"tar-fs": "^2.0.0",
 				"tunnel-agent": "^0.6.0",
 				"which-pm-runs": "^1.0.0"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"pump": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-					"dev": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
 			}
 		},
 		"prelude-ls": {
@@ -18677,6 +15196,15 @@
 				"yaml-unist-parser": "1.0.0"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+					"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.0.0"
+					}
+				},
 				"@babel/parser": {
 					"version": "7.2.0",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.0.tgz",
@@ -18702,15 +15230,9 @@
 					}
 				},
 				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"chalk": {
@@ -18724,11 +15246,48 @@
 						"supports-color": "^4.0.0"
 					}
 				},
+				"cosmiconfig": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
+					"integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^2.0.0",
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.9.0",
+						"parse-json": "^4.0.0"
+					}
+				},
 				"diff": {
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
 					"integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
 					"dev": true
+				},
+				"esutils": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+					"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+					"dev": true
+				},
+				"get-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+					"dev": true
+				},
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
 				},
 				"has-flag": {
 					"version": "2.0.0",
@@ -18736,17 +15295,15 @@
 					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
 					"dev": true
 				},
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
+				"import-fresh": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"dev": true,
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
 				},
 				"jest-docblock": {
 					"version": "23.2.0",
@@ -18757,25 +15314,16 @@
 						"detect-newline": "^2.1.0"
 					}
 				},
-				"mem": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
 					"dev": true
 				},
-				"normalize-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
 					"dev": true
 				},
 				"postcss": {
@@ -18886,6 +15434,12 @@
 						"path-parse": "^1.0.5"
 					}
 				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				},
 				"semver": {
 					"version": "5.4.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -18903,6 +15457,12 @@
 						"strip-ansi": "^5.0.0"
 					},
 					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
 						"strip-ansi": {
 							"version": "5.2.0",
 							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -18912,6 +15472,15 @@
 								"ansi-regex": "^4.1.0"
 							}
 						}
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"supports-color": {
@@ -18953,12 +15522,12 @@
 			}
 		},
 		"pretty-format": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
-			"integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.8.0",
+				"@jest/types": "^24.9.0",
 				"ansi-regex": "^4.0.0",
 				"ansi-styles": "^3.2.0",
 				"react-is": "^16.8.4"
@@ -19022,15 +15591,15 @@
 			"dev": true
 		},
 		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
 		"progress": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-			"integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
 		},
 		"progress-bar-webpack-plugin": {
@@ -19044,6 +15613,12 @@
 				"progress": "^1.1.8"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -19068,6 +15643,15 @@
 					"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
 					"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
 					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
@@ -19099,6 +15683,14 @@
 			"requires": {
 				"pify": "^3.0.0",
 				"read": "^1.0.4"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
 			}
 		},
 		"prompts": {
@@ -19160,9 +15752,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.29",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-			"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
 			"dev": true
 		},
 		"public-encrypt": {
@@ -19234,6 +15826,15 @@
 				"ws": "^5.1.1"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -19252,9 +15853,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"version": "6.7.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
 		},
 		"query-string": {
 			"version": "4.3.4",
@@ -19356,14 +15957,6 @@
 				"ini": "~1.3.0",
 				"minimist": "^1.2.0",
 				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"re-resizable": {
@@ -19372,14 +15965,13 @@
 			"integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
 		},
 		"react": {
-			"version": "16.6.3",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
-			"integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+			"integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.11.2"
+				"prop-types": "^15.6.2"
 			}
 		},
 		"react-addons-create-fragment": {
@@ -19441,20 +16033,20 @@
 			}
 		},
 		"react-dom": {
-			"version": "16.6.3",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
-			"integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+			"integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
-				"scheduler": "^0.11.2"
+				"scheduler": "^0.15.0"
 			}
 		},
 		"react-is": {
-			"version": "16.8.4",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
-			"integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA=="
+			"version": "16.9.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
+			"integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
@@ -19462,28 +16054,29 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
 		"react-moment-proptypes": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz",
-			"integrity": "sha512-4h7EuhDMTzQqZ+02KUUO+AVA7PqhbD88yXB740nFpNDyDS/bj9jiPyn2rwr9sa8oDyaE1ByFN9+t5XPyPTmN6g==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.7.0.tgz",
+			"integrity": "sha512-ZbOn/P4u469WEGAw5hgkS/E+g1YZqdves2BjYsLluJobzUZCtManhjHiZKjniBVT7MSHM6D/iKtRVzlXVv3ikA==",
 			"requires": {
 				"moment": ">=1.6.0"
 			}
 		},
 		"react-outside-click-handler": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.2.tgz",
-			"integrity": "sha512-MgCxmFARGN1VrZdwoLkER/y3So6mC/fSniXI4XcXcB+Jt05nw/k8a/R1hSoa7p414uZUZ8NfClN3eVmZm9bM5Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.4.tgz",
+			"integrity": "sha512-FwLnTllTa65O/HjIyDgIrlAKcgPeXQnRUE+iR1EV4NY5opzN37S87+AtO1FF0rAa8qBDKj2QuNp4VfkjmkiB7g==",
 			"requires": {
-				"airbnb-prop-types": "^2.10.0",
+				"airbnb-prop-types": "^2.13.2",
 				"consolidated-events": "^1.1.1 || ^2.0.0",
-				"object.values": "^1.0.4",
-				"prop-types": "^15.6.1"
+				"document.contains": "^1.0.1",
+				"object.values": "^1.1.0",
+				"prop-types": "^15.7.2"
 			}
 		},
 		"react-portal": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.1.5.tgz",
-			"integrity": "sha512-jJMy9DoVr4HRWPdO8IP/mDHP1Q972/aKkulVQeIrttOIyRNmCkR2IH7gK3HVjhzxy6M+k9TopSWN5q41wO/o6A==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.0.tgz",
+			"integrity": "sha512-Zf+vGQ/VEAb5XAy+muKEn48yhdCNYPZaB1BWg1xc8sAZWD8pXTgPtQT4ihBdmWzsfCq8p8/kqf0GWydSBqc+Eg==",
 			"requires": {
 				"prop-types": "^15.5.8"
 			}
@@ -19551,12 +16144,6 @@
 				"scheduler": "^0.13.6"
 			},
 			"dependencies": {
-				"react-is": {
-					"version": "16.8.6",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-					"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-					"dev": true
-				},
 				"scheduler": {
 					"version": "0.13.6",
 					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
@@ -19581,29 +16168,49 @@
 			}
 		},
 		"react-with-direction": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.0.tgz",
-			"integrity": "sha512-2TflEebNckTNUybw3Rzqjg4BwM/H380ZL5lsbZ5f4UTY2JyE5uQdQZK5T2w+BDJSAMcqoA2RDJYa4e7Cl6C2Kg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.3.1.tgz",
+			"integrity": "sha512-aGcM21ZzhqeXFvDCfPj0rVNYuaVXfTz5D3Rbn0QMz/unZe+CCiLHthrjQWO7s6qdfXORgYFtmS7OVsRgSk5LXQ==",
 			"requires": {
-				"airbnb-prop-types": "^2.8.1",
+				"airbnb-prop-types": "^2.10.0",
 				"brcast": "^2.0.2",
-				"deepmerge": "^1.5.1",
-				"direction": "^1.0.1",
-				"hoist-non-react-statics": "^2.3.1",
+				"deepmerge": "^1.5.2",
+				"direction": "^1.0.2",
+				"hoist-non-react-statics": "^3.3.0",
 				"object.assign": "^4.1.0",
 				"object.values": "^1.0.4",
-				"prop-types": "^15.6.0"
+				"prop-types": "^15.6.2"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+					"requires": {
+						"react-is": "^16.7.0"
+					}
+				}
 			}
 		},
 		"react-with-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.1.tgz",
-			"integrity": "sha512-L+x/EDgrKkqV6pTfDtLMShf7Xs+bVQ+HAT5rByX88QYX+ft9t5Gn4PWMmg36Ur21IVEBMGjjQQIJGJpBrzbsyg==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+			"integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
 			"requires": {
-				"deepmerge": "^1.5.2",
-				"hoist-non-react-statics": "^2.5.0",
-				"prop-types": "^15.6.1",
+				"hoist-non-react-statics": "^3.2.1",
+				"object.assign": "^4.1.0",
+				"prop-types": "^15.6.2",
 				"react-with-direction": "^1.3.0"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+					"requires": {
+						"react-is": "^16.7.0"
+					}
+				}
 			}
 		},
 		"react-with-styles-interface-css": {
@@ -19625,50 +16232,74 @@
 			}
 		},
 		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^1.0.0",
+				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"path-type": "^3.0.0"
 			}
 		},
 		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+			"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "^3.0.0",
+				"read-pkg": "^3.0.0"
 			},
 			"dependencies": {
 				"find-up": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"locate-path": "^3.0.0"
 					}
 				},
-				"path-exists": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				}
 			}
 		},
 		"readable-stream": {
 			"version": "2.3.6",
-			"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"requires": {
@@ -19679,6 +16310,20 @@
 				"safe-buffer": "~5.1.1",
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"readdirp": {
@@ -19702,19 +16347,19 @@
 			}
 		},
 		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+			"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
 			"dev": true,
 			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
+				"indent-string": "^3.0.0",
+				"strip-indent": "^2.0.0"
 			}
 		},
 		"redux": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
-			"integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
+			"integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"symbol-observable": "^1.2.0"
@@ -19759,9 +16404,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.2",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.1",
@@ -19781,12 +16426,6 @@
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
 			}
-		},
-		"regexp-tree": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.13.tgz",
-			"integrity": "sha512-hwdV/GQY5F8ReLZWO+W1SRoN5YfpOKY6852+tBFcma72DKBIcHjPRIlIvQN35bCOljuAfP2G2iB0FC/w236mUw==",
-			"dev": true
 		},
 		"regexp-util": {
 			"version": "1.2.2",
@@ -19830,6 +16469,14 @@
 			"dev": true,
 			"requires": {
 				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				}
 			}
 		},
 		"remark": {
@@ -19961,6 +16608,30 @@
 				"tough-cookie": "~2.4.3",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+					"dev": true
+				},
+				"qs": {
+					"version": "6.5.2",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.24",
+						"punycode": "^1.4.1"
+					}
+				}
 			}
 		},
 		"request-promise": {
@@ -20001,12 +16672,6 @@
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 			"dev": true
 		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true
-		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -20020,12 +16685,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-bin": {
@@ -20055,26 +16720,13 @@
 			}
 		},
 		"resolve-dir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
 			"dev": true,
 			"requires": {
-				"expand-tilde": "^2.0.0",
-				"global-modules": "^1.0.0"
-			},
-			"dependencies": {
-				"global-modules": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-					"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-					"dev": true,
-					"requires": {
-						"global-prefix": "^1.0.1",
-						"is-windows": "^1.0.1",
-						"resolve-dir": "^1.0.0"
-					}
-				}
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
 			}
 		},
 		"resolve-from": {
@@ -20237,18 +16889,18 @@
 			"dev": true
 		},
 		"rxjs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
-			"integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+			"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
 		},
 		"safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 		},
 		"safe-json-parse": {
 			"version": "1.0.1",
@@ -20258,7 +16910,7 @@
 		},
 		"safe-regex": {
 			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
@@ -20285,14 +16937,6 @@
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				}
 			}
 		},
 		"sass-graph": {
@@ -20307,6 +16951,12 @@
 				"yargs": "^7.0.0"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"camelcase": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -20324,6 +16974,38 @@
 						"wrap-ansi": "^2.0.0"
 					}
 				},
+				"find-up": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+					"dev": true,
+					"requires": {
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
+					}
+				},
 				"os-locale": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -20331,6 +17013,91 @@
 					"dev": true,
 					"requires": {
 						"lcid": "^1.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-exists": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+					"dev": true,
+					"requires": {
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"path-type": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+					"dev": true,
+					"requires": {
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+					"dev": true,
+					"requires": {
+						"is-utf8": "^0.2.0"
 					}
 				},
 				"which-module": {
@@ -20384,10 +17151,30 @@
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
-				"pify": {
+				"clone-deep": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+					"integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4",
+						"kind-of": "^6.0.2",
+						"shallow-clone": "^3.0.0"
+					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				},
 				"semver": {
@@ -20395,6 +17182,15 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
+				},
+				"shallow-clone": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+					"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.2"
+					}
 				}
 			}
 		},
@@ -20405,9 +17201,9 @@
 			"dev": true
 		},
 		"scheduler": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
-			"integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+			"integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -20451,9 +17247,9 @@
 			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
 		},
 		"semver": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"dev": true
 		},
 		"semver-compare": {
@@ -20505,13 +17301,19 @@
 					"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
 					"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
 					"dev": true
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
 				}
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-			"integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
 			"dev": true
 		},
 		"serve-static": {
@@ -20533,9 +17335,9 @@
 			"dev": true
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -20552,6 +17354,21 @@
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
+				},
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
 				}
 			}
 		},
@@ -20568,7 +17385,7 @@
 		},
 		"sha.js": {
 			"version": "2.4.11",
-			"resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
@@ -20577,12 +17394,32 @@
 			}
 		},
 		"shallow-clone": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-			"integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+			"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^6.0.2"
+				"is-extendable": "^0.1.1",
+				"kind-of": "^2.0.1",
+				"lazy-cache": "^0.2.3",
+				"mixin-object": "^2.0.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.0.2"
+					}
+				},
+				"lazy-cache": {
+					"version": "0.2.7",
+					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+					"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+					"dev": true
+				}
 			}
 		},
 		"shebang-command": {
@@ -20615,89 +17452,6 @@
 				"yargs": "^10.0.3"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^4.0.1",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
-				"execa": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"mem": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-					"dev": true,
-					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
 				"yargs": {
 					"version": "10.1.2",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
@@ -20716,15 +17470,6 @@
 						"which-module": "^2.0.0",
 						"y18n": "^3.2.1",
 						"yargs-parser": "^8.1.0"
-					}
-				},
-				"yargs-parser": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
-					"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -20748,12 +17493,12 @@
 			"dev": true
 		},
 		"simple-get": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
 			"dev": true,
 			"requires": {
-				"decompress-response": "^3.3.0",
+				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
 				"simple-concat": "^1.0.0"
 			}
@@ -20802,14 +17547,6 @@
 				"ansi-styles": "^3.2.0",
 				"astral-regex": "^1.0.0",
 				"is-fullwidth-code-point": "^2.0.0"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				}
 			}
 		},
 		"snapdragon": {
@@ -21021,9 +17758,9 @@
 			}
 		},
 		"spdx-correct": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+			"integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
 			"dev": true,
 			"requires": {
 				"spdx-expression-parse": "^3.0.0",
@@ -21047,9 +17784,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-			"integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
 			"dev": true
 		},
 		"specificity": {
@@ -21068,14 +17805,14 @@
 			}
 		},
 		"sprintf-js": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-			"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"sshpk": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
 			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
@@ -21111,9 +17848,9 @@
 			"dev": true
 		},
 		"state-toggle": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.1.tgz",
-			"integrity": "sha512-Qe8QntFrrpWTnHwvwj2FZTgv+PKIsp0B9VxLzLLbSpPXWOgRgc5LVj/aTiSfK1RqIeF9jeC1UeOH8Q8y60A7og==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
+			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
 			"dev": true
 		},
 		"static-extend": {
@@ -21204,9 +17941,9 @@
 			"dev": true
 		},
 		"string-argv": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.0.tgz",
-			"integrity": "sha512-NGZHq3nkSXVtGZXTBjFru3MNfoZyIzN25T7BmvdgnSC0LCJczAGLLMQLyjywSIaAoqSemgLzBRHOsnrHbt60+Q==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+			"integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
 			"dev": true
 		},
 		"string-length": {
@@ -21243,14 +17980,30 @@
 			"dev": true
 		},
 		"string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"string.prototype.trim": {
@@ -21262,22 +18015,24 @@
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.13.0",
 				"function-bind": "^1.1.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.13.0",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-					"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.0",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"is-callable": "^1.1.4",
-						"is-regex": "^1.0.4",
-						"object-keys": "^1.0.12"
-					}
-				}
+			}
+		},
+		"string.prototype.trimleft": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+			"integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+			"integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
 			}
 		},
 		"string_decoder": {
@@ -21287,6 +18042,14 @@
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				}
 			}
 		},
 		"stringify-entities": {
@@ -21313,26 +18076,22 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+			"integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "^1.0.0"
 			}
 		},
 		"strip-bom": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
-			"requires": {
-				"is-utf8": "^0.2.0"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-eof": {
 			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
 			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 			"dev": true
 		},
@@ -21343,13 +18102,10 @@
 			"dev": true
 		},
 		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "^4.0.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+			"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+			"dev": true
 		},
 		"strip-json-comments": {
 			"version": "2.0.1",
@@ -21367,46 +18123,14 @@
 				"schema-utils": "^2.0.1"
 			},
 			"dependencies": {
-				"big.js": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-					"dev": true
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
-						"json5": "^1.0.1"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
 				"schema-utils": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.0.1.tgz",
-					"integrity": "sha512-HJFKJ4JixDpRur06QHwi8uu2kZbng318ahWEKgBjc0ZklcE4FDvmm2wghb448q0IRaABxIESt8vqPFvwgMB80A==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.2.0.tgz",
+					"integrity": "sha512-5EwsCNhfFTZvUreQhx/4vVQpJ/lnCAkgoIHLhSpp4ZirE+4hzFvdJi0FMub6hxbFVBJYSpeVVmon+2e7uEGRrA==",
 					"dev": true,
 					"requires": {
-						"ajv": "^6.1.0",
-						"ajv-keywords": "^3.1.0"
+						"ajv": "^6.10.2",
+						"ajv-keywords": "^3.4.1"
 					}
 				}
 			}
@@ -21499,23 +18223,6 @@
 						"fill-range": "^7.0.1"
 					}
 				},
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"dev": true
-				},
-				"camelcase-keys": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-					"integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0",
-						"map-obj": "^2.0.0",
-						"quick-lru": "^1.0.0"
-					}
-				},
 				"clone-regexp": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
@@ -21523,27 +18230,6 @@
 					"dev": true,
 					"requires": {
 						"is-regexp": "^2.0.0"
-					}
-				},
-				"cosmiconfig": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-					"dev": true,
-					"requires": {
-						"import-fresh": "^2.0.0",
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.13.1",
-						"parse-json": "^4.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
 					}
 				},
 				"emoji-regex": {
@@ -21596,58 +18282,22 @@
 						"which": "^1.3.1"
 					}
 				},
-				"globby": {
-					"version": "9.2.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
-					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
-					"dev": true,
-					"requires": {
-						"@types/glob": "^7.1.1",
-						"array-union": "^1.0.2",
-						"dir-glob": "^2.2.2",
-						"fast-glob": "^2.2.6",
-						"glob": "^7.1.3",
-						"ignore": "^4.0.3",
-						"pify": "^4.0.1",
-						"slash": "^2.0.0"
-					},
-					"dependencies": {
-						"ignore": {
-							"version": "4.0.6",
-							"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-							"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-							"dev": true
-						},
-						"slash": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-							"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-							"dev": true
-						}
-					}
-				},
 				"html-tags": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.0.0.tgz",
-					"integrity": "sha512-xiXEBjihaNI+VZ2mKEoI5ZPxqUsevTKM+aeeJ/W4KAg2deGE35minmCJMn51BvwJZmiHaeAxrb2LAS0yZJxuuA==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+					"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
 					"dev": true
 				},
 				"ignore": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
-					"integrity": "sha512-vdqWBp7MyzdmHkkRWV5nY+PfGRbYbahfuvsBCh277tq+w9zyNi7h5CYJCK0kmzti9kU+O/cB7sE8HvKv6aXAKQ==",
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
 					"dev": true
 				},
 				"import-lazy": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
 					"integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-					"dev": true
-				},
-				"indent-string": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-					"integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
@@ -21668,47 +18318,11 @@
 					"integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
 					"dev": true
 				},
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				},
 				"known-css-properties": {
 					"version": "0.14.0",
 					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.14.0.tgz",
 					"integrity": "sha512-P+0a/gBzLgVlCnK8I7VcD0yuYJscmWn66wH9tlKsQnmVdg689tLEmziwB9PuazZYLkcm07fvWOKCJJqI55sD5Q==",
 					"dev": true
-				},
-				"leven": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-					"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-					"dev": true
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-							"dev": true
-						}
-					}
 				},
 				"log-symbols": {
 					"version": "3.0.0",
@@ -21717,29 +18331,6 @@
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.2"
-					}
-				},
-				"map-obj": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-					"integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-					"dev": true
-				},
-				"meow": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-					"integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-					"dev": true,
-					"requires": {
-						"camelcase-keys": "^4.0.0",
-						"decamelize-keys": "^1.0.0",
-						"loud-rejection": "^1.0.0",
-						"minimist-options": "^3.0.1",
-						"normalize-package-data": "^2.3.4",
-						"read-pkg-up": "^3.0.0",
-						"redent": "^2.0.0",
-						"trim-newlines": "^2.0.0",
-						"yargs-parser": "^10.0.0"
 					}
 				},
 				"micromatch": {
@@ -21752,90 +18343,6 @@
 						"picomatch": "^2.0.5"
 					}
 				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "3.0.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-							"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-							"dev": true
-						}
-					}
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.17",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz",
-					"integrity": "sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"postcss-jsx": {
-					"version": "0.36.1",
-					"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.1.tgz",
-					"integrity": "sha512-xaZpy01YR7ijsFUtu5rViYCFHurFIPHir+faiOQp8g/NfTfWqZCKDhKrydQZ4d8WlSAmVdXGwLjpFbsNUI26Sw==",
-					"dev": true,
-					"requires": {
-						"@babel/core": ">=7.2.2"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-					"integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-					"dev": true,
-					"requires": {
-						"find-up": "^2.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
-				"redent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-					"integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-					"dev": true,
-					"requires": {
-						"indent-string": "^3.0.0",
-						"strip-indent": "^2.0.0"
-					}
-				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -21846,12 +18353,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"string-width": {
@@ -21874,27 +18375,6 @@
 						"ansi-regex": "^4.1.0"
 					}
 				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-					"dev": true
-				},
-				"strip-indent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-					"integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				},
 				"to-regex-range": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -21902,21 +18382,6 @@
 					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
-					}
-				},
-				"trim-newlines": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-					"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-					"dev": true
-				},
-				"yargs-parser": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -21928,12 +18393,12 @@
 			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.2.0.tgz",
-			"integrity": "sha512-M8BFHMRf8KNz5EQPKJd8nMCGmBd2o5coDEObfHVbEkyLDgjIf1V+U5dHjaGgvhm0zToUxshxN+Gc5wpbOOew4g==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-3.3.0.tgz",
+			"integrity": "sha512-BvuuLYwoet8JutOP7K1a8YaiENN+0HQn390eDi0SWe1h7Uhx6O3GUQ6Ubgie9b/AmHX4Btmp+ZzVGbzriFTBcA==",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^2.0.0"
+				"stylelint-config-recommended": "^2.2.0"
 			}
 		},
 		"stylelint-config-wordpress": {
@@ -21948,16 +18413,16 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.6.0.tgz",
-			"integrity": "sha512-Qpw0gl6iLBon5JNeFZjVYOEayd/e+WYIdY2vFhZuXeHC6jb8wl0wRZY97jATt/uxZzdtU3tGLAvJOUMuFp18vw==",
+			"version": "3.11.1",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.11.1.tgz",
+			"integrity": "sha512-0FZNSfy5X2Or4VRA3Abwfrw1NHrI6jHT8ji9xSwP8Re2Kno0i90qbHwm8ohPO0kRB1RP9x1vCYBh4Tij+SZjIg==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.15",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-selector-parser": "^6.0.2",
-				"postcss-value-parser": "^3.3.1"
+				"postcss-value-parser": "^4.0.2"
 			},
 			"dependencies": {
 				"postcss-selector-parser": {
@@ -21970,6 +18435,12 @@
 						"indexes-of": "^1.0.1",
 						"uniq": "^1.0.1"
 					}
+				},
+				"postcss-value-parser": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+					"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+					"dev": true
 				}
 			}
 		},
@@ -21998,33 +18469,26 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.1.1.tgz",
-			"integrity": "sha512-GBkJbnTuFpM4jFbiERHDWhZc/S/kpHToqmZag3aEBjPYK44JAN2QBjvrGIxLOoCyMZjuFQIfTO2eJd8uwLY/9g==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+			"integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
 			"dev": true,
 			"requires": {
-				"coa": "~2.0.1",
-				"colors": "~1.1.2",
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
 				"css-select": "^2.0.0",
-				"css-select-base-adapter": "~0.1.0",
-				"css-tree": "1.0.0-alpha.28",
-				"css-url-regex": "^1.1.0",
-				"csso": "^3.5.0",
-				"js-yaml": "^3.12.0",
+				"css-select-base-adapter": "^0.1.1",
+				"css-tree": "1.0.0-alpha.33",
+				"csso": "^3.5.1",
+				"js-yaml": "^3.13.1",
 				"mkdirp": "~0.5.1",
-				"object.values": "^1.0.4",
+				"object.values": "^1.1.0",
 				"sax": "~1.2.4",
-				"stable": "~0.1.6",
+				"stable": "^0.1.8",
 				"unquote": "~1.1.1",
 				"util.promisify": "~1.0.0"
 			},
 			"dependencies": {
-				"colors": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-					"dev": true
-				},
 				"css-select": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
@@ -22035,6 +18499,16 @@
 						"css-what": "^2.1.2",
 						"domutils": "^1.7.0",
 						"nth-check": "^1.0.2"
+					}
+				},
+				"domutils": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+					"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+					"dev": true,
+					"requires": {
+						"dom-serializer": "0",
+						"domelementtype": "1"
 					}
 				}
 			}
@@ -22051,39 +18525,21 @@
 			"dev": true
 		},
 		"table": {
-			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
-			"integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+			"version": "5.4.6",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+			"integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.9.1",
-				"lodash": "^4.17.11",
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
 				"slice-ansi": "^2.1.0",
 				"string-width": "^3.0.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.10.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-					"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
 				"string-width": {
@@ -22117,65 +18573,64 @@
 			}
 		},
 		"tapable": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.0.tgz",
-			"integrity": "sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true
 		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
 			"dev": true,
 			"requires": {
 				"block-stream": "*",
-				"fstream": "^1.0.2",
+				"fstream": "^1.0.12",
 				"inherits": "2"
 			}
 		},
 		"tar-fs": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+			"integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
 			"dev": true,
 			"requires": {
-				"chownr": "^1.0.1",
+				"chownr": "^1.1.1",
 				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
+			}
+		},
+		"tar-stream": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+			"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+			"dev": true,
+			"requires": {
+				"bl": "^3.0.0",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
 			},
 			"dependencies": {
-				"pump": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 					"dev": true,
 					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				}
 			}
 		},
-		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
-			"dev": true,
-			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
-				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
-			}
-		},
 		"terser": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.1.tgz",
-			"integrity": "sha512-pnzH6dnFEsR2aa2SJaKb1uSCl3QmIsJ8dEkj0Fky+2AwMMcC9doMqLOQIH6wVTEKaVfKVvLSk5qxPBEZT9mywg==",
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-4.3.2.tgz",
+			"integrity": "sha512-obxk4x19Zlzj9zY4QeXj9iPCb5W8YGn4v3pn4/fHj0Nw8+R7N02Kvwvz9VpOItCZZD8RC+vnYCDL0gP6FAJ7Xg==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.20.0",
@@ -22183,12 +18638,6 @@
 				"source-map-support": "~0.5.12"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"dev": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -22214,100 +18663,11 @@
 				"worker-farm": "^1.7.0"
 			},
 			"dependencies": {
-				"find-cache-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-					"dev": true,
-					"requires": {
-						"commondir": "^1.0.1",
-						"make-dir": "^2.0.0",
-						"pkg-dir": "^3.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"make-dir": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-					"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-					"dev": true,
-					"requires": {
-						"pify": "^4.0.1",
-						"semver": "^5.6.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-					"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
-				},
-				"webpack-sources": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-					"dev": true,
-					"requires": {
-						"source-list-map": "^2.0.0",
-						"source-map": "~0.6.1"
-					}
 				}
 			}
 		},
@@ -22323,111 +18683,10 @@
 				"require-main-filename": "^2.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"load-json-file": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0",
-						"strip-bom": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-					"dev": true
-				},
-				"parse-json": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-					"dev": true,
-					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
-					}
-				},
-				"path-type": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"read-pkg": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "^4.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^3.0.0"
-					}
-				},
-				"read-pkg-up": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
-					}
-				},
 				"require-main-filename": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-					"dev": true
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
 					"dev": true
 				}
 			}
@@ -22439,9 +18698,9 @@
 			"dev": true
 		},
 		"thread-loader": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.2.tgz",
-			"integrity": "sha512-7xpuc9Ifg6WU+QYw/8uUqNdRwMD+N5gjwHKMqETrs96Qn+7BHwECpt2Brzr4HFlf4IAkZsayNhmGdbkBsTJ//w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
+			"integrity": "sha512-wNrVKH2Lcf8ZrWxDF/khdlLlsTMczdcwPA9VEK4c2exlEPynYWxi9op3nPTo5lAnDIkE0rQEB3VBP+4Zncc9Hg==",
 			"dev": true,
 			"requires": {
 				"loader-runner": "^2.3.1",
@@ -22472,9 +18731,9 @@
 			}
 		},
 		"timers-browserify": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+			"integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
 			"dev": true,
 			"requires": {
 				"setimmediate": "^1.0.4"
@@ -22492,9 +18751,9 @@
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
 		},
 		"tiny-invariant": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.5.tgz",
-			"integrity": "sha512-BziszNEQNwtyMS9OVJia2LK9N9b6VJ35kBrvhDDDpr4hreLYqhCie15dB35uZMdqv9ZTQ55GHQtkz2FnleTHIA=="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+			"integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
 		},
 		"tiny-lr": {
 			"version": "1.1.1",
@@ -22508,6 +18767,17 @@
 				"livereload-js": "^2.3.0",
 				"object-assign": "^4.1.0",
 				"qs": "^6.4.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
 			}
 		},
 		"tiny-warning": {
@@ -22539,12 +18809,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
 			"integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-			"dev": true
-		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
 			"dev": true
 		},
 		"to-fast-properties": {
@@ -22593,26 +18857,6 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
 			}
 		},
 		"toidentifier": {
@@ -22622,21 +18866,13 @@
 			"dev": true
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"tr46": {
@@ -22672,27 +18908,21 @@
 			"integrity": "sha1-puYK1yFeItozcOR7bDRTp8ydSz4="
 		},
 		"trim-newlines": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true
-		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+			"integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
 			"dev": true
 		},
 		"trim-trailing-lines": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz",
-			"integrity": "sha512-bWLv9BbWbbd7mlqqs2oQYnLD/U/ZqeJeJwbO0FG2zA1aTq+HTvxfHNKFa/HGCVyJpDiioUYaBhfiT6rgk+l4mg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.2.tgz",
+			"integrity": "sha512-MUjYItdrqqj2zpcHFTkMa9WAv4JHTI6gnRQGPFLrt5L9a6tRMiDnIqYl8JBvu2d2Tc3lWJKQwlGCp0K8AvCM+Q==",
 			"dev": true
 		},
 		"trough": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.3.tgz",
-			"integrity": "sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.4.tgz",
+			"integrity": "sha512-tdzBRDGWcI1OpPVmChbdSKhvSVurznZ8X36AYURAcl+0o2ldlCY2XPzyXNNxwJwwyIU+rIglTCG4kxtNKBQH7Q==",
 			"dev": true
 		},
 		"true-case-path": {
@@ -22711,9 +18941,9 @@
 			"dev": true
 		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
 			"dev": true
 		},
 		"tty-browserify": {
@@ -22752,9 +18982,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
-			"integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
 			"dev": true
 		},
 		"type-is": {
@@ -22765,23 +18995,6 @@
 			"requires": {
 				"media-typer": "0.3.0",
 				"mime-types": "~2.1.24"
-			},
-			"dependencies": {
-				"mime-db": {
-					"version": "1.40.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-					"dev": true
-				},
-				"mime-types": {
-					"version": "2.1.24",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-					"dev": true,
-					"requires": {
-						"mime-db": "1.40.0"
-					}
-				}
 			}
 		},
 		"typedarray": {
@@ -22797,9 +19010,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.19",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+			"version": "0.7.20",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
+			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
 		},
 		"uglify-js": {
 			"version": "3.6.0",
@@ -22812,13 +19025,6 @@
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.20.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-					"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-					"dev": true,
-					"optional": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -22863,17 +19069,6 @@
 						"ssri": "^5.2.4",
 						"unique-filename": "^1.1.0",
 						"y18n": "^4.0.0"
-					},
-					"dependencies": {
-						"rimraf": {
-							"version": "2.7.1",
-							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-							"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-							"dev": true,
-							"requires": {
-								"glob": "^7.1.3"
-							}
-						}
 					}
 				},
 				"commander": {
@@ -22891,6 +19086,15 @@
 						"commondir": "^1.0.1",
 						"make-dir": "^1.0.0",
 						"pkg-dir": "^2.0.0"
+					}
+				},
+				"make-dir": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+					"dev": true,
+					"requires": {
+						"pify": "^3.0.0"
 					}
 				},
 				"mississippi": {
@@ -22911,6 +19115,21 @@
 						"through2": "^2.0.0"
 					}
 				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				},
 				"pump": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -22919,6 +19138,15 @@
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+					"dev": true,
+					"requires": {
+						"glob": "^7.1.3"
 					}
 				},
 				"schema-utils": {
@@ -22965,9 +19193,9 @@
 			}
 		},
 		"unherit": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
-			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.2.tgz",
+			"integrity": "sha512-W3tMnpaMG7ZY6xe/moK04U9fBhi6wEiCYHUW5Mop/wQHf12+79EQGwxYejNdhEz2mkqkBlGwm7pxmgBKMVUj0w==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
@@ -23028,38 +19256,15 @@
 			}
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"uniq": {
@@ -23084,33 +19289,33 @@
 			}
 		},
 		"unique-slug": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
 		},
 		"unist-util-find-all-after": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.2.tgz",
-			"integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-1.0.4.tgz",
+			"integrity": "sha512-CaxvMjTd+yF93BKLJvZnEfqdM7fgEACsIpQqz8vIj9CJnUb9VpyymFS3tg6TCtgrF7vfCJBF5jbT2Ox9CBRYRQ==",
 			"dev": true,
 			"requires": {
-				"unist-util-is": "^2.0.0"
+				"unist-util-is": "^3.0.0"
 			}
 		},
 		"unist-util-is": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-2.1.2.tgz",
-			"integrity": "sha512-YkXBK/H9raAmG7KXck+UUpnKiNmUdB+aBGrknfQ4EreE1banuzrKABx3jP6Z5Z3fMSPMQQmeXBlKpCbMwBkxVw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
 			"dev": true
 		},
 		"unist-util-remove-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
-			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.3.tgz",
+			"integrity": "sha512-CtszTlOjP2sBGYc2zcKA/CvNdTdEs3ozbiJ63IPBxh8iZg42SCCb8m04f8z2+V1aSk5a7BxbZKEdoDjadmBkWA==",
 			"dev": true,
 			"requires": {
 				"unist-util-visit": "^1.1.0"
@@ -23123,21 +19328,21 @@
 			"dev": true
 		},
 		"unist-util-visit": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.0.tgz",
-			"integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
 			"dev": true,
 			"requires": {
 				"unist-util-visit-parents": "^2.0.0"
 			}
 		},
 		"unist-util-visit-parents": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz",
-			"integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
 			"dev": true,
 			"requires": {
-				"unist-util-is": "^2.1.2"
+				"unist-util-is": "^3.0.0"
 			}
 		},
 		"universal-user-agent": {
@@ -23199,6 +19404,12 @@
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
 					"dev": true
 				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
+				},
 				"isobject": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -23208,9 +19419,9 @@
 			}
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true
 		},
 		"uri-js": {
@@ -23259,6 +19470,14 @@
 			"dev": true,
 			"requires": {
 				"inherits": "2.0.3"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				}
 			}
 		},
 		"util-deprecate": {
@@ -23284,9 +19503,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -23322,9 +19541,9 @@
 			"dev": true
 		},
 		"vendors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-			"integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+			"integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
 			"dev": true
 		},
 		"verror": {
@@ -23359,9 +19578,9 @@
 			}
 		},
 		"vfile-location": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.4.tgz",
-			"integrity": "sha512-KRL5uXQPoUKu+NGvQVL4XLORw45W62v4U4gxJ3vRlDfI9QsT4ZN1PNXn/zQpKUulqGDpYuT0XDfp5q9O87/y/w==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.5.tgz",
+			"integrity": "sha512-Pa1ey0OzYBkLPxPZI3d9E+S4BmvfVwNAAXrrqGbwTVXWaX2p9kM1zZ+n35UtVM06shmWKH4RPRN8KI80qE3wNQ==",
 			"dev": true
 		},
 		"vfile-message": {
@@ -23388,6 +19607,14 @@
 				"chalk": "^2.4.1",
 				"leven": "^2.1.0",
 				"tslib": "^1.9.3"
+			},
+			"dependencies": {
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+					"dev": true
+				}
 			}
 		},
 		"w3c-hr-time": {
@@ -23417,12 +19644,6 @@
 					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
 					"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
 					"dev": true
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
 				}
 			}
 		},
@@ -23437,6 +19658,12 @@
 				"debug": "^2.6.6"
 			},
 			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
 				"ansi-styles": {
 					"version": "2.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -23470,6 +19697,15 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
 				},
 				"supports-color": {
 					"version": "2.0.0",
@@ -23605,6 +19841,15 @@
 						"@webassemblyjs/wast-parser": "1.4.3",
 						"long": "^3.2.0"
 					}
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
 				}
 			}
 		},
@@ -23643,92 +19888,12 @@
 				"terser-webpack-plugin": "^1.4.1",
 				"watchpack": "^1.6.0",
 				"webpack-sources": "^1.4.1"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.10.2",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-					"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"ajv-keywords": {
-					"version": "3.4.1",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-					"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
-					"dev": true
-				},
-				"big.js": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-					"dev": true
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
-						"json5": "^1.0.1"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"dev": true
-				},
-				"neo-async": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-					"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"tapable": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-					"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-					"dev": true
-				},
-				"webpack-sources": {
-					"version": "1.4.3",
-					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
-					"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
-					"dev": true,
-					"requires": {
-						"source-list-map": "^2.0.0",
-						"source-map": "~0.6.1"
-					}
-				}
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz",
-			"integrity": "sha512-Bs8D/1zF+17lhqj2OYmzi7HEVYqEVxu7lCO9Ff8BwajenOU0vAwEoV8e4ICCPNZAcqR1PCR/7o2SkW+cnCmF0A==",
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.5.1.tgz",
+			"integrity": "sha512-CDdaT3TTu4F9X3tcDq6PNJOiNGgREOM0WdN2vVAoUUn+M6NLB5kJ543HImCWbrDwOpbpGARSwU8r+u0Pl367kA==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.7",
@@ -23746,12 +19911,6 @@
 				"ws": "^6.0.0"
 			},
 			"dependencies": {
-				"lodash": {
-					"version": "4.17.15",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-					"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-					"dev": true
-				},
 				"ws": {
 					"version": "6.2.1",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
@@ -23788,10 +19947,10 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
-				"big.js": {
-					"version": "5.2.2",
-					"resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-					"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"cliui": {
@@ -23803,19 +19962,6 @@
 						"string-width": "^3.1.0",
 						"strip-ansi": "^5.2.0",
 						"wrap-ansi": "^5.1.0"
-					}
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
 					}
 				},
 				"find-up": {
@@ -23833,30 +19979,39 @@
 					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 					"dev": true
 				},
-				"is-fullwidth-code-point": {
+				"global-modules": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-					"dev": true
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+					"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
+						"global-prefix": "^3.0.0"
 					}
 				},
-				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+				"global-prefix": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+					"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
 					"dev": true,
 					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
-						"json5": "^1.0.1"
+						"ini": "^1.3.5",
+						"kind-of": "^6.0.2",
+						"which": "^1.3.1"
+					}
+				},
+				"invert-kv": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"dev": true
+				},
+				"lcid": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"dev": true,
+					"requires": {
+						"invert-kv": "^2.0.0"
 					}
 				},
 				"locate-path": {
@@ -23869,11 +20024,33 @@
 						"path-exists": "^3.0.0"
 					}
 				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+				"mem": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"dev": true,
+					"requires": {
+						"map-age-cleaner": "^0.1.1",
+						"mimic-fn": "^2.0.0",
+						"p-is-promise": "^2.0.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
+				},
+				"os-locale": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+					"dev": true,
+					"requires": {
+						"execa": "^1.0.0",
+						"lcid": "^2.0.0",
+						"mem": "^4.0.0"
+					}
 				},
 				"p-limit": {
 					"version": "2.2.1",
@@ -23969,6 +20146,16 @@
 						"y18n": "^4.0.0",
 						"yargs-parser": "^13.1.0"
 					}
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				}
 			}
 		},
@@ -23993,12 +20180,30 @@
 				"cssnano": "4.1.10",
 				"rtlcss": "2.4.0",
 				"webpack-sources": "1.3.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"webpack-sources": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
+					"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+					"dev": true,
+					"requires": {
+						"source-list-map": "^2.0.0",
+						"source-map": "~0.6.1"
+					}
+				}
 			}
 		},
 		"webpack-sources": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
 			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
@@ -24117,12 +20322,49 @@
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
-			"resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -24179,9 +20421,9 @@
 			"dev": true
 		},
 		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true
 		},
 		"y18n": {
@@ -24237,6 +20479,12 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
 				"cliui": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -24261,12 +20509,6 @@
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
 				"locate-path": {
@@ -24345,25 +20587,26 @@
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
 					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
+				},
+				"yargs-parser": {
+					"version": "13.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
 				}
 			}
 		},
 		"yargs-parser": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-			"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+			"integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^5.0.0",
-				"decamelize": "^1.2.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				}
+				"camelcase": "^4.1.0"
 			}
 		},
 		"yauzl": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
 		"har-validator": "5.1.3",
 		"husky": "2.4.1",
 		"ignore-loader": "0.1.2",
-		"interpolate-components": "1.1.1",
 		"js-md5": "0.7.3",
 		"lint-staged": "9.2.5",
 		"mini-css-extract-plugin": "0.8.0",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
 	"extends": [ "config:base" ],
+	"lockFileMaintenance": { "enabled": true },
 	"ignoreDeps": [ "husky" ],
 	"schedule": [ "before 3am on wednesday" ]
 }


### PR DESCRIPTION
This PR does some things:
- Removes `interpolate-components` from packages.json because it wasn't used anywhere in the project.
- Updates package-lock.json. I deleted the file and run `npm install` so it was generated automatically.
- Updates Renovate config to automatically update package-lock.json, so we don't have to do it manually in the future.

Hopefully, that will unblock #823.