### PR TITLE
Change bundle size limit to 400 in Travis tests

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
 	"files": [
 		{
 			"path": "./build/*.js",
-			"maxSize": "300 kB"
+			"maxSize": "400 kB"
 		},
 		{
 			"path": "./build/*frontend*.js",


### PR DESCRIPTION
Our bundle size has reached 300.6kb with Cart and Checkout merged, now every PR will have an ❌beside it, this raises the limit to 400kb, however, we still need to monitor the bundle size.