### PR TITLE
Rename useQueryState to useQueryStateByContext

### DIFF
--- a/assets/js/base/hooks/test/use-query-state.js
+++ b/assets/js/base/hooks/test/use-query-state.js
@@ -8,7 +8,7 @@ import { createRegistry, RegistryProvider } from '@wordpress/data';
  * Internal dependencies
  */
 import {
-	useQueryStateContext,
+	useQueryStateByContext,
 	useQueryStateByKey,
 	useSynchronizedQueryState,
 } from '../use-query-state';
@@ -104,8 +104,8 @@ describe( 'Testing Query State Hooks', () => {
 			},
 		} );
 	};
-	describe( 'useQueryStateContext', () => {
-		const TestComponent = getTestComponent( useQueryStateContext, [
+	describe( 'useQueryStateByContext', () => {
+		const TestComponent = getTestComponent( useQueryStateByContext, [
 			'context',
 		] );
 		let renderer;

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -19,7 +19,7 @@ import { useShallowEqual } from './use-shallow-equal';
  *                 query state value for the given context.  The second element
  *                 is a dispatcher function for setting the query state.
  */
-export const useQueryStateContext = ( context ) => {
+export const useQueryStateByContext = ( context ) => {
 	const queryState = useSelect(
 		( select ) => {
 			const store = select( storeKey );
@@ -65,7 +65,7 @@ export const useQueryStateByKey = ( context, queryKey ) => {
 };
 
 /**
- * A custom hook that works similarly to useQueryStateContext. However, this
+ * A custom hook that works similarly to useQueryStateByContext. However, this
  * hook allows for synchronizing with a provided queryState object.
  *
  * This hook does the following things with the provided `synchronizedQuery`
@@ -90,7 +90,7 @@ export const useQueryStateByKey = ( context, queryKey ) => {
  *                                   synchronize internal query state with.
  */
 export const useSynchronizedQueryState = ( context, synchronizedQuery ) => {
-	const [ queryState, setQueryState ] = useQueryStateContext( context );
+	const [ queryState, setQueryState ] = useQueryStateByContext( context );
 	const currentSynchronizedQuery = useShallowEqual( synchronizedQuery );
 	// used to ensure we allow initial synchronization to occur before
 	// returning non-synced state.

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -4,7 +4,7 @@
 import {
 	useCollection,
 	useQueryStateByKey,
-	useQueryStateContext,
+	useQueryStateByContext,
 } from '@woocommerce/base-hooks';
 import { useCallback } from '@wordpress/element';
 
@@ -26,7 +26,7 @@ const PriceFilterBlock = ( { attributes } ) => {
 		'product-grid',
 		'max_price'
 	);
-	const [ queryState ] = useQueryStateContext( 'product-grid' );
+	const [ queryState ] = useQueryStateByContext( 'product-grid' );
 	const { results, isLoading } = useCollection( {
 		namespace: '/wc/store',
 		resourceName: 'products/collection-data',


### PR DESCRIPTION
 This is more precise and removes ambuiguity about whether this returns React Context or not.

## To Test

- jest tests should pass
- `PriceFilter` and `AllProducts` block should work as expected.
