### PR TITLE
Implement useProductLayoutContext for layout prefix in atomic blocks.

### DIFF
--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -15,6 +15,7 @@ import { useDispatch } from '@wordpress/data';
 import { find } from 'lodash';
 import { useCollection } from '@woocommerce/base-hooks';
 import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 
 /**
  * A custom hook for exposing cart related data for a given product id and an
@@ -94,6 +95,7 @@ const ProductButton = ( { product, className } ) => {
 		cartIsLoading,
 		addToCart,
 	} = useAddToCart( id );
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const addedToCart = cartQuantity > 0;
 	const getButtonText = () => {
 		if ( Number.isFinite( cartQuantity ) && addedToCart ) {
@@ -106,7 +108,7 @@ const ProductButton = ( { product, className } ) => {
 	};
 	const wrapperClasses = classnames(
 		className,
-		'wc-block-grid__product-add-to-cart',
+		`${ layoutStyleClassPrefix }__product-add-to-cart`,
 		'wp-block-button'
 	);
 

--- a/assets/js/atomic/components/product/price/index.js
+++ b/assets/js/atomic/components/product/price/index.js
@@ -3,8 +3,10 @@
  */
 import NumberFormat from 'react-number-format';
 import classnames from 'classnames';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 
 const ProductPrice = ( { className, product } ) => {
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const prices = product.prices || {};
 	const numberFormatArgs = {
 		displayType: 'text',
@@ -24,10 +26,12 @@ const ProductPrice = ( { className, product } ) => {
 			<div
 				className={ classnames(
 					className,
-					'wc-block-grid__product-price'
+					`${ layoutStyleClassPrefix }__product-price`
 				) }
 			>
-				<span className="wc-block-grid__product-price__value">
+				<span
+					className={ `${ layoutStyleClassPrefix }__product-price__value` }
+				>
 					<NumberFormat
 						value={ prices.price_range.min_amount }
 						{ ...numberFormatArgs }
@@ -46,18 +50,22 @@ const ProductPrice = ( { className, product } ) => {
 		<div
 			className={ classnames(
 				className,
-				'wc-block-grid__product-price'
+				`${ layoutStyleClassPrefix }__product-price`
 			) }
 		>
 			{ prices.regular_price !== prices.price && (
-				<del className="wc-block-grid__product-price__regular">
+				<del
+					className={ `${ layoutStyleClassPrefix }__product-price__regular` }
+				>
 					<NumberFormat
 						value={ prices.regular_price }
 						{ ...numberFormatArgs }
 					/>
 				</del>
 			) }
-			<span className="wc-block-grid__product-price__value">
+			<span
+				className={ `${ layoutStyleClassPrefix }__product-price__value` }
+			>
 				<NumberFormat value={ prices.price } { ...numberFormatArgs } />
 			</span>
 		</div>

--- a/assets/js/atomic/components/product/rating/index.js
+++ b/assets/js/atomic/components/product/rating/index.js
@@ -3,51 +3,49 @@
  */
 import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
-import { Component } from 'react';
 import classnames from 'classnames';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 
-class ProductRating extends Component {
-	static propTypes = {
-		className: PropTypes.string,
-		product: PropTypes.object.isRequired,
+const ProductRating = ( { className, product } ) => {
+	const rating = parseFloat( product.average_rating );
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
+
+	if ( ! Number.isFinite( rating ) || rating === 0 ) {
+		return null;
+	}
+
+	const starStyle = {
+		width: ( rating / 5 ) * 100 + '%',
 	};
 
-	render = () => {
-		const { product, className } = this.props;
-		const rating = parseFloat( product.average_rating );
-
-		if ( ! Number.isFinite( rating ) || rating === 0 ) {
-			return null;
-		}
-
-		const starStyle = {
-			width: ( rating / 5 ) * 100 + '%',
-		};
-
-		return (
+	return (
+		<div
+			className={ classnames(
+				className,
+				`${ layoutStyleClassPrefix }__product-rating`
+			) }
+		>
 			<div
-				className={ classnames(
-					className,
-					'wc-block-grid__product-rating'
-				) }
+				className={ `${ layoutStyleClassPrefix }__product-rating__stars` }
+				role="img"
 			>
-				<div
-					className="wc-block-grid__product-rating__stars"
-					role="img"
-				>
-					<span style={ starStyle }>
-						{ sprintf(
-							__(
-								'Rated %d out of 5',
-								'woo-gutenberg-products-block'
-							),
-							rating
-						) }
-					</span>
-				</div>
+				<span style={ starStyle }>
+					{ sprintf(
+						__(
+							'Rated %d out of 5',
+							'woo-gutenberg-products-block'
+						),
+						rating
+					) }
+				</span>
 			</div>
-		);
-	};
-}
+		</div>
+	);
+};
+
+ProductRating.propTypes = {
+	className: PropTypes.string,
+	product: PropTypes.object.isRequired,
+};
 
 export default ProductRating;

--- a/assets/js/atomic/components/product/sale-badge/index.js
+++ b/assets/js/atomic/components/product/sale-badge/index.js
@@ -3,11 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 
 const ProductSaleBadge = ( { className, product, align } ) => {
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const alignClass =
 		typeof align === 'string'
-			? 'wc-block-grid__product-onsale--align' + align
+			? `${ layoutStyleClassPrefix }__product-onsale--align${ align }`
 			: '';
 
 	if ( product && product.on_sale ) {
@@ -16,7 +18,7 @@ const ProductSaleBadge = ( { className, product, align } ) => {
 				className={ classnames(
 					className,
 					alignClass,
-					'wc-block-grid__product-onsale'
+					`${ layoutStyleClassPrefix }__product-onsale`
 				) }
 			>
 				{ __( 'Sale', 'woo-gutenberg-products-block' ) }

--- a/assets/js/atomic/components/product/summary/index.js
+++ b/assets/js/atomic/components/product/summary/index.js
@@ -3,8 +3,10 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 
 const ProductSummary = ( { className, product } ) => {
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	if ( ! product.description ) {
 		return null;
 	}
@@ -13,7 +15,7 @@ const ProductSummary = ( { className, product } ) => {
 		<div
 			className={ classnames(
 				className,
-				'wc-block-grid__product-summary'
+				`${ layoutStyleClassPrefix }__product-summary`
 			) }
 			dangerouslySetInnerHTML={ {
 				__html: product.description,

--- a/assets/js/atomic/components/product/title/index.js
+++ b/assets/js/atomic/components/product/title/index.js
@@ -3,8 +3,15 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 
-const ProductTitle = ( { className, product, headingLevel, productLink } ) => {
+const ProductTitle = ( {
+	className,
+	product,
+	headingLevel = 2,
+	productLink = true,
+} ) => {
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	if ( ! product.name ) {
 		return null;
 	}
@@ -16,7 +23,7 @@ const ProductTitle = ( { className, product, headingLevel, productLink } ) => {
 		<TagName
 			className={ classnames(
 				className,
-				'wc-block-grid__product-title'
+				`${ layoutStyleClassPrefix }__product-title`
 			) }
 		>
 			{ productLink ? (
@@ -35,11 +42,6 @@ ProductTitle.propTypes = {
 	product: PropTypes.object.isRequired,
 	headingLevel: PropTypes.number,
 	productLink: PropTypes.bool,
-};
-
-ProductTitle.defaultProps = {
-	headingLevel: 2,
-	productLink: true,
 };
 
 export default ProductTitle;

--- a/assets/js/base/components/product-list-item/index.js
+++ b/assets/js/base/components/product-list-item/index.js
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useInnerBlockConfigurationContext } from '@woocommerce/base-context/inner-block-configuration-context';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 import withComponentId from '@woocommerce/base-hocs/with-component-id';
 
 /**
@@ -14,8 +15,9 @@ import { renderProductLayout } from './utils';
 const ProductListItem = ( { product, attributes, componentId } ) => {
 	const { layoutConfig } = attributes;
 	const { parentName } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const isLoading = ! Object.keys( product ).length > 0;
-	const classes = classnames( 'wc-block-grid__product', {
+	const classes = classnames( `${ layoutStyleClassPrefix }__product`, {
 		'is-loading': isLoading,
 	} );
 

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -11,6 +11,7 @@ import {
 	useSynchronizedQueryState,
 } from '@woocommerce/base-hooks';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
+import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
 
 /**
  * Internal dependencies
@@ -55,9 +56,8 @@ const ProductList = ( {
 	const [ queryState ] = useSynchronizedQueryState(
 		generateQuery( { attributes, sortValue, currentPage } )
 	);
-	// @todo should add an <ErrorBoundary> in parent component to handle any
-	// errors from the store and format etc.
 	const { products, totalProducts } = useStoreProducts( queryState );
+	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const onPaginationChange = ( newPage ) => {
 		scrollToTop( { focusableSelector: 'a, button' } );
 		onPageChange( newPage );
@@ -68,7 +68,7 @@ const ProductList = ( {
 		const alignClass = typeof align !== 'undefined' ? 'align' + align : '';
 
 		return classnames(
-			'wc-block-grid',
+			layoutStyleClassPrefix,
 			className,
 			alignClass,
 			'has-' + columns + '-columns',
@@ -94,7 +94,7 @@ const ProductList = ( {
 					value={ sortValue }
 				/>
 			) }
-			<ul className="wc-block-grid__products">
+			<ul className={ `${ layoutStyleClassPrefix }__products` }>
 				{ listProducts.map( ( product = {}, i ) => (
 					<ProductListItem
 						key={ product.id || i }

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -25,6 +25,9 @@ import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import { HAS_PRODUCTS } from '@woocommerce/block-settings';
+import { InnerBlockConfigurationProvider } from '@woocommerce/base-context/inner-block-configuration-context';
+import { ProductLayoutContextProvider } from '@woocommerce/base-context/product-layout-context';
+import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Internal dependencies
@@ -41,6 +44,12 @@ import {
 } from '../base-utils';
 import { getSharedContentControls, getSharedListControls } from '../edit';
 import Block from './block';
+
+const layoutContextConfig = {
+	layoutStyleClassPrefix: 'wc-block-grid',
+};
+
+const parentBlockConfig = { parentName: 'woocommerce/all-products' };
 
 /**
  * Component to handle edit mode of "All Products".
@@ -274,16 +283,24 @@ class Editor extends Component {
 		}
 
 		return (
-			<div
-				className={ getBlockClassName(
-					'wc-block-all-products',
-					attributes
-				) }
-			>
-				{ this.getBlockControls() }
-				{ this.getInspectorControls() }
-				{ isEditing ? this.renderEditMode() : this.renderViewMode() }
-			</div>
+			<BlockErrorBoundary>
+				<InnerBlockConfigurationProvider value={ parentBlockConfig }>
+					<ProductLayoutContextProvider value={ layoutContextConfig }>
+						<div
+							className={ getBlockClassName(
+								'wc-block-all-products',
+								attributes
+							) }
+						>
+							{ this.getBlockControls() }
+							{ this.getInspectorControls() }
+							{ isEditing
+								? this.renderEditMode()
+								: this.renderViewMode() }
+						</div>
+					</ProductLayoutContextProvider>
+				</InnerBlockConfigurationProvider>
+			</BlockErrorBoundary>
 		);
 	};
 }


### PR DESCRIPTION
This completes another task on #1094

In this pull, 
- `useProductLayoutContext` is implemented in all components within the `All Products` tree, thus using whatever is provided to that tree via `ProductLayoutContextProvider` for the `layoutStyleClassPrefix` (currently `wc-block-grid`).  This should help simplify switching between grid view and list view (and passing through any other context values that might be needed in the tree for a particular layout).
- the `edit` context for the `All Products` block (which shows inner blocks template) did not have the wrapping providers on it - so I added that.

## To Test

- no existing automated tests should fail
- smoke test the `All Products` block with all inner blocks active and make sure functionality works as expected.  Also check the classnames for each component in the grid and ensure the appropriate `wc-block-grid` css class name is present.  You'll know there's something missing if you see a pattern where a css class is prefixed with `__` instead of `wc-block-grid__`