### PR TITLE
Add All Blocks and filter blocks to readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -57,6 +57,18 @@ Show a list of all product reviews on a landing page, blog post or any other pag
 **Product Search**
 Help shoppers find your products by placing a search box in specific locations.
 
+**All Products**
+Display all products from your store as a grid with pagination and sorting options. Requires WordPress 5.3.
+
+**Filter Products by Price**
+Display a slider to filter products in your store by price. Works in combination with the _All Products_ block. Requires WordPress 5.3.
+
+**Filter Products by Attribute**
+Display a list of filters based on a chosen product attribute. Works in combination with the _All Products_ block. Requires WordPress 5.3.
+
+**Active Product Filters**
+Display a list of active product filters. Works in combination with the _Filter Products by Price_ and _Filter Products by Attribute_ block. Requires WordPress 5.3.
+
 We've also improved the category selection filter. If you select two or more categories, you can now chose to show products that include ANY or ALL selected categories.
 
 == Getting Started ==


### PR DESCRIPTION
Adds a description in `readme.txt` for all blocks added in 2.5, with a note that they require WordPress 5.3.