### PR TITLE
Move ErrorBoundary to renderFrontend() function

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -14,7 +14,6 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
-import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Internal dependencies
@@ -247,7 +246,7 @@ const AttributeFilterBlock = ( {
 	const TagName = `h${ blockAttributes.headingLevel }`;
 
 	return (
-		<BlockErrorBoundary>
+		<Fragment>
 			{ ! isEditor && blockAttributes.heading && (
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
@@ -265,7 +264,7 @@ const AttributeFilterBlock = ( {
 					}
 				/>
 			</div>
-		</BlockErrorBoundary>
+		</Fragment>
 	);
 };
 

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -7,11 +7,10 @@ import {
 	useQueryStateByContext,
 	usePrevious,
 } from '@woocommerce/base-hooks';
-import { useCallback, useState, useEffect } from '@wordpress/element';
+import { Fragment, useCallback, useState, useEffect } from '@wordpress/element';
 import PriceSlider from '@woocommerce/base-components/price-slider';
 import { CURRENCY } from '@woocommerce/settings';
 import { useDebouncedCallback } from 'use-debounce';
-import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Component displaying a price filter.
@@ -151,7 +150,7 @@ const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
 	const TagName = `h${ attributes.headingLevel }`;
 
 	return (
-		<BlockErrorBoundary>
+		<Fragment>
 			{ ! isPreview && attributes.heading && (
 				<TagName>{ attributes.heading }</TagName>
 			) }
@@ -171,7 +170,7 @@ const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
 					isLoading={ isLoading }
 				/>
 			</div>
-		</BlockErrorBoundary>
+		</Fragment>
 	);
 };
 

--- a/assets/js/blocks/products/all-products/block.js
+++ b/assets/js/blocks/products/all-products/block.js
@@ -7,7 +7,6 @@ import ProductListContainer from '@woocommerce/base-components/product-list/cont
 import { InnerBlockConfigurationProvider } from '@woocommerce/base-context/inner-block-configuration-context';
 import { ProductLayoutContextProvider } from '@woocommerce/base-context/product-layout-context';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
-import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 const layoutContextConfig = {
 	layoutStyleClassPrefix: 'wc-block-grid',
@@ -40,16 +39,14 @@ class Block extends Component {
 		 * wc-block-{$this->block_name},
 		 */
 		return (
-			<BlockErrorBoundary>
-				<InnerBlockConfigurationProvider value={ parentBlockConfig }>
-					<ProductLayoutContextProvider value={ layoutContextConfig }>
-						<ProductListContainer
-							attributes={ attributes }
-							urlParameterSuffix={ urlParameterSuffix }
-						/>
-					</ProductLayoutContextProvider>
-				</InnerBlockConfigurationProvider>
-			</BlockErrorBoundary>
+			<InnerBlockConfigurationProvider value={ parentBlockConfig }>
+				<ProductLayoutContextProvider value={ layoutContextConfig }>
+					<ProductListContainer
+						attributes={ attributes }
+						urlParameterSuffix={ urlParameterSuffix }
+					/>
+				</ProductLayoutContextProvider>
+			</InnerBlockConfigurationProvider>
 		);
 	}
 }

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -27,7 +27,6 @@ import GridLayoutControl from '@woocommerce/block-components/grid-layout-control
 import { HAS_PRODUCTS } from '@woocommerce/block-settings';
 import { InnerBlockConfigurationProvider } from '@woocommerce/base-context/inner-block-configuration-context';
 import { ProductLayoutContextProvider } from '@woocommerce/base-context/product-layout-context';
-import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Internal dependencies
@@ -283,24 +282,22 @@ class Editor extends Component {
 		}
 
 		return (
-			<BlockErrorBoundary>
-				<InnerBlockConfigurationProvider value={ parentBlockConfig }>
-					<ProductLayoutContextProvider value={ layoutContextConfig }>
-						<div
-							className={ getBlockClassName(
-								'wc-block-all-products',
-								attributes
-							) }
-						>
-							{ this.getBlockControls() }
-							{ this.getInspectorControls() }
-							{ isEditing
-								? this.renderEditMode()
-								: this.renderViewMode() }
-						</div>
-					</ProductLayoutContextProvider>
-				</InnerBlockConfigurationProvider>
-			</BlockErrorBoundary>
+			<InnerBlockConfigurationProvider value={ parentBlockConfig }>
+				<ProductLayoutContextProvider value={ layoutContextConfig }>
+					<div
+						className={ getBlockClassName(
+							'wc-block-all-products',
+							attributes
+						) }
+					>
+						{ this.getBlockControls() }
+						{ this.getInspectorControls() }
+						{ isEditing
+							? this.renderEditMode()
+							: this.renderViewMode() }
+					</div>
+				</ProductLayoutContextProvider>
+			</InnerBlockConfigurationProvider>
 		);
 	};
 }

--- a/assets/js/blocks/reviews/editor-block.js
+++ b/assets/js/blocks/reviews/editor-block.js
@@ -11,7 +11,6 @@ import LoadMoreButton from '@woocommerce/base-components/load-more-button';
 import ReviewList from '@woocommerce/base-components/review-list';
 import ReviewSortSelect from '@woocommerce/base-components/review-sort-select';
 import withReviews from '@woocommerce/base-hocs/with-reviews';
-import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Block rendered in the editor.
@@ -52,26 +51,20 @@ class EditorBlock extends Component {
 		}
 
 		return (
-			<BlockErrorBoundary>
-				<Disabled>
-					{ attributes.showOrderby && ENABLE_REVIEW_RATING && (
-						<ReviewSortSelect
-							readOnly
-							value={ attributes.orderby }
-						/>
-					) }
-					<ReviewList attributes={ attributes } reviews={ reviews } />
-					{ attributes.showLoadMore &&
-						totalReviews > reviews.length && (
-							<LoadMoreButton
-								screenReaderLabel={ __(
-									'Load more reviews',
-									'woo-gutenberg-products-block'
-								) }
-							/>
+			<Disabled>
+				{ attributes.showOrderby && ENABLE_REVIEW_RATING && (
+					<ReviewSortSelect readOnly value={ attributes.orderby } />
+				) }
+				<ReviewList attributes={ attributes } reviews={ reviews } />
+				{ attributes.showLoadMore && totalReviews > reviews.length && (
+					<LoadMoreButton
+						screenReaderLabel={ __(
+							'Load more reviews',
+							'woo-gutenberg-products-block'
 						) }
-				</Disabled>
-			</BlockErrorBoundary>
+					/>
+				) }
+			</Disabled>
 		);
 	}
 }

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { ENABLE_REVIEW_RATING } from '@woocommerce/block-settings';
 import LoadMoreButton from '@woocommerce/base-components/load-more-button';
 import ReviewSortSelect from '@woocommerce/base-components/review-sort-select';
 import ReviewList from '@woocommerce/base-components/review-list';
 import withReviews from '@woocommerce/base-hocs/with-reviews';
-import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Block rendered in the frontend.
@@ -27,7 +27,7 @@ const FrontendBlock = ( {
 	}
 
 	return (
-		<BlockErrorBoundary>
+		<Fragment>
 			{ attributes.showOrderby !== 'false' && ENABLE_REVIEW_RATING && (
 				<ReviewSortSelect
 					defaultValue={ orderby }
@@ -45,7 +45,7 @@ const FrontendBlock = ( {
 						) }
 					/>
 				) }
-		</BlockErrorBoundary>
+		</Fragment>
 	);
 };
 

--- a/assets/js/utils/render-frontend.js
+++ b/assets/js/utils/render-frontend.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { render } from 'react-dom';
+import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Renders a block component in the place of a specified set of selectors.
@@ -25,7 +26,12 @@ export default ( selector, Block, getProps = () => {} ) => {
 
 			el.classList.remove( 'is-loading' );
 
-			render( <Block { ...props } attributes={ attributes } />, el );
+			render(
+				<BlockErrorBoundary>
+					<Block { ...props } attributes={ attributes } />
+				</BlockErrorBoundary>,
+				el
+			);
 		} );
 	}
 };

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -121,6 +121,8 @@ const mainEntry = {
 	'price-filter': './assets/js/blocks/price-filter/index.js',
 	'attribute-filter': './assets/js/blocks/attribute-filter/index.js',
 	'active-filters': './assets/js/blocks/active-filters/index.js',
+	'block-error-boundary':
+		'./assets/js/base/components/block-error-boundary/style.scss',
 };
 
 const frontEndEntry = {


### PR DESCRIPTION
Moves the `<ErrorBoundary>` to the `errorFrontend()` function so we don't need to add it in every new JS-block we create.

### Screenshots
![image](https://user-images.githubusercontent.com/3616980/68795642-a5ae4280-0651-11ea-978c-9bde6b5911dc.png)

### How to test the changes in this Pull Request:

1. Create a post with a _Reviews_ block, an _All Products_ block and a _Price Filter_ and _Attribute Filter_.
2. Add the following line [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/components/review-sort-select/index.js#L14), [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/components/product-list/index.js#L92), [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/components/price-slider/index.js#L39) and [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/components/checkbox-list/index.js#L40), so we force those blocks to throw errors:
```diff
+ throw new Error();
```
3. Preview the previous post and verify each block shows the error message.