### PR TITLE
Rename SubmitButton to FilterSubmitButton

### DIFF
--- a/assets/js/base/components/filter-submit-button/index.js
+++ b/assets/js/base/components/filter-submit-button/index.js
@@ -10,11 +10,14 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-const SubmitButton = ( { className, disabled, onClick } ) => {
+const FilterSubmitButton = ( { className, disabled, onClick } ) => {
 	return (
 		<button
 			type="submit"
-			className={ classNames( 'wc-block-submit-button', className ) }
+			className={ classNames(
+				'wc-block-filter-submit-button',
+				className
+			) }
 			disabled={ disabled }
 			onClick={ onClick }
 		>
@@ -24,7 +27,8 @@ const SubmitButton = ( { className, disabled, onClick } ) => {
 	);
 };
 
-SubmitButton.propTypes = {
+FilterSubmitButton.propTypes = {
+	className: PropTypes.string,
 	/**
 	 * Is the button disabled?
 	 */
@@ -35,8 +39,8 @@ SubmitButton.propTypes = {
 	onClick: PropTypes.func.isRequired,
 };
 
-SubmitButton.defaultProps = {
+FilterSubmitButton.defaultProps = {
 	disabled: false,
 };
 
-export default SubmitButton;
+export default FilterSubmitButton;

--- a/assets/js/base/components/filter-submit-button/style.scss
+++ b/assets/js/base/components/filter-submit-button/style.scss
@@ -1,4 +1,4 @@
-.wc-block-submit-button {
+.wc-block-filter-submit-button {
 	display: block;
 	margin-left: auto;
 	white-space: nowrap;

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -19,7 +19,7 @@ import classnames from 'classnames';
 import './style.scss';
 import { constrainRangeSliderValues } from './utils';
 import { formatPrice } from '../../utils/price';
-import SubmitButton from '../submit-button';
+import FilterSubmitButton from '../filter-submit-button';
 import PriceLabel from './price-label';
 import PriceInput from './price-input';
 
@@ -309,7 +309,7 @@ const PriceSlider = ( {
 					/>
 				) }
 				{ showFilterButton && (
-					<SubmitButton
+					<FilterSubmitButton
 						className="wc-block-price-filter__button"
 						disabled={ isLoading || ! hasValidConstraints }
 						onClick={ onSubmit }

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -19,7 +19,7 @@ import {
 } from '@wordpress/element';
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
 import DropdownSelector from '@woocommerce/base-components/dropdown-selector';
-import SubmitButton from '@woocommerce/base-components/submit-button';
+import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
@@ -346,7 +346,7 @@ const AttributeFilterBlock = ( {
 					/>
 				) }
 				{ blockAttributes.showFilterButton && (
-					<SubmitButton
+					<FilterSubmitButton
 						className="wc-block-attribute-filter__button"
 						disabled={ isLoading || isDisabled }
 						onClick={ onSubmit }


### PR DESCRIPTION
Extracted from #1366.

This PR renames the `<SubmitButton />` component that was used in filters to `<FilterSubmitButton />` to make its purpose more clear. It was really coupled to filters (its label was _Go_ and it had some specific styles) and in #1366 we are adding a generic `<Button>` block, so in order to keep the distinction, it's better to rename this one.

### How to test the changes in this Pull Request:
1. Create a post with a _Price Filter_ and an _Attribute Filter_ block and enable the _Filter button_ option.
2. Preview it in the frontend.
3. Verify filter buttons render with the correct styles.
