### PR TITLE
Show number of reviews in each category in Reviews per Category block

### DIFF
--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -150,6 +150,7 @@ const ReviewsByCategoryEditor = ( {
 							const ids = value.map( ( { id } ) => id );
 							setAttributes( { categoryIds: ids } );
 						} }
+						showReviewCount={ true }
 					/>
 					<Button isDefault onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -24,6 +24,7 @@ const ProductCategoryControl = ( {
 	operator,
 	selected,
 	isSingle,
+	showReviewCount,
 } ) => {
 	const renderItem = ( args ) => {
 		const { item, search, depth = 0 } = args;
@@ -39,21 +40,54 @@ const ProductCategoryControl = ( {
 			? item.name
 			: `${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
 
+		const listItemAriaLabel = showReviewCount
+			? sprintf(
+				_n(
+					'%s, has %d review',
+					'%s, has %d reviews',
+					item.reviews,
+					'woo-gutenberg-products-block'
+				),
+				accessibleName,
+				item.reviews
+			)
+			: sprintf(
+				_n(
+					'%s, has %d product',
+					'%s, has %d products',
+					item.count,
+					'woo-gutenberg-products-block'
+				),
+				accessibleName,
+				item.count
+			);
+
+			const listItemCountLabel = showReviewCount
+			? sprintf(
+				_n(
+					'%d Review',
+					'%d Reviews',
+					item.reviews,
+					'woo-gutenberg-products-block'
+				),
+				item.reviews
+			)
+			: sprintf(
+				_n(
+					'%d Product',
+					'%d Products',
+					item.count,
+					'woo-gutenberg-products-block'
+				),
+				item.count
+			);
 		return (
 			<SearchListItem
 				className={ classes.join( ' ' ) }
 				{ ...args }
 				showCount
-				aria-label={ sprintf(
-					_n(
-						'%s, has %d product',
-						'%s, has %d products',
-						item.count,
-						'woo-gutenberg-products-block'
-					),
-					accessibleName,
-					item.count
-				) }
+				countLabel={ listItemCountLabel }
+				aria-label={ listItemAriaLabel }
 			/>
 		);
 	};

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -42,45 +42,45 @@ const ProductCategoryControl = ( {
 
 		const listItemAriaLabel = showReviewCount
 			? sprintf(
-				_n(
-					'%s, has %d review',
-					'%s, has %d reviews',
-					item.reviews,
-					'woo-gutenberg-products-block'
-				),
-				accessibleName,
-				item.reviews
-			)
+					_n(
+						'%s, has %d review',
+						'%s, has %d reviews',
+						item.review_count,
+						'woo-gutenberg-products-block'
+					),
+					accessibleName,
+					item.review_count
+			  )
 			: sprintf(
-				_n(
-					'%s, has %d product',
-					'%s, has %d products',
-					item.count,
-					'woo-gutenberg-products-block'
-				),
-				accessibleName,
-				item.count
-			);
+					_n(
+						'%s, has %d product',
+						'%s, has %d products',
+						item.count,
+						'woo-gutenberg-products-block'
+					),
+					accessibleName,
+					item.count
+			  );
 
-			const listItemCountLabel = showReviewCount
+		const listItemCountLabel = showReviewCount
 			? sprintf(
-				_n(
-					'%d Review',
-					'%d Reviews',
-					item.reviews,
-					'woo-gutenberg-products-block'
-				),
-				item.reviews
-			)
+					_n(
+						'%d Review',
+						'%d Reviews',
+						item.review_count,
+						'woo-gutenberg-products-block'
+					),
+					item.review_count
+			  )
 			: sprintf(
-				_n(
-					'%d Product',
-					'%d Products',
-					item.count,
-					'woo-gutenberg-products-block'
-				),
-				item.count
-			);
+					_n(
+						'%d Product',
+						'%d Products',
+						item.count,
+						'woo-gutenberg-products-block'
+					),
+					item.count
+			  );
 		return (
 			<SearchListItem
 				className={ classes.join( ' ' ) }

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -129,10 +129,11 @@ export const getCategory = ( categoryId ) => {
 /**
  * Get a promise that resolves to an array of category objects from the API.
  */
-export const getCategories = () => {
+export const getCategories = ( queryArgs ) => {
 	return apiFetch( {
 		path: addQueryArgs( `${ ENDPOINTS.products }/categories`, {
 			per_page: -1,
+			...queryArgs,
 		} ),
 	} );
 };

--- a/assets/js/hocs/test/with-categories.js
+++ b/assets/js/hocs/test/with-categories.js
@@ -49,7 +49,9 @@ describe( 'withCategories Component', () => {
 		it( 'getCategories is called on mount', () => {
 			const { getCategories } = mockUtils;
 
-			expect( getCategories ).toHaveBeenCalledWith();
+			expect( getCategories ).toHaveBeenCalledWith( {
+				show_review_count: false,
+			} );
 			expect( getCategories ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );

--- a/assets/js/hocs/with-categories.js
+++ b/assets/js/hocs/with-categories.js
@@ -29,7 +29,7 @@ const withCategories = createHigherOrderComponent( ( OriginalComponent ) => {
 		loadCategories() {
 			this.setState( { loading: true } );
 
-			getCategories()
+			getCategories( { show_review_count: this.props.showReviewCount } )
 				.then( ( categories ) => {
 					this.setState( {
 						categories,

--- a/assets/js/hocs/with-categories.js
+++ b/assets/js/hocs/with-categories.js
@@ -29,7 +29,9 @@ const withCategories = createHigherOrderComponent( ( OriginalComponent ) => {
 		loadCategories() {
 			this.setState( { loading: true } );
 
-			getCategories( { show_review_count: this.props.showReviewCount } )
+			getCategories( {
+				show_review_count: this.props.showReviewCount || false,
+			} )
 				.then( ( categories ) => {
 					this.setState( {
 						categories,

--- a/src/RestApi/Controllers/ProductCategories.php
+++ b/src/RestApi/Controllers/ProductCategories.php
@@ -197,13 +197,14 @@ class ProductCategories extends WC_REST_Product_Categories_Controller {
 			'properties' => array(),
 		);
 
-		$schema['properties']['id']           = $raw_schema['properties']['id'];
-		$schema['properties']['name']         = $raw_schema['properties']['name'];
-		$schema['properties']['slug']         = $raw_schema['properties']['slug'];
-		$schema['properties']['parent']       = $raw_schema['properties']['parent'];
-		$schema['properties']['count']        = $raw_schema['properties']['count'];
-		$schema['properties']['description']  = $raw_schema['properties']['description'];
-		$schema['properties']['image']        = $raw_schema['properties']['image'];
+		$schema['properties']['id']          = $raw_schema['properties']['id'];
+		$schema['properties']['name']        = $raw_schema['properties']['name'];
+		$schema['properties']['slug']        = $raw_schema['properties']['slug'];
+		$schema['properties']['parent']      = $raw_schema['properties']['parent'];
+		$schema['properties']['count']       = $raw_schema['properties']['count'];
+		$schema['properties']['description'] = $raw_schema['properties']['description'];
+		$schema['properties']['image']       = $raw_schema['properties']['image'];
+		// review_count will return null unless show_review_count param is trus.
 		$schema['properties']['review_count'] = array(
 			'description' => __( 'Number of reviews in the category.', 'woo-gutenberg-products-block' ),
 			'type'        => 'integer',

--- a/src/RestApi/Controllers/ProductCategories.php
+++ b/src/RestApi/Controllers/ProductCategories.php
@@ -106,34 +106,37 @@ class ProductCategories extends WC_REST_Product_Categories_Controller {
 	 * @return \WP_REST_Response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
-		global $wpdb;
-		$term_id       = $item->term_id;
-		$term_taxonomy = 'product_cat';
-
-		$products_of_category_sql = "
-		SELECT SUM( DISTINCT comment_count) as review_count
-		FROM {$wpdb->posts} AS posts
-		INNER JOIN {$wpdb->term_relationships} AS term_relationships ON posts.ID = term_relationships.object_id
-		INNER JOIN {$wpdb->term_taxonomy} AS term_taxonomy USING( term_taxonomy_id )
-		INNER JOIN {$wpdb->terms} AS terms USING( term_id )
-		WHERE terms.term_id IN ( {$term_id} )
-		AND term_taxonomy.taxonomy IN ( '{$term_taxonomy}' )
-		";
-		$products_of_category = $wpdb->get_results($products_of_category_sql); // phpcs:ignore
-
-		$review_count = $products_of_category[0]->review_count;
-
 		$data = array(
-			'id'           => (int) $item->term_id,
-			'name'         => $item->name,
-			'slug'         => $item->slug,
-			'parent'       => (int) $item->parent,
-			'count'        => (int) $item->count,
-			'description'  => $item->description,
-			'image'        => null,
-			'permalink'    => get_term_link( $item->term_id, 'product_cat' ),
-			'review_count' => (int) $review_count,
+			'id'          => (int) $item->term_id,
+			'name'        => $item->name,
+			'slug'        => $item->slug,
+			'parent'      => (int) $item->parent,
+			'count'       => (int) $item->count,
+			'description' => $item->description,
+			'image'       => null,
+			'permalink'   => get_term_link( $item->term_id, 'product_cat' ),
 		);
+
+		if ( $request->get_param( 'show_review_count' ) ) {
+			global $wpdb;
+			$term_id       = $item->term_id;
+			$term_taxonomy = 'product_cat';
+
+			$products_of_category_sql = "
+			SELECT SUM( DISTINCT comment_count) as review_count
+			FROM {$wpdb->posts} AS posts
+			INNER JOIN {$wpdb->term_relationships} AS term_relationships ON posts.ID = term_relationships.object_id
+			INNER JOIN {$wpdb->term_taxonomy} AS term_taxonomy USING( term_taxonomy_id )
+			INNER JOIN {$wpdb->terms} AS terms USING( term_id )
+			WHERE terms.term_id IN ( {$term_id} )
+			AND term_taxonomy.taxonomy IN ( '{$term_taxonomy}' )
+			";
+			$products_of_category = $wpdb->get_results($products_of_category_sql); // phpcs:ignore
+
+			$review_count = $products_of_category[0]->review_count;
+
+			$data['review_count'] = $review_count;
+		}
 
 		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
 

--- a/src/RestApi/Controllers/ProductCategories.php
+++ b/src/RestApi/Controllers/ProductCategories.php
@@ -165,6 +165,25 @@ class ProductCategories extends WC_REST_Product_Categories_Controller {
 		return $response;
 	}
 
+
+	/**
+	 * Update the collection params.
+	 *
+	 * Adds new options for 'show_review_count'.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                      = parent::get_collection_params();
+		$params['show_review_count'] = array(
+			'description' => __( 'Should we return how many reviews in a category?', 'woo-gutenberg-products-block' ),
+			'type'        => 'boolean',
+			'default'     => false,
+		);
+
+		return $params;
+	}
+
 	/**
 	 * Get the Product's schema, conforming to JSON Schema.
 	 *
@@ -179,14 +198,20 @@ class ProductCategories extends WC_REST_Product_Categories_Controller {
 			'properties' => array(),
 		);
 
-		$schema['properties']['id']          = $raw_schema['properties']['id'];
-		$schema['properties']['name']        = $raw_schema['properties']['name'];
-		$schema['properties']['slug']        = $raw_schema['properties']['slug'];
-		$schema['properties']['parent']      = $raw_schema['properties']['parent'];
-		$schema['properties']['count']       = $raw_schema['properties']['count'];
-		$schema['properties']['description'] = $raw_schema['properties']['description'];
-		$schema['properties']['image']       = $raw_schema['properties']['image'];
-		$schema['properties']['permalink']   = array(
+		$schema['properties']['id']           = $raw_schema['properties']['id'];
+		$schema['properties']['name']         = $raw_schema['properties']['name'];
+		$schema['properties']['slug']         = $raw_schema['properties']['slug'];
+		$schema['properties']['parent']       = $raw_schema['properties']['parent'];
+		$schema['properties']['count']        = $raw_schema['properties']['count'];
+		$schema['properties']['description']  = $raw_schema['properties']['description'];
+		$schema['properties']['image']        = $raw_schema['properties']['image'];
+		$schema['properties']['review_count'] = array(
+			'description' => __( 'Number of reviews in the category.', 'woo-gutenberg-products-block' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+		$schema['properties']['permalink']    = array(
 			'description' => __( 'Category URL.', 'woo-gutenberg-products-block' ),
 			'type'        => 'string',
 			'format'      => 'uri',

--- a/src/RestApi/Controllers/ProductCategories.php
+++ b/src/RestApi/Controllers/ProductCategories.php
@@ -106,6 +106,24 @@ class ProductCategories extends WC_REST_Product_Categories_Controller {
 	 * @return \WP_REST_Response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
+		$products_of_category = get_posts(
+			array(
+				'post_type'   => 'product',
+				'numberposts' => -1,
+				'tax_query'   => array(
+					array(
+						'taxonomy' => 'product_cat',
+						'field'    => 'id',
+						'terms'    => $item->term_id,
+					),
+				),
+			)
+		);
+		$reviews_count = 0;
+		foreach ( $products_of_category as $product ) {
+			$all_comments   = wp_count_comments( $product->ID );
+			$reviews_count += $all_comments->approved;
+		}
 		$data = array(
 			'id'          => (int) $item->term_id,
 			'name'        => $item->name,
@@ -115,6 +133,7 @@ class ProductCategories extends WC_REST_Product_Categories_Controller {
 			'description' => $item->description,
 			'image'       => null,
 			'permalink'   => get_term_link( $item->term_id, 'product_cat' ),
+			'reviews'     => $reviews_count,
 		);
 
 		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR changes the way "Reviews by Category" block shows metadata by showing the number of review in that category instead of the number of products, this is done so that "Reviews by Category" align much better with "Reviews by Product" block.

Reviews count is not a core entity of product category so I hacked it in, hoping @mikejolley can offer some help into writing it better. 

Essentially, the current behavior loops over the category products and aggregate the approved reviews number, I don’t know of any way in core Woo to do this so I went WP style.
 
<!-- Reference any related issues or PRs here -->
Fixes #1068 

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<img width="506" alt="Screen Shot 2019-11-14 at 10 54 45 PM" src="https://user-images.githubusercontent.com/6165348/68900068-56404300-0733-11ea-8c2f-03c25327206d.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Make sure you have some reviews
2. create a new Reviews by Category block
3. see the reviews count

<!-- If you can, add the appropriate labels -->

### What is left to be done
1- Add the reviews to the endpoint via a query flag.
2- add that flag to the request somehow by bubbling that flag to `getCategories` 

### Changelog
- add reviews count to ProductCategory.php endpoints.
- add `showReviews` flag to `productCategoryControl`
