### PR TITLE
Fix messaging when there are no attributes

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -233,7 +233,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		>
 			<p>
 				{ __(
-					"Attributes are needed for filtering your products. You haven't created any products yet.",
+					"Attributes are needed for filtering your products. You haven't created any attributes yet yet.",
 					'woo-gutenberg-products-block'
 				) }
 			</p>


### PR DESCRIPTION
Fixes: #1377 

See original issue for details.  This pull fixes the messaging shown for the "Filter by Attributes" block when there are no attributes setup for the store.

## To Test

- use the steps in the original issue to trigger the no attributes message for the block or temporarily edit your code locally to force it to appear.  Verify the message is as expected.