### PR TITLE
Update version script to account for changes in version setting on bootstrap

### DIFF
--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -12,7 +12,7 @@ perl -i -pe 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
 
 # Update version in main plugin file
 perl -i -pe 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
-perl -i -pe "s/'*.+', \/\//'${VERSION}', \/\//" woocommerce-gutenberg-products-block.php
+perl -i -pe "s/version \= '*.+';/version = '${VERSION}';/" woocommerce-gutenberg-products-block.php
 
 # Update version in package.json
 perl -i -pe 's/"version":*.+/"version": "'${VERSION}'",/' package.json

--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -12,9 +12,7 @@ perl -i -pe 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
 
 # Update version in main plugin file
 perl -i -pe 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
+perl -i -pe "s/'2.5.0-dev', \/\//'${VERSION}', \/\//" woocommerce-gutenberg-products-block.php
 
 # Update version in package.json
 perl -i -pe 's/"version":*.+/"version": "'${VERSION}'",/' package.json
-
-# Update version in main file
-perl -i -pe "s/VERSION =*.+/VERSION = '${VERSION}';/" src/Package.php

--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -12,7 +12,7 @@ perl -i -pe 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
 
 # Update version in main plugin file
 perl -i -pe 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
-perl -i -pe "s/'2.5.0-dev', \/\//'${VERSION}', \/\//" woocommerce-gutenberg-products-block.php
+perl -i -pe "s/'*.+', \/\//'${VERSION}', \/\//" woocommerce-gutenberg-products-block.php
 
 # Update version in package.json
 perl -i -pe 's/"version":*.+/"version": "'${VERSION}'",/' package.json

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -88,7 +88,7 @@ function wc_blocks_container( $reset = false ) {
 			Automattic\WooCommerce\Blocks\Domain\Package::class,
 			function ( $container ) {
 				return new Automattic\WooCommerce\Blocks\Domain\Package(
-					'2.5.0-dev',
+					'2.5.0-dev', // version change placeholder comment (dont' remove).
 					__FILE__
 				);
 			}

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -87,8 +87,10 @@ function wc_blocks_container( $reset = false ) {
 		$container->register(
 			Automattic\WooCommerce\Blocks\Domain\Package::class,
 			function ( $container ) {
+				// leave for automated version bumping.
+				$version = '2.5.0-dev';
 				return new Automattic\WooCommerce\Blocks\Domain\Package(
-					'2.5.0-dev', // version change placeholder comment (dont' remove).
+					$version,
 					__FILE__
 				);
 			}


### PR DESCRIPTION
This updates the automated version replacement script for scripts so that it correctly accounts for the version string used in initializing the new `Package` object.

## To Test

- verified via running the `VERSION=2.5.2 ./bin/version-changes.sh` from the root directory of the plugin locally and ensuring expected string replacements happen (review git diff).