### PR TITLE
Modify collections store to add headers to the store state.

### DIFF
--- a/assets/js/data/collections/README.md
+++ b/assets/js/data/collections/README.md
@@ -10,7 +10,7 @@ import { COLLECTIONS_STORE_KEY } from '@woocommerce/block-data';
 
 ### `receiveCollection( namespace, modelName, queryString, ids = [], items = [], replace = false )`
 
-This will return an action object for the given arguments used in dispatching the collection results to the store.  
+This will return an action object for the given arguments used in dispatching the collection results to the store.
 
 > **Note**: You should rarely have to dispatch this action directly as it is used by the resolver for the `getCollection` selector.
 
@@ -20,7 +20,7 @@ This will return an action object for the given arguments used in dispatching th
 | `modelName`   | string  |  The "model name" for the collection (eg. `products/attributes`)                                                                                              |
 | `queryString` | string  |  An additional query string to add to the request for the collection.  Note, collections are cached by the query string. (eg. '?order=ASC')                   |
 | `ids`         | array   |  If the collection route has placeholders for ids, you provide them via this argument in the order of how the placeholders appear in the route                |
-| `items`       | array   |  An array of items for adding to the store.                                                                                                                   |
+| `response`       | Object   |  An object containing a `items` property with the collection items from the response (array), and a `headers` property that is matches the `window.Headers` interface containing the headers from the response. |
 | `replace`     | boolean |  Whether or not to replace any existing items in the store for the given indexes (namespace, modelName, queryString) if there are already values in the store |
 
 ## Selectors
@@ -33,5 +33,20 @@ This selector will return the collection for the given arguments. It has a sibli
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `namespace`   | string  |  The route namespace for the collection (eg. `/wc/blocks`)                                                                                                                                              |
 | `modelName`   | string  |  The "model name" for the collection (eg. `products/attributes`)                                                                                                                                        |
+| `query`       | Object  |  The query arguments for the collection. Eg. `{ order: 'ASC', sortBy: Price }`                                                                                                                          |
+| `ids`         | Array   |  If the collection route has placeholders for ids you provide the values for those placeholders in this array (in order).                                                                               |
+### `getCollectionHeader( namespace, modelName, header, query = null, ids = [])
+
+This selector will return a header from the collection response using the given arguments. It has a sibling resolver that will resolve `getCollection` using the arguments if that has never been resolved.
+
+If the collection has headers but not a matching header for the given `header` argument, then `undefined` will be returned.
+
+If the collection does not have any matching headers for the given arguments, then `null` is returned.
+
+| argument      | type    |  description                                                                                                                                                                                            |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `namespace`   | string  |  The route namespace for the collection (eg. `/wc/blocks`)                                                                                                                                              |
+| `modelName`   | string  |  The "model name" for the collection (eg. `products/attributes`)                                                                                                                                        |
+| `header` | string | The header key for the header. |
 | `query`       | Object  |  The query arguments for the collection. Eg. `{ order: 'ASC', sortBy: Price }`                                                                                                                          |
 | `ids`         | Array   |  If the collection route has placeholders for ids you provide the values for those placeholders in this array (in order).                                                                               |

--- a/assets/js/data/collections/README.md
+++ b/assets/js/data/collections/README.md
@@ -35,6 +35,7 @@ This selector will return the collection for the given arguments. It has a sibli
 | `modelName`   | string  |  The "model name" for the collection (eg. `products/attributes`)                                                                                                                                        |
 | `query`       | Object  |  The query arguments for the collection. Eg. `{ order: 'ASC', sortBy: Price }`                                                                                                                          |
 | `ids`         | Array   |  If the collection route has placeholders for ids you provide the values for those placeholders in this array (in order).                                                                               |
+
 ### `getCollectionHeader( namespace, modelName, header, query = null, ids = [])
 
 This selector will return a header from the collection response using the given arguments. It has a sibling resolver that will resolve `getCollection` using the arguments if that has never been resolved.

--- a/assets/js/data/collections/actions.js
+++ b/assets/js/data/collections/actions.js
@@ -19,7 +19,7 @@ Headers = Headers
  *                                    model.
  * @param {Object}   [response={}]    An object containing the response from the
  *                                    collection request.
- * @param {Array<*>} response.items	  An array of items for the given collection.
+ * @param {Array<*>} response.items	An array of items for the given collection.
  * @param {Headers}  response.headers A Headers object from the response
  *                                    @link https://developer.mozilla.org/en-US/docs/Web/API/Headers
  * @param {bool}     [replace=false]  If true, signals to replace the current

