### PR TITLE
Refactor permission checks for authors

### DIFF
--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -105,13 +105,19 @@ class Products extends WC_REST_Products_Controller {
 	}
 
 	/**
-	 * Change read permissions to allow author access to this API.
+	 * Change REST API permissions so that authors have access to this API.
 	 *
-	 * @param array $permissions Array of access permissions.
+	 * This code only runs for methods of this class. @see Products::get_items below.
+	 *
+	 * @param bool $permission Does the current user have access to the API.
+	 * @return bool
 	 */
-	public function change_permissions( $permissions ) {
-		$permissions['read'] = 'edit_posts';
-		return $permissions;
+	public function force_edit_posts_permission( $permission ) {
+		// If user has access already, we can bypass additonal checks.
+		if ( $permission ) {
+			return $permission;
+		}
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**
@@ -121,9 +127,9 @@ class Products extends WC_REST_Products_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		add_filter( 'woocommerce_rest_check_permissions', array( $this, 'change_permissions' ) );
+		add_filter( 'woocommerce_rest_check_permissions', array( $this, 'force_edit_posts_permission' ) );
 		$response = parent::get_items( $request );
-		remove_filter( 'woocommerce_rest_check_permissions', array( $this, 'change_permissions' ) );
+		remove_filter( 'woocommerce_rest_check_permissions', array( $this, 'force_edit_posts_permission' ) );
 
 		return $response;
 	}


### PR DESCRIPTION
The products API needs to be accessible to authors as well as admin/shop managers. To permit access we use the `woocommerce_rest_check_permissions` filter.

For some reason, possibly during the rest API package refactor, this was coded to expect and return an array of capabilities instead of a boolean. This patch fixes it to return a boolean instead to prevent type errors.

cc @vedanshujain 

To test, use some product blocks as an author. Unit tests should also pass. They passed before because strings evaluate to true when compared as booleans (false positive).