### PR TITLE
Add additional data to new products store endpoint

### DIFF
--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -119,6 +119,48 @@ class ProductSchema extends AbstractSchema {
 					),
 				),
 			),
+			'has_options'    => array(
+				'description' => __( 'Does the product have options?', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'is_purchasable' => array(
+				'description' => __( 'Is the product purchasable?', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'is_in_stock'    => array(
+				'description' => __( 'Is the product in stock?', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'add_to_cart'    => array(
+				'description' => __( 'Add to cart button parameters.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'text'        => array(
+							'description' => __( 'Button text.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'description' => array(
+							'description' => __( 'Button description.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+
 		];
 	}
 
@@ -141,6 +183,13 @@ class ProductSchema extends AbstractSchema {
 			'average_rating' => $product->get_average_rating(),
 			'review_count'   => $product->get_review_count(),
 			'images'         => ( new ProductImages() )->images_to_array( $product ),
+			'has_options'    => $product->has_options(),
+			'is_purchasable' => $product->is_purchasable(),
+			'is_in_stock'    => $product->is_in_stock(),
+			'add_to_cart'    => [
+				'text'        => $product->add_to_cart_text(),
+				'description' => $product->add_to_cart_description(),
+			],
 		];
 	}
 }

--- a/tests/php/RestApi/StoreApi/Controllers/Products.php
+++ b/tests/php/RestApi/StoreApi/Controllers/Products.php
@@ -24,10 +24,8 @@ class Products extends TestCase {
 		wp_set_current_user( 0 );
 
 		$this->products = [];
-		$this->products[0] = ProductHelper::create_simple_product( false );
-		$this->products[0]->save();
-		$this->products[1] = ProductHelper::create_simple_product( false );
-		$this->products[1]->save();
+		$this->products[0] = ProductHelper::create_simple_product( true );
+		$this->products[1] = ProductHelper::create_simple_product( true );
 	}
 
 	/**
@@ -55,6 +53,11 @@ class Products extends TestCase {
 		$this->assertEquals( $this->products[0]->get_price_html(), $data['price_html'] );
 		$this->assertEquals( $this->products[0]->get_average_rating(), $data['average_rating'] );
 		$this->assertEquals( $this->products[0]->get_review_count(), $data['review_count'] );
+		$this->assertEquals( $this->products[0]->has_options(), $data['has_options'] );
+		$this->assertEquals( $this->products[0]->is_purchasable(), $data['is_purchasable'] );
+		$this->assertEquals( $this->products[0]->is_in_stock(), $data['is_in_stock'] );
+		$this->assertEquals( $this->products[0]->add_to_cart_text(), $data['add_to_cart']['text'] );
+		$this->assertEquals( $this->products[0]->add_to_cart_description(), $data['add_to_cart']['description'] );
 	}
 
 	/**
@@ -77,6 +80,10 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'average_rating', $data[0] );
 		$this->assertArrayHasKey( 'review_count', $data[0] );
 		$this->assertArrayHasKey( 'images', $data[0] );
+		$this->assertArrayHasKey( 'has_options', $data[0] );
+		$this->assertArrayHasKey( 'is_purchasable', $data[0] );
+		$this->assertArrayHasKey( 'is_in_stock', $data[0] );
+		$this->assertArrayHasKey( 'add_to_cart', $data[0] );
 	}
 
 	/**
@@ -97,6 +104,10 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'average_rating', $schema['properties'] );
 		$this->assertArrayHasKey( 'review_count', $schema['properties'] );
 		$this->assertArrayHasKey( 'images', $schema['properties'] );
+		$this->assertArrayHasKey( 'has_options', $schema['properties'] );
+		$this->assertArrayHasKey( 'is_purchasable', $schema['properties'] );
+		$this->assertArrayHasKey( 'is_in_stock', $schema['properties'] );
+		$this->assertArrayHasKey( 'add_to_cart', $schema['properties'] );
 	}
 
 	/**
@@ -117,6 +128,10 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'average_rating', $response->get_data() );
 		$this->assertArrayHasKey( 'review_count', $response->get_data() );
 		$this->assertArrayHasKey( 'images', $response->get_data() );
+		$this->assertArrayHasKey( 'has_options', $response->get_data() );
+		$this->assertArrayHasKey( 'is_purchasable', $response->get_data() );
+		$this->assertArrayHasKey( 'is_in_stock', $response->get_data() );
+		$this->assertArrayHasKey( 'add_to_cart', $response->get_data() );
 	}
 
 	/**


### PR DESCRIPTION
This pull contains work initially done in #1102.  The new `/wc/store/products` endpoint is missing some data needed for the public data on the frontend so the work in this pull adds that.  Tests are updated as well

## To Test

Using a REST client, hit the `/wc/store/products` endpoint.  Results should contain more data on the following keys:

- `has_options`
- `is_purchasable`
- `is_in_stock`
- `add_to_cart` (an object with `text` and `description` properties)

The schema endpoint should also have schema for the additional fields.