### PR TITLE
Move "prices" data from rest API to store API

### DIFF
--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -213,7 +213,6 @@ class Products extends WC_REST_Products_Controller {
 			'onsale'         => $product->is_on_sale(),
 			'price'          => $product->get_price(),
 			'price_html'     => $product->get_price_html(),
-			'prices'         => $this->get_prices( $product ),
 			'images'         => ( new ProductImages() )->images_to_array( $product ),
 			'average_rating' => $product->get_average_rating(),
 			'review_count'   => $product->get_review_count(),
@@ -242,91 +241,6 @@ class Products extends WC_REST_Products_Controller {
 		}
 
 		return $url;
-	}
-
-	/**
-	 * Get an array of pricing data.
-	 *
-	 * @param \WC_Product|\WC_Product_Variation $product Product instance.
-	 * @return array
-	 */
-	protected function get_prices( $product ) {
-		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
-		$position         = get_option( 'woocommerce_currency_pos' );
-		$symbol           = html_entity_decode( get_woocommerce_currency_symbol() );
-		$prefix           = '';
-		$suffix           = '';
-
-		// No break so symbol is added.
-		switch ( $position ) {
-			case 'left_space':
-				$prefix = $symbol . ' ';
-				break;
-			case 'left':
-				$prefix = $symbol;
-				break;
-			case 'right_space':
-				$suffix = ' ' . $symbol;
-				break;
-			case 'right':
-				$suffix = $symbol;
-				break;
-		}
-
-		$prices = [
-			'currency_code'      => get_woocommerce_currency(),
-			'decimal_separator'  => wc_get_price_decimal_separator(),
-			'thousand_separator' => wc_get_price_thousand_separator(),
-			'decimals'           => wc_get_price_decimals(),
-			'price_prefix'       => $prefix,
-			'price_suffix'       => $suffix,
-		];
-
-		$prices['price']         = 'incl' === $tax_display_mode ? wc_get_price_including_tax( $product ) : wc_get_price_excluding_tax( $product );
-		$prices['regular_price'] = 'incl' === $tax_display_mode ? wc_get_price_including_tax( $product, [ 'price' => $product->get_regular_price() ] ) : wc_get_price_excluding_tax( $product, [ 'price' => $product->get_regular_price() ] );
-		$prices['sale_price']    = 'incl' === $tax_display_mode ? wc_get_price_including_tax( $product, [ 'price' => $product->get_sale_price() ] ) : wc_get_price_excluding_tax( $product, [ 'price' => $product->get_sale_price() ] );
-		$prices['price_range']   = $this->get_price_range( $product );
-
-		return $prices;
-	}
-
-	/**
-	 * Get price range from certain product types.
-	 *
-	 * @param \WC_Product|\WC_Product_Variation $product Product instance.
-	 * @return arary|null
-	 */
-	protected function get_price_range( $product ) {
-		if ( $product->is_type( 'variable' ) ) {
-			$prices = $product->get_variation_prices( true );
-
-			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
-				return [
-					'min_amount' => min( $prices['price'] ),
-					'max_amount' => max( $prices['price'] ),
-				];
-			}
-		}
-
-		if ( $product->is_type( 'grouped' ) ) {
-			$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
-			$children         = array_filter( array_map( 'wc_get_product', $product->get_children() ), 'wc_products_array_filter_visible_grouped' );
-
-			foreach ( $children as $child ) {
-				if ( '' !== $child->get_price() ) {
-					$child_prices[] = 'incl' === $tax_display_mode ? wc_get_price_including_tax( $child ) : wc_get_price_excluding_tax( $child );
-				}
-			}
-
-			if ( ! empty( $child_prices ) ) {
-				return [
-					'min_amount' => min( $child_prices ),
-					'max_amount' => max( $child_prices ),
-				];
-			}
-		}
-
-		return null;
 	}
 
 	/**
@@ -428,94 +342,6 @@ class Products extends WC_REST_Products_Controller {
 					'type'        => 'boolean',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
-				),
-				'prices'         => array(
-					'description' => __( 'Price data.', 'woo-gutenberg-products-block' ),
-					'type'        => 'object',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'currency_code'      => array(
-								'description' => __( 'Currency code.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'decimal_separator'  => array(
-								'description' => __( 'Decimal separator.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'thousand_separator' => array(
-								'description' => __( 'Thousand separator.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'decimals'           => array(
-								'description' => __( 'Number of decimal places.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'price_prefix'       => array(
-								'description' => __( 'Price prefix, e.g. currency.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'price_suffix'       => array(
-								'description' => __( 'Price prefix, e.g. currency.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'price'              => array(
-								'description' => __( 'Current product price.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'regular_price'      => array(
-								'description' => __( 'Regular product price', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'sale_price'         => array(
-								'description' => __( 'Sale product price, if applicable.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'price_range'        => array(
-								'description' => __( 'Price range, if applicable.', 'woo-gutenberg-products-block' ),
-								'type'        => 'object',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-								'items'       => array(
-									'type'       => 'object',
-									'properties' => array(
-										'min_amount' => array(
-											'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
-											'type'        => 'string',
-											'context'     => array( 'view', 'edit' ),
-											'readonly'    => true,
-										),
-										'max_amount' => array(
-											'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
-											'type'        => 'string',
-											'context'     => array( 'view', 'edit' ),
-											'readonly'    => true,
-										),
-									),
-								),
-							),
-						),
-					),
 				),
 				'price_html'     => array(
 					'description' => __( 'Price formatted in HTML.', 'woo-gutenberg-products-block' ),

--- a/src/RestApi/StoreApi/README.md
+++ b/src/RestApi/StoreApi/README.md
@@ -222,8 +222,18 @@ Example response:
 		"permalink": "http://local.wordpress.test/product/wordpress-pennant/",
 		"sku": "wp-pennant",
 		"description": "<p>This is an external product.</p>\n",
-		"price": "0",
-		"price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&pound;</span>0.00</span>",
+		"prices": {
+			"currency_code": "GBP",
+			"decimal_separator": ".",
+			"thousand_separator": ",",
+			"decimals": 2,
+			"price_prefix": "£",
+			"price_suffix": "",
+			"price": 18,
+			"regular_price": 18,
+			"sale_price": 18,
+			"price_range": null
+		},
 		"average_rating": "3.60",
 		"review_count": 5,
 		"images": [
@@ -264,8 +274,18 @@ Example response:
 	"permalink": "http://local.wordpress.test/product/wordpress-pennant/",
 	"sku": "wp-pennant",
 	"description": "<p>This is an external product.</p>\n",
-	"price": "0",
-	"price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&pound;</span>0.00</span>",
+	"prices": {
+		"currency_code": "GBP",
+		"decimal_separator": ".",
+		"thousand_separator": ",",
+		"decimals": 2,
+		"price_prefix": "£",
+		"price_suffix": "",
+		"price": 18,
+		"regular_price": 18,
+		"sale_price": 18,
+		"price_range": null
+	},
 	"average_rating": "3.60",
 	"review_count": 5,
 	"images": [

--- a/tests/php/RestApi/StoreApi/Controllers/Products.php
+++ b/tests/php/RestApi/StoreApi/Controllers/Products.php
@@ -49,8 +49,7 @@ class Products extends TestCase {
 		$this->assertEquals( $this->products[0]->get_title(), $data['name'] );
 		$this->assertEquals( $this->products[0]->get_permalink(), $data['permalink'] );
 		$this->assertEquals( $this->products[0]->get_sku(), $data['sku'] );
-		$this->assertEquals( $this->products[0]->get_price(), $data['price'] );
-		$this->assertEquals( $this->products[0]->get_price_html(), $data['price_html'] );
+		$this->assertEquals( $this->products[0]->get_price(), $data['prices']['price'] );
 		$this->assertEquals( $this->products[0]->get_average_rating(), $data['average_rating'] );
 		$this->assertEquals( $this->products[0]->get_review_count(), $data['review_count'] );
 		$this->assertEquals( $this->products[0]->has_options(), $data['has_options'] );
@@ -75,8 +74,7 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'permalink', $data[0] );
 		$this->assertArrayHasKey( 'description', $data[0] );
 		$this->assertArrayHasKey( 'sku', $data[0] );
-		$this->assertArrayHasKey( 'price', $data[0] );
-		$this->assertArrayHasKey( 'price_html', $data[0] );
+		$this->assertArrayHasKey( 'prices', $data[0] );
 		$this->assertArrayHasKey( 'average_rating', $data[0] );
 		$this->assertArrayHasKey( 'review_count', $data[0] );
 		$this->assertArrayHasKey( 'images', $data[0] );
@@ -99,8 +97,7 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'permalink', $schema['properties'] );
 		$this->assertArrayHasKey( 'description', $schema['properties'] );
 		$this->assertArrayHasKey( 'sku', $schema['properties'] );
-		$this->assertArrayHasKey( 'price', $schema['properties'] );
-		$this->assertArrayHasKey( 'price_html', $schema['properties'] );
+		$this->assertArrayHasKey( 'prices', $schema['properties'] );
 		$this->assertArrayHasKey( 'average_rating', $schema['properties'] );
 		$this->assertArrayHasKey( 'review_count', $schema['properties'] );
 		$this->assertArrayHasKey( 'images', $schema['properties'] );
@@ -123,8 +120,7 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'permalink', $response->get_data() );
 		$this->assertArrayHasKey( 'description', $response->get_data() );
 		$this->assertArrayHasKey( 'sku', $response->get_data() );
-		$this->assertArrayHasKey( 'price', $response->get_data() );
-		$this->assertArrayHasKey( 'price_html', $response->get_data() );
+		$this->assertArrayHasKey( 'prices', $response->get_data() );
 		$this->assertArrayHasKey( 'average_rating', $response->get_data() );
 		$this->assertArrayHasKey( 'review_count', $response->get_data() );
 		$this->assertArrayHasKey( 'images', $response->get_data() );


### PR DESCRIPTION
When we switched from the REST API to the Store API for the all products block we forgot to port over the "prices" data in the response. This allows the all products block to construct a price for display without relying on HTML.

To test, view the all products block and ensure prices are shown. Unit tests should also pass.