### PR TITLE
Fix price slider layout in narrow columns

### DIFF
--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -70,17 +70,14 @@
 
 	.wc-block-price-filter__controls {
 		display: flex;
-		flex-flow: row nowrap;
-		justify-content: flex-start;
-		align-items: center;
 		margin: 0 0 20px;
 
 		.wc-block-price-filter__amount {
 			margin: 0;
 			border-radius: 4px;
 			width: auto;
-			flex-grow: 2;
 			max-width: 100px;
+			min-width: 0;
 
 			&.wc-block-price-filter__amount--min {
 				margin-right: 10px;
@@ -89,10 +86,6 @@
 				margin-left: auto;
 			}
 		}
-
-		.wc-block-price-filter__button {
-			margin-left: auto;
-		}
 	}
 	&.wc-block-price-filter--has-filter-button {
 		.wc-block-price-filter__controls {
@@ -100,6 +93,12 @@
 
 			.wc-block-price-filter__amount.wc-block-price-filter__amount--max {
 				margin-left: 0;
+				margin-right: 10px;
+			}
+
+			.wc-block-price-filter__button {
+				margin-left: auto;
+				white-space: nowrap;
 			}
 		}
 	}


### PR DESCRIPTION
### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/69244053-8f017180-0ba4-11ea-8bad-84c443f61088.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/69243994-73966680-0ba4-11ea-89cb-d877feebdf0d.png)

### How to test the changes in this Pull Request:

1. Add a columns block and chose a layout where one of the columns is smaller than the other.
2. Inside the narrow column, add a price filter block with the _Filter button_ attribute set to true.
3. Verify the button text is not broken in two lines and there is margin between the input fields and the button.