### PR TITLE
Expose wp_version on settings api and provide a js version compare function

### DIFF
--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -1,11 +1,15 @@
-export * from './default-constants';
-export { setSetting } from './set-setting';
-
 /**
  * Internal dependencies
  */
 import { getSetting } from './get-setting';
+
+/**
+ * External dependencies
+ */
 import compareVersions from 'compare-versions';
+
+export * from './default-constants';
+export { setSetting } from './set-setting';
 
 /**
  * Note: this attempts to coerce the wp_version to a semver for comparison

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -1,3 +1,4 @@
 export { getSetting } from './get-setting';
 export { setSetting } from './set-setting';
 export * from './default-constants';
+export { default as compareVersions } from 'compare-versions';

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -1,4 +1,24 @@
-export { getSetting } from './get-setting';
-export { setSetting } from './set-setting';
 export * from './default-constants';
-export { default as compareVersions } from 'compare-versions';
+export { setSetting } from './set-setting';
+
+/**
+ * Internal dependencies
+ */
+import { getSetting } from './get-setting';
+import compareVersions from 'compare-versions';
+
+/**
+ * Note: this attempts to coerce the wp_version to a semver for comparison
+ * This will result in dropping any beta/rc values.
+ *
+ * `5.3-beta1-4252` would get converted to `5.3.4252`
+ */
+export const compareWithWpVersion = ( version, operator ) => {
+	return compareVersions.compare(
+		version,
+		getSetting( 'wp_version', '' ).replace( /-[a-zA-Z0-9]*?-/, '.' ),
+		operator
+	);
+};
+
+export { compareVersions, getSetting };

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -12,7 +12,7 @@ export * from './default-constants';
 export { setSetting } from './set-setting';
 
 /**
- * Note: this attempts to coerce the wp_version to a semver for comparison
+ * Note: this attempts to coerce the wpVersion to a semver for comparison
  * This will result in dropping any beta/rc values.
  *
  * `5.3-beta1-4252` would get converted to `5.3.0-rc.4252`
@@ -23,7 +23,7 @@ export { setSetting } from './set-setting';
  * to `rc`.
  */
 export const compareWithWpVersion = ( version, operator ) => {
-	let replacement = getSetting( 'wp_version', '' ).replace(
+	let replacement = getSetting( 'wpVersion', '' ).replace(
 		/-[a-zA-Z0-9]*[\-]*/,
 		'.0-rc.'
 	);

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -11,14 +11,22 @@ import compareVersions from 'compare-versions';
  * Note: this attempts to coerce the wp_version to a semver for comparison
  * This will result in dropping any beta/rc values.
  *
- * `5.3-beta1-4252` would get converted to `5.3.4252`
+ * `5.3-beta1-4252` would get converted to `5.3.0-rc.4252`
+ * `5.3-beta1` would get converted to `5.3.0-rc`.
+ * `5.3` would not be touched.
+ *
+ * For the purpose of these comparisons all pre-release versions are normalized
+ * to `rc`.
  */
 export const compareWithWpVersion = ( version, operator ) => {
-	return compareVersions.compare(
-		version,
-		getSetting( 'wp_version', '' ).replace( /-[a-zA-Z0-9]*?-/, '.' ),
-		operator
+	let replacement = getSetting( 'wp_version', '' ).replace(
+		/-[a-zA-Z0-9]*[\-]*/,
+		'.0-rc.'
 	);
+	replacement = replacement.endsWith( '.' )
+		? replacement.substring( 0, replacement.length - 1 )
+		: replacement;
+	return compareVersions.compare( version, replacement, operator );
 };
 
 export { compareVersions, getSetting };

--- a/assets/js/settings/shared/test/compare-with-wp-version.js
+++ b/assets/js/settings/shared/test/compare-with-wp-version.js
@@ -1,0 +1,21 @@
+import { compareWithWpVersion, setSetting } from '..';
+
+describe( 'compareWithWpVersion', () => {
+	it.each`
+		version             | operator | result
+		${'5.3-beta1'}      | ${'>'}   | ${true}
+		${'5.3'}            | ${'='}   | ${true}
+		${'5.3-beta12-235'} | ${'>'}   | ${true}
+		${'5.3-rc1'}        | ${'<'}   | ${false}
+		${'5.3-rc12-235'}   | ${'>'}   | ${true}
+		${'5.3.1'}          | ${'<'}   | ${true}
+		${'5.4-beta1'}      | ${'<'}   | ${true}
+	`(
+		'should return $result when $version is the current wp_version ' +
+			'and `5.3` is the version compared using `$operator`',
+		( { version, operator, result } ) => {
+			setSetting( 'wp_version', version );
+			expect( compareWithWpVersion( '5.3', operator ) ).toBe( result );
+		}
+	);
+} );

--- a/assets/js/settings/shared/test/compare-with-wp-version.js
+++ b/assets/js/settings/shared/test/compare-with-wp-version.js
@@ -1,3 +1,6 @@
+/**
+ * Internal imports
+ */
 import { compareWithWpVersion, setSetting } from '..';
 
 describe( 'compareWithWpVersion', () => {
@@ -11,10 +14,10 @@ describe( 'compareWithWpVersion', () => {
 		${'5.3.1'}          | ${'<'}   | ${true}
 		${'5.4-beta1'}      | ${'<'}   | ${true}
 	`(
-		'should return $result when $version is the current wp_version ' +
+		'should return $result when $version is the current wpVersion ' +
 			'and `5.3` is the version compared using `$operator`',
 		( { version, operator, result } ) => {
-			setSetting( 'wp_version', version );
+			setSetting( 'wpVersion', version );
 			expect( compareWithWpVersion( '5.3', operator ) ).toBe( result );
 		}
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4912,7 +4912,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -6297,7 +6297,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -6334,7 +6334,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -6394,7 +6394,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -6568,7 +6568,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -7108,6 +7108,11 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "compare-versions": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.5.1.tgz",
+      "integrity": "sha512-9fGPIB7C6AyM18CJJBHt5EnCZDG3oiTJYy0NjfIAGjKpzv0tkxWko7TNQHF5ymqm7IH03tqmeuBxtvD+Izh6mg=="
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -7325,7 +7330,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -7338,7 +7343,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -8084,7 +8089,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -10359,7 +10364,7 @@
     },
     "gettext-parser": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
       "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
       "requires": {
         "encoding": "^0.1.12",
@@ -11556,7 +11561,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -13987,7 +13992,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -14883,7 +14888,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -14944,7 +14949,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -15137,7 +15142,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -17157,7 +17162,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -17768,7 +17773,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -18243,7 +18248,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -18949,7 +18954,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -21131,7 +21136,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 	},
 	"dependencies": {
 		"@woocommerce/components": "3.2.0",
+		"compare-versions": "^3.5.1",
 		"gridicons": "3.3.1",
 		"trim-html": "0.1.9"
 	},

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -76,6 +76,7 @@ class AssetDataRegistry {
 		global $wp_locale;
 		$currency = get_woocommerce_currency();
 		return [
+			'wp_version'    => get_bloginfo( 'version' ),
 			'adminUrl'      => admin_url(),
 			'countries'     => WC()->countries->get_countries(),
 			'currency'      => [

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -76,7 +76,7 @@ class AssetDataRegistry {
 		global $wp_locale;
 		$currency = get_woocommerce_currency();
 		return [
-			'wp_version'    => get_bloginfo( 'version' ),
+			'wpVersion'     => get_bloginfo( 'version' ),
 			'adminUrl'      => admin_url(),
 			'countries'     => WC()->countries->get_countries(),
 			'currency'      => [


### PR DESCRIPTION
This is a continuation of the work supporting what is outlined in #1014.  In the following pull:

- `wp_version` is exposed on the settings api and accessible via `getSetting( 'wp_version' )`.
- I installed the [`compare-versions` npm package](https://www.npmjs.com/package/compare-versions) which has a [weight of 797b minified/zipped](https://bundlephobia.com/result?p=compare-versions@3.5.1).  It is exported on the `@woocommerce/settings` external so can be imported via that ( `import { compareVersions } from '@woocommerce/settings'`) or `wc.wcSettings.compareVersions`.
- exports a helper `compareWithWpVersion` function that receives the version you want to compare the wp_verison against and the operator.  So for instance, `compareWithWpVersion( '5.3', '>' )` would return true if the `wp_version` for the environment is `5.2`.

With this available, we can now prevent code executing in javascript if it doesn't meet specific version requirements.  Example

```js
import { compareVersions, getSetting } from '@woocommerce/settings';

if ( compareVersions( getSetting( 'wp_version' ), '5.3.0', '>' ) ) {
   // register block etc.
}
```

Note:

- builds will still contain the code in the bundle, the code can just be gated from executing behind a version check.

## Testing:

> Note: unit tests cover `compareWithWpVersion` so that should be okay.

* [ ] Verify a build contains the `wp_version` value on `wcSettings`, is accessible via `getSetting` and is the expected value for your environment.
* [ ] Verify `compareVersions` is available in a build.
* [ ] Verify `compareWithWpVersion` returns the expected result for the environment you are testing in.

Both the above can be verified by typing this in your browser console while in a block-editor view:

```js
wcSettings.wp_version
wc.wcSettings.getSetting( 'wp_version' )
wc.wcSettings.compareVersions.compare
wc.wcSettings.compareWithWpVersion
```