### PR TITLE
Update minimum WooCommerce version to 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # WooCommerce Product Blocks
 
-Feature plugin for WooCommerce + Gutenberg. Now that the product blocks have been merged into WooCommerce 3.6, this plugin serves as a space to iterate and explore how else WooCommerce might work with the block editor. 
+Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore with new WooCommerce Blocks and how else WooCommerce might work with the block editor.
 
-If you're just looking to use these blocks, update to WooCommerce 3.6! The blocks are bundled into WooCommerce, and can be added from the "WooCommerce" section in the block inserter.
+If you're just looking to use these blocks, update to the latest version of WooCommerce! The blocks are bundled into WooCommerce since version 3.6, and can be added from the "WooCommerce" section in the block inserter.
 
 If you want to see what we're working on for future versions, or want to help out, read on.
 
@@ -22,13 +22,13 @@ If you want to see what we're working on for future versions, or want to help ou
 
 We release a new version of WooCommerce Blocks onto WordPress.org every few weeks, which can be used as an easier way to preview the features.
 
-1. Make sure you have WordPress 5.0+ and WooCommerce 3.6+
+1. Make sure you have WordPress 5.0+ and WooCommerce 3.7+
 2. The stable version is available on WordPress.org. [Download the stable version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
 3. Activate the plugin.
 
 ## Installing the development version
 
-1. Make sure you have WordPress 5.0+ and WooCommerce 3.6+
+1. Make sure you have WordPress 5.0+ and WooCommerce 3.7+
 2. Get a copy of this plugin using the green "Clone or download" button on the right.
 3. `npm install` to install the dependencies.
 4. `composer install` to install core dependencies.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WooCommerce Product Blocks
 
-Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore with new WooCommerce Blocks and how else WooCommerce might work with the block editor.
+Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks for WooCommerce, and how WooCommerce might work with the block editor.
 
 If you're just looking to use these blocks, update to the latest version of WooCommerce! The blocks are bundled into WooCommerce since version 3.6, and can be added from the "WooCommerce" section in the block inserter.
 

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ We've also improved the category selection filter. If you select two or more cat
 = Minimum Requirements =
 
 * WordPress 5.0
-* WooCommerce 3.6 or greater
+* WooCommerce 3.7 or greater
 * PHP version 5.2.4 or greater (PHP 7.2 or greater is recommended)
 * MySQL version 5.0 or greater (MySQL 5.6 or greater is recommended)
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -9,7 +9,7 @@
  * Text Domain:  woo-gutenberg-products-block
  * Requires at least: 5.0
  * Requires PHP: 5.6
- * WC requires at least: 3.6
+ * WC requires at least: 3.7
  * WC tested up to: 3.8
  *
  * @package WooCommerce\Blocks
@@ -18,8 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$minimum_wp_version  = '5.0';
-$minimum_php_version = '5.6';
+$minimum_wp_version = '5.0';
 
 /**
  * Whether notices must be displayed in the current page (plugins and WooCommerce pages).
@@ -59,27 +58,6 @@ if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
 		}
 	}
 	add_action( 'admin_notices', 'woocommerce_blocks_admin_unsupported_wp_notice' );
-	return;
-}
-
-if ( version_compare( PHP_VERSION, $minimum_php_version, '<' ) ) {
-	/**
-	 * Outputs an admin notice for folks running an outdated version of PHP.
-	 *
-	 * @todo: Remove once WP 5.2 is the minimum version.
-	 *
-	 * @since $VID:$
-	 */
-	function woocommerce_blocks_admin_unsupported_php_notice() {
-		if ( should_display_compatibility_notices() ) {
-			?>
-			<div class="notice notice-error is-dismissible">
-				<p><?php esc_html_e( 'WooCommerce Blocks requires a more recent version of PHP and has been paused. Please update PHP to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
-			</div>
-			<?php
-		}
-	}
-	add_action( 'admin_notices', 'woocommerce_blocks_admin_unsupported_php_notice' );
 	return;
 }
 


### PR DESCRIPTION
As discussed in #1160, we want to bump the minimum WooCommerce version to 3.7. This PR also updates some README texts that I think were a bit outdated, feel free to make any suggestions to the wording!

It also removes the PHP version check now that our minimum PHP version is the same as WooCommerce's.

### Changelog

> The minimum WooCommerce version has been bumped to 3.7.