### PR TITLE
Add context for query state context string.

### DIFF
--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -52,11 +52,7 @@ const ProductList = ( {
 	sortValue,
 	scrollToTop,
 } ) => {
-	// @todo query-state context (which is hardcoded 'product-grid' here) should
-	// be provided via a provider. This allows us to control query state context
-	// at the app level for anything nested within the provider.
 	const [ queryState ] = useSynchronizedQueryState(
-		'product-grid',
 		generateQuery( { attributes, sortValue, currentPage } )
 	);
 	// @todo should add an <ErrorBoundary> in parent component to handle any

--- a/assets/js/base/context/inner-block-configuration-context.js
+++ b/assets/js/base/context/inner-block-configuration-context.js
@@ -15,6 +15,13 @@ const validationMap = {
 	},
 };
 
+/**
+ * This context is a configuration object used for connecting
+ * all children blocks in a given tree contained in the context with information
+ * about the parent block. Typically this is used for extensibility features.
+ *
+ * @var {React.Context} InnerBlockConfigurationContext A react context object
+ */
 const InnerBlockConfigurationContext = createContext( { parentName: null } );
 
 export const useInnerBlockConfigurationContext = () =>

--- a/assets/js/base/context/product-layout-context.js
+++ b/assets/js/base/context/product-layout-context.js
@@ -15,8 +15,14 @@ const validationMap = {
 	},
 };
 
+/**
+ * ProductLayoutContext is an configuration object for layout options shared
+ * among all components in a tree.
+ *
+ * @var {React.Context} ProductLayoutContext A react context object
+ */
 const ProductLayoutContext = createContext( {
-	layoutStyleClassPrefix: '',
+	layoutStyleClassPrefix: 'base',
 } );
 
 export const useProductLayoutContext = () => useContext( ProductLayoutContext );

