### PR TITLE
Install dompurify and use to sanitize product title for review blocks

### DIFF
--- a/assets/js/base/components/review-list-item/index.js
+++ b/assets/js/base/components/review-list-item/index.js
@@ -4,7 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { sanitize } from 'dompurify';
 
 /**
  * Internal dependencies
@@ -95,7 +94,7 @@ function getReviewProductName( review ) {
 					// `product_name` might have html entities for things like
 					// emdash. So to display properly we need to allow the
 					// browser to render.
-					__html: sanitize( review.product_name ),
+					__html: review.product_name,
 				} }
 			/>
 		</div>
@@ -202,4 +201,13 @@ ReviewListItem.propTypes = {
 	review: PropTypes.object,
 };
 
+/**
+ * BE AWARE. ReviewListItem expects product data that is equivalent to what is
+ * made avaialble for output in a public view. Thus content that may contain
+ * html data is not sanitized further.
+ *
+ * Currently the following data is trusted (assumed to already be sanitized):
+ * - `review.review` (review content).
+ * - `review.product_name` (the product title)
+ */
 export default ReviewListItem;

--- a/assets/js/base/components/review-list-item/index.js
+++ b/assets/js/base/components/review-list-item/index.js
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { sanitize } from 'dompurify';
 
 /**
  * Internal dependencies
@@ -88,7 +89,15 @@ function getReviewContent( review ) {
 function getReviewProductName( review ) {
 	return (
 		<div className="wc-block-review-list-item__product">
-			<a href={ review.product_permalink }>{ review.product_name }</a>
+			<a
+				href={ review.product_permalink }
+				dangerouslySetInnerHTML={ {
+					// `product_name` might have html entities for things like
+					// emdash. So to display properly we need to allow the
+					// browser to render.
+					__html: sanitize( review.product_name ),
+				} }
+			/>
 		</div>
 	);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4977,7 +4977,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -6362,7 +6362,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -6399,7 +6399,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -6459,7 +6459,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -6633,7 +6633,7 @@
       "dependencies": {
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
           "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "dev": true
         }
@@ -7395,7 +7395,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -7408,7 +7408,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -8160,7 +8160,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -8258,6 +8258,11 @@
       "requires": {
         "domelementtype": "1"
       }
+    },
+    "dompurify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.7.tgz",
+      "integrity": "sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A=="
     },
     "domutils": {
       "version": "1.5.1",
@@ -10566,7 +10571,7 @@
     },
     "gettext-parser": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
       "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
       "requires": {
         "encoding": "^0.1.12",
@@ -11763,7 +11768,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -14229,7 +14234,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -15125,7 +15130,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -15186,7 +15191,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -15379,7 +15384,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -17383,7 +17388,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -17994,7 +17999,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -18469,7 +18474,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -19175,7 +19180,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -21368,7 +21373,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8259,11 +8259,6 @@
         "domelementtype": "1"
       }
     },
-    "dompurify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.7.tgz",
-      "integrity": "sha512-S3O0lk6rFJtO01ZTzMollCOGg+WAtCwS3U5E2WSDY/x/sy7q70RjEC4Dmrih5/UqzLLB9XoKJ8KqwBxaNvBu4A=="
-    },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 	"dependencies": {
 		"@woocommerce/components": "3.2.0",
 		"compare-versions": "3.5.1",
+		"dompurify": "^2.0.7",
 		"gridicons": "3.3.1",
 		"react-number-format": "4.3.1",
 		"trim-html": "0.1.9"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
 	"dependencies": {
 		"@woocommerce/components": "3.2.0",
 		"compare-versions": "3.5.1",
-		"dompurify": "^2.0.7",
 		"gridicons": "3.3.1",
 		"react-number-format": "4.3.1",
 		"trim-html": "0.1.9"


### PR DESCRIPTION
Closes: #1113 

All the Product Reviews block don't display the product title correctly for the review if it has html entities in it because of the safety escaping React has when rendering strings (which aren't parsed for html).  React provides an escape hatch for this with `dangerouslySetInnerHtml` which is _intentionally_ named because it should not be used on untrusted content.  ~We _don't_ trust the product title so a solution here is to wrap it with a sanitizing function.  I've used `dompurify` here because it is the generally accepted go-to option for this use-case.  Unfortunately this does add some additional size to the frontend build (below sizes are the non-minified dev build)~:

~`reviews-frontend.js` before: 162KiB~
~`reviews-frontend.js` after: 106KiB (+56)~

Update: After some discussion with @mikejolley I realize that while it's true that plugins and extensions can modify the product_title, this is no different than the behaviour in WordPress core for the `post_title` field in posts (which is where _products_ are stored as a custom post type).  Since the endpoint exposes `product_title` via the same function as post_title for the frontend, one can assume the necessary sanitization has been done.  Thus in the latest iteration I've removed the usage of dompurify.

With that said, there's still a security concern here if the component itself is used with data _other_ than the trusted source.  So to that end I've added a js doc to make it clear the assumptions being made.  Being that this is currently only an internally used component and not published in a package, I think we can roll with this for now (but welcome anyone  feedback or concerns)

## Screenies:

Before:

<img width="827" alt="Image 2019-11-01 at 6 49 12 AM" src="https://user-images.githubusercontent.com/1429108/68023954-c1d7da00-fc76-11e9-8bcb-938a077e01af.png">

After:
<img width="839" alt="Image 2019-11-01 at 7 11 38 AM" src="https://user-images.githubusercontent.com/1429108/68024003-e2079900-fc76-11e9-8949-19b2eb3313e9.png">

## To Test:

- Create a product (or edit an existing one) so that it has a single dash (not an emdash) between two words in the title (WordPress internally converts this to an emdash via filters).
- Ensure that product has a review
- Display that product using any review block that also displays product titles.
- Ensure the product title does not have html entities displayed in both the editor and frontend views.

**Note:** We should cherry-pick this into a 2.4.5 release so that it can get in WC 3.8.  