### PR TITLE
Fix color on pagination caused by Twenty Twenty

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,1 +1,3 @@
-/* Moved */
+.wc-block-pagination-page:not(.toggle) {
+	background-color: transparent;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,3 +1,7 @@
+// Twenty Twenty register a background color for buttons that is too specific
+// and broad at the same time `button:not(.toggle)` so We’re Engaging in a
+// specify war with them here.
+// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1203
 .wc-block-pagination-page:not(.toggle) {
 	background-color: transparent;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,7 +1,1 @@
-// Twenty Twenty register a background color for buttons that is too specific
-// and broad at the same time `button:not(.toggle)` so We’re Engaging in a
-// specify war with them here.
-// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1203
-.wc-block-pagination-page:not(.toggle) {
-	background-color: transparent;
-}
+/* Moved */

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -11,6 +11,7 @@
 }
 
 .wc-block-pagination-page {
+	border-color: transparent;
 	padding: 0.3em 0.6em;
 	min-width: 2.2em;
 

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -11,7 +11,6 @@
 }
 
 .wc-block-pagination-page {
-	border-color: transparent;
 	padding: 0.3em 0.6em;
 	min-width: 2.2em;
 

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -11,7 +11,6 @@
 }
 
 .wc-block-pagination-page {
-	background-color: transparent;
 	border-color: transparent;
 	padding: 0.3em 0.6em;
 	min-width: 2.2em;

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -20,6 +20,14 @@
 		padding: 0.1em 0.2em;
 		min-width: 1.6em;
 	}
+
+	// Twenty Twenty register a background color for buttons that is too specific
+	// and broad at the same time `button:not(.toggle)` so We’re Engaging in a
+	// specify war with them here.
+	// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1203
+	&:not(.toggle) {
+		background-color: transparent;
+	}
 }
 
 .wc-block-pagination-ellipsis {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Twenty Twenty register a background color for all buttons, and seems to be very specific about it by using `button:not(.toggle)` which over-specify any other normal selector (tag or class)

This should fix it while we see a solution with TwentyTwenty  
<!-- Reference any related issues or PRs here -->
Fixes #1203
