### PR TITLE
Scroll to top when switching pages in All Products block

### DIFF
--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -102,6 +102,7 @@ const Pagination = ( {
 								? null
 								: () => onPageChange( page )
 						}
+						disabled={ currentPage === page }
 					>
 						{ page }
 					</button>

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -26,6 +26,15 @@
 	}
 }
 
-.wc-block-pagination-page--active {
+.wc-block-pagination-page--active[disabled] {
+	color: #333;
 	font-weight: bold;
+	opacity: 1 !important;
+
+	&:hover,
+	&:focus {
+		background-color: inherit;
+		color: #333;
+		opacity: 1 !important;
+	}
 }

--- a/assets/js/base/components/product-grid/index.js
+++ b/assets/js/base/components/product-grid/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -12,114 +11,80 @@ import Pagination from '../pagination';
 import ProductOrderSelect from '../product-order-select';
 import ProductGridItem from '../product-grid-item';
 import withProducts from '../../hocs/with-products';
+import withScrollToTop from '../../hocs/with-scroll-to-top';
 import './style.scss';
 
-class ProductGrid extends Component {
-	constructor() {
-		super();
-
-		this.scrollPointRef = createRef();
-	}
-
-	onPaginationChange = ( newPage ) => {
-		const { onPageChange } = this.props;
-
-		const srollPointRefYPosition = this.scrollPointRef.current.getBoundingClientRect()
-			.bottom;
-		const isScrollPointRefVisible =
-			srollPointRefYPosition >= 0 &&
-			srollPointRefYPosition <= window.innerHeight;
-		if ( ! isScrollPointRefVisible ) {
-			this.scrollPointRef.current.scrollIntoView();
-		}
-
-		const focusableElements = this.scrollPointRef.current.parentElement.querySelectorAll(
-			'button, a'
-		);
-		if ( focusableElements.length ) {
-			focusableElements[ 0 ].focus();
-		}
-
+const ProductGrid = ( {
+	attributes,
+	currentPage,
+	onOrderChange,
+	onPageChange,
+	orderValue,
+	products,
+	scrollToTop,
+	totalProducts,
+} ) => {
+	const onPaginationChange = ( newPage ) => {
+		scrollToTop( { focusableSelector: 'a, button' } );
 		onPageChange( newPage );
 	};
 
-	render() {
-		const {
-			attributes,
-			currentPage,
-			onOrderChange,
-			orderValue,
-			products,
-			totalProducts,
-		} = this.props;
+	const getClassnames = () => {
+		const { columns, rows, className, alignButtons, align } = attributes;
+		const alignClass = typeof align !== 'undefined' ? 'align' + align : '';
 
-		const getClassnames = () => {
-			const {
-				columns,
-				rows,
-				className,
-				alignButtons,
-				align,
-			} = attributes;
-			const alignClass =
-				typeof align !== 'undefined' ? 'align' + align : '';
-
-			return classnames(
-				'wc-block-grid',
-				className,
-				alignClass,
-				'has-' + columns + '-columns',
-				{
-					'has-multiple-rows': rows > 1,
-					'has-aligned-buttons': alignButtons,
-				}
-			);
-		};
-
-		const perPage = attributes.columns * attributes.rows;
-		const totalPages = Math.ceil( totalProducts / perPage );
-		const gridProducts = products.length
-			? products
-			: Array.from( { length: perPage } );
-
-		return (
-			<div className={ getClassnames() }>
-				<div
-					className="wc-block-grid__products__scroll-point"
-					ref={ this.scrollPointRef }
-					aria-hidden
-				/>
-				{ attributes.showOrderby && (
-					<ProductOrderSelect
-						onChange={ onOrderChange }
-						value={ orderValue }
-					/>
-				) }
-				<ul className="wc-block-grid__products">
-					{ gridProducts.map( ( product = {}, i ) => (
-						<ProductGridItem
-							key={ product.id || i }
-							attributes={ attributes }
-							product={ product }
-						/>
-					) ) }
-				</ul>
-				{ totalProducts > perPage && (
-					<Pagination
-						currentPage={ currentPage }
-						onPageChange={ this.onPaginationChange }
-						totalPages={ totalPages }
-					/>
-				) }
-			</div>
+		return classnames(
+			'wc-block-grid',
+			className,
+			alignClass,
+			'has-' + columns + '-columns',
+			{
+				'has-multiple-rows': rows > 1,
+				'has-aligned-buttons': alignButtons,
+			}
 		);
-	}
-}
+	};
+
+	const perPage = attributes.columns * attributes.rows;
+	const totalPages = Math.ceil( totalProducts / perPage );
+	const gridProducts = products.length
+		? products
+		: Array.from( { length: perPage } );
+
+	return (
+		<div className={ getClassnames() }>
+			{ attributes.showOrderby && (
+				<ProductOrderSelect
+					onChange={ onOrderChange }
+					value={ orderValue }
+				/>
+			) }
+			<ul className="wc-block-grid__products">
+				{ gridProducts.map( ( product = {}, i ) => (
+					<ProductGridItem
+						key={ product.id || i }
+						attributes={ attributes }
+						product={ product }
+					/>
+				) ) }
+			</ul>
+			{ totalProducts > perPage && (
+				<Pagination
+					currentPage={ currentPage }
+					onPageChange={ onPaginationChange }
+					totalPages={ totalPages }
+				/>
+			) }
+		</div>
+	);
+};
 
 ProductGrid.propTypes = {
 	attributes: PropTypes.object.isRequired,
+	// From withScrollToTop.
+	scrollToTop: PropTypes.func,
 	// From withProducts.
 	products: PropTypes.array,
 };
 
-export default withProducts( ProductGrid );
+export default withScrollToTop( withProducts( ProductGrid ) );

--- a/assets/js/base/components/product-grid/index.js
+++ b/assets/js/base/components/product-grid/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -13,64 +14,100 @@ import ProductGridItem from '../product-grid-item';
 import withProducts from '../../hocs/with-products';
 import './style.scss';
 
-const ProductGrid = ( {
-	attributes,
-	currentPage,
-	onOrderChange,
-	onPageChange,
-	orderValue,
-	products,
-	totalProducts,
-} ) => {
-	const getClassnames = () => {
-		const { columns, rows, className, alignButtons, align } = attributes;
-		const alignClass = typeof align !== 'undefined' ? 'align' + align : '';
+class ProductGrid extends Component {
+	constructor() {
+		super();
 
-		return classnames(
-			'wc-block-grid',
-			className,
-			alignClass,
-			'has-' + columns + '-columns',
-			{
-				'has-multiple-rows': rows > 1,
-				'has-aligned-buttons': alignButtons,
-			}
-		);
-	};
-
-	const perPage = attributes.columns * attributes.rows;
-	const totalPages = Math.ceil( totalProducts / perPage );
-	if ( ! products.length ) {
-		products = Array.from( { length: perPage } );
+		this.scrollPointRef = createRef();
 	}
 
-	return (
-		<div className={ getClassnames() }>
-			{ attributes.showOrderby && (
-				<ProductOrderSelect
-					onChange={ onOrderChange }
-					value={ orderValue }
+	onPaginationChange = ( newPage ) => {
+		const { onPageChange } = this.props;
+
+		const srollPointRefYPosition = this.scrollPointRef.current.getBoundingClientRect()
+			.bottom;
+		const isScrollPointRefVisible =
+			srollPointRefYPosition >= 0 &&
+			srollPointRefYPosition <= window.innerHeight;
+		if ( ! isScrollPointRefVisible ) {
+			this.scrollPointRef.current.scrollIntoView();
+		}
+
+		onPageChange( newPage );
+	};
+
+	render() {
+		const {
+			attributes,
+			currentPage,
+			onOrderChange,
+			orderValue,
+			products,
+			totalProducts,
+		} = this.props;
+
+		const getClassnames = () => {
+			const {
+				columns,
+				rows,
+				className,
+				alignButtons,
+				align,
+			} = attributes;
+			const alignClass =
+				typeof align !== 'undefined' ? 'align' + align : '';
+
+			return classnames(
+				'wc-block-grid',
+				className,
+				alignClass,
+				'has-' + columns + '-columns',
+				{
+					'has-multiple-rows': rows > 1,
+					'has-aligned-buttons': alignButtons,
+				}
+			);
+		};
+
+		const perPage = attributes.columns * attributes.rows;
+		const totalPages = Math.ceil( totalProducts / perPage );
+		const gridProducts = products.length
+			? products
+			: Array.from( { length: perPage } );
+
+		return (
+			<div className={ getClassnames() }>
+				<div
+					className="wc-block-grid__products__scroll-point"
+					ref={ this.scrollPointRef }
+					aria-hidden
 				/>
-			) }
-			<ul className="wc-block-grid__products">
-				{ products.map( ( product = {}, i ) => (
-					<ProductGridItem
-						key={ product.id || i }
-						attributes={ attributes }
-						product={ product }
+				{ attributes.showOrderby && (
+					<ProductOrderSelect
+						onChange={ onOrderChange }
+						value={ orderValue }
 					/>
-				) ) }
-			</ul>
-			{ totalProducts > perPage && (
-				<Pagination
-					currentPage={ currentPage }
-					onPageChange={ onPageChange }
-					totalPages={ totalPages }
-				/>
-			) }
-		</div>
-	);
-};
+				) }
+				<ul className="wc-block-grid__products">
+					{ gridProducts.map( ( product = {}, i ) => (
+						<ProductGridItem
+							key={ product.id || i }
+							attributes={ attributes }
+							product={ product }
+						/>
+					) ) }
+				</ul>
+				{ totalProducts > perPage && (
+					<Pagination
+						currentPage={ currentPage }
+						onPageChange={ this.onPaginationChange }
+						totalPages={ totalPages }
+					/>
+				) }
+			</div>
+		);
+	}
+}
 
 ProductGrid.propTypes = {
 	attributes: PropTypes.object.isRequired,

--- a/assets/js/base/components/product-grid/index.js
+++ b/assets/js/base/components/product-grid/index.js
@@ -33,6 +33,13 @@ class ProductGrid extends Component {
 			this.scrollPointRef.current.scrollIntoView();
 		}
 
+		const focusableElements = this.scrollPointRef.current.parentElement.querySelectorAll(
+			'button, a'
+		);
+		if ( focusableElements.length ) {
+			focusableElements[ 0 ].focus();
+		}
+
 		onPageChange( newPage );
 	};
 

--- a/assets/js/base/components/product-grid/style.scss
+++ b/assets/js/base/components/product-grid/style.scss
@@ -16,11 +16,6 @@
 	background-clip: padding-box;
 }
 
-.wc-block-grid__products__scroll-point {
-	position: relative;
-	top: -$gap-larger;
-}
-
 .wc-block-grid__product {
 	box-sizing: border-box;
 	padding: 0;

--- a/assets/js/base/components/product-grid/style.scss
+++ b/assets/js/base/components/product-grid/style.scss
@@ -16,6 +16,11 @@
 	background-clip: padding-box;
 }
 
+.wc-block-grid__products__scroll-point {
+	position: relative;
+	top: -$gap-larger;
+}
+
 .wc-block-grid__product {
 	box-sizing: border-box;
 	padding: 0;

--- a/assets/js/base/hocs/with-scroll-to-top/index.js
+++ b/assets/js/base/hocs/with-scroll-to-top/index.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { Component, createRef, Fragment } from 'react';
+
+import './style.scss';
+
+/**
+ * HOC that provides a function to scroll to the top of the component.
+ */
+const withScrollToTop = ( OriginalComponent ) => {
+	class WrappedComponent extends Component {
+		constructor() {
+			super();
+
+			this.scrollPointRef = createRef();
+		}
+
+		scrollToTopIfNeeded = () => {
+			const srollPointRefYPosition = this.scrollPointRef.current.getBoundingClientRect()
+				.bottom;
+			const isScrollPointRefVisible =
+				srollPointRefYPosition >= 0 &&
+				srollPointRefYPosition <= window.innerHeight;
+			if ( ! isScrollPointRefVisible ) {
+				this.scrollPointRef.current.scrollIntoView();
+			}
+		};
+
+		moveFocusToTop = ( focusableSelector ) => {
+			const focusableElements = this.scrollPointRef.current.parentElement.querySelectorAll(
+				focusableSelector
+			);
+			if ( focusableElements.length ) {
+				focusableElements[ 0 ].focus();
+			}
+		};
+
+		scrollToTop = ( args ) => {
+			if ( ! window || ! Number.isFinite( window.innerHeight ) ) {
+				return;
+			}
+
+			this.scrollToTopIfNeeded();
+			if ( args && args.focusableSelector ) {
+				this.moveFocusToTop( args.focusableSelector );
+			}
+		};
+
+		render() {
+			return (
+				<Fragment>
+					<div
+						className="with-scroll-to-top__scroll-point"
+						ref={ this.scrollPointRef }
+						aria-hidden
+					/>
+					<OriginalComponent
+						{ ...this.props }
+						scrollToTop={ this.scrollToTop }
+					/>
+				</Fragment>
+			);
+		}
+	}
+
+	WrappedComponent.displayName = 'withScrollToTop';
+
+	return WrappedComponent;
+};
+
+export default withScrollToTop;

--- a/assets/js/base/hocs/with-scroll-to-top/index.js
+++ b/assets/js/base/hocs/with-scroll-to-top/index.js
@@ -17,11 +17,11 @@ const withScrollToTop = ( OriginalComponent ) => {
 		}
 
 		scrollToTopIfNeeded = () => {
-			const srollPointRefYPosition = this.scrollPointRef.current.getBoundingClientRect()
+			const scrollPointRefYPosition = this.scrollPointRef.current.getBoundingClientRect()
 				.bottom;
 			const isScrollPointRefVisible =
-				srollPointRefYPosition >= 0 &&
-				srollPointRefYPosition <= window.innerHeight;
+				scrollPointRefYPosition >= 0 &&
+				scrollPointRefYPosition <= window.innerHeight;
 			if ( ! isScrollPointRefVisible ) {
 				this.scrollPointRef.current.scrollIntoView();
 			}

--- a/assets/js/base/hocs/with-scroll-to-top/style.scss
+++ b/assets/js/base/hocs/with-scroll-to-top/style.scss
@@ -1,0 +1,4 @@
+.with-scroll-to-top__scroll-point {
+	position: relative;
+	top: -$gap-larger;
+}

--- a/assets/js/base/hocs/with-scroll-to-top/test/index.js
+++ b/assets/js/base/hocs/with-scroll-to-top/test/index.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import withScrollToTop from '../index';
+
+const TestComponent = withScrollToTop( ( props ) => (
+	<span { ...props }>
+		<button />
+	</span>
+) );
+
+const focusedMock = jest.fn();
+const scrollIntoViewMock = jest.fn();
+
+const mockedButton = {
+	focus: focusedMock,
+};
+const render = ( { inView } ) => {
+	return TestRenderer.create( <TestComponent />, {
+		createNodeMock: ( element ) => {
+			if ( element.type === 'button' ) {
+				return mockedButton;
+			}
+			if ( element.type === 'div' ) {
+				return {
+					getBoundingClientRect: () => ( {
+						bottom: inView ? 0 : -10,
+					} ),
+					parentElement: {
+						querySelectorAll: () => [ mockedButton ],
+					},
+					scrollIntoView: scrollIntoViewMock,
+				};
+			}
+			return null;
+		},
+	} );
+};
+
+describe( 'withScrollToTop Component', () => {
+	afterEach( () => {
+		focusedMock.mockReset();
+		scrollIntoViewMock.mockReset();
+	} );
+
+	describe( 'if component is not in view', () => {
+		beforeEach( () => {
+			const renderer = render( { inView: false } );
+			const props = renderer.root.findByType( 'span' ).props;
+			props.scrollToTop( { focusableSelector: 'button' } );
+		} );
+
+		it( 'scrolls to top of the component when scrollToTop is called', () => {
+			expect( scrollIntoViewMock ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'moves focus to top of the component when scrollToTop is called', () => {
+			expect( focusedMock ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'if component is in view', () => {
+		beforeEach( () => {
+			const renderer = render( { inView: true } );
+			const props = renderer.root.findByType( 'span' ).props;
+			props.scrollToTop( { focusableSelector: 'button' } );
+		} );
+
+		it( "doesn't scroll to top of the component when scrollToTop is called", () => {
+			expect( scrollIntoViewMock ).toHaveBeenCalledTimes( 0 );
+		} );
+		it( 'moves focus to top of the component when scrollToTop is called', () => {
+			expect( focusedMock ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );


### PR DESCRIPTION
Based on #899.

This PR makes it so the window scrolls to the top of the _All Products_ block when navigating pages (focus is moved too).

In parallel, it improves keyboard navigation of the `<Navigation>` component.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### Screenshots

![Peek 2019-10-01 16-39](https://user-images.githubusercontent.com/3616980/65972477-2a5e4c00-e46a-11e9-90ce-646ed720785e.gif)

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block and preview it.
2. Make the window small and scroll so the top of the block is not visible.
3. Switch to another page and verify you are scrolled to the top of the block.
4. Navigate around the block with your keyboard and verify switching pages moves the focus to the top and you can't focus the current page in the `<Navigation>` component.