### PR TITLE
Avoid first and last pages being included in pagination 'pagesToDisplay'

### DIFF
--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -42,8 +42,10 @@ const Pagination = ( {
 	}
 
 	const pages = [];
-	for ( let i = minIndex; i <= maxIndex; i++ ) {
-		pages.push( i );
+	if ( minIndex && maxIndex ) {
+		for ( let i = minIndex; i <= maxIndex; i++ ) {
+			pages.push( i );
+		}
 	}
 
 	return (
@@ -75,7 +77,9 @@ const Pagination = ( {
 			) }
 			{ showFirstPage && (
 				<button
-					className="wc-block-pagination-page"
+					className={ classNames( 'wc-block-pagination-page', {
+						'wc-block-pagination-page--active': currentPage === 1,
+					} ) }
 					onClick={ () => onPageChange( 1 ) }
 				>
 					1
@@ -117,7 +121,10 @@ const Pagination = ( {
 			) }
 			{ showLastPage && (
 				<button
-					className="wc-block-pagination-page"
+					className={ classNames( 'wc-block-pagination-page', {
+						'wc-block-pagination-page--active':
+							currentPage === totalPages,
+					} ) }
 					onClick={ () => onPageChange( totalPages ) }
 				>
 					{ totalPages }

--- a/assets/js/base/components/pagination/test/index.js
+++ b/assets/js/base/components/pagination/test/index.js
@@ -7,15 +7,15 @@ describe( 'getIndexes', () => {
 	describe( 'when on the first page', () => {
 		test( 'indexes include the first pages available', () => {
 			expect( getIndexes( 5, 1, 100 ) ).toEqual( {
-				minIndex: 1,
-				maxIndex: 5,
+				minIndex: 2,
+				maxIndex: 6,
 			} );
 		} );
 
-		test( 'indexes include the only available page if there is only one', () => {
+		test( 'indexes are null if there are 2 pages or less', () => {
 			expect( getIndexes( 5, 1, 1 ) ).toEqual( {
-				minIndex: 1,
-				maxIndex: 1,
+				minIndex: null,
+				maxIndex: null,
 			} );
 		} );
 	} );
@@ -32,8 +32,8 @@ describe( 'getIndexes', () => {
 	describe( 'when on the last page', () => {
 		test( 'indexes include the last pages available', () => {
 			expect( getIndexes( 5, 100, 100 ) ).toEqual( {
-				minIndex: 96,
-				maxIndex: 100,
+				minIndex: 95,
+				maxIndex: 99,
 			} );
 		} );
 	} );

--- a/assets/js/base/components/pagination/utils.js
+++ b/assets/js/base/components/pagination/utils.js
@@ -8,23 +8,26 @@
  * @return {object} Object containing the min and max index to display in the pagination component.
  */
 export const getIndexes = ( pagesToDisplay, currentPage, totalPages ) => {
+	if ( totalPages <= 2 ) {
+		return { minIndex: null, maxIndex: null };
+	}
 	const extraPagesToDisplay = pagesToDisplay - 1;
 	const tentativeMinIndex = Math.max(
 		Math.floor( currentPage - extraPagesToDisplay / 2 ),
-		1
+		2
 	);
 	const maxIndex = Math.min(
 		Math.ceil(
 			currentPage +
 				( extraPagesToDisplay - ( currentPage - tentativeMinIndex ) )
 		),
-		totalPages
+		totalPages - 1
 	);
 	const minIndex = Math.max(
 		Math.floor(
 			currentPage - ( extraPagesToDisplay - ( maxIndex - currentPage ) )
 		),
-		1
+		2
 	);
 
 	return { minIndex, maxIndex };


### PR DESCRIPTION
As described here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/994#pullrequestreview-295582069, we wanted to make some improvements to the `<Pagination>` component so the number of visible page buttons varies less depending on which page you are in.

This PR makes it so the first and last pages are not counted as `pagesToDisplay` in the `<Pagination>` component, so the number of visible pages is more consistent.

### Screenshots
_Before:_
![Peek 2019-10-03 10-26](https://user-images.githubusercontent.com/3616980/66111061-5e4f8380-e5c8-11e9-8007-c87a168d08b3.gif)

_After:_
![Peek 2019-10-03 10-17](https://user-images.githubusercontent.com/3616980/66110661-85598580-e5c7-11e9-99ac-0eac2fa26b67.gif)

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block.
2. Change the number of columns/blocks so there is enough pagination.
3. Verify on every page these page buttons are visible:
  * First page.
  * Three (or more) pages in the middle.
  * Last page.