### PR TITLE
Update `useQueryStateByContext` to remove need for context when setting values

### DIFF
--- a/assets/js/base/hooks/test/use-query-state.js
+++ b/assets/js/base/hooks/test/use-query-state.js
@@ -145,7 +145,9 @@ describe( 'Testing Query State Hooks', () => {
 				act( () => {
 					setQueryState( { foo: 'bar' } );
 				} );
-				expect( action ).toHaveBeenCalledWith( { foo: 'bar' } );
+				expect( action ).toHaveBeenCalledWith( 'test-context', {
+					foo: 'bar',
+				} );
 			}
 		);
 	} );

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -37,7 +37,14 @@ export const useQueryStateByContext = ( context ) => {
 		},
 		[ context ]
 	);
-	const { setValueForQueryContext: setQueryState } = useDispatch( storeKey );
+	const { setValueForQueryContext } = useDispatch( storeKey );
+	const setQueryState = useCallback(
+		( value ) => {
+			setValueForQueryContext( context, value );
+		},
+		[ context ]
+	);
+
 	return [ queryState, setQueryState ];
 };
 
@@ -115,7 +122,7 @@ export const useSynchronizedQueryState = ( synchronizedQuery, context ) => {
 	const isInitialized = useRef( false );
 	// update queryState anytime incoming synchronizedQuery changes
 	useEffect( () => {
-		setQueryState( context, {
+		setQueryState( {
 			...queryState,
 			...currentSynchronizedQuery,
 		} );


### PR DESCRIPTION
This is a small change to `useQueryStateByContext` to remove the need to pass context when setting.

Before:

```jsx
const [ queryState, setQueryState ] = useQueryStateByContext( context );

setQueryState( context, { key: value } );
```

After:

```jsx
const [ queryState, setQueryState ] = useQueryStateByContext( context );

setQueryState( { key: value } );
```

Tests have been updated. There is little usage of this hook across the codebase so not many changes were needed.