### PR TITLE
Ensure frontend script assets are registered with the right suffix for the environment.

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -279,7 +279,7 @@ const getFrontConfig = ( options = {} ) => {
 		entry: getEntryConfig( false, options.exclude || [] ),
 		output: {
 			path: path.resolve( __dirname, '../build/' ),
-			filename: `[name]${ fileSuffix }-frontend.js`,
+			filename: `[name]-frontend${ fileSuffix }.js`,
 			// This fixes an issue with multiple webpack projects using chunking
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -165,8 +165,7 @@ class Assets {
 	 * @param string $name Name of the script used to identify the file inside build folder.
 	 */
 	public static function register_block_script( $name ) {
-		$filename = 'build/' . $name . '.js';
-		self::register_script( 'wc-' . $name, plugins_url( $filename, __DIR__ ) );
+		self::register_script( 'wc-' . $name, plugins_url( self::get_block_asset_build_path( $name ), __DIR__ ) );
 		wp_enqueue_script( 'wc-' . $name );
 	}
 


### PR DESCRIPTION
This is related to the work in #1018 .  I forgot to account for assets registered from the blocks themselves so this ensures that those registrations also account for adding the `-legacy` suffix if in a "legacy" environment.

## To Test

This affects the all products block and all the reviews blocks.

* [ ]  ensure that relevant frontend blocks using javascript work as expected (Review blocks, All Products ) in WP 5.3+ installs
* [ ]  ensure that relevant frontend blocks using javascript work as expected (Review blocks) in WP 5.0 installs