### PR TITLE
Add support for image for product categories block

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -30,7 +30,7 @@ const EmptyPlaceHolder = () => (
  */
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	const getInspectorControls = () => {
-		const { hasCount, hasEmpty, isDropdown, isHierarchical } = attributes;
+		const { hasCount, hasImage, hasEmpty, isDropdown, isHierarchical } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -57,6 +57,27 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 						checked={ hasCount }
 						onChange={ () =>
 							setAttributes( { hasCount: ! hasCount } )
+						}
+					/>
+                    <ToggleControl
+						label={ __(
+							'Show category image',
+							'woo-gutenberg-products-block'
+						) }
+						help={
+							hasImage
+								? __(
+										'Category image is visible.',
+										'woo-gutenberg-products-block'
+								  )
+								: __(
+										'Category image is hidden.',
+										'woo-gutenberg-products-block'
+								  )
+						}
+						checked={ hasImage }
+						onChange={ () =>
+							setAttributes( { hasImage: ! hasImage } )
 						}
 					/>
 					<ToggleControl

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -30,6 +30,7 @@ registerBlockType( 'woocommerce/product-categories', {
 	example: {
 		attributes: {
 			hasCount: true,
+            hasImage: true,
 		},
 	},
 	attributes: {
@@ -39,6 +40,14 @@ registerBlockType( 'woocommerce/product-categories', {
 		hasCount: {
 			type: 'boolean',
 			default: true,
+		},
+
+        /**
+		 * Whether to show the category image in each category.
+		 */
+		hasImage: {
+			type: 'boolean',
+			default: false,
 		},
 
 		/**
@@ -77,6 +86,13 @@ registerBlockType( 'woocommerce/product-categories', {
 					selector: 'div',
 					attribute: 'data-has-count',
 				},
+                hasImage: {
+					type: 'boolean',
+					default: false,
+					source: 'attribute',
+					selector: 'div',
+					attribute: 'data-has-image',
+				},
 				hasEmpty: {
 					type: 'boolean',
 					default: false,
@@ -105,6 +121,7 @@ registerBlockType( 'woocommerce/product-categories', {
 			save( props ) {
 				const {
 					hasCount,
+					hasImage,
 					hasEmpty,
 					isDropdown,
 					isHierarchical,
@@ -112,6 +129,9 @@ registerBlockType( 'woocommerce/product-categories', {
 				const data = {};
 				if ( hasCount ) {
 					data[ 'data-has-count' ] = true;
+				}
+                if ( hasImage ) {
+					data[ 'data-has-image' ] = true;
 				}
 				if ( hasEmpty ) {
 					data[ 'data-has-empty' ] = true;

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -28,6 +28,7 @@ class ProductCategories extends AbstractDynamicBlock {
 	 */
 	protected $defaults = array(
 		'hasCount'       => true,
+		'hasImage'       => false,
 		'hasEmpty'       => false,
 		'isDropdown'     => false,
 		'isHierarchical' => true,
@@ -44,6 +45,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			array(
 				'className'      => $this->get_schema_string(),
 				'hasCount'       => $this->get_schema_boolean( true ),
+				'hasImage'       => $this->get_schema_boolean( false ),
 				'hasEmpty'       => $this->get_schema_boolean( false ),
 				'isDropdown'     => $this->get_schema_boolean( false ),
 				'isHierarchical' => $this->get_schema_boolean( true ),
@@ -256,12 +258,13 @@ class ProductCategories extends AbstractDynamicBlock {
 	 */
 	protected function renderListItems( $categories, $attributes, $uid, $depth = 0 ) {
 		$output = '';
+        $image_size = 'large';
 
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
 					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">
-						' . esc_html( $category->name ) . '
+						' . $this->get_image_html( $category, $image_size ) . esc_html( $category->name ) . '
 					</a>
 					' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
@@ -270,6 +273,24 @@ class ProductCategories extends AbstractDynamicBlock {
 		}
 
 		return $output;
+	}
+
+    /**
+	 * Returns the category image html
+	 *
+	 * @param \WP_Term $category Term object.
+	 * @param string   $size    Image size, defaults to 'full'.
+	 * @return string
+	 */
+	public function get_image_html( $category, $size = 'full' ) {
+		$image_html    = '';
+		$image_id = get_term_meta( $category->term_id, 'thumbnail_id', true );
+
+		if ( $image_id ) {
+			$image_html = wp_get_attachment_image( $image_id, $size );
+		}
+
+		return $image_html;
 	}
 
 	/**


### PR DESCRIPTION
Add option for showing image to product categories block.

https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1188

### Screenshots
### Before
![new-show-image-option-before](https://user-images.githubusercontent.com/9271436/69014906-22615980-098f-11ea-87dc-161e7abf63fb.png)
### Added feature
![new-show-image-option](https://user-images.githubusercontent.com/9271436/69014843-b5e65a80-098e-11ea-8ba0-e8912a467a52.png)



### How to test the changes in this Pull Request:

1. Select a Product Categories List block in Gutenberg editor. 
2. Notice the new option 'Show category image' (disabled by default).
3. Toggle the option, notice how the image is added and shown/not shown per category item.

<!-- If you can, add the appropriate labels -->

### Changelog
Add option for showing category image for Product Categories List block.
