### PR TITLE
Price filter: preserve previous constraints while loading

### DIFF
--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -256,7 +256,7 @@ const PriceSlider = ( {
 				onMouseMove={ findClosestRange }
 				onFocus={ findClosestRange }
 			>
-				{ ! isLoading && hasValidConstraints && (
+				{ hasValidConstraints && (
 					<Fragment>
 						<div
 							className="wc-block-price-filter__range-input-progress"
@@ -275,6 +275,7 @@ const PriceSlider = ( {
 							min={ minConstraint }
 							max={ maxConstraint }
 							ref={ minRange }
+							disabled={ isLoading }
 						/>
 						<input
 							type="range"
@@ -289,6 +290,7 @@ const PriceSlider = ( {
 							min={ minConstraint }
 							max={ maxConstraint }
 							ref={ maxRange }
+							disabled={ isLoading }
 						/>
 					</Fragment>
 				) }

--- a/assets/js/base/utils/price.js
+++ b/assets/js/base/utils/price.js
@@ -16,7 +16,7 @@ export const formatPrice = (
 	priceFormat = CURRENCY.price_format,
 	currencySymbol = CURRENCY.symbol
 ) => {
-	if ( value === '' || undefined === value ) {
+	if ( ! isFinite( parseInt( value ) ) ) {
 		return '';
 	}
 	const formattedNumber = parseInt( value, 10 );

--- a/assets/js/base/utils/price.js
+++ b/assets/js/base/utils/price.js
@@ -9,7 +9,7 @@ import { CURRENCY } from '@woocommerce/settings';
  *
  * @param {number} value Number to format.
  * @param {string} priceFormat  Price format string.
- * @param {string} currencySymbol Curency symbol.
+ * @param {string} currencySymbol Currency symbol.
  */
 export const formatPrice = (
 	value,

--- a/assets/js/base/utils/price.js
+++ b/assets/js/base/utils/price.js
@@ -16,10 +16,10 @@ export const formatPrice = (
 	priceFormat = CURRENCY.price_format,
 	currencySymbol = CURRENCY.symbol
 ) => {
-	if ( ! isFinite( parseInt( value ) ) ) {
+	const formattedNumber = parseInt( value, 10 );
+	if ( ! isFinite( formattedNumber ) ) {
 		return '';
 	}
-	const formattedNumber = parseInt( value, 10 );
 	const formattedValue = sprintf(
 		priceFormat,
 		currencySymbol,

--- a/assets/js/base/utils/test/price.js
+++ b/assets/js/base/utils/test/price.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { formatPrice } from '../price';
+
+describe( 'formatPrice', () => {
+	test.each`
+		value        | priceFormat   | currencySymbol | expected
+		${10}        | ${'%1$s%2$s'} | ${'€'}         | ${'€10'}
+		${10}        | ${'%2$s%1$s'} | ${'€'}         | ${'10€'}
+		${10}        | ${'%2$s%1$s'} | ${'$'}         | ${'10$'}
+		${'10'}      | ${'%1$s%2$s'} | ${'€'}         | ${'€10'}
+		${0}         | ${'%1$s%2$s'} | ${'€'}         | ${'€0'}
+		${''}        | ${'%1$s%2$s'} | ${'€'}         | ${''}
+		${null}      | ${'%1$s%2$s'} | ${'€'}         | ${''}
+		${undefined} | ${'%1$s%2$s'} | ${'€'}         | ${''}
+	`(
+		'correctly formats price given "$value", "$priceFormat", and "$currencySymbol"',
+		( { value, priceFormat, currencySymbol, expected } ) => {
+			const formattedPrice = formatPrice(
+				value,
+				priceFormat,
+				currencySymbol
+			);
+
+			expect( formattedPrice ).toEqual( expected );
+		}
+	);
+} );

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -23,6 +23,7 @@ const useConstraints = ( { minPrice, maxPrice } ) => {
 	const minConstraint = Number.isFinite( currentMinConstraint )
 		? currentMinConstraint
 		: previousMinConstraint;
+
 	const currentMaxConstraint = isNaN( maxPrice )
 		? null
 		: Math.ceil( parseInt( maxPrice, 10 ) / 10 ) * 10;

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -5,7 +5,6 @@ import {
 	useQueryStateByKey,
 	useQueryStateByContext,
 	useCollectionData,
-	usePrevious,
 } from '@woocommerce/base-hooks';
 import { Fragment, useCallback, useState, useEffect } from '@wordpress/element';
 import PriceSlider from '@woocommerce/base-components/price-slider';
@@ -13,29 +12,10 @@ import { CURRENCY } from '@woocommerce/settings';
 import { useDebouncedCallback } from 'use-debounce';
 import PropTypes from 'prop-types';
 
-const useConstraints = ( { minPrice, maxPrice } ) => {
-	const currentMinConstraint = isNaN( minPrice )
-		? null
-		: Math.floor( parseInt( minPrice, 10 ) / 10 ) * 10;
-	const previousMinConstraint = usePrevious( currentMinConstraint, ( val ) =>
-		Number.isFinite( val )
-	);
-	const minConstraint = Number.isFinite( currentMinConstraint )
-		? currentMinConstraint
-		: previousMinConstraint;
-
-	const currentMaxConstraint = isNaN( maxPrice )
-		? null
-		: Math.ceil( parseInt( maxPrice, 10 ) / 10 ) * 10;
-	const previousMaxConstraint = usePrevious( currentMaxConstraint, ( val ) =>
-		Number.isFinite( val )
-	);
-	const maxConstraint = Number.isFinite( currentMaxConstraint )
-		? currentMaxConstraint
-		: previousMaxConstraint;
-
-	return { minConstraint, maxConstraint };
-};
+/**
+ * Internal dependencies
+ */
+import usePriceConstraints from './use-price-constraints.js';
 
 /**
  * Component displaying a price filter.
@@ -56,7 +36,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 	const [ minPrice, setMinPrice ] = useState();
 	const [ maxPrice, setMaxPrice ] = useState();
 
-	const { minConstraint, maxConstraint } = useConstraints( {
+	const { minConstraint, maxConstraint } = usePriceConstraints( {
 		minPrice: results.min_price,
 		maxPrice: results.max_price,
 	} );

--- a/assets/js/blocks/price-filter/test/use-price-constraints.js
+++ b/assets/js/blocks/price-filter/test/use-price-constraints.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import { usePriceConstraint } from '../use-price-constraints';
+
+describe( 'usePriceConstraints', () => {
+	const TestComponent = ( { price } ) => {
+		const priceConstraint = usePriceConstraint( price );
+		return <div priceConstraint={ priceConstraint } />;
+	};
+
+	it( 'price constraint should be updated when new price is set', () => {
+		const renderer = TestRenderer.create( <TestComponent price={ 10 } /> );
+		const container = renderer.root.findByType( 'div' );
+
+		expect( container.props.priceConstraint ).toBe( 10 );
+
+		renderer.update( <TestComponent price={ 20 } /> );
+
+		expect( container.props.priceConstraint ).toBe( 20 );
+	} );
+
+	it( 'previous price constraint should be preserved when new price is not a infinite number', () => {
+		const renderer = TestRenderer.create( <TestComponent price={ 10 } /> );
+		const container = renderer.root.findByType( 'div' );
+
+		expect( container.props.priceConstraint ).toBe( 10 );
+
+		renderer.update( <TestComponent price={ Infinity } /> );
+
+		expect( container.props.priceConstraint ).toBe( 10 );
+	} );
+} );

--- a/assets/js/blocks/price-filter/use-price-constraints.js
+++ b/assets/js/blocks/price-filter/use-price-constraints.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { usePrevious } from '../../base/hooks/use-previous';
+
+export const usePriceConstraint = ( price ) => {
+	const currentConstraint = isNaN( price )
+		? null
+		: Math.floor( parseInt( price, 10 ) / 10 ) * 10;
+	const previousConstraint = usePrevious( currentConstraint, ( val ) =>
+		Number.isFinite( val )
+	);
+	return Number.isFinite( currentConstraint )
+		? currentConstraint
+		: previousConstraint;
+};
+
+export default ( { minPrice, maxPrice } ) => {
+	return {
+		minConstraint: usePriceConstraint( minPrice ),
+		maxConstraint: usePriceConstraint( maxPrice ),
+	};
+};

--- a/assets/js/blocks/price-filter/use-price-constraints.js
+++ b/assets/js/blocks/price-filter/use-price-constraints.js
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { usePrevious } from '../../base/hooks/use-previous';
+import { usePrevious } from '@woocommerce/base-hooks';
 
 export const usePriceConstraint = ( price ) => {
 	const currentConstraint = isNaN( price )

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -15,6 +15,7 @@
 		"@woocommerce/base-components(.*)$": "assets/js/base/components/$1",
 		"@woocommerce/base-context(.*)$": "assets/js/base/context/$1",
 		"@woocommerce/base-hocs(.*)$": "assets/js/base/hocs/$1",
+		"@woocommerce/base-hooks(.*)$": "assets/js/base/hooks/$1",
 		"@woocommerce/block-data": "assets/js/data"
 	},
 	"setupFiles": [


### PR DESCRIPTION
Fixes #1375.

This PR makes it so the previous constraints are preserved in the Price filter, so a `NaN` value is not displayed while loading. I also took the chance to add tests to `formatPrice`.

### Screenshots

_Before:_
<img src="https://cldup.com/qCFJzQnTwY.gif" width="344" alt="" />

_After:_
<img src="https://cldup.com/9MlQkxOo_3.gif" width="344" alt="" />

### How to test the changes in this Pull Request:

Follow the steps described in #1375 and verify the bug is no longer reproducible.

### Changelog

> Price Filter: fix NaN values shown in some occasions while loading .