### PR TITLE
Improved placeholders of translatable string

### DIFF
--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -55,16 +55,14 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 					<RawHTML>
 						{ sprintf(
 							escapeHTML(
-								/* translators: A notice that links to WooCommerce settings. */
+								/* translators: 1: store settings url 2: link attributes */
 								__(
-									'Product rating is disabled in your %sstore settings%s.',
+									'Product rating is disabled in your <a href="%1$s" %2$s>store settings</a>.',
 									'woo-gutenberg-products-block'
 								)
 							),
-							`<a href="${ getAdminLink(
-								'admin.php?page=wc-settings&tab=products'
-							) }" target="_blank">`,
-							'</a>'
+							getAdminLink( 'admin.php?page=wc-settings&tab=products' ),
+							'target="_blank"'
 						) }
 					</RawHTML>
 				</Notice>

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -139,16 +139,14 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 							<RawHTML>
 								{ sprintf(
 									escapeHTML(
-										/* translators: A notice that links to WordPress settings. */
+										/* translators: 1: discussion settings url 2: link attributes */
 										__(
-											'Reviewer photo is disabled in your %ssite settings%s.',
+											'Reviewer photo is disabled in your <a href="%$1s" %$2s>site settings</a>.',
 											'woo-gutenberg-products-block'
 										)
 									),
-									`<a href="${ getAdminLink(
-										'options-discussion.php'
-									) }" target="_blank">`,
-									'</a>'
+									getAdminLink( 'options-discussion.php' ),
+									'target="_blank"'
 								) }
 							</RawHTML>
 						</Notice>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Some HTML is allowed on translatable strings, WordPress core and WooCommerce includes `<a href="%s">` in translatable strings, so becomes less hard to understand, since `%s` will get joined to another words.

It's possible to find some references in: https://github.com/WordPress/WordPress/search?p=2&q=%3Ca+href%3D%22%251%24s%22+%252%24s%3E&unscoped_q=%3Ca+href%3D%22%251%24s%22+%252%24s%3E