### PR TITLE
Filter block previews

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -36,7 +36,7 @@ const AttributeFilterBlock = ( {
 	const getLabel = useCallback(
 		( name, count ) => {
 			return (
-				<Fragment key="label">
+				<Fragment>
 					{ name }
 					{ blockAttributes.showCounts && count !== null && (
 						<span className="wc-block-attribute-filter-list-count">

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -20,7 +20,7 @@ import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundar
  * Internal dependencies
  */
 import './style.scss';
-import { getAttributeFromID } from '../../utils/attributes';
+import { getAttributeFromID, attributeObjects } from '../../utils/attributes';
 import { updateAttributeFilter } from '../../utils/attributes-query';
 
 /**
@@ -28,10 +28,15 @@ import { updateAttributeFilter } from '../../utils/attributes-query';
  */
 const AttributeFilterBlock = ( {
 	attributes: blockAttributes,
-	isPreview = false,
+	isEditor = false,
 } ) => {
 	const [ displayedOptions, setDisplayedOptions ] = useState( [] );
-	const attributeObject = getAttributeFromID( blockAttributes.attributeId );
+
+	const attributeObject =
+		blockAttributes.isPreview && ! blockAttributes.attributeId
+			? attributeObjects[ 0 ]
+			: getAttributeFromID( blockAttributes.attributeId );
+
 	const [ queryState ] = useQueryStateByContext();
 	const [
 		productAttributesQuery,
@@ -223,7 +228,7 @@ const AttributeFilterBlock = ( {
 
 	return (
 		<BlockErrorBoundary>
-			{ ! isPreview && blockAttributes.heading && (
+			{ ! isEditor && blockAttributes.heading && (
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
 			<div className="wc-block-attribute-filter">

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -29,7 +29,9 @@ import { IconExternal } from '../../components/icons';
 import ToggleButtonControl from '../../components/toggle-button-control';
 
 const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
-	const [ isEditing, setIsEditing ] = useState( ! attributes.attributeId );
+	const [ isEditing, setIsEditing ] = useState(
+		! attributes.attributeId && ! attributes.isPreview
+	);
 
 	const getBlockControls = () => {
 		return (
@@ -331,7 +333,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 						/>
 					</TagName>
 					<Disabled>
-						<Block attributes={ attributes } isPreview />
+						<Block attributes={ attributes } isEditor />
 					</Disabled>
 				</Fragment>
 			) }

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -23,6 +23,11 @@ registerBlockType( 'woocommerce/attribute-filter', {
 		'woo-gutenberg-products-block'
 	),
 	supports: {},
+	example: {
+		attributes: {
+			isPreview: true,
+		},
+	},
 	attributes: {
 		attributeId: {
 			type: 'number',
@@ -46,6 +51,13 @@ registerBlockType( 'woocommerce/attribute-filter', {
 		headingLevel: {
 			type: 'number',
 			default: 3,
+		},
+		/**
+		 * Are we previewing?
+		 */
+		isPreview: {
+			type: 'boolean',
+			default: false,
 		},
 	},
 	edit,

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -23,6 +23,7 @@ registerBlockType( 'woocommerce/price-filter', {
 		'woo-gutenberg-products-block'
 	),
 	supports: {},
+	example: {},
 	attributes: {
 		showInputFields: {
 			type: 'boolean',

--- a/assets/js/utils/attributes.js
+++ b/assets/js/utils/attributes.js
@@ -22,7 +22,7 @@ const attributeSettingToObject = ( attribute ) => {
 /**
  * Format all attribute settings into objects.
  */
-const attributeObjects = ATTRIBUTES.reduce( ( acc, current ) => {
+export const attributeObjects = ATTRIBUTES.reduce( ( acc, current ) => {
 	const attributeObject = attributeSettingToObject( current );
 
 	if ( attributeObject.id ) {

--- a/assets/js/utils/attributes.js
+++ b/assets/js/utils/attributes.js
@@ -22,7 +22,7 @@ const attributeSettingToObject = ( attribute ) => {
 /**
  * Format all attribute settings into objects.
  */
-export const attributeObjects = ATTRIBUTES.reduce( ( acc, current ) => {
+const attributeObjects = ATTRIBUTES.reduce( ( acc, current ) => {
 	const attributeObject = attributeSettingToObject( current );
 
 	if ( attributeObject.id ) {


### PR DESCRIPTION
Adds previews for the price and attribute filter blocks.

Price is straightforward, just needed `example` to be defined.

Attributes was more involved; I added some sample terms to avoid API requests, and made use of the new `shouldSelect` option on `useCollection` to avoid it trying to query non-existent taxonomies.

Also renamed `isPreview` to `isEditor` so that distinction is more clear.

Closes #1031

### How to test the changes in this Pull Request:

1. With latest Gutenberg, create post, use the block inserter.
2. Check Filter by Price shows a preview of the slider.
3. Check filter by attribute shows a preview of a checkbox list.
4. Insert the blocks and ensure they still work as normal.