### PR TITLE
Fix incorrect definition of loadProduct in withProduct. (fixes #1087)

### DIFF
--- a/assets/js/hocs/with-product.js
+++ b/assets/js/hocs/with-product.js
@@ -34,7 +34,7 @@ const withProduct = createHigherOrderComponent( ( OriginalComponent ) => {
 			}
 		}
 
-		loadProduct() {
+		loadProduct = () => {
 			const { productId } = this.props.attributes;
 
 			if ( productId === 'preview' ) {
@@ -57,7 +57,7 @@ const withProduct = createHigherOrderComponent( ( OriginalComponent ) => {
 
 					this.setState( { product: null, loading: false, error } );
 				} );
-		}
+		};
 
 		render() {
 			const { error, loading, product } = this.state;


### PR DESCRIPTION
Fixes: #1087

This fixes a regression introduced by #1034 when the `withProduct` hoc was converted to use class properties.  We didn't notice that `loadProduct` is being passed through as a prop but internally references `this`.  In order for that reference to be correct, `loadProduct` needs to be a class property and not method.  Looks like travis did report this in the pull, but we missed it.

## To Test

* [x] This affects the Featured Product block, so tests should verify it works as expected. 
* [x] Our existing test suite should pass on travis as well.