### PR TITLE
Implement new data stores with All Products block

### DIFF
--- a/assets/js/base/hooks/index.js
+++ b/assets/js/base/hooks/index.js
@@ -1,0 +1,3 @@
+export * from './use-query-state';
+export * from './use-shallow-equal';
+export * from './use-store-products';

--- a/assets/js/base/hooks/test/use-query-state.js
+++ b/assets/js/base/hooks/test/use-query-state.js
@@ -1,0 +1,254 @@
+/**
+ * External dependencies
+ */
+import TestRenderer, { act } from 'react-test-renderer';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useQueryStateContext,
+	useQueryStateByKey,
+	useSynchronizedQueryState,
+} from '../use-query-state';
+import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
+
+jest.mock( '@woocommerce/block-data', () => ( {
+	__esModule: true,
+	QUERY_STATE_STORE_KEY: 'test/store',
+} ) );
+
+describe( 'Testing Query State Hooks', () => {
+	let registry, mocks;
+	beforeAll( () => {
+		registry = createRegistry();
+		mocks = {};
+	} );
+	/**
+	 * Test helper to return a tuple containing the expected query value and the
+	 * expected query state action creator from the given rendered test instance.
+	 *
+	 * @param {Object} testRenderer   An instance of the created test component.
+	 *
+	 * @return {array} A tuple containing the expected query value as the first
+	 *                 element and the expected query action creator as the
+	 *                 second argument.
+	 */
+	const getProps = ( testRenderer ) => {
+		const props = testRenderer.root.findByType( 'div' ).props;
+		return [ props.queryState, props.setQueryState ];
+	};
+
+	/**
+	 * Returns the given component wrapped in the registry provider for
+	 * instantiating using the TestRenderer using the current prepared registry
+	 * for the TestRenderer to instantiate with.
+	 *
+	 * @param {React.Component} Component The test component to wrap.
+	 * @param {Object}          props     Props to feed the wrapped component.
+	 *
+	 * @return {React.Component}
+	 */
+	const getWrappedComponent = ( Component, props ) => (
+		<RegistryProvider value={ registry }>
+			<Component { ...props } />
+		</RegistryProvider>
+	);
+
+	/**
+	 * Returns a TestComponent for the provided hook to test with, and the
+	 * expected PropKeys for obtaining the values to be fed to the hook as
+	 * arguments.
+	 *
+	 * @param {function} hookTested      The hook being tested to use in the
+	 *                                   test comopnent.
+	 * @param {array}    propKeysForArgs An array of keys for the props that
+	 *                                   will be used on the test component that
+	 *                                   will have values fed to the tested
+	 *                                   hook.
+	 *
+	 * @return {React.Component}  A component ready for testing with!
+	 */
+	const getTestComponent = ( hookTested, propKeysForArgs ) => ( props ) => {
+		const args = propKeysForArgs.map( ( key ) => props[ key ] );
+		const [ queryValue, setQueryValue ] = hookTested( ...args );
+		return (
+			<div queryState={ queryValue } setQueryState={ setQueryValue } />
+		);
+	};
+
+	/**
+	 * A helper for setting up the `mocks` object and the `registry` mock before
+	 * each test.
+	 *
+	 * @param {string} actionMockName   This should be the name of the action
+	 *                                  that the hook returns. This will be
+	 *                                  mocked using `mocks.action` when
+	 *                                  registered in the mock registry.
+	 * @param {string} selectorMockName This should be the mame of the selector
+	 *                                  that the hook uses. This will be mocked
+	 *                                  using `mocks.selector` when registered
+	 *                                  in the mock registry.
+	 */
+	const setupMocks = ( actionMockName, selectorMockName ) => {
+		mocks.action = jest.fn().mockReturnValue( { type: 'testAction' } );
+		mocks.selector = jest.fn().mockReturnValue( { foo: 'bar' } );
+		registry.registerStore( storeKey, {
+			reducer: () => ( {} ),
+			actions: {
+				[ actionMockName ]: mocks.action,
+			},
+			selectors: {
+				[ selectorMockName ]: mocks.selector,
+			},
+		} );
+	};
+	describe( 'useQueryStateContext', () => {
+		const TestComponent = getTestComponent( useQueryStateContext, [
+			'context',
+		] );
+		let renderer;
+		beforeEach( () => {
+			renderer = null;
+			setupMocks( 'setValueForQueryContext', 'getValueForQueryContext' );
+		} );
+		afterEach( () => {
+			act( () => {
+				renderer.unmount();
+			} );
+		} );
+		it(
+			'calls useSelect with the provided context and returns expected' +
+				' values',
+			() => {
+				const { action, selector } = mocks;
+				act( () => {
+					renderer = TestRenderer.create(
+						getWrappedComponent( TestComponent, {
+							context: 'test-context',
+						} )
+					);
+				} );
+				const [ queryState, setQueryState ] = getProps( renderer );
+				// the {} is because all selectors are called internally in the
+				// registry with the first argument being the state which is empty.
+				expect( selector ).toHaveBeenLastCalledWith(
+					{},
+					'test-context',
+					undefined
+				);
+				expect( queryState ).toEqual( { foo: 'bar' } );
+				expect( action ).not.toHaveBeenCalled();
+
+				//execute dispatcher and make sure it's called.
+				act( () => {
+					setQueryState( { foo: 'bar' } );
+				} );
+				expect( action ).toHaveBeenCalledWith( { foo: 'bar' } );
+			}
+		);
+	} );
+	describe( 'useQueryStateByKey', () => {
+		const TestComponent = getTestComponent( useQueryStateByKey, [
+			'context',
+			'queryKey',
+		] );
+		let renderer;
+		beforeEach( () => {
+			renderer = null;
+			setupMocks( 'setQueryValue', 'getValueForQueryKey' );
+		} );
+		afterEach( () => {
+			act( () => {
+				renderer.unmount();
+			} );
+		} );
+		it(
+			'calls useSelect with the provided context and returns expected' +
+				' values',
+			() => {
+				const { selector, action } = mocks;
+				act( () => {
+					renderer = TestRenderer.create(
+						getWrappedComponent( TestComponent, {
+							context: 'test-context',
+							queryKey: 'someValue',
+						} )
+					);
+				} );
+				const [ queryState, setQueryState ] = getProps( renderer );
+				// the {} is because all selectors are called internally in the
+				// registry with the first argument being the state which is empty.
+				expect( selector ).toHaveBeenLastCalledWith(
+					{},
+					'test-context',
+					'someValue',
+					undefined
+				);
+				expect( queryState ).toEqual( { foo: 'bar' } );
+				expect( action ).not.toHaveBeenCalled();
+
+				//execute dispatcher and make sure it's called.
+				act( () => {
+					setQueryState( { foo: 'bar' } );
+				} );
+				expect( action ).toHaveBeenCalledWith( {
+					foo: 'bar',
+				} );
+			}
+		);
+	} );
+	// @todo, these tests only add partial coverage because the state is not
+	// actually updated by the action dispatch via our mocks.
+	describe( 'useSynchronizedQueryState', () => {
+		const TestComponent = getTestComponent( useSynchronizedQueryState, [
+			'context',
+			'synchronizedQuery',
+		] );
+		const initialQuery = { a: 'b' };
+		let renderer;
+		beforeEach( () => {
+			setupMocks( 'setValueForQueryContext', 'getValueForQueryContext' );
+		} );
+		it( 'returns provided query state on initial render', () => {
+			const { action, selector } = mocks;
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponent( TestComponent, {
+						context: 'test-context',
+						synchronizedQuery: initialQuery,
+					} )
+				);
+			} );
+			const [ queryState ] = getProps( renderer );
+			expect( queryState ).toBe( initialQuery );
+			expect( selector ).toHaveBeenLastCalledWith(
+				{},
+				'test-context',
+				undefined
+			);
+			expect( action ).toHaveBeenCalledWith( 'test-context', {
+				foo: 'bar',
+				a: 'b',
+			} );
+		} );
+		it( 'returns merged queryState on subsequent render', () => {
+			act( () => {
+				renderer.update(
+					getWrappedComponent( TestComponent, {
+						context: 'test-context',
+						synchronizedQuery: initialQuery,
+					} )
+				);
+			} );
+			// note our test doesn't interact with an actual reducer so the
+			// store state is not updated. Here we're just verifying that
+			// what is is returned by the state selector mock is returned.
+			// However we DO expect this to be a new object.
+			const [ queryState ] = getProps( renderer );
+			expect( queryState ).not.toBe( initialQuery );
+			expect( queryState ).toEqual( { foo: 'bar' } );
+		} );
+	} );
+} );

