### PR TITLE
Show notices when WP or PHP versions are not met

### DIFF
--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -4,7 +4,7 @@ IS_PRE_RELEASE=${IS_PRE_RELEASE:=false}
 
 # replace all instances of $VID:$ with the release version but only when not pre-release.
 if [ $IS_PRE_RELEASE = false ]; then
-	find ./src -name "*.php" -print0 | xargs -0 perl -i -pe 's/\$VID:\$/'${VERSION}'/g'
+	find ./src woocommerce-gutenberg-products-block.php -name "*.php" -print0 | xargs -0 perl -i -pe 's/\$VID:\$/'${VERSION}'/g'
 fi
 
 # Update version number in readme.txt

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -22,16 +22,6 @@ $minimum_wp_version  = '5.0';
 $minimum_php_version = '5.6';
 
 if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			sprintf(
-				/* translators: Placeholders are numbers, versions of WordPress in use on the site, and required by WordPress. */
-				esc_html__( 'Your version of WordPress (%1$s) is lower than the version required by WooCommerce Blocks (%2$s). Please update WordPress to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ),
-				$GLOBALS['wp_version'],
-				$minimum_wp_version
-			)
-		);
-	}
 	/**
 	 * Outputs for an admin notice about running WooCommerce Blocks on outdated WordPress.
 	 *
@@ -48,16 +38,6 @@ if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
 }
 
 if ( version_compare( PHP_VERSION, $minimum_php_version, '<' ) ) {
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			sprintf(
-				/* translators: Placeholders are numbers, versions of PHP in use on the site, and required by WooCommerce Blocks. */
-				esc_html__( 'Your version of PHP (%1$s) is lower than the version required by WooCommerce Blocks (%2$s). Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ),
-				esc_html( phpversion() ),
-				$minimum_php_version
-			)
-		);
-	}
 	/**
 	 * Outputs an admin notice for folks running an outdated version of PHP.
 	 *

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -49,17 +49,6 @@ if ( version_compare( PHP_VERSION, $minimum_php_version, '<' ) ) {
 		?>
 		<div class="notice notice-error is-dismissible">
 			<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of PHP and has been paused. Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
-			<p class="button-container">
-				<?php
-				printf(
-					'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
-					esc_url( wp_get_update_php_url() ),
-					esc_html__( 'Learn more about updating PHP' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-					/* translators: accessibility text */
-					esc_html__( '(opens in a new tab)' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-				);
-				?>
-			</p>
 		</div>
 		<?php
 	}

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -18,17 +18,17 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WOOCOMMERCE_BLOCKS__MINIMUM_WP_VERSION', '5.0' );
-define( 'WOOCOMMERCE_BLOCKS__MINIMUM_PHP_VERSION', '5.6' );
+$minimum_wp_version  = '5.0';
+$minimum_php_version = '5.6';
 
