### PR TITLE
Update dependencies order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,9 +6,10 @@ module.exports = {
 	globals: {
 		wcSettings: true,
 	},
-	plugins: [ 'jest' ],
+	plugins: [ 'jest', 'woocommerce' ],
 	rules: {
 		'@wordpress/dependency-group': 'off',
+		'woocommerce/dependency-group': 'error',
 		'valid-jsdoc': 'off',
 		yoda: [ 'error', 'never' ],
 	},

--- a/assets/js/atomic/blocks/product/button/index.js
+++ b/assets/js/atomic/blocks/product/button/index.js
@@ -5,11 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { Disabled } from '@wordpress/components';
 import Gridicon from 'gridicons';
+import { ProductButton } from '@woocommerce/atomic-components/product';
 
 /**
  * Internal dependencies
  */
-import { ProductButton } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 
 const blockConfig = {

--- a/assets/js/atomic/blocks/product/image/index.js
+++ b/assets/js/atomic/blocks/product/image/index.js
@@ -7,14 +7,14 @@ import Gridicon from 'gridicons';
 import { Fragment } from '@wordpress/element';
 import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/editor';
+import ToggleButtonControl from '@woocommerce/block-components/toggle-button-control';
+import { ProductImage } from '@woocommerce/atomic-components/product';
+import { previewProducts } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
  */
-import ToggleButtonControl from '@woocommerce/block-components/toggle-button-control';
-import { ProductImage } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
-import { previewProducts } from '@woocommerce/resource-previews';
 
 const blockConfig = {
 	title: __( 'Product Image', 'woo-gutenberg-products-block' ),

--- a/assets/js/atomic/blocks/product/price/index.js
+++ b/assets/js/atomic/blocks/product/price/index.js
@@ -4,11 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import Gridicon from 'gridicons';
+import { ProductPrice } from '@woocommerce/atomic-components/product';
 
 /**
  * Internal dependencies
  */
-import { ProductPrice } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 
 const blockConfig = {

--- a/assets/js/atomic/blocks/product/rating/index.js
+++ b/assets/js/atomic/blocks/product/rating/index.js
@@ -4,11 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import Gridicon from 'gridicons';
+import { ProductRating } from '@woocommerce/atomic-components/product';
 
 /**
  * Internal dependencies
  */
-import { ProductRating } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 
 const blockConfig = {

--- a/assets/js/atomic/blocks/product/sale-badge/index.js
+++ b/assets/js/atomic/blocks/product/sale-badge/index.js
@@ -3,13 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { ProductSaleBadge } from '@woocommerce/atomic-components/product';
+import { IconProductOnSale } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
-import { ProductSaleBadge } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
-import { IconProductOnSale } from '@woocommerce/block-components/icons';
 
 const blockConfig = {
 	title: __( 'On-Sale Badge', 'woo-gutenberg-products-block' ),

--- a/assets/js/atomic/blocks/product/shared-config.js
+++ b/assets/js/atomic/blocks/product/shared-config.js
@@ -3,10 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import Gridicon from 'gridicons';
-
-/**
- * Internal dependencies
- */
 import { previewProducts } from '@woocommerce/resource-previews';
 
 /**

--- a/assets/js/atomic/blocks/product/summary/index.js
+++ b/assets/js/atomic/blocks/product/summary/index.js
@@ -4,11 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import Gridicon from 'gridicons';
+import { ProductSummary } from '@woocommerce/atomic-components/product';
 
 /**
  * Internal dependencies
  */
-import { ProductSummary } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 
 const blockConfig = {

--- a/assets/js/atomic/blocks/product/title/heading-level-icon.js
+++ b/assets/js/atomic/blocks/product/title/heading-level-icon.js
@@ -1,5 +1,5 @@
 /**
- * WordPress dependencies
+ * External dependencies
  */
 import { Path, SVG } from '@wordpress/components';
 

--- a/assets/js/atomic/blocks/product/title/heading-toolbar.js
+++ b/assets/js/atomic/blocks/product/title/heading-toolbar.js
@@ -2,10 +2,6 @@
  * External dependencies
  */
 import { range } from 'lodash';
-
-/**
- * WordPress dependencies
- */
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
 import { Toolbar } from '@wordpress/components';

--- a/assets/js/atomic/blocks/product/title/index.js
+++ b/assets/js/atomic/blocks/product/title/index.js
@@ -6,14 +6,14 @@ import { registerBlockType } from '@wordpress/blocks';
 import { Fragment } from 'react';
 import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/editor';
+import { ProductTitle } from '@woocommerce/atomic-components/product';
+import { previewProducts } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
  */
-import { ProductTitle } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 import HeadingToolbar from './heading-toolbar';
-import { previewProducts } from '@woocommerce/resource-previews';
 
 const blockConfig = {
 	title: __( 'Product Title', 'woo-gutenberg-products-block' ),

--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -13,10 +13,6 @@ import {
 } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { find } from 'lodash';
-
-/**
- * Internal dependencies
- */
 import { useCollection } from '@woocommerce/base-hooks';
 import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
 

--- a/assets/js/atomic/components/product/image/index.js
+++ b/assets/js/atomic/components/product/image/index.js
@@ -4,11 +4,11 @@
 import PropTypes from 'prop-types';
 import { Component, Fragment } from 'react';
 import classnames from 'classnames';
+import { PLACEHOLDER_IMG_SRC } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
  */
-import { PLACEHOLDER_IMG_SRC } from '@woocommerce/block-settings';
 import { ProductSaleBadge } from '../../../components/product';
 
 class ProductImage extends Component {

--- a/assets/js/base/components/load-more-button/index.js
+++ b/assets/js/base/components/load-more-button/index.js
@@ -3,11 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import Label from '@woocommerce/base-components/label';
 
 /**
  * Internal dependencies
  */
-import Label from '@woocommerce/base-components/label';
 import './style.scss';
 
 export const LoadMoreButton = ( { onClick, label, screenReaderLabel } ) => {

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -4,11 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Label from '@woocommerce/base-components/label';
 
 /**
  * Internal dependencies
  */
-import Label from '@woocommerce/base-components/label';
 import { getIndexes } from './utils.js';
 import './style.scss';
 

--- a/assets/js/base/components/product-list-item/index.js
+++ b/assets/js/base/components/product-list-item/index.js
@@ -1,14 +1,14 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies.
- */
 import { useInnerBlockParentNameContext } from '@woocommerce/base-context/inner-block-parent-name-context';
 import withComponentId from '@woocommerce/base-hocs/with-component-id';
+
+/**
+ * Internal dependencies
+ */
 import { renderProductLayout } from './utils';
 
 const ProductListItem = ( { product, attributes, componentId } ) => {

--- a/assets/js/base/components/product-list/container.js
+++ b/assets/js/base/components/product-list/container.js
@@ -3,12 +3,12 @@
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';
+import withQueryStringValues from '@woocommerce/base-hocs/with-query-string-values';
 
 /**
  * Internal dependencies
  */
 import ProductList from './index';
-import withQueryStringValues from '@woocommerce/base-hocs/with-query-string-values';
 
 class ProductListContainer extends Component {
 	onPageChange = ( newPage ) => {

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -3,10 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import Pagination from '@woocommerce/base-components/pagination';
 import ProductSortSelect from '@woocommerce/base-components/product-sort-select';
 import ProductListItem from '@woocommerce/base-components/product-list-item';
@@ -15,6 +11,10 @@ import {
 	useSynchronizedQueryState,
 } from '@woocommerce/base-hooks';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
+
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 
 const generateQuery = ( { sortValue, currentPage, attributes } ) => {

--- a/assets/js/base/components/product-sort-select/index.js
+++ b/assets/js/base/components/product-sort-select/index.js
@@ -3,11 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import SortSelect from '@woocommerce/base-components/sort-select';
 
 /**
  * Internal dependencies
  */
-import SortSelect from '@woocommerce/base-components/sort-select';
 import './style.scss';
 
 const ProductSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {

--- a/assets/js/base/components/read-more/index.js
+++ b/assets/js/base/components/read-more/index.js
@@ -1,7 +1,5 @@
 /**
- * Show text based content, limited to a number of lines, with a read more link.
- *
- * Based on https://github.com/zoltantothcom/react-clamp-lines.
+ * External dependencies
  */
 import React, { createRef, Component } from 'react';
 import PropTypes from 'prop-types';
@@ -12,6 +10,11 @@ import { __ } from '@wordpress/i18n';
  */
 import { clampLines } from './utils';
 
+/**
+ * Show text based content, limited to a number of lines, with a read more link.
+ *
+ * Based on https://github.com/zoltantothcom/react-clamp-lines.
+ */
 class ReadMore extends Component {
 	constructor( props ) {
 		super( ...arguments );

--- a/assets/js/base/components/read-more/utils.js
+++ b/assets/js/base/components/read-more/utils.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import trimHtml from 'trim-html';
 
 /**

--- a/assets/js/base/components/review-list-item/index.js
+++ b/assets/js/base/components/review-list-item/index.js
@@ -4,11 +4,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import ReadMore from '@woocommerce/base-components/read-more';
 
 /**
  * Internal dependencies
  */
-import ReadMore from '@woocommerce/base-components/read-more';
 import './style.scss';
 
 function getReviewImage( review, imageType, isLoading ) {

--- a/assets/js/base/components/review-list/index.js
+++ b/assets/js/base/components/review-list/index.js
@@ -6,11 +6,11 @@ import {
 	ENABLE_REVIEW_RATING,
 	SHOW_AVATARS,
 } from '@woocommerce/block-settings';
+import ReviewListItem from '@woocommerce/base-components/review-list-item';
 
 /**
  * Internal dependencies
  */
-import ReviewListItem from '@woocommerce/base-components/review-list-item';
 import './style.scss';
 
 const ReviewList = ( { attributes, reviews } ) => {

--- a/assets/js/base/components/review-sort-select/index.js
+++ b/assets/js/base/components/review-sort-select/index.js
@@ -3,11 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import SortSelect from '@woocommerce/base-components/sort-select';
 
 /**
  * Internal dependencies
  */
-import SortSelect from '@woocommerce/base-components/sort-select';
 import './style.scss';
 
 const ReviewSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {

--- a/assets/js/base/components/sort-select/index.js
+++ b/assets/js/base/components/sort-select/index.js
@@ -3,12 +3,12 @@
  */
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Label from '@woocommerce/base-components/label';
+import withComponentId from '@woocommerce/base-hocs/with-component-id';
 
 /**
  * Internal dependencies
  */
-import Label from '@woocommerce/base-components/label';
-import withComponentId from '@woocommerce/base-hocs/with-component-id';
 import './style.scss';
 
 /**

--- a/assets/js/base/hocs/test/with-component-id.js
+++ b/assets/js/base/hocs/test/with-component-id.js
@@ -3,6 +3,9 @@
  */
 import TestRenderer from 'react-test-renderer';
 
+/**
+ * Internal dependencies
+ */
 import withComponentId from '../with-component-id';
 
 const TestComponent = withComponentId( ( props ) => {

--- a/assets/js/base/hocs/with-component-id.js
+++ b/assets/js/base/hocs/with-component-id.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { Component } from 'react';
 
 /**

--- a/assets/js/base/hocs/with-query-string-values.js
+++ b/assets/js/base/hocs/with-query-string-values.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { Component } from 'react';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
 

--- a/assets/js/base/hocs/with-scroll-to-top/index.js
+++ b/assets/js/base/hocs/with-scroll-to-top/index.js
@@ -3,6 +3,9 @@
  */
 import { Component, createRef, Fragment } from 'react';
 
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 
 /**

--- a/assets/js/base/hooks/test/use-collection.js
+++ b/assets/js/base/hooks/test/use-collection.js
@@ -4,12 +4,12 @@
 import TestRenderer, { act } from 'react-test-renderer';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
 import { Component as ReactComponent } from '@wordpress/element';
+import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
  */
 import { useCollection } from '../use-collection';
-import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 jest.mock( '@woocommerce/block-data', () => ( {
 	__esModule: true,

--- a/assets/js/base/hooks/test/use-query-state.js
+++ b/assets/js/base/hooks/test/use-query-state.js
@@ -3,6 +3,7 @@
  */
 import TestRenderer, { act } from 'react-test-renderer';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -12,7 +13,6 @@ import {
 	useQueryStateByKey,
 	useSynchronizedQueryState,
 } from '../use-query-state';
-import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 jest.mock( '@woocommerce/block-data', () => ( {
 	__esModule: true,

--- a/assets/js/base/hooks/test/use-store-products.js
+++ b/assets/js/base/hooks/test/use-store-products.js
@@ -3,12 +3,12 @@
  */
 import TestRenderer, { act } from 'react-test-renderer';
 import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
  */
 import { useStoreProducts } from '../use-store-products';
-import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 jest.mock( '@woocommerce/block-data', () => ( {
 	__esModule: true,

--- a/assets/js/base/hooks/use-debounce.js
+++ b/assets/js/base/hooks/use-debounce.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { useState, useEffect } from 'react';
 
 /**

--- a/assets/js/base/hooks/use-previous.js
+++ b/assets/js/base/hooks/use-previous.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { useRef, useEffect } from 'react';
 
 /**

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -4,6 +4,10 @@
 import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { useShallowEqual } from './use-shallow-equal';
 
 /**

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -31,13 +31,13 @@ import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { MIN_HEIGHT } from '@woocommerce/block-settings';
+import { IconFolderStar } from '@woocommerce/block-components/icons';
+import ProductCategoryControl from '@woocommerce/block-components/product-category-control';
+import ErrorPlaceholder from '@woocommerce/block-components/error-placeholder';
 
 /**
  * Internal dependencies
  */
-import { IconFolderStar } from '@woocommerce/block-components/icons';
-import ProductCategoryControl from '@woocommerce/block-components/product-category-control';
-import ErrorPlaceholder from '@woocommerce/block-components/error-placeholder';
 import {
 	dimRatioToClass,
 	getBackgroundImageStyles,

--- a/assets/js/blocks/featured-category/example.js
+++ b/assets/js/blocks/featured-category/example.js
@@ -2,10 +2,6 @@
  * External dependencies
  */
 import { DEFAULT_HEIGHT } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
 import { previewCategories } from '@woocommerce/resource-previews';
 
 export const example = {

--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { DEFAULT_HEIGHT } from '@woocommerce/block-settings';
+import { IconFolderStar } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import './style.scss';
 import './editor.scss';
 import Block from './block';
 import { example } from './example';
-import { IconFolderStar } from '@woocommerce/block-components/icons';
 
 /**
  * Register and run the "Featured Category" block.

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -32,18 +32,18 @@ import { compose } from '@wordpress/compose';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { MIN_HEIGHT } from '@woocommerce/block-settings';
+import ProductControl from '@woocommerce/block-components/product-control';
+import ErrorPlaceholder from '@woocommerce/block-components/error-placeholder';
+import { withProduct } from '@woocommerce/block-hocs';
 
 /**
  * Internal dependencies
  */
-import ProductControl from '@woocommerce/block-components/product-control';
-import ErrorPlaceholder from '@woocommerce/block-components/error-placeholder';
 import { dimRatioToClass, getBackgroundImageStyles } from './utils';
 import {
 	getImageSrcFromProduct,
 	getImageIdFromProduct,
 } from '../../utils/products';
-import { withProduct } from '@woocommerce/block-hocs';
 
 /**
  * Component to handle edit mode of "Featured Product".

--- a/assets/js/blocks/featured-product/example.js
+++ b/assets/js/blocks/featured-product/example.js
@@ -2,9 +2,6 @@
  * External dependencies
  */
 import { DEFAULT_HEIGHT } from '@woocommerce/block-settings';
-/**
- * Internal dependencies
- */
 import { previewProducts } from '@woocommerce/resource-previews';
 
 export const example = {

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -20,10 +20,6 @@ import {
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { MAX_COLUMNS, MIN_COLUMNS } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import { IconWidgets } from '@woocommerce/block-components/icons';
 import ProductsControl from '@woocommerce/block-components/products-control';

--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { DEFAULT_COLUMNS } from '@woocommerce/block-settings';
+import { IconWidgets } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
@@ -11,7 +12,6 @@ import { DEFAULT_COLUMNS } from '@woocommerce/block-settings';
 import './editor.scss';
 import Block from './block';
 import { deprecatedConvertToShortcode } from '../../utils/deprecations';
-import { IconWidgets } from '@woocommerce/block-components/icons';
 
 registerBlockType( 'woocommerce/handpicked-products', {
 	title: __( 'Hand-picked Products', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -7,10 +7,6 @@ import {
 	useQueryStateByContext,
 } from '@woocommerce/base-hooks';
 import { useCallback } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
 import PriceSlider from '@woocommerce/base-components/price-slider';
 import { CURRENCY } from '@woocommerce/settings';
 

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -12,6 +12,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { PRODUCT_COUNT } from '@woocommerce/block-settings';
+import { ADMIN_URL } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -19,7 +20,6 @@ import { PRODUCT_COUNT } from '@woocommerce/block-settings';
 import Block from './block.js';
 import './editor.scss';
 import { IconMoney, IconExternal } from '../../components/icons';
-import { ADMIN_URL } from '@woocommerce/settings';
 import ToggleButtonControl from '../../components/toggle-button-control';
 
 export default function( { attributes, setAttributes } ) {

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -6,10 +6,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/block-components/product-category-control';

--- a/assets/js/blocks/product-best-sellers/index.js
+++ b/assets/js/blocks/product-best-sellers/index.js
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { without } from 'lodash';
 import Gridicon from 'gridicons';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -7,10 +7,6 @@ import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
 import { IconFolder } from '@woocommerce/block-components/icons';
-
-/**
- * Internal dependencies
- */
 import ToggleButtonControl from '@woocommerce/block-components/toggle-button-control';
 
 const EmptyPlaceHolder = () => (

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { IconFolder } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
@@ -10,7 +11,6 @@ import { registerBlockType } from '@wordpress/blocks';
 import './editor.scss';
 import './style.scss';
 import Block from './block.js';
-import { IconFolder } from '@woocommerce/block-components/icons';
 
 registerBlockType( 'woocommerce/product-categories', {
 	title: __( 'Product Categories List', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -17,10 +17,6 @@ import {
 } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/block-components/product-category-control';

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -6,10 +6,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/block-components/product-category-control';

--- a/assets/js/blocks/product-new/index.js
+++ b/assets/js/blocks/product-new/index.js
@@ -4,13 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { without } from 'lodash';
+import { IconNewReleases } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
 import Block from './block';
 import { deprecatedConvertToShortcode } from '../../utils/deprecations';
-import { IconNewReleases } from '@woocommerce/block-components/icons';
 import sharedAttributes, {
 	sharedAttributeBlockTypes,
 } from '../../utils/shared-attributes';

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -6,10 +6,6 @@ import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/block-components/product-category-control';

--- a/assets/js/blocks/product-on-sale/index.js
+++ b/assets/js/blocks/product-on-sale/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { without } from 'lodash';
+import { IconProductOnSale } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import { deprecatedConvertToShortcode } from '../../utils/deprecations';
 import sharedAttributes, {
 	sharedAttributeBlockTypes,
 } from '../../utils/shared-attributes';
-import { IconProductOnSale } from '@woocommerce/block-components/icons';
 
 registerBlockType( 'woocommerce/product-on-sale', {
 	title: __( 'On Sale Products', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -6,6 +6,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
+import { IconProductSearch } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import { Fragment } from '@wordpress/element';
 import './style.scss';
 import './editor.scss';
 import Block from './block.js';
-import { IconProductSearch } from '@woocommerce/block-components/icons';
 
 registerBlockType( 'woocommerce/product-search', {
 	title: __( 'Product Search', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -18,10 +18,6 @@ import {
 import { Component, Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { HAS_TAGS } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import ProductTagControl from '@woocommerce/block-components/product-tag-control';

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -4,13 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '@woocommerce/block-settings';
+import { IconProductTag } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
 import Block from './block';
-import { IconProductTag } from '@woocommerce/block-components/icons';
 
 /**
  * Register and run the "Products by Tag" block.

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -5,12 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
-
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/block-components/product-category-control';

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -18,10 +18,6 @@ import {
 import { Component, Fragment } from '@wordpress/element';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import ProductAttributeControl from '@woocommerce/block-components/product-attribute-control';

--- a/assets/js/blocks/products/all-products/block.js
+++ b/assets/js/blocks/products/all-products/block.js
@@ -3,10 +3,6 @@
  */
 import { Component } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import ProductListContainer from '@woocommerce/base-components/product-list/container';
 import { InnerBlockParentNameProvider } from '@woocommerce/base-context/inner-block-parent-name-context';
 import { ProductLayoutContextProvider } from '@woocommerce/base-context/product-layout-context';

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -23,6 +23,8 @@ import { Component } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
+import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
+import { HAS_PRODUCTS } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -38,8 +40,6 @@ import {
 	getProductLayoutConfig,
 } from '../base-utils';
 import { getSharedContentControls, getSharedListControls } from '../edit';
-import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
-import { HAS_PRODUCTS } from '@woocommerce/block-settings';
 import Block from './block';
 
 /**

--- a/assets/js/blocks/products/attributes.js
+++ b/assets/js/blocks/products/attributes.js
@@ -1,7 +1,11 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
 import { DEFAULT_COLUMNS, DEFAULT_ROWS } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
 import { DEFAULT_PRODUCT_LIST_LAYOUT } from './base-utils';
 
 export default {

--- a/assets/js/blocks/products/base-utils.js
+++ b/assets/js/blocks/products/base-utils.js
@@ -2,10 +2,6 @@
  * External dependencies
  */
 import { getRegisteredInnerBlocks } from '@woocommerce/blocks-registry';
-
-/**
- * Internal dependencies
- */
 import {
 	ProductTitle,
 	ProductPrice,

--- a/assets/js/blocks/products/utils.js
+++ b/assets/js/blocks/products/utils.js
@@ -4,10 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Placeholder } from '@wordpress/components';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
 import { adminUrl } from '@woocommerce/settings';
 import { IconExternal } from '@woocommerce/block-components/icons';
 

--- a/assets/js/blocks/reviews/all-reviews/edit.js
+++ b/assets/js/blocks/reviews/all-reviews/edit.js
@@ -6,11 +6,11 @@ import { InspectorControls } from '@wordpress/editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import { IconAllReviews } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
-import { IconAllReviews } from '@woocommerce/block-components/icons';
 import EditorContainerBlock from '../editor-container-block.js';
 import NoReviewsPlaceholder from './no-reviews-placeholder.js';
 import {

--- a/assets/js/blocks/reviews/all-reviews/index.js
+++ b/assets/js/blocks/reviews/all-reviews/index.js
@@ -3,13 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { IconAllReviews } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
 import '../editor.scss';
 import Editor from './edit';
-import { IconAllReviews } from '@woocommerce/block-components/icons';
 import sharedAttributes from '../attributes';
 import save from '../save.js';
 import { example } from '../example';

--- a/assets/js/blocks/reviews/all-reviews/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/all-reviews/no-reviews-placeholder.js
@@ -3,10 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Placeholder } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { IconAllReviews } from '@woocommerce/block-components/icons';
 
 const NoCategoryReviewsPlaceholder = () => {

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { __, sprintf } from '@wordpress/i18n';
 import { Fragment, RawHTML } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
@@ -14,10 +17,6 @@ import {
 	ENABLE_REVIEW_RATING,
 	SHOW_AVATARS,
 } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
 import ToggleButtonControl from '@woocommerce/block-components/toggle-button-control';
 
 export const getBlockControls = ( editMode, setAttributes ) => (

--- a/assets/js/blocks/reviews/editor-block.js
+++ b/assets/js/blocks/reviews/editor-block.js
@@ -6,10 +6,6 @@ import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Disabled } from '@wordpress/components';
 import { ENABLE_REVIEW_RATING } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
 import ErrorPlaceholder from '@woocommerce/block-components/error-placeholder';
 import LoadMoreButton from '@woocommerce/base-components/load-more-button';
 import ReviewList from '@woocommerce/base-components/review-list';

--- a/assets/js/blocks/reviews/example.js
+++ b/assets/js/blocks/reviews/example.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { previewReviews } from '@woocommerce/resource-previews';
 
 export const example = {

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -5,10 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { ENABLE_REVIEW_RATING } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
 import LoadMoreButton from '@woocommerce/base-components/load-more-button';
 import ReviewSortSelect from '@woocommerce/base-components/review-sort-select';
 import ReviewList from '@woocommerce/base-components/review-list';

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -13,12 +13,12 @@ import {
 import { SearchListItem } from '@woocommerce/components';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import ProductCategoryControl from '@woocommerce/block-components/product-category-control';
+import { IconReviewsByCategory } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
-import ProductCategoryControl from '@woocommerce/block-components/product-category-control';
-import { IconReviewsByCategory } from '@woocommerce/block-components/icons';
 import EditorContainerBlock from '../editor-container-block.js';
 import NoReviewsPlaceholder from './no-reviews-placeholder.js';
 import {

--- a/assets/js/blocks/reviews/reviews-by-category/index.js
+++ b/assets/js/blocks/reviews/reviews-by-category/index.js
@@ -3,13 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { IconReviewsByCategory } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
 import '../editor.scss';
 import Editor from './edit';
-import { IconReviewsByCategory } from '@woocommerce/block-components/icons';
 import sharedAttributes from '../attributes';
 import save from '../save.js';
 import { example } from '../example';

--- a/assets/js/blocks/reviews/reviews-by-category/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-category/no-reviews-placeholder.js
@@ -3,10 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Placeholder } from '@wordpress/components';
-
-/**
- * Internal dependencies
- */
 import { IconReviewsByCategory } from '@woocommerce/block-components/icons';
 
 const NoReviewsPlaceholder = () => {

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -12,12 +12,12 @@ import {
 import { SearchListItem } from '@woocommerce/components';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
+import ProductControl from '@woocommerce/block-components/product-control';
+import { IconReviewsByProduct } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
-import ProductControl from '@woocommerce/block-components/product-control';
-import { IconReviewsByProduct } from '@woocommerce/block-components/icons';
 import EditorContainerBlock from '../editor-container-block.js';
 import NoReviewsPlaceholder from './no-reviews-placeholder.js';
 import {

--- a/assets/js/blocks/reviews/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews/reviews-by-product/index.js
@@ -3,13 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { IconReviewsByProduct } from '@woocommerce/block-components/icons';
 
 /**
  * Internal dependencies
  */
 import '../editor.scss';
 import Editor from './edit';
-import { IconReviewsByProduct } from '@woocommerce/block-components/icons';
 import sharedAttributes from '../attributes';
 import save from '../save.js';
 import { example } from '../example';

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -4,10 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import ErrorPlaceholder from '@woocommerce/block-components/error-placeholder';
 import { IconReviewsByProduct } from '@woocommerce/block-components/icons';
 import { withProduct } from '@woocommerce/block-hocs';

--- a/assets/js/components/product-attribute-control/index.js
+++ b/assets/js/components/product-attribute-control/index.js
@@ -7,12 +7,12 @@ import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
 import { SelectControl, Spinner } from '@wordpress/components';
+import { withAttributes } from '@woocommerce/block-hocs';
+import ErrorMessage from '@woocommerce/block-components/error-placeholder/error-message.js';
 
 /**
  * Internal dependencies
  */
-import { withAttributes } from '@woocommerce/block-hocs';
-import ErrorMessage from '@woocommerce/block-components/error-placeholder/error-message.js';
 import './style.scss';
 
 const ProductAttributeControl = ( {

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -7,12 +7,12 @@ import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
 import { SelectControl } from '@wordpress/components';
+import { withCategories } from '@woocommerce/block-hocs';
+import ErrorMessage from '@woocommerce/block-components/error-placeholder/error-message.js';
 
 /**
  * Internal dependencies
  */
-import { withCategories } from '@woocommerce/block-hocs';
-import ErrorMessage from '@woocommerce/block-components/error-placeholder/error-message.js';
 import './style.scss';
 
 const ProductCategoryControl = ( {

--- a/assets/js/components/product-control/index.js
+++ b/assets/js/components/product-control/index.js
@@ -12,15 +12,15 @@ import {
 	withSearchedProducts,
 	withTransformSingleSelectToMultipleSelect,
 } from '@woocommerce/block-hocs';
-
-/**
- * Internal dependencies
- */
 import {
 	IconRadioSelected,
 	IconRadioUnselected,
 } from '@woocommerce/block-components/icons';
 import ErrorMessage from '@woocommerce/block-components/error-placeholder/error-message.js';
+
+/**
+ * Internal dependencies
+ */
 import './style.scss';
 
 function getHighlightedName( name, search ) {

--- a/assets/js/components/products-control/index.js
+++ b/assets/js/components/products-control/index.js
@@ -4,10 +4,6 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { SearchListControl } from '@woocommerce/components';
 import PropTypes from 'prop-types';
-
-/**
- * Internal dependencies
- */
 import { withSearchedProducts } from '@woocommerce/block-hocs';
 import ErrorMessage from '@woocommerce/block-components/error-placeholder/error-message.js';
 

--- a/assets/js/components/toggle-button-control/index.js
+++ b/assets/js/components/toggle-button-control/index.js
@@ -4,10 +4,6 @@
 import { isFunction } from 'lodash';
 import classnames from 'classnames';
 import { BaseControl, ButtonGroup, Button } from '@wordpress/components';
-
-/**
- * WordPress dependencies
- */
 import { Component } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
 

--- a/assets/js/data/query-state/selectors.js
+++ b/assets/js/data/query-state/selectors.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { getStateForContext } from './utils';
 
 /**

--- a/assets/js/data/utils/update-state.js
+++ b/assets/js/data/utils/update-state.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { setWith, clone } from 'lodash';
 
 /**

--- a/assets/js/hocs/with-attributes.js
+++ b/assets/js/hocs/with-attributes.js
@@ -5,11 +5,11 @@ import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { debounce } from 'lodash';
+import { getAttributes, getTerms } from '@woocommerce/block-components/utils';
 
 /**
  * Internal dependencies
  */
-import { getAttributes, getTerms } from '@woocommerce/block-components/utils';
 import { formatError } from '../base/utils/errors.js';
 
 const withAttributes = createHigherOrderComponent( ( OriginalComponent ) => {

--- a/assets/js/hocs/with-categories.js
+++ b/assets/js/hocs/with-categories.js
@@ -3,11 +3,11 @@
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { getCategories } from '@woocommerce/block-components/utils';
 
 /**
  * Internal dependencies
  */
-import { getCategories } from '@woocommerce/block-components/utils';
 import { formatError } from '../base/utils/errors.js';
 
 const withCategories = createHigherOrderComponent( ( OriginalComponent ) => {

--- a/assets/js/hocs/with-category.js
+++ b/assets/js/hocs/with-category.js
@@ -3,11 +3,11 @@
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { getCategory } from '@woocommerce/block-components/utils';
 
 /**
  * Internal dependencies
  */
-import { getCategory } from '@woocommerce/block-components/utils';
 import { formatError } from '../base/utils/errors.js';
 
 const withCategory = createHigherOrderComponent( ( OriginalComponent ) => {

--- a/assets/js/hocs/with-product-variations.js
+++ b/assets/js/hocs/with-product-variations.js
@@ -5,11 +5,11 @@ import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+import { getProductVariations } from '@woocommerce/block-components/utils';
 
 /**
  * Internal dependencies
  */
-import { getProductVariations } from '@woocommerce/block-components/utils';
 import { formatError } from '../base/utils/errors.js';
 
 const withProductVariations = createHigherOrderComponent(

--- a/assets/js/hocs/with-product.js
+++ b/assets/js/hocs/with-product.js
@@ -3,11 +3,11 @@
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { getProduct } from '@woocommerce/block-components/utils';
 
 /**
  * Internal dependencies
  */
-import { getProduct } from '@woocommerce/block-components/utils';
 import { formatError } from '../base/utils/errors.js';
 
 const withProduct = createHigherOrderComponent( ( OriginalComponent ) => {

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -6,11 +6,11 @@ import { debounce } from 'lodash';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { IS_LARGE_CATALOG } from '@woocommerce/block-settings';
+import { getProducts } from '@woocommerce/block-components/utils';
 
 /**
  * Internal dependencies
  */
-import { getProducts } from '@woocommerce/block-components/utils';
 import { formatError } from '../base/utils/errors.js';
 
 /**

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import { getSetting } from '@woocommerce/settings';
 
 export const ENABLE_REVIEW_RATING = getSetting( 'enableReviewRating', true );

--- a/assets/js/settings/shared/test/compare-with-wp-version.js
+++ b/assets/js/settings/shared/test/compare-with-wp-version.js
@@ -1,5 +1,5 @@
 /**
- * Internal imports
+ * Internal dependencies
  */
 import { compareWithWpVersion, setSetting } from '..';
 

--- a/bin/eslint-plugin-woocommerce/index.js
+++ b/bin/eslint-plugin-woocommerce/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+	rules: require( './rules' ),
+};

--- a/bin/eslint-plugin-woocommerce/package.json
+++ b/bin/eslint-plugin-woocommerce/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "eslint-plugin-woocommerce",
+	"version": "0.0.1",
+	"main": "index.js",
+	"devDependencies": {
+		"eslint": "6.6.0"
+	},
+	"engines": {
+		"node": "10.17.0"
+	}
+}

--- a/bin/eslint-plugin-woocommerce/rules/__tests__/dependency-group.js
+++ b/bin/eslint-plugin-woocommerce/rules/__tests__/dependency-group.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from '../dependency-group';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'dependency-group', rule, {
+	valid: [
+		{
+			code: `
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import { SearchListControl } from '@woocommerce/components';
+import { withProductVariations } from '@woocommerce/block-hocs';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import './style.scss';`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import './style.scss';
+import { withProductVariations } from '@woocommerce/block-hocs';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import classnames from 'classnames';
+import { Component } from '@wordpress/element';
+import { SearchListControl } from '@woocommerce/components';`,
+			errors: [
+				{
+					message:
+						'Expected preceding "Internal dependencies" comment block',
+				},
+				{
+					message:
+						'Expected preceding "External dependencies" comment block',
+				},
+				{
+					message:
+						'Expected preceding "External dependencies" comment block',
+				},
+				{
+					message:
+						'Expected preceding "External dependencies" comment block',
+				},
+			],
+		},
+	],
+} );

--- a/bin/eslint-plugin-woocommerce/rules/dependency-group.js
+++ b/bin/eslint-plugin-woocommerce/rules/dependency-group.js
@@ -7,8 +7,7 @@ module.exports = {
 		const comments = context.getSourceCode().getAllComments();
 
 		/**
-		 * Locality classification of an import, one of "External",
-		 * "WordPress", "Internal".
+		 * Locality classification of an import, "External" or "Internal".
 		 *
 		 * @typedef {string} WPPackageLocality
 		 */

--- a/bin/eslint-plugin-woocommerce/rules/dependency-group.js
+++ b/bin/eslint-plugin-woocommerce/rules/dependency-group.js
@@ -13,16 +13,6 @@ module.exports = {
 		 */
 
 		/**
-		 * Object describing a dependency block correction to be made.
-		 *
-		 * @property {?espree.Node} comment Comment node on which to replace
-		 *                                  value, if one can be salvaged.
-		 * @property {string}       value   Expected comment node value.
-		 *
-		 * @typedef {Object} WCDependencyBlockCorrection
-		 */
-
-		/**
 		 * Given a desired locality, generates the expected comment node value
 		 * property.
 		 *

--- a/bin/eslint-plugin-woocommerce/rules/dependency-group.js
+++ b/bin/eslint-plugin-woocommerce/rules/dependency-group.js
@@ -9,7 +9,7 @@ module.exports = {
 		/**
 		 * Locality classification of an import, "External" or "Internal".
 		 *
-		 * @typedef {string} WPPackageLocality
+		 * @typedef {string} WCPackageLocality
 		 */
 
 		/**
@@ -19,14 +19,14 @@ module.exports = {
 		 *                                  value, if one can be salvaged.
 		 * @property {string}       value   Expected comment node value.
 		 *
-		 * @typedef {Object} WPDependencyBlockCorrection
+		 * @typedef {Object} WCDependencyBlockCorrection
 		 */
 
 		/**
 		 * Given a desired locality, generates the expected comment node value
 		 * property.
 		 *
-		 * @param {WPPackageLocality} locality Desired package locality.
+		 * @param {WCPackageLocality} locality Desired package locality.
 		 *
 		 * @return {string} Expected comment node value.
 		 */
@@ -40,7 +40,7 @@ module.exports = {
 		 *
 		 * @param {string} source Import source string.
 		 *
-		 * @return {WPPackageLocality} Package locality.
+		 * @return {WCPackageLocality} Package locality.
 		 */
 		function getPackageLocality( source ) {
 			if ( source.startsWith( '.' ) ) {
@@ -55,7 +55,7 @@ module.exports = {
 		 * or false otherwise.
 		 *
 		 * @param {espree.Node}       node     Comment node to check.
-		 * @param {WPPackageLocality} locality Desired package locality.
+		 * @param {WCPackageLocality} locality Desired package locality.
 		 *
 		 * @return {boolean} Whether comment node satisfies locality.
 		 */
@@ -101,7 +101,7 @@ module.exports = {
 		 * updates, the function returns false. Otherwise, it will return true.
 		 *
 		 * @param {espree.Node}       node     Node to test.
-		 * @param {WPPackageLocality} locality Desired package locality.
+		 * @param {WCPackageLocality} locality Desired package locality.
 		 *
 		 * @return {boolean} Whether the node is in the correct locality.
 		 */

--- a/bin/eslint-plugin-woocommerce/rules/dependency-group.js
+++ b/bin/eslint-plugin-woocommerce/rules/dependency-group.js
@@ -1,0 +1,190 @@
+module.exports = {
+	meta: {
+		type: 'layout',
+		schema: [],
+	},
+	create( context ) {
+		const comments = context.getSourceCode().getAllComments();
+
+		/**
+		 * Locality classification of an import, one of "External",
+		 * "WordPress", "Internal".
+		 *
+		 * @typedef {string} WPPackageLocality
+		 */
+
+		/**
+		 * Object describing a dependency block correction to be made.
+		 *
+		 * @property {?espree.Node} comment Comment node on which to replace
+		 *                                  value, if one can be salvaged.
+		 * @property {string}       value   Expected comment node value.
+		 *
+		 * @typedef {Object} WPDependencyBlockCorrection
+		 */
+
+		/**
+		 * Given a desired locality, generates the expected comment node value
+		 * property.
+		 *
+		 * @param {WPPackageLocality} locality Desired package locality.
+		 *
+		 * @return {string} Expected comment node value.
+		 */
+		function getCommentValue( locality ) {
+			return `*\n * ${ locality } dependencies\n `;
+		}
+
+		/**
+		 * Given an import source string, returns the locality classification
+		 * of the import sort.
+		 *
+		 * @param {string} source Import source string.
+		 *
+		 * @return {WPPackageLocality} Package locality.
+		 */
+		function getPackageLocality( source ) {
+			if ( source.startsWith( '.' ) ) {
+				return 'Internal';
+			}
+
+			return 'External';
+		}
+
+		/**
+		 * Returns true if the given comment node satisfies a desired locality,
+		 * or false otherwise.
+		 *
+		 * @param {espree.Node}       node     Comment node to check.
+		 * @param {WPPackageLocality} locality Desired package locality.
+		 *
+		 * @return {boolean} Whether comment node satisfies locality.
+		 */
+		function isLocalityDependencyBlock( node, locality ) {
+			const { type, value } = node;
+			if ( type !== 'Block' ) {
+				return false;
+			}
+
+			// Tolerances:
+			// - Normalize `/**` and `/*`
+			// - Case insensitive "Dependencies" vs. "dependencies"
+			// - Ending period
+			// - "Node" dependencies as an alias for External
+
+			if ( locality === 'External' ) {
+				locality = '(External|Node)';
+			}
+
+			const pattern = new RegExp(
+				`^\\*?\\n \\* ${ locality } dependencies\\.?\\n $`,
+				'i'
+			);
+			return pattern.test( value );
+		}
+
+		/**
+		 * Returns true if the given node occurs prior in code to a reference,
+		 * or false otherwise.
+		 *
+		 * @param {espree.Node} node      Node to test being before reference.
+		 * @param {espree.Node} reference Node against which to compare.
+		 *
+		 * @return {boolean} Whether node occurs before reference.
+		 */
+		function isBefore( node, reference ) {
+			return node.start < reference.start;
+		}
+
+		/**
+		 * Tests source comments to determine whether a comment exists which
+		 * satisfies the desired locality. If a match is found and requires no
+		 * updates, the function returns false. Otherwise, it will return true.
+		 *
+		 * @param {espree.Node}       node     Node to test.
+		 * @param {WPPackageLocality} locality Desired package locality.
+		 *
+		 * @return {boolean} Whether the node is in the correct locality.
+		 */
+		function isNodeInLocality( node, locality ) {
+			const value = getCommentValue( locality );
+
+			let comment;
+			let nextComment;
+			for ( let i = 0; i < comments.length; i++ ) {
+				comment = comments[ i ];
+				nextComment =
+					i < comments.length - 1 ? comments[ i + 1 ] : null;
+
+				if ( nextComment && isBefore( nextComment, node ) ) {
+					// If it's not the immediately previous comment, continue.
+					continue;
+				}
+
+				if ( ! isBefore( comment, node ) ) {
+					// Exhausted options.
+					break;
+				}
+
+				if ( ! isLocalityDependencyBlock( comment, locality ) ) {
+					// Not usable (either not an block comment, or not one
+					// matching a tolerable pattern).
+					continue;
+				}
+
+				if ( comment.value === value ) {
+					// No change needed. (OK)
+					return true;
+				}
+
+				// Found a comment needing correction.
+				return false;
+			}
+
+			return false;
+		}
+
+		return {
+			Program( node ) {
+				// Since we only care to enforce imports which occur at the
+				// top-level scope, match on Program and test its children,
+				// rather than matching the import nodes directly.
+				node.body.forEach( ( child ) => {
+					let source;
+					switch ( child.type ) {
+						case 'ImportDeclaration':
+							source = child.source.value;
+							break;
+
+						case 'CallExpression':
+							const { callee, arguments: args } = child;
+							if (
+								callee.name === 'require' &&
+								args.length === 1 &&
+								args[ 0 ].type === 'Literal' &&
+								typeof args[ 0 ].value === 'string'
+							) {
+								source = args[ 0 ].value;
+							}
+							break;
+					}
+
+					if ( ! source ) {
+						return;
+					}
+
+					const locality = getPackageLocality( source );
+
+					if ( isNodeInLocality( child, locality ) ) {
+						return;
+					}
+
+					context.report( {
+						node: child,
+						message: `Expected preceding "${ locality } dependencies" comment block`,
+					} );
+				} );
+			},
+		};
+	},
+};

--- a/bin/eslint-plugin-woocommerce/rules/index.js
+++ b/bin/eslint-plugin-woocommerce/rules/index.js
@@ -1,0 +1,1 @@
+module.exports = require( 'requireindex' )( __dirname );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9134,6 +9134,9 @@
       "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
       "dev": true
     },
+    "eslint-plugin-woocommerce": {
+      "version": "file:bin/eslint-plugin-woocommerce"
+    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
 	"dependencies": {
 		"@woocommerce/components": "3.2.0",
 		"compare-versions": "3.5.1",
+		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",
 		"gridicons": "3.3.1",
 		"react-number-format": "4.3.1",
 		"trim-html": "0.1.9"


### PR DESCRIPTION
Discussed in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1127#discussion_r343273546.

This PR:
* Updates all dependency imports so all externals and aliases are under `External dependencies` and relative paths are under `Internal dependencies`.
* To make my job easier, I adapted a ESLint rule from Gutenberg to detect this kind of errors. I included it in this PR, ideally we might want to publish it as an NPM package (maybe under `@woocommerce/scripts`, as discussed yesterday in Slack?), but for now I left it as a subfolder of `bin`.

### How to test the changes in this Pull Request:

1. Run `npm run build` and verify everything builds correctly.
2. Open a JS file and start playing with dependencies order, verify errors appear when dependencies are not under the correct section.