### PR TITLE
Restore back-compat loading of assets registry switch which ensures wcSettings is only loaded when necessary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -841,9 +841,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
-      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
+      "integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
       "requires": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.2"
@@ -1980,25 +1980,25 @@
       }
     },
     "@woocommerce/components": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-3.2.0.tgz",
-      "integrity": "sha512-Z4G7+ix7qCFT4xDfR6yUH6chPEIGYSUCkflDe4mpbg+ot9VM9dq3ZB8K0H3TvUzNezAgNnECfEh221XUs4lMrw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-4.0.0.tgz",
+      "integrity": "sha512-eM0jqyBED4/qGZ7afkAtgqGGEp3z4cCpNrn+qGsdqng2CVq3AIydPh0pUskkElkACHJEMhRh09p6CFqwBJzyDw==",
       "requires": {
-        "@babel/runtime-corejs2": "7.5.5",
-        "@woocommerce/csv-export": "1.1.0",
-        "@woocommerce/currency": "1.1.1",
-        "@woocommerce/date": "1.0.7",
-        "@woocommerce/navigation": "2.1.0",
-        "@wordpress/components": "7.4.0",
-        "@wordpress/compose": "3.3.0",
-        "@wordpress/date": "3.3.0",
-        "@wordpress/element": "2.4.0",
-        "@wordpress/html-entities": "2.3.0",
-        "@wordpress/i18n": "3.4.0",
-        "@wordpress/keycodes": "2.3.0",
-        "@wordpress/viewport": "2.4.0",
+        "@babel/runtime-corejs2": "7.7.4",
+        "@woocommerce/csv-export": "1.2.0",
+        "@woocommerce/currency": "2.0.0",
+        "@woocommerce/date": "2.0.0",
+        "@woocommerce/navigation": "4.0.0",
+        "@wordpress/components": "8.4.0",
+        "@wordpress/compose": "3.7.1",
+        "@wordpress/date": "3.5.0",
+        "@wordpress/element": "2.8.1",
+        "@wordpress/html-entities": "2.5.0",
+        "@wordpress/i18n": "3.6.1",
+        "@wordpress/keycodes": "2.6.1",
+        "@wordpress/viewport": "2.8.1",
         "classnames": "2.2.6",
-        "core-js": "2.6.9",
+        "core-js": "2.6.10",
         "d3-axis": "^1.0.12",
         "d3-format": "^1.3.2",
         "d3-scale": "^2.1.2",
@@ -2010,81 +2010,117 @@
         "gridicons": "3.3.1",
         "interpolate-components": "1.1.1",
         "lodash": "4.17.15",
-        "memoize-one": "5.0.5",
+        "memoize-one": "5.1.1",
         "moment": "2.22.1",
         "prop-types": "15.7.2",
-        "qs": "6.7.0",
+        "qs": "6.9.1",
         "react-dates": "17.2.0",
-        "react-router-dom": "5.0.1",
+        "react-router-dom": "5.1.2",
         "react-transition-group": "2.9.0"
       },
       "dependencies": {
         "@wordpress/components": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-          "integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+          "version": "8.4.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.4.0.tgz",
+          "integrity": "sha512-Fr2L8b8RxUC6hPiN2pMVKGaeB25RA+g4ENpA32LzmuEGd0ITBXtZfFUv3+5FMcUe4y9KFQZbXxBRElBf4xA+SQ==",
           "requires": {
             "@babel/runtime": "^7.4.4",
-            "@wordpress/a11y": "^2.3.0",
-            "@wordpress/api-fetch": "^3.2.0",
-            "@wordpress/compose": "^3.3.0",
-            "@wordpress/dom": "^2.3.0",
-            "@wordpress/element": "^2.4.0",
-            "@wordpress/hooks": "^2.3.0",
-            "@wordpress/i18n": "^3.4.0",
-            "@wordpress/is-shallow-equal": "^1.3.0",
-            "@wordpress/keycodes": "^2.3.0",
-            "@wordpress/rich-text": "^3.3.0",
-            "@wordpress/url": "^2.6.0",
+            "@wordpress/a11y": "^2.5.1",
+            "@wordpress/compose": "^3.8.0",
+            "@wordpress/deprecated": "^2.6.1",
+            "@wordpress/dom": "^2.6.0",
+            "@wordpress/element": "^2.9.0",
+            "@wordpress/hooks": "^2.6.0",
+            "@wordpress/i18n": "^3.7.0",
+            "@wordpress/is-shallow-equal": "^1.6.1",
+            "@wordpress/keycodes": "^2.7.0",
+            "@wordpress/rich-text": "^3.8.0",
             "classnames": "^2.2.5",
             "clipboard": "^2.0.1",
-            "diff": "^3.5.0",
             "dom-scroll-into-view": "^1.2.1",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.15",
             "memize": "^1.0.5",
             "moment": "^2.22.1",
             "mousetrap": "^1.6.2",
-            "re-resizable": "^4.7.1",
-            "react-click-outside": "^3.0.0",
+            "re-resizable": "^6.0.0",
             "react-dates": "^17.1.1",
+            "react-spring": "^8.0.20",
             "rememo": "^3.0.0",
             "tinycolor2": "^1.4.1",
             "uuid": "^3.3.2"
-          }
-        },
-        "@wordpress/date": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.3.0.tgz",
-          "integrity": "sha512-xv7vXXPWyFzUUl/MPZnsbEwrNlDBM6TZCeH/66u7x9TcylVujpaI/ePhowXcnNUvYDHxAkGoBtmKQyfjFRf0rg==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "moment": "^2.22.1",
-            "moment-timezone": "^0.5.16"
+          },
+          "dependencies": {
+            "@wordpress/compose": {
+              "version": "3.8.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.8.0.tgz",
+              "integrity": "sha512-n22OFDcwoMZ+/GAjVCd28cwlN6NHslTy4eONLLS7tOrdMKYl4wQ3cFLzxu8XHgf1Pt14ogGyOaJqvdEGbBGrsw==",
+              "requires": {
+                "@babel/runtime": "^7.4.4",
+                "@wordpress/element": "^2.9.0",
+                "@wordpress/is-shallow-equal": "^1.6.1",
+                "lodash": "^4.17.15"
+              }
+            },
+            "@wordpress/element": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.9.0.tgz",
+              "integrity": "sha512-IohEi9EkT+jnZof35l5PxDAHaBZXOcZzFS14B4cBt1eKFjbd5C54b8lHbifaL8b82S26ggMdA44sEoXVutdC0g==",
+              "requires": {
+                "@babel/runtime": "^7.4.4",
+                "@wordpress/escape-html": "^1.6.0",
+                "lodash": "^4.17.15",
+                "react": "^16.9.0",
+                "react-dom": "^16.9.0"
+              }
+            },
+            "@wordpress/i18n": {
+              "version": "3.7.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.7.0.tgz",
+              "integrity": "sha512-yavu3yAKbSkEosQvEd0lCa064SdFFb8i6f7RfZGDq/TQfJHBaJQvRA4Hd/CtrOXqS6DLjw2rLNrVG4XcJFss1A==",
+              "requires": {
+                "@babel/runtime": "^7.4.4",
+                "gettext-parser": "^1.3.1",
+                "lodash": "^4.17.15",
+                "memize": "^1.0.5",
+                "sprintf-js": "^1.1.1",
+                "tannin": "^1.1.0"
+              }
+            },
+            "@wordpress/keycodes": {
+              "version": "2.7.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.7.0.tgz",
+              "integrity": "sha512-FPOFKSPY5WrvQuNr1l/WYn/ey+NoRO+RKQTlGR2EgpfWonqVGpV+CfEVyvgPVj8BBVcQHVDJYGkNEKDsoZ5l+g==",
+              "requires": {
+                "@babel/runtime": "^7.4.4",
+                "@wordpress/i18n": "^3.7.0",
+                "lodash": "^4.17.15"
+              }
+            }
           }
         },
         "@wordpress/element": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-          "integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.8.1.tgz",
