### PR TITLE
Add anti yoda conditional eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
 	rules: {
 		'@wordpress/dependency-group': 'off',
 		'valid-jsdoc': 'off',
+		yoda: [ 'error', 'never' ],
 	},
 };

--- a/assets/js/atomic/components/product/rating/index.js
+++ b/assets/js/atomic/components/product/rating/index.js
@@ -16,7 +16,7 @@ class ProductRating extends Component {
 		const { product, className } = this.props;
 		const rating = parseFloat( product.average_rating );
 
-		if ( ! Number.isFinite( rating ) || 0 === rating ) {
+		if ( ! Number.isFinite( rating ) || rating === 0 ) {
 			return null;
 		}
 

--- a/assets/js/base/components/price-slider/utils.js
+++ b/assets/js/base/components/price-slider/utils.js
@@ -56,7 +56,7 @@ export const formatCurrencyForInput = (
 	priceFormat,
 	currencySymbol
 ) => {
-	if ( '' === value || undefined === value ) {
+	if ( value === '' || undefined === value ) {
 		return '';
 	}
 	const formattedNumber = parseInt( value, 10 );

--- a/assets/js/base/components/read-more/index.js
+++ b/assets/js/base/components/read-more/index.js
@@ -113,7 +113,7 @@ class ReadMore extends Component {
 			return null;
 		}
 
-		if ( false === clampEnabled ) {
+		if ( clampEnabled === false ) {
 			return (
 				<div className={ className }>
 					<div ref={ this.reviewContent }>{ content }</div>
@@ -123,7 +123,7 @@ class ReadMore extends Component {
 
 		return (
 			<div className={ className }>
-				{ ( ! isExpanded || null === clampEnabled ) && (
+				{ ( ! isExpanded || clampEnabled === null ) && (
 					<div
 						ref={ this.reviewSummary }
 						aria-hidden={ isExpanded }
@@ -132,7 +132,7 @@ class ReadMore extends Component {
 						} }
 					/>
 				) }
-				{ ( isExpanded || null === clampEnabled ) && (
+				{ ( isExpanded || clampEnabled === null ) && (
 					<div
 						ref={ this.reviewContent }
 						aria-hidden={ ! isExpanded }

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -58,7 +58,7 @@ export default function( { attributes, setAttributes } ) {
 						] }
 						onChange={ ( value ) =>
 							setAttributes( {
-								showInputFields: 'editable' === value,
+								showInputFields: value === 'editable',
 							} )
 						}
 					/>
@@ -131,7 +131,7 @@ export default function( { attributes, setAttributes } ) {
 
 	return (
 		<Fragment>
-			{ 0 === PRODUCT_COUNT ? (
+			{ PRODUCT_COUNT === 0 ? (
 				noProductsPlaceholder()
 			) : (
 				<Fragment>

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -139,7 +139,7 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 						] }
 						onChange={ ( value ) =>
 							setAttributes( {
-								isDropdown: 'dropdown' === value,
+								isDropdown: value === 'dropdown',
 							} )
 						}
 					/>

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -185,7 +185,7 @@ class Editor extends Component {
 			allowedBlocks: Object.keys( this.blockMap ),
 		};
 
-		if ( 0 !== this.props.attributes.layoutConfig.length ) {
+		if ( this.props.attributes.layoutConfig.length !== 0 ) {
 			InnerBlockProps.renderAppender = false;
 		}
 
@@ -248,7 +248,7 @@ class Editor extends Component {
 	renderViewMode = () => {
 		const { attributes } = this.props;
 		const { layoutConfig } = attributes;
-		const hasContent = layoutConfig && 0 !== layoutConfig.length;
+		const hasContent = layoutConfig && layoutConfig.length !== 0;
 		const blockTitle = this.getTitle();
 		const blockIcon = this.getIcon();
 

--- a/assets/js/blocks/reviews/editor-block.js
+++ b/assets/js/blocks/reviews/editor-block.js
@@ -50,7 +50,7 @@ class EditorBlock extends Component {
 			);
 		}
 
-		if ( 0 === reviews.length && ! isLoading ) {
+		if ( reviews.length === 0 && ! isLoading ) {
 			return <NoReviewsPlaceholder attributes={ attributes } />;
 		}
 

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -26,7 +26,7 @@ const FrontendBlock = ( {
 } ) => {
 	const { orderby } = attributes;
 
-	if ( 0 === reviews.length ) {
+	if ( reviews.length === 0 ) {
 		return null;
 	}
 

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -57,7 +57,7 @@ const ProductAttributeControl = ( {
 					isSelected={ expandedAttribute === item.id }
 					onSelect={ onSelectAttribute }
 					isSingle
-					disabled={ '0' === item.count }
+					disabled={ item.count === '0' }
 					aria-expanded={ expandedAttribute === item.id }
 					aria-label={ sprintf(
 						_n(

--- a/assets/js/utils/get-query.js
+++ b/assets/js/utils/get-query.js
@@ -27,29 +27,29 @@ export default function getQuery( blockAttributes, name ) {
 
 	if ( categories && categories.length ) {
 		query.category = categories.join( ',' );
-		if ( catOperator && 'all' === catOperator ) {
+		if ( catOperator && catOperator === 'all' ) {
 			query.category_operator = 'and';
 		}
 	}
 
 	if ( tags && tags.length > 0 ) {
 		query.tag = tags.join( ',' );
-		if ( tagOperator && 'all' === tagOperator ) {
+		if ( tagOperator && tagOperator === 'all' ) {
 			query.tag_operator = 'and';
 		}
 	}
 
 	if ( orderby ) {
-		if ( 'price_desc' === orderby ) {
+		if ( orderby === 'price_desc' ) {
 			query.orderby = 'price';
 			query.order = 'desc';
-		} else if ( 'price_asc' === orderby ) {
+		} else if ( orderby === 'price_asc' ) {
 			query.orderby = 'price';
 			query.order = 'asc';
-		} else if ( 'title' === orderby ) {
+		} else if ( orderby === 'title' ) {
 			query.orderby = 'title';
 			query.order = 'asc';
-		} else if ( 'menu_order' === orderby ) {
+		} else if ( orderby === 'menu_order' ) {
 			query.orderby = 'menu_order';
 			query.order = 'asc';
 		} else {
@@ -62,7 +62,7 @@ export default function getQuery( blockAttributes, name ) {
 		query.attribute = attributes[ 0 ].attr_slug;
 
 		if ( attrOperator ) {
-			query.attribute_operator = 'all' === attrOperator ? 'and' : 'in';
+			query.attribute_operator = attrOperator === 'all' ? 'and' : 'in';
 		}
 	}
 

--- a/assets/js/utils/get-shortcode.js
+++ b/assets/js/utils/get-shortcode.js
@@ -22,7 +22,7 @@ export default function getShortcode( props, name ) {
 
 	if ( categories && categories.length ) {
 		shortcodeAtts.set( 'category', categories.join( ',' ) );
-		if ( catOperator && 'all' === catOperator ) {
+		if ( catOperator && catOperator === 'all' ) {
 			shortcodeAtts.set( 'cat_operator', 'AND' );
 		}
 	}
@@ -33,19 +33,19 @@ export default function getShortcode( props, name ) {
 			attributes.map( ( { id } ) => id ).join( ',' )
 		);
 		shortcodeAtts.set( 'attribute', attributes[ 0 ].attr_slug );
-		if ( attrOperator && 'all' === attrOperator ) {
+		if ( attrOperator && attrOperator === 'all' ) {
 			shortcodeAtts.set( 'terms_operator', 'AND' );
 		}
 	}
 
 	if ( orderby ) {
-		if ( 'price_desc' === orderby ) {
+		if ( orderby === 'price_desc' ) {
 			shortcodeAtts.set( 'orderby', 'price' );
 			shortcodeAtts.set( 'order', 'DESC' );
-		} else if ( 'price_asc' === orderby ) {
+		} else if ( orderby === 'price_asc' ) {
 			shortcodeAtts.set( 'orderby', 'price' );
 			shortcodeAtts.set( 'order', 'ASC' );
-		} else if ( 'date' === orderby ) {
+		} else if ( orderby === 'date' ) {
 			shortcodeAtts.set( 'orderby', 'date' );
 			shortcodeAtts.set( 'order', 'DESC' );
 		} else {


### PR DESCRIPTION
WordPress core has no official standards regarding the use or non-use of yoda-conditionals for javascript (and neither is enforced via the official eslint rules).  However, unofficially, the GB project favors not using yoda conditionals in JS (and that is the mainstream javascript position).

While we still intend to follow WordPress standards for php (requiring yoda conditionals), the woo-blocks team has decided that we'll adopt _no_ yoda conditionals for javascript (hence the new eslint rule).

This pull adds the strict no yoda rule and also applies fixes to existing files via `eslint --fix` for existing usage of yoda in the codebase.