### PR TITLE
Fix inconsistent heading editor styles for filter blocks

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -39,3 +39,10 @@
 		}
 	}
 }
+
+// Ensure textarea bg color is transparent for block titles.
+// Some themes (e.g. Twenty Twenty) set bg white for textarea, which breaks editor theme styles.
+// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1204
+textarea.wc-block-component-title {
+	background-color: transparent;
+}

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -40,9 +40,3 @@
 	}
 }
 
-// Ensure textarea bg color is transparent for block titles.
-// Some themes (e.g. Twenty Twenty) set bg white for textarea, which breaks editor theme styles.
-// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1204
-textarea.wc-block-component-title {
-	background-color: transparent;
-}

--- a/assets/js/components/block-title/editor.scss
+++ b/assets/js/components/block-title/editor.scss
@@ -1,6 +1,6 @@
 // Ensure textarea bg color is transparent for block titles.
 // Some themes (e.g. Twenty Twenty) set a non-white background for the editor, and Gutenberg sets white background for text inputs, creating this issue.
 // https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1204
-textarea.wc-block-component-title {
+.wc-block-component-title {
 	background-color: transparent;
 }

--- a/assets/js/components/block-title/editor.scss
+++ b/assets/js/components/block-title/editor.scss
@@ -1,0 +1,6 @@
+// Ensure textarea bg color is transparent for block titles.
+// Some themes (e.g. Twenty Twenty) set a non-white background for the editor, adn Gutenberg sets white background for text inputs, creating this issue.
+// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1204
+textarea.wc-block-component-title {
+	background-color: transparent;
+}

--- a/assets/js/components/block-title/editor.scss
+++ b/assets/js/components/block-title/editor.scss
@@ -1,5 +1,5 @@
 // Ensure textarea bg color is transparent for block titles.
-// Some themes (e.g. Twenty Twenty) set a non-white background for the editor, adn Gutenberg sets white background for text inputs, creating this issue.
+// Some themes (e.g. Twenty Twenty) set a non-white background for the editor, and Gutenberg sets white background for text inputs, creating this issue.
 // https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1204
 textarea.wc-block-component-title {
 	background-color: transparent;

--- a/assets/js/components/block-title/index.js
+++ b/assets/js/components/block-title/index.js
@@ -5,6 +5,11 @@ import PropTypes from 'prop-types';
 import { PlainText } from '@wordpress/block-editor';
 import classnames from 'classnames';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 const BlockTitle = ( { className, headingLevel, onChange, heading } ) => {
 	const TagName = `h${ headingLevel }`;
 	return (


### PR DESCRIPTION
Fixes #1204

In the new default theme [Twenty Twenty](https://make.wordpress.org/core/2019/09/06/introducing-twenty-twenty/), the background color of pages is not white, and the theme also sets default styles for `textarea` controls to white.

When editing in the block editor, the front-end styles are used so editing is WYSIWYG. In the "filter" blocks (`Filter Products by Attribute`, `Filter Products by Price`) we're using `textarea` elements are used for editing block titles. These are showing as white-background in the editor. This looks inconsistent with the front end styles.

This PR overrides the background color of these specific textareas in the editor stylesheet to fix the issue.

#### Accessibility

No interactions changed, assuming colour contrast of Twenty Twenty is within guidelines :)

### Screenshots

Before (bug):

<img width="1416" alt="Screen Shot 2019-11-26 at 3 04 56 PM" src="https://user-images.githubusercontent.com/4167300/69593547-5d821d80-105e-11ea-91ac-8d83565b13b9.png">

After:

<img width="1416" alt="Screen Shot 2019-11-26 at 3 04 36 PM" src="https://user-images.githubusercontent.com/4167300/69593556-6246d180-105e-11ea-84cf-461555af0724.png">

### How to test the changes in this Pull Request:
1. Clone this branch in a WordPress + Woo development environment with Twenty Twenty theme installed and active.
2. Add `Filter Products by Attribute` and/or `Filter Products by Price` blocks.
3. Edit blocks, block title. Should look consistent with front-end styles as you edit.

### Changelog

> Fix: Editor styles (background color) for titles of "Filter by …" blocks.
