### PR TITLE
Minor code style fixes in All Products block

### DIFF
--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -160,10 +160,7 @@ class Editor extends Component {
 		const onDone = () => {
 			const { block, setAttributes } = this.props;
 			setAttributes( {
-				layoutConfig: getProductLayoutConfig(
-					this.blockMap,
-					block.innerBlocks
-				),
+				layoutConfig: getProductLayoutConfig( block.innerBlocks ),
 			} );
 			this.setState( { innerBlocks: block.innerBlocks } );
 			this.togglePreview();

--- a/assets/js/blocks/products/base-utils.js
+++ b/assets/js/blocks/products/base-utils.js
@@ -42,10 +42,9 @@ export const DEFAULT_PRODUCT_LIST_LAYOUT = [
 /**
  * Converts innerblocks to a list of layout configs.
  *
- * @param {Object} blockMap Map of blocks as returned by `getBlockMap`.
  * @param {Object[]} innerBlocks Inner block components.
  */
-export const getProductLayoutConfig = ( blockMap, innerBlocks ) => {
+export const getProductLayoutConfig = ( innerBlocks ) => {
 	if ( ! innerBlocks || innerBlocks.length === 0 ) {
 		return [];
 	}
@@ -58,7 +57,7 @@ export const getProductLayoutConfig = ( blockMap, innerBlocks ) => {
 				product: undefined,
 				children:
 					block.innerBlocks.length > 0
-						? getProductLayoutConfig( blockMap, block.innerBlocks )
+						? getProductLayoutConfig( block.innerBlocks )
 						: [],
 			},
 		];

--- a/assets/js/blocks/products/edit.js
+++ b/assets/js/blocks/products/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { ToggleControl, SelectControl } from '@wordpress/components';
 
 /**
@@ -13,81 +12,71 @@ import './editor.scss';
 export const getSharedContentControls = ( attributes, setAttributes ) => {
 	const { contentVisibility } = attributes;
 	return (
-		<Fragment>
-			<ToggleControl
-				label={ __(
-					'Show Sorting Dropdown',
-					'woo-gutenberg-products-block'
-				) }
-				checked={ contentVisibility.orderBy }
-				onChange={ () =>
-					setAttributes( {
-						contentVisibility: {
-							...contentVisibility,
-							orderBy: ! contentVisibility.orderBy,
-						},
-					} )
-				}
-			/>
-		</Fragment>
+		<ToggleControl
+			label={ __(
+				'Show Sorting Dropdown',
+				'woo-gutenberg-products-block'
+			) }
+			checked={ contentVisibility.orderBy }
+			onChange={ () =>
+				setAttributes( {
+					contentVisibility: {
+						...contentVisibility,
+						orderBy: ! contentVisibility.orderBy,
+					},
+				} )
+			}
+		/>
 	);
 };
 
 export const getSharedListControls = ( attributes, setAttributes ) => {
 	return (
-		<Fragment>
-			<SelectControl
-				label={ __(
-					'Order Products By',
-					'woo-gutenberg-products-block'
-				) }
-				value={ attributes.orderby }
-				options={ [
-					{
-						label: __(
-							'Newness - newest first',
-							'woo-gutenberg-products-block'
-						),
-						value: 'date',
-					},
-					{
-						label: __(
-							'Price - low to high',
-							'woo-gutenberg-products-block'
-						),
-						value: 'price',
-					},
-					{
-						label: __(
-							'Price - high to low',
-							'woo-gutenberg-products-block'
-						),
-						value: 'price-desc',
-					},
-					{
-						label: __(
-							'Rating - highest first',
-							'woo-gutenberg-products-block'
-						),
-						value: 'rating',
-					},
-					{
-						label: __(
-							'Sales - most first',
-							'woo-gutenberg-products-block'
-						),
-						value: 'popularity',
-					},
-					{
-						label: __(
-							'Menu Order',
-							'woo-gutenberg-products-block'
-						),
-						value: 'menu_order',
-					},
-				] }
-				onChange={ ( orderby ) => setAttributes( { orderby } ) }
-			/>
-		</Fragment>
+		<SelectControl
+			label={ __( 'Order Products By', 'woo-gutenberg-products-block' ) }
+			value={ attributes.orderby }
+			options={ [
+				{
+					label: __(
+						'Newness - newest first',
+						'woo-gutenberg-products-block'
+					),
+					value: 'date',
+				},
+				{
+					label: __(
+						'Price - low to high',
+						'woo-gutenberg-products-block'
+					),
+					value: 'price',
+				},
+				{
+					label: __(
+						'Price - high to low',
+						'woo-gutenberg-products-block'
+					),
+					value: 'price-desc',
+				},
+				{
+					label: __(
+						'Rating - highest first',
+						'woo-gutenberg-products-block'
+					),
+					value: 'rating',
+				},
+				{
+					label: __(
+						'Sales - most first',
+						'woo-gutenberg-products-block'
+					),
+					value: 'popularity',
+				},
+				{
+					label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
+					value: 'menu_order',
+				},
+			] }
+			onChange={ ( orderby ) => setAttributes( { orderby } ) }
+		/>
 	);
 };


### PR DESCRIPTION
Some minor fixes I did in the code while working on #1084 and #1296 but I prefer to submit in its own PR.
* Remove `<Fragment>` from a couple of places where it wasn't needed.
* Remove first parameter from `getProductLayoutConfig()` which wasn't used inside the function.

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block.
2. Enter the edit mode and add/remove some blocks.
3. Save it and verify it works properly in the editor and the frontend.