### PR TITLE
Use attribute label instead of slug in Filter by Attribute title

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -228,7 +228,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 				return;
 			}
 
-			const attributeName = productAttribute.attribute_name;
+			const attributeName = productAttribute.attribute_label;
 
 			setAttributes( {
 				attributeId: selectedId,


### PR DESCRIPTION
Fixes #1270.

### Screenshots
_Before:_
![image](https://user-images.githubusercontent.com/3616980/69724081-638a0400-111b-11ea-860c-30a922c980da.png)

_After:_
![image](https://user-images.githubusercontent.com/3616980/69724145-8ddbc180-111b-11ea-99d7-8a2c97bd3893.png)

### How to test the changes in this Pull Request:

1. Create an attribute with a multi-word name or with special characters (accents, for example), so slug must be different.
2. Update a product so it has this attribute defined. We need at least one product to use the attribute in order to appear in the list of attributes when adding the block.
3. Create a post with a _Filter Products by Attribute_ block using that attribute.
4. Verify it uses the label instead of the slug for the block title.

### Changelog

> Filter Products by Attribute block now uses the attribute label instead of the slug to set the default title.