### PR TITLE
Enhance useCollection for conditionally returning previous results

### DIFF
--- a/assets/js/base/hooks/use-collection.js
+++ b/assets/js/base/hooks/use-collection.js
@@ -3,6 +3,7 @@
  */
 import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -41,6 +42,7 @@ export const useCollection = ( options ) => {
 		resourceName,
 		resourceValues = [],
 		query = {},
+		shouldSelect = true,
 	} = options;
 	if ( ! namespace || ! resourceName ) {
 		throw new Error(
@@ -48,11 +50,15 @@ export const useCollection = ( options ) => {
 				'the resource properties.'
 		);
 	}
+	const currentResults = useRef( { results: [], isLoading: true } );
 	// ensure we feed the previous reference if it's equivalent
 	const currentQuery = useShallowEqual( query );
 	const currentResourceValues = useShallowEqual( resourceValues );
-	const { results = [], isLoading = true } = useSelect(
+	const results = useSelect(
 		( select ) => {
+			if ( ! shouldSelect ) {
+				return null;
+			}
 			const store = select( storeKey );
 			// filter out query if it is undefined.
 			const args = [
@@ -69,10 +75,18 @@ export const useCollection = ( options ) => {
 				),
 			};
 		},
-		[ namespace, resourceName, currentResourceValues, currentQuery ]
+		[
+			namespace,
+			resourceName,
+			currentResourceValues,
+			currentQuery,
+			shouldSelect,
+		]
 	);
-	return {
-		results,
-		isLoading,
-	};
+	// if selector was not bailed, then update current results. Otherwise return
+	// previous results
+	if ( results !== null ) {
+		currentResults.current = results;
+	}
+	return currentResults.current;
 };

--- a/assets/js/base/hooks/use-collection.js
+++ b/assets/js/base/hooks/use-collection.js
@@ -22,7 +22,7 @@ import { useShallowEqual } from './use-shallow-equal';
  * @param {string} options.resourceName   The name of the resource for the
  *                                        collection. Example:
  *                                        `'products/attributes'`
- * @param {array}  options.resourceValues An array of values (in correct order)
+ * @param {Array}  options.resourceValues An array of values (in correct order)
  *                                        that are substituted in the route
  *                                        placeholders for the collection route.
  *                                        Example: `[10, 20]`
@@ -30,6 +30,9 @@ import { useShallowEqual } from './use-shallow-equal';
  *                                        query to execute on the collection
  *                                        (optional). Example:
  *                                        `{ order: 'ASC', order_by: 'price' }`
+ * @param {boolean} options.shouldSelect  If false, the previous results will be
+ *                                        returned and internal selects will not
+ *                                        fire.
  *
  * @return {Object} This hook will return an object with two properties:
  *                  - results   An array of collection items returned.


### PR DESCRIPTION
Closes: #1150 

There are scenarios where consuming code invokes `useCollection` and depends on the results of it for another request done via a different `useCollection`.  With the rules of hooks, you must [only call hooks at the top level](https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level), that means the consumer can't invoke another call to `useCollection` within a conditional block.  The solution, then, is to provide a way to control whether `useCollection` invokes it's internal `select` calls or not depending on a provide flag.  

Thus, a new flag is introduce, `shouldSelect`.  If this flag is false, then the internal collection store select call is not triggered and the previous value is returned from `useCollection`. 

## To Test

* updates unit tests to add additional condition testing new option - so they should pass
* smoke test All Products block and filters to ensure they work as expected with no errors in the console.

## Next Steps

cc @mikejolley when this is merged are there places you can use this?