### PR TITLE
Honor CSS classes in editor

### DIFF
--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -124,12 +124,11 @@ const ProductList = ( {
 	};
 
 	const getClassnames = () => {
-		const { columns, rows, className, alignButtons, align } = attributes;
+		const { columns, rows, alignButtons, align } = attributes;
 		const alignClass = typeof align !== 'undefined' ? 'align' + align : '';
 
 		return classnames(
 			layoutStyleClassPrefix,
-			className,
 			alignClass,
 			'has-' + columns + '-columns',
 			{

--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { InspectorControls, PlainText } from '@wordpress/block-editor';
 import { Disabled, PanelBody, withSpokenMessages } from '@wordpress/components';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -14,9 +14,9 @@ import Block from './block.js';
 import ToggleButtonControl from '../../components/toggle-button-control';
 
 const Edit = ( { attributes, setAttributes } ) => {
-	const getInspectorControls = () => {
-		const { displayStyle } = attributes;
+	const { className, displayStyle, heading, headingLevel } = attributes;
 
+	const getInspectorControls = () => {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
@@ -63,7 +63,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 						isCollapsed={ false }
 						minLevel={ 2 }
 						maxLevel={ 7 }
-						selectedLevel={ attributes.headingLevel }
+						selectedLevel={ headingLevel }
 						onChange={ ( newLevel ) =>
 							setAttributes( { headingLevel: newLevel } )
 						}
@@ -73,15 +73,15 @@ const Edit = ( { attributes, setAttributes } ) => {
 		);
 	};
 
-	const TagName = `h${ attributes.headingLevel }`;
+	const TagName = `h${ headingLevel }`;
 
 	return (
-		<Fragment>
+		<div className={ classNames( 'is-loading', className ) }>
 			{ getInspectorControls() }
 			<TagName>
 				<PlainText
 					className="wc-block-attribute-filter-heading"
-					value={ attributes.heading }
+					value={ heading }
 					onChange={ ( value ) =>
 						setAttributes( { heading: value } )
 					}
@@ -90,7 +90,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 			<Disabled>
 				<Block attributes={ attributes } isPreview />
 			</Disabled>
-		</Fragment>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls, PlainText } from '@wordpress/block-editor';
 import { Disabled, PanelBody, withSpokenMessages } from '@wordpress/components';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -76,7 +75,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 	const TagName = `h${ headingLevel }`;
 
 	return (
-		<div className={ classNames( 'is-loading', className ) }>
+		<div className={ className }>
 			{ getInspectorControls() }
 			<TagName>
 				<PlainText

--- a/assets/js/blocks/active-filters/index.js
+++ b/assets/js/blocks/active-filters/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -45,14 +46,17 @@ registerBlockType( 'woocommerce/active-filters', {
 	 * Save the props to post content.
 	 */
 	save( { attributes } ) {
-		const { displayStyle, heading, headingLevel } = attributes;
+		const { className, displayStyle, heading, headingLevel } = attributes;
 		const data = {
 			'data-display-style': displayStyle,
 			'data-heading': heading,
 			'data-heading-level': headingLevel,
 		};
 		return (
-			<div className="is-loading" { ...data }>
+			<div
+				className={ classNames( 'is-loading', className ) }
+				{ ...data }
+			>
 				<span
 					aria-hidden
 					className="wc-block-active-product-filters__placeholder"

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -23,7 +23,6 @@ import { mapValues, toArray, sortBy, find } from 'lodash';
 import { ATTRIBUTES } from '@woocommerce/block-settings';
 import { getAdminLink } from '@woocommerce/navigation';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -333,7 +332,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			{ isEditing ? (
 				renderEditMode()
 			) : (
-				<div className={ classNames( 'is-loading', className ) }>
+				<div className={ className }>
 					<TagName>
 						<PlainText
 							className="wc-block-attribute-filter-heading"

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -34,15 +34,17 @@ import ToggleButtonControl from '../../components/toggle-button-control';
 
 const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	const {
+		attributeId,
 		className,
 		heading,
 		headingLevel,
-		showCounts,
+		isPreview,
 		queryType,
+		showCounts,
 	} = attributes;
 
 	const [ isEditing, setIsEditing ] = useState(
-		! attributes.attributeId && ! attributes.isPreview
+		! attributeId && ! isPreview
 	);
 
 	const getBlockControls = () => {
@@ -224,7 +226,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			selectedId.toString(),
 		] );
 
-		if ( ! productAttribute || attributes.attributeId === selectedId ) {
+		if ( ! productAttribute || attributeId === selectedId ) {
 			return;
 		}
 
@@ -241,8 +243,6 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	}, [] );
 
 	const renderAttributeControl = () => {
-		const { attributeId } = attributes;
-
 		const messages = {
 			clear: __(
 				'Clear selected attribute',

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -23,6 +23,7 @@ import { mapValues, toArray, sortBy, find } from 'lodash';
 import { ATTRIBUTES } from '@woocommerce/block-settings';
 import { getAdminLink } from '@woocommerce/navigation';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -33,6 +34,14 @@ import { IconExternal } from '../../components/icons';
 import ToggleButtonControl from '../../components/toggle-button-control';
 
 const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
+	const {
+		className,
+		heading,
+		headingLevel,
+		showCounts,
+		queryType,
+	} = attributes;
+
 	const [ isEditing, setIsEditing ] = useState(
 		! attributes.attributeId && ! attributes.isPreview
 	);
@@ -55,8 +64,6 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	};
 
 	const getInspectorControls = () => {
-		const { showCounts, queryType } = attributes;
-
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
@@ -95,7 +102,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 						isCollapsed={ false }
 						minLevel={ 2 }
 						maxLevel={ 7 }
-						selectedLevel={ attributes.headingLevel }
+						selectedLevel={ headingLevel }
 						onChange={ ( newLevel ) =>
 							setAttributes( { headingLevel: newLevel } )
 						}
@@ -315,7 +322,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		);
 	};
 
-	const TagName = `h${ attributes.headingLevel }`;
+	const TagName = `h${ headingLevel }`;
 
 	return Object.keys( ATTRIBUTES ).length === 0 ? (
 		noAttributesPlaceholder()
@@ -326,11 +333,11 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			{ isEditing ? (
 				renderEditMode()
 			) : (
-				<Fragment>
+				<div className={ classNames( 'is-loading', className ) }>
 					<TagName>
 						<PlainText
 							className="wc-block-attribute-filter-heading"
-							value={ attributes.heading }
+							value={ heading }
 							onChange={ ( value ) =>
 								setAttributes( { heading: value } )
 							}
@@ -339,7 +346,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 					<Disabled>
 						<Block attributes={ attributes } isEditor />
 					</Disabled>
-				</Fragment>
+				</div>
 			) }
 		</Fragment>
 	);

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -66,6 +67,7 @@ registerBlockType( 'woocommerce/attribute-filter', {
 	 */
 	save( { attributes } ) {
 		const {
+			className,
 			showCounts,
 			queryType,
 			attributeId,
@@ -80,7 +82,10 @@ registerBlockType( 'woocommerce/attribute-filter', {
 			'data-heading-level': headingLevel,
 		};
 		return (
-			<div className="is-loading" { ...data }>
+			<div
+				className={ classNames( 'is-loading', className ) }
+				{ ...data }
+			>
 				<span
 					aria-hidden
 					className="wc-block-product-attribute-filter__placeholder"

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -102,7 +102,7 @@ export default function( { attributes, setAttributes } ) {
 						isCollapsed={ false }
 						minLevel={ 2 }
 						maxLevel={ 7 }
-						selectedLevel={ attributes.headingLevel }
+						selectedLevel={ headingLevel }
 						onChange={ ( newLevel ) =>
 							setAttributes( { headingLevel: newLevel } )
 						}

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -14,7 +14,6 @@ import {
 import { PRODUCT_COUNT } from '@woocommerce/block-settings';
 import { getAdminLink } from '@woocommerce/navigation';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -159,7 +158,7 @@ export default function( { attributes, setAttributes } ) {
 			{ PRODUCT_COUNT === 0 ? (
 				noProductsPlaceholder()
 			) : (
-				<div className={ classNames( 'is-loading', className ) }>
+				<div className={ className }>
 					{ getInspectorControls() }
 					<TagName>
 						<PlainText

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -14,6 +14,7 @@ import {
 import { PRODUCT_COUNT } from '@woocommerce/block-settings';
 import { getAdminLink } from '@woocommerce/navigation';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -24,9 +25,15 @@ import { IconMoney, IconExternal } from '../../components/icons';
 import ToggleButtonControl from '../../components/toggle-button-control';
 
 export default function( { attributes, setAttributes } ) {
-	const getInspectorControls = () => {
-		const { showInputFields, showFilterButton } = attributes;
+	const {
+		className,
+		heading,
+		headingLevel,
+		showInputFields,
+		showFilterButton,
+	} = attributes;
 
+	const getInspectorControls = () => {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
@@ -145,19 +152,19 @@ export default function( { attributes, setAttributes } ) {
 		</Placeholder>
 	);
 
-	const TagName = `h${ attributes.headingLevel }`;
+	const TagName = `h${ headingLevel }`;
 
 	return (
 		<Fragment>
 			{ PRODUCT_COUNT === 0 ? (
 				noProductsPlaceholder()
 			) : (
-				<Fragment>
+				<div className={ classNames( 'is-loading', className ) }>
 					{ getInspectorControls() }
 					<TagName>
 						<PlainText
 							className="wc-block-attribute-filter-heading"
-							value={ attributes.heading }
+							value={ heading }
 							onChange={ ( value ) =>
 								setAttributes( { heading: value } )
 							}
@@ -166,7 +173,7 @@ export default function( { attributes, setAttributes } ) {
 					<Disabled>
 						<Block attributes={ attributes } isPreview />
 					</Disabled>
-				</Fragment>
+				</div>
 			) }
 		</Fragment>
 	);

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -50,6 +51,7 @@ registerBlockType( 'woocommerce/price-filter', {
 	 */
 	save( { attributes } ) {
 		const {
+			className,
 			showInputFields,
 			showFilterButton,
 			heading,
@@ -62,7 +64,10 @@ registerBlockType( 'woocommerce/price-filter', {
 			'data-heading-level': headingLevel,
 		};
 		return (
-			<div className="is-loading" { ...data }>
+			<div
+				className={ classNames( 'is-loading', className ) }
+				{ ...data }
+			>
 				<span
 					aria-hidden
 					className="wc-block-product-categories__placeholder"


### PR DESCRIPTION
Additional CSS classes are implemented inconsistently in the new blocks added in 2.5. This PR should fix that.

### Screenshots

![image](https://user-images.githubusercontent.com/3616980/69225107-066fda80-0b7e-11ea-970c-7187b92889a4.png)

### How to test the changes in this Pull Request:

1. Create a post with an _All Blocks_, _Active Filters_, _Filter by Price_ and _Filter by Attribute_ blocks.
2. Add an additional CSS class to each block (for example, `test-1`, `test-2`, etc.).
3. Using your browser devtools, in the editor search for elements with those classes (`.test-1`, `.test-2`, etc.) and verify there is one and only one.
4. Preview the post and verify there is only one element with each class in the frontend as well.

### Changelog

> Honor CSS classes in the editor for blocks added in 2.5.