### PR TITLE
Fix asset namespacing for cart and checkout blocks - round three!

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -175,12 +175,15 @@ class Assets {
 	 * Queues a block script.
 	 *
 	 * @since 2.3.0
+	 * @since $VID:$ Changed $name to $script_name and added $handle argument.
 	 *
-	 * @param string $name Name of the script used to identify the file inside build folder.
+	 * @param string $script_name Name of the script used to identify the file inside build folder.
+	 * @param string $handle      Provided if the handle should be different than the script name. `wc-` prefix automatically added.
 	 */
-	public static function register_block_script( $name ) {
-		self::register_script( 'wc-' . $name, plugins_url( self::get_block_asset_build_path( $name ), __DIR__ ) );
-		wp_enqueue_script( 'wc-' . $name );
+	public static function register_block_script( $script_name, $handle = '' ) {
+		$handle = '' !== $handle ? $handle : $script_name;
+		self::register_script( 'wc-' . $handle, plugins_url( self::get_block_asset_build_path( $script_name ), __DIR__ ) );
+		wp_enqueue_script( 'wc-' . $handle );
 	}
 
 	/**

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -99,12 +99,14 @@ class Api {
 	 * Queues a block script.
 	 *
 	 * @since 2.5.0
+	 * @since $VID:$ Changed $name to $script_name and added $handle argument.
 	 *
-	 * @param string $name Name of the script used to identify the file inside build folder.
+	 * @param string $script_name Name of the script used to identify the file inside build folder .
+	 * @param string $handle      Provided if the handle should be different than the script name . `wc-` prefix automatically added .
 	 */
-	public function register_block_script( $name ) {
-		$src    = 'build/' . $name . '.js';
-		$handle = 'wc-' . $name;
+	public function register_block_script( $script_name, $handle = '' ) {
+		$src    = 'build/' . $script_name . '.js';
+		$handle = '' !== $handle ? 'wc-' . $handle : 'wc-' . $script_name;
 		$this->register_script( $handle, $src );
 		wp_enqueue_script( $handle );
 	}

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -45,6 +45,7 @@ class Cart extends AbstractBlock {
 	 */
 	public function render( $attributes = array(), $content = '' ) {
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
+			$this->block_name . '-frontend',
 			$this->block_name . '-block-frontend'
 		);
 		return $content;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -45,7 +45,7 @@ class Checkout extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-block-frontend' );
+		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
 		return $content;
 	}
 }


### PR DESCRIPTION
This is a continuation of work done in #1343 and #1353.  I noticed that the frontend scripts for checkout and cart blocks were 404'ing 😦 and this is because of the way `register_block_script` assumes the handle from the provided script name.  So in this pull:

- I tweaked `register_block_script` so it optionally accepts a second argument for customizing the handle name.
- implemented that custom argument in the Checkout and Cart block registration server side.

## To Test

- verify cart and checkout blocks work in the editor and the frontend as expected and there are no 404's for scripts.
- verify that the original cart page still loads it's js and it works as expected (i.e. there is no regression in the script handle conflict)