### PR TITLE
Fix Package::init breakage for including plugin in WC core

### DIFF
--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -12,7 +12,9 @@ perl -i -pe 's/Stable tag:*.+/Stable tag: '${VERSION}'/' readme.txt
 
 # Update version in main plugin file
 perl -i -pe 's/Version:*.+/Version: '${VERSION}'/' woocommerce-gutenberg-products-block.php
-perl -i -pe "s/version \= '*.+';/version = '${VERSION}';/" woocommerce-gutenberg-products-block.php
 
 # Update version in package.json
 perl -i -pe 's/"version":*.+/"version": "'${VERSION}'",/' package.json
+
+# Update version in src/Package.php
+perl -i -pe "s/version \= '*.+';/version = '${VERSION}';/" src/Package.php

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -127,7 +127,7 @@ class AssetDataRegistry {
 		 *
 		 * Developers, do not use this hook as it is likely to be removed.
 		 * Instead, use the data api:
-		 * wc_blocks_container()
+		 * Automattic\WooCommerce\Blocks\Package::container()
 		 *     ->get( Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class )
 		 *     ->add( $key, $value )
 		 */

--- a/src/Package.php
+++ b/src/Package.php
@@ -8,13 +8,15 @@
 namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\Domain\Package as NewPackage;
+use Automattic\WooCommerce\Blocks\Domain\Bootstrap;
+use Automattic\WooCommerce\Blocks\Registry\Container;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Main package class.
+ * Main package class. (Loader in the WC Core context as well)
  *
- * @deprecated $VID:$
+ * $VID:$
  */
 class Package {
 
@@ -27,7 +29,7 @@ class Package {
 	 * @return Package  The Package instance class
 	 */
 	protected static function get_package() {
-		return wc_blocks_container()->get( NewPackage::class );
+		return self::container()->get( NewPackage::class );
 	}
 
 	/**
@@ -36,7 +38,7 @@ class Package {
 	 * @since $VID:$ Handled by new NewPackage.
 	 */
 	public static function init() {
-		// noop.
+		self::container()->get( Bootstrap::class );
 	}
 
 	/**
@@ -55,5 +57,44 @@ class Package {
 	 */
 	public static function get_path() {
 		return self::get_package()->get_path();
+	}
+
+	/**
+	 * Loads the dependency injection container for woocommerce blocks.
+	 *
+	 * @param boolean $reset Used to reset the container to a fresh instance.
+	 *                       Note: this means all dependencies will be
+	 *                       reconstructed.
+	 */
+	public static function container( $reset = false ) {
+		static $container;
+		if (
+				! $container instanceof Container
+				|| $reset
+			) {
+			$container = new Container();
+			// register Package.
+			$container->register(
+				NewPackage::class,
+				function ( $container ) {
+					// leave for automated version bumping.
+					$version = '2.5.0-dev';
+					return new NewPackage(
+						$version,
+						WC_BLOCKS_PLUGIN_FILE
+					);
+				}
+			);
+			// register Bootstrap.
+			$container->register(
+				Bootstrap::class,
+				function ( $container ) {
+					return new Bootstrap(
+						$container
+					);
+				}
+			);
+		}
+		return $container;
 	}
 }

--- a/src/Package.php
+++ b/src/Package.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Main package class. (Loader in the WC Core context as well)
  *
- * $VID:$
+ * @since $VID:$
  */
 class Package {
 

--- a/tests/php/Assets/AssetDataRegistry.php
+++ b/tests/php/Assets/AssetDataRegistry.php
@@ -5,6 +5,7 @@ namespace Automattic\WooCommerce\Blocks\Tests\Assets;
 use \WP_UnitTestCase;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\Tests\Mocks\AssetDataRegistryMock;
+use Automattic\WooCommerce\Blocks\Package;
 use InvalidArgumentException;
 
 /**
@@ -17,7 +18,7 @@ class AssetDataRegistry extends WP_UnitTestCase {
 
 	public function setUp() {
 		$this->registry = new AssetDataRegistryMock(
-			wc_blocks_container()->get( API::class )
+			Package::container()->get( API::class )
 		);
 	}
 

--- a/tests/php/Bootstrap/MainFile.php
+++ b/tests/php/Bootstrap/MainFile.php
@@ -11,6 +11,7 @@ namespace Automattic\WooCommerce\Blocks\Tests\Bootstrap;
 use \WP_UnitTestCase;
 use Automattic\WooCommerce\Blocks\Domain\Bootstrap;
 use Automattic\WooCommerce\Blocks\Registry\Container;
+use Automattic\WooCommerce\Blocks\Package;
 
 /**
  * Test class for the bootstrap in the plugin main file
@@ -30,16 +31,16 @@ class MainFile extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		// reset container
-		$this->container = wc_blocks_container( true );
+		$this->container = Package::container( true );
 	}
 
-	public function test_wc_blocks_container_returns_same_instance() {
-		$container = wc_blocks_container();
+	public function test_container_returns_same_instance() {
+		$container = Package::container();
 		$this->assertSame( $container, $this->container );
 	}
 
-	public function test_wc_blocks_container_reset() {
-		$container = wc_blocks_container( true );
+	public function test_container_reset() {
+		$container = Package::container( true );
 		$this->assertNotSame( $container, $this->container );
 	}
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -22,6 +22,8 @@ if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
 	return;
 }
 
+define( 'WC_BLOCKS_PLUGIN_FILE', __FILE__ );
+
 /**
  * Autoload packages.
  *
@@ -70,51 +72,5 @@ if ( is_readable( $autoloader ) ) {
 	return;
 }
 
-/**
- * Loads the dependency injection container for woocommerce blocks.
- *
- * @param boolean $reset Used to reset the container to a fresh instance.
- *                       Note: this means all dependencies will be reconstructed.
- */
-function wc_blocks_container( $reset = false ) {
-	static $container;
-	if (
-		! $container instanceof Automattic\WooCommerce\Blocks\Registry\Container
-		|| $reset
-	) {
-		$container = new Automattic\WooCommerce\Blocks\Registry\Container();
-		// register Package.
-		$container->register(
-			Automattic\WooCommerce\Blocks\Domain\Package::class,
-			function ( $container ) {
-				// leave for automated version bumping.
-				$version = '2.5.0-dev';
-				return new Automattic\WooCommerce\Blocks\Domain\Package(
-					$version,
-					__FILE__
-				);
-			}
-		);
-		// register Bootstrap.
-		$container->register(
-			Automattic\WooCommerce\Blocks\Domain\Bootstrap::class,
-			function ( $container ) {
-				return new Automattic\WooCommerce\Blocks\Domain\Bootstrap(
-					$container
-				);
-			}
-		);
-	}
-	return $container;
-}
+add_action( 'plugins_loaded', array( '\Automattic\WooCommerce\Blocks\Package', 'init' ) );
 
-add_action( 'plugins_loaded', 'wc_blocks_bootstrap' );
-/**
- * Boostrap WooCommerce Blocks App
- */
-function wc_blocks_bootstrap() {
-	// initialize bootstrap.
-	wc_blocks_container()->get(
-		Automattic\WooCommerce\Blocks\Domain\Bootstrap::class
-	);
-}


### PR DESCRIPTION
I didn't realize but #956 introduced a breakage to how the plugin is loaded in core.  I was ignorant of the way the package system works for WC core and missed the importance of bootstrapping through `Package::init` and how the autoloader used automatically handles referencing the correct files 🤦‍♂ 

> Note: this does not impact current releases of WC Core - only when we bundle (eventually) 2.5.0 in core.

This pull fixes that which includes:

- eliminating `wc_bootstrap`.
- move `wc_blocks_container` to a method on `Automattic/WooCommerce/Blocks/Package`
- remove @deprecation tag on `Automattic/WooCommerce/Blocks/Package`
- re-point main file initialization to `Automattic/WooCommerce/Blocks/Package`
- fix version-changes.sh script to point to new location for hardcoded version string in `Automattic/Woocommerce/Blocks/Package`.

## To Test

- ensure that you can load the plugin with no errors.
- smoke test block functionality (basically ensuring assets load correctly due to paths etc)... make sure there are no console errors.
- execute `VERSION=2.5.2 ./bin/version-changes.sh` from the root path of the plugin to verify expected strings change (notably for the `src/Package.php` file - which is what was affected.