### PR TITLE
Update `useQueryStateByKey` to return callback which wraps the dispatcher

### DIFF
--- a/assets/js/base/hooks/test/use-query-state.js
+++ b/assets/js/base/hooks/test/use-query-state.js
@@ -193,9 +193,11 @@ describe( 'Testing Query State Hooks', () => {
 				act( () => {
 					setQueryState( { foo: 'bar' } );
 				} );
-				expect( action ).toHaveBeenCalledWith( {
-					foo: 'bar',
-				} );
+				expect( action ).toHaveBeenCalledWith(
+					'test-context',
+					'someValue',
+					{ foo: 'bar' }
+				);
 			}
 		);
 	} );

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useCallback } from '@wordpress/data';
 import { useRef, useEffect } from '@wordpress/element';
 import { useShallowEqual } from './use-shallow-equal';
 
@@ -52,8 +52,16 @@ export const useQueryStateByKey = ( context, queryKey ) => {
 		},
 		[ context, queryKey ]
 	);
+
 	const { setQueryValue } = useDispatch( storeKey );
-	return [ queryValue, setQueryValue ];
+	const setQueryValueByKey = useCallback(
+		( value ) => {
+			setQueryValue( context, queryKey, value );
+		},
+		[ context, queryKey ]
+	);
+
+	return [ queryValue, setQueryValueByKey ];
 };
 
 /**

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
-import { useSelect, useDispatch, useCallback } from '@wordpress/data';
-import { useRef, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { useShallowEqual } from './use-shallow-equal';
 
 /**


### PR DESCRIPTION
`useQueryStateByKey` was not working as intended because it exposed the dispatcher directly, meaning you were unable to actually update a single query state by key by passing a single value. 

From https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/853

Allows for something like this:

```jsx
const [ maxPrice, setMaxPrice ] = useQueryStateByKey(
	'product-grid',
	'max_price'
);
setMaxPrice( 100 );
```