### PR TITLE
All Products block with filters: avoid showing loading placeholders if there are no results

### DIFF
--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
@@ -61,7 +62,9 @@ const ProductList = ( {
 	);
 	// @todo should add an <ErrorBoundary> in parent component to handle any
 	// errors from the store and format etc.
-	const { products, productsLoading, totalProducts } = useStoreProducts( queryState );
+	const { products, productsLoading, totalProducts } = useStoreProducts(
+		queryState
+	);
 	const onPaginationChange = ( newPage ) => {
 		scrollToTop( { focusableSelector: 'a, button' } );
 		onPageChange( newPage );
@@ -86,26 +89,38 @@ const ProductList = ( {
 	const { contentVisibility } = attributes;
 	const perPage = attributes.columns * attributes.rows;
 	const totalPages = Math.ceil( totalProducts / perPage );
-	const listProducts = productsLoading && ! products.length
-		? Array.from( { length: perPage } )
-		: products;
+	const listProducts =
+		productsLoading && ! products.length
+			? Array.from( { length: perPage } )
+			: products;
+	const noProductsMatchingFilters =
+		products.length === 0 && ! productsLoading;
 
 	return (
 		<div className={ getClassnames() }>
-			{ contentVisibility.orderBy && (
+			{ contentVisibility.orderBy && ! noProductsMatchingFilters && (
 				<ProductSortSelect
 					onChange={ onSortChange }
 					value={ sortValue }
 				/>
 			) }
 			<ul className="wc-block-grid__products">
-				{ listProducts.map( ( product = {}, i ) => (
-					<ProductListItem
-						key={ product.id || i }
-						attributes={ attributes }
-						product={ product }
-					/>
-				) ) }
+				{ noProductsMatchingFilters ? (
+					<div className="wc-block-grid__no-products">
+						{ __(
+							'No products found matching your criteria.',
+							'woo-gutenberg-products-block'
+						) }
+					</div>
+				) : (
+					listProducts.map( ( product = {}, i ) => (
+						<ProductListItem
+							key={ product.id || i }
+							attributes={ attributes }
+							product={ product }
+						/>
+					) )
+				) }
 			</ul>
 			{ totalProducts > perPage && (
 				<Pagination

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -61,7 +61,7 @@ const ProductList = ( {
 	);
 	// @todo should add an <ErrorBoundary> in parent component to handle any
 	// errors from the store and format etc.
-	const { products, totalProducts } = useStoreProducts( queryState );
+	const { products, productsLoading, totalProducts } = useStoreProducts( queryState );
 	const onPaginationChange = ( newPage ) => {
 		scrollToTop( { focusableSelector: 'a, button' } );
 		onPageChange( newPage );
@@ -86,9 +86,9 @@ const ProductList = ( {
 	const { contentVisibility } = attributes;
 	const perPage = attributes.columns * attributes.rows;
 	const totalPages = Math.ceil( totalProducts / perPage );
-	const listProducts = products.length
-		? products
-		: Array.from( { length: perPage } );
+	const listProducts = productsLoading && ! products.length
+		? Array.from( { length: perPage } )
+		: products;
 
 	return (
 		<div className={ getClassnames() }>

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -11,6 +11,12 @@
 	text-align: center;
 }
 
+.wc-block-grid__no-products {
+	padding: $gap-largest;
+	text-align: center;
+	width: 100%;
+}
+
 .wc-block-grid__products {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
Fixes #1137.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/68383540-20f58d00-0156-11ea-93f2-81b5c89582e5.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/68501110-9e57f500-025d-11ea-8fe5-a7bf612c5f07.png)

### How to test the changes in this Pull Request:
1. Create a post with the _All Products_ block and the _Filter Products by Price_ block.
2. Set the price filter values so no results are shown (in my store, I didn't have any product between 70 and 80 €).
3. Verify it doesn't show loading placeholders when there are no results.

### Questions

Even though I marked this PR as `needs review`, in some way I feel it's still in progress because it would make sense to answer these two questions first:

- Should we display a message like _No products found matching your criteria_ instead of making the space completely empty?
- Should we hide the sort select as well?
