### PR TITLE
Initial experiment for api fetch error handling

### DIFF
--- a/assets/js/base/hooks/use-collection.js
+++ b/assets/js/base/hooks/use-collection.js
@@ -70,6 +70,11 @@ export const useCollection = ( options ) => {
 				currentQuery,
 				currentResourceValues,
 			];
+			// is there an error? if so throw!
+			const error = store.getCollectionError( ...args );
+			if ( error ) {
+				throw error;
+			}
 			return {
 				results: store.getCollection( ...args ),
 				isLoading: ! store.hasFinishedResolution(

--- a/assets/js/data/collections/actions.js
+++ b/assets/js/data/collections/actions.js
@@ -99,3 +99,24 @@ export function* __experimentalPersistItemToCollection(
 		);
 	}
 }
+
+export function receiveCollectionError(
+	namespace,
+	resourceName,
+	queryString,
+	ids,
+	error
+) {
+	return {
+		type: 'ERROR',
+		namespace,
+		resourceName,
+		queryString,
+		ids,
+		response: {
+			items: [],
+			headers: Headers,
+			error,
+		},
+	};
+}

--- a/assets/js/data/collections/controls.js
+++ b/assets/js/data/collections/controls.js
@@ -26,7 +26,7 @@ export const apiFetchWithHeaders = ( path ) => {
  */
 export const controls = {
 	API_FETCH_WITH_HEADERS( { path } ) {
-		return new Promise( ( resolve, reject ) => {
+		return new Promise( ( resolve ) => {
 			triggerFetch( { path, parse: false } )
 				.then( ( response ) => {
 					response.json().then( ( items ) => {
@@ -34,7 +34,7 @@ export const controls = {
 					} );
 				} )
 				.catch( ( error ) => {
-					reject( error );
+					throw error;
 				} );
 		} );
 	},

--- a/assets/js/data/collections/reducers.js
+++ b/assets/js/data/collections/reducers.js
@@ -42,6 +42,13 @@ const receiveCollection = ( state = {}, action ) => {
 				response
 			);
 			break;
+		case 'ERROR':
+			state = updateState(
+				state,
+				[ namespace, resourceName, ids, queryString ],
+				response
+			);
+			break;
 	}
 	return state;
 };

--- a/assets/js/data/collections/resolvers.js
+++ b/assets/js/data/collections/resolvers.js
@@ -7,7 +7,11 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
-import { receiveCollection, DEFAULT_EMPTY_ARRAY } from './actions';
+import {
+	receiveCollection,
+	receiveCollectionError,
+	DEFAULT_EMPTY_ARRAY,
+} from './actions';
 import { STORE_KEY as SCHEMA_STORE_KEY } from '../schema/constants';
 import { STORE_KEY } from './constants';
 import { apiFetchWithHeaders } from './controls';
@@ -33,13 +37,25 @@ export function* getCollection( namespace, resourceName, query, ids ) {
 		yield receiveCollection( namespace, resourceName, queryString, ids );
 		return;
 	}
-	const { items = DEFAULT_EMPTY_ARRAY, headers } = yield apiFetchWithHeaders(
-		route + queryString
-	);
-	yield receiveCollection( namespace, resourceName, queryString, ids, {
-		items,
-		headers,
-	} );
+	try {
+		const {
+			items = DEFAULT_EMPTY_ARRAY,
+			headers,
+		} = yield apiFetchWithHeaders( route + queryString );
+		yield receiveCollection( namespace, resourceName, queryString, ids, {
+			items,
+			headers,
+			errors: null,
+		} );
+	} catch ( e ) {
+		yield receiveCollectionError(
+			namespace,
+			resourceName,
+			queryString,
+			ids,
+			e
+		);
+	}
 }
 /**
  * Resolver for retrieving a specific collection header for the given arguments

--- a/assets/js/data/collections/selectors.js
+++ b/assets/js/data/collections/selectors.js
@@ -67,6 +67,24 @@ export const getCollection = (
 	return getFromState( { state, namespace, resourceName, query, ids } );
 };
 
+export const getCollectionError = (
+	state,
+	namespace,
+	resourceName,
+	query = null,
+	ids = DEFAULT_EMPTY_ARRAY
+) => {
+	return getFromState( {
+		state,
+		namespace,
+		resourceName,
+		query,
+		ids,
+		type: 'error',
+		fallback: null,
+	} );
+};
+
 /**
  * This selector enables retrieving a specific header value from a given
  * collection request.


### PR DESCRIPTION
Closes: #1180 

This pull is in progress, but it provides an example for how we could handle fetch error handling by including it in the state for the given query.  Right now it's just throwing the error and the error boundary is catching it, but we _could_ add some more graceful error handling if we wanted.

This pull came about because of some experimentation I was doing to replicate work done for wc-admin in wp.data.  I used the blocks repo to validate some ideas.