### PR TITLE
Add getAdminLink() to shared settings export.

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -17,7 +17,7 @@ import Gridicon from 'gridicons';
 import { SearchListControl } from '@woocommerce/components';
 import { mapValues, toArray, sortBy, find } from 'lodash';
 import { ATTRIBUTES } from '@woocommerce/block-settings';
-import { getAdminLink } from '@woocommerce/navigation';
+import { getAdminLink } from '@woocommerce/settings';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
 import BlockTitle from '@woocommerce/block-components/block-title';
 

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -12,7 +12,7 @@ import {
 	Button,
 } from '@wordpress/components';
 import { PRODUCT_COUNT } from '@woocommerce/block-settings';
-import { getAdminLink } from '@woocommerce/navigation';
+import { getAdminLink } from '@woocommerce/settings';
 import HeadingToolbar from '@woocommerce/block-components/heading-toolbar';
 import BlockTitle from '@woocommerce/block-components/block-title';
 

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -12,7 +12,7 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { BlockControls } from '@wordpress/editor';
-import { getAdminLink } from '@woocommerce/navigation';
+import { getAdminLink } from '@woocommerce/settings';
 import {
 	ENABLE_REVIEW_RATING,
 	SHOW_AVATARS,

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -34,3 +34,11 @@ export const compareWithWpVersion = ( version, operator ) => {
 };
 
 export { compareVersions, getSetting };
+
+/**
+ * Returns a string with the site's wp-admin URL appended. JS version of `admin_url`.
+ *
+ * @param {String} path Relative path.
+ * @return {String} Full admin URL.
+ */
+export const getAdminLink = ( path ) => getSetting( 'adminUrl' ) + path;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2320,18 +2320,6 @@
         }
       }
     },
-    "@woocommerce/navigation": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-3.0.0.tgz",
-      "integrity": "sha512-z9smunpvGQTiuQ98TYz+Mb2jBlP1sl+Qk1XH0i8DZE7xdCh84PwYD/mIAIb796pkKD6Ws9tiJXstK/NwCekreQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime-corejs2": "7.5.5",
-        "history": "4.9.0",
-        "lodash": "4.17.15",
-        "qs": "6.7.0"
-      }
-    },
     "@woocommerce/number": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"@babel/core": "7.7.2",
 		"@babel/plugin-proposal-class-properties": "7.7.0",
 		"@octokit/rest": "16.35.0",
-		"@woocommerce/navigation": "3.0.0",
 		"@wordpress/babel-preset-default": "4.6.0",
 		"@wordpress/blocks": "6.7.0",
 		"@wordpress/browserslist-config": "2.6.0",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR seeks to add a utility method `getAdminLink()`, which returns full admin URLs when given a path (based on `adminUrl` setting).

It's necessary to add this function because https://github.com/woocommerce/woocommerce-admin/pull/3294 removed it from the `@woocommerce/navigation` package.

<!-- Reference any related issues or PRs here -->
Resolves conversation on https://github.com/woocommerce/woocommerce-admin/pull/3294

### How to test the changes in this Pull Request:

1. Verify a new function `getAdminLink()` is on the `wc.wcSettings` module
2. Verify calling `getAdminLink()` returns the given `path` prepended with the `adminUrl`

<!-- If you can, add the appropriate labels -->

### Changelog

> Add `getAdminLink()` utility method.