--- a/assets/js/data/collections/actions.js
+++ b/assets/js/data/collections/actions.js
@@ -1,5 +1,10 @@
 import { ACTION_TYPES as types } from './action-types';
 
+let Headers = window.Headers || null;
+Headers = Headers
+	? new Headers()
+	: { get: () => undefined, has: () => undefined };
+
 /**
  * Returns an action object used in updating the store with the provided items
  * retrieved from a request using the given querystring.
@@ -12,7 +17,11 @@ import { ACTION_TYPES as types } from './action-types';
  * @param {string}   [queryString=''] The query string for the collection
  * @param {array}    [ids=[]]         An array of ids (in correct order) for the
  *                                    model.
- * @param {Array<*>} [items=[]]       Items attached with the collection.
+ * @param {Object}   [response={}]    An object containing the response from the
+ *                                    collection request.
+ * @param {Array<*>} response.items	  An array of items for the given collection.
+ * @param {Headers}  response.headers A Headers object from the response
+ *                                    @link https://developer.mozilla.org/en-US/docs/Web/API/Headers
  * @param {bool}     [replace=false]  If true, signals to replace the current
  *                                    items in the state with the provided
  *                                    items.
@@ -32,7 +41,7 @@ export function receiveCollection(
 	modelName,
 	queryString = '',
 	ids = [],
-	items = [],
+	response = { items: [], headers: Headers },
 	replace = false
 ) {
 	return {
@@ -41,6 +50,6 @@ export function receiveCollection(
 		modelName,
 		queryString,
 		ids,
-		items,
+		response,
 	};
 }

--- a/assets/js/data/collections/constants.js
+++ b/assets/js/data/collections/constants.js
@@ -1,1 +1,2 @@
 export const STORE_KEY = 'wc/store/collections';
+export const DEFAULT_EMPTY_ARRAY = [];

--- a/assets/js/data/collections/controls.js
+++ b/assets/js/data/collections/controls.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import triggerFetch from '@wordpress/api-fetch';
+
+/**
+ * Dispatched a control action for triggering an api fetch call with no parsing.
+ * Typically this would be used in scenarios where headers are needed.
+ *
+ * @param {string} path  The path for the request.
+ *
+ * @return {Object} The control action descriptor.
+ */
+export const apiFetchWithHeaders = ( path ) => {
+	return {
+		type: 'API_FETCH_WITH_HEADERS',
+		path,
+	};
+};
+
+/**
+ * Default export for registering the controls with the store.
+ *
+ * @return {Object} An object with the controls to register with the store on
+ *                  the controls property of the registration object.
+ */
+export const controls = {
+	API_FETCH_WITH_HEADERS( { path } ) {
+		return new Promise( ( resolve ) => {
+			triggerFetch( { path, parse: false } ).then( ( response ) => {
+				response.json().then( ( items ) => {
+					resolve( { items, headers: response.headers } );
+				} );
+			} );
+		} );
+	},
+};

--- a/assets/js/data/collections/index.js
+++ b/assets/js/data/collections/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerStore } from '@wordpress/data';
-import { controls } from '@wordpress/data-controls';
+import { controls as dataControls } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -12,11 +12,12 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer from './reducers';
+import { controls } from './controls';
 
 registerStore( STORE_KEY, {
 	reducer,
 	actions,
-	controls,
+	controls: { ...dataControls, ...controls },
 	selectors,
 	resolvers,
 } );

