### PR TITLE
All Products title block - level -> headingLevel

### DIFF
--- a/assets/js/atomic/blocks/product/title/index.js
+++ b/assets/js/atomic/blocks/product/title/index.js
@@ -30,7 +30,7 @@ const blockConfig = {
 			type: 'object',
 			default: previewProducts[ 0 ],
 		},
-		level: {
+		headingLevel: {
 			type: 'number',
 			default: 2,
 		},
@@ -41,7 +41,7 @@ const blockConfig = {
 	},
 	edit( props ) {
 		const { attributes, setAttributes } = props;
-		const { level, productLink } = attributes;
+		const { headingLevel, productLink } = attributes;
 
 		return (
 			<Fragment>
@@ -57,9 +57,9 @@ const blockConfig = {
 							isCollapsed={ false }
 							minLevel={ 2 }
 							maxLevel={ 7 }
-							selectedLevel={ level }
+							selectedLevel={ headingLevel }
 							onChange={ ( newLevel ) =>
-								setAttributes( { level: newLevel } )
+								setAttributes( { headingLevel: newLevel } )
 							}
 						/>
 						<ToggleControl
@@ -82,7 +82,7 @@ const blockConfig = {
 				</InspectorControls>
 				<Disabled>
 					<ProductTitle
-						headingLevel={ level }
+						headingLevel={ headingLevel }
 						productLink={ productLink }
 						product={ attributes.product }
 					/>


### PR DESCRIPTION
Atomic block attributes need to match the naming of the component's props, otherwise when the layout map is rendered, those attributes won't be recognised.

This PR fixes the name of the `level` attribute of the title block to be `headingLevel` which matches component props.

Fixes #1229

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. Edit the all products block content.
2. Change the title block heading level to 5. Click done, then save.
3. Inspector source on frontend and confirm it's h5.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix heading level setting for the All Products Title Block.
