### PR TITLE
Store API - Add tests for product attributes endpoints

### DIFF
--- a/src/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
+++ b/src/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
@@ -116,8 +116,15 @@ class ProductAttributeTerms extends RestContoller {
 			return new \WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Attribute does not exist.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
 		}
 
-		$request['taxonomy'] = $attribute->slug;
-		$objects             = $this->term_query->get_objects( $request );
+		$term_request = [
+			'taxonomy'   => $attribute->slug,
+			'order'      => $request['order'],
+			'orderby'    => $request['orderby'],
+			'hide_empty' => $request['hide_empty'],
+		];
+
+		$objects = $this->term_query->get_objects( $term_request );
+		$return  = [];
 
 		foreach ( $objects as $object ) {
 			$data     = $this->prepare_item_for_response( $object, $request );
@@ -155,6 +162,12 @@ class ProductAttributeTerms extends RestContoller {
 				'count',
 			),
 			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['hide_empty'] = array(
+			'description' => __( 'Should empty terms be hidden?', 'woo-gutenberg-products-block' ),
+			'type'        => 'boolean',
+			'default'     => true,
 		);
 
 		return $params;

--- a/src/RestApi/StoreApi/Controllers/ProductAttributes.php
+++ b/src/RestApi/StoreApi/Controllers/ProductAttributes.php
@@ -149,16 +149,4 @@ class ProductAttributes extends RestContoller {
 
 		return rest_ensure_response( $return );
 	}
-
-	/**
-	 * Get the query params for collections of attributes.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$params                       = array();
-		$params['context']            = $this->get_context_param();
-		$params['context']['default'] = 'view';
-		return $params;
-	}
 }

--- a/src/RestApi/StoreApi/Schemas/TermSchema.php
+++ b/src/RestApi/StoreApi/Schemas/TermSchema.php
@@ -70,10 +70,11 @@ class TermSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $term ) {
 		return [
-			'id'    => (int) $term->term_id,
-			'name'  => $term->name,
-			'slug'  => $term->slug,
-			'count' => (int) $term->count,
+			'id'          => (int) $term->term_id,
+			'name'        => $term->name,
+			'description' => $term->description,
+			'slug'        => $term->slug,
+			'count'       => (int) $term->count,
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Utilities/TermQuery.php
+++ b/src/RestApi/StoreApi/Utilities/TermQuery.php
@@ -22,10 +22,11 @@ class TermQuery {
 	 * @return array
 	 */
 	public function prepare_objects_query( $request ) {
-		$args             = array();
-		$args['order']    = $request['order'];
-		$args['orderby']  = $request['orderby'];
-		$args['taxonomy'] = $request['taxonomy'];
+		$args               = array();
+		$args['order']      = $request['order'];
+		$args['orderby']    = $request['orderby'];
+		$args['taxonomy']   = $request['taxonomy'];
+		$args['hide_empty'] = (bool) $request['hide_empty'];
 		return $args;
 	}
 

--- a/tests/php/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
+++ b/tests/php/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Controller Tests.
+ *
+ * @package WooCommerce\Blocks\Tests
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\RestApi\StoreApi\Controllers;
+
+use \WP_REST_Request;
+use \WC_REST_Unit_Test_Case as TestCase;
+use \WC_Helper_Product as ProductHelper;
+
+/**
+ * Product Attributes Controller Tests.
+ */
+class ProductAttributeTerms extends TestCase {
+	/**
+	 * Setup test products data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( 0 );
+
+		$this->attributes    = [];
+		$this->attributes[0] = ProductHelper::create_attribute( 'color', [ 'red', 'green', 'blue' ] );
+		$this->attributes[1] = ProductHelper::create_attribute( 'size', [ 'small', 'medium', 'large' ] );
+
+		wp_insert_term( 'test', 'pa_size', [
+			'description' => 'This is a test description',
+			'slug'        => 'test-slug',
+		] );
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/store/products/attributes/(?P<attribute_id>[\d]+)/terms', $routes );
+	}
+
+	/**
+	 * Test getting items.
+	 */
+	public function test_get_items() {
+		$request = new WP_REST_Request( 'GET', '/wc/store/products/attributes/' . $this->attributes[0]['attribute_id'] . '/terms' );
+		$request->set_param( 'hide_empty', false );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 3, count( $data ) );
+		$this->assertArrayHasKey( 'id', $data[0] );
+		$this->assertArrayHasKey( 'name', $data[0] );
+		$this->assertArrayHasKey( 'slug', $data[0] );
+		$this->assertArrayHasKey( 'description', $data[0] );
+		$this->assertArrayHasKey( 'count', $data[0] );
+	}
+
+	/**
+	 * Test schema retrieval.
+	 */
+	public function test_get_item_schema() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\ProductAttributeTerms();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'id', $schema['properties'] );
+		$this->assertArrayHasKey( 'name', $schema['properties'] );
+		$this->assertArrayHasKey( 'slug', $schema['properties'] );
+		$this->assertArrayHasKey( 'description', $schema['properties'] );
+		$this->assertArrayHasKey( 'count', $schema['properties'] );
+	}
+
+	/**
+	 * Test conversion of prdouct to rest response.
+	 */
+	public function test_prepare_item_for_response() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\ProductAttributeTerms();
+		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'test', 'pa_size' ), [] );
+		$data       = $response->get_data();
+
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertEquals( 'test', $data['name'] );
+		$this->assertEquals( 'test-slug', $data['slug'] );
+		$this->assertEquals( 'This is a test description', $data['description'] );
+		$this->assertEquals( 0, $data['count'] );
+	}
+
+	/**
+	 * Test collection params getter.
+	 */
+	public function test_get_collection_params() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\ProductAttributeTerms();
+		$params     = $controller->get_collection_params();
+
+		$this->assertArrayHasKey( 'order', $params );
+		$this->assertArrayHasKey( 'orderby', $params );
+		$this->assertArrayHasKey( 'hide_empty', $params );
+	}
+}

