### PR TITLE
 Filter by Attribute: Allow reselecting unselected attribute 

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -237,7 +237,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 				attributeName
 			),
 		} );
-	}, [] );
+	}, [ attributeId ] );
 
 	const renderAttributeControl = () => {
 		const messages = {

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -216,28 +216,31 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		);
 	}, [] );
 
-	const onChange = useCallback( ( selected ) => {
-		const selectedId = selected[ 0 ].id;
-		const productAttribute = find( ATTRIBUTES, [
-			'attribute_id',
-			selectedId.toString(),
-		] );
+	const onChange = useCallback(
+		( selected ) => {
+			const selectedId = selected[ 0 ].id;
+			const productAttribute = find( ATTRIBUTES, [
+				'attribute_id',
+				selectedId.toString(),
+			] );
 
-		if ( ! productAttribute || attributeId === selectedId ) {
-			return;
-		}
+			if ( ! productAttribute || attributeId === selectedId ) {
+				return;
+			}
 
-		const attributeName = productAttribute.attribute_name;
+			const attributeName = productAttribute.attribute_name;
 
-		setAttributes( {
-			attributeId: selectedId,
-			heading: sprintf(
-				// Translators: %s attribute name.
-				__( 'Filter by %s', 'woo-gutenberg-products-block' ),
-				attributeName
-			),
-		} );
-	}, [ attributeId ] );
+			setAttributes( {
+				attributeId: selectedId,
+				heading: sprintf(
+					// Translators: %s attribute name.
+					__( 'Filter by %s', 'woo-gutenberg-products-block' ),
+					attributeName
+				),
+			} );
+		},
+		[ attributeId ]
+	);
 
 	const renderAttributeControl = () => {
 		const messages = {


### PR DESCRIPTION
Fixes #1236.

### Screenshots

![Peek 2019-11-26 17-34](https://user-images.githubusercontent.com/3616980/69653148-06d30e80-1073-11ea-91e7-eb33ccfb6b0f.gif)

### How to test the changes in this Pull Request:

1. Create a post and add a _Filter Products by Attribute_ block.
2. Select an attribute.
3. Edit the block again, select an attribute different than the currently selected one but before clicking on _Done_, select the previous attribute again (see GIF above).
4. Verify you can select the current attribute.

### Changelog

> Filter by Attribute: fix in the selector that was preventing to reselect the currently selected attribute.