### PR TITLE
Missing homeUrl variable due to white space breaks the product search block.

### DIFF
--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -15,4 +15,4 @@ export const THUMBNAIL_SIZE = getSetting( 'thumbnail_size', 300 );
 export const IS_LARGE_CATALOG = getSetting( 'isLargeCatalog' );
 export const LIMIT_TAGS = getSetting( 'limitTags' );
 export const HAS_TAGS = getSetting( 'hasTags', true );
-export const HOME_URL = getSetting( 'homeUrl ', '' );
+export const HOME_URL = getSetting( 'homeUrl', '' );


### PR DESCRIPTION
Fixes the product search widget which was broken due to a missing Home URL on the form action.

Fixes #1054

This fix does fix new instances of the block, but existing instances would need to be recreated and are invalidated.

### How to test the changes in this Pull Request:

1. Create a product search block on a page.
2. View on the frontend.
3. Search for a term and confirm there is no 404.

### Changelog

> Fix product search form action.
