### PR TITLE
Avoid filtering Attribute Filter options when query type is OR

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -102,6 +102,7 @@ const AttributeFilterBlock = ( {
 		shouldSelect: blockAttributes.attributeId > 0,
 	} );
 
+	const filterAvailableFilters = blockAttributes.queryType === 'and';
 	const {
 		results: filteredCounts,
 		isLoading: filteredCountsLoading,
@@ -110,7 +111,7 @@ const AttributeFilterBlock = ( {
 			taxonomy: attributeObject.taxonomy,
 			queryType: blockAttributes.queryType,
 		},
-		queryState,
+		queryState: filterAvailableFilters ? queryState : null,
 	} );
 
 	/**


### PR DESCRIPTION
Fixes #1338.

**Note:** this was fixed in `master` in #1309, so there is no need to cherry-pick this PR.

### Screenshots
Options should only be hidden when Query Type is `AND`:
![Peek 2019-12-03 17-50](https://user-images.githubusercontent.com/3616980/70071324-79a13400-15f5-11ea-86b2-448d9401921b.gif)

### How to test the changes in this Pull Request:

1. Create a post with a _Filter Products by Attribute_ block and set _Query Type_ to `OR`.
2. Preview the post and check one of the options.
3. Verify other options don't disappear.

### Changelog

> Prevent Filter Products by Attribute block hiding non-matching options when Querty Type is set to OR.