### PR TITLE
Add 'AND' display format to Attribute filter dropdown

### DIFF
--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -134,8 +134,9 @@ const DropdownSelector = ( {
 								inputRef.current.focus();
 							} }
 							placeholder={
-								checked.length === 0 && multiple
-									? sprintf(
+								checked.length > 0 && multiple
+									? null
+									: sprintf(
 											// Translators: %s attribute name.
 											__(
 												'Any %s',
@@ -143,7 +144,6 @@ const DropdownSelector = ( {
 											),
 											attributeLabel
 									  )
-									: null
 							}
 							value={ inputValue }
 						/>

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { useRef } from '@wordpress/element';
 import classNames from 'classnames';
 import Downshift from 'downshift';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -13,32 +14,8 @@ import DropdownSelectorInput from './input';
 import DropdownSelectorInputWrapper from './input-wrapper';
 import DropdownSelectorMenu from './menu';
 import DropdownSelectorSelectedChip from './selected-chip';
+import DropdownSelectorSelectedValue from './selected-value';
 import './style.scss';
-
-/**
- * State reducer for the downshift component.
- * See: https://github.com/downshift-js/downshift#statereducer
- */
-const stateReducer = ( state, changes ) => {
-	switch ( changes.type ) {
-		case Downshift.stateChangeTypes.keyDownEnter:
-		case Downshift.stateChangeTypes.clickItem:
-			return {
-				...changes,
-				highlightedIndex: state.highlightedIndex,
-				isOpen: true,
-				inputValue: '',
-			};
-		case Downshift.stateChangeTypes.blurInput:
-		case Downshift.stateChangeTypes.mouseUp:
-			return {
-				...changes,
-				inputValue: state.inputValue,
-			};
-		default:
-			return changes;
-	}
-};
 
 /**
  * Component used to show an input box with a dropdown with suggestions.
@@ -50,6 +27,7 @@ const DropdownSelector = ( {
 	inputLabel = '',
 	isDisabled = false,
 	isLoading = false,
+	multiple = false,
 	onChange = () => {},
 	options = [],
 } ) => {
@@ -60,9 +38,28 @@ const DropdownSelector = ( {
 		'is-loading': isLoading,
 	} );
 
-	const focusInput = ( isOpen ) => {
-		if ( ! isOpen ) {
-			inputRef.current.focus();
+	/**
+	 * State reducer for the downshift component.
+	 * See: https://github.com/downshift-js/downshift#statereducer
+	 */
+	const stateReducer = ( state, changes ) => {
+		switch ( changes.type ) {
+			case Downshift.stateChangeTypes.keyDownEnter:
+			case Downshift.stateChangeTypes.clickItem:
+				return {
+					...changes,
+					highlightedIndex: state.highlightedIndex,
+					isOpen: multiple,
+					inputValue: '',
+				};
+			case Downshift.stateChangeTypes.blurInput:
+			case Downshift.stateChangeTypes.mouseUp:
+				return {
+					...changes,
+					inputValue: state.inputValue,
+				};
+			default:
+				return changes;
 		}
 	};
 
@@ -82,7 +79,12 @@ const DropdownSelector = ( {
 				isOpen,
 				openMenu,
 			} ) => (
-				<div className={ classes }>
+				<div
+					className={ classNames( classes, {
+						'is-multiple': multiple,
+						'is-single': ! multiple,
+					} ) }
+				>
 					{ /* eslint-disable-next-line jsx-a11y/label-has-for */ }
 					<label
 						{ ...getLabelProps( {
@@ -93,25 +95,32 @@ const DropdownSelector = ( {
 					</label>
 					<DropdownSelectorInputWrapper
 						isOpen={ isOpen }
-						onClick={ () => focusInput( isOpen ) }
+						onClick={ () => inputRef.current.focus() }
 					>
 						{ checked.map( ( value ) => {
 							const option = options.find(
 								( o ) => o.value === value
 							);
-							return (
+							const onRemoveItem = ( val ) => {
+								onChange( val );
+								inputRef.current.focus();
+							};
+							return multiple ? (
 								<DropdownSelectorSelectedChip
 									key={ value }
-									onRemoveItem={ ( val ) => {
-										onChange( val );
-										focusInput( isOpen );
-									} }
+									onRemoveItem={ onRemoveItem }
+									option={ option }
+								/>
+							) : (
+								<DropdownSelectorSelectedValue
+									key={ value }
+									onClick={ () => inputRef.current.focus() }
+									onRemoveItem={ onRemoveItem }
 									option={ option }
 								/>
 							);
 						} ) }
 						<DropdownSelectorInput
-							attributeLabel={ attributeLabel }
 							checked={ checked }
 							getInputProps={ getInputProps }
 							inputRef={ inputRef }
@@ -119,8 +128,20 @@ const DropdownSelector = ( {
 							onFocus={ openMenu }
 							onRemoveItem={ ( val ) => {
 								onChange( val );
-								focusInput( isOpen );
+								inputRef.current.focus();
 							} }
+							placeholder={
+								checked.length === 0 && multiple
+									? sprintf(
+											// Translators: %s attribute name.
+											__(
+												'Any %s',
+												'woo-gutenberg-products-block'
+											),
+											attributeLabel
+									  )
+									: null
+							}
 							value={ inputValue }
 						/>
 					</DropdownSelectorInputWrapper>

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useRef } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 import classNames from 'classnames';
 import Downshift from 'downshift';
 import { __, sprintf } from '@wordpress/i18n';
@@ -42,26 +42,29 @@ const DropdownSelector = ( {
 	 * State reducer for the downshift component.
 	 * See: https://github.com/downshift-js/downshift#statereducer
 	 */
-	const stateReducer = ( state, changes ) => {
-		switch ( changes.type ) {
-			case Downshift.stateChangeTypes.keyDownEnter:
-			case Downshift.stateChangeTypes.clickItem:
-				return {
-					...changes,
-					highlightedIndex: state.highlightedIndex,
-					isOpen: multiple,
-					inputValue: '',
-				};
-			case Downshift.stateChangeTypes.blurInput:
-			case Downshift.stateChangeTypes.mouseUp:
-				return {
-					...changes,
-					inputValue: state.inputValue,
-				};
-			default:
-				return changes;
-		}
-	};
+	const stateReducer = useCallback(
+		( state, changes ) => {
+			switch ( changes.type ) {
+				case Downshift.stateChangeTypes.keyDownEnter:
+				case Downshift.stateChangeTypes.clickItem:
+					return {
+						...changes,
+						highlightedIndex: state.highlightedIndex,
+						isOpen: multiple,
+						inputValue: '',
+					};
+				case Downshift.stateChangeTypes.blurInput:
+				case Downshift.stateChangeTypes.mouseUp:
+					return {
+						...changes,
+						inputValue: state.inputValue,
+					};
+				default:
+					return changes;
+			}
+		},
+		[ multiple ]
+	);
 
 	return (
 		<Downshift

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -1,16 +1,11 @@
-/**
- * External dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-
 const DropdownSelectorInput = ( {
-	attributeLabel,
 	checked,
 	getInputProps,
 	inputRef,
 	isDisabled,
 	onFocus,
 	onRemoveItem,
+	placeholder,
 	value,
 } ) => {
 	return (
@@ -29,14 +24,7 @@ const DropdownSelectorInput = ( {
 						onRemoveItem( checked[ checked.length - 1 ] );
 					}
 				},
-				placeholder:
-					checked.length === 0
-						? sprintf(
-								// Translators: %s attribute name.
-								__( 'Any %s', 'woo-gutenberg-products-block' ),
-								attributeLabel
-						  )
-						: null,
+				placeholder,
 			} ) }
 		/>
 	);

--- a/assets/js/base/components/dropdown-selector/selected-chip.js
+++ b/assets/js/base/components/dropdown-selector/selected-chip.js
@@ -7,8 +7,7 @@ const DropdownSelectorSelectedChip = ( { onRemoveItem, option } ) => {
 	return (
 		<button
 			className="wc-block-dropdown-selector__selected-chip"
-			onClick={ ( e ) => {
-				e.stopPropagation();
+			onClick={ () => {
 				onRemoveItem( option.value );
 			} }
 			onKeyDown={ ( e ) => {
@@ -21,7 +20,9 @@ const DropdownSelectorSelectedChip = ( { onRemoveItem, option } ) => {
 				option.name
 			) }
 		>
-			{ option.label }
+			<span className="wc-block-dropdown-selector__selected-chip__label">
+				{ option.label }
+			</span>
 			<span className="wc-block-dropdown-selector__selected-chip__remove">
 				𝘅
 			</span>

--- a/assets/js/base/components/dropdown-selector/selected-value.js
+++ b/assets/js/base/components/dropdown-selector/selected-value.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useRef } from '@wordpress/element';
+
+const DropdownSelectorSelectedValue = ( { onClick, onRemoveItem, option } ) => {
+	const labelRef = useRef( null );
+
+	useEffect( () => {
+		labelRef.current.focus();
+	}, [ labelRef ] );
+
+	return (
+		<div className="wc-block-dropdown-selector__selected-value">
+			<button
+				ref={ labelRef }
+				className="wc-block-dropdown-selector__selected-value__label"
+				onClick={ ( e ) => {
+					e.stopPropagation();
+					onClick( option.value );
+				} }
+				aria-label={ sprintf(
+					__(
+						'Replace current %s filter',
+						'woo-gutenberg-products-block'
+					),
+					option.name
+				) }
+			>
+				{ option.label }
+			</button>
+			<button
+				className="wc-block-dropdown-selector__selected-value__remove"
+				onClick={ () => {
+					onRemoveItem( option.value );
+				} }
+				onKeyDown={ ( e ) => {
+					if ( e.key === 'Backspace' || e.key === 'Delete' ) {
+						onRemoveItem( option.value );
+					}
+				} }
+				aria-label={ sprintf(
+					__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
+					option.name
+				) }
+			>
+				𝘅
+			</button>
+		</div>
+	);
+};
+
+export default DropdownSelectorSelectedValue;

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -28,6 +28,7 @@
 .wc-block-dropdown-selector__input {
 	font-size: 0.8em;
 	height: 1.8em;
+	min-width: 0;
 
 	.is-single & {
 		margin: 0 4px;
@@ -73,69 +74,76 @@
 	}
 }
 
-// Reset <button> styles
-.wc-block-dropdown-selector__selected-chip,
-.wc-block-dropdown-selector__selected-value__label,
-.wc-block-dropdown-selector__selected-value__remove {
-	background-color: transparent;
-	border: 0;
-	font-weight: inherit;
-
-	&:hover {
+.wc-block-dropdown-selector {
+	// Reset <button> styles
+	.wc-block-dropdown-selector__selected-chip,
+	.wc-block-dropdown-selector__selected-value__label,
+	.wc-block-dropdown-selector__selected-value__remove {
 		background-color: transparent;
+		border: 0;
+		color: inherit;
+		font-weight: inherit;
+
+		&:hover,
+		&:focus,
+		&:active {
+			background-color: transparent;
+		}
 	}
-}
 
-.wc-block-dropdown-selector__selected-value {
-	align-items: center;
-	display: inline-flex;
-	font-size: 0.8em;
-	height: 1.8em;
-	padding: 1.5px 1.5px 1.5px 4px;
-	width: 100%;
-}
-
-.wc-block-dropdown-selector__selected-chip {
-	align-items: center;
-	background-color: $core-grey-light-600;
-	border: 1px solid #9f9f9f;
-	border-radius: 4px;
-	color: $core-grey-dark-600;
-	display: inline-flex;
-	font-size: 0.8em;
-	height: 1.8em;
-	margin: 1.5px;
-	padding: 0 0 0 4px;
-	white-space: nowrap;
-
-	&:hover,
-	&:focus,
-	&:active {
-		background-color: $core-grey-light-400;
-		border: 1px solid #9f9f9f;
+	.wc-block-dropdown-selector__selected-value {
+		align-items: center;
 		color: $core-grey-dark-600;
+		display: inline-flex;
+		font-size: 0.8em;
+		height: 1.8em;
+		padding: 1.5px 1.5px 1.5px 4px;
+		width: 100%;
 	}
-}
 
-.wc-block-dropdown-selector__selected-value__label,
-.wc-block-dropdown-selector__selected-chip__label {
-	flex-grow: 1;
-	padding: 0;
-	text-align: left;
-}
+	.wc-block-dropdown-selector__selected-chip {
+		align-items: center;
+		background-color: $core-grey-light-600;
+		border: 1px solid #9f9f9f;
+		border-radius: 4px;
+		color: $core-grey-dark-600;
+		display: inline-flex;
+		font-size: 0.8em;
+		height: 1.8em;
+		margin: 1.5px;
+		padding: 0 0 0 4px;
+		white-space: nowrap;
 
-.wc-block-dropdown-selector__selected-value__remove,
-.wc-block-dropdown-selector__selected-chip__remove {
-	background-color: transparent;
-	border: 0;
-	display: inline-block;
-	line-height: 1;
-	padding: 0 0.3em;
+		&:hover,
+		&:focus,
+		&:active {
+			background-color: $core-grey-light-400;
+			border: 1px solid #9f9f9f;
+			color: $core-grey-dark-600;
+		}
+	}
+
+	.wc-block-dropdown-selector__selected-value__label,
+	.wc-block-dropdown-selector__selected-chip__label {
+		flex-grow: 1;
+		padding: 0;
+		text-align: left;
+	}
+
+	.wc-block-dropdown-selector__selected-value__remove,
+	.wc-block-dropdown-selector__selected-chip__remove {
+		background-color: transparent;
+		border: 0;
+		display: inline-block;
+		line-height: 1;
+		padding: 0 0.3em;
+	}
 }
 
 .wc-block-dropdown-selector__list {
 	list-style: none;
 	margin: -1px 0 0;
+	padding: 0;
 	position: absolute;
 	left: 0;
 	right: 0;
@@ -154,6 +162,7 @@
 	color: $core-grey-dark-600;
 	cursor: default;
 	font-size: 0.8em;
+	margin: 0;
 	padding: 0 $gap-smallest;
 
 	&.is-selected {

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -26,13 +26,45 @@
 }
 
 .wc-block-dropdown-selector__input {
-	background: transparent;
-	border: 0;
-	flex: 1;
 	font-size: 0.8em;
 	height: 1.8em;
-	min-width: 0;
-	margin: 1.5px;
+
+	.is-single & {
+		margin: 0 4px;
+		padding: 0;
+		width: 100%;
+
+		&:hover,
+		&:focus,
+		&:active {
+			outline: 0;
+		}
+
+		&:not(:first-child):focus {
+			margin-bottom: 1.5px;
+			margin-top: 1.5px;
+		}
+
+		&:not(:first-child):not(:focus) {
+			@include visually-hidden();
+			// Fixes an issue in Firefox that `flex: wrap` in the container was making
+			// this element to still occupy one line.
+			position: absolute;
+		}
+	}
+
+	.is-multiple & {
+		flex: 1;
+		min-width: 0;
+		margin: 1.5px;
+	}
+}
+
+// Visually hide the input
+.is-single .wc-block-dropdown-selector__input:first-child,
+.is-multiple .wc-block-dropdown-selector__input {
+	background: transparent;
+	border: 0;
 
 	&:hover,
 	&:focus,
@@ -41,32 +73,63 @@
 	}
 }
 
+// Reset <button> styles
+.wc-block-dropdown-selector__selected-chip,
+.wc-block-dropdown-selector__selected-value__label,
+.wc-block-dropdown-selector__selected-value__remove {
+	background-color: transparent;
+	border: 0;
+	font-weight: inherit;
+
+	&:hover {
+		background-color: transparent;
+	}
+}
+
+.wc-block-dropdown-selector__selected-value {
+	align-items: center;
+	display: inline-flex;
+	font-size: 0.8em;
+	height: 1.8em;
+	padding: 1.5px 1.5px 1.5px 4px;
+	width: 100%;
+}
+
 .wc-block-dropdown-selector__selected-chip {
+	align-items: center;
 	background-color: $core-grey-light-600;
 	border: 1px solid #9f9f9f;
 	border-radius: 4px;
 	color: $core-grey-dark-600;
-	display: inline-block;
+	display: inline-flex;
 	font-size: 0.8em;
-	font-weight: inherit;
 	height: 1.8em;
 	margin: 1.5px;
-	padding: 0 0 0 0.3em;
+	padding: 0 0 0 4px;
 	white-space: nowrap;
 
 	&:hover,
 	&:focus,
 	&:active {
-		background-color: $core-grey-light-600;
+		background-color: $core-grey-light-400;
 		border: 1px solid #9f9f9f;
 		color: $core-grey-dark-600;
 	}
 }
 
+.wc-block-dropdown-selector__selected-value__label,
+.wc-block-dropdown-selector__selected-chip__label {
+	flex-grow: 1;
+	padding: 0;
+	text-align: left;
+}
+
+.wc-block-dropdown-selector__selected-value__remove,
 .wc-block-dropdown-selector__selected-chip__remove {
 	background-color: transparent;
 	border: 0;
 	display: inline-block;
+	line-height: 1;
 	padding: 0 0.3em;
 }
 
@@ -89,6 +152,7 @@
 .wc-block-dropdown-selector__list-item {
 	background-color: #fff;
 	color: $core-grey-dark-600;
+	font-size: 0.8em;
 	padding: 0 $gap-smallest;
 
 	&.is-selected {

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -152,6 +152,7 @@
 .wc-block-dropdown-selector__list-item {
 	background-color: #fff;
 	color: $core-grey-dark-600;
+	cursor: default;
 	font-size: 0.8em;
 	padding: 0 $gap-smallest;
 

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -5,7 +5,7 @@
 }
 
 .wc-block-dropdown-selector__input-wrapper {
-	align-items: baseline;
+	align-items: center;
 	border: 1px solid #9f9f9f;
 	border-radius: 4px;
 	cursor: text;
@@ -82,12 +82,15 @@
 		background-color: transparent;
 		border: 0;
 		color: inherit;
+		font-size: inherit;
 		font-weight: inherit;
+		text-transform: initial;
 
 		&:hover,
 		&:focus,
 		&:active {
 			background-color: transparent;
+			text-decoration: none;
 		}
 	}
 
@@ -95,7 +98,6 @@
 		align-items: center;
 		color: $core-grey-dark-600;
 		display: inline-flex;
-		font-size: 0.8em;
 		height: 1.8em;
 		padding: 1.5px 1.5px 1.5px 4px;
 		width: 100%;
@@ -108,7 +110,6 @@
 		border-radius: 4px;
 		color: $core-grey-dark-600;
 		display: inline-flex;
-		font-size: 0.8em;
 		height: 1.8em;
 		margin: 1.5px;
 		padding: 0 0 0 4px;
@@ -125,6 +126,7 @@
 
 	.wc-block-dropdown-selector__selected-value__label,
 	.wc-block-dropdown-selector__selected-chip__label {
+		font-size: 0.8em;
 		flex-grow: 1;
 		padding: 0;
 		text-align: left;

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -125,8 +125,8 @@ const AttributeFilterBlock = ( {
 	} );
 
 	const filterAvailableFilters =
-		blockAttributes.displayStyle !== 'dropdown' ||
-		blockAttributes.queryType === 'or';
+		blockAttributes.displayStyle !== 'dropdown' &&
+		blockAttributes.queryType === 'and';
 	const {
 		results: filteredCounts,
 		isLoading: filteredCountsLoading,

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -224,6 +224,7 @@ const AttributeFilterBlock = ( {
 			speak(
 				sprintf(
 					__(
+						// translators: %s attribute terms (for example: 'red', 'blue', 'large'...)
 						'%s filter replaced with %s.',
 						'woo-gutenberg-products-block'
 					),
@@ -235,6 +236,7 @@ const AttributeFilterBlock = ( {
 		} else if ( filterAddedName ) {
 			speak(
 				sprintf(
+					// translators: %s attribute term (for example: 'red', 'blue', 'large'...)
 					__( '%s filter added.', 'woo-gutenberg-products-block' ),
 					filterAddedName
 				),
@@ -243,6 +245,7 @@ const AttributeFilterBlock = ( {
 		} else if ( filterRemovedName ) {
 			speak(
 				sprintf(
+					// translators: %s attribute term (for example: 'red', 'blue', 'large'...)
 					__( '%s filter removed.', 'woo-gutenberg-products-block' ),
 					filterRemovedName
 				),

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -230,8 +230,7 @@ const AttributeFilterBlock = ( {
 					),
 					filterAddedName,
 					filterRemovedName
-				),
-				'assertive'
+				)
 			);
 		} else if ( filterAddedName ) {
 			speak(
@@ -239,8 +238,7 @@ const AttributeFilterBlock = ( {
 					// translators: %s attribute term (for example: 'red', 'blue', 'large'...)
 					__( '%s filter added.', 'woo-gutenberg-products-block' ),
 					filterAddedName
-				),
-				'assertive'
+				)
 			);
 		} else if ( filterRemovedName ) {
 			speak(
@@ -248,8 +246,7 @@ const AttributeFilterBlock = ( {
 					// translators: %s attribute term (for example: 'red', 'blue', 'large'...)
 					__( '%s filter removed.', 'woo-gutenberg-products-block' ),
 					filterRemovedName
-				),
-				'assertive'
+				)
 			);
 		}
 	};

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -1,11 +1,13 @@
 .wc-block-attribute-filter {
 	margin-bottom: $gap-large;
 
-	.wc-block-attribute-filter-list-count::before {
-		content: " (";
-	}
-	.wc-block-attribute-filter-list-count::after {
-		content: ")";
+	.wc-block-attribute-filter-list-count {
+		&::before {
+			content: " (";
+		}
+		&::after {
+			content: ")";
+		}
 	}
 
 	.wc-block-attribute-filter-list {
@@ -25,9 +27,8 @@
 		}
 	}
 
-	.wc-block-dropdown-selector {
-		.wc-block-dropdown-selector__list .wc-block-attribute-filter-list-count {
-			opacity: 0.6;
-		}
+	.is-single .wc-block-attribute-filter-list-count,
+	.wc-block-dropdown-selector .wc-block-dropdown-selector__list .wc-block-attribute-filter-list-count {
+		opacity: 0.6;
 	}
 }


### PR DESCRIPTION
Fixes #1134.
Fixes #1135.

Follow-up of #1255.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![Peek 2019-12-03 11-50](https://user-images.githubusercontent.com/3616980/70044839-607f8f80-15c3-11ea-9819-ebfece5abebd.gif)


### How to test the changes in this Pull Request:

1. Add a _Filter Products by Attribute_ block to a post and set its _Display Style_ to `Dropdown` and the _Query Type_ to `AND`.
2. Preview the post and interact with the filter (search terms, add them, remove them, repeat only using the keyboard, using a screen reader, etc.).
3. Verify everything works as expected.
4. Verify there are no regression in the same component when _Query Type_ is set to `OR`.
