### PR TITLE
Use renderFrontend util in All Products block

### DIFF
--- a/assets/js/base/hocs/test/with-window.js
+++ b/assets/js/base/hocs/test/with-window.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import withWindow from '../with-window';
+
+const render = ( propMap ) => {
+	/* eslint-disable-next-line @wordpress/no-unused-vars-before-return */
+	const TestComponent = withWindow( propMap )(
+		( props ) => ( <div { ...props } /> )
+	);
+
+	return TestRenderer.create(
+		<TestComponent
+			greeting={ 'Hello' }
+			name={ 'Alice' }
+		/>
+	);
+};
+
+describe( 'withWindow Component', () => {
+	it( 'calls the propMap function with the window object and the props', () => {
+		const propMap = jest.fn();
+		const testFunction = jest.fn();
+		propMap.mockImplementation(
+			( window, props ) => {
+				testFunction( window, props );
+			}
+		);
+
+		render( propMap );
+
+		expect( propMap ).toHaveBeenCalledWith( window, { name: 'Alice', greeting: 'Hello' } );
+    expect( propMap ).toHaveBeenCalledTimes( 1 );
+		expect( testFunction ).toHaveBeenCalledWith( window, { name: 'Alice', greeting: 'Hello' } );
+    expect( testFunction ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'sets the resulting props from the propMap into the resulting component', () => {
+		const propMap = () => ( { greeting: 'Good morning' } );
+
+		const renderer = render( propMap );
+
+		const props = renderer.root.findByType( 'div' ).props;
+		expect( props.name ).toBe( 'Alice' );
+		expect( props.greeting ).toBe( 'Good morning' );
+	} );
+} );

--- a/assets/js/blocks/products/all-products/frontend.js
+++ b/assets/js/blocks/products/all-products/frontend.js
@@ -1,28 +1,12 @@
 /**
- * External dependencies
- */
-import { render } from 'react-dom';
-
-/**
  * Internal dependencies
  */
 import Block from './block';
+import renderFrontend from '../../../utils/render-frontend.js';
 
-const containers = document.querySelectorAll(
-	'.wp-block-woocommerce-all-products'
-);
+const getProps = ( el, i ) => ( {
+	attributes: JSON.parse( el.dataset.attributes ),
+	urlParameterSuffix: i > 0 ? `_${ i + 1 }` : '',
+} );
 
-if ( containers.length ) {
-	// Use Array.forEach for IE11 compatibility
-	Array.prototype.forEach.call( containers, ( el, i ) => {
-		const attributes = JSON.parse( el.dataset.attributes );
-
-		render(
-			<Block
-				attributes={ attributes }
-				urlParameterSuffix={ i > 0 ? `_${ i + 1 }` : '' }
-			/>,
-			el
-		);
-	} );
-}
+renderFrontend( '.wp-block-woocommerce-all-products', Block, getProps );

--- a/assets/js/utils/render-frontend.js
+++ b/assets/js/utils/render-frontend.js
@@ -16,8 +16,8 @@ export default ( selector, Block, getProps = () => {} ) => {
 
 	if ( containers.length ) {
 		// Use Array.forEach for IE11 compatibility
-		Array.prototype.forEach.call( containers, ( el ) => {
-			const props = getProps( el );
+		Array.prototype.forEach.call( containers, ( el, i ) => {
+			const props = getProps( el, i );
 			const attributes = {
 				...el.dataset,
 				...props.attributes,


### PR DESCRIPTION
Based on #997.

When work on #899, we didn't have the `renderFrontend` util function yet. This PR updates the _All Products_ branch to use it.

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block and preview it.
2. Verify the _All Products_ block still appears.