### PR TITLE
Add responsive product grid styles

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -23,6 +23,10 @@
 			.wp-block-button__link {
 				color: inherit;
 			}
+
+			.wc-block-grid__product {
+				margin: 0 0 $gap-large 0;
+			}
 		}
 
 		&.components-placeholder {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -182,7 +182,7 @@
 }
 
 // Responsive media styles.
-@media only screen and ( max-width: 479px ) {
+@include breakpoint( "<480px" ) {
 	.wc-block-grid {
 		@for $i from 2 to 9 {
 			&.has-#{$i}-columns {
@@ -203,7 +203,7 @@
 		}
 	}
 }
-@media only screen and ( min-width: 480px ) and ( max-width: 768px ) {
+@include breakpoint( "480px-600px" ) {
 	.wc-block-grid {
 		@for $i from 2 to 9 {
 			&.has-#{$i}-columns {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -198,15 +198,34 @@
 				}
 			}
 		}
+		.wc-block-grid__product-image img {
+			width: 100%;
+		}
 	}
 }
 @media only screen and ( min-width: 480px ) and ( max-width: 768px ) {
 	.wc-block-grid {
 		@for $i from 2 to 9 {
-			&.has-#{$i}-columns .wc-block-grid__product {
-				flex: 1 0 50%;
-				max-width: 50%;
+			&.has-#{$i}-columns {
+				.wc-block-grid__product {
+					flex: 1 0 50%;
+					max-width: 50%;
+					padding: 0;
+					margin: 0 0 $gap-large 0;
+				}
+				.wc-block-grid__product:nth-child(odd) {
+					padding-right: $gap/2;
+				}
+				.wc-block-grid__product:nth-child(even) {
+					padding-left: $gap/2;
+					.wc-block-grid__product-onsale {
+						left: $gap/2;
+					}
+				}
 			}
+		}
+		.wc-block-grid__product-image img {
+			width: 100%;
 		}
 	}
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -156,11 +156,9 @@
 		}
 	}
 	&.has-1-columns {
-
 		.wc-block-grid__products {
 			display: block;
 		}
-
 		.wc-block-grid__product {
 			margin-left: auto;
 			margin-right: auto;
@@ -179,6 +177,36 @@
 	&.has-8-columns {
 		.wc-block-grid__product {
 			font-size: 0.8em;
+		}
+	}
+}
+
+// Responsive media styles.
+@media only screen and ( max-width: 479px ) {
+	.wc-block-grid {
+		@for $i from 2 to 9 {
+			&.has-#{$i}-columns {
+				.wc-block-grid__products {
+					display: block;
+				}
+				.wc-block-grid__product {
+					margin-left: auto;
+					margin-right: auto;
+					flex: 1 0 100%;
+					max-width: 100%;
+					padding: 0;
+				}
+			}
+		}
+	}
+}
+@media only screen and ( min-width: 480px ) and ( max-width: 768px ) {
+	.wc-block-grid {
+		@for $i from 2 to 9 {
+			&.has-#{$i}-columns .wc-block-grid__product {
+				flex: 1 0 50%;
+				max-width: 50%;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a few responsive styles to adjust the number of columns shown on smaller device screens. It currently uses the following breakpoints:

- Up to 480px - mobile 1 column
- Up to 768px - tablet 2 columns

These breakpoints are similar to that of Bootstrap and MDL, and some of the default WP themes also take 768px. @jwold can you take a look and see if you agree with this, or can suggest some alternatives?

Do we need to communicate this somewhere, such as in the settings for columns/rows?

Fixes #1060 

### Screenshots

![Screenshot 2019-10-22 at 16 08 22](https://user-images.githubusercontent.com/90977/67300859-928ed380-f4e6-11e9-8dae-fb0dae006083.png)
![Screenshot 2019-10-22 at 16 08 43](https://user-images.githubusercontent.com/90977/67300864-94589700-f4e6-11e9-8d99-b66b74b69586.png)

### How to test the changes in this Pull Request:

1. Check out and build
2. View a grid widget such as products by categories
3. Shrink browser window or use browser responsive tools and check view

### Changelog

> Adds responsive styles for product grids to reduce number of columns on small screens.
