### PR TITLE
Introduce Checkout Form skeleton and Checkout Form Step Component

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -43,3 +43,9 @@ $notice-yellow: #ffb900;
 $error-red: #d94f4f;
 $box-shadow-blue: #5b9dd9;
 $core-orange: #ca4a1f;
+
+// @todo: replace those colors with the correct values once we settle on a design system palette.
+$gray-10: #c3c4c7;
+$gray-20: #a7aaad;
+$gray-60: #50575e;
+$gray-80: #2c3338;

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -22,10 +22,7 @@ const FormStep = ( {
 } ) => {
 	return (
 		<div
-			className={ classnames(
-				className,
-				'wc-components-checkout-step',
-			) }
+			className={ classnames( className, 'wc-components-checkout-step' ) }
 			id={ id }
 		>
 			<StepNumber stepNumber={ stepNumber } />

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -8,8 +8,8 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './style.scss';
 import Label from '../../label';
+import './style.scss';
 
 const StepNumber = ( { stepNumber } ) => {
 	return (

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -18,7 +18,7 @@ const FormStep = ( {
 	title,
 	description,
 	children,
-	secondaryAction,
+	StepHeadingContent,
 } ) => {
 	return (
 		<div
@@ -26,7 +26,10 @@ const FormStep = ( {
 			id={ id }
 		>
 			<StepNumber stepNumber={ stepNumber } />
-			<StepHeading title={ title } secondaryAction={ secondaryAction } />
+			<StepHeading
+				title={ title }
+				StepHeadingContent={ StepHeadingContent }
+			/>
 			<span className="wc-components-checkout-step__description">
 				{ description }
 			</span>
@@ -55,16 +58,13 @@ const StepNumber = ( { stepNumber } ) => {
 	);
 };
 
-const StepHeading = ( { title, secondaryAction } ) => (
+const StepHeading = ( { title, StepHeadingContent } ) => (
 	<div className="wc-components-checkout-step__heading">
 		<h4 className="wc-components-checkout-step__title">{ title }</h4>
-		{ secondaryAction && <SecondaryAction link={ secondaryAction } /> }
+		<span className="wc-components-checkout-step__heading-content">
+			{ StepHeadingContent }
+		</span>
 	</div>
-);
-const SecondaryAction = ( { link } ) => (
-	<span className="wc-components-checkout-step__secondary-action">
-		{ link }
-	</span>
 );
 
 FormStep.propTypes = {

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -45,7 +45,7 @@ const FormStep = ( {
 	title,
 	description,
 	children,
-	StepHeadingContent,
+	stepHeadingContent,
 } ) => {
 	return (
 		<div
@@ -55,7 +55,7 @@ const FormStep = ( {
 			<StepNumber stepNumber={ stepNumber } />
 			<StepHeading
 				title={ title }
-				StepHeadingContent={ StepHeadingContent }
+				StepHeadingContent={ stepHeadingContent }
 			/>
 			<span className="wc-components-checkout-step__description">
 				{ description }

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -3,11 +3,13 @@
  */
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import Label from '../../label';
 
 const FormStep = ( {
 	id,
@@ -43,7 +45,19 @@ const FormStep = ( {
 const StepNumber = ( { stepNumber } ) => {
 	return (
 		<div className="wc-components-checkout-step__number">
-			{ stepNumber }
+			<Label
+				label={ stepNumber }
+				screenReaderLabel={
+					sprintf(
+						__(
+							// translators: %s is a step number (1, 2, 3...)
+							'Step %s',
+							'woo-gutenberg-products-block'
+						),
+						stepNumber
+					)
+				}
+		/>
 		</div>
 	);
 };

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const FormStep = ( {
+	id,
+	className,
+	stepNumber,
+	title,
+	description,
+	children,
+	secondaryAction,
+} ) => {
+	return (
+		<div
+			className={ classnames( [
+				className,
+				'wc-components-checkout-step',
+			] ) }
+			id={ id }
+		>
+			<StepNumber stepNumber={ stepNumber } />
+			<StepHeading title={ title } secondaryAction={ secondaryAction } />
+			<span className="wc-components-checkout-step__description">
+				{ description }
+			</span>
+			<div className="wc-components-checkout-step__content">
+				{ children }
+			</div>
+		</div>
+	);
+};
+
+const StepNumber = ( { stepNumber } ) => {
+	return (
+		<div className="wc-components-checkout-step__number">
+			{ stepNumber }
+		</div>
+	);
+};
+
+const StepHeading = ( { title, secondaryAction } ) => (
+	<div className="wc-components-checkout-step__heading">
+		<h4 className="wc-components-checkout-step__title">{ title }</h4>
+		{ secondaryAction && <SecondaryAction link={ secondaryAction } /> }
+	</div>
+);
+const SecondaryAction = ( { link } ) => (
+	<span className="wc-components-checkout-step__secondary-action">
+		{ link }
+	</span>
+);
+export default FormStep;

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -19,14 +19,12 @@ const FormStep = ( {
 	description,
 	children,
 	secondaryAction,
-	isLastStep,
 } ) => {
 	return (
 		<div
 			className={ classnames( [
 				className,
 				'wc-components-checkout-step',
-				{ 'is-last-step': isLastStep },
 			] ) }
 			id={ id }
 		>
@@ -47,17 +45,15 @@ const StepNumber = ( { stepNumber } ) => {
 		<div className="wc-components-checkout-step__number">
 			<Label
 				label={ stepNumber }
-				screenReaderLabel={
-					sprintf(
-						__(
-							// translators: %s is a step number (1, 2, 3...)
-							'Step %s',
-							'woo-gutenberg-products-block'
-						),
-						stepNumber
-					)
-				}
-		/>
+				screenReaderLabel={ sprintf(
+					__(
+						// translators: %s is a step number (1, 2, 3...)
+						'Step %s',
+						'woo-gutenberg-products-block'
+					),
+					stepNumber
+				) }
+			/>
 		</div>
 	);
 };
@@ -82,7 +78,6 @@ FormStep.propTypes = {
 	description: PropTypes.string,
 	children: PropTypes.node,
 	secondaryAction: PropTypes.node,
-	isLastStep: PropTypes.bool,
 };
 
 export default FormStep;

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -15,12 +15,14 @@ const FormStep = ( {
 	description,
 	children,
 	secondaryAction,
+	isLastStep,
 } ) => {
 	return (
 		<div
 			className={ classnames( [
 				className,
 				'wc-components-checkout-step',
+				{ 'is-last-step': isLastStep },
 			] ) }
 			id={ id }
 		>

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */
@@ -57,4 +59,16 @@ const SecondaryAction = ( { link } ) => (
 		{ link }
 	</span>
 );
+
+FormStep.propTypes = {
+	id: PropTypes.string,
+	className: PropTypes.string,
+	stepNumber: PropTypes.number,
+	title: PropTypes.string,
+	description: PropTypes.string,
+	children: PropTypes.node,
+	secondaryAction: PropTypes.node,
+	isLastStep: PropTypes.bool,
+};
+
 export default FormStep;

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -29,11 +29,11 @@ const StepNumber = ( { stepNumber } ) => {
 	);
 };
 
-const StepHeading = ( { title, StepHeadingContent } ) => (
+const StepHeading = ( { title, stepHeadingContent } ) => (
 	<div className="wc-components-checkout-step__heading">
 		<h4 className="wc-components-checkout-step__title">{ title }</h4>
 		<span className="wc-components-checkout-step__heading-content">
-			{ StepHeadingContent }
+			{ stepHeadingContent }
 		</span>
 	</div>
 );
@@ -45,7 +45,7 @@ const FormStep = ( {
 	title,
 	description,
 	children,
-	stepHeadingContent,
+	stepHeadingContent = () => null,
 } ) => {
 	return (
 		<div
@@ -55,7 +55,7 @@ const FormStep = ( {
 			<StepNumber stepNumber={ stepNumber } />
 			<StepHeading
 				title={ title }
-				StepHeadingContent={ stepHeadingContent }
+				stepHeadingContent={ stepHeadingContent() }
 			/>
 			<span className="wc-components-checkout-step__description">
 				{ description }
@@ -74,7 +74,7 @@ FormStep.propTypes = {
 	title: PropTypes.string,
 	description: PropTypes.string,
 	children: PropTypes.node,
-	secondaryAction: PropTypes.node,
+	stepHeadingContent: PropTypes.func,
 };
 
 export default FormStep;

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -22,10 +22,10 @@ const FormStep = ( {
 } ) => {
 	return (
 		<div
-			className={ classnames( [
+			className={ classnames(
 				className,
 				'wc-components-checkout-step',
-			] ) }
+			) }
 			id={ id }
 		>
 			<StepNumber stepNumber={ stepNumber } />

--- a/assets/js/base/components/checkout/form-step/index.js
+++ b/assets/js/base/components/checkout/form-step/index.js
@@ -11,6 +11,33 @@ import { __, sprintf } from '@wordpress/i18n';
 import './style.scss';
 import Label from '../../label';
 
+const StepNumber = ( { stepNumber } ) => {
+	return (
+		<div className="wc-components-checkout-step__number">
+			<Label
+				label={ stepNumber }
+				screenReaderLabel={ sprintf(
+					__(
+						// translators: %s is a step number (1, 2, 3...)
+						'Step %s',
+						'woo-gutenberg-products-block'
+					),
+					stepNumber
+				) }
+			/>
+		</div>
+	);
+};
+
+const StepHeading = ( { title, StepHeadingContent } ) => (
+	<div className="wc-components-checkout-step__heading">
+		<h4 className="wc-components-checkout-step__title">{ title }</h4>
+		<span className="wc-components-checkout-step__heading-content">
+			{ StepHeadingContent }
+		</span>
+	</div>
+);
+
 const FormStep = ( {
 	id,
 	className,
@@ -39,33 +66,6 @@ const FormStep = ( {
 		</div>
 	);
 };
-
-const StepNumber = ( { stepNumber } ) => {
-	return (
-		<div className="wc-components-checkout-step__number">
-			<Label
-				label={ stepNumber }
-				screenReaderLabel={ sprintf(
-					__(
-						// translators: %s is a step number (1, 2, 3...)
-						'Step %s',
-						'woo-gutenberg-products-block'
-					),
-					stepNumber
-				) }
-			/>
-		</div>
-	);
-};
-
-const StepHeading = ( { title, StepHeadingContent } ) => (
-	<div className="wc-components-checkout-step__heading">
-		<h4 className="wc-components-checkout-step__title">{ title }</h4>
-		<span className="wc-components-checkout-step__heading-content">
-			{ StepHeadingContent }
-		</span>
-	</div>
-);
 
 FormStep.propTypes = {
 	id: PropTypes.string,

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -2,9 +2,16 @@ $inner-circle-size: 24px;
 $circle-border-size: 8px;
 $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 
+// @todo: replace those colors with the correct values once we settle on a design system palette.
+$gray-20: #c3c4c7;
+$gray-20: #a7aaad;
+$gray-60: #50575e;
+$gray-80: #2c3338;
+
+
 .wc-components-checkout-step {
 	position: relative;
-	border-left: 1px solid $core-grey-light-700;
+	border-left: 1px solid $gray-20;
 	padding-left: $gap-large;
 	padding-bottom: $gap-larger;
 
@@ -22,25 +29,24 @@ $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 // @todo: remove the parent class once we dial the specification down.
 .wc-components-checkout-step__heading .wc-components-checkout-step__title {
 	@include font-size(16, 24px);
-	// @todo: replace this with a variable
-	color: #2c3338;
+	color: $gray-80;
 	margin-bottom: $gap-smaller;
 	font-weight: 400;
 }
 
-.wc-components-checkout-step__secondary-action {
+// @todo: remove the parent class once we dial the specification down.
+.wc-components-checkout-step .wc-components-checkout-step__secondary-action {
 	@include font-size(12, 22px);
-	// @todo: replace this with a variable
-	color: #2c3338;
+	color: $gray-80;
 
 	a {
 		font-weight: bold;
+		color: $gray-80;
 	}
 }
 .wc-components-checkout-step__description {
 	@include font-size(14, 20px);
-	// @todo: replace this with a variable
-	color: #50575e;
+	color: $gray-60;
 	// @todo: delete this after we remove placeholders
 	display: block;
 	margin-bottom: $gap-large;
@@ -52,7 +58,7 @@ $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 	height: $inner-circle-size;
 	left: -$outer-circle-size / 2;
 	top: -$circle-border-size;
-	background: $core-grey-dark-300;
+	background: $gray-20;
 	color: $white;
 	font-size: 14px;
 	line-height: $inner-circle-size;

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -2,13 +2,6 @@ $inner-circle-size: 24px;
 $circle-border-size: 8px;
 $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 
-// @todo: replace those colors with the correct values once we settle on a design system palette.
-$gray-10: #c3c4c7;
-$gray-20: #a7aaad;
-$gray-60: #50575e;
-$gray-80: #2c3338;
-
-
 .wc-components-checkout-step {
 	position: relative;
 	border-left: 1px solid $gray-10;

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -7,6 +7,10 @@ $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 	border-left: 1px solid $core-grey-light-700;
 	padding-left: $gap-large;
 	padding-bottom: $gap-larger;
+
+	&.is-last-step {
+		border-left: none;
+	}
 }
 
 .wc-components-checkout-step__heading {

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -35,7 +35,7 @@ $gray-80: #2c3338;
 }
 
 // @todo: remove the parent class once we dial the specification down.
-.wc-components-checkout-step .wc-components-checkout-step__secondary-action {
+.wc-components-checkout-step .wc-components-checkout-step__heading-content {
 	@include font-size(12, 24px);
 	color: $gray-80;
 

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -17,14 +17,16 @@ $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 	display: flex;
 	justify-content: space-between;
 	align-content: center;
+	flex-wrap: wrap;
+	margin-bottom: $gap-smaller;
 }
 
 // @todo: remove the parent class once we dial the specification down.
 .wc-components-checkout-step__heading .wc-components-checkout-step__title {
 	@include font-size(16, 24px);
 	color: $gray-80;
-	margin-bottom: $gap-smaller;
 	font-weight: 400;
+	margin-right: $gap-small;
 }
 
 // @todo: remove the parent class once we dial the specification down.

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -3,7 +3,7 @@ $circle-border-size: 8px;
 $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 
 // @todo: replace those colors with the correct values once we settle on a design system palette.
-$gray-20: #c3c4c7;
+$gray-10: #c3c4c7;
 $gray-20: #a7aaad;
 $gray-60: #50575e;
 $gray-80: #2c3338;
@@ -11,7 +11,7 @@ $gray-80: #2c3338;
 
 .wc-components-checkout-step {
 	position: relative;
-	border-left: 1px solid $gray-20;
+	border-left: 1px solid $gray-10;
 	padding-left: $gap-large;
 	padding-bottom: $gap-larger;
 

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -1,15 +1,13 @@
-$inner-circle-size: 24px;
-$circle-border-size: 8px;
-$outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
+$circle-size: 24px;
+$line-offset-from-circle-size: 8px;
 
 .wc-components-checkout-step {
 	position: relative;
-	border-left: 1px solid $gray-10;
 	padding-left: $gap-large;
 	padding-bottom: $gap-larger;
 
-	&:last-child {
-		border-left: none;
+	&:last-child::before {
+		content: none;
 	}
 }
 
@@ -23,15 +21,17 @@ $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 
 // @todo: remove the parent class once we dial the specification down.
 .wc-components-checkout-step__heading .wc-components-checkout-step__title {
-	@include font-size(16, 24px);
+	font-size: 16px;
+	line-height: 24px;
 	color: $gray-80;
 	font-weight: 400;
-	margin-right: $gap-small;
+	margin: 0 $gap-small 0 0;
 }
 
 // @todo: remove the parent class once we dial the specification down.
 .wc-components-checkout-step .wc-components-checkout-step__heading-content {
-	@include font-size(12, 24px);
+	font-size: 12px;
+	line-height: 24px;
 	color: $gray-80;
 
 	a {
@@ -40,7 +40,8 @@ $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 	}
 }
 .wc-components-checkout-step__description {
-	@include font-size(14, 20px);
+	font-size: 14px;
+	line-height: 20px;
 	color: $gray-60;
 	// @todo: delete this after we remove placeholders
 	display: block;
@@ -49,16 +50,28 @@ $outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
 
 .wc-components-checkout-step__number {
 	position: absolute;
-	width: $inner-circle-size;
-	height: $inner-circle-size;
-	left: -$outer-circle-size / 2;
-	top: -$circle-border-size;
+	width: $circle-size;
+	height: $circle-size;
+	left: -$circle-size / 2;
+	top: 0;
 	background: $gray-20;
 	color: $white;
 	font-size: 14px;
-	line-height: $inner-circle-size;
+	line-height: $circle-size;
 	text-align: center;
-	border-radius: $outer-circle-size / 2;
-	border: $circle-border-size solid $white;
+	border-radius: $circle-size / 2;
 	box-sizing: content-box;
+}
+
+// because themes can register different background colors, we can't always
+// relay on using white border to offest the step left line,
+.wc-components-checkout-step::before {
+	content: "";
+	// 1 Circle size + offset of the first circle and next circle.
+	height: calc(100% - #{$circle-size + $line-offset-from-circle-size * 2});
+	width: 1px;
+	background-color: $gray-10;
+	position: absolute;
+	left: 0;
+	top: $circle-size + $line-offset-from-circle-size;
 }

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -1,0 +1,59 @@
+$inner-circle-size: 24px;
+$circle-border-size: 8px;
+$outer-circle-size: $inner-circle-size + (2 * $circle-border-size);
+
+.wc-components-checkout-step {
+	position: relative;
+	border-left: 1px solid $core-grey-light-700;
+	padding-left: $gap-large;
+	padding-bottom: $gap-larger;
+}
+
+.wc-components-checkout-step__heading {
+	display: flex;
+	justify-content: space-between;
+	align-content: center;
+}
+
+// @todo: remove the parent class once we dial the specification down.
+.wc-components-checkout-step__heading .wc-components-checkout-step__title {
+	@include font-size(16, 24px);
+	// @todo: replace this with a variable
+	color: #2c3338;
+	margin-bottom: $gap-smaller;
+	font-weight: 400;
+}
+
+.wc-components-checkout-step__secondary-action {
+	@include font-size(12, 22px);
+	// @todo: replace this with a variable
+	color: #2c3338;
+
+	a {
+		font-weight: bold;
+	}
+}
+.wc-components-checkout-step__description {
+	@include font-size(14, 20px);
+	// @todo: replace this with a variable
+	color: #50575e;
+	// @todo: delete this after we remove placeholders
+	display: block;
+	margin-bottom: $gap-large;
+}
+
+.wc-components-checkout-step__number {
+	position: absolute;
+	width: $inner-circle-size;
+	height: $inner-circle-size;
+	left: -$outer-circle-size / 2;
+	top: -$circle-border-size;
+	background: $core-grey-dark-300;
+	color: $white;
+	font-size: 14px;
+	line-height: $inner-circle-size;
+	text-align: center;
+	border-radius: $outer-circle-size / 2;
+	border: $circle-border-size solid $white;
+	box-sizing: content-box;
+}

--- a/assets/js/base/components/checkout/form-step/style.scss
+++ b/assets/js/base/components/checkout/form-step/style.scss
@@ -15,7 +15,7 @@ $gray-80: #2c3338;
 	padding-left: $gap-large;
 	padding-bottom: $gap-larger;
 
-	&.is-last-step {
+	&:last-child {
 		border-left: none;
 	}
 }

--- a/assets/js/base/components/checkout/form/index.js
+++ b/assets/js/base/components/checkout/form/index.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */

--- a/assets/js/base/components/checkout/form/index.js
+++ b/assets/js/base/components/checkout/form/index.js
@@ -12,10 +12,10 @@ import './style.scss';
 const CheckoutForm = ( { className, children } ) => {
 	return (
 		<form
-			className={ classnames( [
+			className={ classnames(
 				'wc-components-checkout-form',
 				className,
-			] ) }
+			) }
 		>
 			{ children }
 		</form>

--- a/assets/js/base/components/checkout/form/index.js
+++ b/assets/js/base/components/checkout/form/index.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const CheckoutForm = ( { className, children } ) => {
+	return (
+		<form
+			className={ classnames( [
+				'wc-components-checkout-form',
+				className,
+			] ) }
+		>
+			{ children }
+		</form>
+	);
+};
+
+export default CheckoutForm;

--- a/assets/js/base/components/checkout/form/index.js
+++ b/assets/js/base/components/checkout/form/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
@@ -18,6 +19,11 @@ const CheckoutForm = ( { className, children } ) => {
 			{ children }
 		</form>
 	);
+};
+
+CheckoutForm.propTypes = {
+	className: PropTypes.string,
+	children: PropTypes.node,
 };
 
 export default CheckoutForm;

--- a/assets/js/base/components/checkout/form/index.js
+++ b/assets/js/base/components/checkout/form/index.js
@@ -12,10 +12,7 @@ import './style.scss';
 const CheckoutForm = ( { className, children } ) => {
 	return (
 		<form
-			className={ classnames(
-				'wc-components-checkout-form',
-				className,
-			) }
+			className={ classnames( 'wc-components-checkout-form', className ) }
 		>
 			{ children }
 		</form>

--- a/assets/js/base/components/checkout/form/style.scss
+++ b/assets/js/base/components/checkout/form/style.scss
@@ -1,0 +1,5 @@
+.wc-components-checkout-form {
+	margin-left: $gap-large;
+	margin-right: $gap-large;
+	width: $content-width;
+}

--- a/assets/js/base/components/checkout/form/style.scss
+++ b/assets/js/base/components/checkout/form/style.scss
@@ -2,4 +2,13 @@
 	margin-left: $gap-large;
 	margin-right: $gap-large;
 	width: $content-width;
+	max-width: 100%;
+}
+
+// Responsive media styles.
+@include breakpoint( "<480px" ) {
+	.wc-components-checkout-form {
+		margin-left: $gap-smaller;
+		margin-right: $gap;
+	}
 }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -83,6 +83,7 @@ const Block = () => {
 				) }
 				stepNumber={ 4 }
 				id="checkout-payment-fields"
+				isLastStep={ true }
 			>
 				<Placeholder>A checkout step, coming soon near you</Placeholder>
 			</FormStep>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -30,7 +30,7 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 1 }
-				stepHeadingContent={
+				stepHeadingContent={ () =>
 					<Fragment>
 						{ __(
 							'Already have an account? ',

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -30,7 +30,7 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 1 }
-				secondaryAction={
+				StepHeadingContent={
 					<Fragment>
 						{ __(
 							'Already have an account? ',

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -30,7 +30,7 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 1 }
-				StepHeadingContent={
+				stepHeadingContent={
 					<Fragment>
 						{ __(
 							'Already have an account? ',

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -25,7 +25,7 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				description={ __(
-					'We’ll use this email to send you details and updates about your order.',
+					'We\'ll use this email to send you details and updates about your order.',
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 1 }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -83,7 +83,6 @@ const Block = () => {
 				) }
 				stepNumber={ 4 }
 				id="checkout-payment-fields"
-				isLastStep={ true }
 			>
 				<Placeholder>A checkout step, coming soon near you</Placeholder>
 			</FormStep>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -19,17 +19,17 @@ const Block = () => {
 	return (
 		<CheckoutForm>
 			<FormStep
+				id="billing-fields"
 				className="wc-blocks-checkout__billing-fields"
 				title={ __(
 					'Contact information',
 					'woo-gutenberg-products-block'
 				) }
 				description={ __(
-					'We\'ll use this email to send you details and updates about your order.',
+					"We'll use this email to send you details and updates about your order.",
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 1 }
-				id="checkout-billing-fields"
 				secondaryAction={
 					<Fragment>
 						{ __(
@@ -45,6 +45,7 @@ const Block = () => {
 				<Placeholder>A checkout step, coming soon near you</Placeholder>
 			</FormStep>
 			<FormStep
+				id="shipping-fields"
 				className="wc-blocks-checkout__shipping-fields"
 				title={ __(
 					'Shipping address',
@@ -55,11 +56,11 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 2 }
-				id="checkout-shipping-fields"
 			>
 				<Placeholder>A checkout step, coming soon near you</Placeholder>
 			</FormStep>
 			<FormStep
+				id="shipping-methods"
 				className="wc-blocks-checkout__shipping-methods"
 				title={ __(
 					'Shipping options',
@@ -70,11 +71,11 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 3 }
-				id="checkout-shipping-methods"
 			>
 				<Placeholder>A checkout step, coming soon near you</Placeholder>
 			</FormStep>
 			<FormStep
+				id="payment-fields"
 				className="wc-blocks-checkout__payment-fields"
 				title={ __( 'Payment method', 'woo-gutenberg-products-block' ) }
 				description={ __(
@@ -82,7 +83,6 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 4 }
-				id="checkout-payment-fields"
 			>
 				<Placeholder>A checkout step, coming soon near you</Placeholder>
 			</FormStep>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
+import { Fragment } from '@wordpress/element';
 import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import FormStep from '@woocommerce/base-components/checkout/form-step';
+import CheckoutForm from '@woocommerce/base-components/checkout/form';
 
 /**
  * Internal dependencies
@@ -13,7 +17,76 @@ import './style.scss';
  */
 const Block = () => {
 	return (
-		<Placeholder>Checkout block coming soon to store near you</Placeholder>
+		<CheckoutForm>
+			<FormStep
+				className="wc-blocks-checkout__billing-fields"
+				title={ __(
+					'Contact information',
+					'woo-gutenberg-products-block'
+				) }
+				description={ __(
+					'We’ll use this email to send you details and updates about your order.',
+					'woo-gutenberg-products-block'
+				) }
+				stepNumber={ 1 }
+				id="checkout-billing-fields"
+				secondaryAction={
+					<Fragment>
+						{ __(
+							'Already have an account? ',
+							'woo-gutenberg-products-block'
+						) }
+						<a href="/wp-login.php">
+							{ __( 'Log in.', 'woo-gutenberg-products-block' ) }
+						</a>
+					</Fragment>
+				}
+			>
+				<Placeholder>A checkout step, coming soon near you</Placeholder>
+			</FormStep>
+			<FormStep
+				className="wc-blocks-checkout__shipping-fields"
+				title={ __(
+					'Shipping address',
+					'woo-gutenberg-products-block'
+				) }
+				description={ __(
+					'Enter the physical address where you want us to deliver your order.',
+					'woo-gutenberg-products-block'
+				) }
+				stepNumber={ 2 }
+				id="checkout-shipping-fields"
+			>
+				<Placeholder>A checkout step, coming soon near you</Placeholder>
+			</FormStep>
+			<FormStep
+				className="wc-blocks-checkout__shipping-methods"
+				title={ __(
+					'Shipping options',
+					'woo-gutenberg-products-block'
+				) }
+				description={ __(
+					'Select your shipping method below.',
+					'woo-gutenberg-products-block'
+				) }
+				stepNumber={ 3 }
+				id="checkout-shipping-methods"
+			>
+				<Placeholder>A checkout step, coming soon near you</Placeholder>
+			</FormStep>
+			<FormStep
+				className="wc-blocks-checkout__payment-fields"
+				title={ __( 'Payment method', 'woo-gutenberg-products-block' ) }
+				description={ __(
+					'Select a payment method below.',
+					'woo-gutenberg-products-block'
+				) }
+				stepNumber={ 4 }
+				id="checkout-payment-fields"
+			>
+				<Placeholder>A checkout step, coming soon near you</Placeholder>
+			</FormStep>
+		</CheckoutForm>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -30,7 +30,7 @@ const Block = () => {
 					'woo-gutenberg-products-block'
 				) }
 				stepNumber={ 1 }
-				stepHeadingContent={ () =>
+				stepHeadingContent={ () => (
 					<Fragment>
 						{ __(
 							'Already have an account? ',
@@ -40,7 +40,7 @@ const Block = () => {
 							{ __( 'Log in.', 'woo-gutenberg-products-block' ) }
 						</a>
 					</Fragment>
-				}
+				) }
 			>
 				<Placeholder>A checkout step, coming soon near you</Placeholder>
 			</FormStep>

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -7,6 +7,7 @@ import { Disabled } from '@wordpress/components';
  * Internal dependencies
  */
 import Block from './block.js';
+import './editor.scss';
 
 const Edit = ( { attributes } ) => {
 	const { className } = attributes;

--- a/assets/js/blocks/cart-checkout/checkout/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/editor.scss
@@ -1,0 +1,5 @@
+.editor-styles-wrapper .wp-block h4.wc-components-checkout-step__title {
+	font-size: 16px;
+	line-height: 24px;
+	margin: 0 $gap-small 0 0;
+}

--- a/assets/js/blocks/cart-checkout/checkout/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/index.js
@@ -9,6 +9,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import edit from './edit';
 import { example } from './example';
+import './editor.scss';
 
 registerBlockType( 'woocommerce/checkout', {
 	title: __( 'Checkout', 'woo-gutenberg-products-block' ),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR introduces the checkout form step component that handles showing and building steps.
<!-- Reference any related issues or PRs here -->
Closes #1328

Things that are left to do:
- [x] Add `PropTypes`.
- [x] Change colors to variables.

Inspirations:
[`composite-checkout/checkout-step`](https://github.com/Automattic/wp-calypso/blob/master/packages/composite-checkout/src/components/checkout-step.js)

### Screenshots
**Editor: StoreFront**
![image](https://user-images.githubusercontent.com/6165348/70320977-61fcc200-1826-11ea-9db2-fffd6d625e1d.png)

**Frontend: StoreFront**
![image](https://user-images.githubusercontent.com/6165348/70320997-7345ce80-1826-11ea-91fb-4e814c1d89a0.png)

**Editor: TwentyTwenty**
![image](https://user-images.githubusercontent.com/6165348/70320929-3a0d5e80-1826-11ea-8261-b84358258a5c.png)

**Frontend: TwentyTwenty**
![image](https://user-images.githubusercontent.com/6165348/70320939-41cd0300-1826-11ea-87a8-592399413e76.png)

**Frontend: StoreFront - Mobile**
![image](https://user-images.githubusercontent.com/6165348/70320986-6a54fd00-1826-11ea-9bb0-908d2f069f17.png)

**Frontend: TwentyTwenty - Mobile**
![image](https://user-images.githubusercontent.com/6165348/70320957-53160f80-1826-11ea-8bf1-58868f19ab49.png)