--- a/assets/js/base/hooks/test/use-shallow-equal.js
+++ b/assets/js/base/hooks/test/use-shallow-equal.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import TestRenderer, { act } from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { useShallowEqual } from '../use-shallow-equal';
+
+describe( 'useShallowEqual', () => {
+	const TestComponent = ( { testValue } ) => {
+		const newValue = useShallowEqual( testValue );
+		return <div newValue={ newValue } />;
+	};
+	let renderer;
+	beforeEach( () => ( renderer = null ) );
+	it.each`
+		testValueA                | aType       | testValueB                | bType       | expectEqual
+		${{ a: 'b', foo: 'bar' }} | ${'object'} | ${{ foo: 'bar', a: 'b' }} | ${'object'} | ${true}
+		${{ a: 'b', foo: 'bar' }} | ${'object'} | ${{ foo: 'bar', a: 'c' }} | ${'object'} | ${false}
+		${[ 'b', 'bar' ]}         | ${'array'}  | ${[ 'b', 'bar' ]}         | ${'array'}  | ${true}
+		${[ 'b', 'bar' ]}         | ${'array'}  | ${[ 'bar', 'b' ]}         | ${'array'}  | ${false}
+		${1}                      | ${'number'} | ${1}                      | ${'number'} | ${true}
+		${1}                      | ${'number'} | ${'1'}                    | ${'string'} | ${false}
+		${'1'}                    | ${'string'} | ${'1'}                    | ${'string'} | ${true}
+		${1}                      | ${'number'} | ${2}                      | ${'number'} | ${false}
+		${1}                      | ${'number'} | ${true}                   | ${'bool'}   | ${false}
+		${0}                      | ${'number'} | ${false}                  | ${'bool'}   | ${false}
+		${true}                   | ${'bool'}   | ${true}                   | ${'bool'}   | ${true}
+	`(
+		'$testValueA ($aType) and $testValueB ($bType) are expected to be equal ($expectEqual)',
+		( { testValueA, testValueB, expectEqual } ) => {
+			let testPropValue;
+			act( () => {
+				renderer = TestRenderer.create(
+					<TestComponent testValue={ testValueA } />
+				);
+			} );
+			testPropValue = renderer.root.findByType( 'div' ).props.newValue;
+			expect( testPropValue ).toBe( testValueA );
+			// do update
+			act( () => {
+				renderer.update( <TestComponent testValue={ testValueB } /> );
+			} );
+			testPropValue = renderer.root.findByType( 'div' ).props.newValue;
+			if ( expectEqual ) {
+				expect( testPropValue ).toBe( testValueA );
+			} else {
+				expect( testPropValue ).toBe( testValueB );
+			}
+		}
+	);
+} );

