### PR TITLE
All Products: avoid pagination disappearing when switching pages/changing sort value (take 2)

### DIFF
--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -86,7 +86,7 @@ const ProductList = ( {
 		if ( previousPage === queryState.page && isInitialized.current ) {
 			onPageChange( 1 );
 		}
-	}, [ queryState ] );
+	}, [ queryState.page ] );
 	const results = useStoreProducts( queryState );
 	const { products, productsLoading } = results;
 	const totalProducts = parseInt( results.totalProducts );

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -95,8 +95,8 @@ const ProductList = ( {
 			onPageChange( 1 );
 		}
 	}, [ queryState ] );
-    const results = useStoreProducts( queryState );
-    const { products, productsLoading } = results;
+	const results = useStoreProducts( queryState );
+	const { products, productsLoading } = results;
 	const totalProducts = parseInt( results.totalProducts );
 
 	useEffect( () => {
@@ -106,13 +106,7 @@ const ProductList = ( {
 	}, [ productsLoading ] );
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const previousTotalProducts = usePrevious( totalProducts, Number.isFinite );
-    if ( 
-        ! Number.isFinite( totalProducts ) &&
-        areQueryFiltersTheSame( queryState, previousQueryState )
-    ) {
-        totalProducts = previousTotalProducts;
-    }
-    const previousQueryState = usePrevious( queryState );
+	const previousQueryState = usePrevious( queryState );
 	const onPaginationChange = ( newPage ) => {
 		scrollToTop( { focusableSelector: 'a, button' } );
 		onPageChange( newPage );

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 import Pagination from '@woocommerce/base-components/pagination';
 import ProductSortSelect from '@woocommerce/base-components/product-sort-select';
 import ProductListItem from '@woocommerce/base-components/product-list-item';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import {
 	usePrevious,
 	useStoreProducts,
@@ -78,17 +78,10 @@ const ProductList = ( {
 			currentPage,
 		} )
 	);
-	const previousPage = usePrevious( queryState.page );
-	const isInitialized = useRef( false );
 	const results = useStoreProducts( queryState );
-	const { products, productsLoading } = results;
+	const { products } = results;
 	const totalProducts = parseInt( results.totalProducts );
 
-	useEffect( () => {
-		if ( ! productsLoading ) {
-			isInitialized.current = true;
-		}
-	}, [ productsLoading ] );
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const totalQuery = extractPaginationAndSortAttributes( queryState );
 	// Only update previous query totals if the query is different and
@@ -106,13 +99,9 @@ const ProductList = ( {
 		typeof previousQueryTotals === 'object' &&
 		isEqual( totalQuery, previousQueryTotals.totalQuery );
 	useEffect( () => {
-		// if page did not change in the query state then that means something
-		// else changed and we should reset the current page number
-		if (
-			! isPreviousTotalQueryEqual &&
-			previousPage === queryState.page &&
-			isInitialized.current
-		) {
+		// If query state (excluding pagination/sorting attributes) changed,
+		// reset pagination to the first page.
+		if ( ! isPreviousTotalQueryEqual ) {
 			onPageChange( 1 );
 		}
 	}, [ queryState ] );
@@ -120,7 +109,6 @@ const ProductList = ( {
 	const onPaginationChange = ( newPage ) => {
 		scrollToTop( { focusableSelector: 'a, button' } );
 		onPageChange( newPage );
-		isInitialized.current = false;
 	};
 
 	const getClassnames = () => {

--- a/assets/js/base/hooks/test/use-previous.js
+++ b/assets/js/base/hooks/test/use-previous.js
@@ -9,8 +9,8 @@ import TestRenderer, { act } from 'react-test-renderer';
 import { usePrevious } from '../use-previous';
 
 describe( 'usePrevious', () => {
-	const TestComponent = ( { testValue } ) => {
-		const previousValue = usePrevious( testValue );
+	const TestComponent = ( { testValue, validation } ) => {
+		const previousValue = usePrevious( testValue, validation );
 		return <div testValue={ testValue } previousValue={ previousValue } />;
 	};
 
@@ -53,5 +53,37 @@ describe( 'usePrevious', () => {
 			.previousValue;
 		expect( testValue ).toBe( 3 );
 		expect( testPreviousValue ).toBe( 2 );
+	} );
+
+	it( 'should not update value if validation fails', () => {
+		let testValue;
+		let testPreviousValue;
+		act( () => {
+			renderer = TestRenderer.create(
+				<TestComponent testValue={ 1 } validation={ Number.isFinite } />
+			);
+		} );
+
+		act( () => {
+			renderer.update(
+				<TestComponent testValue="abc" validation={ Number.isFinite } />
+			);
+		} );
+		testValue = renderer.root.findByType( 'div' ).props.testValue;
+		testPreviousValue = renderer.root.findByType( 'div' ).props
+			.previousValue;
+		expect( testValue ).toBe( 'abc' );
+		expect( testPreviousValue ).toBe( 1 );
+
+		act( () => {
+			renderer.update(
+				<TestComponent testValue={ 3 } validation={ Number.isFinite } />
+			);
+		} );
+		testValue = renderer.root.findByType( 'div' ).props.testValue;
+		testPreviousValue = renderer.root.findByType( 'div' ).props
+			.previousValue;
+		expect( testValue ).toBe( 3 );
+		expect( testPreviousValue ).toBe( 1 );
 	} );
 } );

--- a/assets/js/base/hooks/use-previous.js
+++ b/assets/js/base/hooks/use-previous.js
@@ -13,10 +13,13 @@ export const usePrevious = ( value, validation ) => {
 	const ref = useRef();
 
 	useEffect( () => {
-		if ( ! validation || validation( value ) ) {
+		if (
+			ref.current !== value &&
+			( ! validation || validation( value, ref.current ) )
+		) {
 			ref.current = value;
 		}
-	}, [ value ] );
+	}, [ value, ref.current ] );
 
 	return ref.current;
 };

--- a/assets/js/base/hooks/use-previous.js
+++ b/assets/js/base/hooks/use-previous.js
@@ -4,14 +4,18 @@
 import { useRef, useEffect } from 'react';
 
 /**
- * Use Previous from https://usehooks.com/usePrevious/.
- * @param {mixed} value
+ * Use Previous based on https://usehooks.com/usePrevious/.
+ * @param {mixed}    value
+ * @param {Function} [validation] Function that needs to validate for the value
+ *                                to be updated.
  */
-export const usePrevious = ( value ) => {
+export const usePrevious = ( value, validation ) => {
 	const ref = useRef();
 
 	useEffect( () => {
-		ref.current = value;
+		if ( ! validation || validation( value ) ) {
+			ref.current = value;
+		}
 	}, [ value ] );
 
 	return ref.current;

--- a/assets/js/base/hooks/use-store-products.js
+++ b/assets/js/base/hooks/use-store-products.js
@@ -32,11 +32,9 @@ export const useStoreProducts = ( query ) => {
 		...collectionOptions,
 		query,
 	} );
-	// eslint-disable-next-line no-unused-vars, camelcase
-	const { order, orderby, page, per_page, ...totalQuery } = query;
 	const { value: totalProducts } = useCollectionHeader( 'x-wp-total', {
 		...collectionOptions,
-		query: totalQuery,
+		query,
 	} );
 	return {
 		products,


### PR DESCRIPTION
Same as #1144 but implementing it in the component side (doing it in the store caused problems: see #1196).

When loading a new page or changing the sort order for the same query, we want to preserve the total number of products which is used for the pagination. This way, the pagination component doesn't disappear and appear on every change.

In the other hand, when applying a filter, we can't reuse the total number of products because it might be different.

### Screenshots
_Before (branch `fix/reduce-products-endpoint-requests`):_
![Peek 2019-11-18 18-01-before](https://user-images.githubusercontent.com/3616980/69073323-833f6f00-0a2d-11ea-8350-548d947b3e20.gif)

_After:_
![Peek 2019-11-18 17-58-after](https://user-images.githubusercontent.com/3616980/69073331-863a5f80-0a2d-11ea-89bd-bed33dd9de9f.gif)

### How to test the changes in this Pull Request:

1. Create a post with the _All Products_ and a filter block.
2. Click on a page number.
3. Verify the pagination buttons are still visible while the next page is loading.
4. Change the sort order.
5. Verify the pagination buttons are visible while loading.
6. Activate a filter.
7. Verify the pagination buttons are not visible while loading.

cc @mikejolley 