### PR TITLE
BlocksWpQuery wrapper for WP_Query

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -261,7 +261,8 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		$is_cacheable = (bool) apply_filters( 'woocommerce_blocks_product_grid_is_cacheable', true, $this->query_args );
 
 		if ( $is_cacheable ) {
-			$query_hash        = md5( wp_json_encode( $this->query_args ) . __CLASS__ );
+			$hash_args         = apply_filters( 'woocommerce_blocks_product_grid_hash_args', $this->query_args );
+			$query_hash        = md5( wp_json_encode( $hash_args ) . __CLASS__ );
 			$transient_name    = 'wc_block_' . $query_hash;
 			$transient_value   = get_transient( $transient_name );
 			$transient_version = \WC_Cache_Helper::get_transient_version( 'product_query' );

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Utils\BlocksWpQuery;
+
 /**
  * AbstractProductGrid class.
  */
@@ -258,33 +260,14 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @return array List of product IDs
 	 */
 	protected function get_products() {
-		$is_cacheable = (bool) apply_filters( 'woocommerce_blocks_product_grid_is_cacheable', true, $this->query_args );
+		$is_cacheable      = (bool) apply_filters( 'woocommerce_blocks_product_grid_is_cacheable', true, $this->query_args );
+		$transient_version = \WC_Cache_Helper::get_transient_version( 'product_query' );
 
-		if ( $is_cacheable ) {
-			$hash_args         = apply_filters( 'woocommerce_blocks_product_grid_hash_args', $this->query_args );
-			$query_hash        = md5( wp_json_encode( $hash_args ) . __CLASS__ );
-			$transient_name    = 'wc_block_' . $query_hash;
-			$transient_value   = get_transient( $transient_name );
-			$transient_version = \WC_Cache_Helper::get_transient_version( 'product_query' );
-		}
+		$query   = new BlocksWpQuery( $this->query_args );
+		$results = wp_parse_id_list( $is_cacheable ? $query->get_cached_posts( $transient_version ) : $query->get_posts() );
 
-		if ( isset( $transient_value['value'], $transient_value['version'], $transient_version ) && $transient_value['version'] === $transient_version ) {
-			$results = $transient_value['value'];
-		} else {
-			$query   = new \WP_Query( $this->query_args );
-			$results = wp_parse_id_list( $query->posts );
-
-			if ( $is_cacheable ) {
-				$transient_value = array(
-					'version' => $transient_version,
-					'value'   => $results,
-				);
-				set_transient( $transient_name, $transient_value, DAY_IN_SECONDS * 30 );
-			}
-
-			// Remove ordering query arguments which may have been added by get_catalog_ordering_args.
-			WC()->query->remove_ordering_args();
-		}
+		// Remove ordering query arguments which may have been added by get_catalog_ordering_args.
+		WC()->query->remove_ordering_args();
 
 		// Prime caches to reduce future queries.
 		if ( is_callable( '_prime_post_caches' ) ) {

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -38,13 +38,24 @@ class BlocksWpQuery extends WP_Query {
 	}
 
 	/**
-	 * Cache cached posts, if a cache exists.
+	 * Get cached posts, if a cache exists.
+	 *
+	 * A hash is generated using the array of query_vars. If doing custom queries via filters such as posts_where
+	 * (where the SQL query is manipulated directly) you can still ensure there is a unique hash by injecting custom
+	 * query vars via the parse_query filter. For example:
+	 *
+	 *      add_filter( 'parse_query', function( $wp ) {
+	 *           $wp->query_vars['my_custom_query_var'] = true;
+	 *      } );
+	 *
+	 * Doing so won't have any negative effect on the query itself, and it will cause the hash to change.
 	 *
 	 * @param string $transient_version Transient version to allow for invalidation.
 	 * @return WP_Post[]|int[] Array of post objects or post IDs.
 	 */
 	public function get_cached_posts( $transient_version = '' ) {
-		$transient_name  = 'wc_blocks_query_' . $this->query_vars_hash;
+		$hash            = md5( wp_json_encode( $this->query_vars ) );
+		$transient_name  = 'wc_blocks_query_' . $hash;
 		$transient_value = get_transient( $transient_name );
 
 		if ( isset( $transient_value, $transient_value['version'], $transient_value['value'] ) && $transient_value['version'] === $transient_version ) {

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -44,8 +44,8 @@ class BlocksWpQuery extends WP_Query {
 	 * (where the SQL query is manipulated directly) you can still ensure there is a unique hash by injecting custom
 	 * query vars via the parse_query filter. For example:
 	 *
-	 *      add_filter( 'parse_query', function( $wp ) {
-	 *           $wp->query_vars['my_custom_query_var'] = true;
+	 *      add_filter( 'parse_query', function( $wp_query ) {
+	 *           $wp_query->query_vars['my_custom_query_var'] = true;
 	 *      } );
 	 *
 	 * Doing so won't have any negative effect on the query itself, and it will cause the hash to change.

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Wrapper for WP Query with additonal helper methods.
+ *
+ * Allows query args to be set and parsed without doing running it, so that a cache can be used.
+ *
+ * @package Automattic/WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+use \WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * BlocksWpQuery query.
+ *
+ * @deprecated $VID:$
+ */
+class BlocksWpQuery extends WP_Query {
+	/**
+	 * Constructor.
+	 *
+	 * Sets up the WordPress query, if parameter is not empty.
+	 *
+	 * Unlike the constructor in WP_Query, this does not RUN the query.
+	 *
+	 * @param string|array $query URL query string or array of vars.
+	 */
+	public function __construct( $query = '' ) {
+		if ( ! empty( $query ) ) {
+			$this->init();
+			$this->query      = wp_parse_args( $query );
+			$this->query_vars = $this->query;
+			$this->parse_query_vars();
+		}
+	}
+
+	/**
+	 * Cache cached posts, if a cache exists.
+	 *
+	 * @param string $transient_version Transient version to allow for invalidation.
+	 * @return WP_Post[]|int[] Array of post objects or post IDs.
+	 */
+	public function get_cached_posts( $transient_version = '' ) {
+		$transient_name  = 'wc_blocks_query_' . $this->query_vars_hash;
+		$transient_value = get_transient( $transient_name );
+
+		if ( isset( $transient_value, $transient_value['version'], $transient_value['value'] ) && $transient_value['version'] === $transient_version ) {
+			return $transient_value['value'];
+		}
+
+		$results = $this->get_posts();
+
+		set_transient(
+			$transient_name,
+			array(
+				'version' => $transient_version,
+				'value'   => $results,
+			),
+			DAY_IN_SECONDS * 30
+		);
+
+		return $results;
+	}
+}


### PR DESCRIPTION
As an alternative to #1056 which uses a custom hook to invalidate caches, this PR introduces a new wrapper for `WP_Query` to create a cache based on parsed query args in a standardized manner.

`BlocksWpQuery` is a class that wraps `WP_Query` and has 2 differences:

1. A constructor that doesn't run the query, just sets the query vars and parses them.
2. A new `get_cached_posts` method which attempts to pull results from a transient, falling back to `get_posts` if needed.

Closes #1056

### How to test the changes in this Pull Request:

1. Create a products by category block
2. View / Refresh, ensure results are set.
3. Manually check DB to ensure a transient with prefix `wc_blocks_query_` exists.