### PR TITLE
Update NPM package docs after deprecation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,9 @@ __Important:__ Before running the release script ensure you have already pushed 
 
 ## Publishing `@woocommerce/block-library`
 
-We publish the blocks to npm at [@woocommerce/block-library,](https://www.npmjs.com/package/@woocommerce/block-library).
+In the past, we published the blocks to NPM at [@woocommerce/block-library](https://www.npmjs.com/package/@woocommerce/block-library).
+
+**Note: since version 2.3.0 `@woocommerce/block-library` has been deprecated, you shouldn't publish a new version without first discussing it with the team**
 
 To release a new version, perform the following steps:
 


### PR DESCRIPTION
Closes #1044.

Updates `CONTRIBUTING.md` explaining the NPM package has been deprecated.

### How to test the changes in this Pull Request:

Go to https://www.npmjs.com/package/@woocommerce/block-library and verify the package is marked as deprecated.

<!-- If you can, add the appropriate labels -->

### Changelog

> Officialy deprecate NPM package `@woocommerce/block-library`.