### PR TITLE
Store API: Add cart coupon endpoints

### DIFF
--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -94,6 +94,7 @@ class RestApi {
 			'product-reviews'               => __NAMESPACE__ . '\RestApi\Controllers\ProductReviews',
 			'store-cart'                    => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\Cart',
 			'store-cart-items'              => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\CartItems',
+			'store-cart-coupons'            => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\CartCoupons',
 			'store-products'                => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\Products',
 			'store-product-collection-data' => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductCollectionData',
 			'store-product-attributes'      => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductAttributes',

--- a/src/RestApi/StoreApi/Controllers/CartCoupons.php
+++ b/src/RestApi/StoreApi/Controllers/CartCoupons.php
@@ -228,17 +228,7 @@ class CartCoupons extends RestController {
 	 * @return RestResponse Response object.
 	 */
 	public function prepare_item_for_response( $coupon_code, $request ) {
-		$controller           = new CartController();
-		$cart                 = $controller->get_cart_instance();
-		$total_discounts      = $cart->get_coupon_discount_totals();
-		$total_discount_taxes = $cart->get_coupon_discount_tax_totals();
-		$data                 = $this->schema->get_item_response(
-			$coupon_code,
-			isset( $total_discounts[ $coupon_code ] ) ? $total_discounts[ $coupon_code ] : 0,
-			isset( $total_discount_taxes[ $coupon_code ] ) ? $total_discount_taxes[ $coupon_code ] : 0
-		);
-
-		return rest_ensure_response( $data );
+		return rest_ensure_response( $this->schema->get_item_response( $coupon_code ) );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Controllers/CartCoupons.php
+++ b/src/RestApi/StoreApi/Controllers/CartCoupons.php
@@ -228,9 +228,17 @@ class CartCoupons extends RestController {
 	 * @return RestResponse Response object.
 	 */
 	public function prepare_item_for_response( $coupon_code, $request ) {
-		$data     = $this->schema->get_item_response( $coupon_code );
-		$response = rest_ensure_response( $data );
-		return $response;
+		$controller           = new CartController();
+		$cart                 = $controller->get_cart_instance();
+		$total_discounts      = $cart->get_coupon_discount_totals();
+		$total_discount_taxes = $cart->get_coupon_discount_tax_totals();
+		$data                 = $this->schema->get_item_response(
+			$coupon_code,
+			isset( $total_discounts[ $coupon_code ] ) ? $total_discounts[ $coupon_code ] : 0,
+			isset( $total_discount_taxes[ $coupon_code ] ) ? $total_discount_taxes[ $coupon_code ] : 0
+		);
+
+		return rest_ensure_response( $data );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Controllers/CartCoupons.php
+++ b/src/RestApi/StoreApi/Controllers/CartCoupons.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Cart Coupons controller.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers;
+
+defined( 'ABSPATH' ) || exit;
+
+use \WP_Error as RestError;
+use \WP_REST_Server as RestServer;
+use \WP_REST_Controller as RestController;
+use \WP_REST_Response as RestResponse;
+use \WP_REST_Request as RestRequest;
+use \WC_REST_Exception as RestException;
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartCouponSchema;
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
+
+/**
+ * Cart Coupons API.
+ */
+class CartCoupons extends RestController {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/store';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'cart/coupons';
+
+	/**
+	 * Schema class instance.
+	 *
+	 * @var object
+	 */
+	protected $schema;
+
+	/**
+	 * Setup API class.
+	 */
+	public function __construct() {
+		$this->schema = new CartCouponSchema();
+	}
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'  => RestServer::READABLE,
+					'callback' => [ $this, 'get_items' ],
+					'args'     => [
+						'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+					],
+				],
+				[
+					'methods'  => RestServer::CREATABLE,
+					'callback' => array( $this, 'create_item' ),
+					'args'     => $this->get_endpoint_args_for_item_schema( RestServer::CREATABLE ),
+				],
+				[
+					'methods'  => RestServer::DELETABLE,
+					'callback' => [ $this, 'delete_items' ],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<code>[\w-]+)',
+			[
+				'args'   => [
+					'code' => [
+						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+					],
+				],
+				[
+					'methods'  => RestServer::READABLE,
+					'callback' => [ $this, 'get_item' ],
+					'args'     => [
+						'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+					],
+				],
+				[
+					'methods'  => RestServer::DELETABLE,
+					'callback' => [ $this, 'delete_item' ],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Get a collection of cart coupons.
+	 *
+	 * @param RestRequest $request Full details about the request.
+	 * @return RestError|RestResponse
+	 */
+	public function get_items( $request ) {
+		$controller   = new CartController();
+		$cart_coupons = $controller->get_cart_coupons();
+		$items        = [];
+
+		foreach ( $cart_coupons as $coupon_code ) {
+			$response = $this->prepare_item_for_response( $coupon_code, $request );
+			$response->add_links( $this->prepare_links( $coupon_code ) );
+
+			$response = $this->prepare_response_for_collection( $response );
+			$items[]  = $response;
+		}
+
+		$response = rest_ensure_response( $items );
+
+		return $response;
+	}
+
+	/**
+	 * Get a single cart coupon.
+	 *
+	 * @param RestRequest $request Full details about the request.
+	 * @return RestError|RestResponse
+	 */
+	public function get_item( $request ) {
+		$controller = new CartController();
+
+		if ( ! $controller->has_coupon( $request['code'] ) ) {
+			return new RestError( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+		}
+
+		$data     = $this->prepare_item_for_response( $request['code'], $request );
+		$response = rest_ensure_response( $data );
+
+		return $response;
+	}
+
+	/**
+	 * Add a coupon to the cart and return the result.
+	 *
+	 * @param RestRequest $request Full data about the request.
+	 * @return RestError|RestResponse Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item( $request ) {
+		if ( ! wc_coupons_enabled() ) {
+			return new RestError( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+		}
+
+		$controller = new CartController();
+
+		try {
+			$controller->apply_coupon( $request['code'] );
+		} catch ( RestException $e ) {
+			return new RestError( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
+		}
+
+		$response = $this->get_item( $request );
+
+		if ( \is_a( $response, 'RestError' ) ) {
+			return $response;
+		}
+
+		$response = rest_ensure_response( $response );
+		$response->set_status( 201 );
+
+		return $response;
+	}
+
+	/**
+	 * Delete a single cart coupon.
+	 *
+	 * @param RestRequest $request Full data about the request.
+	 * @return RestError|RestResponse Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_item( $request ) {
+		$controller = new CartController();
+
+		if ( ! $controller->has_coupon( $request['code'] ) ) {
+			return new RestError( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+		}
+
+		$cart = $controller->get_cart_instance();
+		$cart->remove_coupon( $request['code'] );
+
+		return new RestResponse( null, 204 );
+	}
+
+	/**
+	 * Deletes all coupons in the cart.
+	 *
+	 * @param RestRequest $request Full data about the request.
+	 * @return RestError|RestResponse Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_items( $request ) {
+		$controller = new CartController();
+		$cart       = $controller->get_cart_instance();
+		$cart->remove_coupons();
+
+		return new RestResponse( [], 200 );
+	}
+
+	/**
+	 * Cart item schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return $this->schema->get_item_schema();
+	}
+
+	/**
+	 * Prepares a single item output for response.
+	 *
+	 * @param string      $coupon_code Coupon code.
+	 * @param RestRequest $request Request object.
+	 * @return RestResponse Response object.
+	 */
+	public function prepare_item_for_response( $coupon_code, $request ) {
+		$data     = $this->schema->get_item_response( $coupon_code );
+		$response = rest_ensure_response( $data );
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param string $coupon_code Coupon code.
+	 * @return array
+	 */
+	protected function prepare_links( $coupon_code ) {
+		$base  = $this->namespace . '/' . $this->rest_base;
+		$links = array(
+			'self'       => array(
+				'href' => rest_url( trailingslashit( $base ) . $coupon_code ),
+			),
+			'collection' => array(
+				'href' => rest_url( $base ),
+			),
+		);
+		return $links;
+	}
+}

--- a/src/RestApi/StoreApi/Controllers/CartCoupons.php
+++ b/src/RestApi/StoreApi/Controllers/CartCoupons.php
@@ -168,7 +168,7 @@ class CartCoupons extends RestController {
 
 		$response = $this->get_item( $request );
 
-		if ( \is_a( $response, 'RestError' ) ) {
+		if ( $response instanceof RestError ) {
 			return $response;
 		}
 

--- a/src/RestApi/StoreApi/README.md
+++ b/src/RestApi/StoreApi/README.md
@@ -820,23 +820,32 @@ Example response:
 
 ```json
 [
-	{
-		"code": "20off",
-		"total_discount": "1667",
-		"total_discount_tax": "333",
-		"_links": {
-			"self": [
-				{
-					"href": "http://local.wordpress.test/wp-json/wc/store/cart/coupons/20off"
-				}
-			],
-			"collection": [
-				{
-					"href": "http://local.wordpress.test/wp-json/wc/store/cart/coupons"
-				}
-			]
-		}
-	}
+  {
+    "code": "20off",
+    "totals": {
+      "currency_code": "GBP",
+      "currency_symbol": "£",
+      "currency_minor_unit": 2,
+      "currency_decimal_separator": ".",
+      "currency_thousand_separator": ",",
+      "currency_prefix": "£",
+      "currency_suffix": "",
+      "total_discount": "1667",
+      "total_discount_tax": "333"
+    },
+    "_links": {
+      "self": [
+        {
+          "href": "http:\/\/local.wordpress.test\/wp-json\/wc\/store\/cart\/coupons\/20off"
+        }
+      ],
+      "collection": [
+        {
+          "href": "http:\/\/local.wordpress.test\/wp-json\/wc\/store\/cart\/coupons"
+        }
+      ]
+    }
+  }
 ]
 ```
 
@@ -860,9 +869,18 @@ Example response:
 
 ```json
 {
-	"code": "20off",
-	"total_discount": "1667",
-	"total_discount_tax": "333"
+  "code": "20off",
+  "totals": {
+    "currency_code": "GBP",
+    "currency_symbol": "£",
+    "currency_minor_unit": 2,
+    "currency_decimal_separator": ".",
+    "currency_thousand_separator": ",",
+    "currency_prefix": "£",
+    "currency_suffix": "",
+    "total_discount": "1667",
+    "total_discount_tax": "333"
+  }
 }
 ```
 
@@ -886,9 +904,18 @@ Example response:
 
 ```json
 {
-	"code": "20off",
-	"total_discount": "1667",
-	"total_discount_tax": "333"
+  "code": "20off",
+  "totals": {
+    "currency_code": "GBP",
+    "currency_symbol": "£",
+    "currency_minor_unit": 2,
+    "currency_decimal_separator": ".",
+    "currency_thousand_separator": ",",
+    "currency_prefix": "£",
+    "currency_suffix": "",
+    "total_discount": "1667",
+    "total_discount_tax": "333"
+  }
 }
 ```
 

--- a/src/RestApi/StoreApi/README.md
+++ b/src/RestApi/StoreApi/README.md
@@ -322,7 +322,7 @@ Example response:
 
 ```json
 {
-  "coupons": [],
+	"coupons": [],
 	"items": [
 		{
 			"key": "6512bd43d9caa6e02c990b0a82652dca",

--- a/src/RestApi/StoreApi/README.md
+++ b/src/RestApi/StoreApi/README.md
@@ -90,6 +90,7 @@ Available resources in the Store API include:
 | [`Products`](#products-api)                                | `/wc/store/products`                    |
 | [`Cart`](#cart-api)                                        | `/wc/store/cart`                        |
 | [`Cart Items`](#cart-items-api)                            | `/wc/store/cart/items`                  |
+| [`Cart Coupons`](#cart-coupons-api)                        | `/wc/store/cart/coupons`                |
 | [`Cart Shipping Rates`](#cart-shipping-rates-api)          | `/wc/store/cart/shipping-rates`         |
 | [`Product Attributes`](#product-attributes-api)            | `/wc/store/products/attributes`         |
 | [`Product Attribute Terms`](#product-attribute-terms-api)  | `/wc/store/products/attributes/1/terms` |
@@ -321,6 +322,7 @@ Example response:
 
 ```json
 {
+  "coupons": [],
 	"items": [
 		{
 			"key": "6512bd43d9caa6e02c990b0a82652dca",
@@ -792,6 +794,132 @@ There are no parameters required for this endpoint.
 
 ```http
 curl --request DELETE https://example-store.com/wp-json/wc/store/cart/items
+```
+
+Example response:
+
+```json
+[]
+```
+
+## Cart coupons API
+
+### List cart coupons
+
+```http
+GET /cart/coupons
+```
+
+There are no parameters required for this endpoint.
+
+```http
+curl "https://example-store.com/wp-json/wc/store/cart/items"
+```
+
+Example response:
+
+```json
+[
+	{
+		"code": "20off",
+		"total_discount": "1667",
+		"total_discount_tax": "333",
+		"_links": {
+			"self": [
+				{
+					"href": "http://local.wordpress.test/wp-json/wc/store/cart/coupons/20off"
+				}
+			],
+			"collection": [
+				{
+					"href": "http://local.wordpress.test/wp-json/wc/store/cart/coupons"
+				}
+			]
+		}
+	}
+]
+```
+
+### Single cart coupon
+
+Get a single cart coupon.
+
+```http
+GET /cart/coupons/:code
+```
+
+| Attribute | Type   | Required | Description                                     |
+| :-------- | :----- | :------: | :---------------------------------------------- |
+| `code`    | string |   Yes    | The coupon code of the cart coupon to retrieve. |
+
+```http
+curl "https://example-store.com/wp-json/wc/store/cart/coupons/20off"
+```
+
+Example response:
+
+```json
+{
+	"code": "20off",
+	"total_discount": "1667",
+	"total_discount_tax": "333"
+}
+```
+
+### New cart coupon
+
+Apply a coupon to the cart.
+
+```http
+POST /cart/coupons/
+```
+
+| Attribute | Type   | Required | Description                                    |
+| :-------- | :----- | :------: | :--------------------------------------------- |
+| `code`    | string |   Yes    | The coupon code you wish to apply to the cart. |
+
+```http
+curl --request POST https://example-store.com/wp-json/wc/store/cart/coupons?code=20off
+```
+
+Example response:
+
+```json
+{
+	"code": "20off",
+	"total_discount": "1667",
+	"total_discount_tax": "333"
+}
+```
+
+### Delete single cart coupon
+
+Delete/remove a coupon from the cart.
+
+```http
+DELETE /cart/coupons/:code
+```
+
+| Attribute | Type   | Required | Description                                       |
+| :-------- | :----- | :------: | :------------------------------------------------ |
+| `code`    | string |   Yes    | The coupon code you wish to remove from the cart. |
+
+```http
+curl --request DELETE https://example-store.com/wp-json/wc/store/cart/coupons/20off
+```
+
+### Delete all cart coupons
+
+Delete/remove all coupons from the cart.
+
+```http
+DELETE /cart/coupons/
+```
+
+There are no parameters required for this endpoint.
+
+```http
+curl --request DELETE https://example-store.com/wp-json/wc/store/cart/coupons
 ```
 
 Example response:

--- a/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
@@ -63,7 +63,7 @@ class CartCouponSchema extends AbstractSchema {
 	 */
 	public function coupon_exists( $coupon_code ) {
 		$coupon = new \WC_Coupon( $coupon_code );
-		return (bool) $coupon;
+		return (bool) $coupon->get_id() || $coupon->get_virtual();
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
@@ -31,7 +31,7 @@ class CartCouponSchema extends AbstractSchema {
 	 */
 	protected function get_properties() {
 		return [
-			'code'               => [
+			'code'   => [
 				'description' => __( 'The coupons unique code.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
@@ -40,17 +40,28 @@ class CartCouponSchema extends AbstractSchema {
 					'validate_callback' => [ $this, 'coupon_exists' ],
 				],
 			],
-			'total_discount'     => [
-				'description' => __( 'Total discount applied by this coupon. Amount provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
-				'type'        => 'string',
+			'totals' => [
+				'description' => __( 'Total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
-			],
-			'total_discount_tax' => [
-				'description' => __( 'Total tax removed due to discount applied by this coupon. Amount provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
-				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
-				'readonly'    => true,
+				'properties'  => array_merge(
+					$this->get_store_currency_properties(),
+					[
+						'total_discount'     => [
+							'description' => __( 'Total discount applied by this coupon.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'total_discount_tax' => [
+							'description' => __( 'Total tax removed due to discount applied by this coupon.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					]
+				),
 			],
 		];
 	}
@@ -78,9 +89,14 @@ class CartCouponSchema extends AbstractSchema {
 		$total_discounts      = $cart->get_coupon_discount_totals();
 		$total_discount_taxes = $cart->get_coupon_discount_tax_totals();
 		return [
-			'code'               => $coupon_code,
-			'total_discount'     => $this->prepare_money_response( isset( $total_discounts[ $coupon_code ] ) ? $total_discounts[ $coupon_code ] : 0, wc_get_price_decimals() ),
-			'total_discount_tax' => $this->prepare_money_response( isset( $total_discount_taxes[ $coupon_code ] ) ? $total_discount_taxes[ $coupon_code ] : 0, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
+			'code'   => $coupon_code,
+			'totals' => array_merge(
+				$this->get_store_currency_response(),
+				[
+					'total_discount'     => $this->prepare_money_response( isset( $total_discounts[ $coupon_code ] ) ? $total_discounts[ $coupon_code ] : 0, wc_get_price_decimals() ),
+					'total_discount_tax' => $this->prepare_money_response( isset( $total_discount_taxes[ $coupon_code ] ) ? $total_discount_taxes[ $coupon_code ] : 0, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
+				]
+			),
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
@@ -39,13 +39,13 @@ class CartCouponSchema extends AbstractSchema {
 				],
 			],
 			'total_discount'     => [
-				'description' => __( 'Total discount applied by this coupon.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Total discount applied by this coupon. Amount provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
 			'total_discount_tax' => [
-				'description' => __( 'Total tax removed due to discount applied by this coupon.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Total tax removed due to discount applied by this coupon. Amount provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
@@ -75,8 +75,8 @@ class CartCouponSchema extends AbstractSchema {
 	public function get_item_response( $coupon_code, $total_discount, $total_discount_tax ) {
 		return [
 			'code'               => $coupon_code,
-			'total_discount'     => $total_discount,
-			'total_discount_tax' => $total_discount_tax,
+			'total_discount'     => $this->prepare_money_response( $total_discount, wc_get_price_decimals() ),
+			'total_discount_tax' => $this->prepare_money_response( $total_discount_tax, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
@@ -68,13 +68,15 @@ class CartCouponSchema extends AbstractSchema {
 	 * Convert a WooCommerce cart item to an object suitable for the response.
 	 *
 	 * @param string $coupon_code Coupon code from the cart.
+	 * @param string $total_discount Total discount from cart for this coupon.
+	 * @param string $total_discount_tax Total discount tax from cart for this coupon.
 	 * @return array
 	 */
-	public function get_item_response( $coupon_code ) {
+	public function get_item_response( $coupon_code, $total_discount, $total_discount_tax ) {
 		return [
 			'code'               => $coupon_code,
-			'total_discount'     => 0,
-			'total_discount_tax' => 0,
+			'total_discount'     => $total_discount,
+			'total_discount_tax' => $total_discount_tax,
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
+
 /**
  * CartCouponSchema class.
  *
@@ -68,15 +70,17 @@ class CartCouponSchema extends AbstractSchema {
 	 * Convert a WooCommerce cart item to an object suitable for the response.
 	 *
 	 * @param string $coupon_code Coupon code from the cart.
-	 * @param string $total_discount Total discount from cart for this coupon.
-	 * @param string $total_discount_tax Total discount tax from cart for this coupon.
 	 * @return array
 	 */
-	public function get_item_response( $coupon_code, $total_discount, $total_discount_tax ) {
+	public function get_item_response( $coupon_code ) {
+		$controller           = new CartController();
+		$cart                 = $controller->get_cart_instance();
+		$total_discounts      = $cart->get_coupon_discount_totals();
+		$total_discount_taxes = $cart->get_coupon_discount_tax_totals();
 		return [
 			'code'               => $coupon_code,
-			'total_discount'     => $this->prepare_money_response( $total_discount, wc_get_price_decimals() ),
-			'total_discount_tax' => $this->prepare_money_response( $total_discount_tax, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
+			'total_discount'     => $this->prepare_money_response( isset( $total_discounts[ $coupon_code ] ) ? $total_discounts[ $coupon_code ] : 0, wc_get_price_decimals() ),
+			'total_discount_tax' => $this->prepare_money_response( isset( $total_discount_taxes[ $coupon_code ] ) ? $total_discount_taxes[ $coupon_code ] : 0, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartCouponSchema.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Cart Coupon Schema.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * CartCouponSchema class.
+ *
+ * @since 2.5.0
+ */
+class CartCouponSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'cart_coupon';
+
+	/**
+	 * Cart schema properties.
+	 *
+	 * @return array
+	 */
+	protected function get_properties() {
+		return [
+			'code'               => [
+				'description' => __( 'The coupons unique code.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'arg_options' => [
+					'sanitize_callback' => 'wc_format_coupon_code',
+					'validate_callback' => [ $this, 'coupon_exists' ],
+				],
+			],
+			'total_discount'     => [
+				'description' => __( 'Total discount applied by this coupon.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'total_discount_tax' => [
+				'description' => __( 'Total tax removed due to discount applied by this coupon.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+		];
+	}
+
+	/**
+	 * Check given coupon exists.
+	 *
+	 * @param string $coupon_code Coupon code.
+	 * @return bool
+	 */
+	public function coupon_exists( $coupon_code ) {
+		$coupon = new \WC_Coupon( $coupon_code );
+		return (bool) $coupon;
+	}
+
+	/**
+	 * Convert a WooCommerce cart item to an object suitable for the response.
+	 *
+	 * @param string $coupon_code Coupon code from the cart.
+	 * @return array
+	 */
+	public function get_item_response( $coupon_code ) {
+		return [
+			'code'               => $coupon_code,
+			'total_discount'     => 0,
+			'total_discount_tax' => 0,
+		];
+	}
+}

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
- * Abstract Schema.
- *
- * Rest API schema class.
+ * Cart Item Schema.
  *
  * @package WooCommerce/Blocks
  */
@@ -14,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductImages;
 
 /**
- * AbstractBlock class.
+ * CartItemSchema class.
  *
  * @since 2.5.0
  */

--- a/src/RestApi/StoreApi/Schemas/CartSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartSchema.php
@@ -29,6 +29,16 @@ class CartSchema extends AbstractSchema {
 	 */
 	protected function get_properties() {
 		return [
+			'coupons'        => [
+				'description' => __( 'List of applied cart coupons.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( ( new CartCouponSchema() )->get_properties() ),
+				],
+			],
 			'items'          => [
 				'description' => __( 'List of cart items.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
@@ -161,8 +171,10 @@ class CartSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $cart ) {
-		$cart_item_schema = new CartItemSchema();
+		$cart_coupon_schema = new CartCouponSchema();
+		$cart_item_schema   = new CartItemSchema();
 		return [
+			'coupons'        => array_values( array_map( [ $cart_coupon_schema, 'get_item_response' ], array_filter( $cart->get_applied_coupons() ) ) ),
 			'items'          => array_values( array_map( [ $cart_item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
 			'items_count'    => $cart->get_cart_contents_count(),
 			'items_weight'   => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),

--- a/tests/php/RestApi/StoreApi/Controllers/CartCoupons.php
+++ b/tests/php/RestApi/StoreApi/Controllers/CartCoupons.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Controller Tests.
+ *
+ * @package WooCommerce\Blocks\Tests
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\RestApi\StoreApi\Controllers;
+
+use \WP_REST_Request;
+use \WC_REST_Unit_Test_Case as TestCase;
+use \WC_Helper_Product as ProductHelper;
+use \WC_Helper_Coupon as CouponHelper;
+
+/**
+ * Cart Coupons Controller Tests.
+ */
+class CartCoupons extends TestCase {
+	/**
+	 * Setup test products data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		wp_set_current_user( 0 );
+
+		$this->product = ProductHelper::create_simple_product( false );
+		$this->coupon  = CouponHelper::create_coupon();
+
+		wc_empty_cart();
+
+		wc()->cart->add_to_cart( $this->product->get_id(), 2 );
+		wc()->cart->apply_coupon( $this->coupon->get_code() );
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/store/cart/coupons', $routes );
+		$this->assertArrayHasKey( '/wc/store/cart/coupons/(?P<code>[\w-]+)', $routes );
+	}
+
+	/**
+	 * Test getting cart.
+	 */
+	public function test_get_items() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart/coupons' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $data ) );
+	}
+
+	/**
+	 * Test getting cart item by key.
+	 */
+	public function test_get_item() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart/coupons/' . $this->coupon->get_code() ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $this->coupon->get_code(), $data['code'] );
+		$this->assertEquals( '0', $data['total_discount'] );
+		$this->assertEquals( '0', $data['total_discount_tax'] );
+	}
+
+	/**
+	 * Test add to cart.
+	 */
+	public function test_create_item() {
+		wc()->cart->remove_coupons();
+
+		$request = new WP_REST_Request( 'POST', '/wc/store/cart/coupons' );
+		$request->set_body_params(
+			array(
+				'code' => $this->coupon->get_code(),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( $this->coupon->get_code(), $data['code'] );
+	}
+
+	/**
+	 * Test add to cart does not allow invalid items.
+	 */
+	public function test_invalid_create_item() {
+		wc()->cart->remove_coupons();
+
+		$request = new WP_REST_Request( 'POST', '/wc/store/cart/coupons' );
+		$request->set_body_params(
+			array(
+				'code' => 'IDONOTEXIST'
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test delete item.
+	 */
+	public function test_delete_item() {
+		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/' . $this->coupon->get_code() );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 204, $response->get_status() );
+		$this->assertEmpty( $data );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/' . $this->coupon->get_code() );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+
+		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/i-do-not-exist' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test delete all items.
+	 */
+	public function test_delete_items() {
+		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [], $data );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart/coupons' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 0, count( $data ) );
+	}
+
+	/**
+	 * Test schema retrieval.
+	 */
+	public function test_get_item_schema() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\CartCoupons();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'code', $schema['properties'] );
+		$this->assertArrayHasKey( 'total_discount', $schema['properties'] );
+		$this->assertArrayHasKey( 'total_discount_tax', $schema['properties'] );
+	}
+
+	/**
+	 * Test conversion of cart item to rest response.
+	 */
+	public function test_prepare_item_for_response() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\CartCoupons();
+		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), [] );
+
+		$this->assertArrayHasKey( 'code', $response->get_data() );
+		$this->assertArrayHasKey( 'total_discount', $response->get_data() );
+		$this->assertArrayHasKey( 'total_discount_tax', $response->get_data() );
+	}
+}

--- a/tests/php/RestApi/StoreApi/Controllers/CartCoupons.php
+++ b/tests/php/RestApi/StoreApi/Controllers/CartCoupons.php
@@ -62,8 +62,8 @@ class CartCoupons extends TestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $this->coupon->get_code(), $data['code'] );
-		$this->assertEquals( '0', $data['total_discount'] );
-		$this->assertEquals( '0', $data['total_discount_tax'] );
+		$this->assertEquals( '0', $data['totals']['total_discount'] );
+		$this->assertEquals( '0', $data['totals']['total_discount_tax'] );
 	}
 
 	/**
@@ -94,33 +94,33 @@ class CartCoupons extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/wc/store/cart/coupons' );
 		$request->set_body_params(
 			array(
-				'code' => 'IDONOTEXIST'
+				'code' => 'IDONOTEXIST',
 			)
 		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 400, $response->get_status() );
 	}
 
 	/**
 	 * Test delete item.
 	 */
 	public function test_delete_item() {
-		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/' . $this->coupon->get_code() );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/' . $this->coupon->get_code() );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 204, $response->get_status() );
 		$this->assertEmpty( $data );
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/' . $this->coupon->get_code() );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/' . $this->coupon->get_code() );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 404, $response->get_status() );
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/i-do-not-exist' );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons/i-do-not-exist' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -131,7 +131,7 @@ class CartCoupons extends TestCase {
 	 * Test delete all items.
 	 */
 	public function test_delete_items() {
-		$request = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons' );
+		$request  = new WP_REST_Request( 'DELETE', '/wc/store/cart/coupons' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -153,8 +153,7 @@ class CartCoupons extends TestCase {
 		$schema     = $controller->get_item_schema();
 
 		$this->assertArrayHasKey( 'code', $schema['properties'] );
-		$this->assertArrayHasKey( 'total_discount', $schema['properties'] );
-		$this->assertArrayHasKey( 'total_discount_tax', $schema['properties'] );
+		$this->assertArrayHasKey( 'totals', $schema['properties'] );
 	}
 
 	/**
@@ -165,7 +164,6 @@ class CartCoupons extends TestCase {
 		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), [] );
 
 		$this->assertArrayHasKey( 'code', $response->get_data() );
-		$this->assertArrayHasKey( 'total_discount', $response->get_data() );
-		$this->assertArrayHasKey( 'total_discount_tax', $response->get_data() );
+		$this->assertArrayHasKey( 'totals', $response->get_data() );
 	}
 }


### PR DESCRIPTION
Adds endpoints to add, remove, and get coupons from the Store API.

Closes #1323 

Docs are updated also. _Note_ Whilst working on that I noticed we didn't update the price formats for products and filters - that will be a follow up task along with more updated docs.

### How to test the changes in this Pull Request:

1. Add items to your cart, create 2 coupons, and add 1 to your cart manually. This is so you can test the responses. 
2. Check `wc/store/cart` lists applied coupons.
3. Check `wc/store/cart/coupons` lists applied coupons.
4. For one of the listed coupons, try and access it's endpoint: `wc/store/cart/coupons/<code>`
5. For one of the listed coupons, try and delete it DELETE request to `wc/store/cart/coupons/<code>`
6. Add it again, POST `{ "code": "<code>" }`  to `wc/store/cart/coupons`
7. Finally, delete all coupons by doing DELETE request to `wc/store/cart/coupons`
