### PR TITLE
Only allow one instance of the All Products block per page/post.

### DIFF
--- a/assets/js/blocks/active-filters/index.js
+++ b/assets/js/blocks/active-filters/index.js
@@ -23,7 +23,9 @@ registerBlockType( 'woocommerce/active-filters', {
 		'Display a list of active product filters.',
 		'woo-gutenberg-products-block'
 	),
-	supports: {},
+	supports: {
+		multiple: false,
+	},
 	example: {
 		attributes: {},
 	},

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -23,7 +23,9 @@ registerBlockType( 'woocommerce/price-filter', {
 		'Display a slider to filter products in your store by price.',
 		'woo-gutenberg-products-block'
 	),
-	supports: {},
+	supports: {
+		multiple: false,
+	},
 	example: {},
 	attributes: {
 		showInputFields: {

--- a/assets/js/blocks/products/all-products/index.js
+++ b/assets/js/blocks/products/all-products/index.js
@@ -32,6 +32,7 @@ registerBlockType( 'woocommerce/all-products', {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
+		multiple: false,
 	},
 	example: {
 		attributes: {


### PR DESCRIPTION
Fixes: #1376 

For background, see #1376.  One problem we face in fixing this, is currently our implementation of All Products (and related filter blocks) doesn't really support multiple instances at the top level of the post_content.  While we _do_ have support for multiple instances, that must happen within a container block level otherwise there is no way to _link_ various filter blocks to controlling the request for the All Products block.  So currently, any blocks added to the top level context will inherit the same query context (which is "page") for all blocks added on the page.  So if setting changes are made to one block, it will apply to all blocks linked to the same client data store (+ related requests for that specific data store) and context.

So, the only way we can have isolated settings per `All Products` block and `Filter Block` variations is to have them within a container that defines the context (see #1261).  That is something I don't think would be too hard to implement, and we will want to do it in a future iteration, but it'd be good to see if this is something even needed right away (by gauging response/feedback to the current blocks)?

As a result, I think the short term fix here is to simply only allow one `All Products` block to be inserted at the top level page (and the same for filter blocks).  The exception will be the attribute filter blocks because there may be more than one of them (for multiple attributes).

## To Test

Verify there can only be one instance of the following blocks added to a page/post:

- All Products
- Price Filter
- Active Filter

Attribute Filter blocks can still have multiple instances added.

cc @pmcpinto, @jwold, @garymurray  for your input on this solution for the WC 3.9 release.  Do you have any concerns about this approach?
