### PR TITLE
Use placeholder when contraints are invalid

### DIFF
--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -90,15 +90,15 @@ const PriceSlider = ( {
 		);
 	}, [ maxPrice, priceFormat, currencySymbol ] );
 
+	const hasValidConstraints = useMemo( () => {
+		return isFinite( minConstraint ) && isFinite( maxConstraint );
+	}, [ minConstraint, maxConstraint ] );
+
 	useEffect( () => {
 		if ( ! showFilterButton && ! isLoading && hasValidConstraints ) {
 			triggerChange();
 		}
 	}, [ debouncedChangeValue ] );
-
-	const hasValidConstraints = useMemo( () => {
-		return isFinite( minConstraint ) && isFinite( maxConstraint );
-	}, [ minConstraint, maxConstraint ] );
 
 	/**
 	 * Handles styles for the shaded area of the range slider.

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -51,6 +51,10 @@ const PriceSlider = ( {
 	const prevMaxConstraint = usePrevious( maxConstraint );
 
 	useEffect( () => {
+		if ( isNaN( minConstraint ) ) {
+			setMinPrice( 0 );
+			return;
+		}
 		if (
 			minPrice === undefined ||
 			minConstraint > minPrice ||
@@ -61,6 +65,10 @@ const PriceSlider = ( {
 	}, [ minConstraint ] );
 
 	useEffect( () => {
+		if ( isNaN( maxConstraint ) ) {
+			setMaxPrice( 100 );
+			return;
+		}
 		if (
 			maxPrice === undefined ||
 			maxConstraint < maxPrice ||
@@ -83,20 +91,23 @@ const PriceSlider = ( {
 	}, [ maxPrice, priceFormat, currencySymbol ] );
 
 	useEffect( () => {
-		if ( ! showFilterButton && ! isLoading ) {
+		if ( ! showFilterButton && ! isLoading && hasValidConstraints ) {
 			triggerChange();
 		}
 	}, [ debouncedChangeValue ] );
 
+	const hasValidConstraints = useMemo( () => {
+		return isFinite( minConstraint ) && isFinite( maxConstraint );
+	}, [ minConstraint, maxConstraint ] );
+
 	/**
 	 * Handles styles for the shaded area of the range slider.
 	 */
-	const getProgressStyle = useMemo( () => {
+	const progressStyles = useMemo( () => {
 		if (
 			! isFinite( minPrice ) ||
 			! isFinite( maxPrice ) ||
-			! isFinite( minConstraint ) ||
-			! isFinite( maxConstraint )
+			! hasValidConstraints
 		) {
 			return {
 				'--low': '0%',
@@ -121,7 +132,13 @@ const PriceSlider = ( {
 			'--low': low + '%',
 			'--high': high + '%',
 		};
-	}, [ minPrice, maxPrice, minConstraint, maxConstraint ] );
+	}, [
+		minPrice,
+		maxPrice,
+		minConstraint,
+		maxConstraint,
+		hasValidConstraints,
+	] );
 
 	/**
 	 * Trigger the onChange prop callback with new values.
@@ -138,7 +155,7 @@ const PriceSlider = ( {
 	 */
 	const findClosestRange = useCallback(
 		( event ) => {
-			if ( isLoading ) {
+			if ( isLoading || ! hasValidConstraints ) {
 				return;
 			}
 			const bounds = event.target.getBoundingClientRect();
@@ -166,7 +183,7 @@ const PriceSlider = ( {
 				maxRange.current.style.zIndex = 20;
 			}
 		},
-		[ isLoading, maxConstraint ]
+		[ isLoading, maxConstraint, hasValidConstraints ]
 	);
 
 	/**
@@ -256,7 +273,8 @@ const PriceSlider = ( {
 		'wc-block-price-filter',
 		showInputFields && 'wc-block-price-filter--has-input-fields',
 		showFilterButton && 'wc-block-price-filter--has-filter-button',
-		isLoading && 'is-loading'
+		isLoading && 'is-loading',
+		! hasValidConstraints && 'is-disabled'
 	);
 
 	return (
@@ -266,11 +284,11 @@ const PriceSlider = ( {
 				onMouseMove={ findClosestRange }
 				onFocus={ findClosestRange }
 			>
-				{ ! isLoading && (
+				{ ! isLoading && hasValidConstraints && (
 					<Fragment>
 						<div
 							className="wc-block-price-filter__range-input-progress"
-							style={ getProgressStyle }
+							style={ progressStyles }
 						/>
 						<input
 							type="range"
@@ -306,7 +324,7 @@ const PriceSlider = ( {
 			<div className="wc-block-price-filter__controls">
 				{ showInputFields ? (
 					<PriceInput
-						disabled={ isLoading }
+						disabled={ isLoading || ! hasValidConstraints }
 						onChange={ priceInputOnChange }
 						onBlur={ priceInputOnBlur }
 						minPrice={ formattedMinPrice }
@@ -320,7 +338,7 @@ const PriceSlider = ( {
 				) }
 				{ showFilterButton && (
 					<SubmitButton
-						disabled={ isLoading }
+						disabled={ isLoading || ! hasValidConstraints }
 						onClick={ triggerChange }
 					/>
 				) }

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -180,12 +180,21 @@
 		}
 	}
 
-	&.is-loading {
+	&.is-loading,
+	&.is-disabled {
 		.wc-block-price-filter__range-input-wrapper,
 		.wc-block-price-filter__amount,
 		.wc-block-price-filter__button {
 			@include placeholder();
 			box-shadow: none;
+		}
+	}
+
+	&.is-disabled:not(&.isLoading) {
+		.wc-block-price-filter__range-input-wrapper,
+		.wc-block-price-filter__amount,
+		.wc-block-price-filter__button {
+			animation: none;
 		}
 	}
 }
@@ -247,10 +256,17 @@
 			}
 		}
 
-		&.is-loading {
+		&.is-loading,
+		&.is-disabled {
 			.wc-block-price-filter__range-input-wrapper {
 				@include placeholder();
 				box-shadow: none;
+			}
+		}
+
+		&.is-disabled:not(&.isLoading) {
+			.wc-block-price-filter__range-input-wrapper {
+				animation: none;
 			}
 		}
 	}

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -264,7 +264,7 @@
 			}
 		}
 
-		&.is-disabled:not(&.isLoading) {
+		&.is-disabled:not(.is-loading) {
 			.wc-block-price-filter__range-input-wrapper {
 				animation: none;
 			}

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -190,7 +190,7 @@
 		}
 	}
 
-	&.is-disabled:not(&.isLoading) {
+	&.is-disabled:not(.is-loading) {
 		.wc-block-price-filter__range-input-wrapper,
 		.wc-block-price-filter__amount,
 		.wc-block-price-filter__button {


### PR DESCRIPTION
To prevent display issues when the constraints of the price slider are missing or invalid, this PR applies non-animated placeholder styles and hides the sliders.

Fixes #1141

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

You can test with the attribute filter PR, or hardcode invalid values in the price filter block, changing:

```
minConstraint={ minConstraint }
maxConstraint={ maxConstraint }
```

to strings. Once done, the slider won't appear, only the placeholder will.