--- a/assets/js/base/context/product-layout-context.js
+++ b/assets/js/base/context/product-layout-context.js
@@ -22,7 +22,7 @@ const validationMap = {
  * @var {React.Context} ProductLayoutContext A react context object
  */
 const ProductLayoutContext = createContext( {
-	layoutStyleClassPrefix: 'base',
+	layoutStyleClassPrefix: '',
 } );
 
 export const useProductLayoutContext = () => useContext( ProductLayoutContext );

--- a/assets/js/base/context/query-state-context.js
+++ b/assets/js/base/context/query-state-context.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { createContext, useContext } from '@wordpress/element';
+
+/**
+ * Query state context is the index for used for a query state store. By
+ * exposing this via context, it allows for all children blocks to be
+ * synchronized to the same query state defined by the parent in the tree.
+ *
+ * Defaults to 'page' for general global querystate shared among all blocks
+ * in a view.
+ *
+ * @var  {React.Context}  QueryStateContext A react context object
+ */
+const QueryStateContext = createContext( 'page' );
+
+export const useQueryStateContext = () => useContext( QueryStateContext );
+export const QueryStateContextProvider = QueryStateContext.Provider;

--- a/assets/js/base/hooks/test/use-query-state.js
+++ b/assets/js/base/hooks/test/use-query-state.js
@@ -151,8 +151,9 @@ describe( 'Testing Query State Hooks', () => {
 	} );
 	describe( 'useQueryStateByKey', () => {
 		const TestComponent = getTestComponent( useQueryStateByKey, [
-			'context',
 			'queryKey',
+			undefined,
+			'context',
 		] );
 		let renderer;
 		beforeEach( () => {
@@ -205,8 +206,8 @@ describe( 'Testing Query State Hooks', () => {
 	// actually updated by the action dispatch via our mocks.
 	describe( 'useSynchronizedQueryState', () => {
 		const TestComponent = getTestComponent( useSynchronizedQueryState, [
-			'context',
 			'synchronizedQuery',
+			'context',
 		] );
 		const initialQuery = { a: 'b' };
 		let renderer;

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -4,6 +4,7 @@
 import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
+import { useQueryStateContext } from '@woocommerce/base-context/query-state-context';
 
 /**
  * Internal dependencies
@@ -17,13 +18,18 @@ import { useShallowEqual } from './use-shallow-equal';
  * "Query State" is a wp.data store that keeps track of an arbitrary object of
  * query keys and their values.
  *
- * @param {string} context What context to retrieve the query state for.
+ * @param {string} [context] What context to retrieve the query state for. If not
+ *                           provided, this hook will attempt to get the context
+ *                           from the query state context provided by the
+ *                           QueryStateContextProvider
  *
  * @return {array} An array that has two elements. The first element is the
  *                 query state value for the given context.  The second element
  *                 is a dispatcher function for setting the query state.
  */
 export const useQueryStateByContext = ( context ) => {
+	const queryStateContext = useQueryStateContext();
+	context = context || queryStateContext;
 	const queryState = useSelect(
 		( select ) => {
 			const store = select( storeKey );
@@ -42,18 +48,18 @@ export const useQueryStateByContext = ( context ) => {
  * "Query State" is a wp.data store that keeps track of an arbitrary object of
  * query keys and their values.
  *
- * @param {string} context  What context to retrieve the query state for.
- * @param {*}      queryKey The specific query key to retrieve the value for.
- * @param {*}      defaultValue  Default value if query does not exist.
+ * @param {*}      queryKey     The specific query key to retrieve the value for.
+ * @param {*}      defaultValue Default value if query does not exist.
+ * @param {string} [context]    What context to retrieve the query state for. If
+ *                              not provided will attempt to use what is provided
+ *                              by query state context.
  *
  * @return {*}  Whatever value is set at the query state index using the
  *              provided context and query key.
  */
-export const useQueryStateByKey = (
-	context,
-	queryKey,
-	defaultValue
-) => {
+export const useQueryStateByKey = ( queryKey, defaultValue, context ) => {
+	const queryStateContext = useQueryStateContext();
+	context = context || queryStateContext;
 	const queryValue = useSelect(
 		( select ) => {
 			const store = select( storeKey );
@@ -93,12 +99,15 @@ export const useQueryStateByKey = (
  * state by hydration or component attributes, or routing url changes that
  * affect query state).
  *
- * @param {string} context           What context to retrieve the query state
- *                                   for.
  * @param {Object} synchronizedQuery A provided query state object to
  *                                   synchronize internal query state with.
+ * @param {string} context           What context to retrieve the query state
+ *                                   for. If not provided, will be pulled from
+ *                                   the QueryStateContextProvider in the tree.
  */
-export const useSynchronizedQueryState = ( context, synchronizedQuery ) => {
+export const useSynchronizedQueryState = ( synchronizedQuery, context ) => {
+	const queryStateContext = useQueryStateContext();
+	context = context || queryStateContext;
 	const [ queryState, setQueryState ] = useQueryStateByContext( context );
 	const currentSynchronizedQuery = useShallowEqual( synchronizedQuery );
 	// used to ensure we allow initial synchronization to occur before

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -101,7 +101,7 @@ export const useQueryStateByKey = ( queryKey, defaultValue, context ) => {
  *
  * @param {Object} synchronizedQuery A provided query state object to
  *                                   synchronize internal query state with.
- * @param {string} context           What context to retrieve the query state
+ * @param {string} [context]         What context to retrieve the query state
  *                                   for. If not provided, will be pulled from
  *                                   the QueryStateContextProvider in the tree.
  */

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -30,10 +30,8 @@ const AttributeFilterBlock = ( { attributes, isPreview = false } ) => {
 	const [ checkedOptions, setCheckedOptions ] = useState( [] );
 	const { showCounts, attributeId, queryType } = attributes;
 	const taxonomy = getTaxonomyFromAttributeId( attributeId );
-
-	const [ queryState ] = useQueryStateByContext( 'product-grid' );
+	const [ queryState ] = useQueryStateByContext();
 	const [ productAttributes, setProductAttributes ] = useQueryStateByKey(
-		'product-grid',
 		'attributes',
 		[]
 	);

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -14,15 +14,9 @@ import { CURRENCY } from '@woocommerce/settings';
  * Component displaying a price filter.
  */
 const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
-	const [ minPrice, setMinPrice ] = useQueryStateByKey(
-		'product-grid',
-		'min_price'
-	);
-	const [ maxPrice, setMaxPrice ] = useQueryStateByKey(
-		'product-grid',
-		'max_price'
-	);
-	const [ queryState ] = useQueryStateByContext( 'product-grid' );
+	const [ minPrice, setMinPrice ] = useQueryStateByKey( 'min-price' );
+	const [ maxPrice, setMaxPrice ] = useQueryStateByKey( 'max_price' );
+	const [ queryState ] = useQueryStateByContext();
 	const { results, isLoading } = useCollection( {
 		namespace: '/wc/store',
 		resourceName: 'products/collection-data',

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -13,6 +13,7 @@
 		"@woocommerce/block-components(.*)$": "assets/js/components/$1",
 		"@woocommerce/block-hocs(.*)$": "assets/js/hocs/$1",
 		"@woocommerce/base-components(.*)$": "assets/js/base/components/$1",
+		"@woocommerce/base-context(.*)$": "assets/js/base/context/$1",
 		"@woocommerce/base-hocs(.*)$": "assets/js/base/hocs/$1",
 		"@woocommerce/block-data": "assets/js/data"
 	},


### PR DESCRIPTION
This completes one of the follow-up tasks outlined in #1094.  Specifically, introduces a new context for the query state context string.  In this pull:

- `QueryStateContext` is exposed via `useQueryStateContext` and `QueryStateContextProvider`.  It defaults to `'page'`.  This means that until we implement the provider on a tree, the context for any components using this context will be `page`.   This is a pre-requisite to in a follow-up pull adding automatically generated usages of the provider so that trees have their own context for query state
- The new `useQueryStateContext` has been implemented in the `useQueryState` family of hooks so that consumers of those hooks don't even need to worry about the context.  This required adjusting the argument order in those hooks so this needs to be kept in mind when merging this into other pulls using the hooks.
- the `useQueryState` family of hooks can still override the context from a `QueryStateContextProvider` in the tree when invoked (and takes precedence over that if the argument is provided), however there should rarely be need to do so and I'm actually considering whether we should even make that possible.  I'd like some feedback on this.
- there is a minor bug fix for `ProductLayoutContext` in this pull as well and I added inline docs where missing to existing Contexts.

## Example usage.

Note this is a contrived example.  Practically I could see our frontend loader handle assigning the unique context to the provider for each detected All Products block.

```jsx
import { QueryStateContextProvider } from '@woocommerce/base-context/query-state-context';
import { useQueryStateByContext } from '@woocommerce/base-hooks';

const MyTopLevelComponent1 = ( { children } ) => {
  return <QueryStateContextProvider value='my-toplevel-component-1'>
    { children }
  </QueryStateContextProvider>
};

const MyTopLevelComponent2 = ( { children } ) => {
  return <QueryStateContextProvider value='my-toplevel-component-2'>
    { children }
  </QueryStateContextProvider>
};

const MyComponentUsingQueryState = ( { props } ) => {
  const [ queryState, setQueryState ] = useQueryStateByContext();
  return <div>{ JSON.stringify( queryState ) }</div>
};

// block a query state context will be isolated from BlockB query state context
const BlockA = () => {
  <MyTopLevelComponent1>
    <MyComponentUsingQueryState/>
  </MyTopLevelComponent1>
};

const BlockB = () => {
  <MyTopLevelComponent2>
     <MyComponentUsingQueryState/>
  </MyTopLevelComponent2>
};
```

## Testing

Smoke test of All Products block and the filter blocks continue to work as expected.