### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,7 @@
 /phpunit.* export-ignore
 /composer.lock export-ignore
 /composer.json export-ignore
+/CODEOWNERS export-ignore
 /renovate.json export-ignore
 /webpack.config.js export-ignore
 /postcss.config.js export-ignore

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Define @woocommerce/blocks as the code owners of the repo so the team is
+# tagged to review new PRs automatically.
+*       @woocommerce/blocks

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -43,6 +43,7 @@ copy_dest_files() {
 		--exclude=tests/ \
 		--exclude=phpcs.xml \
 		--exclude=phpunit.xml.dist \
+		--exclude=CODEOWNERS \
 		--exclude=renovate.json \
 		--exclude="*.config.js" \
 		--exclude="*-config.js" \

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -54,6 +54,7 @@ copy_dest_files() {
 	--exclude=tests/ \
 	--exclude=phpcs.xml \
 	--exclude=phpunit.xml.dist \
+	--exclude=CODEOWNERS \
 	--exclude=renovate.json \
 	--exclude="*.config.js" \
 	--exclude="*-config.js" \


### PR DESCRIPTION
Define @woocommerce/blocks as the code owners of the repo so the team is tagged to review new PRs automatically.

For more info about code owners, see: https://help.github.com/en/articles/about-code-owners

### How to test the changes in this Pull Request:

1. We need this to be merge before it can be tested. But after being in `master`, new PRs should set the _Reviewers_ to `@woocommerce/blocks` by default.