### PR TITLE
Update docblock for `remove_core_blocks`

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -133,7 +133,12 @@ class Bootstrap {
 	}
 
 	/**
-	 * Remove core blocks (for 3.6 and above).
+	 * Remove core blocks.
+	 *
+	 * Older installs of WooCommerce (3.6 and below) did not use the blocks package and instead included classes directly.
+	 * This code disables those core classes when running blocks as a feature plugin. Newer versions which use the Blocks package are unaffected.
+	 *
+	 * When the feature plugin supports only WooCommerce 3.7+ this method can be removed.
 	 */
 	protected function remove_core_blocks() {
 		remove_action( 'init', array( 'WC_Block_Library', 'init' ) );


### PR DESCRIPTION
Ref: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/956#discussion_r327176532

Clarifies what the `remove_core_blocks` method actually does and for what versions.