### PR TITLE
Rename properties and components from 'order' to 'sort'

### DIFF
--- a/assets/js/base/components/product-grid/container.js
+++ b/assets/js/base/components/product-grid/container.js
@@ -24,13 +24,13 @@ class ProductGridContainer extends Component {
 		this.props.onPageChange( newPage );
 	};
 
-	onOrderChange = ( event ) => {
+	onSortChange = ( event ) => {
 		const sortValue = event.target.value;
 		this.setState( {
 			currentPage: 1,
 			sortValue,
 		} );
-		this.props.onOrderChange( sortValue );
+		this.props.onSortChange( sortValue );
 	};
 
 	render() {
@@ -42,7 +42,7 @@ class ProductGridContainer extends Component {
 			<ProductGrid
 				attributes={ attributes }
 				currentPage={ currentPage }
-				onOrderChange={ this.onOrderChange }
+				onSortChange={ this.onSortChange }
 				onPageChange={ this.onPageChange }
 				sortValue={ sortValue }
 			/>
@@ -73,7 +73,7 @@ export default withWindow(
 					} )
 				);
 			},
-			onOrderChange( sortValue ) {
+			onSortChange( sortValue ) {
 				history.pushState(
 					null,
 					'',

--- a/assets/js/base/components/product-grid/container.js
+++ b/assets/js/base/components/product-grid/container.js
@@ -14,7 +14,7 @@ import withWindow from '../../hocs/with-window';
 class ProductGridContainer extends Component {
 	state = {
 		currentPage: this.props.currentPage || 1,
-		orderValue: this.props.orderValue,
+		sortValue: this.props.sortValue,
 	};
 
 	onPageChange = ( newPage ) => {
@@ -25,19 +25,18 @@ class ProductGridContainer extends Component {
 	};
 
 	onOrderChange = ( event ) => {
-		const orderValue = event.target.value;
+		const sortValue = event.target.value;
 		this.setState( {
 			currentPage: 1,
-			orderValue,
+			sortValue,
 		} );
-		this.props.onOrderChange( orderValue );
+		this.props.onOrderChange( sortValue );
 	};
 
 	render() {
 		const { attributes } = this.props;
 		const { currentPage } = this.state;
-		const orderValue =
-			this.state.orderValue || this.props.attributes.orderby;
+		const sortValue = this.state.sortValue || this.props.attributes.orderby;
 
 		return (
 			<ProductGrid
@@ -45,7 +44,7 @@ class ProductGridContainer extends Component {
 				currentPage={ currentPage }
 				onOrderChange={ this.onOrderChange }
 				onPageChange={ this.onPageChange }
-				orderValue={ orderValue }
+				sortValue={ sortValue }
 			/>
 		);
 	}
@@ -58,24 +57,28 @@ ProductGridContainer.propTypes = {
 
 export default withWindow(
 	( { location, history }, { urlParameterSuffix } ) => {
-		const pageParameter = `page${ urlParameterSuffix }`;
-		const orderParameter = `order${ urlParameterSuffix }`;
+		const pageParameter = `product_page${ urlParameterSuffix }`;
+		const sortParameter = `product_sort${ urlParameterSuffix }`;
 		return {
-			currentPage: parseInt( getQueryArg( location.href, pageParameter ) ),
-			orderValue: getQueryArg( location.href, orderParameter ),
+			currentPage: parseInt(
+				getQueryArg( location.href, pageParameter )
+			),
+			sortValue: getQueryArg( location.href, sortParameter ),
 			onPageChange( newPage ) {
 				history.pushState(
 					null,
 					'',
-					addQueryArgs( location.href, { [ pageParameter ]: newPage })
-				)
+					addQueryArgs( location.href, {
+						[ pageParameter ]: newPage,
+					} )
+				);
 			},
-			onOrderChange( orderValue ) {
+			onOrderChange( sortValue ) {
 				history.pushState(
 					null,
 					'',
 					addQueryArgs( location.href, {
-						[ orderParameter ]: orderValue,
+						[ sortParameter ]: sortValue,
 						[ pageParameter ]: 1,
 					} )
 				);

--- a/assets/js/base/components/product-grid/index.js
+++ b/assets/js/base/components/product-grid/index.js
@@ -16,7 +16,7 @@ import './style.scss';
 const ProductGrid = ( {
 	attributes,
 	currentPage,
-	onOrderChange,
+	onSortChange,
 	onPageChange,
 	sortValue,
 	products,
@@ -48,7 +48,7 @@ const ProductGrid = ( {
 		<div className={ getClassnames() }>
 			{ attributes.showOrderby && (
 				<ProductSortSelect
-					onChange={ onOrderChange }
+					onChange={ onSortChange }
 					value={ sortValue }
 				/>
 			) }

--- a/assets/js/base/components/product-grid/index.js
+++ b/assets/js/base/components/product-grid/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import Pagination from '../pagination';
-import ProductOrderSelect from '../product-order-select';
+import ProductSortSelect from '../product-sort-select';
 import ProductGridItem from '../product-grid-item';
 import withProducts from '../../hocs/with-products';
 import './style.scss';
@@ -18,7 +18,7 @@ const ProductGrid = ( {
 	currentPage,
 	onOrderChange,
 	onPageChange,
-	orderValue,
+	sortValue,
 	products,
 	totalProducts,
 } ) => {
@@ -47,9 +47,9 @@ const ProductGrid = ( {
 	return (
 		<div className={ getClassnames() }>
 			{ attributes.showOrderby && (
-				<ProductOrderSelect
+				<ProductSortSelect
 					onChange={ onOrderChange }
-					value={ orderValue }
+					value={ sortValue }
 				/>
 			) }
 			<ul className="wc-block-grid__products">

--- a/assets/js/base/components/product-order-select/style.scss
+++ b/assets/js/base/components/product-order-select/style.scss
@@ -1,3 +1,0 @@
-.wc-block-product-order-select {
-	margin-bottom: $gap-large;
-}

--- a/assets/js/base/components/product-sort-select/index.js
+++ b/assets/js/base/components/product-sort-select/index.js
@@ -7,13 +7,13 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import OrderSelect from '../order-select';
+import SortSelect from '../sort-select';
 import './style.scss';
 
-const ProductOrderSelect = ( { defaultValue, onChange, readOnly, value } ) => {
+const ProductSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 	return (
-		<OrderSelect
-			className="wc-block-product-order-select"
+		<SortSelect
+			className="wc-block-product-sort-select"
 			defaultValue={ defaultValue }
 			name="orderby"
 			onChange={ onChange }
@@ -65,7 +65,7 @@ const ProductOrderSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 	);
 };
 
-ProductOrderSelect.propTypes = {
+ProductSortSelect.propTypes = {
 	defaultValue: PropTypes.oneOf( [
 		'menu_order',
 		'popularity',
@@ -86,4 +86,4 @@ ProductOrderSelect.propTypes = {
 	] ),
 };
 
-export default ProductOrderSelect;
+export default ProductSortSelect;

--- a/assets/js/base/components/product-sort-select/style.scss
+++ b/assets/js/base/components/product-sort-select/style.scss
@@ -1,0 +1,3 @@
+.wc-block-product-sort-select {
+	margin-bottom: $gap-large;
+}

--- a/assets/js/base/components/review-order-select/style.scss
+++ b/assets/js/base/components/review-order-select/style.scss
@@ -1,3 +1,0 @@
-.wc-block-review-order-select {
-	text-align: right;
-}

--- a/assets/js/base/components/review-sort-select/index.js
+++ b/assets/js/base/components/review-sort-select/index.js
@@ -7,13 +7,13 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import OrderSelect from '../order-select';
+import SortSelect from '../sort-select';
 import './style.scss';
 
-const ReviewOrderSelect = ( { defaultValue, onChange, readOnly, value } ) => {
+const ReviewSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 	return (
-		<OrderSelect
-			className="wc-block-review-order-select"
+		<SortSelect
+			className="wc-block-review-sort-select"
 			defaultValue={ defaultValue }
 			label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
 			onChange={ onChange }
@@ -47,7 +47,7 @@ const ReviewOrderSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 	);
 };
 
-ReviewOrderSelect.propTypes = {
+ReviewSortSelect.propTypes = {
 	defaultValue: PropTypes.oneOf( [
 		'most-recent',
 		'highest-rating',
@@ -62,4 +62,4 @@ ReviewOrderSelect.propTypes = {
 	] ),
 };
 
-export default ReviewOrderSelect;
+export default ReviewSortSelect;

--- a/assets/js/base/components/review-sort-select/style.scss
+++ b/assets/js/base/components/review-sort-select/style.scss
@@ -1,0 +1,3 @@
+.wc-block-review-sort-select {
+	text-align: right;
+}

--- a/assets/js/base/components/sort-select/index.js
+++ b/assets/js/base/components/sort-select/index.js
@@ -15,7 +15,7 @@ import './style.scss';
  * Component used for 'Order by' selectors, which renders a label
  * and a <select> with the options provided in the props.
  */
-const OrderSelect = ( {
+const SortSelect = ( {
 	className,
 	componentId,
 	defaultValue,
@@ -26,22 +26,22 @@ const OrderSelect = ( {
 	readOnly,
 	value,
 } ) => {
-	const selectId = `wc-block-order-select__select-${ componentId }`;
+	const selectId = `wc-block-sort-select__select-${ componentId }`;
 
 	return (
-		<div className={ classNames( 'wc-block-order-select', className ) }>
+		<div className={ classNames( 'wc-block-sort-select', className ) }>
 			<Label
 				label={ label }
 				screenReaderLabel={ screenReaderLabel }
 				wrapperElement="label"
 				wrapperProps={ {
-					className: 'wc-block-order-select__label',
+					className: 'wc-block-sort-select__label',
 					htmlFor: selectId,
 				} }
 			/>
 			<select // eslint-disable-line jsx-a11y/no-onchange
 				id={ selectId }
-				className="wc-block-order-select__select"
+				className="wc-block-sort-select__select"
 				defaultValue={ defaultValue }
 				onChange={ onChange }
 				readOnly={ readOnly }
@@ -57,7 +57,7 @@ const OrderSelect = ( {
 	);
 };
 
-OrderSelect.propTypes = {
+SortSelect.propTypes = {
 	defaultValue: PropTypes.string,
 	label: PropTypes.string,
 	onChange: PropTypes.func,
@@ -74,4 +74,4 @@ OrderSelect.propTypes = {
 	componentId: PropTypes.number.isRequired,
 };
 
-export default withComponentId( OrderSelect );
+export default withComponentId( SortSelect );

--- a/assets/js/base/components/sort-select/style.scss
+++ b/assets/js/base/components/sort-select/style.scss
@@ -1,8 +1,8 @@
-.wc-block-order-select {
+.wc-block-sort-select {
 	margin-bottom: $gap-small;
 }
 
-.wc-block-order-select__label {
+.wc-block-sort-select__label {
 	margin-right: $gap-small;
 	display: inline-block;
 	font-weight: normal;

--- a/assets/js/base/hocs/test/with-products.js
+++ b/assets/js/base/hocs/test/with-products.js
@@ -46,7 +46,7 @@ const render = () => {
 				rows: 3,
 			} }
 			currentPage={ 1 }
-			orderValue="menu_order"
+			sortValue="menu_order"
 			productId={ 1 }
 			productsToDisplay={ 2 }
 		/>

--- a/assets/js/base/hocs/test/with-reviews.js
+++ b/assets/js/base/hocs/test/with-reviews.js
@@ -11,7 +11,7 @@ import * as mockUtils from '../../../blocks/reviews/utils';
 import * as mockBaseUtils from '../../utils/errors';
 
 jest.mock( '../../../blocks/reviews/utils', () => ( {
-	getOrderArgs: () => ( {
+	getSortArgs: () => ( {
 		order: 'desc',
 		orderby: 'date_gmt',
 	} ),

--- a/assets/js/base/hocs/with-products.js
+++ b/assets/js/base/hocs/with-products.js
@@ -30,7 +30,7 @@ const withProducts = ( OriginalComponent ) => {
 		componentDidUpdate( prevProps ) {
 			if (
 				prevProps.currentPage !== this.props.currentPage ||
-				prevProps.orderValue !== this.props.orderValue ||
+				prevProps.sortValue !== this.props.sortValue ||
 				prevProps.attributes.columns !==
 					this.props.attributes.columns ||
 				prevProps.attributes.rows !== this.props.attributes.rows
@@ -39,7 +39,7 @@ const withProducts = ( OriginalComponent ) => {
 			}
 		}
 
-		getOrderArgs( orderName ) {
+		getSortArgs( orderName ) {
 			switch ( orderName ) {
 				case 'menu_order':
 				case 'popularity':
@@ -59,12 +59,12 @@ const withProducts = ( OriginalComponent ) => {
 		}
 
 		loadProducts() {
-			const { attributes, currentPage, orderValue } = this.props;
+			const { attributes, currentPage, sortValue } = this.props;
 
 			this.setState( { loading: true, products: [] } );
 
 			const args = {
-				...this.getOrderArgs( orderValue ),
+				...this.getSortArgs( sortValue ),
 				per_page: attributes.columns * attributes.rows,
 				page: currentPage,
 			};

--- a/assets/js/blocks/reviews/editor-block.js
+++ b/assets/js/blocks/reviews/editor-block.js
@@ -13,7 +13,7 @@ import { ENABLE_REVIEW_RATING } from '@woocommerce/block-settings';
 import ErrorPlaceholder from '../../components/error-placeholder';
 import LoadMoreButton from '../../base/components/load-more-button';
 import ReviewList from '../../base/components/review-list';
-import ReviewOrderSelect from '../../base/components/review-order-select';
+import ReviewSortSelect from '../../base/components/review-sort-select';
 import withReviews from '../../base/hocs/with-reviews';
 
 /**
@@ -57,7 +57,7 @@ class EditorBlock extends Component {
 		return (
 			<Disabled>
 				{ attributes.showOrderby && ENABLE_REVIEW_RATING && (
-					<ReviewOrderSelect readOnly value={ attributes.orderby } />
+					<ReviewSortSelect readOnly value={ attributes.orderby } />
 				) }
 				<ReviewList attributes={ attributes } reviews={ reviews } />
 				{ attributes.showLoadMore && totalReviews > reviews.length && (

--- a/assets/js/blocks/reviews/editor-container-block.js
+++ b/assets/js/blocks/reviews/editor-container-block.js
@@ -11,7 +11,7 @@ import { Placeholder } from '@wordpress/components';
  * Internal dependencies
  */
 import EditorBlock from './editor-block.js';
-import { getBlockClassName, getOrderArgs } from './utils.js';
+import { getBlockClassName, getSortArgs } from './utils.js';
 
 /**
  * Container of the block rendered in the editor.
@@ -43,7 +43,7 @@ class EditorContainerBlock extends Component {
 			showReviewImage,
 			showReviewRating,
 		} = attributes;
-		const { order, orderby } = getOrderArgs( attributes.orderby );
+		const { order, orderby } = getSortArgs( attributes.orderby );
 		const isAllContentHidden =
 			! showReviewContent &&
 			! showReviewRating &&

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -10,7 +10,7 @@ import { ENABLE_REVIEW_RATING } from '@woocommerce/block-settings';
  * Internal dependencies
  */
 import LoadMoreButton from '../../base/components/load-more-button';
-import ReviewOrderSelect from '../../base/components/review-order-select';
+import ReviewSortSelect from '../../base/components/review-sort-select';
 import ReviewList from '../../base/components/review-list';
 import withReviews from '../../base/hocs/with-reviews';
 
@@ -33,7 +33,7 @@ const FrontendBlock = ( {
 	return (
 		<Fragment>
 			{ attributes.showOrderby !== 'false' && ENABLE_REVIEW_RATING && (
-				<ReviewOrderSelect
+				<ReviewSortSelect
 					defaultValue={ orderby }
 					onChange={ onChangeOrderby }
 				/>

--- a/assets/js/blocks/reviews/frontend-container-block.js
+++ b/assets/js/blocks/reviews/frontend-container-block.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { getOrderArgs } from './utils';
+import { getSortArgs } from './utils';
 import FrontendBlock from './frontend-block';
 
 /**
@@ -79,7 +79,7 @@ class FrontendContainerBlock extends Component {
 		const { attributes } = this.props;
 		const { categoryIds, productId } = attributes;
 		const { reviewsToDisplay } = this.state;
-		const { order, orderby } = getOrderArgs( this.state.orderby );
+		const { order, orderby } = getSortArgs( this.state.orderby );
 
 		return (
 			<FrontendBlock

--- a/assets/js/blocks/reviews/utils.js
+++ b/assets/js/blocks/reviews/utils.js
@@ -5,15 +5,15 @@ import apiFetch from '@wordpress/api-fetch';
 import classNames from 'classnames';
 import { ENABLE_REVIEW_RATING } from '@woocommerce/block-settings';
 
-export const getOrderArgs = ( orderValue ) => {
+export const getSortArgs = ( sortValue ) => {
 	if ( ENABLE_REVIEW_RATING ) {
-		if ( orderValue === 'lowest-rating' ) {
+		if ( sortValue === 'lowest-rating' ) {
 			return {
 				order: 'asc',
 				orderby: 'rating',
 			};
 		}
-		if ( orderValue === 'highest-rating' ) {
+		if ( sortValue === 'highest-rating' ) {
 			return {
 				order: 'desc',
 				orderby: 'rating',


### PR DESCRIPTION
As discussed on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/994#discussion_r329580479, we want to prioritize the use of _sort_ instead of _order_ for components/values related to sorting elements, to avoid confusion with orders.

### How to test the changes in this Pull Request:

1. Create a post with a _All Reviews_ and a _All Products_ block and verify the _Order by_ select still works as expected.