--- a/assets/js/base/hooks/test/use-store-products.js
+++ b/assets/js/base/hooks/test/use-store-products.js
@@ -1,0 +1,203 @@
+/**
+ * External dependencies
+ */
+import TestRenderer, { act } from 'react-test-renderer';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { Component as ReactComponent } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useStoreProducts } from '../use-store-products';
+import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
+
+jest.mock( '@woocommerce/block-data', () => ( {
+	__esModule: true,
+	COLLECTIONS_STORE_KEY: 'test/store',
+} ) );
+
+class TestErrorBoundary extends ReactComponent {
+	constructor( props ) {
+		super( props );
+		this.state = { hasError: false, error: {} };
+	}
+	static getDerivedStateFromError( error ) {
+		// Update state so the next render will show the fallback UI.
+		return { hasError: true, error };
+	}
+
+	render() {
+		if ( this.state.hasError ) {
+			return <div error={ this.state.error } />;
+		}
+
+		return this.props.children;
+	}
+}
+
+describe( 'useStoreProducts', () => {
+	let registry, mocks, renderer;
+	const getProps = ( testRenderer ) => {
+		const {
+			products,
+			totalProducts,
+			productsLoading,
+		} = testRenderer.root.findByType( 'div' ).props;
+		return {
+			products,
+			totalProducts,
+			productsLoading,
+		};
+	};
+
+	const getWrappedComponents = ( Component, props ) => (
+		<RegistryProvider value={ registry }>
+			<TestErrorBoundary>
+				<Component { ...props } />
+			</TestErrorBoundary>
+		</RegistryProvider>
+	);
+
+	const getTestComponent = ( options ) => ( { query } ) => {
+		const items = useStoreProducts( query, options );
+		return <div { ...items } />;
+	};
+
+	const setUpMocks = () => {
+		mocks = {
+			selectors: {
+				getCollection: jest
+					.fn()
+					.mockImplementation( () => ( { foo: 'bar' } ) ),
+				getCollectionHeader: jest.fn().mockReturnValue( 22 ),
+				hasFinishedResolution: jest.fn().mockReturnValue( true ),
+			},
+		};
+		registry.registerStore( storeKey, {
+			reducer: () => ( {} ),
+			selectors: mocks.selectors,
+		} );
+	};
+
+	beforeEach( () => {
+		registry = createRegistry();
+		mocks = {};
+		renderer = null;
+		setUpMocks();
+	} );
+	it(
+		'should throw an error if an options object is provided without ' +
+			'a namespace property',
+		() => {
+			const TestComponent = getTestComponent( { modelName: 'products' } );
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent, {
+						query: { bar: 'foo' },
+					} )
+				);
+			} );
+			const props = renderer.root.findByType( 'div' ).props;
+			expect( props.error.message ).toMatch( /options object/ );
+			expect( console ).toHaveErrored( /your React components:/ );
+			renderer.unmount();
+		}
+	);
+	it(
+		'should throw an error if an options object is provided without ' +
+			'a modelName property',
+		() => {
+			const TestComponent = getTestComponent( {
+				namespace: '/wc/blocks',
+			} );
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent, {
+						query: { bar: 'foo' },
+					} )
+				);
+			} );
+			const props = renderer.root.findByType( 'div' ).props;
+			expect( props.error.message ).toMatch( /options object/ );
+			expect( console ).toHaveErrored( /your React components:/ );
+			renderer.unmount();
+		}
+	);
+	it( 'should use the default options if options not provided', () => {
+		const TestComponent = getTestComponent();
+		const {
+			getCollection,
+			getCollectionHeader,
+			hasFinishedResolution,
+		} = mocks.selectors;
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent, {
+					query: { bar: 'foo' },
+				} )
+			);
+		} );
+		expect( getCollection ).toHaveBeenCalledWith(
+			{},
+			'/wc/blocks',
+			'products',
+			{ bar: 'foo' }
+		);
+		expect( getCollectionHeader ).toHaveBeenCalledWith(
+			{},
+			'x-wp-total',
+			'/wc/blocks',
+			'products',
+			{ bar: 'foo' }
+		);
+		expect( hasFinishedResolution ).toHaveBeenCalledWith(
+			{},
+			'getCollection',
+			[ '/wc/blocks', 'products', { bar: 'foo' } ]
+		);
+		renderer.unmount();
+	} );
+	it(
+		'should return expected behaviour for equivalent query on props ' +
+			'across renders',
+		() => {
+			const TestComponent = getTestComponent();
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent, {
+						query: { bar: 'foo' },
+					} )
+				);
+			} );
+			const { products } = getProps( renderer );
+			// rerender
+			act( () => {
+				renderer.update(
+					getWrappedComponents( TestComponent, {
+						query: { bar: 'foo' },
+					} )
+				);
+			} );
+			// re-render should result in same products object because although
+			// query-state is a different instance, it's still equivalent.
+			const { products: newProducts } = getProps( renderer );
+			expect( newProducts ).toBe( products );
+			// now let's change the query passed through to verify new object
+			// is created.
+			// remember this won't actually change the results because the mock
+			// selector is returning an equivalent object when it is called,
+			// however it SHOULD be a new object instance.
+			act( () => {
+				renderer.update(
+					getWrappedComponents( TestComponent, {
+						query: { foo: 'bar' },
+					} )
+				);
+			} );
+			const { products: productsVerification } = getProps( renderer );
+			expect( productsVerification ).not.toBe( products );
+			expect( productsVerification ).toEqual( products );
+			renderer.unmount();
+		}
+	);
+} );

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useRef, useEffect } from '@wordpress/element';
+import { useShallowEqual } from './use-shallow-equal';
+
+/**
+ * A custom hook that exposes the current query state and a setter for the query
+ * state store for the given context.
+ *
+ * "Query State" is a wp.data store that keeps track of an arbitrary object of
+ * query keys and their values.
+ *
+ * @param {string} context What context to retrieve the query state for.
+ *
+ * @return {array} An array that has two elements. The first element is the
+ *                 query state value for the given context.  The second element
+ *                 is a dispatcher function for setting the query state.
+ */
+export const useQueryStateContext = ( context ) => {
+	const queryState = useSelect(
+		( select ) => {
+			const store = select( storeKey );
+			return store.getValueForQueryContext( context, undefined );
+		},
+		[ context ]
+	);
+	const { setValueForQueryContext: setQueryState } = useDispatch( storeKey );
+	return [ queryState, setQueryState ];
+};
+
+/**
+ * A custom hook that exposes the current query state value and a setter for the
+ * given context and query key.
+ *
+ * "Query State" is a wp.data store that keeps track of an arbitrary object of
+ * query keys and their values.
+ *
+ * @param {string} context  What context to retrieve the query state for.
+ * @param {*}      queryKey The specific query key to retrieve the value for.
+ *
+ * @return {*}  Whatever value is set at the query state index using the
+ *              provided context and query key.
+ */
+export const useQueryStateByKey = ( context, queryKey ) => {
+	const queryValue = useSelect(
+		( select ) => {
+			const store = select( storeKey );
+			return store.getValueForQueryKey( context, queryKey, undefined );
+		},
+		[ context, queryKey ]
+	);
+	const { setQueryValue } = useDispatch( storeKey );
+	return [ queryValue, setQueryValue ];
+};
+
+/**
+ * A custom hook that works similarly to useQueryStateContext. However, this
+ * hook allows for synchronizing with a provided queryState object.
+ *
+ * This hook does the following things with the provided `synchronizedQuery`
+ * object:
+ *
+ * - whenever synchronizedQuery varies between renders, the queryState will be
+ *   updated to a merged object of the internal queryState and the provided
+ *   object.  Note, any values from the same properties between objects will
+ *   be set from synchronizedQuery.
+ * - if there are no changes between renders, then the existing internal
+ *   queryState is always returned.
+ * - on initial render, the synchronizedQuery value is returned.
+ *
+ * Typically, this hook would be used in a scenario where there may be external
+ * triggers for updating the query state (i.e. initial population of query
+ * state by hydration or component attributes, or routing url changes that
+ * affect query state).
+ *
+ * @param {string} context           What context to retrieve the query state
+ *                                   for.
+ * @param {Object} synchronizedQuery A provided query state object to
+ *                                   synchronize internal query state with.
+ */
+export const useSynchronizedQueryState = ( context, synchronizedQuery ) => {
+	const [ queryState, setQueryState ] = useQueryStateContext( context );
+	const currentSynchronizedQuery = useShallowEqual( synchronizedQuery );
+	// used to ensure we allow initial synchronization to occur before
+	// returning non-synced state.
+	const isInitialized = useRef( false );
+	// update queryState anytime incoming synchronizedQuery changes
+	useEffect( () => {
+		setQueryState( context, {
+			...queryState,
+			...currentSynchronizedQuery,
+		} );
+		isInitialized.current = true;
+	}, [ currentSynchronizedQuery ] );
+	return isInitialized.current
+		? [ queryState, setQueryState ]
+		: [ synchronizedQuery, setQueryState ];
+};