+          "integrity": "sha512-iKdeuf0aSKVO1PxjCCmCUBYk531Iesh6E2ayWsWjj/JNRAcVuAOGiAIxCxU7pE127upjSLmkRh+dXNZ244IWQw==",
           "requires": {
             "@babel/runtime": "^7.4.4",
-            "@wordpress/escape-html": "^1.3.0",
-            "lodash": "^4.17.11",
-            "react": "^16.8.4",
-            "react-dom": "^16.8.4"
+            "@wordpress/escape-html": "^1.5.0",
+            "lodash": "^4.17.15",
+            "react": "^16.9.0",
+            "react-dom": "^16.9.0"
           }
         },
         "@wordpress/i18n": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-          "integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.1.tgz",
+          "integrity": "sha512-hrmhW53XZ5VAK9+DQjjTHoshnZHWGpj7w4q7jl7KMhONgzRtSdDaHtgNLHuwCZPAJzTFJbExU6b02lyrRogXzg==",
           "requires": {
             "@babel/runtime": "^7.4.4",
             "gettext-parser": "^1.3.1",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.15",
             "memize": "^1.0.5",
             "sprintf-js": "^1.1.1",
-            "tannin": "^1.0.1"
+            "tannin": "^1.1.0"
           }
         },
         "@wordpress/is-shallow-equal": {
@@ -2164,36 +2200,27 @@
           }
         },
         "core-js": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-          "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
