### PR TITLE
Remove unnecessary package version reading of @wordpress/components

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -75,26 +75,15 @@ class Bootstrap {
 		$this->container->register(
 			AssetDataRegistry::class,
 			function( Container $container ) {
-				$asset_api  = $container->get( AssetApi::class );
-				$js_package = \json_decode(
-					// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-					\file_get_contents(
-						$this->package->get_path( 'package.json' )
-					),
-					true
-				);
-				$woocommerce_components_version =
-					isset( $js_package['dependencies']['@woocommerce/components'] )
-						? $js_package['dependencies']['@woocommerce/components']
-						: 0;
-				$load_back_compat               = '3.2.0' === $woocommerce_components_version
-					|| (
-						defined( 'WC_ADMIN_VERSION_NUMBER' )
-						&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' )
-					);
-				return $load_back_compat
-					? new BackCompatAssetDataRegistry( $asset_api )
-					: new AssetDataRegistry( $asset_api );
+				$asset_api        = $container->get( AssetApi::class );
+				$load_back_compat = defined( 'WC_ADMIN_VERSION_NUMBER' )
+					&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' );
+				// @todo: this needs added back in once the @woocommerce/components
+				// package has been updated.
+				// return $load_back_compat
+				// ? new BackCompatAssetDataRegistry( $asset_api )
+				// : new AssetDataRegistry( $asset_api );
+				return new BackCompatAssetDataRegistry( $asset_api );
 			}
 		);
 

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -75,14 +75,16 @@ class Bootstrap {
 		$this->container->register(
 			AssetDataRegistry::class,
 			function( Container $container ) {
-				$asset_api        = $container->get( AssetApi::class );
-				$load_back_compat = defined( 'WC_ADMIN_VERSION_NUMBER' )
-					&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' );
+				$asset_api = $container->get( AssetApi::class );
+				// phpcs:disable Squiz . PHP . CommentedOutCode . Found
 				// @todo: this needs added back in once the @woocommerce/components
 				// package has been updated.
+				// $load_back_compat = defined( 'WC_ADMIN_VERSION_NUMBER' )
+				// && version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' );
 				// return $load_back_compat
 				// ? new BackCompatAssetDataRegistry( $asset_api )
 				// : new AssetDataRegistry( $asset_api );
+				// phpcs:enable
 				return new BackCompatAssetDataRegistry( $asset_api );
 			}
 		);


### PR DESCRIPTION
In #1017, there was a fix addressed for an error related to the latest published package of `@woocommerce/components` relying on older package requirements.  The fix relied on loading `package.json` to detect what version is being used and load the back-compat layer accordingly.  However, this didn't account for the fact that we release builds without `package.json` 🤦‍♂️which resulted in #1147 .

I'll also rework #1020 as a part of this work to make sure that it accounts for these changes.