### PR TITLE
All Products Block: Fix default sort order changes not updating block in editor.

### DIFF
--- a/assets/js/base/components/product-list/container.js
+++ b/assets/js/base/components/product-list/container.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import PropTypes from 'prop-types';
 
 /**
@@ -12,6 +12,10 @@ import ProductList from './index';
 const ProductListContainer = ( { attributes } ) => {
 	const [ currentPage, setPage ] = useState( 1 );
 	const [ currentSort, setSort ] = useState( attributes.orderby );
+	useEffect( () => {
+		// if default sort is changed in editor
+		setSort( attributes.orderby );
+	}, [ attributes.orderby ] );
 	const onPageChange = ( newPage ) => {
 		setPage( newPage );
 	};


### PR DESCRIPTION
Thanks to @senff for surfacing this bug while testing WooCommerce 3.9.

Steps to reproduce bug:

- add All Products block to content
- select the block.
- change the sort order for products via the control in the block settings panel.
- Notice the block does not update for the new sort order.  The new attribute selection is changed however but you'll only see that affect results on a full refresh of the editor.

This pull fixes the above bug by ensuring the component is accounting for the possible attribute change.

## To test

Try the steps above, this time the results should update immediately on changing the sort order.