--- a/tests/php/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
+++ b/tests/php/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
@@ -74,7 +74,7 @@ class ProductAttributeTerms extends TestCase {
 	}
 
 	/**
-	 * Test conversion of prdouct to rest response.
+	 * Test conversion of product to rest response.
 	 */
 	public function test_prepare_item_for_response() {
 		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\ProductAttributeTerms();

--- a/tests/php/RestApi/StoreApi/Controllers/ProductAttributes.php
+++ b/tests/php/RestApi/StoreApi/Controllers/ProductAttributes.php
@@ -89,7 +89,7 @@ class ProductAttributes extends TestCase {
 	}
 
 	/**
-	 * Test conversion of prdouct to rest response.
+	 * Test conversion of product to rest response.
 	 */
 	public function test_prepare_item_for_response() {
 		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\ProductAttributes();

--- a/tests/php/RestApi/StoreApi/Controllers/ProductAttributes.php
+++ b/tests/php/RestApi/StoreApi/Controllers/ProductAttributes.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Controller Tests.
+ *
+ * @package WooCommerce\Blocks\Tests
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\RestApi\StoreApi\Controllers;
+
+use \WP_REST_Request;
+use \WC_REST_Unit_Test_Case as TestCase;
+use \WC_Helper_Product as ProductHelper;
+
+/**
+ * Product Attributes Controller Tests.
+ */
+class ProductAttributes extends TestCase {
+	/**
+	 * Setup test products data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( 0 );
+
+		$color_attribute = ProductHelper::create_attribute( 'color', [ 'red', 'green', 'blue' ] );
+		$size_attribute = ProductHelper::create_attribute( 'size', [ 'small', 'medium', 'large' ] );
+
+		$this->attributes   = [];
+		$this->attributes[] = wc_get_attribute( $color_attribute['attribute_id'] );
+		$this->attributes[] = wc_get_attribute( $size_attribute['attribute_id'] );
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/store/products/attributes', $routes );
+		$this->assertArrayHasKey( '/wc/store/products/attributes/(?P<id>[\d]+)', $routes );
+	}
+
+	/**
+	 * Test getting item.
+	 */
+	public function test_get_item() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/products/attributes/' . $this->attributes[0]->id ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $this->attributes[0]->id, $data['id'] );
+		$this->assertEquals( $this->attributes[0]->name, $data['name'] );
+		$this->assertEquals( $this->attributes[0]->slug, $data['slug'] );
+		$this->assertEquals( $this->attributes[0]->type, $data['type'] );
+		$this->assertEquals( $this->attributes[0]->order_by, $data['order'] );
+		$this->assertEquals( $this->attributes[0]->has_archives, $data['has_archives'] );
+	}
+
+	/**
+	 * Test getting items.
+	 */
+	public function test_get_items() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/products/attributes' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $data ) );
+		$this->assertArrayHasKey( 'id', $data[0] );
+		$this->assertArrayHasKey( 'name', $data[0] );
+		$this->assertArrayHasKey( 'slug', $data[0] );
+		$this->assertArrayHasKey( 'type', $data[0] );
+		$this->assertArrayHasKey( 'order', $data[0] );
+		$this->assertArrayHasKey( 'has_archives', $data[0] );
+	}
+
+	/**
+	 * Test schema retrieval.
+	 */
+	public function test_get_item_schema() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\ProductAttributes();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'id', $schema['properties'] );
+		$this->assertArrayHasKey( 'name', $schema['properties'] );
+		$this->assertArrayHasKey( 'slug', $schema['properties'] );
+		$this->assertArrayHasKey( 'type', $schema['properties'] );
+		$this->assertArrayHasKey( 'order', $schema['properties'] );
+		$this->assertArrayHasKey( 'has_archives', $schema['properties'] );
+	}
+
+	/**
+	 * Test conversion of prdouct to rest response.
+	 */
+	public function test_prepare_item_for_response() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\ProductAttributes();
+		$response   = $controller->prepare_item_for_response( $this->attributes[0], [] );
+
+		$this->assertArrayHasKey( 'id', $response->get_data() );
+		$this->assertArrayHasKey( 'name', $response->get_data() );
+		$this->assertArrayHasKey( 'slug', $response->get_data() );
+		$this->assertArrayHasKey( 'type', $response->get_data() );
+		$this->assertArrayHasKey( 'order', $response->get_data() );
+		$this->assertArrayHasKey( 'has_archives', $response->get_data() );
+	}
+}


### PR DESCRIPTION
This PR adds test coverage for the `products/attributes` and `products/attributes/terms` endpoints to ensure schema is respected and results are returned.

In doing this I made 2 fixes to the APIs:

1. Missing term `description`
2. Ability to return empty terms, which unit tests require

If tests pass this should be mergable - the APIs are already in master :)