-        }
-      }
-    },
-    "@woocommerce/csv-export": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.1.0.tgz",
-      "integrity": "sha512-9fd2CuZAHhhSp+x5lLbHyTkOKSokTkqdpjv2+0hETwK+VBHPRN294rHtCOvKpyI4JKfVxqteTI0q4E3LyEjEVA==",
-      "requires": {
-        "@babel/runtime-corejs2": "7.4.3",
-        "browser-filesaver": "1.1.1",
-        "moment": "2.22.2"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
-          "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "core-js": {
           "version": "2.6.10",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
           "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
         },
+        "qs": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+        }
+      }
+    },
+    "@woocommerce/csv-export": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.2.0.tgz",
+      "integrity": "sha512-86kNC0C79YnaRv35zCo134p9mAXFz9y6JExcXCVLPgwvDqj9BOr8aWvgWuRBO7uOIdhFbOuK4rd4i/WNpPjPyw==",
+      "requires": {
+        "@babel/runtime-corejs2": "7.7.4",
+        "browser-filesaver": "1.1.1",
+        "moment": "2.22.2"
+      },
+      "dependencies": {
         "moment": {
           "version": "2.22.2",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
@@ -2202,89 +2229,38 @@
       }
     },
     "@woocommerce/currency": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-1.1.1.tgz",
-      "integrity": "sha512-g/KmmaNMa15MXC+ayVPysfbmSkRAUqaJzk6a+bd9JdR4fmdQCD4NsKkakSubvdT3Rbvsf2Hw0PE8oJpAumDoWg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-2.0.0.tgz",
+      "integrity": "sha512-zoQbVBZTlgqT5uGTrEHhqQ5iUFZHuYZDyf/+nit3v2a9vUzZAQm1zuqRgu1cd8LbaAQgNHumEUArvXFzacsyVQ==",
       "requires": {
-        "@babel/runtime-corejs2": "7.4.3",
-        "@woocommerce/number": "1.0.2",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
-          "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "@babel/runtime-corejs2": "7.7.4",
+        "@woocommerce/number": "2.0.0"
       }
     },
     "@woocommerce/date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-1.0.7.tgz",
-      "integrity": "sha512-yTNMjrESy5RSmasCjoZiKp2Zs5UAF4115c6BPHozjUEmgHtgXQykHUpr0ijY2ZhNb0Jgm1Zgj92MdIpytccqug==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.0.0.tgz",
+      "integrity": "sha512-2urIGUXL+lywLBSBXUi4l0CKk3s3BHr8RAe8acsK1FCFV12HujuwT+TcIHcED0MI2w0DY9dg2mQ0/40ektj70A==",
       "requires": {
-        "@babel/runtime-corejs2": "7.4.3",
-        "@wordpress/date": "3.0.1",
-        "@wordpress/i18n": "3.1.0",
-        "lodash": "4.17.11",
+        "@babel/runtime-corejs2": "7.7.4",
+        "@wordpress/date": "3.5.0",
+        "@wordpress/i18n": "3.6.1",
+        "lodash": "4.17.15",
         "moment": "2.22.2"
       },
       "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
-          "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "@wordpress/date": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.0.1.tgz",
-          "integrity": "sha512-LOOwZM0A5OeElWgdyuR3LJQ7sJJZ5oHdXnNTs3LEB5GH7FUoozF6B6KY5Qm13pizzWX018C8vggsHrsltuLo3A==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "moment": "^2.22.1",
-            "moment-timezone": "^0.5.16"
-          }
-        },
         "@wordpress/i18n": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.1.0.tgz",
