### PR TITLE
Fix bug with cart not updating

### DIFF
--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -114,7 +114,7 @@ const ProductButton = ( { product, className } ) => {
 		const event = document.createEvent( 'Event' );
 		event.initEvent( 'wc_fragment_refresh', true, true );
 		document.body.dispatchEvent( event );
-	}, [ addedToCart ] )
+	}, [ addedToCart ] );
 	const wrapperClasses = classnames(
 		className,
 		`${ layoutStyleClassPrefix }__product-add-to-cart`,

--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -111,8 +111,8 @@ const ProductButton = ( { product, className } ) => {
 	// that relies on the store, see
 	// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
 	useEffect( () => {
-		const event = document.createEvent( 'Event' );
-		event.initEvent( 'wc_fragment_refresh', true, true );
+		// eslint-disable-next-line no-undef
+		const event = new Event( "wc_fragment_refresh", { "bubbles":true, "cancelable":true } );
 		document.body.dispatchEvent( event );
 	}, [ addedToCart ] );
 	const wrapperClasses = classnames(

--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -106,6 +106,15 @@ const ProductButton = ( { product, className } ) => {
 		}
 		return productCartDetails.text;
 	};
+
+	// This is a hack to trigger cart updates till we migrate to block based card
+	// that relies on the store, see
+	// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
+	useEffect( () => {
+		const event = document.createEvent( 'Event' );
+		event.initEvent( 'wc_fragment_refresh', true, true );
+		document.body.dispatchEvent( event );
+	}, [ addedToCart ] )
 	const wrapperClasses = classnames(
 		className,
 		`${ layoutStyleClassPrefix }__product-add-to-cart`,

--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -112,7 +112,10 @@ const ProductButton = ( { product, className } ) => {
 	// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
 	useEffect( () => {
 		// eslint-disable-next-line no-undef
-		const event = new Event( "wc_fragment_refresh", { "bubbles":true, "cancelable":true } );
+		const event = new Event( 'wc_fragment_refresh', {
+			bubbles: true,
+			cancelable: true,
+		} );
 		document.body.dispatchEvent( event );
 	}, [ addedToCart ] );
 	const wrapperClasses = classnames(

--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -80,6 +80,8 @@ const useAddToCart = ( productId ) => {
 	};
 };
 
+const Event = window.Event || {};
+
 const ProductButton = ( { product, className } ) => {
 	const {
 		id,
@@ -111,13 +113,20 @@ const ProductButton = ( { product, className } ) => {
 	// that relies on the store, see
 	// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
 	useEffect( () => {
-		// eslint-disable-next-line no-undef
-		const event = new Event( 'wc_fragment_refresh', {
-			bubbles: true,
-			cancelable: true,
-		} );
-		document.body.dispatchEvent( event );
-	}, [ addedToCart ] );
+		// Test if we have our Event defined
+		if ( Object.entries( Event ).length !== 0 ) {
+			const event = new Event( 'wc_fragment_refresh', {
+				bubbles: true,
+				cancelable: true,
+			} );
+			document.body.dispatchEvent( event );
+		} else {
+			const event = document.createEvent( 'Event' );
+			event.initEvent( 'wc_fragment_refresh', true, true );
+			document.body.dispatchEvent( event );
+		}
+	}, [ cartQuantity ] );
+
 	const wrapperClasses = classnames(
 		className,
 		`${ layoutStyleClassPrefix }__product-add-to-cart`,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a hack to trigger `wc_fragment_refresh` that updates the cart content when you click `Add to Cart` button, we should migrate to a store based approach when we build a cart block.

<!-- Reference any related issues or PRs here -->
Fixes #1247
