### PR TITLE
Add 'Go' button to Attribute Filter

### DIFF
--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Fragment, isValidElement } from 'react';
+import { Fragment } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -18,7 +18,11 @@ const Label = ( {
 } ) => {
 	let Wrapper;
 
-	if ( ! isValidElement( label ) && isValidElement( screenReaderLabel ) ) {
+	const hasLabel = typeof label !== 'undefined' && label !== null;
+	const hasScreenReaderLabel =
+		typeof screenReaderLabel !== 'undefined' && screenReaderLabel !== null;
+
+	if ( ! hasLabel && hasScreenReaderLabel ) {
 		Wrapper = wrapperElement || 'span';
 		wrapperProps = {
 			...wrapperProps,
@@ -33,11 +37,7 @@ const Label = ( {
 
 	Wrapper = wrapperElement || Fragment;
 
-	if (
-		isValidElement( label ) &&
-		isValidElement( screenReaderLabel ) &&
-		label !== screenReaderLabel
-	) {
+	if ( hasLabel && hasScreenReaderLabel && label !== screenReaderLabel ) {
 		return (
 			<Wrapper { ...wrapperProps }>
 				<span aria-hidden="true">{ label }</span>

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Fragment } from 'react';
+import { Fragment, isValidElement } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -18,7 +18,7 @@ const Label = ( {
 } ) => {
 	let Wrapper;
 
-	if ( ! label && screenReaderLabel ) {
+	if ( ! isValidElement( label ) && isValidElement( screenReaderLabel ) ) {
 		Wrapper = wrapperElement || 'span';
 		wrapperProps = {
 			...wrapperProps,
@@ -33,7 +33,11 @@ const Label = ( {
 
 	Wrapper = wrapperElement || Fragment;
 
-	if ( label && screenReaderLabel && label !== screenReaderLabel ) {
+	if (
+		isValidElement( label ) &&
+		isValidElement( screenReaderLabel ) &&
+		label !== screenReaderLabel
+	) {
 		return (
 			<Wrapper { ...wrapperProps }>
 				<span aria-hidden="true">{ label }</span>

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -19,7 +19,7 @@ import classnames from 'classnames';
 import './style.scss';
 import { constrainRangeSliderValues } from './utils';
 import { formatPrice } from '../../utils/price';
-import SubmitButton from './submit-button';
+import SubmitButton from '../submit-button';
 import PriceLabel from './price-label';
 import PriceInput from './price-input';
 
@@ -307,6 +307,7 @@ const PriceSlider = ( {
 				) }
 				{ showFilterButton && (
 					<SubmitButton
+						className="wc-block-price-filter__button"
 						disabled={ isLoading || ! hasValidConstraints }
 						onClick={ onSubmit }
 					/>

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -96,11 +96,6 @@
 				margin-left: 0;
 				margin-right: 10px;
 			}
-
-			.wc-block-price-filter__button {
-				margin-left: auto;
-				white-space: nowrap;
-			}
 		}
 	}
 	.wc-block-price-filter__range-input {

--- a/assets/js/base/components/submit-button/index.js
+++ b/assets/js/base/components/submit-button/index.js
@@ -18,7 +18,7 @@ const SubmitButton = ( { className, disabled, onClick } ) => {
 			disabled={ disabled }
 			onClick={ onClick }
 		>
-			{ // translators: Submit button text for the filters.
+			{ // translators: Submit button text for filters.
 			__( 'Go', 'woo-gutenberg-products-block' ) }
 		</button>
 	);

--- a/assets/js/base/components/submit-button/index.js
+++ b/assets/js/base/components/submit-button/index.js
@@ -3,16 +3,22 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const SubmitButton = ( { disabled, onClick } ) => {
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const SubmitButton = ( { className, disabled, onClick } ) => {
 	return (
 		<button
 			type="submit"
-			className="wc-block-price-filter__button wc-block-form-button"
+			className={ classNames( 'wc-block-submit-button', className ) }
 			disabled={ disabled }
 			onClick={ onClick }
 		>
-			{ // translators: Submit button text for the price filter.
+			{ // translators: Submit button text for the filters.
 			__( 'Go', 'woo-gutenberg-products-block' ) }
 		</button>
 	);

--- a/assets/js/base/components/submit-button/style.scss
+++ b/assets/js/base/components/submit-button/style.scss
@@ -1,0 +1,5 @@
+.wc-block-submit-button {
+	display: block;
+	margin-left: auto;
+	white-space: nowrap;
+}

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -158,11 +158,16 @@ const AttributeFilterBlock = ( {
 	] );
 
 	// Track checked STATE changes - if state changes, update the query.
-	useEffect( () => {
-		if ( ! blockAttributes.showFilterButton ) {
-			onSubmit();
-		}
-	}, [ checked, onSubmit ] );
+	useEffect(
+		() => {
+			if ( ! blockAttributes.showFilterButton ) {
+				onSubmit();
+			}
+		},
+		// There is no need to add blockAttributes.showFilterButton as a dependency.
+		// It will only change in the editor and there we don't need to call onSubmit in any case.
+		[ checked, onSubmit ]
+	);
 
 	const curentCheckedQuery = useShallowEqual( checkedQuery );
 
@@ -193,6 +198,10 @@ const AttributeFilterBlock = ( {
 	);
 
 	const onSubmit = () => {
+		if ( isEditor ) {
+			return;
+		}
+
 		updateAttributeFilter(
 			productAttributesQuery,
 			setProductAttributesQuery,

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -186,23 +186,17 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 							'Filter button',
 							'woo-gutenberg-products-block'
 						) }
-						help={ () => {
-							if ( showFilterButton ) {
-								return __(
-									'Results will only update when the button is pressed.',
-									'woo-gutenberg-products-block'
-								);
-							}
-							return displayStyle === 'list'
+						help={
+							showFilterButton
 								? __(
-										'Results will update when the options are checked.',
+										'Products will only update when the button is pressed.',
 										'woo-gutenberg-products-block'
 								  )
 								: __(
-										'Results will update when the options are selected.',
+										'Products will update as options are selected.',
 										'woo-gutenberg-products-block'
-								  );
-						} }
+								  )
+						}
 						checked={ showFilterButton }
 						onChange={ ( value ) =>
 							setAttributes( {

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -39,6 +39,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		isPreview,
 		queryType,
 		showCounts,
+		showFilterButton,
 	} = attributes;
 
 	const [ isEditing, setIsEditing ] = useState(
@@ -177,6 +178,35 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 						onChange={ ( value ) =>
 							setAttributes( {
 								displayStyle: value,
+							} )
+						}
+					/>
+					<ToggleControl
+						label={ __(
+							'Filter button',
+							'woo-gutenberg-products-block'
+						) }
+						help={ () => {
+							if ( showFilterButton ) {
+								return __(
+									'Results will only update when the button is pressed.',
+									'woo-gutenberg-products-block'
+								);
+							}
+							return displayStyle === 'list'
+								? __(
+										'Results will update when the options are checked.',
+										'woo-gutenberg-products-block'
+								  )
+								: __(
+										'Results will update when the options are selected.',
+										'woo-gutenberg-products-block'
+								  );
+						} }
+						checked={ showFilterButton }
+						onChange={ ( value ) =>
+							setAttributes( {
+								showFilterButton: value,
 							} )
 						}
 					/>

--- a/assets/js/blocks/attribute-filter/frontend.js
+++ b/assets/js/blocks/attribute-filter/frontend.js
@@ -18,6 +18,7 @@ const getProps = ( el ) => {
 			heading: el.dataset.heading,
 			headingLevel: el.dataset.headingLevel || 3,
 			displayStyle: el.dataset.displayStyle,
+			showFilterButton: el.dataset.showFilterButton === 'true',
 		},
 	};
 };

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -57,6 +57,10 @@ registerBlockType( 'woocommerce/attribute-filter', {
 			type: 'string',
 			default: 'list',
 		},
+		showFilterButton: {
+			type: 'boolean',
+			default: false,
+		},
 		/**
 		 * Are we previewing?
 		 */
@@ -78,6 +82,7 @@ registerBlockType( 'woocommerce/attribute-filter', {
 			heading,
 			headingLevel,
 			displayStyle,
+			showFilterButton,
 		} = attributes;
 		const data = {
 			'data-attribute-id': attributeId,
@@ -88,6 +93,9 @@ registerBlockType( 'woocommerce/attribute-filter', {
 		};
 		if ( displayStyle !== 'list' ) {
 			data[ 'data-display-style' ] = displayStyle;
+		}
+		if ( showFilterButton ) {
+			data[ 'data-show-filter-button' ] = showFilterButton;
 		}
 		return (
 			<div

--- a/assets/js/blocks/attribute-filter/label.js
+++ b/assets/js/blocks/attribute-filter/label.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { _n, sprintf } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import Label from '@woocommerce/base-components/label';
+
+/**
+ * The label for an attribute term filter.
+ */
+const AttributeFilterLabel = ( { name, count } ) => {
+	return (
+		<Fragment>
+			{ name }
+			{ Number.isFinite( count ) && (
+				<Label
+					label={ count }
+					screenReaderLabel={ sprintf(
+						// translators: %s number of products.
+						_n(
+							'%s product',
+							'%s products',
+							count,
+							'woo-gutenberg-products-block'
+						),
+						count
+					) }
+					wrapperElement="span"
+					wrapperProps={ {
+						className: 'wc-block-attribute-filter-list-count',
+					} }
+				/>
+			) }
+		</Fragment>
+	);
+};
+
+export default AttributeFilterLabel;

--- a/assets/js/blocks/attribute-filter/preview.js
+++ b/assets/js/blocks/attribute-filter/preview.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import Label from './label';
+
+export const previewOptions = [
+	{
+		value: 'preview-1',
+		name: 'Blue',
+		label: <Label name="Blue" count={ 3 } />,
+	},
+	{
+		value: 'preview-2',
+		name: 'Green',
+		label: <Label name="Green" count={ 3 } />,
+	},
+	{
+		value: 'preview-3',
+		name: 'Red',
+		label: <Label name="Red" count={ 2 } />,
+	},
+];
+
+export const previewAttributeObject = {
+	id: 0,
+	name: 'preview',
+	taxonomy: 'preview',
+	label: 'Preview',
+};

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -19,7 +19,7 @@
 			label,
 			input {
 				cursor: pointer;
-				display: inline;
+				display: inline-block;
 			}
 		}
 

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -31,4 +31,8 @@
 	.wc-block-dropdown-selector .wc-block-dropdown-selector__list .wc-block-attribute-filter-list-count {
 		opacity: 0.6;
 	}
+
+	.wc-block-attribute-filter__button {
+		margin-top: $gap-smaller;
+	}
 }

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -19,6 +19,7 @@
 			label,
 			input {
 				cursor: pointer;
+				display: inline;
 			}
 		}
 

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -78,11 +78,11 @@ export default function( { attributes, setAttributes } ) {
 						help={
 							showFilterButton
 								? __(
-										'Results will only update when the button is pressed.',
+										'Products will only update when the button is pressed.',
 										'woo-gutenberg-products-block'
 								  )
 								: __(
-										'Results will update when the slider is moved.',
+										'Products will update when the slider is moved.',
 										'woo-gutenberg-products-block'
 								  )
 						}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1255#issuecomment-560552802. I also refactored `/attribute-filter/block.js` a bit because after the changes it was a bit too long so I tried to move some parts to other files.

### Screenshots
![Peek 2019-12-05 20-54](https://user-images.githubusercontent.com/3616980/70268789-7054ca80-17a1-11ea-86eb-ab89b4acbecb.gif)

### How to test the changes in this Pull Request:

1. Create a post with an _Attribute Filter_ and _All Products_ blocks.
2. In the _Attribute Filter_ enable the _Filter Button_ option.
3. Preview the post and verify selecting/unselecting options doesn't update the _All Products_ block until you press the _Go_ button.

### Changelog

> Add option to display a Filter button to Filter Products by Attribute block. 
