### PR TITLE
Replace 'isPreview' with 'isEditor' when it refers to the editor

### DIFF
--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useQueryStateByKey } from '@woocommerce/base-hooks';
 import { useMemo, Fragment } from '@wordpress/element';
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -113,6 +114,17 @@ const ActiveFiltersBlock = ( {
 			</div>
 		</Fragment>
 	);
+};
+
+ActiveFiltersBlock.propTypes = {
+	/**
+	 * The attributes for this block.
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * Whether it's in the editor or frontend display.
+	 */
+	isEditor: PropTypes.bool,
 };
 
 export default ActiveFiltersBlock;

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -19,7 +19,7 @@ import ActiveAttributeFilters from './active-attribute-filters';
  */
 const ActiveFiltersBlock = ( {
 	attributes: blockAttributes,
-	isPreview = false,
+	isEditor = false,
 } ) => {
 	const [ productAttributes, setProductAttributes ] = useQueryStateByKey(
 		'attributes',
@@ -65,7 +65,7 @@ const ActiveFiltersBlock = ( {
 		);
 	};
 
-	if ( ! hasFilters() && ! isPreview ) {
+	if ( ! hasFilters() && ! isEditor ) {
 		return null;
 	}
 
@@ -77,12 +77,12 @@ const ActiveFiltersBlock = ( {
 
 	return (
 		<Fragment>
-			{ ! isPreview && blockAttributes.heading && (
+			{ ! isEditor && blockAttributes.heading && (
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
 			<div className="wc-block-active-filters">
 				<ul className={ listClasses }>
-					{ isPreview ? (
+					{ isEditor ? (
 						<Fragment>
 							{ renderRemovableListItem(
 								__( 'Size', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -82,7 +82,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 				onChange={ ( value ) => setAttributes( { heading: value } ) }
 			/>
 			<Disabled>
-				<Block attributes={ attributes } isEditor />
+				<Block attributes={ attributes } isEditor={ true } />
 			</Disabled>
 		</div>
 	);

--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -82,7 +82,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 				onChange={ ( value ) => setAttributes( { heading: value } ) }
 			/>
 			<Disabled>
-				<Block attributes={ attributes } isPreview />
+				<Block attributes={ attributes } isEditor />
 			</Disabled>
 		</div>
 	);

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -14,7 +14,7 @@ import { useDebouncedCallback } from 'use-debounce';
 /**
  * Component displaying a price filter.
  */
-const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
+const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 	const [ minPriceQuery, setMinPriceQuery ] = useQueryStateByKey(
 		'min_price'
 	);
@@ -101,7 +101,7 @@ const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
 
 	return (
 		<Fragment>
-			{ ! isPreview && attributes.heading && (
+			{ ! isEditor && attributes.heading && (
 				<TagName>{ attributes.heading }</TagName>
 			) }
 			<div className="wc-block-price-slider">

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -10,6 +10,7 @@ import { Fragment, useCallback, useState, useEffect } from '@wordpress/element';
 import PriceSlider from '@woocommerce/base-components/price-slider';
 import { CURRENCY } from '@woocommerce/settings';
 import { useDebouncedCallback } from 'use-debounce';
+import PropTypes from 'prop-types';
 
 /**
  * Component displaying a price filter.
@@ -122,6 +123,17 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 			</div>
 		</Fragment>
 	);
+};
+
+PriceFilterBlock.propTypes = {
+	/**
+	 * The attributes for this block.
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * Whether it's in the editor or frontend display.
+	 */
+	isEditor: PropTypes.bool,
 };
 
 export default PriceFilterBlock;

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -167,7 +167,7 @@ export default function( { attributes, setAttributes } ) {
 						}
 					/>
 					<Disabled>
-						<Block attributes={ attributes } isPreview />
+						<Block attributes={ attributes } isEditor />
 					</Disabled>
 				</div>
 			) }

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -167,7 +167,7 @@ export default function( { attributes, setAttributes } ) {
 						}
 					/>
 					<Disabled>
-						<Block attributes={ attributes } isEditor />
+						<Block attributes={ attributes } isEditor={ true } />
 					</Disabled>
 				</div>
 			) }

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -152,7 +152,7 @@ class ProductSearchBlock extends Component {
 	}
 
 	render() {
-		if ( this.props.isPreview ) {
+		if ( this.props.isEditor ) {
 			return this.renderEdit();
 		}
 
@@ -170,9 +170,9 @@ ProductSearchBlock.propTypes = {
 	 */
 	instanceId: PropTypes.number,
 	/**
-	 * Whether this is the block preview or frontend display.
+	 * Whether it's in the editor or frontend display.
 	 */
-	isPreview: PropTypes.bool,
+	isEditor: PropTypes.bool,
 	/**
 	 * A callback to update attributes.
 	 */

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -113,7 +113,7 @@ registerBlockType( 'woocommerce/product-search', {
 						/>
 					</PanelBody>
 				</InspectorControls>
-				<Block { ...props } isPreview />
+				<Block { ...props } isEditor />
 			</Fragment>
 		);
 	},

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -113,7 +113,7 @@ registerBlockType( 'woocommerce/product-search', {
 						/>
 					</PanelBody>
 				</InspectorControls>
-				<Block { ...props } isEditor />
+				<Block { ...props } isEditor={ true } />
 			</Fragment>
 		);
 	},


### PR DESCRIPTION
Coming from the discussion here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1169#discussion_r345863986.

In several places we were using the boolean `isPreview` when we meant the block was seen in the editor. That made it very confusing because in some other places `isPreview` refers to the block being seen in the inserter previewer. This PR replaces all instances of `isPreview` that were referring to the editor to `isEditor`.

### How to test the changes in this Pull Request:

1. Create a post with these blocks: _Active Filter_, _Price Filter_ and _Product Search_.
2. Verify they work as expected in the editor.
3. Now search them in the top bar inserter and verify a preview is shown for all of them and it looks correctly.

