### PR TITLE
Move renderFrontend to internal dependencies

### DIFF
--- a/assets/js/blocks/attribute-filter/frontend.js
+++ b/assets/js/blocks/attribute-filter/frontend.js
@@ -1,12 +1,8 @@
 /**
- * External dependencies
- */
-import renderFrontend from '../../utils/render-frontend.js';
-
-/**
  * Internal dependencies
  */
 import Block from './block.js';
+import renderFrontend from '../../utils/render-frontend.js';
 
 const getProps = ( el ) => {
 	return {


### PR DESCRIPTION
Fixes a linting rule violation now there is verification for internal/external dependencies.