### PR TITLE
Pagination: disable first/last page if they are active

### DIFF
--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -81,6 +81,7 @@ const Pagination = ( {
 						'wc-block-pagination-page--active': currentPage === 1,
 					} ) }
 					onClick={ () => onPageChange( 1 ) }
+					disabled={ currentPage === 1 }
 				>
 					1
 				</button>
@@ -127,6 +128,7 @@ const Pagination = ( {
 							currentPage === totalPages,
 					} ) }
 					onClick={ () => onPageChange( totalPages ) }
+					disabled={ currentPage === totalPages }
 				>
 					{ totalPages }
 				</button>


### PR DESCRIPTION
Fixes an issue introduced in #1015. First and last pages were still enabled when they were active, while all other pages were disabled when active.

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block and preview it.
2. Verify you can't click on the `1` page when you are on the first page.
3. Go to the last page and verify you can't click on it.