### PR TITLE
Add Checkout Form components

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -47,5 +47,9 @@ $core-orange: #ca4a1f;
 // @todo: replace those colors with the correct values once we settle on a design system palette.
 $gray-10: #c3c4c7;
 $gray-20: #a7aaad;
+$gray-50: #646970;
 $gray-60: #50575e;
 $gray-80: #2c3338;
+// @todo: align those colors with what we have
+$input-border-gray: #8d96a0;
+$input-text-active: #2b2d2f;

--- a/assets/js/base/components/checkout/no-shipping/index.js
+++ b/assets/js/base/components/checkout/no-shipping/index.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Placeholder, Button } from '@wordpress/components';
+import ShippingIcon from 'gridicons/dist/shipping';
+import { ADMIN_URL } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const NoShipping = () => {
+	return (
+		<Placeholder
+			icon={ <ShippingIcon /> }
+			label={ __( 'Shipping options', 'woo-gutenberg-products-block' ) }
+			className="wc-blocks-checkout__no-shipping"
+		>
+			<span className="wc-blocks-checkout__no-shipping-description">
+				{ __(
+					'Your store does not have any Shipping Options configured. Once you have added your Shipping Options they will appear here.',
+					'woo-gutenberg-products-block'
+				) }
+			</span>
+			<Button
+				isDefault
+				href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping` }
+			>
+				{ __(
+					'Configure Shipping Options',
+					'woo-gutenberg-products-block'
+				) }
+			</Button>
+		</Placeholder>
+	);
+};
+
+export default NoShipping;

--- a/assets/js/base/components/checkout/no-shipping/style.scss
+++ b/assets/js/base/components/checkout/no-shipping/style.scss
@@ -1,0 +1,5 @@
+.wc-blocks-checkout__no-shipping-description {
+	display: block;
+	margin: 0.25em 0 1em 0;
+	font-size: 13px;
+}

--- a/assets/js/base/components/input-row/index.js
+++ b/assets/js/base/components/input-row/index.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const InputRow = ( { className, children } ) => {
+	return (
+		<div className={ classnames( 'wc-components-input-row', className ) }>
+			{ children }
+		</div>
+	);
+};
+
+export default InputRow;

--- a/assets/js/base/components/input-row/index.js
+++ b/assets/js/base/components/input-row/index.js
@@ -10,7 +10,7 @@ import './style.scss';
 
 const InputRow = ( { className, children } ) => {
 	return (
-		<div className={ classnames( 'wc-components-input-row', className ) }>
+		<div className={ classnames( 'wc-blocks-input-row', className ) }>
 			{ children }
 		</div>
 	);

--- a/assets/js/base/components/input-row/style.scss
+++ b/assets/js/base/components/input-row/style.scss
@@ -2,10 +2,12 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
+	margin-top: $gap;
 
-	& > * {
+	& > .wc-components-text-input {
 		margin-right: $gap-small;
 		flex-grow: 1;
+		margin-top: 0;
 		&:last-child {
 			margin-right: 0;
 		}

--- a/assets/js/base/components/input-row/style.scss
+++ b/assets/js/base/components/input-row/style.scss
@@ -1,0 +1,13 @@
+.wc-components-input-row {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+
+	& > * {
+		margin-right: $gap-small;
+		flex-grow: 1;
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+}

--- a/assets/js/base/components/input-row/style.scss
+++ b/assets/js/base/components/input-row/style.scss
@@ -2,13 +2,19 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
-	margin-top: $gap;
 
 	& > .wc-blocks-text-input {
 		margin-right: $gap-small;
 		flex-grow: 1;
-		margin-top: 0;
+		margin-top: $gap;
 		&:last-child {
+			margin-right: 0;
+		}
+	}
+
+	// Responsive media styles.
+	@include breakpoint( "<480px" ) {
+		.wc-blocks-text-input {
 			margin-right: 0;
 		}
 	}

--- a/assets/js/base/components/input-row/style.scss
+++ b/assets/js/base/components/input-row/style.scss
@@ -1,10 +1,10 @@
-.wc-components-input-row {
+.wc-blocks-input-row {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;
 	margin-top: $gap;
 
-	& > .wc-components-text-input {
+	& > .wc-blocks-text-input {
 		margin-right: $gap-small;
 		flex-grow: 1;
 		margin-top: 0;

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Label from '../label';
+import './style.scss';
+
+const RadioControl = ( {
+	className,
+	selected,
+	help,
+	id,
+	onChange,
+	options = [],
+} ) => {
+	const onChangeValue = ( event ) => onChange( event.target.value );
+	return (
+		options.length && (
+			<div
+				className={ classnames(
+					'wc-components-radio-control',
+					className
+				) }
+			>
+				{ options.map( ( option, index ) => (
+					<label
+						key={ `${ id }-${ index }` }
+						className="wc-components-radio-control__option"
+						htmlFor={ `${ id }-${ index }` }
+					>
+						<input
+							id={ `${ id }-${ index }` }
+							className="wc-components-radio-control__input"
+							type="radio"
+							name={ id }
+							value={ option.value }
+							onChange={ onChangeValue }
+							checked={ option.value === selected }
+							aria-describedby={
+								!! help ? `${ id }__help` : undefined
+							}
+						/>
+						<Label
+							label={ option.label }
+							wrapperElement="span"
+							wrapperProps={ {
+								className: 'wc-components-radio-control__label',
+							} }
+						>
+							{ option.label }
+						</Label>
+						<Label
+							label={ option.secondaryLabel }
+							wrapperElement="span"
+							wrapperProps={ {
+								className:
+									'wc-components-radio-control__secondary-label',
+							} }
+						>
+							{ option.secondaryLabel }
+						</Label>
+						<Label
+							label={ option.description }
+							wrapperElement="span"
+							wrapperProps={ {
+								className:
+									'wc-components-radio-control__description',
+							} }
+						>
+							{ option.description }
+						</Label>
+						<Label
+							label={ option.secondaryDescription }
+							wrapperElement="span"
+							wrapperProps={ {
+								className:
+									'wc-components-radio-control__secondary-description',
+							} }
+						>
+							{ option.secondaryDescription }
+						</Label>
+					</label>
+				) ) }
+			</div>
+		)
+	);
+};
+
+export default RadioControl;

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -23,23 +23,20 @@ const RadioControl = ( {
 				className={ classnames( 'wc-blocks-radio-control', className ) }
 			>
 				{ options.map(
-					(
-						{
-							value,
-							label,
-							description,
-							secondaryLabel,
-							secondaryDescription,
-						},
-						index
-					) => (
+					( {
+						value,
+						label,
+						description,
+						secondaryLabel,
+						secondaryDescription,
+					} ) => (
 						<label
-							key={ `${ id }-${ index }` }
+							key={ `${ id }-${ value }` }
 							className="wc-blocks-radio-control__option"
-							htmlFor={ `${ id }-${ index }` }
+							htmlFor={ `${ id }-${ value }` }
 						>
 							<input
-								id={ `${ id }-${ index }` }
+								id={ `${ id }-${ value }` }
 								className="wc-blocks-radio-control__input"
 								type="radio"
 								name={ id }
@@ -47,10 +44,10 @@ const RadioControl = ( {
 								onChange={ onChangeValue }
 								checked={ value === selected }
 								aria-describedby={ classnames( {
-									[ `${ id }-${ index }__label` ]: label,
-									[ `${ id }-${ index }__secondary-label` ]: secondaryLabel,
-									[ `${ id }-${ index }__description` ]: description,
-									[ `${ id }-${ index }__secondary-description` ]: secondaryDescription,
+									[ `${ id }-${ value }__label` ]: label,
+									[ `${ id }-${ value }__secondary-label` ]: secondaryLabel,
+									[ `${ id }-${ value }__description` ]: description,
+									[ `${ id }-${ value }__secondary-description` ]: secondaryDescription,
 								} ) }
 							/>
 							{ label && (
@@ -60,7 +57,7 @@ const RadioControl = ( {
 									wrapperProps={ {
 										className:
 											'wc-blocks-radio-control__label',
-										id: `${ id }-${ index }__label`,
+										id: `${ id }-${ value }__label`,
 									} }
 								>
 									{ label }
@@ -73,7 +70,7 @@ const RadioControl = ( {
 									wrapperProps={ {
 										className:
 											'wc-blocks-radio-control__secondary-label',
-										id: `${ id }-${ index }__secondary-label`,
+										id: `${ id }-${ value }__secondary-label`,
 									} }
 								>
 									{ secondaryLabel }
@@ -86,7 +83,7 @@ const RadioControl = ( {
 									wrapperProps={ {
 										className:
 											'wc-blocks-radio-control__description',
-										id: `${ id }-${ index }__description`,
+										id: `${ id }-${ value }__description`,
 									} }
 								>
 									{ description }
@@ -99,7 +96,7 @@ const RadioControl = ( {
 									wrapperProps={ {
 										className:
 											'wc-blocks-radio-control__secondary-description',
-										id: `${ id }-${ index }__secondary-description`,
+										id: `${ id }-${ value }__secondary-description`,
 									} }
 								>
 									{ secondaryDescription }

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -20,10 +20,7 @@ const RadioControl = ( {
 	return (
 		options.length && (
 			<div
-				className={ classnames(
-					'wc-components-radio-control',
-					className
-				) }
+				className={ classnames( 'wc-blocks-radio-control', className ) }
 			>
 				{ options.map(
 					(
@@ -38,12 +35,12 @@ const RadioControl = ( {
 					) => (
 						<label
 							key={ `${ id }-${ index }` }
-							className="wc-components-radio-control__option"
+							className="wc-blocks-radio-control__option"
 							htmlFor={ `${ id }-${ index }` }
 						>
 							<input
 								id={ `${ id }-${ index }` }
-								className="wc-components-radio-control__input"
+								className="wc-blocks-radio-control__input"
 								type="radio"
 								name={ id }
 								value={ value }
@@ -62,7 +59,7 @@ const RadioControl = ( {
 									wrapperElement="span"
 									wrapperProps={ {
 										className:
-											'wc-components-radio-control__label',
+											'wc-blocks-radio-control__label',
 										id: `${ id }-${ index }__label`,
 									} }
 								>
@@ -75,7 +72,7 @@ const RadioControl = ( {
 									wrapperElement="span"
 									wrapperProps={ {
 										className:
-											'wc-components-radio-control__secondary-label',
+											'wc-blocks-radio-control__secondary-label',
 										id: `${ id }-${ index }__secondary-label`,
 									} }
 								>
@@ -88,7 +85,7 @@ const RadioControl = ( {
 									wrapperElement="span"
 									wrapperProps={ {
 										className:
-											'wc-components-radio-control__description',
+											'wc-blocks-radio-control__description',
 										id: `${ id }-${ index }__description`,
 									} }
 								>
@@ -101,7 +98,7 @@ const RadioControl = ( {
 									wrapperElement="span"
 									wrapperProps={ {
 										className:
-											'wc-components-radio-control__secondary-description',
+											'wc-blocks-radio-control__secondary-description',
 										id: `${ id }-${ index }__secondary-description`,
 									} }
 								>

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -12,7 +12,6 @@ import './style.scss';
 const RadioControl = ( {
 	className,
 	selected,
-	help,
 	id,
 	onChange,
 	options = [],
@@ -26,65 +25,92 @@ const RadioControl = ( {
 					className
 				) }
 			>
-				{ options.map( ( option, index ) => (
-					<label
-						key={ `${ id }-${ index }` }
-						className="wc-components-radio-control__option"
-						htmlFor={ `${ id }-${ index }` }
-					>
-						<input
-							id={ `${ id }-${ index }` }
-							className="wc-components-radio-control__input"
-							type="radio"
-							name={ id }
-							value={ option.value }
-							onChange={ onChangeValue }
-							checked={ option.value === selected }
-							aria-describedby={
-								!! help ? `${ id }__help` : undefined
-							}
-						/>
-						<Label
-							label={ option.label }
-							wrapperElement="span"
-							wrapperProps={ {
-								className: 'wc-components-radio-control__label',
-							} }
+				{ options.map(
+					(
+						{
+							value,
+							label,
+							description,
+							secondaryLabel,
+							secondaryDescription,
+						},
+						index
+					) => (
+						<label
+							key={ `${ id }-${ index }` }
+							className="wc-components-radio-control__option"
+							htmlFor={ `${ id }-${ index }` }
 						>
-							{ option.label }
-						</Label>
-						<Label
-							label={ option.secondaryLabel }
-							wrapperElement="span"
-							wrapperProps={ {
-								className:
-									'wc-components-radio-control__secondary-label',
-							} }
-						>
-							{ option.secondaryLabel }
-						</Label>
-						<Label
-							label={ option.description }
-							wrapperElement="span"
-							wrapperProps={ {
-								className:
-									'wc-components-radio-control__description',
-							} }
-						>
-							{ option.description }
-						</Label>
-						<Label
-							label={ option.secondaryDescription }
-							wrapperElement="span"
-							wrapperProps={ {
-								className:
-									'wc-components-radio-control__secondary-description',
-							} }
-						>
-							{ option.secondaryDescription }
-						</Label>
-					</label>
-				) ) }
+							<input
+								id={ `${ id }-${ index }` }
+								className="wc-components-radio-control__input"
+								type="radio"
+								name={ id }
+								value={ value }
+								onChange={ onChangeValue }
+								checked={ value === selected }
+								aria-describedby={ classnames( {
+									[ `${ id }-${ index }__label` ]: label,
+									[ `${ id }-${ index }__secondary-label` ]: secondaryLabel,
+									[ `${ id }-${ index }__description` ]: description,
+									[ `${ id }-${ index }__secondary-description` ]: secondaryDescription,
+								} ) }
+							/>
+							{ label && (
+								<Label
+									label={ label }
+									wrapperElement="span"
+									wrapperProps={ {
+										className:
+											'wc-components-radio-control__label',
+										id: `${ id }-${ index }__label`,
+									} }
+								>
+									{ label }
+								</Label>
+							) }
+							{ secondaryLabel && (
+								<Label
+									label={ secondaryLabel }
+									wrapperElement="span"
+									wrapperProps={ {
+										className:
+											'wc-components-radio-control__secondary-label',
+										id: `${ id }-${ index }__secondary-label`,
+									} }
+								>
+									{ secondaryLabel }
+								</Label>
+							) }
+							{ description && (
+								<Label
+									label={ description }
+									wrapperElement="span"
+									wrapperProps={ {
+										className:
+											'wc-components-radio-control__description',
+										id: `${ id }-${ index }__description`,
+									} }
+								>
+									{ description }
+								</Label>
+							) }
+							{ secondaryDescription && (
+								<Label
+									label={ secondaryDescription }
+									wrapperElement="span"
+									wrapperProps={ {
+										className:
+											'wc-components-radio-control__secondary-description',
+										id: `${ id }-${ index }__secondary-description`,
+									} }
+								>
+									{ secondaryDescription }
+								</Label>
+							) }
+						</label>
+					)
+				) }
 			</div>
 		)
 	);

--- a/assets/js/base/components/radio-control/style.scss
+++ b/assets/js/base/components/radio-control/style.scss
@@ -1,4 +1,4 @@
-.wc-components-radio-control__option {
+.wc-blocks-radio-control__option {
 	display: flex;
 	position: relative;
 	justify-content: space-between;
@@ -7,30 +7,30 @@
 	border-bottom: 1px solid $core-grey-light-600;
 }
 
-.wc-components-radio-control__input {
+.wc-blocks-radio-control__input {
 	position: absolute;
 	left: $gap-large;
 	top: $gap-large;
 }
 
-.wc-components-radio-control__label,
-.wc-components-radio-control__secondary-label {
+.wc-blocks-radio-control__label,
+.wc-blocks-radio-control__secondary-label {
 	font-size: 16px;
 	line-height: 24px;
 	color: $core-grey-dark-600;
 	flex-basis: 50%;
 }
 
-.wc-components-radio-control__description,
-.wc-components-radio-control__secondary-description {
+.wc-blocks-radio-control__description,
+.wc-blocks-radio-control__secondary-description {
 	font-size: 14px;
 	line-height: 20px;
 	color: $core-grey-dark-400;
 	flex-basis: 50%;
 }
 
-.wc-components-radio-control__secondary-label,
-.wc-components-radio-control__secondary-description {
+.wc-blocks-radio-control__secondary-label,
+.wc-blocks-radio-control__secondary-description {
 	text-align: right;
 }
 

--- a/assets/js/base/components/radio-control/style.scss
+++ b/assets/js/base/components/radio-control/style.scss
@@ -1,0 +1,36 @@
+.wc-components-radio-control__option {
+	display: flex;
+	position: relative;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	padding: $gap-small $gap-small $gap-small ($gap-larger * 2);
+	border-bottom: 1px solid $core-grey-light-600;
+}
+
+.wc-components-radio-control__input {
+	position: absolute;
+	left: $gap-large;
+	top: $gap-large;
+}
+
+.wc-components-radio-control__label,
+.wc-components-radio-control__secondary-label {
+	font-size: 16px;
+	line-height: 24px;
+	color: $core-grey-dark-600;
+	flex-basis: 50%;
+}
+
+.wc-components-radio-control__description,
+.wc-components-radio-control__secondary-description {
+	font-size: 14px;
+	line-height: 20px;
+	color: $core-grey-dark-400;
+	flex-basis: 50%;
+}
+
+.wc-components-radio-control__secondary-label,
+.wc-components-radio-control__secondary-description {
+	text-align: right;
+}
+

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Label from '../label';
+import './style.scss';
+
+const TextInput = ( {
+	className,
+	id,
+	ariaLabel,
+	label,
+	screenReaderLabel,
+	disabled,
+	help,
+} ) => {
+	const [ isActive, setIsActive ] = useState( false );
+	const [ value, setValue ] = useState( '' );
+	return (
+		<div
+			className={ classnames( 'wc-components-text-input', className, {
+				'is-active': isActive || value,
+			} ) }
+		>
+			<Label
+				label={ label }
+				screenReaderLabel={ screenReaderLabel || label }
+				wrapperElement="label"
+				wrapperProps={ {
+					htmlFor: id,
+				} }
+				htmlFor={ id }
+			/>
+			<input
+				type="text"
+				id={ id }
+				value={ value }
+				onChange={ ( { target } ) => setValue( target.value ) }
+				onFocus={ () => setIsActive( true ) }
+				onBlur={ () => setIsActive( false ) }
+				aria-label={ ariaLabel || label }
+				disabled={ disabled }
+				aria-describedby={ !! help ? id + '__help' : undefined }
+			/>
+			{ !! help && (
+				<p
+					id={ id + '__help' }
+					className="wc-components-text-input__help"
+				>
+					{ help }
+				</p>
+			) }
+		</div>
+	);
+};
+
+TextInput.propTypes = {
+	id: PropTypes.string,
+	value: PropTypes.string,
+	onChangeValue: PropTypes.func,
+	ariaLabel: PropTypes.string,
+	label: PropTypes.string,
+	screenReaderLabel: PropTypes.string,
+	disabled: PropTypes.bool,
+	help: PropTypes.string,
+};
+
+export default TextInput;

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -26,7 +26,7 @@ const TextInput = ( {
 	const onChangeValue = ( event ) => onChange( event.target.value );
 	return (
 		<div
-			className={ classnames( 'wc-components-text-input', className, {
+			className={ classnames( 'wc-blocks-text-input', className, {
 				'is-active': isActive || value,
 			} ) }
 		>
@@ -51,10 +51,7 @@ const TextInput = ( {
 				aria-describedby={ !! help ? id + '__help' : undefined }
 			/>
 			{ !! help && (
-				<p
-					id={ id + '__help' }
-					className="wc-components-text-input__help"
-				>
+				<p id={ id + '__help' } className="wc-blocks-text-input__help">
 					{ help }
 				</p>
 			) }

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -19,9 +19,11 @@ const TextInput = ( {
 	screenReaderLabel,
 	disabled,
 	help,
+	value,
+	onChange,
 } ) => {
 	const [ isActive, setIsActive ] = useState( false );
-	const [ value, setValue ] = useState( '' );
+	const onChangeValue = ( event ) => onChange( event.target.value );
 	return (
 		<div
 			className={ classnames( 'wc-components-text-input', className, {
@@ -41,7 +43,7 @@ const TextInput = ( {
 				type="text"
 				id={ id }
 				value={ value }
-				onChange={ ( { target } ) => setValue( target.value ) }
+				onChange={ onChangeValue }
 				onFocus={ () => setIsActive( true ) }
 				onBlur={ () => setIsActive( false ) }
 				aria-label={ ariaLabel || label }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -9,6 +9,7 @@
 	font-size: 16px;
 	line-height: 22px;
 	transition: all 200ms ease;
+	color: $gray-50;
 }
 
 .wc-components-text-input.is-active label {
@@ -31,4 +32,5 @@
 	margin: 0;
 	box-sizing: border-box;
 	height: 48px;
+	color: $input-text-active;
 }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -5,7 +5,6 @@
 
 .wc-components-text-input label {
 	position: absolute;
-	// +1px is to account for border
 	transform: translateX(#{$gap}) translateY(#{$gap-small});
 	font-size: 16px;
 	line-height: 22px;
@@ -13,9 +12,6 @@
 }
 
 .wc-components-text-input.is-active label {
-	/*font-size: 12px;
-	top: $gap-smaller + 1px;
-	line-height: 12px;*/
 	transform: translateX(#{$gap - $gap-small}) translateY(#{$gap-smallest}) scale(0.75);
 	transition: all 200ms ease;
 }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -17,10 +17,6 @@
 	transition: all 200ms ease;
 }
 
-.wc-components-text-input.is-active input[type="text"] {
-	padding: $gap-large $gap $gap-smallest;
-}
-
 .wc-components-text-input input[type="text"] {
 	padding: $gap-small $gap;
 	border-radius: 4px;
@@ -33,4 +29,8 @@
 	box-sizing: border-box;
 	height: 48px;
 	color: $input-text-active;
+}
+
+.wc-components-text-input.is-active input[type="text"] {
+	padding: $gap-large $gap $gap-smallest;
 }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -1,9 +1,9 @@
-.wc-components-text-input {
+.wc-blocks-text-input {
 	position: relative;
 	margin-top: $gap;
 }
 
-.wc-components-text-input label {
+.wc-blocks-text-input label {
 	position: absolute;
 	transform: translateX(#{$gap}) translateY(#{$gap-small});
 	font-size: 16px;
@@ -12,12 +12,12 @@
 	color: $gray-50;
 }
 
-.wc-components-text-input.is-active label {
+.wc-blocks-text-input.is-active label {
 	transform: translateX(#{$gap - $gap-small}) translateY(#{$gap-smallest}) scale(0.75);
 	transition: all 200ms ease;
 }
 
-.wc-components-text-input input[type="text"] {
+.wc-blocks-text-input input[type="text"] {
 	padding: $gap-small $gap;
 	border-radius: 4px;
 	border: 1px solid $input-border-gray;
@@ -31,6 +31,6 @@
 	color: $input-text-active;
 }
 
-.wc-components-text-input.is-active input[type="text"] {
+.wc-blocks-text-input.is-active input[type="text"] {
 	padding: $gap-large $gap $gap-smallest;
 }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -1,0 +1,35 @@
+.wc-components-text-input {
+	position: relative;
+	margin-top: $gap;
+}
+
+.wc-components-text-input label {
+	position: absolute;
+	// +1px is to account for border
+	transform: translateX(#{$gap}) translateY(#{$gap-small});
+	font-size: 16px;
+	line-height: 22px;
+}
+
+.wc-components-text-input.is-active label {
+	/*font-size: 12px;
+	top: $gap-smaller + 1px;
+	line-height: 12px;*/
+	transform: translateX(#{$gap - $gap-small}) translateY(#{$gap-smaller}) scale(0.75);
+	transition: all 200ms ease;
+}
+
+.wc-components-text-input.is-active input[type="text"] {
+	padding: $gap-large $gap 0;
+}
+
+.wc-components-text-input input[type="text"] {
+	padding: $gap-small $gap;
+	border-radius: 4px;
+	border: 1px solid $input-border-gray;
+	width: 100%;
+	font-size: 16px;
+	line-height: 22px;
+	font-family: inherit;
+	margin: 0;
+}

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -9,18 +9,19 @@
 	transform: translateX(#{$gap}) translateY(#{$gap-small});
 	font-size: 16px;
 	line-height: 22px;
+	transition: all 200ms ease;
 }
 
 .wc-components-text-input.is-active label {
 	/*font-size: 12px;
 	top: $gap-smaller + 1px;
 	line-height: 12px;*/
-	transform: translateX(#{$gap - $gap-small}) translateY(#{$gap-smaller}) scale(0.75);
+	transform: translateX(#{$gap - $gap-small}) translateY(#{$gap-smallest}) scale(0.75);
 	transition: all 200ms ease;
 }
 
 .wc-components-text-input.is-active input[type="text"] {
-	padding: $gap-large $gap 0;
+	padding: $gap-large $gap $gap-smallest;
 }
 
 .wc-components-text-input input[type="text"] {
@@ -32,4 +33,6 @@
 	line-height: 22px;
 	font-family: inherit;
 	margin: 0;
+	box-sizing: border-box;
+	height: 48px;
 }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -5,6 +5,7 @@ import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import FormStep from '@woocommerce/base-components/checkout/form-step';
 import CheckoutForm from '@woocommerce/base-components/checkout/form';
+import NoShipping from '@woocommerce/base-components/checkout/no-shipping';
 import TextInput from '@woocommerce/base-components/text-input';
 import RadioControl from '@woocommerce/base-components/radio-control';
 import InputRow from '@woocommerce/base-components/input-row';
@@ -17,7 +18,7 @@ import './style.scss';
 /**
  * Component displaying an attribute filter.
  */
-const Block = () => {
+const Block = ( { shippingMethods = [], isEditor = true } ) => {
 	const [ shippingMethod, setShippingMethod ] = useState( {} );
 	const [ contactFields, setContactFields ] = useState( {} );
 	const [ shouldSavePayment, setShouldSavePayment ] = useState( true );
@@ -77,215 +78,245 @@ const Block = () => {
 					}
 				/>
 			</FormStep>
-			<FormStep
-				id="shipping-fields"
-				className="wc-blocks-checkout__shipping-fields"
-				title={ __(
-					'Shipping address',
-					'woo-gutenberg-products-block'
-				) }
-				description={ __(
-					'Enter the physical address where you want us to deliver your order.',
-					'woo-gutenberg-products-block'
-				) }
-				stepNumber={ 2 }
-			>
-				<InputRow>
-					<TextInput
-						id="shipping-first-name"
-						label={ __(
-							'First name',
-							'woo-gutenberg-products-block'
-						) }
-						value={ shippingFields.firstName }
-						onChange={ ( newValue ) =>
-							setShippingFields( {
-								...shippingFields,
-								firstName: newValue,
-							} )
-						}
-					/>
-					<TextInput
-						id="shipping-last-name"
-						label={ __(
-							'Surname',
-							'woo-gutenberg-products-block'
-						) }
-						value={ shippingFields.lastName }
-						onChange={ ( newValue ) =>
-							setShippingFields( {
-								...shippingFields,
-								lastName: newValue,
-							} )
-						}
-					/>
-				</InputRow>
-				<TextInput
-					id="shipping-street-address"
-					label={ __(
-						'Street address',
+			{ shippingMethods.length === 0 && (
+				<FormStep
+					id="shipping-fields"
+					className="wc-blocks-checkout__shipping-fields"
+					title={ __(
+						'Shipping address',
 						'woo-gutenberg-products-block'
 					) }
-					value={ shippingFields.streetAddress }
-					onChange={ ( newValue ) =>
-						setShippingFields( {
-							...shippingFields,
-							streetAddress: newValue,
-						} )
-					}
-				/>
-				<TextInput
-					id="shipping-apartment"
-					label={ __(
-						'Apartment, suite, etc.',
+					description={ __(
+						'Enter the physical address where you want us to deliver your order.',
 						'woo-gutenberg-products-block'
 					) }
-					value={ shippingFields.apartment }
-					onChange={ ( newValue ) =>
-						setShippingFields( {
-							...shippingFields,
-							apartment: newValue,
-						} )
-					}
-				/>
-				<InputRow>
-					<TextInput
-						id="shipping-country"
-						label={ __(
-							'Country',
+					stepNumber={ 2 }
+				>
+					{ isEditor && <NoShipping /> }
+				</FormStep>
+			) }
+			{ shippingMethods.length > 0 && (
+				<Fragment>
+					<FormStep
+						id="shipping-fields"
+						className="wc-blocks-checkout__shipping-fields"
+						title={ __(
+							'Shipping address',
 							'woo-gutenberg-products-block'
 						) }
-						value={ shippingFields.country }
-						onChange={ ( newValue ) =>
-							setShippingFields( {
-								...shippingFields,
-								country: newValue,
-							} )
-						}
-					/>
-					<TextInput
-						id="shipping-city"
-						label={ __( 'City', 'woo-gutenberg-products-block' ) }
-						value={ shippingFields.country }
-						onChange={ ( newValue ) =>
-							setShippingFields( {
-								...shippingFields,
-								country: newValue,
-							} )
-						}
-					/>
-				</InputRow>
-				<InputRow>
-					<TextInput
-						id="shipping-county"
-						label={ __( 'County', 'woo-gutenberg-products-block' ) }
-						value={ shippingFields.county }
-						onChange={ ( newValue ) =>
-							setShippingFields( {
-								...shippingFields,
-								county: newValue,
-							} )
-						}
-					/>
-					<TextInput
-						id="shipping-postal-code"
-						label={ __(
-							'Postal code',
+						description={ __(
+							'Enter the physical address where you want us to deliver your order.',
 							'woo-gutenberg-products-block'
 						) }
-						value={ shippingFields.postalCode }
-						onChange={ ( newValue ) =>
-							setShippingFields( {
-								...shippingFields,
-								postalCode: newValue,
-							} )
-						}
-					/>
-				</InputRow>
-				<TextInput
-					id="shipping-phone"
-					label={ __( 'Phone', 'woo-gutenberg-products-block' ) }
-					value={ shippingFields.phone }
-					onChange={ ( newValue ) =>
-						setShippingFields( {
-							...shippingFields,
-							phone: newValue,
-						} )
-					}
-				/>
-				<CheckboxControl
-					className="wc-blocks-checkout__use-address-for-billing"
-					label={ __(
-						'Use same address for billing',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ shippingFields.useSameForBilling }
-					onChange={ () =>
-						setShippingFields( {
-							...shippingFields,
-							useSameForBilling: ! shippingFields.useSameForBilling,
-						} )
-					}
-				/>
-			</FormStep>
-			<FormStep
-				id="shipping-option"
-				className="wc-blocks-checkout__shipping-option"
-				title={ __(
-					'Shipping options',
-					'woo-gutenberg-products-block'
-				) }
-				description={ __(
-					'Select your shipping method below.',
-					'woo-gutenberg-products-block'
-				) }
-				stepNumber={ 3 }
-			>
-				<RadioControl
-					selected={ shippingMethod.method || 'collect' }
-					id="shipping-method"
-					onChange={ ( option ) =>
-						setShippingMethod( {
-							...shippingMethod,
-							method: option,
-						} )
-					}
-					options={ [
-						{
-							label: 'Click & Collect',
-							value: 'collect',
-							description:
-								'Pickup between 12:00 - 16:00 (Mon-Fri)',
-							secondaryLabel: 'FREE',
-						},
-						{
-							label: 'Regular shipping',
-							value: 'usps-normal',
-							description: 'Dispatched via USPS',
-							secondaryLabel: '€10.00',
-							secondaryDescription: '5 business days',
-						},
-						{
-							label: 'Express shipping',
-							value: 'ups-express',
-							description: 'Dispatched via USPS',
-							secondaryLabel: '€50.00',
-							secondaryDescription: '2 business days',
-						},
-					] }
-				/>
-				<CheckboxControl
-					className="wc-blocks-checkout__add-note"
-					label="Add order notes?"
-					checked={ shippingMethod.orderNote }
-					onChange={ () =>
-						setShippingMethod( {
-							...shippingMethod,
-							orderNote: ! shippingMethod.orderNote,
-						} )
-					}
-				/>
-			</FormStep>
+						stepNumber={ 2 }
+					>
+						<InputRow>
+							<TextInput
+								id="shipping-first-name"
+								label={ __(
+									'First name',
+									'woo-gutenberg-products-block'
+								) }
+								value={ shippingFields.firstName }
+								onChange={ ( newValue ) =>
+									setShippingFields( {
+										...shippingFields,
+										firstName: newValue,
+									} )
+								}
+							/>
+							<TextInput
+								id="shipping-last-name"
+								label={ __(
+									'Surname',
+									'woo-gutenberg-products-block'
+								) }
+								value={ shippingFields.lastName }
+								onChange={ ( newValue ) =>
+									setShippingFields( {
+										...shippingFields,
+										lastName: newValue,
+									} )
+								}
+							/>
+						</InputRow>
+						<TextInput
+							id="shipping-street-address"
+							label={ __(
+								'Street address',
+								'woo-gutenberg-products-block'
+							) }
+							value={ shippingFields.streetAddress }
+							onChange={ ( newValue ) =>
+								setShippingFields( {
+									...shippingFields,
+									streetAddress: newValue,
+								} )
+							}
+						/>
+						<TextInput
+							id="shipping-apartment"
+							label={ __(
+								'Apartment, suite, etc.',
+								'woo-gutenberg-products-block'
+							) }
+							value={ shippingFields.apartment }
+							onChange={ ( newValue ) =>
+								setShippingFields( {
+									...shippingFields,
+									apartment: newValue,
+								} )
+							}
+						/>
+						<InputRow>
+							<TextInput
+								id="shipping-country"
+								label={ __(
+									'Country',
+									'woo-gutenberg-products-block'
+								) }
+								value={ shippingFields.country }
+								onChange={ ( newValue ) =>
+									setShippingFields( {
+										...shippingFields,
+										country: newValue,
+									} )
+								}
+							/>
+							<TextInput
+								id="shipping-city"
+								label={ __(
+									'City',
+									'woo-gutenberg-products-block'
+								) }
+								value={ shippingFields.country }
+								onChange={ ( newValue ) =>
+									setShippingFields( {
+										...shippingFields,
+										country: newValue,
+									} )
+								}
+							/>
+						</InputRow>
+						<InputRow>
+							<TextInput
+								id="shipping-county"
+								label={ __(
+									'County',
+									'woo-gutenberg-products-block'
+								) }
+								value={ shippingFields.county }
+								onChange={ ( newValue ) =>
+									setShippingFields( {
+										...shippingFields,
+										county: newValue,
+									} )
+								}
+							/>
+							<TextInput
+								id="shipping-postal-code"
+								label={ __(
+									'Postal code',
+									'woo-gutenberg-products-block'
+								) }
+								value={ shippingFields.postalCode }
+								onChange={ ( newValue ) =>
+									setShippingFields( {
+										...shippingFields,
+										postalCode: newValue,
+									} )
+								}
+							/>
+						</InputRow>
+						<TextInput
+							id="shipping-phone"
+							label={ __(
+								'Phone',
+								'woo-gutenberg-products-block'
+							) }
+							value={ shippingFields.phone }
+							onChange={ ( newValue ) =>
+								setShippingFields( {
+									...shippingFields,
+									phone: newValue,
+								} )
+							}
+						/>
+						<CheckboxControl
+							className="wc-blocks-checkout__use-address-for-billing"
+							label={ __(
+								'Use same address for billing',
+								'woo-gutenberg-products-block'
+							) }
+							checked={ shippingFields.useSameForBilling }
+							onChange={ () =>
+								setShippingFields( {
+									...shippingFields,
+									useSameForBilling: ! shippingFields.useSameForBilling,
+								} )
+							}
+						/>
+					</FormStep>
+					<FormStep
+						id="shipping-option"
+						className="wc-blocks-checkout__shipping-option"
+						title={ __(
+							'Shipping options',
+							'woo-gutenberg-products-block'
+						) }
+						description={ __(
+							'Select your shipping method below.',
+							'woo-gutenberg-products-block'
+						) }
+						stepNumber={ 3 }
+					>
+						<RadioControl
+							selected={ shippingMethod.method || 'collect' }
+							id="shipping-method"
+							onChange={ ( option ) =>
+								setShippingMethod( {
+									...shippingMethod,
+									method: option,
+								} )
+							}
+							options={ [
+								{
+									label: 'Click & Collect',
+									value: 'collect',
+									description:
+										'Pickup between 12:00 - 16:00 (Mon-Fri)',
+									secondaryLabel: 'FREE',
+								},
+								{
+									label: 'Regular shipping',
+									value: 'usps-normal',
+									description: 'Dispatched via USPS',
+									secondaryLabel: '€10.00',
+									secondaryDescription: '5 business days',
+								},
+								{
+									label: 'Express shipping',
+									value: 'ups-express',
+									description: 'Dispatched via USPS',
+									secondaryLabel: '€50.00',
+									secondaryDescription: '2 business days',
+								},
+							] }
+						/>
+						<CheckboxControl
+							className="wc-blocks-checkout__add-note"
+							label="Add order notes?"
+							checked={ shippingMethod.orderNote }
+							onChange={ () =>
+								setShippingMethod( {
+									...shippingMethod,
+									orderNote: ! shippingMethod.orderNote,
+								} )
+							}
+						/>
+					</FormStep>
+				</Fragment>
+			) }
 			<FormStep
 				id="payment-method"
 				className="wc-blocks-checkout__payment-method"

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -18,7 +18,7 @@ import './style.scss';
 /**
  * Component displaying an attribute filter.
  */
-const Block = ( { shippingMethods = [], isEditor = true } ) => {
+const Block = ( { shippingMethods = [], isEditor = false } ) => {
 	const [ shippingMethod, setShippingMethod ] = useState( {} );
 	const [ contactFields, setContactFields ] = useState( {} );
 	const [ shouldSavePayment, setShouldSavePayment ] = useState( true );

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -64,7 +64,10 @@ const Block = () => {
 				/>
 				<CheckboxControl
 					className="wc-blocks-checkout__keep-updated"
-					label="Keep me up to date on news and exclusive offers"
+					label={ __(
+						'Keep me up to date on news and exclusive offers',
+						'woo-gutenberg-products-block'
+					) }
 					checked={ contactFields.keepUpdated }
 					onChange={ () =>
 						setContactFields( {
@@ -212,7 +215,10 @@ const Block = () => {
 				/>
 				<CheckboxControl
 					className="wc-blocks-checkout__use-address-for-billing"
-					label="Use same address for billing"
+					label={ __(
+						'Use same address for billing',
+						'woo-gutenberg-products-block'
+					) }
 					checked={ shippingFields.useSameForBilling }
 					onChange={ () =>
 						setShippingFields( {
@@ -293,7 +299,10 @@ const Block = () => {
 				<Placeholder>Payment methods, coming soon</Placeholder>
 				<CheckboxControl
 					className="wc-blocks-checkout__save-card-info"
-					label="Save payment information to my account for future purchases."
+					label={ __(
+						'Save payment information to my account for future purchases.',
+						'woo-gutenberg-products-block'
+					) }
 					checked={ shouldSavePayment }
 					onChange={ () =>
 						setShouldSavePayment( ! shouldSavePayment )

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -2,10 +2,11 @@
  * External dependencies
  */
 import { Fragment } from '@wordpress/element';
-import { Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import FormStep from '@woocommerce/base-components/checkout/form-step';
 import CheckoutForm from '@woocommerce/base-components/checkout/form';
+import TextInput from '@woocommerce/base-components/text-input';
+import InputRow from '@woocommerce/base-components/input-row';
 
 /**
  * Internal dependencies
@@ -42,49 +43,52 @@ const Block = () => {
 					</Fragment>
 				) }
 			>
-				<Placeholder>A checkout step, coming soon near you</Placeholder>
-			</FormStep>
-			<FormStep
-				id="shipping-fields"
-				className="wc-blocks-checkout__shipping-fields"
-				title={ __(
-					'Shipping address',
-					'woo-gutenberg-products-block'
-				) }
-				description={ __(
-					'Enter the physical address where you want us to deliver your order.',
-					'woo-gutenberg-products-block'
-				) }
-				stepNumber={ 2 }
-			>
-				<Placeholder>A checkout step, coming soon near you</Placeholder>
-			</FormStep>
-			<FormStep
-				id="shipping-methods"
-				className="wc-blocks-checkout__shipping-methods"
-				title={ __(
-					'Shipping options',
-					'woo-gutenberg-products-block'
-				) }
-				description={ __(
-					'Select your shipping method below.',
-					'woo-gutenberg-products-block'
-				) }
-				stepNumber={ 3 }
-			>
-				<Placeholder>A checkout step, coming soon near you</Placeholder>
-			</FormStep>
-			<FormStep
-				id="payment-fields"
-				className="wc-blocks-checkout__payment-fields"
-				title={ __( 'Payment method', 'woo-gutenberg-products-block' ) }
-				description={ __(
-					'Select a payment method below.',
-					'woo-gutenberg-products-block'
-				) }
-				stepNumber={ 4 }
-			>
-				<Placeholder>A checkout step, coming soon near you</Placeholder>
+				<TextInput
+					id="email-field"
+					label={ __(
+						'Email address',
+						'woo-gutenberg-products-block'
+					) }
+				/>
+				<InputRow>
+					<TextInput
+						id="email-field-2"
+						label={ __(
+							'Email address',
+							'woo-gutenberg-products-block'
+						) }
+					/>
+					<TextInput
+						id="name-field"
+						label={ __(
+							'Name address',
+							'woo-gutenberg-products-block'
+						) }
+					/>
+				</InputRow>
+				<InputRow>
+					<TextInput
+						id="name-field-2"
+						label={ __(
+							'Name address',
+							'woo-gutenberg-products-block'
+						) }
+					/>
+					<TextInput
+						id="name-field-3"
+						label={ __(
+							'Name address',
+							'woo-gutenberg-products-block'
+						) }
+					/>
+					<TextInput
+						id="name-field-4"
+						label={ __(
+							'Name address',
+							'woo-gutenberg-products-block'
+						) }
+					/>
+				</InputRow>
 			</FormStep>
 		</CheckoutForm>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -56,7 +56,10 @@ const Block = () => {
 					) }
 					value={ contactFields.email }
 					onChange={ ( newValue ) =>
-						setContactFields( { ...contactFields, eail: newValue } )
+						setContactFields( {
+							...contactFields,
+							email: newValue,
+						} )
 					}
 				/>
 				<CheckboxControl

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -1,13 +1,14 @@
 /**
  * External dependencies
  */
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import FormStep from '@woocommerce/base-components/checkout/form-step';
 import CheckoutForm from '@woocommerce/base-components/checkout/form';
 import TextInput from '@woocommerce/base-components/text-input';
+import RadioControl from '@woocommerce/base-components/radio-control';
 import InputRow from '@woocommerce/base-components/input-row';
-
+import { CheckboxControl, Placeholder } from '@wordpress/components';
 /**
  * Internal dependencies
  */
@@ -17,6 +18,10 @@ import './style.scss';
  * Component displaying an attribute filter.
  */
 const Block = () => {
+	const [ shippingMethod, setShippingMethod ] = useState( {} );
+	const [ contactFields, setContactFields ] = useState( {} );
+	const [ shouldSavePayment, setShouldSavePayment ] = useState( true );
+	const [ shippingFields, setShippingFields ] = useState( {} );
 	return (
 		<CheckoutForm>
 			<FormStep
@@ -49,46 +54,248 @@ const Block = () => {
 						'Email address',
 						'woo-gutenberg-products-block'
 					) }
+					value={ contactFields.email }
+					onChange={ ( newValue ) =>
+						setContactFields( { ...contactFields, eail: newValue } )
+					}
+				/>
+				<CheckboxControl
+					className="wc-blocks-checkout__keep-updated"
+					label="Keep me up to date on news and exclusive offers"
+					checked={ contactFields.keepUpdated }
+					onChange={ () =>
+						setContactFields( {
+							...contactFields,
+							keepUpdated: ! contactFields.keepUpdated,
+						} )
+					}
+				/>
+			</FormStep>
+			<FormStep
+				id="shipping-fields"
+				className="wc-blocks-checkout__shipping-fields"
+				title={ __(
+					'Shipping address',
+					'woo-gutenberg-products-block'
+				) }
+				description={ __(
+					'Enter the physical address where you want us to deliver your order.',
+					'woo-gutenberg-products-block'
+				) }
+				stepNumber={ 2 }
+			>
+				<InputRow>
+					<TextInput
+						id="shipping-first-name"
+						label={ __(
+							'First name',
+							'woo-gutenberg-products-block'
+						) }
+						value={ shippingFields.firstName }
+						onChange={ ( newValue ) =>
+							setShippingFields( {
+								...shippingFields,
+								firstName: newValue,
+							} )
+						}
+					/>
+					<TextInput
+						id="shipping-last-name"
+						label={ __(
+							'Surname',
+							'woo-gutenberg-products-block'
+						) }
+						value={ shippingFields.lastName }
+						onChange={ ( newValue ) =>
+							setShippingFields( {
+								...shippingFields,
+								lastName: newValue,
+							} )
+						}
+					/>
+				</InputRow>
+				<TextInput
+					id="shipping-street-address"
+					label={ __(
+						'Street address',
+						'woo-gutenberg-products-block'
+					) }
+					value={ shippingFields.streetAddress }
+					onChange={ ( newValue ) =>
+						setShippingFields( {
+							...shippingFields,
+							streetAddress: newValue,
+						} )
+					}
+				/>
+				<TextInput
+					id="shipping-apartment"
+					label={ __(
+						'Apartment, suite, etc.',
+						'woo-gutenberg-products-block'
+					) }
+					value={ shippingFields.apartment }
+					onChange={ ( newValue ) =>
+						setShippingFields( {
+							...shippingFields,
+							apartment: newValue,
+						} )
+					}
 				/>
 				<InputRow>
 					<TextInput
-						id="email-field-2"
+						id="shipping-country"
 						label={ __(
-							'Email address',
+							'Country',
 							'woo-gutenberg-products-block'
 						) }
+						value={ shippingFields.country }
+						onChange={ ( newValue ) =>
+							setShippingFields( {
+								...shippingFields,
+								country: newValue,
+							} )
+						}
 					/>
 					<TextInput
-						id="name-field"
-						label={ __(
-							'Name address',
-							'woo-gutenberg-products-block'
-						) }
+						id="shipping-city"
+						label={ __( 'City', 'woo-gutenberg-products-block' ) }
+						value={ shippingFields.country }
+						onChange={ ( newValue ) =>
+							setShippingFields( {
+								...shippingFields,
+								country: newValue,
+							} )
+						}
 					/>
 				</InputRow>
 				<InputRow>
 					<TextInput
-						id="name-field-2"
-						label={ __(
-							'Name address',
-							'woo-gutenberg-products-block'
-						) }
+						id="shipping-county"
+						label={ __( 'County', 'woo-gutenberg-products-block' ) }
+						value={ shippingFields.county }
+						onChange={ ( newValue ) =>
+							setShippingFields( {
+								...shippingFields,
+								county: newValue,
+							} )
+						}
 					/>
 					<TextInput
-						id="name-field-3"
+						id="shipping-postal-code"
 						label={ __(
-							'Name address',
+							'Postal code',
 							'woo-gutenberg-products-block'
 						) }
-					/>
-					<TextInput
-						id="name-field-4"
-						label={ __(
-							'Name address',
-							'woo-gutenberg-products-block'
-						) }
+						value={ shippingFields.postalCode }
+						onChange={ ( newValue ) =>
+							setShippingFields( {
+								...shippingFields,
+								postalCode: newValue,
+							} )
+						}
 					/>
 				</InputRow>
+				<TextInput
+					id="shipping-phone"
+					label={ __( 'Phone', 'woo-gutenberg-products-block' ) }
+					value={ shippingFields.phone }
+					onChange={ ( newValue ) =>
+						setShippingFields( {
+							...shippingFields,
+							phone: newValue,
+						} )
+					}
+				/>
+				<CheckboxControl
+					className="wc-blocks-checkout__use-address-for-billing"
+					label="Use same address for billing"
+					checked={ shippingFields.useSameForBilling }
+					onChange={ () =>
+						setShippingFields( {
+							...shippingFields,
+							useSameForBilling: ! shippingFields.useSameForBilling,
+						} )
+					}
+				/>
+			</FormStep>
+			<FormStep
+				id="shipping-option"
+				className="wc-blocks-checkout__shipping-option"
+				title={ __(
+					'Shipping options',
+					'woo-gutenberg-products-block'
+				) }
+				description={ __(
+					'Select your shipping method below.',
+					'woo-gutenberg-products-block'
+				) }
+				stepNumber={ 3 }
+			>
+				<RadioControl
+					selected={ shippingMethod.method || 'collect' }
+					id="shipping-method"
+					onChange={ ( option ) =>
+						setShippingMethod( {
+							...shippingMethod,
+							method: option,
+						} )
+					}
+					options={ [
+						{
+							label: 'Click & Collect',
+							value: 'collect',
+							description:
+								'Pickup between 12:00 - 16:00 (Mon-Fri)',
+							secondaryLabel: 'FREE',
+						},
+						{
+							label: 'Regular shipping',
+							value: 'usps-normal',
+							description: 'Dispatched via USPS',
+							secondaryLabel: '€10.00',
+							secondaryDescription: '5 business days',
+						},
+						{
+							label: 'Express shipping',
+							value: 'ups-express',
+							description: 'Dispatched via USPS',
+							secondaryLabel: '€50.00',
+							secondaryDescription: '2 business days',
+						},
+					] }
+				/>
+				<CheckboxControl
+					className="wc-blocks-checkout__add-note"
+					label="Add order notes?"
+					checked={ shippingMethod.orderNote }
+					onChange={ () =>
+						setShippingMethod( {
+							...shippingMethod,
+							orderNote: ! shippingMethod.orderNote,
+						} )
+					}
+				/>
+			</FormStep>
+			<FormStep
+				id="payment-method"
+				className="wc-blocks-checkout__payment-method"
+				title={ __( 'Payment method', 'woo-gutenberg-products-block' ) }
+				description={ __(
+					'Select a payment method below.',
+					'woo-gutenberg-products-block'
+				) }
+				stepNumber={ 4 }
+			>
+				<Placeholder>Payment methods, coming soon</Placeholder>
+				<CheckboxControl
+					className="wc-blocks-checkout__save-card-info"
+					label="Save payment information to my account for future purchases."
+					checked={ shouldSavePayment }
+					onChange={ () =>
+						setShouldSavePayment( ! shouldSavePayment )
+					}
+				/>
 			</FormStep>
 		</CheckoutForm>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Disabled } from '@wordpress/components';
 import { withFeedbackPrompt } from '@woocommerce/block-hocs';
 
 /**
@@ -16,9 +15,7 @@ const CheckoutEditor = ( { attributes } ) => {
 
 	return (
 		<div className={ className }>
-			<Disabled>
-				<Block attributes={ attributes } />
-			</Disabled>
+			<Block attributes={ attributes } />
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -15,7 +15,7 @@ const CheckoutEditor = ( { attributes } ) => {
 	// @todo: wrap Block with Disabled once you finish building the form
 	return (
 		<div className={ className }>
-			<Block attributes={ attributes } />
+			<Block attributes={ attributes } isEditor={ true } />
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -12,7 +12,7 @@ import './editor.scss';
 
 const CheckoutEditor = ( { attributes } ) => {
 	const { className } = attributes;
-
+	// @todo: wrap Block with Disabled once you finish building the form
 	return (
 		<div className={ className }>
 			<Block attributes={ attributes } />

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -11,7 +11,9 @@ import renderFrontend from '../../../utils/render-frontend.js';
 
 const getProps = () => {
 	return {
-		attributes: {},
+		attributes: {
+			isEditor: false,
+		},
 	};
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -1,1 +1,5 @@
-// To be written
+.wc-blocks-checkout__add-note,
+.wc-blocks-checkout__keep-updated,
+.wc-blocks-checkout__use-address-for-billing {
+	margin-top: $gap;
+}


### PR DESCRIPTION
## Introduction
This PR introduces the majority of work in the checkout fields area, it introduces:

### `InputRow`
A component that can hold 1,2 or 3 input fields and lay them out using flex, without the need to pass 50% or size props.

```js
<InputRow>
    <TextInput { ...props } />
    <TextInput { ...props } />
</InputRow>
```

### `TextInput` (to be refactored into base control)
A component that renders a floating label input, in theory, this component is accessible.

```js
const [ email, setEmail ] = useState();
return <TextInput
    id="email"
    label="Email"
    ariaLabel="Shipping Email address"
    screenReaderLabel="Shipping Email address"
    help="We will use this email to update you about your order"
    value={ email }
    onChange={ ( newValue ) => setEmail( newValue ) }
/>
```
![image](https://user-images.githubusercontent.com/6165348/70565510-95c34900-1b92-11ea-86d1-b92134685f2a.png)

![image](https://user-images.githubusercontent.com/6165348/70565488-893ef080-1b92-11ea-97e2-411fff36743c.png)
![image](https://user-images.githubusercontent.com/6165348/70565496-8e9c3b00-1b92-11ea-95e8-016c26a066c9.png)

### `RadioControl`
A component that renders a set of radio buttons with labels, secondary labels, descriptions, and secondary descriptions.

```js
const [ shippingMethod, setShippingMethod ] = useState( 'collect' );
return <RadioControl
    selected={ shippingMethod }
    id="shipping-method"
    onChange={ ( option ) => setShippingMethod( option ) }
    options={ [
        {
            label: 'Click & Collect',
            value: 'collect',
            description: 'Pickup between 12:00 - 16:00 (Mon-Fri)',
            secondaryLabel: 'FREE',
        },
        {
            label: 'Regular shipping',
            value: 'usps-normal',
            description: 'Dispatched via USPS',
            secondaryLabel: '€10.00',
            secondaryDescription: '5 business days',
        },
        {
            label: 'Express shipping',
            value: 'ups-express',
            description: 'Dispatched via USPS',
            secondaryLabel: '€50.00',
            secondaryDescription: '2 business days',
        },
    ] }
/>
```
![image](https://user-images.githubusercontent.com/6165348/70565224-ed14e980-1b91-11ea-8416-989de533d84f.png)

## Inspired by

- `@wordpress/components/radio-control`
- `@wordpress/components/text-control`
- `@automattic/composite-checkout`
- `reakit`

## Problems

- While Gutenberg provides default nice styles for radio, it does not provide them in the frontend, I chose not to tackle the tedious task of customizing checkout and radio fields and focus on other things for now.
- Form management is starting to get out of hand with so many fields and so many states to watch, I suggest we migrate to a hook/slot behavior of defining custom hooks that encapsulates a step `useShippingFieldsStep` that returns the state of that step and fills a slot in the form, another method is to have a global data store and separate those fields to other files and have them all connect to that store.
I'm sure we will figure it.
For reference of how much this can get messy, [composite-checkout demo](https://github.com/Automattic/wp-calypso/blob/master/packages/composite-checkout/demo/index.js).
- Colors are still getting out of hand.

## Questions
- How should we handle extendability for this in the future, this should define how we should define our input fields default values, should we query all fields from the backend and render based on that? or should we have some default fields that exist by default and live in the code? this means we can have slots and fills. js filters or php filters.

## To be tackled in separate PRs
- fixing the checkbox & Radio in the frontend.
- ensuring compatibility with other default themes.
- using Fieldset and Legend in the `formStep` wrapper.

## Future steps
- Introduce a select and phone fields.
- Simplify the code or abstract it more.
- Add sidebar settings to it.


