### PR TITLE
Followup: Ensure version check for back-compat AssetDataRegistry is correct

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -76,13 +76,8 @@ class Bootstrap {
 			AssetDataRegistry::class,
 			function( Container $container ) {
 				$asset_api        = $container->get( AssetApi::class );
-				$load_back_compat = (
-					defined( 'WC_ADMIN_VERSION_NUMBER' )
-					&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' )
-				) ||
-				(
-					version_compare( WC_VERSION, '3.7.0', '<=' )
-				);
+				$load_back_compat = defined( 'WC_ADMIN_VERSION_NUMBER' )
+					&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' );
 				return $load_back_compat
 					? new BackCompatAssetDataRegistry( $asset_api )
 					: new AssetDataRegistry( $asset_api );


### PR DESCRIPTION
This is a followup to #956 and closes #972.

WC-Admin was released _without_ the changes making it compatible with `AssetDataRegistry` so the version check for WC-Admin is correct (`WC_VERSION <= 0.19.0`).

I realized that the check for `WC_VERSION` (Woo Core) was unnecessary as this will get merged _into_ Woo core.

## Testing

- Build master of the WC-Blocks.
- Build master of WC-Admin.
* [ ] Verify that `wcSettings` is present on _every_ route and that WC-Admin works as expected (note this is an indicator that back-compat is active).
- Switch `WC_ADMIN_VERSION_NUMBER` in WC-Admin to be `0.20.0`.
* [ ] Verify that `wcSettings` is **only** present on either `WC-Admin` routes or routes that load WC-Blocks (this is an indicator that back-compat is not active).  Also smoke test WC-Admin and WC-Blocks load as expected.