### PR TITLE
Create withBrowserLocation and withBrowserHistory HOC

### DIFF
--- a/assets/js/base/components/product-grid/container.js
+++ b/assets/js/base/components/product-grid/container.js
@@ -9,7 +9,8 @@ import { addQueryArgs, getQueryArg } from '@wordpress/url';
  * Internal dependencies
  */
 import ProductGrid from './index';
-import withWindow from '../../hocs/with-window';
+import withBrowserHistory from '../../hocs/with-browser-history';
+import withBrowserLocation from '../../hocs/with-browser-location';
 
 class ProductGridContainer extends Component {
 	state = {
@@ -56,30 +57,40 @@ ProductGridContainer.propTypes = {
 	urlParameterSuffix: PropTypes.string,
 };
 
-export default withWindow(
-	( { location, history }, { urlParameterSuffix } ) => {
-		const pageParameter = `page${ urlParameterSuffix }`;
-		const orderParameter = `order${ urlParameterSuffix }`;
-		return {
-			currentPage: parseInt( getQueryArg( location.href, pageParameter ) ),
-			orderValue: getQueryArg( location.href, orderParameter ),
-			onPageChange( newPage ) {
-				history.pushState(
-					null,
-					'',
-					addQueryArgs( location.href, { [ pageParameter ]: newPage })
-				)
-			},
-			onOrderChange( orderValue ) {
-				history.pushState(
-					null,
-					'',
-					addQueryArgs( location.href, {
-						[ orderParameter ]: orderValue,
-						[ pageParameter ]: 1,
-					} )
-				);
-			},
-		};
-	}
-)( ProductGridContainer );
+export default withBrowserLocation( ( location, { urlParameterSuffix } ) => {
+	const pageParameter = `page${ urlParameterSuffix }`;
+	const orderParameter = `order${ urlParameterSuffix }`;
+	return {
+		currentPage: parseInt( getQueryArg( location.href, pageParameter ) ),
+		location,
+		orderValue: getQueryArg( location.href, orderParameter ),
+		pageParameter,
+		orderParameter,
+	};
+} )(
+	withBrowserHistory(
+		( history, { location, orderParameter, pageParameter } ) => {
+			return {
+				onPageChange( newPage ) {
+					history.pushState(
+						null,
+						'',
+						addQueryArgs( location.href, {
+							[ pageParameter ]: newPage,
+						} )
+					);
+				},
+				onOrderChange( orderValue ) {
+					history.pushState(
+						null,
+						'',
+						addQueryArgs( location.href, {
+							[ orderParameter ]: orderValue,
+							[ pageParameter ]: 1,
+						} )
+					);
+				},
+			};
+		}
+	)( ProductGridContainer )
+);

--- a/assets/js/base/hocs/test/with-browser-history.js
+++ b/assets/js/base/hocs/test/with-browser-history.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import withBrowserHistory from '../with-browser-history';
+import withBrowserWindowProp from '../with-browser-window-prop.js';
+
+jest.mock( '../with-browser-window-prop.js', () => jest.fn() );
+
+describe( 'withBrowserHistory Component', () => {
+	it( 'calls withBrowserWindowProp with the correct arguments', () => {
+		const propMap = jest.fn();
+		withBrowserHistory( propMap );
+
+		expect( withBrowserWindowProp ).toHaveBeenCalledTimes( 1 );
+		expect( withBrowserWindowProp ).toHaveBeenCalledWith(
+			'history',
+			propMap
+		);
+	} );
+} );

--- a/assets/js/base/hocs/test/with-browser-location.js
+++ b/assets/js/base/hocs/test/with-browser-location.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import withBrowserLocation from '../with-browser-location';
+import withBrowserWindowProp from '../with-browser-window-prop.js';
+
+jest.mock( '../with-browser-window-prop.js', () => jest.fn() );
+
+describe( 'withBrowserLocation Component', () => {
+	it( 'calls withBrowserWindowProp with the correct arguments', () => {
+		const propMap = jest.fn();
+		withBrowserLocation( propMap );
+
+		expect( withBrowserWindowProp ).toHaveBeenCalledTimes( 1 );
+		expect( withBrowserWindowProp ).toHaveBeenCalledWith(
+			'location',
+			propMap
+		);
+	} );
+} );

--- a/assets/js/base/hocs/test/with-browser-window-prop.js
+++ b/assets/js/base/hocs/test/with-browser-window-prop.js
@@ -6,35 +6,36 @@ import TestRenderer from 'react-test-renderer';
 /**
  * Internal dependencies
  */
-import withWindow from '../with-window';
+import withBrowserWindowProp from '../with-browser-window-prop';
 
+const windowProp = 'location';
 const render = ( propMap ) => {
 	/* eslint-disable-next-line @wordpress/no-unused-vars-before-return */
-	const TestComponent = withWindow( propMap )( ( props ) => (
-		<div { ...props } />
-	) );
+	const TestComponent = withBrowserWindowProp( windowProp, propMap )(
+		( props ) => <div { ...props } />
+	);
 
 	return TestRenderer.create(
 		<TestComponent greeting={ 'Hello' } name={ 'Alice' } />
 	);
 };
 
-describe( 'withWindow Component', () => {
-	it( 'calls the propMap function with the window object and the props', () => {
+describe( 'withBrowserWindowProp Component', () => {
+	it( 'calls the propMap function with the window property and the props', () => {
 		const propMap = jest.fn();
 		const testFunction = jest.fn();
-		propMap.mockImplementation( ( window, props ) => {
-			testFunction( window, props );
+		propMap.mockImplementation( ( wProp, props ) => {
+			testFunction( wProp, props );
 		} );
 
 		render( propMap );
 
-		expect( propMap ).toHaveBeenCalledWith( window, {
+		expect( propMap ).toHaveBeenCalledWith( window[ windowProp ], {
 			name: 'Alice',
 			greeting: 'Hello',
 		} );
 		expect( propMap ).toHaveBeenCalledTimes( 1 );
-		expect( testFunction ).toHaveBeenCalledWith( window, {
+		expect( testFunction ).toHaveBeenCalledWith( window[ windowProp ], {
 			name: 'Alice',
 			greeting: 'Hello',
 		} );

--- a/assets/js/base/hocs/test/with-browser-window-prop.js
+++ b/assets/js/base/hocs/test/with-browser-window-prop.js
@@ -23,10 +23,6 @@ const render = ( propMap ) => {
 describe( 'withBrowserWindowProp Component', () => {
 	it( 'calls the propMap function with the window property and the props', () => {
 		const propMap = jest.fn();
-		const testFunction = jest.fn();
-		propMap.mockImplementation( ( wProp, props ) => {
-			testFunction( wProp, props );
-		} );
 
 		render( propMap );
 
@@ -35,11 +31,6 @@ describe( 'withBrowserWindowProp Component', () => {
 			greeting: 'Hello',
 		} );
 		expect( propMap ).toHaveBeenCalledTimes( 1 );
-		expect( testFunction ).toHaveBeenCalledWith( window[ windowProp ], {
-			name: 'Alice',
-			greeting: 'Hello',
-		} );
-		expect( testFunction ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'sets the resulting props from the propMap into the resulting component', () => {

--- a/assets/js/base/hocs/with-browser-history.js
+++ b/assets/js/base/hocs/with-browser-history.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import withBrowserWindowProp from './with-browser-window-prop.js';
+
+const withBrowserHistory = ( propMap ) =>
+	withBrowserWindowProp( 'history', propMap );
+
+export default withBrowserHistory;

--- a/assets/js/base/hocs/with-browser-location.js
+++ b/assets/js/base/hocs/with-browser-location.js
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import withBrowserWindowProp from './with-browser-window-prop.js';
+
+const withBrowserLocation = ( propMap ) =>
+	withBrowserWindowProp( 'location', propMap );
+
+export default withBrowserLocation;

--- a/assets/js/base/hocs/with-browser-window-prop.js
+++ b/assets/js/base/hocs/with-browser-window-prop.js
@@ -4,7 +4,7 @@ const withBrowserWindowProp = ( prop, propMap ) => ( WrappedComponent ) => (
 	incomingProps
 ) => {
 	const props = w.hasOwnProperty( prop )
-		? propMap( w[ prop ] || {}, incomingProps )
+		? propMap( w[ prop ], incomingProps )
 		: {};
 	return <WrappedComponent { ...incomingProps } { ...props } />;
 };

--- a/assets/js/base/hocs/with-browser-window-prop.js
+++ b/assets/js/base/hocs/with-browser-window-prop.js
@@ -1,0 +1,12 @@
+const w = window || {};
+
+const withBrowserWindowProp = ( prop, propMap ) => ( WrappedComponent ) => (
+	incomingProps
+) => {
+	const props = w.hasOwnProperty( prop )
+		? propMap( w[ prop ] || {}, incomingProps )
+		: {};
+	return <WrappedComponent { ...incomingProps } { ...props } />;
+};
+
+export default withBrowserWindowProp;

--- a/assets/js/base/hocs/with-window.js
+++ b/assets/js/base/hocs/with-window.js
@@ -1,8 +1,0 @@
-const w = window || {};
-
-const withWindow = ( propMap ) => ( WrappedComponent ) => ( incomingProps ) => {
-	const props = propMap( w, incomingProps );
-	return <WrappedComponent { ...incomingProps } { ...props } />;
-};
-
-export default withWindow;


### PR DESCRIPTION
This PR implements the improvements discussed in #997 comments, creating a `withBrowserWindowProp` internal HOC and a `withBrowserLocation` and `withBrowserHistory` consumer HOCs.

cc @nerrad 

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block.
2. Preview it.
3. Change the order and navigate to another page using the pagination at the bottom of the block.
4. Reload the page and verify order and page changes persist.
