### PR TITLE
Fix product categories block refreshing more than expected.

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -13,6 +13,22 @@ import { IconFolder } from '@woocommerce/block-components/icons';
  */
 import ToggleButtonControl from '@woocommerce/block-components/toggle-button-control';
 
+const EmptyPlaceHolder = () => (
+	<Placeholder
+		icon={ <IconFolder /> }
+		label={ __(
+			'Product Categories List',
+			'woo-gutenberg-products-block'
+		) }
+		className="wc-block-product-categories"
+	>
+		{ __(
+			"This block shows product categories for your store. To use it, you'll first need to create a product and assign it to a category.",
+			'woo-gutenberg-products-block'
+		) }
+	</Placeholder>
+);
+
 /**
  * Component displaying the categories as dropdown or list.
  */
@@ -138,21 +154,7 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 			<ServerSideRender
 				block={ name }
 				attributes={ attributes }
-				EmptyResponsePlaceholder={ () => (
-					<Placeholder
-						icon={ <IconFolder /> }
-						label={ __(
-							'Product Categories List',
-							'woo-gutenberg-products-block'
-						) }
-						className="wc-block-product-categories"
-					>
-						{ __(
-							"This block shows product categories for your store. To use it, you'll first need to create a product and assign it to a category.",
-							'woo-gutenberg-products-block'
-						) }
-					</Placeholder>
-				) }
+				EmptyResponsePlaceholder={ EmptyPlaceHolder }
 			/>
 		</Fragment>
 	);


### PR DESCRIPTION
@mikejolley noticed that the `ProductCategoriesList` block was refreshing when focus was changed from inside to outside the block (and vice-versa).  The work in this pull fixes that.

> **Note:** This would only surface on WP 5.3 installs where `<ServerSideRender />` has the new `EmptyResponsePlaceholder` prop available.

The source of the problem is that `ProductCategoriesList` block is a functional component, and everytime it is invoked, any function in it are re-created.  Thus the anonymous function that was passed through to `<ServerSideRender />` on the `EmptyResponsePlaceholder` prop was getting re-created and this changed the reference equality on the prop signaling to `ServerSideRender` that props have changed and it needed to re-render.

## To Test

* Verify changing focus in (or out of) the `ProductCategoriesList` does not cause it to refresh.