### PR TITLE
Rename modelName to resourceName everywhere

### DIFF
--- a/assets/js/base/hooks/use-collection-header.js
+++ b/assets/js/base/hooks/use-collection-header.js
@@ -50,7 +50,7 @@ export const useCollectionHeader = ( headerKey, options ) => {
 	if ( ! namespace || ! resourceName ) {
 		throw new Error(
 			'The options object must have valid values for the namespace and ' +
-				'the modelName properties.'
+				'the resource name properties.'
 		);
 	}
 	// ensure we feed the previous reference if it's equivalent

--- a/assets/js/base/hooks/use-collection.js
+++ b/assets/js/base/hooks/use-collection.js
@@ -45,7 +45,7 @@ export const useCollection = ( options ) => {
 	if ( ! namespace || ! resourceName ) {
 		throw new Error(
 			'The options object must have valid values for the namespace and ' +
-				'the modelName properties.'
+				'the resource properties.'
 		);
 	}
 	// ensure we feed the previous reference if it's equivalent

--- a/assets/js/data/collections/README.md
+++ b/assets/js/data/collections/README.md
@@ -8,7 +8,7 @@ import { COLLECTIONS_STORE_KEY } from '@woocommerce/block-data';
 
 ## Actions
 
-### `receiveCollection( namespace, modelName, queryString, ids = [], items = [], replace = false )`
+### `receiveCollection( namespace, resourceName, queryString, ids = [], items = [], replace = false )`
 
 This will return an action object for the given arguments used in dispatching the collection results to the store.
 
@@ -17,26 +17,26 @@ This will return an action object for the given arguments used in dispatching th
 | argument      | type    |  description                                                                                                                                                  |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `namespace`   | string  |  The route namespace for the collection (eg. `/wc/blocks`)                                                                                                    |
-| `modelName`   | string  |  The "model name" for the collection (eg. `products/attributes`)                                                                                              |
+| `resourceName`   | string  |  The resource name for the collection (eg. `products/attributes`)                                                                                              |
 | `queryString` | string  |  An additional query string to add to the request for the collection.  Note, collections are cached by the query string. (eg. '?order=ASC')                   |
 | `ids`         | array   |  If the collection route has placeholders for ids, you provide them via this argument in the order of how the placeholders appear in the route                |
 | `response`       | Object   |  An object containing a `items` property with the collection items from the response (array), and a `headers` property that is matches the `window.Headers` interface containing the headers from the response. |
-| `replace`     | boolean |  Whether or not to replace any existing items in the store for the given indexes (namespace, modelName, queryString) if there are already values in the store |
+| `replace`     | boolean |  Whether or not to replace any existing items in the store for the given indexes (namespace, resourceName, queryString) if there are already values in the store |
 
 ## Selectors
 
-### `getCollection( namespace, modelName, query = null, ids=[] )`
+### `getCollection( namespace, resourceName, query = null, ids=[] )`
 
 This selector will return the collection for the given arguments. It has a sibling resolver, so if the selector has never been resolved, the resolver will make a request to the server for the collection and dispatch results to the store.
 
 | argument      | type    |  description                                                                                                                                                                                            |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `namespace`   | string  |  The route namespace for the collection (eg. `/wc/blocks`)                                                                                                                                              |
-| `modelName`   | string  |  The "model name" for the collection (eg. `products/attributes`)                                                                                                                                        |
+| `resourceName`   | string  |  The resource name for the collection (eg. `products/attributes`)                                                                                                                                        |
 | `query`       | Object  |  The query arguments for the collection. Eg. `{ order: 'ASC', sortBy: Price }`                                                                                                                          |
 | `ids`         | Array   |  If the collection route has placeholders for ids you provide the values for those placeholders in this array (in order).                                                                               |
 
-### `getCollectionHeader( namespace, modelName, header, query = null, ids = [])`
+### `getCollectionHeader( namespace, resourceName, header, query = null, ids = [])`
 
 This selector will return a header from the collection response using the given arguments. It has a sibling resolver that will resolve `getCollection` using the arguments if that has never been resolved.
 
@@ -47,7 +47,7 @@ If the collection does not have any matching headers for the given arguments, th
 | argument      | type    |  description                                                                                                                                                                                            |
 | ------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `namespace`   | string  |  The route namespace for the collection (eg. `/wc/blocks`)                                                                                                                                              |
-| `modelName`   | string  |  The "model name" for the collection (eg. `products/attributes`)                                                                                                                                        |
+| `resourceName`   | string  |  The resource name for the collection (eg. `products/attributes`)                                                                                                                                        |
 | `header` | string | The header key for the header. |
 | `query`       | Object  |  The query arguments for the collection. Eg. `{ order: 'ASC', sortBy: Price }`                                                                                                                          |
 | `ids`         | Array   |  If the collection route has placeholders for ids you provide the values for those placeholders in this array (in order).                                                                               |

--- a/assets/js/data/collections/actions.js
+++ b/assets/js/data/collections/actions.js
@@ -21,8 +21,7 @@ Headers = Headers
  * This is a generic response action.
  *
  * @param {string}   namespace        The namespace for the collection route.
- * @param {string}   modelName        The model name for the collection route.
- *                                    string generating them.
+ * @param {string}   resourceName     The resource name for the collection route.
  * @param {string}   [queryString=''] The query string for the collection
  * @param {array}    [ids=[]]         An array of ids (in correct order) for the
  *                                    model.
@@ -38,7 +37,7 @@ Headers = Headers
  * 	{
  * 		type: string,
  * 		namespace: string,
- * 		modelName: string,
+ * 		resourceName: string,
  * 		queryString: string,
  * 		ids: Array<*>,
  * 		items: Array<*>,
@@ -47,7 +46,7 @@ Headers = Headers
  */
 export function receiveCollection(
 	namespace,
-	modelName,
+	resourceName,
 	queryString = '',
 	ids = [],
 	response = { items: [], headers: Headers },
@@ -56,7 +55,7 @@ export function receiveCollection(
 	return {
 		type: replace ? types.RESET_COLLECTION : types.RECEIVE_COLLECTION,
 		namespace,
-		modelName,
+		resourceName,
 		queryString,
 		ids,
 		response,

--- a/assets/js/data/collections/reducers.js
+++ b/assets/js/data/collections/reducers.js
@@ -14,26 +14,31 @@ import { hasInState, updateState } from '../utils';
  *                            any changes.
  */
 const receiveCollection = ( state = {}, action ) => {
-	const { type, namespace, modelName, queryString, response } = action;
+	const { type, namespace, resourceName, queryString, response } = action;
 	// ids are stringified so they can be used as an index.
 	const ids = action.ids ? JSON.stringify( action.ids ) : '[]';
 	switch ( type ) {
 		case types.RECEIVE_COLLECTION:
 			if (
-				hasInState( state, [ namespace, modelName, ids, queryString ] )
+				hasInState( state, [
+					namespace,
+					resourceName,
+					ids,
+					queryString,
+				] )
 			) {
 				return state;
 			}
 			state = updateState(
 				state,
-				[ namespace, modelName, ids, queryString ],
+				[ namespace, resourceName, ids, queryString ],
 				response
 			);
 			break;
 		case types.RESET_COLLECTION:
 			state = updateState(
 				state,
-				[ namespace, modelName, ids, queryString ],
+				[ namespace, resourceName, ids, queryString ],
 				response
 			);
 			break;

--- a/assets/js/data/collections/resolvers.js
+++ b/assets/js/data/collections/resolvers.js
@@ -16,27 +16,27 @@ import { apiFetchWithHeaders } from './controls';
  * Resolver for retrieving a collection via a api route.
  *
  * @param {string} namespace
- * @param {string} modelName
+ * @param {string} resourceName
  * @param {Object} query
  * @param {Array}  ids
  */
-export function* getCollection( namespace, modelName, query, ids ) {
+export function* getCollection( namespace, resourceName, query, ids ) {
 	const route = yield select(
 		SCHEMA_STORE_KEY,
 		'getRoute',
 		namespace,
-		modelName,
+		resourceName,
 		ids
 	);
 	const queryString = addQueryArgs( '', query );
 	if ( ! route ) {
-		yield receiveCollection( namespace, modelName, queryString, ids );
+		yield receiveCollection( namespace, resourceName, queryString, ids );
 		return;
 	}
 	const { items = DEFAULT_EMPTY_ARRAY, headers } = yield apiFetchWithHeaders(
 		route + queryString
 	);
-	yield receiveCollection( namespace, modelName, queryString, ids, {
+	yield receiveCollection( namespace, resourceName, queryString, ids, {
 		items,
 		headers,
 	} );
@@ -49,21 +49,21 @@ export function* getCollection( namespace, modelName, query, ids ) {
  *
  * @param {string} header
  * @param {string} namespace
- * @param {string} modelName
+ * @param {string} resourceName
  * @param {Object} query
  * @param {Array}  ids
  */
 export function* getCollectionHeader(
 	header,
 	namespace,
-	modelName,
+	resourceName,
 	query,
 	ids
 ) {
 	// feed the correct number of args in for the select so we don't resolve
 	// unnecessarily. Any undefined args will be excluded. This is important
 	// because resolver resolution is cached by both number and value of args.
-	const args = [ namespace, modelName, query, ids ].filter(
+	const args = [ namespace, resourceName, query, ids ].filter(
 		( arg ) => typeof arg !== 'undefined'
 	);
 	//we call this simply to do any resolution of the collection if necessary.

--- a/assets/js/data/collections/selectors.js
+++ b/assets/js/data/collections/selectors.js
@@ -12,7 +12,7 @@ import { DEFAULT_EMPTY_ARRAY } from './constants';
 const getFromState = ( {
 	state,
 	namespace,
-	modelName,
+	resourceName,
 	query,
 	ids,
 	type = 'items',
@@ -21,8 +21,8 @@ const getFromState = ( {
 	// prep ids and query for state retrieval
 	ids = JSON.stringify( ids );
 	query = query !== null ? addQueryArgs( '', query ) : '';
-	if ( hasInState( state, [ namespace, modelName, ids, query, type ] ) ) {
-		return state[ namespace ][ modelName ][ ids ][ query ][ type ];
+	if ( hasInState( state, [ namespace, resourceName, ids, query, type ] ) ) {
+		return state[ namespace ][ resourceName ][ ids ][ query ][ type ];
 	}
 	return fallback;
 };
@@ -30,14 +30,14 @@ const getFromState = ( {
 const getCollectionHeaders = (
 	state,
 	namespace,
-	modelName,
+	resourceName,
 	query = null,
 	ids = DEFAULT_EMPTY_ARRAY
 ) => {
 	return getFromState( {
 		state,
 		namespace,
-		modelName,
+		resourceName,
 		query,
 		ids,
 		type: 'headers',
@@ -50,7 +50,7 @@ const getCollectionHeaders = (
  *
  * @param {Object} state        The current collections state.
  * @param {string} namespace    The namespace for the collection.
- * @param {string} modelName    The model name for the collection.
+ * @param {string} resourceName The resource name for the collection.
  * @param {Object} [query=null] The query for the collection request.
  * @param {Array}  [ids=[]]     Any ids for the collection request (these are
  *                              values that would be added to the route for a
@@ -60,11 +60,11 @@ const getCollectionHeaders = (
 export const getCollection = (
 	state,
 	namespace,
-	modelName,
+	resourceName,
 	query = null,
 	ids = DEFAULT_EMPTY_ARRAY
 ) => {
-	return getFromState( { state, namespace, modelName, query, ids } );
+	return getFromState( { state, namespace, resourceName, query, ids } );
 };
 
 /**
@@ -81,7 +81,7 @@ export const getCollection = (
  * @param {string} state        The current collection state.
  * @param {string} header       The header to retrieve.
  * @param {string} namespace    The namespace for the collection.
- * @param {string} modelName    The model name for the collection.
+ * @param {string} resourceName    The model name for the collection.
  * @param {Object} [query=null] The query object on the collection request.
  * @param {Array}  [ids=[]]     Any ids for the collection request (these are
  *                              values that would be added to the route for a
@@ -95,14 +95,14 @@ export const getCollectionHeader = (
 	state,
 	header,
 	namespace,
-	modelName,
+	resourceName,
 	query = null,
 	ids = DEFAULT_EMPTY_ARRAY
 ) => {
 	const headers = getCollectionHeaders(
 		state,
 		namespace,
-		modelName,
+		resourceName,
 		query,
 		ids
 	);

--- a/assets/js/data/collections/selectors.js
+++ b/assets/js/data/collections/selectors.js
@@ -81,7 +81,7 @@ export const getCollection = (
  * @param {string} state        The current collection state.
  * @param {string} header       The header to retrieve.
  * @param {string} namespace    The namespace for the collection.
- * @param {string} resourceName    The model name for the collection.
+ * @param {string} resourceName The model name for the collection.
  * @param {Object} [query=null] The query object on the collection request.
  * @param {Array}  [ids=[]]     Any ids for the collection request (these are
  *                              values that would be added to the route for a

--- a/assets/js/data/collections/test/reducers.js
+++ b/assets/js/data/collections/test/reducers.js
@@ -29,7 +29,7 @@ describe( 'receiveCollection', () => {
 			const testAction = {
 				type: types.RECEIVE_COLLECTION,
 				namespace: 'wc/blocks',
-				modelName: 'products',
+				resourceName: 'products',
 				queryString: '?someQuery=2',
 				response: {
 					items: [ 'bar' ],
@@ -48,7 +48,7 @@ describe( 'receiveCollection', () => {
 			const testAction = {
 				type: types.RESET_COLLECTION,
 				namespace: 'wc/blocks',
-				modelName: 'products',
+				resourceName: 'products',
 				queryString: '?someQuery=2',
 				response: {
 					items: [ 'cheeseburger' ],
@@ -69,7 +69,7 @@ describe( 'receiveCollection', () => {
 		const testAction = {
 			type: types.RECEIVE_COLLECTION,
 			namespace: 'wc/blocks',
-			modelName: 'products',
+			resourceName: 'products',
 			queryString: '?someQuery=3',
 			response: { items: [ 'cheeseburger' ], headers: { foo: 'bar' } },
 		};
@@ -83,7 +83,7 @@ describe( 'receiveCollection', () => {
 		const testAction = {
 			type: types.RECEIVE_COLLECTION,
 			namespace: 'wc/blocks',
-			modelName: 'products/attributes',
+			resourceName: 'products/attributes',
 			queryString: '?something',
 			response: { items: [ 10, 20 ], headers: { foo: 'bar' } },
 			ids: [ 30, 42 ],

--- a/assets/js/data/collections/test/resolvers.js
+++ b/assets/js/data/collections/test/resolvers.js
@@ -55,7 +55,7 @@ describe( 'getCollection', () => {
 				);
 				expect( value.type ).toBe( expected.type );
 				expect( value.namespace ).toBe( expected.namespace );
-				expect( value.modelName ).toBe( expected.modelName );
+				expect( value.resourceName ).toBe( expected.resourceName );
 				expect( value.queryString ).toBe( expected.queryString );
 				expect( value.ids ).toEqual( expected.ids );
 				expect( Object.keys( value.response ) ).toEqual(

--- a/assets/js/data/collections/test/selectors.js
+++ b/assets/js/data/collections/test/selectors.js
@@ -44,7 +44,7 @@ describe( 'getCollection', () => {
 	it( 'returns empty array when namespace does not exist in state', () => {
 		expect( getCollection( state, 'invalid', 'products' ) ).toEqual( [] );
 	} );
-	it( 'returns empty array when modelName does not exist in state', () => {
+	it( 'returns empty array when resourceName does not exist in state', () => {
 		expect( getCollection( state, 'wc/blocks', 'invalid' ) ).toEqual( [] );
 	} );
 	it( 'returns empty array when query does not exist in state', () => {
@@ -63,15 +63,21 @@ describe( 'getCollection', () => {
 	} );
 	describe( 'returns expected values for items existing in state', () => {
 		test.each`
-			modelName                      | ids          | query                | expected
+			resourceName                   | ids          | query                | expected
 			${'products'}                  | ${'[]'}      | ${{ someQuery: 2 }}  | ${[ 'foo' ]}
 			${'products/attributes'}       | ${'[10]'}    | ${{ someQuery: 2 }}  | ${[ 'bar' ]}
 			${'products/attributes/terms'} | ${'[10,30]'} | ${{ someQuery: 10 }} | ${[ 42 ]}
 		`(
-			'for "$modelName", "$ids", and "$query"',
-			( { modelName, ids, query } ) => {
+			'for "$resourceName", "$ids", and "$query"',
+			( { resourceName, ids, query } ) => {
 				expect(
-					getCollection( state, 'wc/blocks', modelName, query, ids )
+					getCollection(
+						state,
+						'wc/blocks',
+						resourceName,
+						query,
+						ids
+					)
 				);
 			}
 		);

--- a/assets/js/data/schema/README.md
+++ b/assets/js/data/schema/README.md
@@ -13,7 +13,7 @@ The following actions are used for dispatching data to this store state.
 
 ### `receiveRoutes( routes, namespace = '/wc/blocks' )`
 
-This returns an action object used to update the store with the provided list of model routes.
+This returns an action object used to update the store with the provided list of resource routes.
 
 | Argument    | Type   | Description                                                                                                                                         |
 | ----------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -22,11 +22,11 @@ This returns an action object used to update the store with the provided list of
 
 ## Selectors
 
-### `getRoute( namespace, modelName, ids = [] )`
+### `getRoute( namespace, resourceName, ids = [] )`
 
-This is used for retrieving a route for the given namespace, model name and (if necessary) ids.
+This is used for retrieving a route for the given namespace, resource name and (if necessary) ids.
 
-Example:  If you are looking for a route for a single product on the `wc/blocks` namespace, then you'd have `[20]` as the ids.  
+Example:  If you are looking for a route for a single product on the `wc/blocks` namespace, then you'd have `[20]` as the ids.
 
 ```js
 // '/wc/blocks/products/20'
@@ -35,7 +35,7 @@ wp.data.select( SCHEMA_STORE_KEY ).getRoute( '/wc/blocks', 'products', [20] );
 | Argument    | Type   | Description                                                    |
 | ----------- | ------ | -------------------------------------------------------------- |
 | `namespace` | string | Namespace for the route (eg. `/wc/blocks`)                     |
-| `modelName` | string | The model name for the route (eg. `products/attributes/terms`) |
+| `resourceName` | string | The resource name for the route (eg. `products/attributes/terms`) |
 | `ids`       | array  | Only needed if the route has placeholders for ids.             |
 
 ### `getRoutes( namespace )`

--- a/assets/js/data/schema/reducers.js
+++ b/assets/js/data/schema/reducers.js
@@ -8,7 +8,7 @@ import { combineReducers } from '@wordpress/data';
  */
 import { ACTION_TYPES as types } from './action-types';
 import {
-	extractModelNameFromRoute,
+	extractResourceNameFromRoute,
 	getRouteIds,
 	simplifyRouteWithId,
 } from './utils';
@@ -26,16 +26,23 @@ export const receiveRoutes = ( state = {}, action ) => {
 	const { type, routes, namespace } = action;
 	if ( type === types.RECEIVE_MODEL_ROUTES ) {
 		routes.forEach( ( route ) => {
-			const modelName = extractModelNameFromRoute( namespace, route );
-			if ( modelName && modelName !== namespace ) {
+			const resourceName = extractResourceNameFromRoute(
+				namespace,
+				route
+			);
+			if ( resourceName && resourceName !== namespace ) {
 				const routeIdNames = getRouteIds( route );
 				const savedRoute = simplifyRouteWithId( route, routeIdNames );
 				if (
-					! hasInState( state, [ namespace, modelName, savedRoute ] )
+					! hasInState( state, [
+						namespace,
+						resourceName,
+						savedRoute,
+					] )
 				) {
 					state = updateState(
 						state,
-						[ namespace, modelName, savedRoute ],
+						[ namespace, resourceName, savedRoute ],
 						routeIdNames
 					);
 				}

--- a/assets/js/data/schema/selectors.js
+++ b/assets/js/data/schema/selectors.js
@@ -12,12 +12,13 @@ import { STORE_KEY } from './constants';
 /**
  * Returns the requested route for the given arguments.
  *
- * @param {Object} state     The original state.
- * @param {string} namespace The namespace for the route.
- * @param {string} modelName The model being requested (i.e. products/attributes)
- * @param {Array}  [ids]     This is for any ids that might be implemented in
- *                           the route request. It is not for any query
- *                           parameters.
+ * @param {Object} state        The original state.
+ * @param {string} namespace    The namespace for the route.
+ * @param {string} resourceName The resource being requested
+ *                              (eg. products/attributes)
+ * @param {Array}  [ids]        This is for any ids that might be implemented in
+ *                              the route request. It is not for any query
+ *                              parameters.
  *
  * Ids example:
  * If you are looking for the route for a single product on the `wc/blocks`
@@ -31,7 +32,7 @@ import { STORE_KEY } from './constants';
  * @return {string} The route if it is available.
  */
 export const getRoute = createRegistrySelector(
-	( select ) => ( state, namespace, modelName, ids = [] ) => {
+	( select ) => ( state, namespace, resourceName, ids = [] ) => {
 		const hasResolved = select( STORE_KEY ).hasFinishedResolution(
 			'getRoutes',
 			[ namespace ]
@@ -43,10 +44,10 @@ export const getRoute = createRegistrySelector(
 				'There is no route for the given namespace (%s) in the store',
 				namespace
 			);
-		} else if ( ! state[ namespace ][ modelName ] ) {
+		} else if ( ! state[ namespace ][ resourceName ] ) {
 			error = sprintf(
-				'There is no route for the given model name (%s) in the store',
-				modelName
+				'There is no route for the given resource name (%s) in the store',
+				resourceName
 			);
 		}
 		if ( error !== '' ) {
@@ -55,18 +56,18 @@ export const getRoute = createRegistrySelector(
 			}
 			return '';
 		}
-		const route = getRouteFromModelEntries(
-			state[ namespace ][ modelName ],
+		const route = getRouteFromResourceEntries(
+			state[ namespace ][ resourceName ],
 			ids
 		);
 		if ( route === '' ) {
 			if ( hasResolved ) {
 				throw new Error(
 					sprintf(
-						'While there is a route for the given namespace (%s) and model name (%s), there is no route utilizing the number of ids you included in the select arguments. The available routes are: (%s)',
+						'While there is a route for the given namespace (%s) and resource name (%s), there is no route utilizing the number of ids you included in the select arguments. The available routes are: (%s)',
 						namespace,
-						modelName,
-						JSON.stringify( state[ namespace ][ modelName ] )
+						resourceName,
+						JSON.stringify( state[ namespace ][ resourceName ] )
 					)
 				);
 			}
@@ -102,10 +103,10 @@ export const getRoutes = createRegistrySelector(
 			return [];
 		}
 		let namespaceRoutes = [];
-		for ( const modelName in routes ) {
+		for ( const resourceName in routes ) {
 			namespaceRoutes = [
 				...namespaceRoutes,
-				...Object.keys( routes[ modelName ] ),
+				...Object.keys( routes[ resourceName ] ),
 			];
 		}
 		return namespaceRoutes;
@@ -116,13 +117,13 @@ export const getRoutes = createRegistrySelector(
  * Returns the route from the given slice of the route state.
  *
  * @param {Object} stateSlice This will be a slice of the route state from a
- *                            given namespace and model name.
+ *                            given namespace and resource name.
  * @param {Array} [ids=[]]  Any id references that are to be replaced in
  *                            route placeholders.
  *
  * @returns {string}  The route or an empty string if nothing found.
  */
-const getRouteFromModelEntries = ( stateSlice, ids = [] ) => {
+const getRouteFromResourceEntries = ( stateSlice, ids = [] ) => {
 	// convert to array for easier discovery
 	stateSlice = Object.entries( stateSlice );
 	const match = stateSlice.find( ( [ , idNames ] ) => {

--- a/assets/js/data/schema/test/selectors.js
+++ b/assets/js/data/schema/test/selectors.js
@@ -34,8 +34,8 @@ const testState = deepFreeze( {
 } );
 
 describe( 'getRoute', () => {
-	const invokeTest = ( namespace, modelName, ids = [] ) => () => {
-		return getRoute( testState, namespace, modelName, ids );
+	const invokeTest = ( namespace, resourceName, ids = [] ) => () => {
+		return getRoute( testState, namespace, resourceName, ids );
 	};
 	describe( 'with throwing errors', () => {
 		beforeEach( () => mockHasFinishedResolution.mockReturnValue( true ) );
@@ -44,16 +44,14 @@ describe( 'getRoute', () => {
 		} );
 		it(
 			'throws an error if there are routes for the given namespace, but no ' +
-				'route for the given model',
+				'route for the given resource',
 			() => {
-				expect( invokeTest( 'wc/blocks', 'invalid' ) ).toThrowError(
-					/given model name/
-				);
+				expect( invokeTest( 'wc/blocks', 'invalid' ) ).toThrowError();
 			}
 		);
 		it(
 			'throws an error if there are routes for the given namespace and ' +
-				'model name, but no routes for the given ids',
+				'resource name, but no routes for the given ids',
 			() => {
 				expect(
 					invokeTest( 'wc/blocks', 'products/attributes', [ 10 ] )
@@ -64,10 +62,10 @@ describe( 'getRoute', () => {
 	describe( 'with no throwing of errors if resolution has not finished', () => {
 		beforeEach( () => mockHasFinishedResolution.mockReturnValue( false ) );
 		it.each`
-			description                                                                             | args
-			${'is no route for the given namespace'}                                                | ${[ 'invalid' ]}
-			${'are no routes for the given namespace, but no route for the given model'}            | ${[ 'wc/blocks', 'invalid' ]}
-			${'are routes for the given namespace and model name, but no routes for the given ids'} | ${[ 'wc/blocks', 'products/attributes', [ 10 ] ]}
+			description                                                                                | args
+			${'is no route for the given namespace'}                                                   | ${[ 'invalid' ]}
+			${'are no routes for the given namespace, but no route for the given resource'}            | ${[ 'wc/blocks', 'invalid' ]}
+			${'are routes for the given namespace and resource name, but no routes for the given ids'} | ${[ 'wc/blocks', 'products/attributes', [ 10 ] ]}
 		`( 'does not throw an error if there $description', ( { args } ) => {
 			expect( invokeTest( ...args ) ).not.toThrowError();
 		} );

--- a/assets/js/data/schema/test/utils.js
+++ b/assets/js/data/schema/test/utils.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import {
-	extractModelNameFromRoute,
+	extractResourceNameFromRoute,
 	getRouteIds,
 	simplifyRouteWithId,
 } from '../utils';
 
-describe( 'extractModelNameFromRoute', () => {
+describe( 'extractResourceNameFromRoute', () => {
 	it.each`
 		namespace      | route                                                                          | expected
 		${'wc/blocks'} | ${'wc/blocks/products'}                                                        | ${'products'}
@@ -19,7 +19,7 @@ describe( 'extractModelNameFromRoute', () => {
 	`(
 		'returns "$expected" when namespace is "$namespace" and route is "$route"',
 		( { namespace, route, expected } ) => {
-			expect( extractModelNameFromRoute( namespace, route ) ).toBe(
+			expect( extractResourceNameFromRoute( namespace, route ) ).toBe(
 				expected
 			);
 		}

--- a/assets/js/data/schema/utils.js
+++ b/assets/js/data/schema/utils.js
@@ -1,5 +1,5 @@
 /**
- * This returns a "modelName" string as an index for a given route.
+ * This returns a resource name string as an index for a given route.
  *
  * For example:
  * /wc/blocks/products/attributes/(?P<id>[\d]+)/terms
@@ -9,9 +9,9 @@
  * @param {string} namespace
  * @param {string} route
  *
- * @return {string} The model name extracted from the route.
+ * @return {string} The resource name extracted from the route.
  */
-export const extractModelNameFromRoute = ( namespace, route ) => {
+export const extractResourceNameFromRoute = ( namespace, route ) => {
 	route = route.replace( `${ namespace }/`, '' );
 	return route.replace( /\/\(\?P\<[a-z_]*\>\[\\*[a-z]\]\+\)/g, '' );
 };


### PR DESCRIPTION
This pull improves the variable names for the various stores by changing references to `model` and `modelName` to `resource` and `resourceName`.  This more accurately describes the values held by these variables (and actions for functions).

## To Test

- Verify all existing tests pass
- smoke test of existing All Products block and filters (which use the affected code) and ensure there are no console errors and things work as expected.