### PR TITLE
Fix ProductAttributeControl not reacting to clicks

### DIFF
--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -20,6 +20,7 @@ const ProductAttributeControl = ( {
 	error,
 	expandedAttribute,
 	onChange,
+	onExpandAttribute,
 	onOperatorChange,
 	isLoading,
 	operator,
@@ -27,7 +28,7 @@ const ProductAttributeControl = ( {
 	termsAreLoading,
 	termsList,
 } ) => {
-	const onExpandAttribute = ( item ) => {
+	const onSelectAttribute = ( item ) => {
 		return () => {
 			onChange( [] );
 			onExpandAttribute( item.id );
@@ -54,7 +55,7 @@ const ProductAttributeControl = ( {
 					{ ...args }
 					className={ classes.join( ' ' ) }
 					isSelected={ expandedAttribute === item.id }
-					onSelect={ onExpandAttribute }
+					onSelect={ onSelectAttribute }
 					isSingle
 					disabled={ '0' === item.count }
 					aria-expanded={ expandedAttribute === item.id }


### PR DESCRIPTION
Fixes #1019.

The regression was introduced in #935.

### Screenshot
![image](https://user-images.githubusercontent.com/3616980/66213868-e31dc880-e6c0-11e9-9cf2-9f7738e0b536.png)

### How to test the changes in this Pull Request:

1. Create a post with a _Products by Attribute_ block.
2. Verify you can select attributes and, when selected, their terms appear below.