-          "integrity": "sha512-zHqLRuKrDV3FYh8PYDs4ABO/csiEAy1EfTffMtMS/8GAz4BcWrcqDjyH42GJF8iwWdG5+DdsllP5oerAQMHnng==",
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.1.tgz",
+          "integrity": "sha512-hrmhW53XZ5VAK9+DQjjTHoshnZHWGpj7w4q7jl7KMhONgzRtSdDaHtgNLHuwCZPAJzTFJbExU6b02lyrRogXzg==",
           "requires": {
-            "@babel/runtime": "^7.0.0",
+            "@babel/runtime": "^7.4.4",
             "gettext-parser": "^1.3.1",
-            "lodash": "^4.17.10",
+            "lodash": "^4.17.15",
             "memize": "^1.0.5",
             "sprintf-js": "^1.1.1",
-            "tannin": "^1.0.1"
+            "tannin": "^1.1.0"
           }
-        },
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "moment": {
           "version": "2.22.2",
@@ -2294,66 +2270,30 @@
       }
     },
     "@woocommerce/navigation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-2.1.0.tgz",
-      "integrity": "sha512-lxw6OQkP4mOiOIButbyOPIFLIgABkrgJEbdGi1N6+VhyWKbGsB1elKukRi7bo57FK+p/+bRFiqeDU+FeusFkcA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-4.0.0.tgz",
+      "integrity": "sha512-dwDyr54eKSa38bAP18ZEgs2POJI2NypIGGHXG7S5gjVwFYOi9t9zR4voso4CK/onH5Yc3Ql4Yi2tJqZq9issoA==",
       "requires": {
-        "@babel/runtime-corejs2": "7.4.3",
-        "history": "4.9.0",
-        "lodash": "4.17.11",
-        "qs": "6.7.0"
+        "@babel/runtime-corejs2": "7.7.4",
+        "history": "4.10.1",
+        "lodash": "4.17.15",
+        "qs": "6.9.1"
       },
       "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
-          "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        "qs": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
         }
       }
     },
     "@woocommerce/number": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-1.0.2.tgz",
-      "integrity": "sha512-3cnKiuTfrtzs+CH2PSbdr3ksVIO3gCMWKArzvIDe62FG9oDM8jQ9M+leeu0sC2Tva2Nc65h+3H4YEICaPBmwaw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
+      "integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
       "requires": {
-        "@babel/runtime-corejs2": "7.4.3",
-        "locutus": "2.0.10",
-        "lodash": "4.17.11"
-      },
-      "dependencies": {
-        "@babel/runtime-corejs2": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.4.3.tgz",
-          "integrity": "sha512-anTLTF7IK8Hd5f73zpPzt875I27UaaTWARJlfMGgnmQhvEe1uNHQRKBUbXL0Gc0VEYiVzsHsTPso5XdK8NGvFg==",
-          "requires": {
-            "core-js": "^2.6.5",
-            "regenerator-runtime": "^0.13.2"
-          }
-        },
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
-        },
-        "lodash": {
-          "version": "4.17.11",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        }
+        "@babel/runtime-corejs2": "7.7.4",
+        "locutus": "2.0.11"
       }
     },
     "@wordpress/a11y": {
@@ -2369,6 +2309,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.7.0.tgz",
       "integrity": "sha512-D5RsDNZDMqPAZXE8ffXJpO5lG/C1nyOmsLFGyYMinxoPLNaXkXN9zFv6R/Afp31DJk4h2c8S1ynyc4FJg1bFrw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@wordpress/i18n": "^3.7.0",
@@ -2379,6 +2320,7 @@
           "version": "3.7.0",
           "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.7.0.tgz",
           "integrity": "sha512-yavu3yAKbSkEosQvEd0lCa064SdFFb8i6f7RfZGDq/TQfJHBaJQvRA4Hd/CtrOXqS6DLjw2rLNrVG4XcJFss1A==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.4.4",
             "gettext-parser": "^1.3.1",
@@ -3021,14 +2963,14 @@
       }
     },
     "@wordpress/compose": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-      "integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.1.tgz",
