### PR TITLE
Add filter to control whether product grid results should be cacheable

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -253,21 +253,28 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @return array List of product IDs
 	 */
 	protected function get_products() {
-		$query_hash        = md5( wp_json_encode( $this->query_args ) . __CLASS__ );
-		$transient_name    = 'wc_block_' . $query_hash;
-		$transient_value   = get_transient( $transient_name );
-		$transient_version = \WC_Cache_Helper::get_transient_version( 'product_query' );
+		$is_cacheable = (bool) apply_filters( 'woocommerce_blocks_product_grid_is_cacheable', true, $this->query_args );
 
-		if ( isset( $transient_value['value'], $transient_value['version'] ) && $transient_value['version'] === $transient_version ) {
+		if ( $is_cacheable ) {
+			$query_hash        = md5( wp_json_encode( $this->query_args ) . __CLASS__ );
+			$transient_name    = 'wc_block_' . $query_hash;
+			$transient_value   = get_transient( $transient_name );
+			$transient_version = \WC_Cache_Helper::get_transient_version( 'product_query' );
+		}
+
+		if ( isset( $transient_value['value'], $transient_value['version'], $transient_version ) && $transient_value['version'] === $transient_version ) {
 			$results = $transient_value['value'];
 		} else {
-			$query           = new \WP_Query( $this->query_args );
-			$results         = wp_parse_id_list( $query->posts );
-			$transient_value = array(
-				'version' => $transient_version,
-				'value'   => $results,
-			);
-			set_transient( $transient_name, $transient_value, DAY_IN_SECONDS * 30 );
+			$query   = new \WP_Query( $this->query_args );
+			$results = wp_parse_id_list( $query->posts );
+
+			if ( $is_cacheable ) {
+				$transient_value = array(
+					'version' => $transient_version,
+					'value'   => $results,
+				);
+				set_transient( $transient_name, $transient_value, DAY_IN_SECONDS * 30 );
+			}
 
 			// Remove ordering query arguments which may have been added by get_catalog_ordering_args.
 			WC()->query->remove_ordering_args();


### PR DESCRIPTION
This PR introduces a filter `woocommerce_blocks_product_grid_is_cacheable` which can be used by developers to control whether transient cache should be used for product results. Results are cacheable by default, which is the current behavior without the filter in place.

To prevent results from being stored in transient cache, simply add:

```php
add_filter( 'woocommerce_blocks_product_grid_is_cacheable', '__return_false' );
```

Or examine the passed `$query_args` to prevent only certain conditions from being cacheable.

PR tested with **WooCommerce 3.7.1** and **WordPress 5.2.4**.

### How to test the changes in this Pull Request:

1. Flush all transients using WP-CLI: `wp transient delete --all`
2. Add the filter above to a must-use plugin using the `__return_false` callback to disable caching.
3. Load the website so that a products block is rendered.
4. Run a MySQL query to confirm that there are NO transient values in the database:
```
wp db query "SELECT * FROM wp_options WHERE option_name LIKE '%transient%_wc_block_%';"
```
5. Repeat steps 2-4, this time removing the filter to exhibit the default behavior and confirming that transient values ARE present in the database.

### Changelog

> Added a filter to control whether product grid results should be cacheable
