### PR TITLE
Update WooCommerce compatibility version to 3.8.0

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,8 +7,8 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * Requires at least: 5.2.0
- * Requires PHP: 5.6.20
+ * Requires at least: 5.0
+ * Requires PHP: 5.6
  * WC requires at least: 3.6.0
  * WC tested up to: 3.8.0
  *

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -9,8 +9,8 @@
  * Text Domain:  woo-gutenberg-products-block
  * Requires at least: 5.0
  * Requires PHP: 5.6
- * WC requires at least: 3.6.0
- * WC tested up to: 3.8.0
+ * WC requires at least: 3.6
+ * WC tested up to: 3.8
  *
  * @package WooCommerce\Blocks
  * @internal This file is only used when running the REST API as a feature plugin.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,8 +7,8 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * WC requires at least: 3.6
- * WC tested up to: 3.7
+ * WC requires at least: 3.6.0
+ * WC tested up to: 3.8.0
  *
  * @package WooCommerce\Blocks
  * @internal This file is only used when running the REST API as a feature plugin.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,6 +7,8 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
+ * Requires at least: 5.2.0
+ * Requires PHP: 5.6.20
  * WC requires at least: 3.6.0
  * WC tested up to: 3.8.0
  *


### PR DESCRIPTION
This PR adds a check for PHP versions and updates the WooCommerce _tested up to_ version to 3.8.0. I think WC version checks were not currently working (or at least, they were not appearing for me in a test site I have), not sure if that was because the missing `.0` at the end or there is something else going on.

### Changelog Note:

> WooCommerce Blocks has been marked as compatible with WooCommerce 3.8.0.