### PR TITLE
Add dropdown display style to Attribute Filter block

### DIFF
--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -97,7 +97,7 @@ const CheckboxList = ( {
 		return (
 			<Fragment>
 				{ options.map( ( option, index ) => (
-					<Fragment key={ option.key }>
+					<Fragment key={ option.value }>
 						<li
 							{ ...shouldTruncateOptions &&
 								! showExpanded &&
@@ -105,13 +105,15 @@ const CheckboxList = ( {
 						>
 							<input
 								type="checkbox"
-								id={ option.key }
-								value={ option.key }
-								onChange={ onChange }
-								checked={ checked.includes( option.key ) }
+								id={ option.value }
+								value={ option.value }
+								onChange={ ( event ) => {
+									onChange( event.target.value );
+								} }
+								checked={ checked.includes( option.value ) }
 								disabled={ isDisabled }
 							/>
-							<label htmlFor={ option.key }>
+							<label htmlFor={ option.value }>
 								{ option.label }
 							</label>
 						</li>
@@ -152,7 +154,7 @@ CheckboxList.propTypes = {
 	onChange: PropTypes.func,
 	options: PropTypes.arrayOf(
 		PropTypes.shape( {
-			key: PropTypes.string.isRequired,
+			value: PropTypes.string.isRequired,
 			label: PropTypes.node.isRequired,
 		} )
 	),

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -154,8 +154,8 @@ CheckboxList.propTypes = {
 	onChange: PropTypes.func,
 	options: PropTypes.arrayOf(
 		PropTypes.shape( {
-			value: PropTypes.string.isRequired,
 			label: PropTypes.node.isRequired,
+			value: PropTypes.string.isRequired,
 		} )
 	),
 	checked: PropTypes.array,

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -69,6 +69,7 @@ const DropdownSelector = ( {
 			{ ( {
 				getInputProps,
 				getItemProps,
+				getLabelProps,
 				getMenuProps,
 				highlightedIndex,
 				inputValue,
@@ -76,6 +77,12 @@ const DropdownSelector = ( {
 				openMenu,
 			} ) => (
 				<div className={ classes }>
+					{ /* eslint-disable-next-line jsx-a11y/label-has-for */ }
+					<label { ...getLabelProps( {
+						className: 'screen-reader-text',
+					} ) }>
+						{ inputLabel }
+					</label>
 					<DropdownSelectorInputWrapper
 						isOpen={ isOpen }
 						onClick={
@@ -104,7 +111,6 @@ const DropdownSelector = ( {
 							getInputProps={ getInputProps }
 							inputRef={ inputRef }
 							isDisabled={ isDisabled }
-							label={ inputLabel }
 							onFocus={ openMenu }
 							onRemoveItem={ onChange }
 							value={ inputValue }

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -60,6 +60,12 @@ const DropdownSelector = ( {
 		'is-loading': isLoading,
 	} );
 
+	const focusInput = ( isOpen ) => {
+		if ( ! isOpen ) {
+			inputRef.current.focus();
+		}
+	};
+
 	return (
 		<Downshift
 			onChange={ onChange }
@@ -78,20 +84,16 @@ const DropdownSelector = ( {
 			} ) => (
 				<div className={ classes }>
 					{ /* eslint-disable-next-line jsx-a11y/label-has-for */ }
-					<label { ...getLabelProps( {
-						className: 'screen-reader-text',
-					} ) }>
+					<label
+						{ ...getLabelProps( {
+							className: 'screen-reader-text',
+						} ) }
+					>
 						{ inputLabel }
 					</label>
 					<DropdownSelectorInputWrapper
 						isOpen={ isOpen }
-						onClick={
-							isOpen
-								? null
-								: () => {
-										inputRef.current.focus();
-								  }
-						}
+						onClick={ () => focusInput( isOpen ) }
 					>
 						{ checked.map( ( value ) => {
 							const option = options.find(
@@ -100,7 +102,10 @@ const DropdownSelector = ( {
 							return (
 								<DropdownSelectorSelectedChip
 									key={ value }
-									onClick={ onChange }
+									onRemoveItem={ ( val ) => {
+										onChange( val );
+										focusInput( isOpen );
+									} }
 									option={ option }
 								/>
 							);
@@ -112,7 +117,10 @@ const DropdownSelector = ( {
 							inputRef={ inputRef }
 							isDisabled={ isDisabled }
 							onFocus={ openMenu }
-							onRemoveItem={ onChange }
+							onRemoveItem={ ( val ) => {
+								onChange( val );
+								focusInput( isOpen );
+							} }
 							value={ inputValue }
 						/>
 					</DropdownSelectorInputWrapper>

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -40,6 +40,7 @@ const stateReducer = ( state, changes ) => {
  * Component used to show a list of checkboxes in a group.
  */
 const CheckboxList = ( {
+	attributeLabel = '',
 	className,
 	checked = [],
 	inputLabel = '',
@@ -138,7 +139,7 @@ const CheckboxList = ( {
 														'Any %s',
 														'woo-gutenberg-products-block'
 													),
-													'' //@todo attributeName
+													attributeLabel
 											  )
 											: null,
 								} ) }
@@ -203,6 +204,7 @@ const CheckboxList = ( {
 };
 
 CheckboxList.propTypes = {
+	attributeLabel: PropTypes.string,
 	checked: PropTypes.array,
 	className: PropTypes.string,
 	inputLabel: PropTypes.string,

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -78,7 +78,6 @@ const DropdownSelector = ( {
 				<div className={ classes }>
 					<DropdownSelectorInputWrapper
 						isOpen={ isOpen }
-						inputRef={ inputRef }
 						onClick={
 							isOpen
 								? null

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -1,0 +1,221 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+import { useRef } from '@wordpress/element';
+import classNames from 'classnames';
+import Downshift from 'downshift';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * State reducer for the downshift component.
+ * See: https://github.com/downshift-js/downshift#statereducer
+ */
+const stateReducer = ( state, changes ) => {
+	switch ( changes.type ) {
+		case Downshift.stateChangeTypes.keyDownEnter:
+		case Downshift.stateChangeTypes.clickItem:
+			return {
+				...changes,
+				highlightedIndex: state.highlightedIndex,
+				isOpen: true,
+				inputValue: '',
+			};
+		case Downshift.stateChangeTypes.mouseUp:
+			return {
+				...changes,
+				inputValue: state.inputValue,
+			};
+		default:
+			return changes;
+	}
+};
+
+/**
+ * Component used to show a list of checkboxes in a group.
+ */
+const CheckboxList = ( {
+	className,
+	checked = [],
+	inputLabel = '',
+	isDisabled = false,
+	isLoading = false,
+	onChange = () => {},
+	options = [],
+} ) => {
+	const inputRef = useRef( null );
+
+	const classes = classNames( className, 'wc-block-dropdown-selector', {
+		'is-disabled': isDisabled,
+		'is-loading': isLoading,
+	} );
+
+	return (
+		<div className={ classes }>
+			<Downshift
+				stateReducer={ stateReducer }
+				onChange={ onChange }
+				selectedItem={ null }
+			>
+				{ ( {
+					getInputProps,
+					getItemProps,
+					getMenuProps,
+					highlightedIndex,
+					inputValue,
+					isOpen,
+					toggleMenu,
+				} ) => (
+					<div>
+						{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */ }
+						<div
+							className="wc-block-dropdown-selector__fake-input"
+							onClick={
+								isOpen
+									? null
+									: () => {
+											inputRef.current.focus();
+									  }
+							}
+						>
+							{ checked.length > 0 &&
+								checked.map( ( value ) => {
+									const { label, name } = options.find(
+										( option ) => option.value === value
+									);
+									return (
+										<button
+											key={ value }
+											onClick={ ( e ) => {
+												e.stopPropagation();
+												onChange( value );
+											} }
+											className="wc-block-dropdown-selector__selected-chip"
+											aria-label={ sprintf(
+												__(
+													'Remove %s filter',
+													'woo-gutenberg-products-block'
+												),
+												name
+											) }
+										>
+											{ label }
+											<span className="wc-block-dropdown-selector__selected-chip__remove">
+												𝘅
+											</span>
+										</button>
+									);
+								} ) }
+							<input
+								{ ...getInputProps( {
+									ref: inputRef,
+									className:
+										'wc-block-dropdown-selector__input',
+									disabled: isDisabled,
+									'aria-label': inputLabel,
+									onKeyDown( event ) {
+										if (
+											event.key === 'Backspace' &&
+											! inputValue &&
+											checked.length > 0
+										) {
+											onChange(
+												checked[ checked.length - 1 ]
+											);
+										}
+									},
+									onFocus: isOpen ? null : () => toggleMenu(),
+									placeholder:
+										checked.length === 0
+											? sprintf(
+													// Translators: %s attribute name.
+													__(
+														'Any %s',
+														'woo-gutenberg-products-block'
+													),
+													'' //@todo attributeName
+											  )
+											: null,
+								} ) }
+							/>
+						</div>
+						<ul
+							{ ...getMenuProps( {
+								className: 'wc-block-dropdown-selector__list',
+							} ) }
+						>
+							{ isOpen && ! isDisabled
+								? options
+										.filter(
+											( option ) =>
+												! inputValue ||
+												option.value.startsWith(
+													inputValue
+												)
+										)
+										.map( ( option, index ) => {
+											const selected = checked.includes(
+												option.value
+											);
+											return (
+												// eslint-disable-next-line react/jsx-key
+												<li
+													{ ...getItemProps( {
+														key: option.value,
+														className: classNames(
+															'wc-block-dropdown-selector__list-item',
+															{
+																'is-selected': selected,
+																'is-focused':
+																	highlightedIndex ===
+																	index,
+															}
+														),
+														index,
+														item: option.value,
+														'aria-label': selected
+															? sprintf(
+																	__(
+																		'Remove %s filter',
+																		'woo-gutenberg-products-block'
+																	),
+																	option.name
+															  )
+															: null,
+													} ) }
+												>
+													{ option.label }
+												</li>
+											);
+										} )
+								: null }
+						</ul>
+					</div>
+				) }
+			</Downshift>
+		</div>
+	);
+};
+
+CheckboxList.propTypes = {
+	checked: PropTypes.array,
+	className: PropTypes.string,
+	inputLabel: PropTypes.string,
+	isLoading: PropTypes.bool,
+	isDisabled: PropTypes.bool,
+	limit: PropTypes.number,
+	onChange: PropTypes.func,
+	options: PropTypes.arrayOf(
+		PropTypes.shape( {
+			value: PropTypes.string.isRequired,
+			label: PropTypes.node.isRequired,
+		} )
+	),
+};
+
+export default CheckboxList;

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -29,6 +29,7 @@ const stateReducer = ( state, changes ) => {
 				isOpen: true,
 				inputValue: '',
 			};
+		case Downshift.stateChangeTypes.blurInput:
 		case Downshift.stateChangeTypes.mouseUp:
 			return {
 				...changes,
@@ -76,6 +77,8 @@ const DropdownSelector = ( {
 			} ) => (
 				<div className={ classes }>
 					<DropdownSelectorInputWrapper
+						isOpen={ isOpen }
+						inputRef={ inputRef }
 						onClick={
 							isOpen
 								? null
@@ -83,20 +86,16 @@ const DropdownSelector = ( {
 										inputRef.current.focus();
 								  }
 						}
-						isOpen={ isOpen }
-						inputRef={ inputRef }
 					>
 						{ checked.map( ( value ) => {
-							const { label, name } = options.find(
-								( option ) => option.value === value
+							const option = options.find(
+								( o ) => o.value === value
 							);
 							return (
 								<DropdownSelectorSelectedChip
 									key={ value }
-									label={ label }
-									name={ name }
 									onClick={ onChange }
-									value={ value }
+									option={ option }
 								/>
 							);
 						} ) }
@@ -107,8 +106,8 @@ const DropdownSelector = ( {
 							inputRef={ inputRef }
 							isDisabled={ isDisabled }
 							label={ inputLabel }
-							onRemoveItem={ onChange }
 							onFocus={ openMenu }
+							onRemoveItem={ onChange }
 							value={ inputValue }
 						/>
 					</DropdownSelectorInputWrapper>

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -124,23 +124,19 @@ const DropdownSelector = ( {
 							value={ inputValue }
 						/>
 					</DropdownSelectorInputWrapper>
-					<DropdownSelectorMenu
-						checked={ checked }
-						getItemProps={ getItemProps }
-						getMenuProps={ getMenuProps }
-						highlightedIndex={ highlightedIndex }
-						options={
-							isOpen && ! isDisabled
-								? options.filter(
-										( option ) =>
-											! inputValue ||
-											option.value.startsWith(
-												inputValue
-											)
-								  )
-								: []
-						}
-					/>
+					{ isOpen && ! isDisabled && (
+						<DropdownSelectorMenu
+							checked={ checked }
+							getItemProps={ getItemProps }
+							getMenuProps={ getMenuProps }
+							highlightedIndex={ highlightedIndex }
+							options={ options.filter(
+								( option ) =>
+									! inputValue ||
+									option.value.startsWith( inputValue )
+							) }
+						/>
+					) }
 				</div>
 			) }
 		</Downshift>

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { useRef } from '@wordpress/element';
 import classNames from 'classnames';
@@ -10,6 +9,10 @@ import Downshift from 'downshift';
 /**
  * Internal dependencies
  */
+import DropdownSelectorInput from './input';
+import DropdownSelectorInputWrapper from './input-wrapper';
+import DropdownSelectorMenu from './menu';
+import DropdownSelectorSelectedChip from './selected-chip';
 import './style.scss';
 
 /**
@@ -37,9 +40,9 @@ const stateReducer = ( state, changes ) => {
 };
 
 /**
- * Component used to show a list of checkboxes in a group.
+ * Component used to show an input box with a dropdown with suggestions.
  */
-const CheckboxList = ( {
+const DropdownSelector = ( {
 	attributeLabel = '',
 	className,
 	checked = [],
@@ -57,167 +60,96 @@ const CheckboxList = ( {
 	} );
 
 	return (
-		<div className={ classes }>
-			<Downshift
-				stateReducer={ stateReducer }
-				onChange={ onChange }
-				selectedItem={ null }
-			>
-				{ ( {
-					getInputProps,
-					getItemProps,
-					getMenuProps,
-					highlightedIndex,
-					inputValue,
-					isOpen,
-					toggleMenu,
-				} ) => (
-					<div>
-						{ /* eslint-disable-next-line jsx-a11y/click-events-have-key-events */ }
-						<div
-							className="wc-block-dropdown-selector__fake-input"
-							onClick={
-								isOpen
-									? null
-									: () => {
-											inputRef.current.focus();
-									  }
-							}
-						>
-							{ checked.length > 0 &&
-								checked.map( ( value ) => {
-									const { label, name } = options.find(
-										( option ) => option.value === value
-									);
-									return (
-										<button
-											key={ value }
-											onClick={ ( e ) => {
-												e.stopPropagation();
-												onChange( value );
-											} }
-											className="wc-block-dropdown-selector__selected-chip"
-											aria-label={ sprintf(
-												__(
-													'Remove %s filter',
-													'woo-gutenberg-products-block'
-												),
-												name
-											) }
-										>
-											{ label }
-											<span className="wc-block-dropdown-selector__selected-chip__remove">
-												𝘅
-											</span>
-										</button>
-									);
-								} ) }
-							<input
-								{ ...getInputProps( {
-									ref: inputRef,
-									className:
-										'wc-block-dropdown-selector__input',
-									disabled: isDisabled,
-									'aria-label': inputLabel,
-									onKeyDown( event ) {
-										if (
-											event.key === 'Backspace' &&
-											! inputValue &&
-											checked.length > 0
-										) {
-											onChange(
-												checked[ checked.length - 1 ]
-											);
-										}
-									},
-									onFocus: isOpen ? null : () => toggleMenu(),
-									placeholder:
-										checked.length === 0
-											? sprintf(
-													// Translators: %s attribute name.
-													__(
-														'Any %s',
-														'woo-gutenberg-products-block'
-													),
-													attributeLabel
-											  )
-											: null,
-								} ) }
-							/>
-						</div>
-						<ul
-							{ ...getMenuProps( {
-								className: 'wc-block-dropdown-selector__list',
-							} ) }
-						>
-							{ isOpen && ! isDisabled
-								? options
-										.filter(
-											( option ) =>
-												! inputValue ||
-												option.value.startsWith(
-													inputValue
-												)
-										)
-										.map( ( option, index ) => {
-											const selected = checked.includes(
-												option.value
-											);
-											return (
-												// eslint-disable-next-line react/jsx-key
-												<li
-													{ ...getItemProps( {
-														key: option.value,
-														className: classNames(
-															'wc-block-dropdown-selector__list-item',
-															{
-																'is-selected': selected,
-																'is-focused':
-																	highlightedIndex ===
-																	index,
-															}
-														),
-														index,
-														item: option.value,
-														'aria-label': selected
-															? sprintf(
-																	__(
-																		'Remove %s filter',
-																		'woo-gutenberg-products-block'
-																	),
-																	option.name
-															  )
-															: null,
-													} ) }
-												>
-													{ option.label }
-												</li>
-											);
-										} )
-								: null }
-						</ul>
-					</div>
-				) }
-			</Downshift>
-		</div>
+		<Downshift
+			onChange={ onChange }
+			selectedItem={ null }
+			stateReducer={ stateReducer }
+		>
+			{ ( {
+				getInputProps,
+				getItemProps,
+				getMenuProps,
+				highlightedIndex,
+				inputValue,
+				isOpen,
+				openMenu,
+			} ) => (
+				<div className={ classes }>
+					<DropdownSelectorInputWrapper
+						onClick={
+							isOpen
+								? null
+								: () => {
+										inputRef.current.focus();
+								  }
+						}
+						isOpen={ isOpen }
+						inputRef={ inputRef }
+					>
+						{ checked.map( ( value ) => {
+							const { label, name } = options.find(
+								( option ) => option.value === value
+							);
+							return (
+								<DropdownSelectorSelectedChip
+									key={ value }
+									label={ label }
+									name={ name }
+									onClick={ onChange }
+									value={ value }
+								/>
+							);
+						} ) }
+						<DropdownSelectorInput
+							attributeLabel={ attributeLabel }
+							checked={ checked }
+							getInputProps={ getInputProps }
+							inputRef={ inputRef }
+							isDisabled={ isDisabled }
+							label={ inputLabel }
+							onRemoveItem={ onChange }
+							onFocus={ openMenu }
+							value={ inputValue }
+						/>
+					</DropdownSelectorInputWrapper>
+					<DropdownSelectorMenu
+						checked={ checked }
+						getItemProps={ getItemProps }
+						getMenuProps={ getMenuProps }
+						highlightedIndex={ highlightedIndex }
+						options={
+							isOpen && ! isDisabled
+								? options.filter(
+										( option ) =>
+											! inputValue ||
+											option.value.startsWith(
+												inputValue
+											)
+								  )
+								: []
+						}
+					/>
+				</div>
+			) }
+		</Downshift>
 	);
 };
 
-CheckboxList.propTypes = {
+DropdownSelector.propTypes = {
 	attributeLabel: PropTypes.string,
 	checked: PropTypes.array,
 	className: PropTypes.string,
 	inputLabel: PropTypes.string,
-	isLoading: PropTypes.bool,
 	isDisabled: PropTypes.bool,
+	isLoading: PropTypes.bool,
 	limit: PropTypes.number,
 	onChange: PropTypes.func,
 	options: PropTypes.arrayOf(
 		PropTypes.shape( {
-			value: PropTypes.string.isRequired,
 			label: PropTypes.node.isRequired,
+			value: PropTypes.string.isRequired,
 		} )
 	),
 };
 
-export default CheckboxList;
+export default DropdownSelector;

--- a/assets/js/base/components/dropdown-selector/input-wrapper.js
+++ b/assets/js/base/components/dropdown-selector/input-wrapper.js
@@ -1,0 +1,13 @@
+const DropdownSelectorInputWrapper = ( { children, onClick } ) => {
+	return (
+		/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+		<div
+			className="wc-block-dropdown-selector__input-wrapper"
+			onClick={ onClick }
+		>
+			{ children }
+		</div>
+	);
+};
+
+export default DropdownSelectorInputWrapper;

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -9,7 +9,6 @@ const DropdownSelectorInput = ( {
 	getInputProps,
 	inputRef,
 	isDisabled,
-	label,
 	onFocus,
 	onRemoveItem,
 	value,
@@ -38,7 +37,6 @@ const DropdownSelectorInput = ( {
 								attributeLabel
 						  )
 						: null,
-				'aria-label': label,
 			} ) }
 		/>
 	);

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -7,12 +7,12 @@ const DropdownSelectorInput = ( {
 	attributeLabel,
 	checked,
 	getInputProps,
-	label,
 	inputRef,
-	value,
 	isDisabled,
+	label,
 	onFocus,
 	onRemoveItem,
+	value,
 } ) => {
 	return (
 		<input
@@ -20,7 +20,7 @@ const DropdownSelectorInput = ( {
 				ref: inputRef,
 				className: 'wc-block-dropdown-selector__input',
 				disabled: isDisabled,
-				'aria-label': label,
+				onFocus,
 				onKeyDown( event ) {
 					if (
 						event.key === 'Backspace' &&
@@ -30,7 +30,6 @@ const DropdownSelectorInput = ( {
 						onRemoveItem( checked[ checked.length - 1 ] );
 					}
 				},
-				onFocus,
 				placeholder:
 					checked.length === 0
 						? sprintf(
@@ -39,6 +38,7 @@ const DropdownSelectorInput = ( {
 								attributeLabel
 						  )
 						: null,
+				'aria-label': label,
 			} ) }
 		/>
 	);

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -20,14 +20,13 @@ const DropdownSelectorInput = ( {
 				className: 'wc-block-dropdown-selector__input',
 				disabled: isDisabled,
 				onFocus,
-				onKeyDown( event ) {
+				onKeyDown( e ) {
 					if (
-						event.key === 'Backspace' &&
+						e.key === 'Backspace' &&
 						! value &&
 						checked.length > 0
 					) {
 						onRemoveItem( checked[ checked.length - 1 ] );
-						inputRef.current.focus();
 					}
 				},
 				placeholder:

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+const DropdownSelectorInput = ( {
+	attributeLabel,
+	checked,
+	getInputProps,
+	label,
+	inputRef,
+	value,
+	isDisabled,
+	onFocus,
+	onRemoveItem,
+} ) => {
+	return (
+		<input
+			{ ...getInputProps( {
+				ref: inputRef,
+				className: 'wc-block-dropdown-selector__input',
+				disabled: isDisabled,
+				'aria-label': label,
+				onKeyDown( event ) {
+					if (
+						event.key === 'Backspace' &&
+						! value &&
+						checked.length > 0
+					) {
+						onRemoveItem( checked[ checked.length - 1 ] );
+					}
+				},
+				onFocus,
+				placeholder:
+					checked.length === 0
+						? sprintf(
+								// Translators: %s attribute name.
+								__( 'Any %s', 'woo-gutenberg-products-block' ),
+								attributeLabel
+						  )
+						: null,
+			} ) }
+		/>
+	);
+};
+
+export default DropdownSelectorInput;

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -27,6 +27,7 @@ const DropdownSelectorInput = ( {
 						checked.length > 0
 					) {
 						onRemoveItem( checked[ checked.length - 1 ] );
+						inputRef.current.focus();
 					}
 				},
 				placeholder:

--- a/assets/js/base/components/dropdown-selector/menu.js
+++ b/assets/js/base/components/dropdown-selector/menu.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import classNames from 'classnames';
+
+const DropdownSelectorMenu = ( {
+	checked,
+	getItemProps,
+	getMenuProps,
+	highlightedIndex,
+	options,
+} ) => {
+	return (
+		<ul
+			{ ...getMenuProps( {
+				className: 'wc-block-dropdown-selector__list',
+			} ) }
+		>
+			{ options.map( ( option, index ) => {
+				const selected = checked.includes( option.value );
+				return (
+					// eslint-disable-next-line react/jsx-key
+					<li
+						{ ...getItemProps( {
+							key: option.value,
+							className: classNames(
+								'wc-block-dropdown-selector__list-item',
+								{
+									'is-selected': selected,
+									'is-focused': highlightedIndex === index,
+								}
+							),
+							index,
+							item: option.value,
+							'aria-label': selected
+								? sprintf(
+										__(
+											'Remove %s filter',
+											'woo-gutenberg-products-block'
+										),
+										option.name
+								  )
+								: null,
+						} ) }
+					>
+						{ option.label }
+					</li>
+				);
+			} ) }
+		</ul>
+	);
+};
+
+export default DropdownSelectorMenu;

--- a/assets/js/base/components/dropdown-selector/menu.js
+++ b/assets/js/base/components/dropdown-selector/menu.js
@@ -28,7 +28,8 @@ const DropdownSelectorMenu = ( {
 								'wc-block-dropdown-selector__list-item',
 								{
 									'is-selected': selected,
-									'is-focused': highlightedIndex === index,
+									'is-highlighted':
+										highlightedIndex === index,
 								}
 							),
 							index,

--- a/assets/js/base/components/dropdown-selector/selected-chip.js
+++ b/assets/js/base/components/dropdown-selector/selected-chip.js
@@ -3,20 +3,20 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 
-const DropdownSelectorSelectedChip = ( { label, name, onClick, value } ) => {
+const DropdownSelectorSelectedChip = ( { onClick, option } ) => {
 	return (
 		<button
 			className="wc-block-dropdown-selector__selected-chip"
 			onClick={ ( e ) => {
 				e.stopPropagation();
-				onClick( value );
+				onClick( option.value );
 			} }
 			aria-label={ sprintf(
 				__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
-				name
+				option.name
 			) }
 		>
-			{ label }
+			{ option.label }
 			<span className="wc-block-dropdown-selector__selected-chip__remove">
 				𝘅
 			</span>

--- a/assets/js/base/components/dropdown-selector/selected-chip.js
+++ b/assets/js/base/components/dropdown-selector/selected-chip.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+const DropdownSelectorSelectedChip = ( { label, name, onClick, value } ) => {
+	return (
+		<button
+			className="wc-block-dropdown-selector__selected-chip"
+			onClick={ ( e ) => {
+				e.stopPropagation();
+				onClick( value );
+			} }
+			aria-label={ sprintf(
+				__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
+				name
+			) }
+		>
+			{ label }
+			<span className="wc-block-dropdown-selector__selected-chip__remove">
+				𝘅
+			</span>
+		</button>
+	);
+};
+
+export default DropdownSelectorSelectedChip;

--- a/assets/js/base/components/dropdown-selector/selected-chip.js
+++ b/assets/js/base/components/dropdown-selector/selected-chip.js
@@ -3,13 +3,18 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 
-const DropdownSelectorSelectedChip = ( { onClick, option } ) => {
+const DropdownSelectorSelectedChip = ( { onRemoveItem, option } ) => {
 	return (
 		<button
 			className="wc-block-dropdown-selector__selected-chip"
 			onClick={ ( e ) => {
 				e.stopPropagation();
-				onClick( option.value );
+				onRemoveItem( option.value );
+			} }
+			onKeyDown={ ( e ) => {
+				if ( e.key === 'Backspace' || e.key === 'Delete' ) {
+					onRemoveItem( option.value );
+				}
 			} }
 			aria-label={ sprintf(
 				__( 'Remove %s filter', 'woo-gutenberg-products-block' ),

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -13,10 +13,6 @@
 	flex-wrap: wrap;
 	padding: 2px;
 
-	.is-loading & {
-		@include placeholder();
-	}
-
 	.is-disabled & {
 		background-color: $core-grey-light-500;
 	}
@@ -42,10 +38,6 @@
 	&:focus,
 	&:active {
 		outline: 0;
-	}
-
-	.is-loading &::placeholder {
-		color: transparent;
 	}
 }
 

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -1,0 +1,114 @@
+.wc-block-dropdown-selector {
+	max-width: 300px;
+	position: relative;
+	width: 100%;
+}
+
+.wc-block-dropdown-selector__fake-input {
+	align-items: baseline;
+	border: 1px solid #9f9f9f;
+	border-radius: 4px;
+	cursor: text;
+	display: flex;
+	flex-wrap: wrap;
+	padding: 2px;
+
+	.is-loading & {
+		@include placeholder();
+	}
+
+	.is-disabled & {
+		background-color: $core-grey-light-500;
+	}
+}
+
+.wc-block-dropdown-selector__placeholder {
+	font-size: 0.8em;
+	height: 1.8em;
+	margin: 0 $gap-smallest;
+	white-space: nowrap;
+}
+
+.wc-block-dropdown-selector__input {
+	background: transparent;
+	border: 0;
+	flex: 1;
+	font-size: 0.8em;
+	height: 1.8em;
+	min-width: 0;
+	margin: 1.5px;
+
+	&:hover,
+	&:focus,
+	&:active {
+		outline: 0;
+	}
+
+	.is-loading &::placeholder {
+		color: transparent;
+	}
+}
+
+.wc-block-dropdown-selector__selected-chip {
+	background-color: #dfdfdf;
+	border: 1px solid #9f9f9f;
+	border-radius: 4px;
+	color: inherit;
+	display: inline-block;
+	font-size: 0.8em;
+	font-weight: inherit;
+	height: 1.8em;
+	margin: 1.5px;
+	padding: 0 0 0 0.3em;
+	white-space: nowrap;
+
+	&:hover,
+	&:focus,
+	&:active {
+		border: 1px solid #9f9f9f;
+	}
+}
+
+.wc-block-dropdown-selector__selected-chip__remove {
+	background-color: transparent;
+	border: 0;
+	display: inline-block;
+	padding: 0 0.3em;
+}
+
+.wc-block-dropdown-selector__list {
+	list-style: none;
+	margin: -1px 0 0;
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 100%;
+	max-height: 300px;
+	overflow-y: auto;
+	z-index: 1;
+
+	&:not(:empty) {
+		border: 1px solid #9f9f9f;
+	}
+}
+
+.wc-block-dropdown-selector__list-item {
+	background-color: #fff;
+	padding: 0 $gap-smallest;
+
+	&.is-selected {
+		background-color: #d8d8d8;
+	}
+
+	&:hover,
+	&:focus,
+	&.is-focused,
+	&:active {
+		background-color: #00669e;
+		color: #fff;
+	}
+
+	.wc-block-attribute-filter-list-count {
+		opacity: 0.6;
+	}
+}

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -4,7 +4,7 @@
 	width: 100%;
 }
 
-.wc-block-dropdown-selector__fake-input {
+.wc-block-dropdown-selector__input-wrapper {
 	align-items: baseline;
 	border: 1px solid #9f9f9f;
 	border-radius: 4px;

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -107,8 +107,4 @@
 		background-color: #00669e;
 		color: #fff;
 	}
-
-	.wc-block-attribute-filter-list-count {
-		opacity: 0.6;
-	}
 }

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -42,10 +42,10 @@
 }
 
 .wc-block-dropdown-selector__selected-chip {
-	background-color: #dfdfdf;
+	background-color: $core-grey-light-600;
 	border: 1px solid #9f9f9f;
 	border-radius: 4px;
-	color: inherit;
+	color: $core-grey-dark-600;
 	display: inline-block;
 	font-size: 0.8em;
 	font-weight: inherit;
@@ -57,7 +57,9 @@
 	&:hover,
 	&:focus,
 	&:active {
+		background-color: $core-grey-light-600;
 		border: 1px solid #9f9f9f;
+		color: $core-grey-dark-600;
 	}
 }
 
@@ -86,10 +88,11 @@
 
 .wc-block-dropdown-selector__list-item {
 	background-color: #fff;
+	color: $core-grey-dark-600;
 	padding: 0 $gap-smallest;
 
 	&.is-selected {
-		background-color: #d8d8d8;
+		background-color: $core-grey-light-600;
 	}
 
 	&:hover,

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -102,7 +102,7 @@
 
 	&:hover,
 	&:focus,
-	&.is-focused,
+	&.is-highlighted,
 	&:active {
 		background-color: #00669e;
 		color: #fff;

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -48,8 +48,8 @@ const Label = ( {
 };
 
 Label.propTypes = {
-	label: PropTypes.string,
-	screenReaderLabel: PropTypes.string,
+	label: PropTypes.node,
+	screenReaderLabel: PropTypes.node,
 	wrapperElement: PropTypes.elementType,
 	wrapperProps: PropTypes.object,
 };

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -47,6 +47,8 @@
 }
 
 .wc-block-price-filter {
+	margin-bottom: $gap-large;
+
 	.wc-block-price-filter__range-input-wrapper {
 		@include reset;
 		height: 9px;
@@ -73,7 +75,6 @@
 		flex-flow: row nowrap;
 		justify-content: flex-start;
 		align-items: center;
-		margin: 0 0 20px;
 
 		.wc-block-price-filter__amount {
 			margin: 0;

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -1,5 +1,5 @@
 .wc-block-active-filters {
-	margin: 0 0 $gap;
+	margin-bottom: $gap-large;
 	overflow: hidden;
 
 	.wc-block-active-filters__clear-all {

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -274,16 +274,7 @@ const AttributeFilterBlock = ( {
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
 			<div className="wc-block-attribute-filter">
-				{ blockAttributes.displayStyle === 'list' ? (
-					<CheckboxList
-						className={ 'wc-block-attribute-filter-list' }
-						options={ displayedOptions }
-						checked={ checked }
-						onChange={ onChange }
-						isLoading={ isLoading }
-						isDisabled={ isDisabled }
-					/>
-				) : (
+				{ blockAttributes.displayStyle === 'dropdown' ? (
 					<DropdownSelector
 						attributeLabel={ attributeObject.label }
 						checked={ checked }
@@ -293,6 +284,15 @@ const AttributeFilterBlock = ( {
 						isLoading={ isLoading }
 						onChange={ onChange }
 						options={ displayedOptions }
+					/>
+				) : (
+					<CheckboxList
+						className={ 'wc-block-attribute-filter-list' }
+						options={ displayedOptions }
+						checked={ checked }
+						onChange={ onChange }
+						isLoading={ isLoading }
+						isDisabled={ isDisabled }
 					/>
 				) }
 			</div>

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import {
 	useCollection,
 	useQueryStateByKey,
@@ -15,6 +17,8 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
+import DropdownSelector from '@woocommerce/base-components/dropdown-selector';
+import Label from '@woocommerce/base-components/label';
 
 /**
  * Internal dependencies
@@ -39,9 +43,24 @@ const AttributeFilterBlock = ( {
 				<Fragment>
 					{ name }
 					{ blockAttributes.showCounts && count !== null && (
-						<span className="wc-block-attribute-filter-list-count">
-							{ count }
-						</span>
+						<Label
+							label={ count }
+							screenReaderLabel={ sprintf(
+								// translators: %s number of products.
+								_n(
+									'%s product',
+									'%s products',
+									count,
+									'woo-gutenberg-products-block'
+								),
+								count
+							) }
+							wrapperElement="span"
+							wrapperProps={ {
+								className:
+									'wc-block-attribute-filter-list-count',
+							} }
+						/>
 					) }
 				</Fragment>
 			);
@@ -62,15 +81,18 @@ const AttributeFilterBlock = ( {
 		blockAttributes.isPreview && ! blockAttributes.attributeId
 			? [
 					{
-						key: 'preview-1',
+						value: 'preview-1',
+						name: 'Blue',
 						label: getLabel( 'Blue', 3 ),
 					},
 					{
-						key: 'preview-2',
+						value: 'preview-2',
+						name: 'Green',
 						label: getLabel( 'Green', 3 ),
 					},
 					{
-						key: 'preview-3',
+						value: 'preview-3',
+						name: 'Red',
 						label: getLabel( 'Red', 2 ),
 					},
 			  ]
@@ -149,7 +171,8 @@ const AttributeFilterBlock = ( {
 			}
 
 			newOptions.push( {
-				key: term.slug,
+				value: term.slug,
+				name: term.name,
 				label: getLabel( term.name, count ),
 			} );
 		} );
@@ -183,16 +206,37 @@ const AttributeFilterBlock = ( {
 	 * When a checkbox in the list changes, update state.
 	 */
 	const onChange = useCallback(
-		( event ) => {
-			const isChecked = event.target.checked;
-			const checkedValue = event.target.value;
+		( checkedValue ) => {
+			const isChecked = ! checked.includes( checkedValue );
 			const newChecked = checked.filter(
 				( value ) => value !== checkedValue
+			);
+			const checkedOption = displayedOptions.find(
+				( option ) => option.value === checkedValue
 			);
 
 			if ( isChecked ) {
 				newChecked.push( checkedValue );
 				newChecked.sort();
+				speak(
+					sprintf(
+						__(
+							'%s filter added.',
+							'woo-gutenberg-products-block'
+						),
+						checkedOption.name
+					)
+				);
+			} else {
+				speak(
+					sprintf(
+						__(
+							'%s filter removed.',
+							'woo-gutenberg-products-block'
+						),
+						checkedOption.name
+					)
+				);
 			}
 
 			const newSelectedTerms = getSelectedTerms( newChecked );
@@ -212,6 +256,7 @@ const AttributeFilterBlock = ( {
 			setProductAttributesQuery,
 			attributeObject,
 			blockAttributes,
+			displayedOptions,
 		]
 	);
 
@@ -220,6 +265,8 @@ const AttributeFilterBlock = ( {
 	}
 
 	const TagName = `h${ blockAttributes.headingLevel }`;
+	const isLoading = ! blockAttributes.isPreview && attributeTermsLoading;
+	const isDisabled = ! blockAttributes.isPreview && filteredCountsLoading;
 
 	return (
 		<Fragment>
@@ -227,18 +274,26 @@ const AttributeFilterBlock = ( {
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
 			<div className="wc-block-attribute-filter">
-				<CheckboxList
-					className={ 'wc-block-attribute-filter-list' }
-					options={ displayedOptions }
-					checked={ checked }
-					onChange={ onChange }
-					isLoading={
-						! blockAttributes.isPreview && attributeTermsLoading
-					}
-					isDisabled={
-						! blockAttributes.isPreview && filteredCountsLoading
-					}
-				/>
+				{ blockAttributes.displayStyle === 'list' ? (
+					<CheckboxList
+						className={ 'wc-block-attribute-filter-list' }
+						options={ displayedOptions }
+						checked={ checked }
+						onChange={ onChange }
+						isLoading={ isLoading }
+						isDisabled={ isDisabled }
+					/>
+				) : (
+					<DropdownSelector
+						checked={ checked }
+						className={ 'wc-block-attribute-filter-dropdown' }
+						inputLabel={ blockAttributes.heading }
+						isDisabled={ isDisabled }
+						isLoading={ isLoading }
+						onChange={ onChange }
+						options={ displayedOptions }
+					/>
+				) }
 			</div>
 		</Fragment>
 	);

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -280,7 +280,6 @@ const AttributeFilterBlock = ( {
 						checked={ checked }
 						className={ 'wc-block-attribute-filter-dropdown' }
 						inputLabel={ blockAttributes.heading }
-						isDisabled={ isDisabled }
 						isLoading={ isLoading }
 						onChange={ onChange }
 						options={ displayedOptions }

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -285,6 +285,7 @@ const AttributeFilterBlock = ( {
 					/>
 				) : (
 					<DropdownSelector
+						attributeLabel={ attributeObject.label }
 						checked={ checked }
 						className={ 'wc-block-attribute-filter-dropdown' }
 						inputLabel={ blockAttributes.heading }

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -38,6 +38,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		isPreview,
 		queryType,
 		showCounts,
+		displayStyle,
 	} = attributes;
 
 	const [ isEditing, setIsEditing ] = useState(
@@ -148,6 +149,34 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 						onChange={ ( value ) =>
 							setAttributes( {
 								queryType: value,
+							} )
+						}
+					/>
+					<ToggleButtonControl
+						label={ __(
+							'Display Style',
+							'woo-gutenberg-products-block'
+						) }
+						value={ displayStyle }
+						options={ [
+							{
+								label: __(
+									'List',
+									'woo-gutenberg-products-block'
+								),
+								value: 'list',
+							},
+							{
+								label: __(
+									'Dropdown',
+									'woo-gutenberg-products-block'
+								),
+								value: 'dropdown',
+							},
+						] }
+						onChange={ ( value ) =>
+							setAttributes( {
+								displayStyle: value,
 							} )
 						}
 					/>

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -33,12 +33,12 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	const {
 		attributeId,
 		className,
+		displayStyle,
 		heading,
 		headingLevel,
 		isPreview,
 		queryType,
 		showCounts,
-		displayStyle,
 	} = attributes;
 
 	const [ isEditing, setIsEditing ] = useState(

--- a/assets/js/blocks/attribute-filter/frontend.js
+++ b/assets/js/blocks/attribute-filter/frontend.js
@@ -17,6 +17,7 @@ const getProps = ( el ) => {
 			queryType: el.dataset.queryType,
 			heading: el.dataset.heading,
 			headingLevel: el.dataset.headingLevel || 3,
+			displayStyle: el.dataset.displayStyle,
 		},
 	};
 };

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -85,8 +85,10 @@ registerBlockType( 'woocommerce/attribute-filter', {
 			'data-query-type': queryType,
 			'data-heading': heading,
 			'data-heading-level': headingLevel,
-			'data-display-style': displayStyle,
 		};
+		if ( displayStyle !== 'list' ) {
+			data[ 'data-display-style' ] = displayStyle;
+		}
 		return (
 			<div
 				className={ classNames( 'is-loading', className ) }

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -53,6 +53,10 @@ registerBlockType( 'woocommerce/attribute-filter', {
 			type: 'number',
 			default: 3,
 		},
+		displayStyle: {
+			type: 'string',
+			default: 'list',
+		},
 		/**
 		 * Are we previewing?
 		 */
@@ -73,6 +77,7 @@ registerBlockType( 'woocommerce/attribute-filter', {
 			attributeId,
 			heading,
 			headingLevel,
+			displayStyle,
 		} = attributes;
 		const data = {
 			'data-attribute-id': attributeId,
@@ -80,6 +85,7 @@ registerBlockType( 'woocommerce/attribute-filter', {
 			'data-query-type': queryType,
 			'data-heading': heading,
 			'data-heading-level': headingLevel,
+			'data-display-style': displayStyle,
 		};
 		return (
 			<div

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -1,4 +1,11 @@
 .wc-block-attribute-filter {
+	.wc-block-attribute-filter-list-count::before {
+		content: " (";
+	}
+	.wc-block-attribute-filter-list-count::after {
+		content: ")";
+	}
+
 	.wc-block-attribute-filter-list {
 		margin: 0 0 $gap;
 
@@ -13,12 +20,6 @@
 
 		.wc-block-attribute-filter-list-count {
 			float: right;
-		}
-		.wc-block-attribute-filter-list-count::before {
-			content: " (";
-		}
-		.wc-block-attribute-filter-list-count::after {
-			content: ")";
 		}
 	}
 }

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -24,4 +24,10 @@
 			float: right;
 		}
 	}
+
+	.wc-block-dropdown-selector {
+		.wc-block-attribute-filter-list-count {
+			opacity: 0.6;
+		}
+	}
 }

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -26,7 +26,7 @@
 	}
 
 	.wc-block-dropdown-selector {
-		.wc-block-attribute-filter-list-count {
+		.wc-block-dropdown-selector__list .wc-block-attribute-filter-list-count {
 			opacity: 0.6;
 		}
 	}

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -1,4 +1,6 @@
 .wc-block-attribute-filter {
+	margin-bottom: $gap-large;
+
 	.wc-block-attribute-filter-list-count::before {
 		content: " (";
 	}
@@ -7,7 +9,7 @@
 	}
 
 	.wc-block-attribute-filter-list {
-		margin: 0 0 $gap;
+		margin: 0;
 
 		li {
 			text-decoration: underline;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7188,6 +7188,11 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
       "dev": true
     },
+    "compute-scroll-into-view": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz",
+      "integrity": "sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A=="
+    },
     "computed-style": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
@@ -8255,6 +8260,17 @@
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
+      }
+    },
+    "downshift": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.4.3.tgz",
+      "integrity": "sha512-lk0Q1VF4eTDe4EMzYtdVCPdu58ZRFyK3wxEAGUeKqPRDoHDgoS9/TaxW2w+hEbeh9yBMU2IKX8lQkNn6YTfZ4w==",
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "compute-scroll-into-view": "^1.0.9",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.9.0"
       }
     },
     "duplexer": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 	"dependencies": {
 		"@woocommerce/components": "3.2.0",
 		"compare-versions": "3.5.1",
+		"downshift": "^3.4.2",
 		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",
 		"gridicons": "3.3.1",
 		"react-number-format": "4.3.1",


### PR DESCRIPTION
Part of #1134 and #1135.

This PR implements the dropdown display style for the _Filter Products by Attribute_ block with the _Query Type_ set to `OR` (see #1134 for the difference between `OR` and `AND`).

I plan to implement the `AND` format in a follow-up, but wanted to get feedback early before starting with it.

#### Accessibility
- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
![Peek 2019-11-25 20-03](https://user-images.githubusercontent.com/3616980/69569869-db8ee780-0fbe-11ea-80f9-52fd95c9be20.gif)

### How to test the changes in this Pull Request:

1. Create a post with a _Filter Products by Attribute_ block and select the _Dropdown_ option in _Display Style_.
2. Preview the post and interact with the filter (search terms, add them, remove them, repeat only using the keyboard, using a screen reader, etc.).
3. Verify everything works as expected.

### Follow-ups
* As mentioned, the `AND` dropdown format will be implemented in a follow-up.
* I didn't implement the _Apply_ button that can be seen in the mockups. I would like to discuss with @jwold not showing it or making it optional as in the _Price Filter_, so instant updates can happen.

### Changelog

> Add dropdown display style to Filter Products by Attribute block.