-if ( version_compare( $GLOBALS['wp_version'], WOOCOMMERCE_BLOCKS__MINIMUM_WP_VERSION, '<' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(
 				/* translators: Placeholders are numbers, versions of WordPress in use on the site, and required by WordPress. */
 				esc_html__( 'Your version of WordPress (%1$s) is lower than the version required by WooCommerce Blocks (%2$s). Please update WordPress to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ),
 				$GLOBALS['wp_version'],
-				WOOCOMMERCE_BLOCKS__MINIMUM_WP_VERSION
+				$minimum_wp_version
 			)
 		);
 	}
@@ -47,14 +47,14 @@ if ( version_compare( $GLOBALS['wp_version'], WOOCOMMERCE_BLOCKS__MINIMUM_WP_VER
 	return;
 }
 
-if ( version_compare( PHP_VERSION, WOOCOMMERCE_BLOCKS__MINIMUM_PHP_VERSION, '<' ) ) {
+if ( version_compare( PHP_VERSION, $minimum_php_version, '<' ) ) {
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
 		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			sprintf(
 				/* translators: Placeholders are numbers, versions of PHP in use on the site, and required by WooCommerce Blocks. */
 				esc_html__( 'Your version of PHP (%1$s) is lower than the version required by WooCommerce Blocks (%2$s). Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ),
 				esc_html( phpversion() ),
-				WOOCOMMERCE_BLOCKS__MINIMUM_PHP_VERSION
+				$minimum_php_version
 			)
 		);
 	}

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -21,17 +21,42 @@ defined( 'ABSPATH' ) || exit;
 $minimum_wp_version  = '5.0';
 $minimum_php_version = '5.6';
 
+/**
+ * Whether notices must be displayed in the current page (plugins and WooCommerce pages).
+ *
+ * @since $VID:$
+ */
+function should_display_compatibility_notices() {
+	$current_screen = get_current_screen();
+
+	if ( ! isset( $current_screen ) ) {
+		return false;
+	}
+
+	$is_plugins_page     =
+		property_exists( $current_screen, 'id' ) &&
+		'plugins' === $current_screen->id;
+	$is_woocommerce_page =
+		property_exists( $current_screen, 'parent_base' ) &&
+		'woocommerce' === $current_screen->parent_base;
+
+	return $is_plugins_page || $is_woocommerce_page;
+}
+
 if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
 	/**
 	 * Outputs for an admin notice about running WooCommerce Blocks on outdated WordPress.
 	 *
 	 * @since $VID:$
 	 */
-	function woocommerce_blocks_admin_unsupported_wp_notice() { ?>
-		<div class="notice notice-error is-dismissible">
-			<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of WordPress and has been paused. Please update WordPress to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
-		</div>
-		<?php
+	function woocommerce_blocks_admin_unsupported_wp_notice() {
+		if ( should_display_compatibility_notices() ) {
+			?>
+			<div class="notice notice-error is-dismissible">
+				<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of WordPress and has been paused. Please update WordPress to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
+			</div>
+			<?php
+		}
 	}
 	add_action( 'admin_notices', 'woocommerce_blocks_admin_unsupported_wp_notice' );
 	return;
@@ -46,11 +71,13 @@ if ( version_compare( PHP_VERSION, $minimum_php_version, '<' ) ) {
 	 * @since $VID:$
 	 */
 	function woocommerce_blocks_admin_unsupported_php_notice() {
-		?>
-		<div class="notice notice-error is-dismissible">
-			<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of PHP and has been paused. Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
-		</div>
-		<?php
+		if ( should_display_compatibility_notices() ) {
+			?>
+			<div class="notice notice-error is-dismissible">
+				<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of PHP and has been paused. Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
+			</div>
+			<?php
+		}
 	}
 	add_action( 'admin_notices', 'woocommerce_blocks_admin_unsupported_php_notice' );
 	return;

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -18,7 +18,72 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
+define( 'WOOCOMMERCE_BLOCKS__MINIMUM_WP_VERSION', '5.0' );
+define( 'WOOCOMMERCE_BLOCKS__MINIMUM_PHP_VERSION', '5.6' );
+
+if ( version_compare( $GLOBALS['wp_version'], WOOCOMMERCE_BLOCKS__MINIMUM_WP_VERSION, '<' ) ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			sprintf(
+				/* translators: Placeholders are numbers, versions of WordPress in use on the site, and required by WordPress. */
+				esc_html__( 'Your version of WordPress (%1$s) is lower than the version required by WooCommerce Blocks (%2$s). Please update WordPress to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ),
+				$GLOBALS['wp_version'],
+				WOOCOMMERCE_BLOCKS__MINIMUM_WP_VERSION
+			)
+		);
+	}
+	/**
+	 * Outputs for an admin notice about running WooCommerce Blocks on outdated WordPress.
+	 *
+	 * @since $VID:$
+	 */
+	function woocommerce_blocks_admin_unsupported_wp_notice() { ?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of WordPress and has been paused. Please update WordPress to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
+		</div>
+		<?php
+	}
+	add_action( 'admin_notices', 'woocommerce_blocks_admin_unsupported_wp_notice' );
+	return;
+}
+
+if ( version_compare( PHP_VERSION, WOOCOMMERCE_BLOCKS__MINIMUM_PHP_VERSION, '<' ) ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			sprintf(
+				/* translators: Placeholders are numbers, versions of PHP in use on the site, and required by WooCommerce Blocks. */
+				esc_html__( 'Your version of PHP (%1$s) is lower than the version required by WooCommerce Blocks (%2$s). Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ),
+				esc_html( phpversion() ),
+				WOOCOMMERCE_BLOCKS__MINIMUM_PHP_VERSION
+			)
+		);
+	}
+	/**
+	 * Outputs an admin notice for folks running an outdated version of PHP.
+	 *
+	 * @todo: Remove once WP 5.2 is the minimum version.
+	 *
+	 * @since $VID:$
+	 */
+	function woocommerce_blocks_admin_unsupported_php_notice() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of PHP and has been paused. Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
+			<p class="button-container">
+				<?php
+				printf(
+					'<a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+					esc_url( wp_get_update_php_url() ),
+					esc_html__( 'Learn more about updating PHP' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					/* translators: accessibility text */
+					esc_html__( '(opens in a new tab)' ) // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+	add_action( 'admin_notices', 'woocommerce_blocks_admin_unsupported_php_notice' );
 	return;
 }
 


### PR DESCRIPTION
While reviewing #1157 I noticed we are not showing any feedback to the user when PHP or WP dependencies are not met. This PR adapts the [Jetpack version check](https://github.com/Automattic/jetpack/blob/master/jetpack.php) to WooCommerce Blocks so we display a notice when minimum requirements are not met.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/68659320-5378fe80-0537-11ea-9150-9860dd070625.png)

### How to test the changes in this Pull Request:

1. In a WP 4.9 install, try to activate WooCommerce Blocks and verify a notice appears.
2. Same for a install with PHP < 5.6.
3. Alternatively, you can change the values of `WOOCOMMERCE_BLOCKS__MINIMUM_WP_VERSION` and `WOOCOMMERCE_BLOCKS__MINIMUM_PHP_VERSION` to something higher than your current install to trigger the notices.

### Changelog

> Show error notices when WP or PHP minimum versions are not met