### PR TITLE
Fix package init for WooCommerce 3.9

### DIFF
--- a/src/Domain/Package.php
+++ b/src/Domain/Package.php
@@ -15,36 +15,28 @@ namespace Automattic\WooCommerce\Blocks\Domain;
 class Package {
 
 	/**
-	 * Holds the current version for the plugin.
+	 * Holds the current version of the blocks plugin.
 	 *
 	 * @var string
 	 */
 	private $version;
 
 	/**
-	 * Holds the main path to the plugin directory.
+	 * Holds the main path to the blocks plugin directory.
 	 *
 	 * @var string
 	 */
 	private $path;
 
 	/**
-	 * Holds the path to the main plugin file (entry)
-	 *
-	 * @var string
-	 */
-	private $plugin_file;
-
-	/**
 	 * Constructor
 	 *
 	 * @param string $version      Version of the plugin.
-	 * @param string $plugin_file  Path to the main plugin file.
+	 * @param string $plugin_path  Path to the main plugin file.
 	 */
-	public function __construct( $version, $plugin_file ) {
-		$this->version     = $version;
-		$this->plugin_file = $plugin_file;
-		$this->path        = dirname( $plugin_file );
+	public function __construct( $version, $plugin_path ) {
+		$this->version = $version;
+		$this->path    = $plugin_path;
 	}
 
 	/**
@@ -57,15 +49,6 @@ class Package {
 	}
 
 	/**
-	 * Returns the path to the main plugin file.
-	 *
-	 * @return string
-	 */
-	public function get_plugin_file() {
-		return $this->plugin_file;
-	}
-
-	/**
 	 * Returns the path to the plugin directory.
 	 *
 	 * @param string $relative_path  If provided, the relative path will be
@@ -74,13 +57,11 @@ class Package {
 	 * @return string
 	 */
 	public function get_path( $relative_path = '' ) {
-		return '' === $relative_path
-			? trailingslashit( $this->path )
-			: trailingslashit( $this->path ) . $relative_path;
+		return trailingslashit( $this->path ) . $relative_path;
 	}
 
 	/**
-	 * Returns the url to the plugin directory.
+	 * Returns the url to the blocks plugin directory.
 	 *
 	 * @param string $relative_url If provided, the relative url will be
 	 *                             appended to the plugin url.
@@ -88,8 +69,7 @@ class Package {
 	 * @return string
 	 */
 	public function get_url( $relative_url = '' ) {
-		return '' === $relative_url
-			? plugin_dir_url( $this->get_plugin_file() )
-			: plugin_dir_url( $this->get_plugin_file() ) . $relative_url;
+		// Append index.php so WP does not return the parent directory.
+		return plugin_dir_url( $this->path . '/index.php' ) . $relative_url;
 	}
 }

--- a/src/Package.php
+++ b/src/Package.php
@@ -2,6 +2,12 @@
 /**
  * Returns information about the package and handles init.
  *
+ * In the context of this plugin, it handles init and is called from the main
+ * plugin file (woocommerce-gutenberg-products-block.php).
+ *
+ * In the context of WooCommere core, it handles init and is called from
+ * WooCommerce's package loader. The main plugin file is _not_ loaded.
+ *
  * @package Automattic/WooCommerce/Blocks
  */
 
@@ -14,7 +20,7 @@ use Automattic\WooCommerce\Blocks\Registry\Container;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Main package class. (Loader in the WC Core context as well)
+ * Main package class.
  *
  * @since 2.5.0
  */
@@ -81,7 +87,7 @@ class Package {
 					$version = '2.6.0-dev';
 					return new NewPackage(
 						$version,
-						WC_BLOCKS_PLUGIN_FILE
+						dirname( __DIR__ )
 					);
 				}
 			);

--- a/tests/php/Domain/Package.php
+++ b/tests/php/Domain/Package.php
@@ -13,24 +13,20 @@ use Automattic\WooCommerce\Blocks\Domain\Package as TestedPackage;
 class Package extends WP_UnitTestCase {
 
 	private function get_package() {
-		return new TestedPackage( '1.0.0', __FILE__ );
+		return new TestedPackage( '1.0.0', __DIR__ );
 	}
 
 	public function test_get_version() {
 		$this->assertEquals( '1.0.0', $this->get_package()->get_version() );
 	}
 
-	public function test_get_plugin_file() {
-		$this->assertEquals( __FILE__, $this->get_package()->get_plugin_file() );
-	}
-
 	public function test_get_path() {
 		$package = $this->get_package();
 		// test without relative
-		$this->assertEquals( dirname( __FILE__ ) . '/', $package->get_path() );
+		$this->assertEquals( __DIR__ . '/', $package->get_path() );
 
 		//test with relative
-		$expect = dirname( __FILE__ ) . '/build/test';
+		$expect = __DIR__ . '/build/test';
 		$this->assertEquals( $expect, $package->get_path( 'build/test') );
 	}
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -61,8 +61,6 @@ if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
 	return;
 }
 
-define( 'WC_BLOCKS_PLUGIN_FILE', __FILE__ );
-
 /**
  * Autoload packages.
  *


### PR DESCRIPTION
Fixes the issue reported here due to a missing constant when in Woo core context: https://github.com/woocommerce/woocommerce/pull/25181

### How to test the changes in this Pull Request:

Check for notices when running the feature plugin.

To test this resolves issues in core, we'll need to:

- Merge to release branch
- Create a tag (can be rc tag)
- Checkout woo core and update the version in the composer file
- Ensure it is pulled in and the notices reported in https://github.com/woocommerce/woocommerce/pull/25181 are resolved.

Then we can release `2.5.3` ready for core inclusion.
