### PR TITLE
Set loading state when searching

### DIFF
--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -54,6 +54,7 @@ const withSearchedProducts = createHigherOrderComponent(
 
 			onSearch( search ) {
 				const { selected } = this.props;
+				this.setState( { loading: true } );
 				getProducts( { selected, search } )
 					.then( ( list ) => {
 						this.setState( { list, loading: false } );
@@ -77,7 +78,12 @@ const withSearchedProducts = createHigherOrderComponent(
 						products={ list }
 						isLoading={ loading }
 						onSearch={
-							IS_LARGE_CATALOG ? this.debouncedOnSearch : null
+							IS_LARGE_CATALOG
+								? ( search ) => {
+										this.setState( { loading: true } );
+										this.debouncedOnSearch( search );
+								  }
+								: null
 						}
 					/>
 				);

--- a/assets/js/hocs/with-searched-products.js
+++ b/assets/js/hocs/with-searched-products.js
@@ -54,7 +54,7 @@ const withSearchedProducts = createHigherOrderComponent(
 
 			onSearch( search ) {
 				const { selected } = this.props;
-				this.setState( { loading: true } );
+
 				getProducts( { selected, search } )
 					.then( ( list ) => {
 						this.setState( { list, loading: false } );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -109,7 +109,7 @@ class Assets {
 				'placeholderImgSrc'  => wc_placeholder_img_src(),
 				'min_height'         => wc_get_theme_support( 'featured_block::min_height', 500 ),
 				'default_height'     => wc_get_theme_support( 'featured_block::default_height', 500 ),
-				'isLargeCatalog'     => $product_counts->publish > 200,
+				'isLargeCatalog'     => $product_counts->publish > 100,
 				'limitTags'          => $tag_count > 100,
 				'hasTags'            => $tag_count > 0,
 				'homeUrl'            => esc_url( home_url( '/' ) ),


### PR DESCRIPTION
There was a report in #1120 about our 100 limit cap on products - when we have a large catalog, the page limit is set to 100. That part is not a bug, confirmed.

But I did notice an issue which I believe led to:

> but it is possible see, search and add to page only from first100

I think this was a misunderstanding due to our UI. When you start typing it immediately says "No products found for X" - the search itself is deferred. This is misleading. 

To resolve this, we need to set loading state to true so there is a visual indication that searching has no yet complete. This PR does this.

Closes #1120

### How to test the changes in this Pull Request:

1. Use a catalog > 200 products or hardcode change the isLargeCatalog option so deferring is enabled.
2. In `getProductsRequests` force per_page to 2 to make this easier to test.
3. Use a handpicked products block.
3. Search for a term. As you type, loading state should be indicated. Results will update once the search is completed.

### Changelog

> Fix loading state indicator during searches in the handpicked products block.
