### PR TITLE
Fix broken cart & checkout blocks due to inconsistent block names between server side and client side registration

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -126,8 +126,8 @@ const mainEntry = {
 		'./assets/js/base/components/block-error-boundary/style.scss',
 
 	// cart & checkout blocks
-	'cart-block': './assets/js/blocks/cart-checkout/cart/index.js',
-	'checkout-block': './assets/js/blocks/cart-checkout/checkout/index.js',
+	cart: './assets/js/blocks/cart-checkout/cart/index.js',
+	checkout: './assets/js/blocks/cart-checkout/checkout/index.js',
 };
 
 const frontEndEntry = {
@@ -136,8 +136,8 @@ const frontEndEntry = {
 	'price-filter': './assets/js/blocks/price-filter/frontend.js',
 	'attribute-filter': './assets/js/blocks/attribute-filter/frontend.js',
 	'active-filters': './assets/js/blocks/active-filters/frontend.js',
-	'checkout-block': './assets/js/blocks/cart-checkout/checkout/frontend.js',
-	'cart-block': './assets/js/blocks/cart-checkout/cart/frontend.js',
+	checkout: './assets/js/blocks/cart-checkout/checkout/frontend.js',
+	cart: './assets/js/blocks/cart-checkout/cart/frontend.js',
 };
 
 const getEntryConfig = ( main = true, exclude = [] ) => {

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -18,7 +18,7 @@ class Cart extends AbstractBlock {
 	 *
 	 * @var string
 	 */
-	protected $block_name = 'cart-block';
+	protected $block_name = 'cart';
 
 	/**
 	 * Registers the block type with WordPress.
@@ -28,10 +28,10 @@ class Cart extends AbstractBlock {
 			$this->namespace . '/' . $this->block_name,
 			array(
 				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
+				'editor_script'   => 'wc-' . $this->block_name . '-block',
 				'editor_style'    => 'wc-block-editor',
 				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
+				'script'          => 'wc-' . $this->block_name . '-block-frontend',
 			)
 		);
 	}
@@ -45,7 +45,7 @@ class Cart extends AbstractBlock {
 	 */
 	public function render( $attributes = array(), $content = '' ) {
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
-			$this->block_name . '-frontend'
+			$this->block_name . '-block-frontend'
 		);
 		return $content;
 	}

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -19,7 +19,7 @@ class Checkout extends AbstractBlock {
 	 *
 	 * @var string
 	 */
-	protected $block_name = 'checkout-block';
+	protected $block_name = 'checkout';
 
 	/**
 	 * Registers the block type with WordPress.
@@ -29,10 +29,10 @@ class Checkout extends AbstractBlock {
 			$this->namespace . '/' . $this->block_name,
 			array(
 				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
+				'editor_script'   => 'wc-' . $this->block_name . '-block',
 				'editor_style'    => 'wc-block-editor',
 				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
+				'script'          => 'wc-' . $this->block_name . '-block-frontend',
 			)
 		);
 	}
@@ -45,7 +45,7 @@ class Checkout extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend' );
+		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-block-frontend' );
 		return $content;
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,8 +112,8 @@ const LegacyBlocksConfig = {
 			'price-filter',
 			'attribute-filter',
 			'active-filters',
-			'checkout-block',
-			'cart-block',
+			'checkout',
+			'cart',
 		],
 	} ),
 };
@@ -135,8 +135,8 @@ const LegacyFrontendBlocksConfig = {
 			'price-filter',
 			'attribute-filter',
 			'active-filters',
-			'checkout-block',
-			'cart-block',
+			'checkout',
+			'cart',
 		],
 	} ),
 };


### PR DESCRIPTION
I merged #1343 before making some changes that were necessary.  Currently on master, cart and checkout blocks are broken because of that merge 🤦‍♂ . In this pull:

- removed the unnecessary additions to webpack and webpack helpers for block chunk names of cart and checkout.
- removed changing block name server side to include `-block` and instead just modified handles to add additional namespacing.

## To Test

- existing cart and checkout blocks should load fine in this branch.
- WooCommerce core _cart_ javascript should load and work as expected on the frontend.