### PR TITLE
Only allow one cart or checkout block per page.

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -28,6 +28,7 @@ registerBlockType( 'woocommerce/cart', {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
+		multiple: false,
 	},
 	example,
 	attributes: {},

--- a/assets/js/blocks/cart-checkout/checkout/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/index.js
@@ -25,7 +25,11 @@ registerBlockType( 'woocommerce/checkout', {
 		'Display the checkout experience for customers.',
 		'woo-gutenberg-products-block'
 	),
-	supports: {},
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+		multiple: false,
+	},
 	example,
 	attributes: {
 		/**


### PR DESCRIPTION
This pull is fairly straightforward:

- Add `multiple: false`  to the supports property for the block registration of cart and checkout blocks so that only one instance of them is allowed per page.
- Update `supports` property of cart block to add some missing properties it should have.

## To Test

Verify you can only add one instance of either cart or checkout block per page.