### PR TITLE
Fix mutation of default state

### DIFF
--- a/assets/js/data/query-state/reducers.js
+++ b/assets/js/data/query-state/reducers.js
@@ -4,24 +4,20 @@
 import { ACTION_TYPES as types } from './action-types';
 import { getStateForContext } from './utils';
 
-const DEFAULT_QUERY_STATE = {};
-
 /**
  * Reducer for processing actions related to the query state store.
  *
  * @param {Object} state  Current state in store.
  * @param {Object} action Action being processed.
  */
-const queryStateReducer = ( state = DEFAULT_QUERY_STATE, action ) => {
+const queryStateReducer = ( state = {}, action ) => {
 	const { type, context, queryKey, value } = action;
 	const prevState = getStateForContext( state, context );
 	let newState;
 	switch ( type ) {
 		case types.SET_QUERY_KEY_VALUE:
 			const prevStateObject =
-				prevState !== null
-					? JSON.parse( prevState )
-					: DEFAULT_QUERY_STATE;
+				prevState !== null ? JSON.parse( prevState ) : {};
 
 			// mutate it and JSON.stringify to compare
 			prevStateObject[ queryKey ] = value;


### PR DESCRIPTION
I noticed when testing another pull and monitoring the `wc/store/query-state` store (via redux tools) that there was a unexpected key/value pair in the state.  At first I couldn't figure out where that was coming from because there was nothing in the code dispatching an action that would land the state in the store. However, in looking closely at the reducer, I noticed that the code was mutating the default value of the store state which caused the issue.  While the scope of this mutation was limited, it's still bad, so this pull fixes that.

## To test

The impact of this change is hard to measure because it didn't affect user-facing behaviour and was only exposed via looking at the state via redux tools.  So testing merely confirms the unexpected state no longer exists and a smoke test of the all products block to ensure no new issues introduced.