--- a/assets/js/base/hooks/use-shallow-equal.js
+++ b/assets/js/base/hooks/use-shallow-equal.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { useRef } from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+
+/**
+ * A custom hook that compares the provided value across renders and returns the
+ * previous instance if shallow equality with previous instance exists.
+ *
+ * This is particularly useful when non-primitive types are used as
+ * dependencies for react hooks.
+ *
+ * @param {mixed} value Value to keep the same if satisfies shallow equality.
+ *
+ * @return {mixed} The previous cached instance of the value if the current has
+ *                 shallow equality with it.
+ */
+export const useShallowEqual = ( value ) => {
+	const ref = useRef();
+	if ( ! isShallowEqual( value, ref.current ) ) {
+		ref.current = value;
+	}
+	return ref.current;
+};

--- a/assets/js/base/hooks/use-store-products.js
+++ b/assets/js/base/hooks/use-store-products.js
@@ -14,6 +14,24 @@ const DEFAULT_OPTIONS = {
 	modelName: 'products',
 };
 
+/**
+ * This is a custom hook that is wired up to the `wc/store/collections` data
+ * store. Given a query object, this will ensure a component is kept up to date
+ * with the products matching that query in the store state.
+ *
+ * @param {Object} query   An object containing any query arguments to be
+ *                         included with the collection request for the
+ *                         products. Does not have to be included.
+ * @param {Object} options An optional object for adjusting the namespace and
+ *                         modelName for the products query.
+ *
+ * @return {Object} This hook will return an object with three properties:
+ *                  - products        An array of product objects.
+ *                  - totalProducts   The total number of products that match the
+ *                                    given query parameters.
+ *                  - productsLoading A boolean indicating whether the products
+ *                                    are still loading or not.
+ */
 export const useStoreProducts = ( query, options = DEFAULT_OPTIONS ) => {
 	const { namespace, modelName } = options;
 	if ( ! namespace || ! modelName ) {

--- a/assets/js/base/hooks/use-store-products.js
+++ b/assets/js/base/hooks/use-store-products.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useShallowEqual } from './use-shallow-equal';
+
+const DEFAULT_OPTIONS = {
+	namespace: '/wc/blocks',
+	modelName: 'products',
+};
+
+export const useStoreProducts = ( query, options = DEFAULT_OPTIONS ) => {
+	const { namespace, modelName } = options;
+	if ( ! namespace || ! modelName ) {
+		throw new Error(
+			'If you provide an options object, you must have valid values ' +
+				'for the namespace and the modelName properties.'
+		);
+	}
+	// ensure we feed the previous reference object if it's equivalent
+	const currentQuery = useShallowEqual( query );
+	const {
+		products = [],
+		totalProducts = 0,
+		productsLoading = true,
+	} = useSelect(
+		( select ) => {
+			const store = select( storeKey );
+			// filter out query if it is undefined.
+			const args = [ namespace, modelName, currentQuery ].filter(
+				( item ) => typeof item !== undefined
+			);
+			return {
+				products: store.getCollection( ...args ),
+				productsTotal: store.getCollectionHeader(
+					'x-wp-total',
+					...args
+				),
+				productsLoading: store.hasFinishedResolution(
+					'getCollection',
+					args
+				),
+			};
+		},
+		[ namespace, modelName, currentQuery ]
+	);
+	return {
+		products,
+		totalProducts,
+		productsLoading,
+	};
+};

--- a/assets/js/base/hooks/use-store-products.js
+++ b/assets/js/base/hooks/use-store-products.js
@@ -55,7 +55,7 @@ export const useStoreProducts = ( query, options = DEFAULT_OPTIONS ) => {
 			);
 			return {
 				products: store.getCollection( ...args ),
-				productsTotal: store.getCollectionHeader(
+				totalProducts: store.getCollectionHeader(
 					'x-wp-total',
 					...args
 				),

--- a/assets/js/data/collections/controls.js
+++ b/assets/js/data/collections/controls.js
@@ -26,12 +26,16 @@ export const apiFetchWithHeaders = ( path ) => {
  */
 export const controls = {
 	API_FETCH_WITH_HEADERS( { path } ) {
-		return new Promise( ( resolve ) => {
-			triggerFetch( { path, parse: false } ).then( ( response ) => {
-				response.json().then( ( items ) => {
-					resolve( { items, headers: response.headers } );
+		return new Promise( ( resolve, reject ) => {
+			triggerFetch( { path, parse: false } )
+				.then( ( response ) => {
+					response.json().then( ( items ) => {
+						resolve( { items, headers: response.headers } );
+					} );
+				} )
+				.catch( ( error ) => {
+					reject( error );
 				} );
-			} );
 		} );
 	},
 };

--- a/assets/js/data/collections/resolvers.js
+++ b/assets/js/data/collections/resolvers.js
@@ -47,16 +47,16 @@ export function* getCollection( namespace, modelName, query, ids ) {
  * Note: This triggers the `getCollection` resolver if it hasn't been resolved
  * yet.
  *
+ * @param {string} header
  * @param {string} namespace
  * @param {string} modelName
- * @param {string} header
  * @param {Object} query
  * @param {Array}  ids
  */
 export function* getCollectionHeader(
+	header,
 	namespace,
 	modelName,
-	header,
 	query,
 	ids
 ) {

--- a/assets/js/data/collections/selectors.js
+++ b/assets/js/data/collections/selectors.js
@@ -79,9 +79,9 @@ export const getCollection = (
  * ```
  *
  * @param {string} state        The current collection state.
+ * @param {string} header       The header to retrieve.
  * @param {string} namespace    The namespace for the collection.
  * @param {string} modelName    The model name for the collection.
- * @param {string} header       The header to retrieve.
  * @param {Object} [query=null] The query object on the collection request.
  * @param {Array}  [ids=[]]     Any ids for the collection request (these are
  *                              values that would be added to the route for a
@@ -93,9 +93,9 @@ export const getCollection = (
  */
 export const getCollectionHeader = (
 	state,
+	header,
 	namespace,
 	modelName,
-	header,
 	query = null,
 	ids = DEFAULT_EMPTY_ARRAY
 ) => {

--- a/assets/js/data/collections/test/resolvers.js
+++ b/assets/js/data/collections/test/resolvers.js
@@ -128,7 +128,7 @@ describe( 'getCollectionHeader', () => {
 	const rewind = ( ...testArgs ) =>
 		( fulfillment = getCollectionHeader( ...testArgs ) );
 	it( 'yields expected select control when called with less args', () => {
-		rewind( '/wc/blocks', 'products', 'x-wp-total' );
+		rewind( 'x-wp-total', '/wc/blocks', 'products' );
 		const { value } = fulfillment.next();
 		expect( value ).toEqual(
 			select( STORE_KEY, 'getCollection', '/wc/blocks', 'products' )
@@ -136,9 +136,9 @@ describe( 'getCollectionHeader', () => {
 	} );
 	it( 'yields expected select control when called with all args', () => {
 		const args = [
+			'x-wp-total',
 			'/wc/blocks',
 			'products/attributes',
-			'x-wp-total',
 			{ sort: 'ASC' },
 			[ 10 ],
 		];

--- a/assets/js/data/collections/test/selectors.js
+++ b/assets/js/data/collections/test/selectors.js
@@ -86,9 +86,9 @@ describe( 'getCollectionHeader', () => {
 			expect(
 				getCollectionHeader(
 					state,
+					'invalid',
 					'wc/blocks',
 					'products',
-					'invalid',
 					{
 						someQuery: 2,
 					}
@@ -103,7 +103,7 @@ describe( 'getCollectionHeader', () => {
 	} );
 	it( 'returns expected header when it exists', () => {
 		expect(
-			getCollectionHeader( state, 'wc/blocks', 'products', 'total', {
+			getCollectionHeader( state, 'total', 'wc/blocks', 'products', {
 				someQuery: 2,
 			} )
 		).toBe( 22 );

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -67,6 +67,10 @@ const getAlias = ( options = {} ) => {
 			__dirname,
 			`../assets/js/${ pathPart }base/hocs/`
 		),
+		'@woocommerce/base-hooks': path.resolve(
+			__dirname,
+			`../assets/js/${ pathPart }base/hooks/`
+		),
 		'@woocommerce/block-components': path.resolve(
 			__dirname,
 			`../assets/js/${ pathPart }components/`


### PR DESCRIPTION
This pull integrates the new data stores into the `ProductList` component so that the content of the All Products block is powered by it.  

## New hooks oh my!

As a part of the integration there are a number of custom React hooks introduced:

### For the `wc/store/query-state` data store.

As a reminder, the `query-state` data store keeps track of an arbitrary object of query keys and their values.  Typically it will be used to track the query fed into a collection request.

#### `useQueryStateContext( context )`

This is a custom hook that exposes the current query state and a setter for the query state store for a given context.

It returns a tuple-like array: `[ queryState, setQueryState ]`.  The first element is an object representing the queryState existing in the store state for the given context identifier, and the second element is an action dispatcher used to update the queryState for the given context.  It should be noted that dispatching a new query state for the given context will completely replace the existing queryState for that context (vs merging).  I chose this form for the return value because its similar to the React hook `useState`.

#### `useQueryStateByKey( context, queryKey )`

This is a custom hook that exposes the current value in the query state for the given context and query key.

It returns a tuple-like array: `[ queryValue, setQueryValue ]`.  The first element is whatever was set as the value for the `context` and `queryKey` in the state.  The second element is an action dispatcher used to update the queryState for the given context and query key.  

#### `useSynchronizedQueryState( context, synchronizedQuery )`

Functionally, this performs similarly to `useQueryStateContext` and returns the same tuple-like shape as that hook.  However, it receives a second argument, `synchronizedQuery` which represents a query state you wish to synchronize with the global state kept in the `query-state` store.  The behaviour of this hook is:

- whenever `synchronizedQuery` varies between renders, the queryState will be updated to a merged object of the internal queryState and the provided `synchronizedQuery` object.  A shallow equality comparison is done between renders on `synchronizedQuery` values to determine whether it has varied.
- if there are no changes between renders, then the existing global `queryState` value for the given context is returned.  Thus any changes in that state will always be returned.
- on _initial render_, the `synchronizedQuery` value is simply passed through the hook and returned.

### `useShallowEqual( value )`

This is a custom hook that compares the provided value across renders and returns the previous instance if shallow equality with the previous instance exists.  This is particularly useful when non-primitive types are used as dependencies on react hooks and there's uncertainty on whether object instances might vary across renders (but are still shallow equal).

### `useStoreProducts( query, options = { namespace: '/wc/blocks', modelName: 'products' } )`

This is a custom hook wired up to the `wc/store/collections` data store.  Given a query object, this will ensure a component is kept up to date with the products matching that query in the store state. The query argument does not have to be provided.

The second argument this hook receives is an options object that allows for overriding the namespace or the modelName used for the request.  

> **Note**: I'm on the fence with this second argument.  I'm thinking if this is a specific hook for products, then it should be hardcoded to what namespace and model name it queries.  For more general usage we should probably provide a `useCollection` hook (that maybe `useStoreProducts` could use internally).  However, I've submitted this as is for discussion/feedback first.

It returns an object with the following properties:

Property | Type | Description 
--------|---------|----------
`products` | `array` | An array of product objects.
`totalProducts` | `number` | The total number of products available for the query (used for paging).
`productsLoading` | `bool` | Whether the products have finished loading or not.  If this is true and `products` is an empty array, then you know there were no results for the request.

## Integration with All Products

The new hooks are used to power the retrieval of products for the All Products block.  You can see this in the ProductList component.

## Testing

> **Note:** The `useStoreProducts` hook is currently wired up to retrieve products using the `/wc/blocks` namespace which requires auth.  So keep that in mind when testing.  There is a todo to switch to the new `/wc/store` namespace but that requires further related work in the atomic button block (see note at end of pull description).

* The new hooks are mostly covered by jest tests.
* [ ] Verify that the All Products block works as expected on the frontend and backend using the hooks.  Remember this needs to be run in a WordPress 5.3+ environment (or with the latest Gutenberg plugin active.

One thing you should watch for when manually testing this is the network requests.  There should only ever be one request for a given set of query arguments.  This means when you go back to an already queried view, the view data should be served from the collections state vs another request.

## Next steps.

Everything except the first item here I don't think need to be done in this pull.  I can create issues for them before merging this pull.

* [x]  get review/feedback on this pull
* [ ] Create a new context api for passing through query state context to component children.  This will avoid hard-coding a specific context in the component and allow for store merchants to potentially embed multiple All Products pages in a page (where context is controlled dynamically for each block by tracking multiple instances on each page).
* [ ] Create our own custom ErrorBoundary component for both frontend usage and backend usage that will help with capturing and displaying useful errors to end users instead of just breaking things.  Frontend will be especially important (editor right now is caught by the GB editor error boundary but I think it'd be helpful to add our own for our own blocks so we can customize the output and handling).
* [ ] Consider creating a more generic `useCollection` hook that `useStoreProduct` could use under the hood.  This would allow for rapid prototyping against any endpoint in a wp install (and can power more specific collection hooks under the hood).
* [ ] `withQueryStringValues` hoc (along with other hocs used by the all products block) should be converted to a hook as well.  I also am a bit wary about accepting any query arguments for security reasons. With the hook (and the hoc if we keep it for pre WP 5.3 use) we should look at passing in a whitelist of query arguments allowed (this also ensures any generated query state from these arguments will be "pure" for the intended use).
* [ ] Speaking of that, now that we have a `wc/store/query-state` store, I think the new `useQueryStringValues` should integrate with that and set the query state from the query string values, passing along the query state to whatever is wired up for that.  So for example the product-list would not be implementing the `useSynchronizedQueryState` but instead will use `useQueryStringValues` which internally uses `useSynchronizedQueryState`.
* [ ] `useStoreProducts` is currently using the `/wc/blocks` namespace which means it requires auth to view.  We'll need to switch to use the new `/wc/store` namespace.  However this also might require creating and implementing a hook for the new cart api as well because the  `ProductButton` component currently relies on some cart info that is not available in the products response from the `/wc/store` namespace.