### PR TITLE
Fix: Page selection will reset to 1 after deselecting filterable item, re-sorting products, and selecting new page.

### DIFF
--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -56,7 +56,11 @@ const ProductList = ( {
 	scrollToTop,
 } ) => {
 	const [ queryState ] = useSynchronizedQueryState(
-		generateQuery( { attributes, sortValue, currentPage } )
+		generateQuery( {
+			attributes,
+			sortValue,
+			currentPage,
+		} )
 	);
 	const previousPage = usePrevious( queryState.page );
 	const isInitialized = useRef( false );
@@ -81,6 +85,7 @@ const ProductList = ( {
 	const onPaginationChange = ( newPage ) => {
 		scrollToTop( { focusableSelector: 'a, button' } );
 		onPageChange( newPage );
+		isInitialized.current = false;
 	};
 
 	const getClassnames = () => {

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -71,6 +71,7 @@ const ProductList = ( {
 	const { products, totalProducts, productsLoading } = useStoreProducts(
 		queryState
 	);
+
 	useEffect( () => {
 		if ( ! productsLoading ) {
 			isInitialized.current = true;


### PR DESCRIPTION
@Aljullu reported this as a regression introduced here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1202#pullrequestreview-318910251

## To Test

- Activate an Attribute Filter.
- Deactivate it.
- Change the Sort value.
- Go to a page different from 1.
- Page change should stick.

Also do smoke testing of other things as well (changing other filters, sort order and then going through pages etc). Also ensure there's no regression with what #1202 fixed.