### PR TITLE
introduce block title component

### DIFF
--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, PlainText } from '@wordpress/block-editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { Disabled, PanelBody, withSpokenMessages } from '@wordpress/components';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
+import BlockTitle from '@woocommerce/block-components/block-title';
 
 /**
  * Internal dependencies
@@ -72,20 +73,16 @@ const Edit = ( { attributes, setAttributes } ) => {
 		);
 	};
 
-	const TagName = `h${ headingLevel }`;
-
 	return (
 		<div className={ className }>
 			{ getInspectorControls() }
-			<TagName>
-				<PlainText
-					className="wc-block-attribute-filter-heading"
-					value={ heading }
-					onChange={ ( value ) =>
-						setAttributes( { heading: value } )
-					}
-				/>
-			</TagName>
+			<BlockTitle
+				headingLevel={ headingLevel }
+				heading={ heading }
+				onChange={ ( value ) =>
+							setAttributes( { heading: value } )
+						}
+					/>
 			<Disabled>
 				<Block attributes={ attributes } isPreview />
 			</Disabled>

--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -79,10 +79,8 @@ const Edit = ( { attributes, setAttributes } ) => {
 			<BlockTitle
 				headingLevel={ headingLevel }
 				heading={ heading }
-				onChange={ ( value ) =>
-							setAttributes( { heading: value } )
-						}
-					/>
+				onChange={ ( value ) => setAttributes( { heading: value } ) }
+			/>
 			<Disabled>
 				<Block attributes={ attributes } isPreview />
 			</Disabled>

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -6,7 +6,6 @@ import { Fragment, useState, useCallback } from '@wordpress/element';
 import {
 	InspectorControls,
 	BlockControls,
-	PlainText,
 } from '@wordpress/block-editor';
 import {
 	Placeholder,
@@ -23,6 +22,7 @@ import { mapValues, toArray, sortBy, find } from 'lodash';
 import { ATTRIBUTES } from '@woocommerce/block-settings';
 import { getAdminLink } from '@woocommerce/navigation';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
+import BlockTitle from '@woocommerce/block-components/block-title';
 
 /**
  * Internal dependencies
@@ -321,7 +321,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		);
 	};
 
-	const TagName = `h${ headingLevel }`;
+
 
 	return Object.keys( ATTRIBUTES ).length === 0 ? (
 		noAttributesPlaceholder()
@@ -333,15 +333,13 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 				renderEditMode()
 			) : (
 				<div className={ className }>
-					<TagName>
-						<PlainText
-							className="wc-block-attribute-filter-heading"
-							value={ heading }
-							onChange={ ( value ) =>
-								setAttributes( { heading: value } )
-							}
-						/>
-					</TagName>
+					<BlockTitle
+						headingLevel={ headingLevel }
+						heading={ heading }
+						onChange={ ( value ) =>
+							setAttributes( { heading: value } )
+						}
+					/>
 					<Disabled>
 						<Block attributes={ attributes } isEditor />
 					</Disabled>

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -3,10 +3,7 @@
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { Fragment, useState, useCallback } from '@wordpress/element';
-import {
-	InspectorControls,
-	BlockControls,
-} from '@wordpress/block-editor';
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import {
 	Placeholder,
 	Disabled,
@@ -320,8 +317,6 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			</Placeholder>
 		);
 	};
-
-
 
 	return Object.keys( ATTRIBUTES ).length === 0 ? (
 		noAttributesPlaceholder()

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -16,7 +16,6 @@ import { getAdminLink } from '@woocommerce/navigation';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
 import BlockTitle from '@woocommerce/block-components/block-title';
 
-
 /**
  * Internal dependencies
  */

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { InspectorControls, PlainText } from '@wordpress/block-editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Placeholder,
 	Disabled,
