### PR TITLE
Fix increase in some bundle sizes

### DIFF
--- a/assets/js/blocks/reviews/example.js
+++ b/assets/js/blocks/reviews/example.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { previewReviews } from '@woocommerce/resource-previews';
+import { previewReviews } from '@woocommerce/resource-previews/reviews';
 
 export const example = {
 	attributes: {

--- a/assets/js/blocks/reviews/example.js
+++ b/assets/js/blocks/reviews/example.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { previewReviews } from '@woocommerce/resource-previews/reviews';
+import { previewReviews } from '@woocommerce/resource-previews';
 
 export const example = {
 	attributes: {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"wordpress",
 		"blocks"
 	],
+	"sideEffects": ["*.css", "*.scss"],
 	"repository": {
 		"type": "git",
 		"url": "https://github.com:woocommerce/woocommerce-gutenberg-products-block.git"


### PR DESCRIPTION
Fixes: #1362

## Background

The proton team noticed that the size of the WC3.9 build jumped from 4.6mb for 3.8.1 to around 10Mb for 3.9.0 (zip) and discovered that the bulk of this increase came from the blocks plugin.  On digging I discovered that our total bundle sizes had jumped from 1.7mb in v2.45 12.4mb in 2.5.3.  Keep mind 2.5 also introduced `*.legacy` builds which is a back-compat layer.  So we did expect a roughly double size increase, but accounting for that still leaves us with 6.4mb (if we remove the legacy layer).  That's huge!

## Troubleshooting

I took a look at actual built bundles using `all-reviews.js` which jumped from around ~37kb to 311kb (!) and noticed that the `previewReviews` import from `@woocommerce/resource-previews` alias in `example.js` was not just pulling in `previewReviews` to the built bundle, but also all the other exports in `assets/previews/index.js`.  If this same thing got replicated through all our imports, it would definitely account for the size increases.

I remembered that webpack has the ability to tree-shake but it has to be enabled via config.  Since our builds import `.css` and `.scss` (which are considered side-effects), I needed to account for them in the configuration.  So figured I'd give this one-liner addition to our `package.json` a try:

```json
"sideEffects": ["*.css", "*.scss"],
```

## Profit!

With this change, the build dropped from **12.4mb** to **4.9** (a 60% decrease!) .  Accounting for the legacy bundles effectively doubling size, that means we dropped from **6.4mb** to **2.45mb** which means even for all the javascript added between 2.4 and 2.5 there's only roughly a 30% increase in file size (relatively).

**Note:** tree-shaking is _only_ applied on **production** builds.  So you will only see these results when running `npm run build`.

## Testing

This affects every build so every block needs verified to ensure:

- styling looks as expected
- block functionality works as expected
- there are no errors in the console.