### PR TITLE
Add source-maps for easier debugging development builds

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -153,6 +153,7 @@ const getMainConfig = ( options = {} ) => {
 	return {
 		entry: getEntryConfig( true, options.exclude || [] ),
 		output: {
+			devtoolNamespace: 'wc',
 			path: path.resolve( __dirname, '../build/' ),
 			filename: `[name]${ fileSuffix }.js`,
 			library: [ 'wc', 'blocks', '[name]' ],
@@ -286,6 +287,7 @@ const getFrontConfig = ( options = {} ) => {
 	return {
 		entry: getEntryConfig( false, options.exclude || [] ),
 		output: {
+			devtoolNamespace: 'wc',
 			path: path.resolve( __dirname, '../build/' ),
 			filename: `[name]-frontend${ fileSuffix }.js`,
 			// This fixes an issue with multiple webpack projects using chunking

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ const baseConfig = {
 	watchOptions: {
 		ignored: /node_modules/,
 	},
+	devtool: NODE_ENV === 'production' ? false : 'source-map',
 };
 
 const CoreConfig = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ const baseConfig = {
 	watchOptions: {
 		ignored: /node_modules/,
 	},
-	devtool: NODE_ENV === 'production' ? false : 'source-map',
+	devtool: NODE_ENV === 'development' ? 'source-map' : false,
 };
 
 const CoreConfig = {


### PR DESCRIPTION
Hat tip to @haszari  for the prompt to get this added.  I guess I just never noticed we didn't have source maps enabled.

This pull enables source maps for our development builds so that you can more easily debug errors using the browser inspector.