### PR TITLE
Filter by Attribute: selector fixes

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -249,7 +249,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 				attributeName
 			),
 		} );
-	}, [] );
+	}, [ attributeId ] );
 
 	const renderAttributeControl = () => {
 		const messages = {

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -220,6 +220,15 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	}, [] );
 
 	const onChange = useCallback( ( selected ) => {
+		if ( ! selected || ! selected[ 0 ] ) {
+			setAttributes( {
+				attributeId: 0,
+				heading: __( 'Filter by attribute', 'woo-gutenberg-products-block' )
+			} );
+
+			return;
+		}
+
 		const selectedId = selected[ 0 ].id;
 		const productAttribute = find( ATTRIBUTES, [
 			'attribute_id',
@@ -313,7 +322,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			>
 				<div className="wc-block-attribute-filter__selection">
 					{ renderAttributeControl() }
-					<Button isDefault onClick={ onDone }>
+					<Button isDefault disabled={ attributeId === 0 } onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -219,37 +219,43 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		);
 	}, [] );
 
-	const onChange = useCallback( ( selected ) => {
-		if ( ! selected || ! selected[ 0 ] ) {
+	const onChange = useCallback(
+		( selected ) => {
+			if ( ! selected || ! selected[ 0 ] ) {
+				setAttributes( {
+					attributeId: 0,
+					heading: __(
+						'Filter by attribute',
+						'woo-gutenberg-products-block'
+					),
+				} );
+
+				return;
+			}
+
+			const selectedId = selected[ 0 ].id;
+			const productAttribute = find( ATTRIBUTES, [
+				'attribute_id',
+				selectedId.toString(),
+			] );
+
+			if ( ! productAttribute || attributeId === selectedId ) {
+				return;
+			}
+
+			const attributeName = productAttribute.attribute_name;
+
 			setAttributes( {
-				attributeId: 0,
-				heading: __( 'Filter by attribute', 'woo-gutenberg-products-block' )
+				attributeId: selectedId,
+				heading: sprintf(
+					// Translators: %s attribute name.
+					__( 'Filter by %s', 'woo-gutenberg-products-block' ),
+					attributeName
+				),
 			} );
-
-			return;
-		}
-
-		const selectedId = selected[ 0 ].id;
-		const productAttribute = find( ATTRIBUTES, [
-			'attribute_id',
-			selectedId.toString(),
-		] );
-
-		if ( ! productAttribute || attributeId === selectedId ) {
-			return;
-		}
-
-		const attributeName = productAttribute.attribute_name;
-
-		setAttributes( {
-			attributeId: selectedId,
-			heading: sprintf(
-				// Translators: %s attribute name.
-				__( 'Filter by %s', 'woo-gutenberg-products-block' ),
-				attributeName
-			),
-		} );
-	}, [ attributeId ] );
+		},
+		[ attributeId ]
+	);
 
 	const renderAttributeControl = () => {
 		const messages = {
@@ -322,7 +328,11 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			>
 				<div className="wc-block-attribute-filter__selection">
 					{ renderAttributeControl() }
-					<Button isDefault disabled={ attributeId === 0 } onClick={ onDone }>
+					<Button
+						isDefault
+						disabled={ attributeId === 0 }
+						onClick={ onDone }
+					>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>


### PR DESCRIPTION
Fixes #1235.
Fixes #1236.

Prettier made the diff of this PR quite long, but you can just review the first two commits and it will be easier. :slightly_smiling_face: 

### Screenshots

![Peek 2019-11-21 10-02](https://user-images.githubusercontent.com/3616980/69322962-1b17a580-0c46-11ea-85b3-d5ff4b269433.gif)

### How to test the changes in this Pull Request:

1. Add a _Filter by Attribute_ block and verify the _Done_ button is disabled until you select an attribute.
2. Select an attribute, save the post and reload the page.
3. Edit the _Filter by Attribute_ block and verify you can unselect the current attribute and you can switch between other attributes and select the first one again.

### Changelog

> Filter by Attribute: fixes in the selector that were preventing to unselect the currently selected attribute and selecting it again.