--- a/assets/js/data/collections/reducers.js
+++ b/assets/js/data/collections/reducers.js
@@ -14,7 +14,7 @@ import { hasInState, updateState } from '../utils';
  *                            any changes.
  */
 const receiveCollection = ( state = {}, action ) => {
-	const { type, namespace, modelName, queryString, items } = action;
+	const { type, namespace, modelName, queryString, response } = action;
 	// ids are stringified so they can be used as an index.
 	const ids = action.ids ? JSON.stringify( action.ids ) : '[]';
 	switch ( type ) {
@@ -27,14 +27,14 @@ const receiveCollection = ( state = {}, action ) => {
 			state = updateState(
 				state,
 				[ namespace, modelName, ids, queryString ],
-				items
+				response
 			);
 			break;
 		case types.RESET_COLLECTION:
 			state = updateState(
 				state,
 				[ namespace, modelName, ids, queryString ],
-				items
+				response
 			);
 			break;
 	}

--- a/assets/js/data/collections/selectors.js
+++ b/assets/js/data/collections/selectors.js
@@ -9,15 +9,15 @@ import { addQueryArgs } from '@wordpress/url';
 import { hasInState } from '../utils';
 import { DEFAULT_EMPTY_ARRAY } from './constants';
 
-const getFromState = (
+const getFromState = ( {
 	state,
 	namespace,
 	modelName,
 	query,
 	ids,
 	type = 'items',
-	fallback = DEFAULT_EMPTY_ARRAY
-) => {
+	fallback = DEFAULT_EMPTY_ARRAY,
+} ) => {
 	// prep ids and query for state retrieval
 	ids = JSON.stringify( ids );
 	query = query !== null ? addQueryArgs( '', query ) : '';
@@ -34,15 +34,15 @@ const getCollectionHeaders = (
 	query = null,
 	ids = DEFAULT_EMPTY_ARRAY
 ) => {
-	return getFromState(
+	return getFromState( {
 		state,
 		namespace,
 		modelName,
 		query,
 		ids,
-		'headers',
-		undefined
-	);
+		type: 'headers',
+		fallback: undefined,
+	} );
 };
 
 /**
@@ -64,7 +64,7 @@ export const getCollection = (
 	query = null,
 	ids = DEFAULT_EMPTY_ARRAY
 ) => {
-	return getFromState( state, namespace, modelName, query, ids );
+	return getFromState( { state, namespace, modelName, query, ids } );
 };
 
 /**

--- a/assets/js/data/collections/selectors.js
+++ b/assets/js/data/collections/selectors.js
@@ -7,31 +7,110 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { hasInState } from '../utils';
+import { DEFAULT_EMPTY_ARRAY } from './constants';
 
-const DEFAULT_EMPTY_ARRAY = [];
+const getFromState = (
+	state,
+	namespace,
+	modelName,
+	query,
+	ids,
+	type = 'items',
+	fallback = DEFAULT_EMPTY_ARRAY
+) => {
+	// prep ids and query for state retrieval
+	ids = JSON.stringify( ids );
+	query = query !== null ? addQueryArgs( '', query ) : '';
+	if ( hasInState( state, [ namespace, modelName, ids, query, type ] ) ) {
+		return state[ namespace ][ modelName ][ ids ][ query ][ type ];
+	}
+	return fallback;
+};
+
+const getCollectionHeaders = (
+	state,
+	namespace,
+	modelName,
+	query = null,
+	ids = DEFAULT_EMPTY_ARRAY
+) => {
+	return getFromState(
+		state,
+		namespace,
+		modelName,
+		query,
+		ids,
+		'headers',
+		undefined
+	);
+};
 
 /**
- * Retrieves the collection from the state for the given arguments.
+ * Retrieves the collection items from the state for the given arguments.
  *
- * @param {Object} state
- * @param {string} namespace
- * @param {string} modelName
- * @param {Object} [query=null]
- * @param {Array}  [ids=[]]
- * @returns
+ * @param {Object} state        The current collections state.
+ * @param {string} namespace    The namespace for the collection.
+ * @param {string} modelName    The model name for the collection.
+ * @param {Object} [query=null] The query for the collection request.
+ * @param {Array}  [ids=[]]     Any ids for the collection request (these are
+ *                              values that would be added to the route for a
+ *                              route with id placeholders)
+ * @return {array} an array of items stored in the collection.
  */
 export const getCollection = (
 	state,
 	namespace,
 	modelName,
 	query = null,
-	ids = []
+	ids = DEFAULT_EMPTY_ARRAY
 ) => {
-	// prep ids and query for state retrieval
-	ids = JSON.stringify( ids );
-	query = query !== null ? addQueryArgs( '', query ) : '';
-	if ( hasInState( state, [ namespace, modelName, ids, query ] ) ) {
-		return state[ namespace ][ modelName ][ ids ][ query ];
+	return getFromState( state, namespace, modelName, query, ids );
+};
+
+/**
+ * This selector enables retrieving a specific header value from a given
+ * collection request.
+ *
+ * Example:
+ *
+ * ```js
+ * const totalProducts = wp.data.select( COLLECTION_STORE_KEY )
+ *   .getCollectionHeader( '/wc/blocks', 'products', 'x-wp-total' )
+ * ```
+ *
+ * @param {string} state        The current collection state.
+ * @param {string} namespace    The namespace for the collection.
+ * @param {string} modelName    The model name for the collection.
+ * @param {string} header       The header to retrieve.
+ * @param {Object} [query=null] The query object on the collection request.
+ * @param {Array}  [ids=[]]     Any ids for the collection request (these are
+ *                              values that would be added to the route for a
+ *                              route with id placeholders)
+ *
+ * @return {*|null} The value for the specified header, null if there are no
+ * headers available and undefined if the header does not exist for the
+ * collection.
+ */
+export const getCollectionHeader = (
+	state,
+	namespace,
+	modelName,
+	header,
+	query = null,
+	ids = DEFAULT_EMPTY_ARRAY
+) => {
+	const headers = getCollectionHeaders(
+		state,
+		namespace,
+		modelName,
+		query,
+		ids
+	);
+	// Can't just do a truthy check because `getCollectionHeaders` resolver
+	// invokes the `getCollection` selector to trigger the resolution of the
+	// collection request. It's fallback is an empty array.
+	if ( headers && headers.get ) {
+		return headers.has( header ) ? headers.get( header ) : undefined;
 	}
-	return DEFAULT_EMPTY_ARRAY;
+	return null;
 };

--- a/assets/js/data/collections/test/reducers.js
+++ b/assets/js/data/collections/test/reducers.js
@@ -14,7 +14,10 @@ describe( 'receiveCollection', () => {
 		'wc/blocks': {
 			products: {
 				'[]': {
-					'?someQuery=2': [ 'foo' ],
+					'?someQuery=2': {
+						items: [ 'foo' ],
+						headers: { 'x-wp-total': 22 },
+					},
 				},
 			},
 		},
@@ -28,7 +31,10 @@ describe( 'receiveCollection', () => {
 				namespace: 'wc/blocks',
 				modelName: 'products',
 				queryString: '?someQuery=2',
-				items: [ 'bar' ],
+				response: {
+					items: [ 'bar' ],
+					headers: { foo: 'bar' },
+				},
 			};
 			expect( receiveCollection( originalState, testAction ) ).toBe(
 				originalState
@@ -44,13 +50,19 @@ describe( 'receiveCollection', () => {
 				namespace: 'wc/blocks',
 				modelName: 'products',
 				queryString: '?someQuery=2',
-				items: [ 'cheeseburger' ],
+				response: {
+					items: [ 'cheeseburger' ],
+					headers: { foo: 'bar' },
+				},
 			};
 			const newState = receiveCollection( originalState, testAction );
 			expect( newState ).not.toBe( originalState );
 			expect(
 				newState[ 'wc/blocks' ].products[ '[]' ][ '?someQuery=2' ]
-			).toEqual( [ 'cheeseburger' ] );
+			).toEqual( {
+				items: [ 'cheeseburger' ],
+				headers: { foo: 'bar' },
+			} );
 		}
 	);
 	it( 'returns new state when items do not exist in collection yet', () => {
@@ -59,13 +71,13 @@ describe( 'receiveCollection', () => {
 			namespace: 'wc/blocks',
 			modelName: 'products',
 			queryString: '?someQuery=3',
-			items: [ 'cheeseburger' ],
+			response: { items: [ 'cheeseburger' ], headers: { foo: 'bar' } },
 		};
 		const newState = receiveCollection( originalState, testAction );
 		expect( newState ).not.toBe( originalState );
 		expect(
 			newState[ 'wc/blocks' ].products[ '[]' ][ '?someQuery=3' ]
-		).toEqual( [ 'cheeseburger' ] );
+		).toEqual( { items: [ 'cheeseburger' ], headers: { foo: 'bar' } } );
 	} );
 	it( 'sets expected state when ids are passed in', () => {
 		const testAction = {
@@ -73,7 +85,7 @@ describe( 'receiveCollection', () => {
 			namespace: 'wc/blocks',
 			modelName: 'products/attributes',
 			queryString: '?something',
-			items: [ 10, 20 ],
+			response: { items: [ 10, 20 ], headers: { foo: 'bar' } },
 			ids: [ 30, 42 ],
 		};
 		const newState = receiveCollection( originalState, testAction );
@@ -82,6 +94,6 @@ describe( 'receiveCollection', () => {
 			newState[ 'wc/blocks' ][ 'products/attributes' ][ '[30,42]' ][
 				'?something'
 			]
-		).toEqual( [ 10, 20 ] );
+		).toEqual( { items: [ 10, 20 ], headers: { foo: 'bar' } } );
 	} );
 } );

--- a/assets/js/data/collections/test/selectors.js
+++ b/assets/js/data/collections/test/selectors.js
@@ -1,28 +1,46 @@
 /**
  * Internal dependencies
  */
-import { getCollection } from '../selectors';
+import { getCollection, getCollectionHeader } from '../selectors';
 
-describe( 'getCollection', () => {
-	const state = {
-		'wc/blocks': {
-			products: {
-				'[]': {
-					'?someQuery=2': [ 'foo' ],
-				},
-			},
-			'products/attributes': {
-				'[10]': {
-					'?someQuery=2': [ 'bar' ],
-				},
-			},
-			'products/attributes/terms': {
-				'[10, 20]': {
-					'?someQuery=10': [ 42 ],
+const getHeaderMock = ( total ) => {
+	const headers = { total };
+	return {
+		get: ( key ) => headers[ key ] || null,
+		has: ( key ) => !! headers[ key ],
+	};
+};
+
+const state = {
+	'wc/blocks': {
+		products: {
+			'[]': {
+				'?someQuery=2': {
+					items: [ 'foo' ],
+					headers: getHeaderMock( 22 ),
 				},
 			},
 		},
-	};
+		'products/attributes': {
+			'[10]': {
+				'?someQuery=2': {
+					items: [ 'bar' ],
+					headers: getHeaderMock( 42 ),
+				},
+			},
+		},
+		'products/attributes/terms': {
+			'[10, 20]': {
+				'?someQuery=10': {
+					items: [ 42 ],
+					headers: getHeaderMock( 12 ),
+				},
+			},
+		},
+	},
+};
+
+describe( 'getCollection', () => {
 	it( 'returns empty array when namespace does not exist in state', () => {
 		expect( getCollection( state, 'invalid', 'products' ) ).toEqual( [] );
 	} );
@@ -57,5 +75,37 @@ describe( 'getCollection', () => {
 				);
 			}
 		);
+	} );
+} );
+
+describe( 'getCollectionHeader', () => {
+	it(
+		'returns undefined when there are headers but the specific header ' +
+			'does not exist',
+		() => {
+			expect(
+				getCollectionHeader(
+					state,
+					'wc/blocks',
+					'products',
+					'invalid',
+					{
+						someQuery: 2,
+					}
+				)
+			).toBeUndefined();
+		}
+	);
+	it( 'returns null when there are no headers for the given arguments', () => {
+		expect( getCollectionHeader( state, 'wc/blocks', 'invalid' ) ).toBe(
+			null
+		);
+	} );
+	it( 'returns expected header when it exists', () => {
+		expect(
+			getCollectionHeader( state, 'wc/blocks', 'products', 'total', {
+				someQuery: 2,
+			} )
+		).toBe( 22 );
 	} );
 } );


### PR DESCRIPTION
In #1008 the new data stores were added.  However I forgot that for collections, we will want to have access to the headers of the response for things like paging (`x-wp-total`) etc. So, the work in this pull:

- adds a new `getCollectionHeader` selector,
- adds a `apiFetchWithHeaders` control for retrieving the full non-parsed response using `wp.apiFetch` (default `wp.dataControls.apiFetch` only return parsed body).
- updates `reducers`, `actions`, `selectors`, and `resolvers` to handle the response.  Data is now stored in the state with the value for the matching query being an object with two properties: `items` which is the response body as json and `headers` which is a native [`Headers`](https://developer.mozilla.org/en-US/docs/Web/API/Headers) object.  This is all hidden behind the scenes and is not accessed directly.  Consumers only deal with requested header values and the items via the appropriate selectors.
- docs updated for the collections store

## Testing

- unit tests were updated.
- I force enqueuing the built bundle and then monkey tested that I could retrieve headers okay.  Also made sure there was only ever one request for a given collection.

![screenshot](https://p72.f4.n0.cdn.getcloudapp.com/items/yAu465qX/Image+2019-10-22+at+4.37.40+PM.png?v=89e9a76915a18ee6dd71083ae4110bcf)

You can try yourself using these commands in the browser console when you know the stores are registered:

```js
storeKey = wc.wcBlocksData.COLLECTIONS_STORE_KEY
// get collection -- might have to execute twice to allow for resolution.
value = wp.data.select(storeKey).getCollection( '/wc/blocks', 'products' );
// get collection header
header = wp.data.select(storeKey).getCollectionHeader( '/wc/blocks', 'products', 'x-wp-total' );
```
You can verify via the Network tab in your browser dev tools that the request to the products route only happens once.