### PR TITLE
Add php5.3 restriction for All Products block

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -8,6 +8,7 @@ const ProgressBarPlugin = require( 'progress-bar-webpack-plugin' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const chalk = require( 'chalk' );
+const { omit } = require( 'lodash' );
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
@@ -86,6 +87,41 @@ const getAlias = ( options = {} ) => {
 	};
 };
 
+const mainEntry = {
+	// Shared blocks code
+	blocks: './assets/js/index.js',
+	// Blocks
+	'handpicked-products': './assets/js/blocks/handpicked-products/index.js',
+	'product-best-sellers': './assets/js/blocks/product-best-sellers/index.js',
+	'product-category': './assets/js/blocks/product-category/index.js',
+	'product-categories': './assets/js/blocks/product-categories/index.js',
+	'product-new': './assets/js/blocks/product-new/index.js',
+	'product-on-sale': './assets/js/blocks/product-on-sale/index.js',
+	'product-top-rated': './assets/js/blocks/product-top-rated/index.js',
+	'products-by-attribute':
+		'./assets/js/blocks/products-by-attribute/index.js',
+	'featured-product': './assets/js/blocks/featured-product/index.js',
+	'all-reviews': './assets/js/blocks/reviews/all-reviews/index.js',
+	'reviews-by-product':
+		'./assets/js/blocks/reviews/reviews-by-product/index.js',
+	'reviews-by-category':
+		'./assets/js/blocks/reviews/reviews-by-category/index.js',
+	'product-search': './assets/js/blocks/product-search/index.js',
+	'product-tag': './assets/js/blocks/product-tag/index.js',
+	'featured-category': './assets/js/blocks/featured-category/index.js',
+	'all-products': './assets/js/blocks/products/all-products/index.js',
+};
+
+const frontEndEntry = {
+	reviews: './assets/js/blocks/reviews/frontend.js',
+	'all-products': './assets/js/blocks/products/all-products/frontend.js',
+};
+
+const getEntryConfig = ( main = true, exclude = [] ) => {
+	const entryConfig = main ? mainEntry : frontEndEntry;
+	return omit( entryConfig, exclude );
+};
+
 const getMainConfig = ( options = {} ) => {
 	let { fileSuffix } = options;
 	const { alias, resolvePlugins = [] } = options;
@@ -99,35 +135,7 @@ const getMainConfig = ( options = {} ) => {
 				plugins: resolvePlugins,
 		  };
 	return {
-		entry: {
-			// Shared blocks code
-			blocks: './assets/js/index.js',
-			// Blocks
-			'handpicked-products':
-				'./assets/js/blocks/handpicked-products/index.js',
-			'product-best-sellers':
-				'./assets/js/blocks/product-best-sellers/index.js',
-			'product-category': './assets/js/blocks/product-category/index.js',
-			'product-categories':
-				'./assets/js/blocks/product-categories/index.js',
-			'product-new': './assets/js/blocks/product-new/index.js',
-			'product-on-sale': './assets/js/blocks/product-on-sale/index.js',
-			'product-top-rated':
-				'./assets/js/blocks/product-top-rated/index.js',
-			'products-by-attribute':
-				'./assets/js/blocks/products-by-attribute/index.js',
-			'featured-product': './assets/js/blocks/featured-product/index.js',
-			'all-reviews': './assets/js/blocks/reviews/all-reviews/index.js',
-			'reviews-by-product':
-				'./assets/js/blocks/reviews/reviews-by-product/index.js',
-			'reviews-by-category':
-				'./assets/js/blocks/reviews/reviews-by-category/index.js',
-			'product-search': './assets/js/blocks/product-search/index.js',
-			'product-tag': './assets/js/blocks/product-tag/index.js',
-			'featured-category':
-				'./assets/js/blocks/featured-category/index.js',
-			'all-products': './assets/js/blocks/products/all-products/index.js',
-		},
+		entry: getEntryConfig( true, options.exclude || [] ),
 		output: {
 			path: path.resolve( __dirname, '../build/' ),
 			filename: `[name]${ fileSuffix }.js`,
@@ -257,11 +265,7 @@ const getFrontConfig = ( options = {} ) => {
 				plugins: resolvePlugins,
 		  };
 	return {
-		entry: {
-			reviews: './assets/js/blocks/reviews/frontend.js',
-			'all-products':
-				'./assets/js/blocks/products/all-products/frontend.js',
-		},
+		entry: getEntryConfig( false, options.exclude || [] ),
 		output: {
 			path: path.resolve( __dirname, '../build/' ),
 			filename: `[name]${ fileSuffix }-frontend.js`,

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -232,8 +232,11 @@ const getMainConfig = ( options = {} ) => {
 				filename: `[name]${ fileSuffix }.css`,
 			} ),
 			new MergeExtractFilesPlugin(
-				[ 'build/editor.js', 'build/style.js' ],
-				'build/vendors.js'
+				[
+					`build/editor${ fileSuffix }.js`,
+					`build/style${ fileSuffix }.js`,
+				],
+				`build/vendors${ fileSuffix }.js`
 			),
 			new ProgressBarPlugin( {
 				format:

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -124,9 +124,8 @@ class Assets {
 	 * @return string The cache buster value to use for the given file.
 	 */
 	protected static function get_file_version( $file ) {
-		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-			$file = trim( $file, '/' );
-			return filemtime( \Automattic\WooCommerce\Blocks\Package::get_path() . '/' . $file );
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && file_exists( \Automattic\WooCommerce\Blocks\Package::get_path() . $file ) ) {
+			return filemtime( \Automattic\WooCommerce\Blocks\Package::get_path() . $file );
 		}
 		return \Automattic\WooCommerce\Blocks\Package::get_version();
 	}

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -42,7 +42,7 @@ class Assets {
 
 		// Shared libraries and components across all blocks.
 		self::register_script( 'wc-blocks-data-store', plugins_url( 'build/wc-blocks-data.js', __DIR__ ), [], false );
-		self::register_script( 'wc-blocks', plugins_url( 'build/blocks.js', __DIR__ ), [], false );
+		self::register_script( 'wc-blocks', plugins_url( self::get_block_asset_build_path( 'blocks' ), __DIR__ ), [], false );
 		self::register_script( 'wc-vendors', plugins_url( self::get_block_asset_build_path( 'vendors' ), __DIR__ ), [], false );
 
 		self::register_script( 'wc-blocks-registry', plugins_url( 'build/wc-blocks-registry.js', __DIR__ ), [], false );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -35,37 +35,37 @@ class Assets {
 	 * as part of ongoing refactoring.
 	 */
 	public static function register_assets() {
-		self::register_style( 'wc-block-editor', plugins_url( 'build/editor.css', __DIR__ ), array( 'wp-edit-blocks' ) );
+		self::register_style( 'wc-block-editor', plugins_url( self::get_block_asset_build_path( 'editor', 'css' ), __DIR__ ), array( 'wp-edit-blocks' ) );
 		wp_style_add_data( 'wc-block-editor', 'rtl', 'replace' );
-		self::register_style( 'wc-block-style', plugins_url( 'build/style.css', __DIR__ ), [] );
+		self::register_style( 'wc-block-style', plugins_url( self::get_block_asset_build_path( 'style', 'css' ), __DIR__ ), [] );
 		wp_style_add_data( 'wc-block-style', 'rtl', 'replace' );
 
 		// Shared libraries and components across all blocks.
 		self::register_script( 'wc-blocks-data-store', plugins_url( 'build/wc-blocks-data.js', __DIR__ ), [], false );
 		self::register_script( 'wc-blocks', plugins_url( 'build/blocks.js', __DIR__ ), [], false );
-		self::register_script( 'wc-vendors', plugins_url( 'build/vendors.js', __DIR__ ), [], false );
+		self::register_script( 'wc-vendors', plugins_url( self::get_block_asset_build_path( 'vendors' ), __DIR__ ), [], false );
 
 		self::register_script( 'wc-blocks-registry', plugins_url( 'build/wc-blocks-registry.js', __DIR__ ), [], false );
 
 		// Individual blocks.
 		$block_dependencies = array( 'wc-vendors', 'wc-blocks' );
 
-		self::register_script( 'wc-handpicked-products', plugins_url( 'build/handpicked-products.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-best-sellers', plugins_url( 'build/product-best-sellers.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-category', plugins_url( 'build/product-category.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-new', plugins_url( 'build/product-new.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-on-sale', plugins_url( 'build/product-on-sale.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-top-rated', plugins_url( 'build/product-top-rated.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-products-by-attribute', plugins_url( 'build/products-by-attribute.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-featured-product', plugins_url( 'build/featured-product.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-featured-category', plugins_url( 'build/featured-category.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-categories', plugins_url( 'build/product-categories.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-tag', plugins_url( 'build/product-tag.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-all-reviews', plugins_url( 'build/all-reviews.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-reviews-by-product', plugins_url( 'build/reviews-by-product.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-reviews-by-category', plugins_url( 'build/reviews-by-category.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-product-search', plugins_url( 'build/product-search.js', __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-all-products', plugins_url( 'build/all-products.js', __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-handpicked-products', plugins_url( self::get_block_asset_build_path( 'handpicked-products' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-best-sellers', plugins_url( self::get_block_asset_build_path( 'product-best-sellers' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-category', plugins_url( self::get_block_asset_build_path( 'product-category' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-new', plugins_url( self::get_block_asset_build_path( 'product-new' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-on-sale', plugins_url( self::get_block_asset_build_path( 'product-on-sale' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-top-rated', plugins_url( self::get_block_asset_build_path( 'product-top-rated' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-products-by-attribute', plugins_url( self::get_block_asset_build_path( 'products-by-attribute' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-featured-product', plugins_url( self::get_block_asset_build_path( 'featured-product' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-featured-category', plugins_url( self::get_block_asset_build_path( 'featured-category' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-categories', plugins_url( self::get_block_asset_build_path( 'product-categories' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-tag', plugins_url( self::get_block_asset_build_path( 'product-tag' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-all-reviews', plugins_url( self::get_block_asset_build_path( 'all-reviews' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-reviews-by-product', plugins_url( self::get_block_asset_build_path( 'reviews-by-product' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-reviews-by-category', plugins_url( self::get_block_asset_build_path( 'reviews-by-category' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-product-search', plugins_url( self::get_block_asset_build_path( 'product-search' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-all-products', plugins_url( self::get_block_asset_build_path( 'all-products' ), __DIR__ ), $block_dependencies );
 	}
 
 	/**
@@ -182,5 +182,22 @@ class Assets {
 		$filename = str_replace( plugins_url( '/', __DIR__ ), '', $src );
 		$ver      = self::get_file_version( $filename );
 		wp_register_style( $handle, $src, $deps, $ver, $media );
+	}
+
+	/**
+	 * Returns the appropriate asset path for loading either legacy builds or
+	 * current builds.
+	 *
+	 * @param   string $filename  Filename for asset path (without extension).
+	 * @param   string $type      File type (.css or .js).
+	 *
+	 * @return  string             The generated path.
+	 */
+	protected static function get_block_asset_build_path( $filename, $type = 'js' ) {
+		global $wp_version;
+		$suffix = version_compare( $wp_version, '5.2', '>' )
+			? ''
+			: '-legacy';
+		return "build/$filename$suffix.$type";
 	}
 }

--- a/src/Library.php
+++ b/src/Library.php
@@ -25,6 +25,7 @@ class Library {
 	 * Register blocks, hooking up assets and render functions as needed.
 	 */
 	public static function register_blocks() {
+		global $wp_version;
 		$blocks = [
 			'AllReviews',
 			'FeaturedCategory',
@@ -41,8 +42,12 @@ class Library {
 			'ReviewsByCategory',
 			'ProductSearch',
 			'ProductTag',
-			'AllProducts',
 		];
+		// @todo after refactoring dynamic block registration, this will be moved
+		// to block level config.
+		if ( version_compare( $wp_version, '5.2', '>' ) ) {
+			$blocks[] = 'AllProducts';
+		}
 		foreach ( $blocks as $class ) {
 			$class    = __NAMESPACE__ . '\\BlockTypes\\' . $class;
 			$instance = new $class();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,6 +82,15 @@ const GutenbergBlocksConfig = {
 	...getMainConfig( { alias: getAlias() } ),
 };
 
+const BlocksFrontendConfig = {
+	...baseConfig,
+	...getFrontConfig( { alias: getAlias() } ),
+};
+
+/**
+ * Currently Legacy Configs are for builds targeting < WP5.3
+ */
+
 // eslint-disable-next-line no-unused-vars
 const LegacyBlocksConfig = {
 	...baseConfig,
@@ -94,12 +103,8 @@ const LegacyBlocksConfig = {
 				getAlias( { pathPart: 'legacy' } )
 			),
 		],
+		exclude: [ 'all-products' ],
 	} ),
-};
-
-const BlocksFrontendConfig = {
-	...baseConfig,
-	...getFrontConfig( { alias: getAlias() } ),
 };
 
 // eslint-disable-next-line no-unused-vars
@@ -114,6 +119,7 @@ const LegacyFrontendBlocksConfig = {
 				getAlias( { pathPart: 'legacy' } )
 			),
 		],
+		exclude: [ 'all-products' ],
 	} ),
 };
 
@@ -121,6 +127,6 @@ module.exports = [
 	CoreConfig,
 	GutenbergBlocksConfig,
 	BlocksFrontendConfig,
-	// LegacyBlocksConfig,
-	// LegacyFrontendBlocksConfig,
+	LegacyBlocksConfig,
+	LegacyFrontendBlocksConfig,
 ];


### PR DESCRIPTION
This pull is a part of the work for #1032.  In it:

- Enabled the asset legacy build system adding improvements so we don't build assets unnecessarily if they aren't being needed for legacy (i.e. allProducts block assets).
- Added php side handling for triggering whether to register legacy assets on handles or not.
- Added php side handling for triggering whether block registration happens in the current PHP environment or not.

PHP side, the work is just to get this viable.  I still want to eventually refactor the block loading process so it's more dynamic, but that's outside the scope of this pull and the work for getting All Products merged.

## To test

* [ ] Verify All products block loads/works on PHP 5.3 environments (including current RC candidates)
* [ ] Verify All products block does NOT load in < PHP5.3 environment and all other existing blocks work fine without errors in the console.

**Note:** There will be a `filemtime` warning for the block registration on WP < 5.3 but in production this shouldn't be an issue because we only use `filemtime` for asset versions in development.  The dependency extraction plugin now exposes has versions for files, so we should consider switching to use those instead (for both production and dev) which will remove the necessity for using filemtime.