@@ -14,6 +14,8 @@ import {
 import { PRODUCT_COUNT } from '@woocommerce/block-settings';
 import { getAdminLink } from '@woocommerce/navigation';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
+import BlockTitle from '@woocommerce/block-components/block-title';
+
 
 /**
  * Internal dependencies
@@ -151,8 +153,6 @@ export default function( { attributes, setAttributes } ) {
 		</Placeholder>
 	);
 
-	const TagName = `h${ headingLevel }`;
-
 	return (
 		<Fragment>
 			{ PRODUCT_COUNT === 0 ? (
@@ -160,15 +160,13 @@ export default function( { attributes, setAttributes } ) {
 			) : (
 				<div className={ className }>
 					{ getInspectorControls() }
-					<TagName>
-						<PlainText
-							className="wc-block-attribute-filter-heading"
-							value={ heading }
-							onChange={ ( value ) =>
-								setAttributes( { heading: value } )
-							}
-						/>
-					</TagName>
+					<BlockTitle
+						headingLevel={ headingLevel }
+						heading={ heading }
+						onChange={ ( value ) =>
+							setAttributes( { heading: value } )
+						}
+					/>
 					<Disabled>
 						<Block attributes={ attributes } isPreview />
 					</Disabled>

--- a/assets/js/components/README.md
+++ b/assets/js/components/README.md
@@ -46,4 +46,4 @@ There are some functions that work across components, these have been extracted 
 
 ## Block Title
 
-A block that is responsible for showing the title for all of our blocks.
+A block that is responsible for showing the title for some of our blocks.

--- a/assets/js/components/README.md
+++ b/assets/js/components/README.md
@@ -43,3 +43,7 @@ These are a collection of custom icons used by the blocks or components, usually
 ## Utilities
 
 There are some functions that work across components, these have been extracted into this utilities folder.
+
+## Block Title
+
+A block that is responsible for showing the title for all of our blocks.

--- a/assets/js/components/block-title/index.js
+++ b/assets/js/components/block-title/index.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { PlainText } from '@wordpress/block-editor';
+import classnames from 'classnames'
+
+const BlockTitle = ( { className, headingLevel, onChange, heading } ) => {
+	const TagName = `h${ headingLevel }`;
+	return (
+		<TagName>
+			<PlainText
+				className={ classnames( "wc-block-attribute-filter-heading", className ) }
+				value={ heading }
+				onChange={ onChange }
+							/>
+		</TagName>
+	)
+}
+;
+
+BlockTitle.propTypes = {
+	/**
+	 * Classname to add to title in addition to the defaults.
+	 */
+	className: PropTypes.string,
+	/**
+	 * The value of the heading
+	 */
+	value: PropTypes.string,
+	/**
+	 * Callback to update the attribute when text is changed
+	 */
+	onChange: PropTypes.func,
+	/**
+	 * Callback to update the attribute when text is changed
+	 */
+	headingLevel: PropTypes.func,
+};
+
+export default BlockTitle;
+

--- a/assets/js/components/block-title/index.js
+++ b/assets/js/components/block-title/index.js
@@ -3,22 +3,23 @@
  */
 import PropTypes from 'prop-types';
 import { PlainText } from '@wordpress/block-editor';
-import classnames from 'classnames'
+import classnames from 'classnames';
 
 const BlockTitle = ( { className, headingLevel, onChange, heading } ) => {
 	const TagName = `h${ headingLevel }`;
 	return (
 		<TagName>
 			<PlainText
-				className={ classnames( "wc-block-attribute-filter-heading", className ) }
+				className={ classnames(
+					'wc-block-attribute-filter-heading',
+					className
+				) }
 				value={ heading }
 				onChange={ onChange }
-							/>
+			/>
 		</TagName>
-	)
-}
-;
-
+	);
+};
 BlockTitle.propTypes = {
 	/**
 	 * Classname to add to title in addition to the defaults.
@@ -39,4 +40,3 @@ BlockTitle.propTypes = {
 };
 
 export default BlockTitle;
-

--- a/assets/js/components/block-title/index.js
+++ b/assets/js/components/block-title/index.js
@@ -11,7 +11,7 @@ const BlockTitle = ( { className, headingLevel, onChange, heading } ) => {
 		<TagName>
 			<PlainText
 				className={ classnames(
-					'wc-block-attribute-filter-heading',
+					'wc-block-component-title',
 					className
 				) }
 				value={ heading }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR introduces a `BlockTitle` component that encapsulates the `PlainText` and `TagName` logic into a single component so it’s better handled, consistent and easily modifiable.

### How to test the changes in this Pull Request:

1. Create a Filter by Price|Attribute|All Filters block.
2. play with the title like change text and side
3. test on frontend as well

