### PR TITLE
allow merchant to toggle cart empty/full modes in block editor

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -1,13 +1,66 @@
 /**
  * External dependencies
  */
-import { Placeholder } from '@wordpress/components';
+import { BlockControls } from '@wordpress/block-editor';
+import { Toolbar } from '@wordpress/components';
+import { Fragment, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import FullCart from './components/full-cart';
+import EmptyCart from './components/empty-cart';
 
 /**
  * Component to handle edit mode of "Cart Block".
  */
 const Cart = () => {
-	return <Placeholder>Cart block coming soon…</Placeholder>;
+	const [ isFullCartMode, setFullCartMode ] = useState( true );
+
+	const toggleFullCartMode = () => {
+		setFullCartMode( ! isFullCartMode );
+	};
+
+	const getBlockControls = () => {
+		return (
+			<BlockControls>
+				<Toolbar
+					controls={ [
+						{
+							// Using dashicons for now, but we need to decide whether we're using
+							// icons or text. These icons are not ideal :)
+							icon: 'yes-alt',
+							title: __(
+								'Full Cart',
+								'woo-gutenberg-products-block'
+							),
+							onClick: toggleFullCartMode,
+							isActive: isFullCartMode,
+						},
+						{
+							icon: 'marker',
+							title: __(
+								'Empty Cart',
+								'woo-gutenberg-products-block'
+							),
+							onClick: toggleFullCartMode,
+							isActive: ! isFullCartMode,
+						},
+					] }
+				/>
+			</BlockControls>
+		);
+	};
+
+	const cart = isFullCartMode ? <FullCart /> : <EmptyCart />;
+
+	return (
+		<Fragment>
+			{ getBlockControls() }
+			{ cart }
+		</Fragment>
+	);
 };
 
 Cart.propTypes = {};

--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -2,9 +2,10 @@
  * External dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
-import { Button, Toolbar } from '@wordpress/components';
+import { Toolbar } from '@wordpress/components';
 import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import TextToolbarButton from '@woocommerce/block-components/text-toolbar-button';
 
 /**
  * Internal dependencies
@@ -24,24 +25,24 @@ const Cart = () => {
 
 	const getBlockControls = () => {
 		return (
-			<BlockControls>
+			<BlockControls className='wc-block-cart-toolbar'>
 				<Toolbar>
-					<Button
+					<TextToolbarButton
 						onClick={ toggleFullCartMode }
 						isToggled={ isFullCartMode }>
 						{  __(
 							'Full Cart',
 							'woo-gutenberg-products-block'
 						) }
-					</Button>
-					<Button
+					</TextToolbarButton>
+					<TextToolbarButton
 						onClick={ toggleFullCartMode }
 						isToggled={ ! isFullCartMode }>
 						{  __(
 							'Empty Cart',
 							'woo-gutenberg-products-block'
 						) }
-					</Button>
+					</TextToolbarButton>
 				</Toolbar>
 			</BlockControls>
 		);

--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
+import { Button, Toolbar } from '@wordpress/components';
 import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -25,30 +25,24 @@ const Cart = () => {
 	const getBlockControls = () => {
 		return (
 			<BlockControls>
-				<Toolbar
-					controls={ [
-						{
-							// Using dashicons for now, but we need to decide whether we're using
-							// icons or text. These icons are not ideal :)
-							icon: 'yes-alt',
-							title: __(
-								'Full Cart',
-								'woo-gutenberg-products-block'
-							),
-							onClick: toggleFullCartMode,
-							isActive: isFullCartMode,
-						},
-						{
-							icon: 'marker',
-							title: __(
-								'Empty Cart',
-								'woo-gutenberg-products-block'
-							),
-							onClick: toggleFullCartMode,
-							isActive: ! isFullCartMode,
-						},
-					] }
-				/>
+				<Toolbar>
+					<Button
+						onClick={ toggleFullCartMode }
+						isToggled={ isFullCartMode }>
+						{  __(
+							'Full Cart',
+							'woo-gutenberg-products-block'
+						) }
+					</Button>
+					<Button
+						onClick={ toggleFullCartMode }
+						isToggled={ ! isFullCartMode }>
+						{  __(
+							'Empty Cart',
+							'woo-gutenberg-products-block'
+						) }
+					</Button>
+				</Toolbar>
 			</BlockControls>
 		);
 	};

--- a/assets/js/blocks/cart-checkout/cart/components/empty-cart.js
+++ b/assets/js/blocks/cart-checkout/cart/components/empty-cart.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { Placeholder } from '@wordpress/components';
+
+/**
+ * Component to handle edit mode for the Cart block when cart is empty.
+ */
+const Cart = () => {
+	return (
+		<Placeholder>
+			<span>
+				Cart block <b>empty state</b> coming soon…
+			</span>
+		</Placeholder>
+	);
+};
+
+Cart.propTypes = {};
+
+export default Cart;

--- a/assets/js/blocks/cart-checkout/cart/components/full-cart.js
+++ b/assets/js/blocks/cart-checkout/cart/components/full-cart.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { Placeholder } from '@wordpress/components';
+
+/**
+ * Component to handle edit mode for the Cart block when user has something in cart aka "full".
+ */
+const Cart = () => {
+	return (
+		<Placeholder>
+			<span>
+				Cart block <b>full state</b> coming soon…
+			</span>
+		</Placeholder>
+	);
+};
+
+Cart.propTypes = {};
+
+export default Cart;

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -10,6 +10,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import Block from './block';
 import { example } from './example';
+
 /**
  * Register and run the Cart block.
  */

--- a/assets/js/components/text-toolbar-button/README.md
+++ b/assets/js/components/text-toolbar-button/README.md
@@ -1,0 +1,34 @@
+# TextToolbarButton
+
+TextToolbarButton is used in Toolbar for text buttons which show isToggled state.
+
+Note: Gutenberg core has `ToolbarGroup` and `ToolbarButton` in progress. When these are available this component may not be needed.
+
+## Usage
+
+Example: two text buttons to select edit modes for cart block.
+
+```jsx
+<BlockControls>
+  <Toolbar>
+    <TextToolbarButton
+      onClick={ toggleFullCartMode }
+      isToggled={ isFullCartMode }>
+      {  __(
+        'Full Cart',
+        'woo-gutenberg-products-block'
+      ) }
+    </TextToolbarButton>
+    <TextToolbarButton
+      onClick={ toggleFullCartMode }
+      isToggled={ ! isFullCartMode }>
+      {  __(
+        'Empty Cart',
+        'woo-gutenberg-products-block'
+      ) }
+    </TextToolbarButton>
+  </Toolbar>
+</BlockControls>
+```
+
+

--- a/assets/js/components/text-toolbar-button/index.js
+++ b/assets/js/components/text-toolbar-button/index.js
@@ -12,7 +12,7 @@ import './style.scss';
 function TextToolbarButton( { className, ...props } ) {
 	const classes = classnames(
 		'wc-block-text-toolbar-button',
-		props.className
+		className
 	);
 	return (
 		<Button className={ classes } { ...props } />

--- a/assets/js/components/text-toolbar-button/index.js
+++ b/assets/js/components/text-toolbar-button/index.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+function TextToolbarButton( props ) {
+	const classes = classnames(
+		'wc-block-text-toolbar-button',
+		props.className
+	);
+	return (
+		<Button className={ classes } { ...props } />
+	);
+}
+
+export default TextToolbarButton;

--- a/assets/js/components/text-toolbar-button/index.js
+++ b/assets/js/components/text-toolbar-button/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-function TextToolbarButton( props ) {
+function TextToolbarButton( { className, ...props } ) {
 	const classes = classnames(
 		'wc-block-text-toolbar-button',
 		props.className

--- a/assets/js/components/text-toolbar-button/style.scss
+++ b/assets/js/components/text-toolbar-button/style.scss
@@ -1,0 +1,7 @@
+.wc-block-text-toolbar-button {
+	&.is-toggled,
+	&.is-toggled:focus {
+		background: #555d65;
+		color: #fff;
+	}
+}

--- a/assets/js/components/text-toolbar-button/style.scss
+++ b/assets/js/components/text-toolbar-button/style.scss
@@ -1,7 +1,7 @@
 .wc-block-text-toolbar-button {
 	&.is-toggled,
 	&.is-toggled:focus {
-		background: #555d65;
-		color: #fff;
+		background: $core-grey-dark-500;
+		color: $white;
 	}
 }


### PR DESCRIPTION
Fixes #1326

Adds full & empty modes to the cart block, with basic placeholder content. 

Also includes a new (temporary) component `TextToolbarButton`. This allows us to use a text label for a toggleable toolbar button. 

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="848" alt="Screen Shot 2019-12-06 at 9 43 31 AM" src="https://user-images.githubusercontent.com/4167300/70272335-f4906780-180c-11ea-8077-cbae2325f059.png">

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Open editor, add a cart block.
3. Toggle the different modes, see the different placeholder content.

<!-- If you can, add the appropriate labels -->

### Changelog

This is a small part of the new cart block, changelog handled elsewhere.
