### PR TITLE
Fix the PHP Notice in Featured Category Block when the category Id is invalid

### DIFF
--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -46,7 +46,7 @@ class FeaturedCategory extends AbstractDynamicBlock {
 	public function render( $attributes = array(), $content = '' ) {
 		$id       = isset( $attributes['categoryId'] ) ? (int) $attributes['categoryId'] : 0;
 		$category = get_term( $id, 'product_cat' );
-		if ( ! $category ) {
+		if ( ! $category || is_wp_error( $category ) ) {
 			return '';
 		}
 		$attributes = wp_parse_args( $attributes, $this->defaults );


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1290

If the category Id is invalid, `get_term` will return a `\WP_Error` and we'll bail out.

Fixes #1290

### How to test the changes in this Pull Request:

As a theorical steps to reproduce, you can add the following block manually in the DB:

```html
<!-- wp:woocommerce/featured-category {"editMode":false,"categoryId":0} -->
<!-- wp:button {"align":"center"} -->
<div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="http://domainl.local/product-category/more/">Shop now</a></div>
<!-- /wp:button -->
<!-- /wp:woocommerce/featured-category -->
```

=> The PHP Notice should not show up and the no HTML should be rendered for the block.

### Changelog

> Fixed a PHP Notice in Featured Category Block when th category is invalid.
