### PR TITLE
Fix wrong proptypes definition in BlockTitle component

### DIFF
--- a/assets/js/components/block-title/index.js
+++ b/assets/js/components/block-title/index.js
@@ -20,23 +20,24 @@ const BlockTitle = ( { className, headingLevel, onChange, heading } ) => {
 		</TagName>
 	);
 };
+
 BlockTitle.propTypes = {
 	/**
 	 * Classname to add to title in addition to the defaults.
 	 */
 	className: PropTypes.string,
 	/**
-	 * The value of the heading
+	 * The value of the heading.
 	 */
 	value: PropTypes.string,
 	/**
-	 * Callback to update the attribute when text is changed
+	 * Callback to update the attribute when text is changed.
 	 */
 	onChange: PropTypes.func,
 	/**
-	 * Callback to update the attribute when text is changed
+	 * Level of the heading tag (1, 2, 3... will render <h1>, <h2>, <h3>... elements).
 	 */
-	headingLevel: PropTypes.func,
+	headingLevel: PropTypes.number,
 };
 
 export default BlockTitle;


### PR DESCRIPTION
There was an error in the console when the `<BlockTitle>` component was rendered (filter blocks, for example).

### Screenshots

![image](https://user-images.githubusercontent.com/3616980/69623292-e4290180-1042-11ea-8dee-1adb56a1a889.png)

### How to test the changes in this Pull Request:

1. Create a post and add an _Active Filters_, _Filter Products by Price_ and _Filter Products by Attribute_ blocks.
2. Verify there are no errors in your browser devtools console.
