### PR TITLE
Improve cart and checkout block namespacing

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -122,12 +122,12 @@ const mainEntry = {
 	'price-filter': './assets/js/blocks/price-filter/index.js',
 	'attribute-filter': './assets/js/blocks/attribute-filter/index.js',
 	'active-filters': './assets/js/blocks/active-filters/index.js',
-	checkout: './assets/js/blocks/cart-checkout/checkout/index.js',
 	'block-error-boundary':
 		'./assets/js/base/components/block-error-boundary/style.scss',
 
 	// cart & checkout blocks
-	cart: './assets/js/blocks/cart-checkout/cart/index.js',
+	'cart-block': './assets/js/blocks/cart-checkout/cart/index.js',
+	'checkout-block': './assets/js/blocks/cart-checkout/checkout/index.js',
 };
 
 const frontEndEntry = {
@@ -136,8 +136,8 @@ const frontEndEntry = {
 	'price-filter': './assets/js/blocks/price-filter/frontend.js',
 	'attribute-filter': './assets/js/blocks/attribute-filter/frontend.js',
 	'active-filters': './assets/js/blocks/active-filters/frontend.js',
-	checkout: './assets/js/blocks/cart-checkout/checkout/frontend.js',
-	cart: './assets/js/blocks/cart-checkout/cart/frontend.js',
+	'checkout-block': './assets/js/blocks/cart-checkout/checkout/frontend.js',
+	'cart-block': './assets/js/blocks/cart-checkout/cart/frontend.js',
 };
 
 const getEntryConfig = ( main = true, exclude = [] ) => {

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -69,8 +69,8 @@ class Assets {
 		self::register_script( 'wc-price-filter', plugins_url( self::get_block_asset_build_path( 'price-filter' ), __DIR__ ), $block_dependencies );
 		self::register_script( 'wc-attribute-filter', plugins_url( self::get_block_asset_build_path( 'attribute-filter' ), __DIR__ ), $block_dependencies );
 		self::register_script( 'wc-active-filters', plugins_url( self::get_block_asset_build_path( 'active-filters' ), __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-checkout', plugins_url( self::get_block_asset_build_path( 'checkout' ), __DIR__ ), $block_dependencies );
-		self::register_script( 'wc-cart', plugins_url( self::get_block_asset_build_path( 'cart' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-checkout-block', plugins_url( self::get_block_asset_build_path( 'checkout' ), __DIR__ ), $block_dependencies );
+		self::register_script( 'wc-cart-block', plugins_url( self::get_block_asset_build_path( 'cart' ), __DIR__ ), $block_dependencies );
 	}
 
 	/**

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -18,7 +18,7 @@ class Cart extends AbstractBlock {
 	 *
 	 * @var string
 	 */
-	protected $block_name = 'cart';
+	protected $block_name = 'cart-block';
 
 	/**
 	 * Registers the block type with WordPress.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -19,7 +19,7 @@ class Checkout extends AbstractBlock {
 	 *
 	 * @var string
 	 */
-	protected $block_name = 'checkout';
+	protected $block_name = 'checkout-block';
 
 	/**
 	 * Registers the block type with WordPress.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,8 +112,8 @@ const LegacyBlocksConfig = {
 			'price-filter',
 			'attribute-filter',
 			'active-filters',
-			'checkout',
-			'cart',
+			'checkout-block',
+			'cart-block',
 		],
 	} ),
 };
@@ -135,8 +135,8 @@ const LegacyFrontendBlocksConfig = {
 			'price-filter',
 			'attribute-filter',
 			'active-filters',
-			'checkout',
-			'cart',
+			'checkout-block',
+			'cart-block',
 		],
 	} ),
 };


### PR DESCRIPTION
Fixes: #1342 

This applies more specific namespacing to asset handles for cart and checkout blocks to avoid conflicting with WooCommerce core handles.

## To Test

* [ ] Verify WooCommerce core javascript on cart and checkout routes works as expected with this branch active.