### PR TITLE
Add on_sale to Store API for it to work.

### DIFF
--- a/assets/js/atomic/components/product/sale-badge/index.js
+++ b/assets/js/atomic/components/product/sale-badge/index.js
@@ -10,7 +10,7 @@ const ProductSaleBadge = ( { className, product, align } ) => {
 			? 'wc-block-grid__product-onsale--align' + align
 			: '';
 
-	if ( product && product.onsale ) {
+	if ( product && product.on_sale ) {
 		return (
 			<div
 				className={ classnames(

--- a/assets/js/previews/products.js
+++ b/assets/js/previews/products.js
@@ -52,6 +52,6 @@ export const previewProducts = [
 		has_options: false,
 		is_purchasable: true,
 		is_in_stock: true,
-		onsale: true,
+		on_sale: true,
 	},
 ];

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -59,6 +59,12 @@ class ProductSchema extends AbstractSchema {
 				'type'        => 'string',
 				'context'     => array( 'view', 'edit' ),
 			),
+			'on_sale'        => array(
+				'description' => __( 'Is the product on sale?', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
 			'sku'            => array(
 				'description' => __( 'Unique identifier.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
@@ -254,6 +260,7 @@ class ProductSchema extends AbstractSchema {
 			'permalink'      => $product->get_permalink(),
 			'sku'            => $product->get_sku(),
 			'description'    => apply_filters( 'woocommerce_short_description', $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ),
+			'on_sale'        => $product->is_on_sale(),
 			'prices'         => $this->get_prices( $product ),
 			'average_rating' => $product->get_average_rating(),
 			'review_count'   => $product->get_review_count(),

--- a/tests/php/RestApi/StoreApi/Controllers/Products.php
+++ b/tests/php/RestApi/StoreApi/Controllers/Products.php
@@ -57,6 +57,7 @@ class Products extends TestCase {
 		$this->assertEquals( $this->products[0]->is_in_stock(), $data['is_in_stock'] );
 		$this->assertEquals( $this->products[0]->add_to_cart_text(), $data['add_to_cart']['text'] );
 		$this->assertEquals( $this->products[0]->add_to_cart_description(), $data['add_to_cart']['description'] );
+		$this->assertEquals( $this->products[0]->is_on_sale(), $data['on_sale'] );
 	}
 
 	/**
@@ -73,6 +74,7 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'variation', $data[0] );
 		$this->assertArrayHasKey( 'permalink', $data[0] );
 		$this->assertArrayHasKey( 'description', $data[0] );
+		$this->assertArrayHasKey( 'on_sale', $data[0] );
 		$this->assertArrayHasKey( 'sku', $data[0] );
 		$this->assertArrayHasKey( 'prices', $data[0] );
 		$this->assertArrayHasKey( 'average_rating', $data[0] );
@@ -96,6 +98,7 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'variation', $schema['properties'] );
 		$this->assertArrayHasKey( 'permalink', $schema['properties'] );
 		$this->assertArrayHasKey( 'description', $schema['properties'] );
+		$this->assertArrayHasKey( 'on_sale', $schema['properties'] );
 		$this->assertArrayHasKey( 'sku', $schema['properties'] );
 		$this->assertArrayHasKey( 'prices', $schema['properties'] );
 		$this->assertArrayHasKey( 'average_rating', $schema['properties'] );
@@ -119,6 +122,7 @@ class Products extends TestCase {
 		$this->assertArrayHasKey( 'variation', $response->get_data() );
 		$this->assertArrayHasKey( 'permalink', $response->get_data() );
 		$this->assertArrayHasKey( 'description', $response->get_data() );
+		$this->assertArrayHasKey( 'on_sale', $response->get_data() );
 		$this->assertArrayHasKey( 'sku', $response->get_data() );
 		$this->assertArrayHasKey( 'prices', $response->get_data() );
 		$this->assertArrayHasKey( 'average_rating', $response->get_data() );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR was raised by @nerrad in slack, `on_sale` wasn’t showing for products that are on sale and while on sale was active, this is because `on_sale` wasn’t added to the `wc/store/products` endpoints.
It also updates the atomic On Sale block and preview to use `on_sale` instead of `onsale`.
It adds `on_sale` to the store tests.


### Screenshots
![image](https://user-images.githubusercontent.com/6165348/68964871-b4743100-07da-11ea-99f5-28efb19cb072.png)

### How to test the changes in this Pull Request:

1. Have a product that is on sale
2. Make sure on sale badge is visible by editing All Product and checking it
3. See the badge

<!-- If you can, add the appropriate labels -->

### Changelog
- update `onsale` to `on_sale` to align with Woo Core
- add `on_sale` to store API
