### PR TITLE
Fix bug with ProductTitle component

### DIFF
--- a/assets/js/atomic/components/product/title/index.js
+++ b/assets/js/atomic/components/product/title/index.js
@@ -24,7 +24,7 @@ const ProductTitle = ( { className, product, headingLevel, productLink } ) => {
 					{ productName }
 				</a>
 			) : (
-				{ productName }
+				productName
 			) }
 		</TagName>
 	);


### PR DESCRIPTION
While prepping a demo for the all products block, I exposed a but with the atomic product title component when toggling the link off or on.  This pull fixes that so the block/component works as expected.