### PR TITLE
Fix Price Filter block if minPrice or maxPrice are null

### DIFF
--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -92,12 +92,14 @@ const PriceFilterBlock = ( { attributes, isPreview = false } ) => {
 	}
 
 	const TagName = `h${ attributes.headingLevel }`;
-	const min = Number.isFinite( minConstraint )
-		? Math.max( minPrice, minConstraint )
-		: minPrice;
-	const max = Number.isFinite( maxConstraint )
-		? Math.min( maxPrice, maxConstraint )
-		: maxPrice;
+	const min = Math.max(
+		Number.isFinite( minPrice ) ? minPrice : -Infinity,
+		Number.isFinite( minConstraint ) ? minConstraint : -Infinity
+	);
+	const max = Math.min(
+		Number.isFinite( maxPrice ) ? maxPrice : Infinity,
+		Number.isFinite( maxConstraint ) ? maxConstraint : Infinity
+	);
 
 	return (
 		<Fragment>


### PR DESCRIPTION
Fixes #1277. _Active Filters_ _Clear All_ button was setting min and max price to `null`, that was causing unexpected results in the _Price Filter_ block. See GIF:

![Peek 2019-11-28 18-40](https://user-images.githubusercontent.com/3616980/69825163-9b25a880-120e-11ea-9ab6-743d5403379c.gif)

### How to test the changes in this Pull Request:

1. In a post with _Active Filters_ and _Price Filter_ blocks, move the price slider.
2. Click on _Clear all_ filters.
3. Verify _Price Filter_ is reset to constraint values (instead of 0-0).

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix Filter Products by Price slider being reset to 0-0 when filters were cleared from the Active Filters block.