### PR TITLE
Fix 'invalid attributes' error in Products by Tag, Products by Attribute and Handpicked products blocks

### DIFF
--- a/src/BlockTypes/HandpickedProducts.php
+++ b/src/BlockTypes/HandpickedProducts.php
@@ -64,6 +64,7 @@ class HandpickedProducts extends AbstractProductGrid {
 			'orderby'           => $this->get_schema_orderby(),
 			'products'          => $this->get_schema_list_ids(),
 			'contentVisibility' => $this->get_schema_content_visibility(),
+			'isPreview'         => $this->get_schema_boolean( false ),
 		);
 	}
 }

--- a/src/BlockTypes/ProductTag.php
+++ b/src/BlockTypes/ProductTag.php
@@ -55,6 +55,7 @@ class ProductTag extends AbstractProductGrid {
 				'type'    => 'string',
 				'default' => 'any',
 			),
+			'isPreview'         => $this->get_schema_boolean( false ),
 		);
 	}
 }

--- a/src/BlockTypes/ProductsByAttribute.php
+++ b/src/BlockTypes/ProductsByAttribute.php
@@ -74,6 +74,7 @@ class ProductsByAttribute extends AbstractProductGrid {
 			'editMode'          => $this->get_schema_boolean( true ),
 			'orderby'           => $this->get_schema_orderby(),
 			'rows'              => $this->get_schema_number( wc_get_theme_support( 'product_blocks::default_rows', 1 ) ),
+			'isPreview'         => $this->get_schema_boolean( false ),
 		);
 	}
 }


### PR DESCRIPTION
Fixes #1253. Some blocks were missing the `isPreview` attribute and that made them to show an error.

### How to test the changes in this Pull Request:
1. Create a post and add _Products by Tag_, _Products by Attribute_ and _Handpicked products_ blocks.
2. Verify there are no errors appears.

### Changelog

> Fix Products by Tag, Products by Attribute and Handpicked products blocks showing an invalid attributes error.