### PR TITLE
All Products: avoid pagination disappearing when switching pages/changing sort value

### DIFF
--- a/assets/js/base/hooks/use-store-products.js
+++ b/assets/js/base/hooks/use-store-products.js
@@ -27,14 +27,15 @@ export const useStoreProducts = ( query ) => {
 	const collectionOptions = {
 		namespace: '/wc/store',
 		resourceName: 'products',
-		query,
 	};
 	const { results: products, isLoading: productsLoading } = useCollection(
-		collectionOptions
+		{ ...collectionOptions, query }
 	);
+	// eslint-disable-next-line no-unused-vars, camelcase
+	const { order, orderby, page, per_page, ...totalQuery } = query;
 	const { value: totalProducts } = useCollectionHeader(
 		'x-wp-total',
-		collectionOptions
+		{ ...collectionOptions, query: totalQuery }
 	);
 	return {
 		products,


### PR DESCRIPTION
Fixes #1143.

When getting the `x-wp-total` header, we can ignore some query params which we know have no effect on the total number of results: `order`, `orderby`, `page` and `per_page`.

### Screenshots
_Before:_
![Peek 2019-11-07 16-10](https://user-images.githubusercontent.com/3616980/68401222-a76f9600-0179-11ea-8c40-0accc13a3200.gif)

_After:_
![Peek 2019-11-07 16-10b](https://user-images.githubusercontent.com/3616980/68401442-09c89680-017a-11ea-977b-26370c9b2e18.gif)

### How to test the changes in this Pull Request:

1. Create a post with the _All Products_ block.
2. Click on a page number.
3. Verify the pagination buttons are still visible while the next page is loading.
4. Change the sort order.
5. Verify the pagination buttons are visible while loading.
