### PR TITLE
Fix eslint prettier conflict

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
 	rules: {
 		'@wordpress/dependency-group': 'off',
 		'valid-jsdoc': 'off',
+		'operator-linebreak': [ 'error', 'after' ],
 	},
 };

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -92,9 +92,9 @@ const Pagination = ( {
 								currentPage === page,
 						} ) }
 						onClick={
-							currentPage === page
-								? null
-								: () => onPageChange( page )
+							currentPage === page ?
+								null :
+								() => onPageChange( page )
 						}
 					>
 						{ page }

--- a/assets/js/base/hocs/with-reviews.js
+++ b/assets/js/base/hocs/with-reviews.js
@@ -46,9 +46,9 @@ const withReviews = ( OriginalComponent ) => {
 			error: null,
 			loading: true,
 			reviews: this.isPreview ? this.props.attributes.previewReviews : [],
-			totalReviews: this.isPreview
-				? this.props.attributes.previewReviews.length
-				: 0,
+			totalReviews: this.isPreview ?
+				this.props.attributes.previewReviews.length :
+				0,
 		};
 
 		componentDidMount() {
@@ -97,9 +97,9 @@ const withReviews = ( OriginalComponent ) => {
 			};
 
 			if ( categoryIds && categoryIds.length ) {
-				args.category_id = Array.isArray( categoryIds )
-					? categoryIds.join( ',' )
-					: categoryIds;
+				args.category_id = Array.isArray( categoryIds ) ?
+					categoryIds.join( ',' ) :
+					categoryIds;
 			}
 
 			if ( productId ) {

--- a/assets/js/blocks/featured-category/utils.js
+++ b/assets/js/blocks/featured-category/utils.js
@@ -49,9 +49,9 @@ function getBackgroundImageStyles( url ) {
  * @return {string} The class name, if applicable (not used for ratio 0 or 50).
  */
 function dimRatioToClass( ratio ) {
-	return ratio === 0 || ratio === 50
-		? null
-		: `has-background-dim-${ 10 * Math.round( ratio / 10 ) }`;
+	return ratio === 0 || ratio === 50 ?
+		null :
+		`has-background-dim-${ 10 * Math.round( ratio / 10 ) }`;
 }
 
 export {

--- a/assets/js/blocks/featured-product/utils.js
+++ b/assets/js/blocks/featured-product/utils.js
@@ -32,9 +32,9 @@ function getBackgroundImageStyles( url ) {
  * @return {string} The class name, if applicable (not used for ratio 0 or 50).
  */
 function dimRatioToClass( ratio ) {
-	return ratio === 0 || ratio === 50
-		? null
-		: `has-background-dim-${ 10 * Math.round( ratio / 10 ) }`;
+	return ratio === 0 || ratio === 50 ?
+		null :
+		`has-background-dim-${ 10 * Math.round( ratio / 10 ) }`;
 }
 
 export { getBackgroundImageStyles, dimRatioToClass };

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -66,12 +66,12 @@ class ProductsBlock extends Component {
 							'woo-gutenberg-products-block'
 						) }
 						help={
-							alignButtons
-								? __(
+							alignButtons ?
+								__(
 										'Buttons are aligned vertically.',
 										'woo-gutenberg-products-block'
-								  )
-								: __(
+								  ) :
+								__(
 										'Buttons follow content.',
 										'woo-gutenberg-products-block'
 								  )

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -32,12 +32,12 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							'woo-gutenberg-products-block'
 						) }
 						help={
-							hasCount
-								? __(
+							hasCount ?
+								__(
 										'Product count is visible.',
 										'woo-gutenberg-products-block'
-								  )
-								: __(
+								  ) :
+								__(
 										'Product count is hidden.',
 										'woo-gutenberg-products-block'
 								  )
@@ -53,12 +53,12 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							'woo-gutenberg-products-block'
 						) }
 						help={
-							isHierarchical
-								? __(
+							isHierarchical ?
+								__(
 										'Hierarchy is visible.',
 										'woo-gutenberg-products-block'
-								  )
-								: __(
+								  ) :
+								__(
 										'Hierarchy is hidden.',
 										'woo-gutenberg-products-block'
 								  )
@@ -76,12 +76,12 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							'woo-gutenberg-products-block'
 						) }
 						help={
-							hasEmpty
-								? __(
+							hasEmpty ?
+								__(
 										'Empty categories are visible.',
 										'woo-gutenberg-products-block'
-								  )
-								: __(
+								  ) :
+								__(
 										'Empty categories are hidden.',
 										'woo-gutenberg-products-block'
 								  )

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -282,9 +282,9 @@ class ProductByCategoryBlock extends Component {
 								icon: 'edit',
 								title: __( 'Edit' ),
 								onClick: () =>
-									isEditing
-										? this.stopEditing()
-										: this.startEditing(),
+									isEditing ?
+										this.stopEditing() :
+										this.startEditing(),
 								isActive: isEditing,
 							},
 						] }

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -42,9 +42,9 @@ class ProductSearchBlock extends Component {
 					<label
 						htmlFor={ formId }
 						className={
-							hasLabel
-								? 'wc-block-product-search__label'
-								: 'wc-block-product-search__label screen-reader-text'
+							hasLabel ?
+								'wc-block-product-search__label' :
+								'wc-block-product-search__label screen-reader-text'
 						}
 					>
 						{ label }

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -92,12 +92,12 @@ registerBlockType( 'woocommerce/product-search', {
 								'woo-gutenberg-products-block'
 							) }
 							help={
-								hasLabel
-									? __(
+								hasLabel ?
+									__(
 											'Label is visible.',
 											'woo-gutenberg-products-block'
-									  )
-									: __(
+									  ) :
+									__(
 											'Label is hidden.',
 											'woo-gutenberg-products-block'
 									  )

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -264,18 +264,18 @@ class ProductsByTagBlock extends Component {
 										icon: 'edit',
 										title: __( 'Edit' ),
 										onClick: () =>
-											isEditing
-												? this.stopEditing()
-												: this.startEditing(),
+											isEditing ?
+												this.stopEditing() :
+												this.startEditing(),
 										isActive: isEditing,
 									},
 								] }
 							/>
 						</BlockControls>
 						{ this.getInspectorControls() }
-						{ isEditing
-							? this.renderEditMode()
-							: this.renderViewMode() }
+						{ isEditing ?
+							this.renderEditMode() :
+							this.renderViewMode() }
 					</Fragment>
 				) : (
 					<Placeholder

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -47,9 +47,9 @@ const ReviewsByCategoryEditor = ( {
 			classes.push( 'is-skip-level' );
 		}
 
-		const accessibleName = ! item.breadcrumbs.length
-			? item.name
-			: `${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
+		const accessibleName = ! item.breadcrumbs.length ?
+			item.name :
+			`${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
 
 		return (
 			<SearchListItem

--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -16,12 +16,12 @@ const GridContentControl = ( { onChange, settings } ) => {
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
 				help={
-					title
-						? __(
+					title ?
+						__(
 								'Product title is visible.',
 								'woo-gutenberg-products-block'
-						  )
-						: __(
+						  ) :
+						__(
 								'Product title is hidden.',
 								'woo-gutenberg-products-block'
 						  )
@@ -32,12 +32,12 @@ const GridContentControl = ( { onChange, settings } ) => {
 			<ToggleControl
 				label={ __( 'Product price', 'woo-gutenberg-products-block' ) }
 				help={
-					price
-						? __(
+					price ?
+						__(
 								'Product price is visible.',
 								'woo-gutenberg-products-block'
-						  )
-						: __(
+						  ) :
+						__(
 								'Product price is hidden.',
 								'woo-gutenberg-products-block'
 						  )
@@ -48,12 +48,12 @@ const GridContentControl = ( { onChange, settings } ) => {
 			<ToggleControl
 				label={ __( 'Product rating', 'woo-gutenberg-products-block' ) }
 				help={
-					rating
-						? __(
+					rating ?
+						__(
 								'Product rating is visible.',
 								'woo-gutenberg-products-block'
-						  )
-						: __(
+						  ) :
+						__(
 								'Product rating is hidden.',
 								'woo-gutenberg-products-block'
 						  )
@@ -67,12 +67,12 @@ const GridContentControl = ( { onChange, settings } ) => {
 					'woo-gutenberg-products-block'
 				) }
 				help={
-					button
-						? __(
+					button ?
+						__(
 								'Add to Cart button is visible.',
 								'woo-gutenberg-products-block'
-						  )
-						: __(
+						  ) :
+						__(
 								'Add to Cart button is hidden.',
 								'woo-gutenberg-products-block'
 						  )

--- a/assets/js/components/grid-layout-control/index.js
+++ b/assets/js/components/grid-layout-control/index.js
@@ -54,12 +54,12 @@ const GridLayoutControl = ( {
 					'woo-gutenberg-products-block'
 				) }
 				help={
-					alignButtons
-						? __(
+					alignButtons ?
+						__(
 								'Buttons are aligned vertically.',
 								'woo-gutenberg-products-block'
-						  )
-						: __(
+						  ) :
+						__(
 								'Buttons follow content.',
 								'woo-gutenberg-products-block'
 						  )

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -35,9 +35,9 @@ const ProductCategoryControl = ( {
 			classes.push( 'is-skip-level' );
 		}
 
-		const accessibleName = ! item.breadcrumbs.length
-			? item.name
-			: `${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
+		const accessibleName = ! item.breadcrumbs.length ?
+			item.name :
+			`${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
 
 		return (
 			<SearchListItem

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -67,9 +67,9 @@ const ProductControl = ( {
 	const renderItemWithVariations = ( args ) => {
 		const { item, search, depth = 0, isSelected, onSelect } = args;
 		const variationsCount =
-			item.variations && Array.isArray( item.variations )
-				? item.variations.length
-				: 0;
+			item.variations && Array.isArray( item.variations ) ?
+				item.variations.length :
+				0;
 		const classes = classnames(
 			'woocommerce-search-product__item',
 			'woocommerce-search-list__item',
@@ -181,9 +181,9 @@ const ProductControl = ( {
 	}
 
 	const currentVariations =
-		variations && variations[ expandedProduct ]
-			? variations[ expandedProduct ]
-			: [];
+		variations && variations[ expandedProduct ] ?
+			variations[ expandedProduct ] :
+			[];
 	const currentList = [ ...products, ...currentVariations ];
 
 	return (

--- a/assets/js/components/product-tag-control/index.js
+++ b/assets/js/components/product-tag-control/index.js
@@ -64,9 +64,9 @@ class ProductTagControl extends Component {
 			classes.push( 'is-skip-level' );
 		}
 
-		const accessibleName = ! item.breadcrumbs.length
-			? item.name
-			: `${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
+		const accessibleName = ! item.breadcrumbs.length ?
+			item.name :
+			`${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
 
 		return (
 			<SearchListItem

--- a/assets/js/hocs/with-product-variations.js
+++ b/assets/js/hocs/with-product-variations.js
@@ -146,9 +146,9 @@ const withProductVariations = createHigherOrderComponent(
 				}
 
 				if ( ! isLoading && selectedItem ) {
-					return this.isProductId( selectedItem )
-						? selectedItem
-						: this.findParentProduct( selectedItem );
+					return this.isProductId( selectedItem ) ?
+						selectedItem :
+						this.findParentProduct( selectedItem );
 				}
 
 				return null;

--- a/assets/js/settings/shared/get-setting.js
+++ b/assets/js/settings/shared/get-setting.js
@@ -19,8 +19,8 @@ import { allSettings } from './settings-init';
  * @returns {mixed}
  */
 export function getSetting( name, fallback = false, filter = ( val ) => val ) {
-	const value = allSettings.hasOwnProperty( name )
-		? allSettings[ name ]
-		: fallback;
+	const value = allSettings.hasOwnProperty( name ) ?
+		allSettings[ name ] :
+		fallback;
 	return filter( value, fallback );
 }

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -27,9 +27,9 @@ export const compareWithWpVersion = ( version, operator ) => {
 		/-[a-zA-Z0-9]*[\-]*/,
 		'.0-rc.'
 	);
-	replacement = replacement.endsWith( '.' )
-		? replacement.substring( 0, replacement.length - 1 )
-		: replacement;
+	replacement = replacement.endsWith( '.' ) ?
+		replacement.substring( 0, replacement.length - 1 ) :
+		replacement;
 	return compareVersions.compare( version, replacement, operator );
 };
 

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
 			"npm run lint:css"
 		],
 		"*.js": [
-			"prettier --write",
 			"npm run lint:js"
 		],
 		"*.php": [


### PR DESCRIPTION
In #945 we added prettier to our build stack.  However, recently I noticed that the `operator-linebreak` rule in the eslint config was getting overridden by prettier. This is most noticeable with ternary conditions across multi-lines.  For example:

Expected:

```js
const someValue = someCheck === true ?
    doThis :
    doThat;
```

Prettier over-rides:
```js
const someValue = someCheck === true
    ? doThis
    : doThat;
```

The latter is the php code style, but the former is javascript code style (WP no less).  In order to fix I had to do a couple things:

- add `'operator-linebreak': [ 'error', 'after' ],` rule in the `.eslintrc` config (which takes precedence over prettier).
- remove prettier execution on the husky `pre-commit` hook.  It would override the styles enforced by eslint.  We should all be just using the "format on save" option in our IDE's.
- ran `npm lint:js-fix` to update all the files that had been erroneously re-configured by prettier.

## Testing

- ran `npm run lint:js` and `npm run lint:js-fix` to update errant files.
- verified in my IDE (vs-code) that reformatting a file kept the correct rule for operator position on multi-line expressions.