### PR TITLE
Price Slider -- Only do instant updates if filter button is disabled

### DIFF
--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -75,7 +75,7 @@ const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
 		if ( ! attributes.showFilterButton ) {
 			debouncedUpdateQuery();
 		}
-	}, [ minPrice, maxPrice, attributes ] );
+	}, [ minPrice, maxPrice, attributes.showFilterButton ] );
 
 	// Track PRICE QUERY changes so the slider reflects current filters.
 	useEffect( () => {

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -72,8 +72,10 @@ const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
 
 	// Track price STATE changes - if state changes, update the query.
 	useEffect( () => {
-		debouncedUpdateQuery();
-	}, [ minPrice, maxPrice ] );
+		if ( ! attributes.showFilterButton ) {
+			debouncedUpdateQuery();
+		}
+	}, [ minPrice, maxPrice, attributes ] );
 
 	// Track PRICE QUERY changes so the slider reflects current filters.
 	useEffect( () => {


### PR DESCRIPTION
The price filter block has a `useEffect` to track state changes and update the query. This should only run if the filter button is disabled, otherwise query updates should be manual.

Fixes #1211

### How to test the changes in this Pull Request:

1. Test all products with price slider
2. Enable the filter button in block settings
3. Change the range slider. Nothing should update. Click the button. The products should then update.
4. Disable the filter button and ensure original behaviour still exists.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix the price slider filter button.