+      "integrity": "sha512-OFcPu/EYL9/LqO2fq9Frxmx2cVmQly8XqzOUq525ytGb4fadBUkNJepdGMo+V7+13zV8FzZpX1f8AfidBig3MQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/element": "^2.4.0",
-        "@wordpress/is-shallow-equal": "^1.3.0",
-        "lodash": "^4.17.11"
+        "@wordpress/element": "^2.8.1",
+        "@wordpress/is-shallow-equal": "^1.6.0",
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "@wordpress/element": {
@@ -3041,14 +2983,6 @@
             "lodash": "^4.17.15",
             "react": "^16.9.0",
             "react-dom": "^16.9.0"
-          }
-        },
-        "@wordpress/is-shallow-equal": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.6.1.tgz",
-          "integrity": "sha512-0vrTVuE6S/lmW4QKklTNqwSUyvxeCPRq02gKk6ViTw3I/QhE65g7dLRwwEDZ+42obSNA7XousutZ3YoN/NpPbA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4"
           }
         }
       }
@@ -3161,7 +3095,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.5.0.tgz",
       "integrity": "sha512-eg3/o7Z0SgeXtPhJxMuxSQUk9Lx0GGgQptpnparsFzgW69KgibLmGuDqepEhfClhKLeIR3kDVf/m1HRPSosbRA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "moment": "^2.22.1",
@@ -3376,9 +3309,9 @@
       }
     },
     "@wordpress/html-entities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.3.0.tgz",
-      "integrity": "sha512-pVK1IMOvErrhWXJcsrT970H/tV9GZX4KdGjTYTNVDYFxayCXPYq6HLcWWFn2r+QqNkhCpR+fuH6oee6BZx0JEg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
+      "integrity": "sha512-7TKaJKkOX2Tas0OyXNPz1kA2my1Z804weBf2RsPLiNXm593JDsf6Em8z1TA4mXtn7FO2ZAKTj/3yRemKK4PhnA==",
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
@@ -3401,7 +3334,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.6.0.tgz",
       "integrity": "sha512-Yi3JvowB1+bpiKnx9OYv5Ni2zA/j8zJa5dTA5IuchOgdODRGlg9XAuC1Kl0Bd9nLmQsoU50TJYiAlffv0lUhzQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
@@ -3431,13 +3363,13 @@
       }
     },
     "@wordpress/keycodes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.3.0.tgz",
-      "integrity": "sha512-iutKSqHcvhxEvkV/QjgOXlWi/FLaOTtRumQtGxXd7eb8fDqs+8LmhExNn4dw6QJ+vvY+sjUnJh8121eTzCmPjw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.1.tgz",
+      "integrity": "sha512-xsQKiknpybwNsJkfIj8JyORhvRqDNagQm5dCKs5CZ5AvmOqS43Qghn8DLccBQPpnSevlDyb9ZwuyA+VCOBBzdQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/i18n": "^3.4.0",
-        "lodash": "^4.17.11"
+        "@wordpress/i18n": "^3.6.1",
+        "lodash": "^4.17.15"
       },
       "dependencies": {
         "@wordpress/i18n": {
@@ -4589,35 +4521,21 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.2.tgz",
       "integrity": "sha512-adTOs94K5G1riTQveIH/pJoDmFGegzBWFSDe/YzhP6mg64AGOWLQLwi0xzfIyoFC4d+kchx4fCyFTqYfcCbRVg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "qs": "^6.5.2"
       }
     },
     "@wordpress/viewport": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.4.0.tgz",
-      "integrity": "sha512-PTWvCJrpAy2Avs3GhkwRvj+aebv83rAb4gsnZOl0VU0YMdLOOgwc/l+p6ieFVUNuncfES6lLT6pP3UNgOJzpRQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.8.1.tgz",
+      "integrity": "sha512-2e+tkxc/UIYfEP5JxkRmIubWpEfOqnXorb9xSIyfq+ZRQsLm7Zy7CwHHk/C48dE7u3iXdncdmw4MMt0sm3SbAg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/compose": "^3.3.0",
-        "@wordpress/data": "^4.5.0",
-        "@wordpress/element": "^2.4.0",
-        "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "@wordpress/element": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.9.0.tgz",
-          "integrity": "sha512-IohEi9EkT+jnZof35l5PxDAHaBZXOcZzFS14B4cBt1eKFjbd5C54b8lHbifaL8b82S26ggMdA44sEoXVutdC0g==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/escape-html": "^1.6.0",
-            "lodash": "^4.17.15",
-            "react": "^16.9.0",
-            "react-dom": "^16.9.0"
-          }
-        }
+        "@wordpress/compose": "^3.7.1",
+        "@wordpress/data": "^4.9.1",
+        "lodash": "^4.17.15"
       }
     },
     "@wordpress/wordcount": {
@@ -8129,7 +8047,8 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -8582,8 +8501,7 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -9421,8 +9339,7 @@
     "fast-memoize": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
-      "integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g==",
-      "dev": true
+      "integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g=="
     },
     "fastq": {
       "version": "1.6.0",
@@ -10956,16 +10873,16 @@
       "dev": true
     },
     "history": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
