### PR TITLE
All Products: Allow core blocks as inner blocks

### DIFF
--- a/assets/js/base/components/product-list-item/utils.js
+++ b/assets/js/base/components/product-list-item/utils.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { RawHTML } from '@wordpress/element';
+import { getSaveContent, getSaveElement } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { getBlockMap } from '../../../blocks/products/base-utils';
@@ -38,7 +44,9 @@ export const renderProductLayout = (
 		const LayoutComponent = blockMap[ name ];
 
 		if ( ! LayoutComponent ) {
-			return null;
+			return <RawHTML>{ getSaveContent( name, props ) }</RawHTML>;
+			// @todo investigate why `getSaveElement` adds a wrapping `<div>` to the paragraph content.
+			// return getSaveElement( name, props );
 		}
 
 		const productID = product.id || 0;

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -187,7 +187,10 @@ class Editor extends Component {
 		const InnerBlockProps = {
 			template: this.props.attributes.layoutConfig,
 			templateLock: false,
-			allowedBlocks: Object.keys( this.blockMap ),
+			allowedBlocks: [
+				'core/paragraph',
+				...Object.keys( this.blockMap ),
+			],
 		};
 
 		if ( this.props.attributes.layoutConfig.length !== 0 ) {


### PR DESCRIPTION
WIP attempt to fix #1084.

### Screenshots
![Screenshot](https://cldup.com/xJvjB7vJRH.gif)

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block.
2. Enter the edit mode and add a paragraph and enable the _Drop Cap_ option.
3. Save the block and verify the paragraph renders correctly both in the editor and the frontend.

### Next tasks
* [ ] `getSaveElement` seems to add a `<div>` around the block content. For now I used `getSaveContent` instead but it would be better to use `getSaveElement` if possible.
* [ ] It doesn't work yet in the frontend.
* [ ] We should whitelist some more core components (list, image, quote...).
* [ ] Fix `Warning: Each child in a list should have a unique "key" prop.` warning.

### Changelog

> Allow new core blocks inside _All Products_.