### PR TITLE
Fix bugs in useCollection hook

### DIFF
--- a/assets/js/base/hooks/index.js
+++ b/assets/js/base/hooks/index.js
@@ -1,3 +1,5 @@
 export * from './use-query-state';
 export * from './use-shallow-equal';
 export * from './use-store-products';
+export * from './use-collection';
+export * from './use-collection-header';

--- a/assets/js/base/hooks/use-collection.js
+++ b/assets/js/base/hooks/use-collection.js
@@ -58,7 +58,10 @@ export const useCollection = ( options ) => {
 			].filter( ( item ) => typeof item !== 'undefined' );
 			return {
 				results: store.getCollection( ...args ),
-				isLoading: store.hasFinishedResolution( 'getCollection', args ),
+				isLoading: ! store.hasFinishedResolution(
+					'getCollection',
+					args
+				),
 			};
 		},
 		[ namespace, resourceName, currentResourceValues, currentQuery ]


### PR DESCRIPTION
While working on #1102 I discovered a couple bugs in the new `useCollection` hooks.  The following is addressed in this pull:

- export `useCollection` and `useCollectionHeader` on the `@woocommerce/base-hooks` alias.
- fix the incorrect boolean returned for `isLoading` on the `hasFinishedResolution` selector call in the `useCollection` hook.

## Testing

- Fixes were verified in work dong on #1102