-      "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
-        "resolve-pathname": "^2.2.0",
+        "resolve-pathname": "^3.0.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0",
-        "value-equal": "^0.4.0"
+        "value-equal": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -10980,9 +10897,12 @@
       }
     },
     "hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.3",
@@ -13303,9 +13223,12 @@
       }
     },
     "locutus": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.10.tgz",
-      "integrity": "sha512-AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+      "integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+      "requires": {
+        "es6-promise": "^4.2.5"
+      }
     },
     "lodash": {
       "version": "4.17.15",
@@ -13729,9 +13652,9 @@
       "integrity": "sha512-Dm8Jhb5kiC4+ynYsVR4QDXKt+o2dfqGuY4hE2x+XlXZkdndlT80bJxfcMv5QGp/FCy6MhG7f5ElpmKPFKOSEpg=="
     },
     "memoize-one": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
-      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -16739,7 +16662,8 @@
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true
     },
     "query-string": {
       "version": "4.3.4",
@@ -16844,9 +16768,12 @@
       }
     },
     "re-resizable": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-4.11.0.tgz",
-      "integrity": "sha512-dye+7rERqNf/6mDT1iwps+4Gf42420xuZgygF33uX178DxffqcyeuHbBuJ382FIcB5iP6mMZOhfW7kI0uXwb/Q=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.1.1.tgz",
+      "integrity": "sha512-ngzX5xbXi9LlIghJUYZaBDkJUIMLYqO3tQ2cJZoNprCRGhfHnbyufKm51MZRIOBlLigLzPPFKBxQE8ZLezKGfA==",
+      "requires": {
+        "fast-memoize": "^2.5.1"
+      }
     },
     "react": {
       "version": "16.12.0",
@@ -16886,14 +16813,6 @@
         "autosize": "^4.0.0",
         "line-height": "^0.3.1",
         "prop-types": "^15.5.6"
-      }
-    },
-    "react-click-outside": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/react-click-outside/-/react-click-outside-3.0.1.tgz",
-      "integrity": "sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==",
-      "requires": {
-        "hoist-non-react-statics": "^2.1.1"
       }
     },
     "react-dates": {
@@ -16974,9 +16893,9 @@
       }
     },
     "react-router": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
-      "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
+      "integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
@@ -16988,28 +16907,18 @@
         "react-is": "^16.6.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        }
       }
     },
     "react-router-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
-      "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
+      "integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "history": "^4.9.0",
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.2",
-        "react-router": "5.0.1",
+        "react-router": "5.1.2",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
       }
@@ -17018,7 +16927,6 @@
       "version": "8.0.27",
       "resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
       "integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
         "prop-types": "^15.5.8"
