### PR TITLE
Store API: Add shipping rate api

### DIFF
--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -98,6 +98,7 @@ class RestApi {
 			'store-product-collection-data' => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductCollectionData',
 			'store-product-attributes'      => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductAttributes',
 			'store-product-attribute-terms' => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductAttributeTerms',
+			'store-cart-shipping-rates'     => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\CartShippingRates',
 		];
 	}
 }

--- a/src/RestApi/Controllers/Cart.php
+++ b/src/RestApi/Controllers/Cart.php
@@ -127,7 +127,7 @@ class Cart extends WP_REST_Controller {
 				),
 				'variation'    => array(
 					'description' => __( 'If this cart item represents a variation, chosen attributes are shown here.', 'woo-gutenberg-products-block' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'items'       => array(

--- a/src/RestApi/Controllers/Products.php
+++ b/src/RestApi/Controllers/Products.php
@@ -114,7 +114,7 @@ class Products extends WC_REST_Products_Controller {
 	 * @return bool
 	 */
 	public function force_edit_posts_permission( $permission ) {
-		// If user has access already, we can bypass additonal checks.
+		// If user has access already, we can bypass additional checks.
 		if ( $permission ) {
 			return $permission;
 		}
@@ -363,7 +363,7 @@ class Products extends WC_REST_Products_Controller {
 				),
 				'images'         => array(
 					'description' => __( 'List of images.', 'woo-gutenberg-products-block' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'items'       => array(
 						'type'       => 'object',
@@ -431,21 +431,18 @@ class Products extends WC_REST_Products_Controller {
 					'type'        => 'object',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
-					'items'       => array(
-						'type'       => 'object',
-						'properties' => array(
-							'text'        => array(
-								'description' => __( 'Button text.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
-							'description' => array(
-								'description' => __( 'Button description.', 'woo-gutenberg-products-block' ),
-								'type'        => 'string',
-								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
-							),
+					'properties'  => array(
+						'text'        => array(
+							'description' => __( 'Button text.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'description' => array(
+							'description' => __( 'Button description.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
 						),
 					),
 				),

--- a/src/RestApi/StoreApi/Controllers/Cart.php
+++ b/src/RestApi/StoreApi/Controllers/Cart.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \WP_Error as RestError;
 use \WP_REST_Server as RestServer;
-use \WP_REST_Controller as RestContoller;
+use \WP_REST_Controller as RestController;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartSchema;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 
@@ -21,7 +21,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
  *
  * @since 2.5.0
  */
-class Cart extends RestContoller {
+class Cart extends RestController {
 	/**
 	 * Endpoint namespace.
 	 *

--- a/src/RestApi/StoreApi/Controllers/CartItems.php
+++ b/src/RestApi/StoreApi/Controllers/CartItems.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \WP_Error as RestError;
 use \WP_REST_Server as RestServer;
-use \WP_REST_Controller as RestContoller;
+use \WP_REST_Controller as RestController;
 use \WP_REST_Response as RestResponse;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartItemSchema;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
@@ -22,7 +22,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
  *
  * @since 2.5.0
  */
-class CartItems extends RestContoller {
+class CartItems extends RestController {
 	/**
 	 * Endpoint namespace.
 	 *

--- a/src/RestApi/StoreApi/Controllers/CartItems.php
+++ b/src/RestApi/StoreApi/Controllers/CartItems.php
@@ -252,8 +252,29 @@ class CartItems extends RestContoller {
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $cart_item, $request ) {
-		$data = $this->schema->get_item_response( $cart_item );
+		$data     = $this->schema->get_item_response( $cart_item );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $cart_item ) );
 
-		return rest_ensure_response( $data );
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param array $cart_item Object to prepare.
+	 * @return array
+	 */
+	protected function prepare_links( $cart_item ) {
+		$base  = $this->namespace . '/' . $this->rest_base;
+		$links = array(
+			'self'       => array(
+				'href' => rest_url( trailingslashit( $base ) . $cart_item['key'] ),
+			),
+			'collection' => array(
+				'href' => rest_url( $base ),
+			),
+		);
+		return $links;
 	}
 }

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -12,14 +12,14 @@ defined( 'ABSPATH' ) || exit;
 
 use \WP_Error as RestError;
 use \WP_REST_Server as RestServer;
-use \WP_REST_Controller as RestContoller;
+use \WP_REST_Controller as RestController;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartShippingRateSchema;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 
 /**
  * Cart Shipping Rates API.
  */
-class CartShippingRates extends RestContoller {
+class CartShippingRates extends RestController {
 	/**
 	 * Endpoint namespace.
 	 *

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -137,7 +137,7 @@ class CartShippingRates extends RestContoller {
 		$params['context']['default'] = 'view';
 
 		$params['address_1'] = array(
-			'description'       => __( 'First line of address being shipped to.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'First line of the address being shipped to.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'default'           => '',
 			'sanitize_callback' => 'wc_clean',
@@ -145,7 +145,7 @@ class CartShippingRates extends RestContoller {
 		);
 
 		$params['address_2'] = array(
-			'description'       => __( 'Second line of address being shipped to.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'Second line of the address being shipped to.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'default'           => '',
 			'sanitize_callback' => 'wc_clean',
@@ -153,7 +153,7 @@ class CartShippingRates extends RestContoller {
 		);
 
 		$params['city'] = array(
-			'description'       => __( 'City name being shipped to.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'City of the address being shipped to.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'default'           => '',
 			'sanitize_callback' => 'wc_clean',
@@ -161,7 +161,7 @@ class CartShippingRates extends RestContoller {
 		);
 
 		$params['state'] = array(
-			'description'       => __( 'ISO code or name of the state, province or district being shipped to.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'ISO code, or name, for the state, province, or district of the address being shipped to.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'default'           => '',
 			'sanitize_callback' => 'wc_clean',
@@ -169,7 +169,7 @@ class CartShippingRates extends RestContoller {
 		);
 
 		$params['postcode'] = array(
-			'description'       => __( 'Postal code being shipped to.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'Zip or Postcode of the address being shipped to.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'default'           => '',
 			'sanitize_callback' => 'wc_clean',
@@ -177,7 +177,7 @@ class CartShippingRates extends RestContoller {
 		);
 
 		$params['country'] = array(
-			'description'       => __( 'ISO code of the country being shipped to.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'ISO code for the country of the address being shipped to.', 'woo-gutenberg-products-block' ),
 			'type'              => 'string',
 			'default'           => '',
 			'sanitize_callback' => 'wc_clean',
@@ -190,35 +190,26 @@ class CartShippingRates extends RestContoller {
 	/**
 	 * Get packages to calculate shipping for.
 	 *
-	 * Based on WC_Cart::get_shipping_packages but allows the destination to be customised.
+	 * Based on WC_Cart::get_shipping_packages but allows the destination to be
+	 * customised based on passed params.
 	 *
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array of cart items
 	 */
 	protected function get_shipping_packages( $request ) {
-		$controller = new CartController();
-		$cart_items = $controller->get_cart_items(
-			function( $item ) {
-				return ! empty( $item['data'] ) && $item['data']->needs_shipping();
-			}
-		);
+		$packages = WC()->cart->get_shipping_packages();
 
-		return apply_filters(
-			'woocommerce_cart_shipping_packages',
-			array(
-				array(
-					'contents'      => $cart_items,
-					'contents_cost' => array_sum( wp_list_pluck( $cart_items, 'line_total' ) ),
-					'destination'   => array(
-						'country'   => $request['country'],
-						'state'     => $request['state'],
-						'postcode'  => $request['postcode'],
-						'city'      => $request['city'],
-						'address_1' => $request['address_1'],
-						'address_2' => $request['address_2'],
-					),
-				),
-			)
-		);
+		foreach ( $packages as $key => $package ) {
+			$packages[ $key ]['destination'] = [
+				'address_1' => $request['address_1'],
+				'address_2' => $request['address_2'],
+				'city'      => $request['city'],
+				'state'     => $request['state'],
+				'postcode'  => $request['postcode'],
+				'country'   => $request['country'],
+			];
+		}
+
+		return $packages;
 	}
 }

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -101,7 +101,7 @@ class CartShippingRates extends RestContoller {
 		$packages_response    = [];
 
 		foreach ( $packages_with_quotes as $package_id => $package ) {
-			$packages_response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package_id, $package ) );
+			$packages_response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package ) );
 		}
 
 		return rest_ensure_response( $packages_response );
@@ -119,12 +119,11 @@ class CartShippingRates extends RestContoller {
 	/**
 	 * Prepares a single item output for response.
 	 *
-	 * @param int   $package_id Package index (ID).
-	 * @param array $package    Shipping package complete with rates from WooCommerce.
+	 * @param array $package Shipping package complete with rates from WooCommerce.
 	 * @return \WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $package_id, $package ) {
-		return rest_ensure_response( $this->schema->get_item_response( $package_id, $package ) );
+	public function prepare_item_for_response( $package ) {
+		return rest_ensure_response( $this->schema->get_item_response( $package ) );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -86,7 +86,7 @@ class CartShippingRates extends RestContoller {
 			return new RestError( 'woocommerce_rest_cart_shipping_rates_missing_country', __( 'Shipping destination country is required.', 'woo-gutenberg-products-block' ), array( 'status' => 400 ) );
 		}
 
-		$request = $this->validate_destination( $request );
+		$request = $this->validate_shipping_address( $request );
 
 		if ( is_wp_error( $request ) ) {
 			return $request;
@@ -113,12 +113,12 @@ class CartShippingRates extends RestContoller {
 	}
 
 	/**
-	 * Format the request destination.
+	 * Format the request address.
 	 *
 	 * @param \WP_REST_Request $request Full details about the request.
 	 * @return \WP_Error|\WP_REST_Response
 	 */
-	protected function validate_destination( $request ) {
+	protected function validate_shipping_address( $request ) {
 		$request['country']  = wc_strtoupper( $request['country'] );
 		$request['postcode'] = $request['postcode'] ? wc_format_postcode( $request['postcode'], $request['country'] ) : null;
 

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Cart shippnig rates controller.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers;
+
+defined( 'ABSPATH' ) || exit;
+
+use \WP_Error as RestError;
+use \WP_REST_Server as RestServer;
+use \WP_REST_Controller as RestContoller;
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartShippingRateSchema;
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
+
+/**
+ * Cart Shipping Rates API.
+ */
+class CartShippingRates extends RestContoller {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/store';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'cart/shipping-rates';
+
+	/**
+	 * Schema class instance.
+	 *
+	 * @var object
+	 */
+	protected $schema;
+
+	/**
+	 * Setup API class.
+	 */
+	public function __construct() {
+		$this->schema = new CartShippingRateSchema();
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'  => RestServer::READABLE,
+					'callback' => [ $this, 'get_items' ],
+					'args'     => [
+						'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Get shipping rates for the cart.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$controller = new CartController();
+		$cart       = $controller->get_cart_instance();
+
+		if ( ! $cart || ! $cart instanceof \WC_Cart ) {
+			return new RestError( 'woocommerce_rest_cart_error', __( 'Unable to retrieve cart.', 'woo-gutenberg-products-block' ), array( 'status' => 500 ) );
+		}
+
+		if ( empty( $request['country'] ) ) {
+			return new RestError( 'woocommerce_rest_cart_error', __( 'Shipping destination country is required.', 'woo-gutenberg-products-block' ), array( 'status' => 400 ) );
+		}
+
+		$cart_items = $controller->get_cart_items(
+			function( $item ) {
+				return ! empty( $item['data'] ) && $item['data']->needs_shipping();
+			}
+		);
+
+		if ( empty( $cart_items ) ) {
+			return new RestError( 'woocommerce_rest_cart_error', __( 'There are no shippable items in the cart.', 'woo-gutenberg-products-block' ), array( 'status' => 400 ) );
+		}
+
+		$packages_to_quote = $this->get_shipping_packages( $request );
+		$quotes            = WC()->shipping()->calculate_shipping( $packages_to_quote );
+
+		foreach ( $quotes as $quote ) {
+			var_dump( $quote['rates'] );
+		}
+
+		//$data     = $this->prepare_item_for_response( $cart, $request );
+		$data = [];
+		$response = rest_ensure_response( $data );
+
+		return $response;
+	}
+
+	/**
+	 * Cart item schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return $this->schema->get_item_schema();
+	}
+
+	/**
+	 * Prepares a single item output for response.
+	 *
+	 * @param array            $cart    Cart array.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $cart, $request ) {
+		$data = $this->schema->get_item_response( $cart );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Get the query params available for this endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                       = array();
+		$params['context']            = $this->get_context_param();
+		$params['context']['default'] = 'view';
+
+		$params['address_1'] = array(
+			'description'       => __( 'First line of address being shipped to.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'default'           => '',
+			'sanitize_callback' => 'wc_clean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['address_2'] = array(
+			'description'       => __( 'Second line of address being shipped to.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'default'           => '',
+			'sanitize_callback' => 'wc_clean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['city'] = array(
+			'description'       => __( 'City name being shipped to.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'default'           => '',
+			'sanitize_callback' => 'wc_clean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['state'] = array(
+			'description'       => __( 'ISO code or name of the state, province or district being shipped to.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'default'           => '',
+			'sanitize_callback' => 'wc_clean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['postcode'] = array(
+			'description'       => __( 'Postal code being shipped to.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'default'           => '',
+			'sanitize_callback' => 'wc_clean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		$params['country'] = array(
+			'description'       => __( 'ISO code of the country being shipped to.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'default'           => '',
+			'sanitize_callback' => 'wc_clean',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
+
+	/**
+	 * Get packages to calculate shipping for.
+	 *
+	 * Based on WC_Cart::get_shipping_packages but allows the destination to be customised.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array of cart items
+	 */
+	protected function get_shipping_packages( $request ) {
+		$controller = new CartController();
+		$cart_items = $controller->get_cart_items(
+			function( $item ) {
+				return ! empty( $item['data'] ) && $item['data']->needs_shipping();
+			}
+		);
+
+		return apply_filters(
+			'woocommerce_cart_shipping_packages',
+			array(
+				array(
+					'contents'      => $cart_items,
+					'contents_cost' => array_sum( wp_list_pluck( $cart_items, 'line_total' ) ),
+					'destination'   => array(
+						'country'   => $request['country'],
+						'state'     => $request['state'],
+						'postcode'  => $request['postcode'],
+						'city'      => $request['city'],
+						'address_1' => $request['address_1'],
+						'address_2' => $request['address_2'],
+					),
+				),
+			)
+		);
+	}
+}

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -106,7 +106,7 @@ class CartShippingRates extends RestContoller {
 		$response = [];
 
 		foreach ( $packages as $package ) {
-			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package ) );
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package, $request ) );
 		}
 
 		return rest_ensure_response( $response );
@@ -164,10 +164,11 @@ class CartShippingRates extends RestContoller {
 	/**
 	 * Prepares a single item output for response.
 	 *
-	 * @param array $package Shipping package complete with rates from WooCommerce.
-	 * @return \WP_REST_Response Response object.
+	 * @param array            $package Shipping package complete with rates from WooCommerce.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response $response Response data.
 	 */
-	public function prepare_item_for_response( $package ) {
+	public function prepare_item_for_response( $package, $request ) {
 		return rest_ensure_response( $this->schema->get_item_response( $package ) );
 	}
 

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -98,18 +98,13 @@ class CartShippingRates extends RestContoller {
 
 		$packages_to_quote    = $this->get_shipping_packages( $request );
 		$packages_with_quotes = WC()->shipping()->calculate_shipping( $packages_to_quote );
-		$rates                = [];
+		$packages_response    = [];
 
 		foreach ( $packages_with_quotes as $package_id => $package ) {
-			foreach ( $package['rates'] as $rate ) {
-				$data    = $this->prepare_item_for_response( $rate, $package_id, $package, $request );
-				$rates[] = $this->prepare_response_for_collection( $data );
-			}
+			$packages_response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package_id, $package ) );
 		}
 
-		$response = rest_ensure_response( $rates );
-
-		return $response;
+		return rest_ensure_response( $packages_response );
 	}
 
 	/**
@@ -124,14 +119,12 @@ class CartShippingRates extends RestContoller {
 	/**
 	 * Prepares a single item output for response.
 	 *
-	 * @param ShippingRate     $rate Shipping rate object instance.
-	 * @param int              $package_id ID/index of the package.
-	 * @param array            $package Shipping package this rate is for.
-	 * @param \WP_REST_Request $request Request object.
+	 * @param int   $package_id Package index (ID).
+	 * @param array $package    Shipping package complete with rates from WooCommerce.
 	 * @return \WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $rate, $package_id, $package, $request ) {
-		return rest_ensure_response( $this->schema->get_item_response( $rate, $package_id, $package ) );
+	public function prepare_item_for_response( $package_id, $package ) {
+		return rest_ensure_response( $this->schema->get_item_response( $package_id, $package ) );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Cart shippnig rates controller.
+ * Cart shipping rates controller.
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @package WooCommerce/Blocks
@@ -140,7 +140,7 @@ class CartShippingRates extends RestController {
 						'woocommerce_rest_cart_shipping_rates_invalid_state',
 						sprintf(
 							/* translators: 1: valid states */
-							__( 'Desintation state is not valid. Please enter one of the following: %s', 'woo-gutenberg-products-block' ),
+							__( 'Destination state is not valid. Please enter one of the following: %s', 'woo-gutenberg-products-block' ),
 							implode( ', ', $valid_states )
 						),
 						[ 'status' => 400 ]

--- a/src/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
+++ b/src/RestApi/StoreApi/Controllers/ProductAttributeTerms.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \WP_Error as RestError;
 use \WP_REST_Server as RestServer;
-use \WP_REST_Controller as RestContoller;
+use \WP_REST_Controller as RestController;
 use \WC_REST_Exception as RestException;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\TermSchema;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\TermQuery;
@@ -22,7 +22,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\TermQuery;
  *
  * @since 2.5.0
  */
-class ProductAttributeTerms extends RestContoller {
+class ProductAttributeTerms extends RestController {
 	/**
 	 * Endpoint namespace.
 	 *

--- a/src/RestApi/StoreApi/Controllers/ProductAttributes.php
+++ b/src/RestApi/StoreApi/Controllers/ProductAttributes.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \WP_Error as RestError;
 use \WP_REST_Server as RestServer;
-use \WP_REST_Controller as RestContoller;
+use \WP_REST_Controller as RestController;
 use \WC_REST_Exception as RestException;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductAttributeSchema;
 
@@ -21,7 +21,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductAttributeSchem
  *
  * @since 2.5.0
  */
-class ProductAttributes extends RestContoller {
+class ProductAttributes extends RestController {
 	/**
 	 * Endpoint namespace.
 	 *

--- a/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
+++ b/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
@@ -79,7 +79,7 @@ class ProductCollectionData extends RestController {
 				),
 				'attribute_counts' => array(
 					'description' => __( 'Returns number of products within attribute terms, indexed by term ID.', 'woo-gutenberg-products-block' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'items'       => array(
@@ -102,7 +102,7 @@ class ProductCollectionData extends RestController {
 				),
 				'rating_counts'    => array(
 					'description' => __( 'Returns number of products with each average rating.', 'woo-gutenberg-products-block' ),
-					'type'        => 'object',
+					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 					'items'       => array(

--- a/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
+++ b/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Products collection data controller. Get's aggregate data from a collection of products.
+ * Products collection data controller. Get aggregate data from a collection of products.
  *
  * Supports the same parameters as /products, but returns a different response.
  *

--- a/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
+++ b/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
@@ -12,7 +12,7 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers;
 
 defined( 'ABSPATH' ) || exit;
 
-use \WP_REST_Controller as RestContoller;
+use \WP_REST_Controller as RestController;
 use \WP_REST_Server as RestServer;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ProductQueryFilters;
 
@@ -21,7 +21,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ProductQueryFilters
  *
  * @since 2.5.0
  */
-class ProductCollectionData extends RestContoller {
+class ProductCollectionData extends RestController {
 	/**
 	 * Endpoint namespace.
 	 *

--- a/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
+++ b/src/RestApi/StoreApi/Controllers/ProductCollectionData.php
@@ -78,7 +78,7 @@ class ProductCollectionData extends RestController {
 					'readonly'    => true,
 				),
 				'attribute_counts' => array(
-					'description' => __( 'Returns number of products within attribute terms, indexed by term ID.', 'woo-gutenberg-products-block' ),
+					'description' => __( 'Returns number of products within attribute terms.', 'woo-gutenberg-products-block' ),
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,

--- a/src/RestApi/StoreApi/Controllers/Products.php
+++ b/src/RestApi/StoreApi/Controllers/Products.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 use \WP_Error as RestError;
 use \WP_REST_Server as RestServer;
-use \WP_REST_Controller as RestContoller;
+use \WP_REST_Controller as RestController;
 use \WC_REST_Exception as RestException;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductSchema;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\Pagination;
@@ -23,7 +23,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ProductQuery;
  *
  * @since 2.5.0
  */
-class Products extends RestContoller {
+class Products extends RestController {
 	/**
 	 * Endpoint namespace.
 	 *

--- a/src/RestApi/StoreApi/README.md
+++ b/src/RestApi/StoreApi/README.md
@@ -90,6 +90,7 @@ Available resources in the Store API include:
 | [`Products`](#products-api)                                | `/wc/store/products`                    |
 | [`Cart`](#cart-api)                                        | `/wc/store/cart`                        |
 | [`Cart Items`](#cart-items-api)                            | `/wc/store/cart/items`                  |
+| [`Cart Shipping Rates`](#cart-shipping-rates-api)          | `/wc/store/cart/shipping-rates`         |
 | [`Product Attributes`](#product-attributes-api)            | `/wc/store/products/attributes`         |
 | [`Product Attribute Terms`](#product-attribute-terms-api)  | `/wc/store/products/attributes/1/terms` |
 
@@ -552,6 +553,62 @@ Example response:
 
 ```json
 []
+```
+
+## Cart shipping rates API
+
+### Get shipping rates for current cart
+
+```http
+GET /cart/shipping-rates?address_1=&address_2=&city=&state=&postcode=90210&country=US
+```
+
+| Attribute   | Type   | Required | Description                                                                              |
+| :---------- | :----- | :------: | :--------------------------------------------------------------------------------------- |
+| `address_1` | string |    no    | First line of the address being shipped to.                                              |
+| `address_2` | string |    no    | Second line of the address being shipped to.                                             |
+| `city`      | string |    no    | City of the address being shipped to.                                                    |
+| `state`     | string |    no    | ISO code, or name, for the state, province, or district of the address being shipped to. |
+| `postcode`  | string |    no    | Zip or Postcode of the address being shipped to.                                         |
+| `country`   | string |   yes    | ISO code for the country of the address being shipped to.                                |
+
+```http
+curl "https://example-store.com/wp-json/wc/store/cart/shipping-rates?country=US&state=AL"
+```
+
+Example response:
+
+```json
+[
+	{
+		"destination": {
+			"address_1": null,
+			"address_2": null,
+			"city": null,
+			"state": "AL",
+			"postcode": null,
+			"country": "US"
+		},
+		"items": [ "6512bd43d9caa6e02c990b0a82652dca" ],
+		"shipping-rates": [
+			{
+				"name": "International",
+				"description": "",
+				"delivery_time": "",
+				"price": "20.00",
+				"rate_id": "flat_rate:3",
+				"instance_id": 3,
+				"method_id": "flat_rate",
+				"meta_data": [
+					{
+						"key": "Items",
+						"value": "Beanie &times; 1"
+					}
+				]
+			}
+		]
+	}
+]
 ```
 
 ## Product Attributes API

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -79,7 +79,7 @@ class CartItemSchema extends AbstractSchema {
 			),
 			'images'     => array(
 				'description' => __( 'List of images.', 'woo-gutenberg-products-block' ),
-				'type'        => 'object',
+				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
 				'items'       => array(

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -34,7 +34,7 @@ class CartShippingRateSchema extends AbstractSchema {
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-				'items'       => [
+				'properties'  => [
 					'address_1' => [
 						'description' => __( 'First line of the address being shipped to.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -29,12 +29,49 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	protected function get_properties() {
 		return [
-			'shipping-rates' => [
-				'description' => __( 'List of shipping rates.', 'woo-gutenberg-products-block' ),
-				'type'        => 'array',
+			'destination'    => [
+				'description' => __( 'Shipping destination address.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-				'items'       => $this->get_rate_properties(),
+				'items'       => [
+					'address_1' => [
+						'description' => __( 'First line of the address being shipped to.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+					'address_2' => [
+						'description' => __( 'Second line of the address being shipped to.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+					'city'      => [
+						'description' => __( 'City of the address being shipped to.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+					'state'     => [
+						'description' => __( 'ISO code, or name, for the state, province, or district of the address being shipped to.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+					'postcode'  => [
+						'description' => __( 'Zip or Postcode of the address being shipped to.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+					'country'   => [
+						'description' => __( 'ISO code for the country of the address being shipped to.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+				],
 			],
 			'items'          => [
 				'description' => __( 'List of cart items (keys) the returned shipping rates apply to.', 'woo-gutenberg-products-block' ),
@@ -44,6 +81,13 @@ class CartShippingRateSchema extends AbstractSchema {
 				'items'       => [
 					'type' => 'string',
 				],
+			],
+			'shipping-rates' => [
+				'description' => __( 'List of shipping rates.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => $this->get_rate_properties(),
 			],
 		];
 	}
@@ -130,6 +174,14 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $package ) {
 		return [
+			'destination'    => [
+				'address_1' => $package['destination']['address_1'],
+				'address_2' => $package['destination']['address_2'],
+				'city'      => $package['destination']['city'],
+				'state'     => $package['destination']['state'],
+				'postcode'  => $package['destination']['postcode'],
+				'country'   => $package['destination']['country'],
+			],
 			'items'          => array_values( wp_list_pluck( $package['contents'], 'key' ) ),
 			'shipping-rates' => array_values( array_map( [ $this, 'get_rate_response' ], $package['rates'] ) ),
 		];

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
 
 defined( 'ABSPATH' ) || exit;
 
+use \WC_Shipping_Rate as ShippingRate;
+
 /**
  * CartShippingRateSchema class.
  */
@@ -27,65 +29,103 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	protected function get_properties() {
 		return [
-			'currency'       => array(
-				'description' => __( 'Currency code (in ISO format) of the cart item prices.', 'woo-gutenberg-products-block' ),
+			'id'            => [
+				'description' => __( 'ID of the shipping rate.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
-				'default'     => get_woocommerce_currency(),
-				'enum'        => array_keys( get_woocommerce_currencies() ),
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'item_count'     => array(
-				'description' => __( 'Number of items in the cart.', 'woo-gutenberg-products-block' ),
-				'type'        => 'integer',
-				'context'     => array( 'view', 'edit' ),
+			],
+			'name'          => [
+				'description' => __( 'Name of the shipping rate, e.g. Express shipping.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'items'          => array(
-				'description' => __( 'List of cart items.', 'woo-gutenberg-products-block' ),
-				'type'        => 'array',
-				'context'     => array( 'view', 'edit' ),
+			],
+			'description'   => [
+				'description' => __( 'Description of the shipping rate, e.g. Dispatched via USPS.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => $this->force_schema_readonly( ( new CartItemSchema() )->get_properties() ),
-				),
-			),
-			'needs_shipping' => array(
-				'description' => __( 'True if the cart needs shipping. False for carts with only digital goods or stores with no shipping methods set-up.', 'woo-gutenberg-products-block' ),
+			],
+			'delivery_time' => [
+				'description' => __( 'Delivery time estimate text, e.g. 3-5 business days.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'price'         => [
+				'description' => __( 'Price of this shipping rate.', 'woo-gutenberg-products-block' ),
 				'type'        => 'boolean',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'total_price'    => array(
-				'description' => __( 'Total price of all products in the cart.', 'woo-gutenberg-products-block' ),
+			],
+			'source'        => [
+				'description' => __( 'Source of the shipping rate, e.g. the name of the shipping method.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
-			'total_weight'   => array(
-				'description' => __( 'Total weight (in grams) of all products in the cart.', 'woo-gutenberg-products-block' ),
-				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
+			],
+			'group'         => [
+				'description' => __( 'Group that the rate is part of, if the cart is made up of multiple shipments.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			),
+			],
+			'meta_data'     => [
+				'description' => __( 'Meta data attached to the shipping rate.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'key'   => [
+							'description' => __( 'Meta key.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'value' => [
+							'description' => __( 'Meta value.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
+				],
+			],
 		];
 	}
 
 	/**
-	 * Convert a woo cart into an object suitable for the response.
+	 * Convert a shipping rate from WooCommerce into a valid response.
 	 *
-	 * @param \WC_Cart $cart Cart class instance.
+	 * @param ShippingRate $rate Shipping rate object instance.
+	 * @param int          $package_id ID/index of the package.
+	 * @param array        $package Shipping package this rate is for.
 	 * @return array
 	 */
-	public function get_item_response( $cart ) {
+	public function get_item_response( $rate, $package_id, $package ) {
+		$meta_data   = $rate->get_meta_data();
+		$return_meta = array_reduce(
+			array_keys( $meta_data ),
+			function( $return, $key ) use ( $meta_data ) {
+				$return[] = [
+					'key'   => $key,
+					'value' => $meta_data[ $key ],
+				];
+				return $return;
+			},
+			[]
+		);
 		return [
-			'currency'       => get_woocommerce_currency(),
-			'item_count'     => $cart->get_cart_contents_count(),
-			'items'          => array_values( array_map( [ $cart_item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
-			'needs_shipping' => $cart->needs_shipping(),
-			'total_price'    => $cart->get_cart_contents_total(),
-			'total_weight'   => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
+			'id'            => $rate->get_instance_id(),
+			'name'          => $rate->get_label(),
+			'description'   => '',
+			'handling_time' => '',
+			'price'         => $rate->get_cost(),
+			'source'        => $rate->get_method_id(),
+			'group'         => $package_id,
+			'meta_data'     => $return_meta,
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Cart shipping rate schema.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * CartShippingRateSchema class.
+ */
+class CartShippingRateSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'cart-shipping-rate';
+
+	/**
+	 * Cart schema properties.
+	 *
+	 * @return array
+	 */
+	protected function get_properties() {
+		return [
+			'currency'       => array(
+				'description' => __( 'Currency code (in ISO format) of the cart item prices.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'default'     => get_woocommerce_currency(),
+				'enum'        => array_keys( get_woocommerce_currencies() ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'item_count'     => array(
+				'description' => __( 'Number of items in the cart.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'items'          => array(
+				'description' => __( 'List of cart items.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( ( new CartItemSchema() )->get_properties() ),
+				),
+			),
+			'needs_shipping' => array(
+				'description' => __( 'True if the cart needs shipping. False for carts with only digital goods or stores with no shipping methods set-up.', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'total_price'    => array(
+				'description' => __( 'Total price of all products in the cart.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'total_weight'   => array(
+				'description' => __( 'Total weight (in grams) of all products in the cart.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		];
+	}
+
+	/**
+	 * Convert a woo cart into an object suitable for the response.
+	 *
+	 * @param \WC_Cart $cart Cart class instance.
+	 * @return array
+	 */
+	public function get_item_response( $cart ) {
+		return [
+			'currency'       => get_woocommerce_currency(),
+			'item_count'     => $cart->get_cart_contents_count(),
+			'items'          => array_values( array_map( [ $cart_item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
+			'needs_shipping' => $cart->needs_shipping(),
+			'total_price'    => $cart->get_cart_contents_total(),
+			'total_weight'   => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
+		];
+	}
+}

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -87,7 +87,10 @@ class CartShippingRateSchema extends AbstractSchema {
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-				'items'       => $this->get_rate_properties(),
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->get_rate_properties(),
+				],
 			],
 		];
 	}

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -125,11 +125,10 @@ class CartShippingRateSchema extends AbstractSchema {
 	/**
 	 * Convert a shipping rate from WooCommerce into a valid response.
 	 *
-	 * @param int   $package_id Package index (ID).
-	 * @param array $package    Shipping package complete with rates from WooCommerce.
+	 * @param array $package Shipping package complete with rates from WooCommerce.
 	 * @return array
 	 */
-	public function get_item_response( $package_id, $package ) {
+	public function get_item_response( $package ) {
 		return [
 			'items'          => array_values( wp_list_pluck( $package['contents'], 'key' ) ),
 			'shipping-rates' => array_values( array_map( [ $this, 'get_rate_response' ], $package['rates'] ) ),

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -123,7 +123,7 @@ class CartShippingRateSchema extends AbstractSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'id'            => [
+			'rate_id'       => [
 				'description' => __( 'ID of the shipping rate.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
@@ -197,7 +197,7 @@ class CartShippingRateSchema extends AbstractSchema {
 		return [
 			'name'          => $this->get_rate_prop( $rate, 'label' ),
 			'description'   => $this->get_rate_prop( $rate, 'description' ),
-			'handling_time' => $this->get_rate_prop( $rate, 'handling_time' ),
+			'delivery_time' => $this->get_rate_prop( $rate, 'delivery_time' ),
 			'price'         => $this->get_rate_prop( $rate, 'cost' ),
 			'rate_id'       => $this->get_rate_prop( $rate, 'id' ),
 			'instance_id'   => $this->get_rate_prop( $rate, 'instance_id' ),

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -75,84 +75,78 @@ class ProductSchema extends AbstractSchema {
 				'type'        => 'object',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'currency_code'      => array(
-							'description' => __( 'Currency code.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'decimal_separator'  => array(
-							'description' => __( 'Decimal separator.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'thousand_separator' => array(
-							'description' => __( 'Thousand separator.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'decimals'           => array(
-							'description' => __( 'Number of decimal places.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'price_prefix'       => array(
-							'description' => __( 'Price prefix, e.g. currency.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'price_suffix'       => array(
-							'description' => __( 'Price prefix, e.g. currency.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'price'              => array(
-							'description' => __( 'Current product price.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'regular_price'      => array(
-							'description' => __( 'Regular product price', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'sale_price'         => array(
-							'description' => __( 'Sale product price, if applicable.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'price_range'        => array(
-							'description' => __( 'Price range, if applicable.', 'woo-gutenberg-products-block' ),
-							'type'        => 'object',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-							'items'       => array(
-								'type'       => 'object',
-								'properties' => array(
-									'min_amount' => array(
-										'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
-										'type'        => 'string',
-										'context'     => array( 'view', 'edit' ),
-										'readonly'    => true,
-									),
-									'max_amount' => array(
-										'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
-										'type'        => 'string',
-										'context'     => array( 'view', 'edit' ),
-										'readonly'    => true,
-									),
-								),
+				'properties'  => array(
+					'currency_code'      => array(
+						'description' => __( 'Currency code.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'decimal_separator'  => array(
+						'description' => __( 'Decimal separator.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'thousand_separator' => array(
+						'description' => __( 'Thousand separator.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'decimals'           => array(
+						'description' => __( 'Number of decimal places.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'price_prefix'       => array(
+						'description' => __( 'Price prefix, e.g. currency.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'price_suffix'       => array(
+						'description' => __( 'Price prefix, e.g. currency.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'price'              => array(
+						'description' => __( 'Current product price.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'regular_price'      => array(
+						'description' => __( 'Regular product price', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'sale_price'         => array(
+						'description' => __( 'Sale product price, if applicable.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'price_range'        => array(
+						'description' => __( 'Price range, if applicable.', 'woo-gutenberg-products-block' ),
+						'type'        => 'object',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+						'properties'  => array(
+							'min_amount' => array(
+								'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'max_amount' => array(
+								'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
 							),
 						),
 					),
@@ -172,7 +166,7 @@ class ProductSchema extends AbstractSchema {
 			),
 			'images'              => array(
 				'description' => __( 'List of images.', 'woo-gutenberg-products-block' ),
-				'type'        => 'object',
+				'type'        => 'array',
 				'context'     => array( 'view', 'edit' ),
 				'items'       => array(
 					'type'       => 'object',
@@ -230,25 +224,21 @@ class ProductSchema extends AbstractSchema {
 				'type'        => 'object',
 				'context'     => array( 'view', 'edit' ),
 				'readonly'    => true,
-				'items'       => array(
-					'type'       => 'object',
-					'properties' => array(
-						'text'        => array(
-							'description' => __( 'Button text.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
-						'description' => array(
-							'description' => __( 'Button description.', 'woo-gutenberg-products-block' ),
-							'type'        => 'string',
-							'context'     => array( 'view', 'edit' ),
-							'readonly'    => true,
-						),
+				'properties'  => array(
+					'text'        => array(
+						'description' => __( 'Button text.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+					),
+					'description' => array(
+						'description' => __( 'Button description.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
 					),
 				),
 			),
-
 		];
 	}
 
@@ -345,7 +335,7 @@ class ProductSchema extends AbstractSchema {
 	 * Get price range from certain product types.
 	 *
 	 * @param \WC_Product $product Product instance.
-	 * @return arary|null
+	 * @return array|null
 	 */
 	protected function get_price_range( \WC_Product $product ) {
 		if ( $product->is_type( 'variable' ) ) {

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -142,10 +142,11 @@ class CartController {
 	/**
 	 * Returns all cart items.
 	 *
+	 * @param callable $callback Optional callback to apply to the array filter.
 	 * @return array
 	 */
-	public function get_cart_items() {
-		return array_filter( wc()->cart->get_cart() );
+	public function get_cart_items( $callback = null ) {
+		return $callback ? array_filter( wc()->cart->get_cart(), $callback ) : array_filter( wc()->cart->get_cart() );
 	}
 
 	/**

--- a/tests/php/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/tests/php/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Controller Tests.
+ *
+ * @package WooCommerce\Blocks\Tests
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\RestApi\StoreApi\Controllers;
+
+use \WP_REST_Request;
+use \WC_REST_Unit_Test_Case as TestCase;
+use \WC_Helper_Product as ProductHelper;
+
+/**
+ * Cart Shipping Rates Controller Tests.
+ */
+class CartShippingRates extends TestCase {
+	/**
+	 * Setup test products data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( 0 );
+
+		$this->products = [];
+
+		// Create some test products.
+		$this->products[0] = ProductHelper::create_simple_product( false );
+		$this->products[0]->save();
+
+		$this->products[1] = ProductHelper::create_simple_product( false );
+		$this->products[1]->save();
+
+		wc_empty_cart();
+		wc()->cart->add_to_cart( $this->products[0]->get_id(), 2 );
+		wc()->cart->add_to_cart( $this->products[1]->get_id(), 1 );
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/store/cart/shipping-rates', $routes );
+	}
+
+	/**
+	 * Test getting shipping.
+	 */
+	public function test_get_items() {
+		$request = new WP_REST_Request( 'GET', '/wc/store/cart/shipping-rates' );
+		$request->set_param( 'country', 'US' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $data ) );
+
+		$this->assertArrayHasKey( 'destination', $data[0] );
+		$this->assertArrayHasKey( 'items', $data[0] );
+		$this->assertArrayHasKey( 'shipping-rates', $data[0] );
+
+		$this->assertEquals( null, $data[0]['destination']['address_1'] );
+		$this->assertEquals( null, $data[0]['destination']['address_2'] );
+		$this->assertEquals( null, $data[0]['destination']['city'] );
+		$this->assertEquals( null, $data[0]['destination']['state'] );
+		$this->assertEquals( null, $data[0]['destination']['postcode'] );
+		$this->assertEquals( 'US', $data[0]['destination']['country'] );
+	}
+
+	/**
+	 * Test getting shipping.
+	 */
+	public function test_get_items_missing_address() {
+		$request = new WP_REST_Request( 'GET', '/wc/store/cart/shipping-rates' );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test getting shipping.
+	 */
+	public function test_get_items_address_validation() {
+		// US address.
+		$request = new WP_REST_Request( 'GET', '/wc/store/cart/shipping-rates' );
+		$request->set_param( 'address_1', 'Test address 1' );
+		$request->set_param( 'address_2', 'Test address 2' );
+		$request->set_param( 'city', 'Test City' );
+		$request->set_param( 'state', 'AL' );
+		$request->set_param( 'postcode', '90210' );
+		$request->set_param( 'country', 'US' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Test address 1', $data[0]['destination']['address_1'] );
+		$this->assertEquals( 'Test address 2', $data[0]['destination']['address_2'] );
+		$this->assertEquals( 'Test City', $data[0]['destination']['city'] );
+		$this->assertEquals( 'AL', $data[0]['destination']['state'] );
+		$this->assertEquals( '90210', $data[0]['destination']['postcode'] );
+		$this->assertEquals( 'US', $data[0]['destination']['country'] );
+
+		// US address with invalid state.
+		$request = new WP_REST_Request( 'GET', '/wc/store/cart/shipping-rates' );
+		$request->set_param( 'state', 'ZZZZZZZZ' );
+		$request->set_param( 'country', 'US' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+
+		// US address with named state.
+		$request = new WP_REST_Request( 'GET', '/wc/store/cart/shipping-rates' );
+		$request->set_param( 'state', 'Alabama' );
+		$request->set_param( 'country', 'US' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'AL', $data[0]['destination']['state'] );
+		$this->assertEquals( 'US', $data[0]['destination']['country'] );
+	}
+
+	/**
+	 * Test schema retrieval.
+	 */
+	public function test_get_item_schema() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\CartShippingRates();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'destination', $schema['properties'] );
+		$this->assertArrayHasKey( 'items', $schema['properties'] );
+		$this->assertArrayHasKey( 'shipping-rates', $schema['properties'] );
+		$this->assertArrayHasKey( 'name', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'description', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'delivery_time', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'price', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'rate_id', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'instance_id', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'method_id', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'meta_data', $schema['properties']['shipping-rates']['items'] );
+	}
+
+	/**
+	 * Test conversion of cart item to rest response.
+	 */
+	public function test_prepare_item_for_response() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\CartShippingRates();
+		$packages   = wc()->shipping->calculate_shipping( wc()->cart->get_shipping_packages() );
+		$response   = $controller->prepare_item_for_response( current( $packages ), [] );
+
+		$this->assertArrayHasKey( 'destination', $response->get_data() );
+		$this->assertArrayHasKey( 'items', $response->get_data() );
+		$this->assertArrayHasKey( 'shipping-rates', $response->get_data() );
+	}
+
+	/**
+	 * Test collection params getter.
+	 */
+	public function test_get_collection_params() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\CartShippingRates();
+		$params     = $controller->get_collection_params();
+
+		$this->assertArrayHasKey( 'address_1', $params );
+		$this->assertArrayHasKey( 'address_2', $params );
+		$this->assertArrayHasKey( 'city', $params );
+		$this->assertArrayHasKey( 'state', $params );
+		$this->assertArrayHasKey( 'country', $params );
+		$this->assertArrayHasKey( 'postcode', $params );
+	}
+}

--- a/tests/php/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/tests/php/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -132,14 +132,14 @@ class CartShippingRates extends TestCase {
 		$this->assertArrayHasKey( 'destination', $schema['properties'] );
 		$this->assertArrayHasKey( 'items', $schema['properties'] );
 		$this->assertArrayHasKey( 'shipping-rates', $schema['properties'] );
-		$this->assertArrayHasKey( 'name', $schema['properties']['shipping-rates']['items'] );
-		$this->assertArrayHasKey( 'description', $schema['properties']['shipping-rates']['items'] );
-		$this->assertArrayHasKey( 'delivery_time', $schema['properties']['shipping-rates']['items'] );
-		$this->assertArrayHasKey( 'price', $schema['properties']['shipping-rates']['items'] );
-		$this->assertArrayHasKey( 'rate_id', $schema['properties']['shipping-rates']['items'] );
-		$this->assertArrayHasKey( 'instance_id', $schema['properties']['shipping-rates']['items'] );
-		$this->assertArrayHasKey( 'method_id', $schema['properties']['shipping-rates']['items'] );
-		$this->assertArrayHasKey( 'meta_data', $schema['properties']['shipping-rates']['items'] );
+		$this->assertArrayHasKey( 'name', $schema['properties']['shipping-rates']['items']['properties'] );
+		$this->assertArrayHasKey( 'description', $schema['properties']['shipping-rates']['items']['properties'] );
+		$this->assertArrayHasKey( 'delivery_time', $schema['properties']['shipping-rates']['items']['properties'] );
+		$this->assertArrayHasKey( 'price', $schema['properties']['shipping-rates']['items']['properties'] );
+		$this->assertArrayHasKey( 'rate_id', $schema['properties']['shipping-rates']['items']['properties'] );
+		$this->assertArrayHasKey( 'instance_id', $schema['properties']['shipping-rates']['items']['properties'] );
+		$this->assertArrayHasKey( 'method_id', $schema['properties']['shipping-rates']['items']['properties'] );
+		$this->assertArrayHasKey( 'meta_data', $schema['properties']['shipping-rates']['items']['properties'] );
 	}
 
 	/**


### PR DESCRIPTION
Shipping Rates API which allows you to retrieve shipping quotes for a given address for the current cart.

Closes #1318

Address is passed to the request, and at least country is required in order to return rates. There may be multiple arrays of rates if someone is using the 'packages' and splitting the cart into chunks. Items in the package are returned in the response you they can be referenced to the cart itself.

Example request:
```
http://local.wordpress.test/wp-json/wc/store/cart/shipping-rates?country=US&state=AL
```

Example response:

```json
[
  {
    "destination": {
      "address_1": null,
      "address_2": null,
      "city": null,
      "state": "AL",
      "postcode": null,
      "country": "US"
    },
    "items": [
      "6512bd43d9caa6e02c990b0a82652dca",
      "c20ad4d76fe97759aa27a0c99bff6710"
    ],
    "shipping-rates": [
      {
        "name": "International",
        "description": "Posted via UPS international.",
        "delivery_time": "Delivered in 7-14 days",
        "price": "20.00",
        "rate_id": "flat_rate:3",
        "instance_id": 3,
        "method_id": "flat_rate",
        "meta_data": [
          {
            "key": "Items",
            "value": "Beanie &times; 1, Belt &times; 1"
          }
        ]
      }
    ]
  }
]
```

For a cart with multiple packages, it would be split like this:

```json
[
  {
    "destination": {
      "address_1": null,
      "address_2": null,
      "city": null,
      "state": "AL",
      "postcode": null,
      "country": "US"
    },
    "items": [
      "6512bd43d9caa6e02c990b0a82652dca"
    ],
    "shipping-rates": [
      {
        "name": "International",
        "description": "Posted via UPS international.",
        "delivery_time": "Delivered in 7-14 days",
        "price": "20.00",
        "rate_id": "flat_rate:3",
        "instance_id": 3,
        "method_id": "flat_rate",
        "meta_data": [
          {
            "key": "Items",
            "value": "Beanie &times; 1"
          }
        ]
      }
    ]
  },
  {
    "destination": {
      "address_1": null,
      "address_2": null,
      "city": null,
      "state": "AL",
      "postcode": null,
      "country": "US"
    },
    "items": [
      "c20ad4d76fe97759aa27a0c99bff6710"
    ],
    "shipping-rates": [
      {
        "name": "International",
        "description": "Posted via UPS international.",
        "delivery_time": "Delivered in 7-14 days",
        "price": "20.00",
        "rate_id": "flat_rate:3",
        "instance_id": 3,
        "method_id": "flat_rate",
        "meta_data": [
          {
            "key": "Items",
            "value": "Belt &times; 1"
          }
        ]
      }
    ]
  }
]
```

`delivery_time` and `description` are not fields that are currently included in Woo Core. In my test branch I have introduced them and I will be raising a core PR for feedback in due time so we can support that.  

## Testing this PR

- Ensure you have configured Woo shipping zones and have some shipping methods
- Add some items to your cart. You can confirm shipping is working on your cart page.
- Now do an API request using basic auth with the same user. You can customise the address fields if you wish: `http://local.wordpress.test/wp-json/wc/store/cart/shipping-rates?country=US&state=AL`
- Check the response is accurate.

