### PR TITLE
Normalize set minPrice and maxPrice values by step

### DIFF
--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -81,16 +81,21 @@ const PriceSlider = ( {
 			};
 		}
 
+		// normalize to whatever is the closest step (because range input will
+		// only jump to the closest step in the range)
+		const min = Math.round( minPrice / step ) * step;
+		const max = Math.round( maxPrice / step ) * step;
+
 		const low =
 			Math.round(
 				100 *
-					( ( minPrice - minConstraint ) /
+					( ( min - minConstraint ) /
 						( maxConstraint - minConstraint ) )
 			) - 0.5;
 		const high =
 			Math.round(
 				100 *
-					( ( maxPrice - minConstraint ) /
+					( ( max - minConstraint ) /
 						( maxConstraint - minConstraint ) )
 			) + 0.5;
 
@@ -104,6 +109,7 @@ const PriceSlider = ( {
 		minConstraint,
 		maxConstraint,
 		hasValidConstraints,
+		step,
 	] );
 
 	/**

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -81,8 +81,8 @@ const PriceSlider = ( {
 			};
 		}
 
-		// normalize to whatever is the closest step (because range input will
-		// only jump to the closest step in the range)
+		// Normalize to whatever is the closest step (because range input will
+		// only jump to the closest step in the range).
 		const min = Math.round( minPrice / step ) * step;
 		const max = Math.round( maxPrice / step ) * step;
 


### PR DESCRIPTION
Fixes: #1373 

See connected issue for details.  The problem was that the range slider only moves to the closest step for the given value (according to what is set for step values) but the colored mask was using the actual value for calculating the width of the mask.  In this pull, the actual min/max price values are normalized by the step to ensure percentages are accurate for the displayed range.

## To Test

- try reproducing as per the instructions in #1373 and verify that using any value within the range is respected by the calculated display.