@@ -17571,9 +17479,9 @@
       "dev": true
     },
     "resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -20460,9 +20368,9 @@
       "dev": true
     },
     "value-equal": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
 		"npm": "6.11.3"
 	},
 	"dependencies": {
-		"@woocommerce/components": "3.2.0",
+		"@woocommerce/components": "4.0.0",
 		"compare-versions": "3.5.1",
 		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",
 		"gridicons": "3.3.1",

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -135,9 +135,10 @@ class AssetDataRegistry {
 			'woocommerce_shared_settings',
 			$this->data
 		);
+
 		// note this WILL wipe any data already registered to these keys because
 		// they are protected.
-		$this->data = array_merge_recursive( $settings, $this->get_core_data() );
+		$this->data = array_replace_recursive( $settings, $this->get_core_data() );
 	}
 
 	/**

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -75,17 +75,12 @@ class Bootstrap {
 		$this->container->register(
 			AssetDataRegistry::class,
 			function( Container $container ) {
-				$asset_api = $container->get( AssetApi::class );
-				// phpcs:disable Squiz . PHP . CommentedOutCode . Found
-				// @todo: this needs added back in once the @woocommerce/components
-				// package has been updated.
-				// $load_back_compat = defined( 'WC_ADMIN_VERSION_NUMBER' )
-				// && version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' );
-				// return $load_back_compat
-				// ? new BackCompatAssetDataRegistry( $asset_api )
-				// : new AssetDataRegistry( $asset_api );
-				// phpcs:enable
-				return new BackCompatAssetDataRegistry( $asset_api );
+				$asset_api        = $container->get( AssetApi::class );
+				$load_back_compat = defined( 'WC_ADMIN_VERSION_NUMBER' )
+					&& version_compare( WC_ADMIN_VERSION_NUMBER, '0.19.0', '<=' );
+				return $load_back_compat
+					? new BackCompatAssetDataRegistry( $asset_api )
+					: new AssetDataRegistry( $asset_api );
 			}
 		);
 

--- a/tests/php/Assets/AssetDataRegistry.php
+++ b/tests/php/Assets/AssetDataRegistry.php
@@ -53,4 +53,41 @@ class AssetDataRegistry extends WP_UnitTestCase {
 		$this->expectException( InvalidArgumentException::class );
 		$this->registry->add( 'foo', 'yar' );
 	}
+
+	/**
+	 * This tests the 'woocommerce_shared_settings' filter.
+	 * A reminder this filter is only temporary but just using this as for
+	 * testing with.
+	 * @group newTest
+	 */
+	public function test_woocommerce_filter_with_protected_data() {
+		$this->registry->initialize_core_data();
+		$original_data = $this->registry->get();
+		add_filter( 'woocommerce_shared_settings', [ self::class, 'pdatcallback' ] );
+		$data = $this->registry->get();
+		$this->registry->initialize_core_data();
+		$this->assertEquals( $original_data, $data );
+		remove_filter( 'woocommerce_shared_settings', [ self::class, 'pdatcallback' ] );
+	}
+
+	public static function pdatcallback( $existing_data ) {
+		$existing_data['locale']['siteLocale'] = 'cheeseburger';
+		return $existing_data;
+	}
+
+	public static function ndcallback( $existing_data ) {
+		$existing_data['cheeseburger'] = 'fries';
+		return $existing_data;
+	}
+
+	public function test_woocommerce_filter_with_new_data() {
+		$this->registry->initialize_core_data();
+		$original_data = $this->registry->get();
+		add_filter( 'woocommerce_shared_settings', [ self::class, 'ndcallback' ] );
+		$this->registry->initialize_core_data();
+		$data = $this->registry->get();
+		$original_data['cheeseburger'] = 'fries';
+		$this->assertEquals( $original_data, $data );
+		remove_filter( 'woocommerce_shared_settings', [ self::class, 'ndcallback' ] );
+	}
 }

--- a/tests/php/mocks/AssetDataRegistry.php
+++ b/tests/php/mocks/AssetDataRegistry.php
@@ -20,6 +20,10 @@ class AssetDataRegistryMock extends AssetDataRegistry {
 		$this->debug = $debug;
 	}
 
+	public function initialize_core_data() {
+		return parent::initialize_core_data();
+	}
+
 	protected function debug() {
 		return $this->debug;
 	}


### PR DESCRIPTION
Fixes #1020 

See #1020  for further details.  In this pull:

- updated `@woocommerce/components` to the latest version (`4.0.0`) which has `wcSettings` decoupled so no more errors when back-compat code isn't loaded.
- restored the back-compat switch in `Automattic\WooCommerce\Domain\Bootstrap`
- fixed a bug in `AssetDataRegistry` and added tests to guard against regressions.

## To Test

Testing of this is fairly involved to ensure that there is appropriate back-compatibility between different versions of woo-blocks and woo-admin loaded.  So for each scenario the following needs verified:

- there are no console errors related to `wcSettings`
- the functionality of blocks and woo-admin is as expected.
- for versions of woo-admin that have onboarding, make sure onboarding works as expected.
- All tests should use this branch of Woo-Blocks.

| Scenario # | WooAdmin Version | Other notes |
| -------- | ------------- | ------------- |
| 1 | Not Active | - also verify `wcSettings` is only loaded on routes needing it. |
| 2 | Master | - `wcSettings` should only be loaded on routes needing it (including wc-admin routes).
| 3 | 0.19.0 | - `wcSettings` will load on every route.
| 4 | 0.20.0 | - `wcSettings` only loaded on routes needing it (including wc-admin routes).

### Changelog

> Don't enqueue wcSettings unless the route requires it.
