### PR TITLE
Fix incorrect parsing of routes from placeholder route strings.

### DIFF
--- a/assets/js/data/schema/test/utils.js
+++ b/assets/js/data/schema/test/utils.js
@@ -9,13 +9,13 @@ import {
 
 describe( 'extractModelNameFromRoute', () => {
 	it.each`
-		namespace      | route                                                                        | expected
-		${'wc/blocks'} | ${'wc/blocks/products'}                                                      | ${'products'}
-		${'wc/other'}  | ${'wc/blocks/product'}                                                       | ${'wc/blocks/product'}
-		${'wc/blocks'} | ${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)'}                    | ${'products/attributes'}
-		${'wc/blocks'} | ${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)/terms'}              | ${'products/attributes/terms'}
-		${'wc/blocks'} | ${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)/terms/(?P<id>[d]+)'} | ${'products/attributes/terms'}
-		${'wc/blocks'} | ${'wc/blocks/cart/(?P<id>[s]+)'}                                             | ${'cart'}
+		namespace      | route                                                                          | expected
+		${'wc/blocks'} | ${'wc/blocks/products'}                                                        | ${'products'}
+		${'wc/other'}  | ${'wc/blocks/product'}                                                         | ${'wc/blocks/product'}
+		${'wc/blocks'} | ${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)'}                    | ${'products/attributes'}
+		${'wc/blocks'} | ${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)/terms'}              | ${'products/attributes/terms'}
+		${'wc/blocks'} | ${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)/terms/(?P<id>[d]+)'} | ${'products/attributes/terms'}
+		${'wc/blocks'} | ${'wc/blocks/cart/(?P<id>[\\s]+)'}                                             | ${'cart'}
 	`(
 		'returns "$expected" when namespace is "$namespace" and route is "$route"',
 		( { namespace, route, expected } ) => {
@@ -28,10 +28,10 @@ describe( 'extractModelNameFromRoute', () => {
 
 describe( 'getRouteIds', () => {
 	it.each`
-		route                                                                        | expected
-		${'wc/blocks/products'}                                                      | ${[]}
-		${'wc/blocks/products/(?P<id>[d]+)'}                                         | ${[ 'id' ]}
-		${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)/terms/(?P<id>[d]+)'} | ${[ 'attribute_id', 'id' ]}
+		route                                                                            | expected
+		${'wc/blocks/products'}                                                          | ${[]}
+		${'wc/blocks/products/(?P<id>[\\d]+)'}                                           | ${[ 'id' ]}
+		${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)/terms/(?P<id>[\\d]+)'} | ${[ 'attribute_id', 'id' ]}
 	`(
 		'returns "$expected" when route is "$route"',
 		( { route, expected } ) => {
@@ -42,14 +42,14 @@ describe( 'getRouteIds', () => {
 
 describe( 'simplifyRouteWithId', () => {
 	it.each`
-		route                                                                        | matchIds                    | expected
-		${'wc/blocks/products'}                                                      | ${[]}                       | ${'wc/blocks/products'}
-		${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)'}                    | ${[ 'attribute_id' ]}       | ${'wc/blocks/products/attributes/{attribute_id}'}
-		${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)/terms'}              | ${[ 'attribute_id' ]}       | ${'wc/blocks/products/attributes/{attribute_id}/terms'}
-		${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)/terms/(?P<id>[d]+)'} | ${[ 'attribute_id', 'id' ]} | ${'wc/blocks/products/attributes/{attribute_id}/terms/{id}'}
-		${'wc/blocks/products/attributes/(?P<attribute_id>[d]+)/terms/(?P<id>[d]+)'} | ${[ 'id', 'attribute_id' ]} | ${'wc/blocks/products/attributes/{attribute_id}/terms/{id}'}
-		${'wc/blocks/cart/(?P<id>[s]+)'}                                             | ${[ 'id' ]}                 | ${'wc/blocks/cart/{id}'}
-		${'wc/blocks/cart/(?P<id>[s]+)'}                                             | ${[ 'attribute_id' ]}       | ${'wc/blocks/cart/(?P<id>[s]+)'}
+		route                                                                            | matchIds                    | expected
+		${'wc/blocks/products'}                                                          | ${[]}                       | ${'wc/blocks/products'}
+		${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)'}                      | ${[ 'attribute_id' ]}       | ${'wc/blocks/products/attributes/{attribute_id}'}
+		${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)/terms'}                | ${[ 'attribute_id' ]}       | ${'wc/blocks/products/attributes/{attribute_id}/terms'}
+		${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)/terms/(?P<id>[\\d]+)'} | ${[ 'attribute_id', 'id' ]} | ${'wc/blocks/products/attributes/{attribute_id}/terms/{id}'}
+		${'wc/blocks/products/attributes/(?P<attribute_id>[\\d]+)/terms/(?P<id>[\\d]+)'} | ${[ 'id', 'attribute_id' ]} | ${'wc/blocks/products/attributes/{attribute_id}/terms/{id}'}
+		${'wc/blocks/cart/(?P<id>[\\s]+)'}                                               | ${[ 'id' ]}                 | ${'wc/blocks/cart/{id}'}
+		${'wc/blocks/cart/(?P<id>[\\s]+)'}                                               | ${[ 'attribute_id' ]}       | ${'wc/blocks/cart/(?P<id>[\\s]+)'}
 	`(
 		'returns "$expected" when route is "$route" and matchIds is "$matchIds"',
 		( { route, matchIds, expected } ) => {

--- a/assets/js/data/schema/utils.js
+++ b/assets/js/data/schema/utils.js
@@ -13,7 +13,7 @@
  */
 export const extractModelNameFromRoute = ( namespace, route ) => {
 	route = route.replace( `${ namespace }/`, '' );
-	return route.replace( /\/\(\?P\<[a-z_]*\>\[[a-z]]\+\)/g, '' );
+	return route.replace( /\/\(\?P\<[a-z_]*\>\[\\*[a-z]\]\+\)/g, '' );
 };
 
 /**


### PR DESCRIPTION
@mikejolley discovered a bug in working with complex routes with resource names like `products/attributes/terms`.  The issue is that the utils used by the schema store reducers for saving routes to the state were not correctly translating something like:

```
products/attributes/(?P<attribute_id>[\\d]+)/terms/(?P<id>[\\d]+)
```

to

```
products/attributes/terms
```

Not only that but the test fixtures covering this expectation were incorrect because prettier was seeing something like `[\d]+` and mutating it to `[d]+` (which wouldn't be in a route string) so the regex I had setup was working fine for the test but not for the actual parsing of a route.

The work in this pull addresses this bug and fixes tests so that they test the correct expectation.

To Test:

Along with the fix to the unit test that should pass you can also execute the following in your browser console (with the post editor loaded) to verify that things are setup correctly:

- `wp.data.select( 'wc/store/schema' ).getRoutes( '/wc/blocks' );` After executing this, open up redux tools and in the `root` state for the `wc/store/schema` store you should see the expected keys for all the routes (products, products/attributes/terms, etc)

<details>
<summary>Click to view expected schema routes state</summary>

```
routes: {
      '/wc/blocks': {
        'products/attributes': {
          '/wc/blocks/products/attributes': [],
          '/wc/blocks/products/attributes/{id}': [
            'id'
          ]
        },
        'products/attributes/terms': {
          '/wc/blocks/products/attributes/{attribute_id}/terms': [
            'attribute_id'
          ],
          '/wc/blocks/products/attributes/{attribute_id}/terms/{id}': [
            'attribute_id',
            'id'
          ]
        },
        'products/categories': {
          '/wc/blocks/products/categories': [],
          '/wc/blocks/products/categories/{id}': [
            'id'
          ]
        },
        'products/tags': {
          '/wc/blocks/products/tags': [],
          '/wc/blocks/products/tags/{id}': [
            'id'
          ]
        },
        products: {
          '/wc/blocks/products': [],
          '/wc/blocks/products/{id}': [
            'id'
          ]
        },
        'products/variations': {
          '/wc/blocks/products/{product_id}/variations': [
            'product_id'
          ]
        },
        'products/reviews': {
          '/wc/blocks/products/reviews': []
        }
      }
    }
```
</details>

- `wp.data.select( 'wc/store/collection' ).getCollection( '/wc/blocks', 'products/attributes/term', {}, [1] );` - After executing this (you may have to execute twice to allow for the resolver to finish resolving, you should get the expected terms for the attribute with the id of 1.