### PR TITLE
Fix: Load back-compat wcSettings global for old `@woocommerce/settings` package

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -75,9 +75,23 @@ class Bootstrap {
 		$this->container->register(
 			AssetDataRegistry::class,
 			function( Container $container ) {
-				$asset_api        = $container->get( AssetApi::class );
-				$load_back_compat = defined( 'WC_ADMIN_VERSION_NUMBER' )
-					&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' );
+				$asset_api  = $container->get( AssetApi::class );
+				$js_package = \json_decode(
+					// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+					\file_get_contents(
+						$this->package->get_path( 'package.json' )
+					),
+					true
+				);
+				$woocommerce_components_version =
+					isset( $js_package['dependencies']['@woocommerce/components'] )
+						? $js_package['dependencies']['@woocommerce/components']
+						: 0;
+				$load_back_compat               = '3.2.0' === $woocommerce_components_version
+					|| (
+						defined( 'WC_ADMIN_VERSION_NUMBER' )
+						&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' )
+					);
 				return $load_back_compat
 					? new BackCompatAssetDataRegistry( $asset_api )
 					: new AssetDataRegistry( $asset_api );


### PR DESCRIPTION
While working in a separate branch I noticed the following error in my console:

> VM30177 index.js:601 Uncaught TypeError: Cannot read property 'userLocale' of undefined

The stack trace pointed to the `@woocommerce/components` package.

My environment at the time of the error was:

- WooCommerce Blocks master
- WooCommerce Admin plugin inactive.
- WooCommerce Core 3.8.0-dev

This was a regression introduced by 96c1c7702 (part of #1000).  I thought I had tested the scenarios fully for that pull, but I obviously didn't.  While the commit itself was sound (checking WC core version is unneeded), the original check there hid the bug where I wasn't accounting for the old `@woocommerce/components` package included for builds.  Until that package is updated to include the wcSettings refactor for the required package, we'll need to load the back-compat.

**Note:**  this pull can be merged to prevent breakage, but I'm working on getting https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1017 before the next `@woocommerce-packages` update so we can bump our dependency and remove this shim.

## Testing:

The back compat will be loaded constantly now until we bump the package dependency.  So basically testing involves just ensuring that in the following environments there are no errors when smoke-testing functionality:

* [x] WC Blocks (this branch), WC-Admin active (smoke test WC-Admin as well)
* [x] WC Blocks (this branch), WC-Admin inactive