### PR TITLE
Remove unnecessary logic (setSetting)

### DIFF
--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -12,6 +12,5 @@ import { allSettings } from './settings-init';
  *                                               ensure it's a number)
  */
 export function setSetting( name, value, filter = ( val ) => val ) {
-	value = filter( value );
 	allSettings[ name ] = filter( value );
 }


### PR DESCRIPTION
While writing documentation for the recent `wcSettings` refactor I noticed that `setSetting` had some unnecessary logic in it.  This pull addresses that.