### PR TITLE
All products - Use same query for headers as collection

### DIFF
--- a/assets/js/base/hooks/use-store-products.js
+++ b/assets/js/base/hooks/use-store-products.js
@@ -32,11 +32,9 @@ export const useStoreProducts = ( query ) => {
 		...collectionOptions,
 		query,
 	} );
-	// eslint-disable-next-line no-unused-vars, camelcase
-	const { order, orderby, page, per_page, ...totalQuery } = query;
 	const { value: totalProducts } = useCollectionHeader( 'x-wp-total', {
 		...collectionOptions,
-		query: totalQuery,
+		query,
 	} );
 	return {
 		products,


### PR DESCRIPTION
Pinging @Aljullu because you made this change.

When gathering pagination headers the `useStoreProducts` was removing query vars which don't impact pagination. Whilst this is valid, it causes a 2nd API request to fire because the query vars do not match the original `useCollection` hook (it caches the request and response).

By using the same query vars only a single API request is made which is more efficient.

### How to test the changes in this Pull Request:

Test that the all products block pagination works as expected. In the `network` console, check only one API request is made to the `products` endpoint on page load.
