### PR TITLE
Reformat files

### DIFF
--- a/assets/js/base/hocs/test/with-products.js
+++ b/assets/js/base/hocs/test/with-products.js
@@ -18,10 +18,7 @@ jest.mock( '../../utils/errors', () => ( {
 	formatError: jest.fn(),
 } ) );
 
-const mockProducts = [
-	{ id: 10, name: 'foo' },
-	{ id: 20, name: 'bar' },
-];
+const mockProducts = [ { id: 10, name: 'foo' }, { id: 20, name: 'bar' } ];
 const defaultArgs = {
 	orderby: 'menu_order',
 	order: 'asc',

--- a/assets/js/components/icons/external.js
+++ b/assets/js/components/icons/external.js
@@ -12,8 +12,18 @@ export default () => (
 				height="24"
 				viewBox="0 0 24 24"
 			>
-				<mask id="external-mask" width="24" height="24" x="0" y="0" maskUnits="userSpaceOnUse">
-					<path fill="#fff" d="M6.3431 6.3431v1.994l7.8984.0072-8.6055 8.6054 1.4142 1.4143 8.6055-8.6055.0071 7.8984h1.994V6.3431H6.3431z" />
+				<mask
+					id="external-mask"
+					width="24"
+					height="24"
+					x="0"
+					y="0"
+					maskUnits="userSpaceOnUse"
+				>
+					<path
+						fill="#fff"
+						d="M6.3431 6.3431v1.994l7.8984.0072-8.6055 8.6054 1.4142 1.4143 8.6055-8.6055.0071 7.8984h1.994V6.3431H6.3431z"
+					/>
 				</mask>
 				<g mask="url(#external-mask)">
 					<path d="M0 0h24v24H0z" />
@@ -22,4 +32,3 @@ export default () => (
 		}
 	/>
 );
-

--- a/assets/js/components/icons/money.js
+++ b/assets/js/components/icons/money.js
@@ -12,8 +12,20 @@ export default () => (
 				height="24"
 				viewBox="0 0 24 24"
 			>
-				<mask id="money-mask" width="20" height="14" x="2" y="5" maskUnits="userSpaceOnUse">
-					<path fill="#fff" fillRule="evenodd" d="M2 5v14h20V5H2zm5 12c0-1.657-1.343-3-3-3v-4c1.657 0 3-1.343 3-3h10c0 1.657 1.343 3 3 3v4c-1.657 0-3 1.343-3 3H7zm7-5c0-1.7-.9-3-2-3s-2 1.3-2 3 .9 3 2 3 2-1.3 2-3z" clipRule="evenodd" />
+				<mask
+					id="money-mask"
+					width="20"
+					height="14"
+					x="2"
+					y="5"
+					maskUnits="userSpaceOnUse"
+				>
+					<path
+						fill="#fff"
+						fillRule="evenodd"
+						d="M2 5v14h20V5H2zm5 12c0-1.657-1.343-3-3-3v-4c1.657 0 3-1.343 3-3h10c0 1.657 1.343 3 3 3v4c-1.657 0-3 1.343-3 3H7zm7-5c0-1.7-.9-3-2-3s-2 1.3-2 3 .9 3 2 3 2-1.3 2-3z"
+						clipRule="evenodd"
+					/>
 				</mask>
 				<g mask="url(#money-mask)">
 					<path d="M0 0h24v24H0z" />

--- a/assets/js/components/text-toolbar-button/index.js
+++ b/assets/js/components/text-toolbar-button/index.js
@@ -10,13 +10,8 @@ import classnames from 'classnames';
 import './style.scss';
 
 function TextToolbarButton( { className, ...props } ) {
-	const classes = classnames(
-		'wc-block-text-toolbar-button',
-		className
-	);
-	return (
-		<Button className={ classes } { ...props } />
-	);
+	const classes = classnames( 'wc-block-text-toolbar-button', className );
+	return <Button className={ classes } { ...props } />;
 }
 
 export default TextToolbarButton;

--- a/assets/js/data/schema/selectors.js
+++ b/assets/js/data/schema/selectors.js
@@ -33,9 +33,10 @@ import { STORE_KEY } from './constants';
  */
 export const getRoute = createRegistrySelector(
 	( select ) => ( state, namespace, resourceName, ids = [] ) => {
-		const hasResolved = select(
-			STORE_KEY
-		).hasFinishedResolution( 'getRoutes', [ namespace ] );
+		const hasResolved = select( STORE_KEY ).hasFinishedResolution(
+			'getRoutes',
+			[ namespace ]
+		);
 		state = state.routes;
 		let error = '';
 		if ( ! state[ namespace ] ) {
@@ -85,9 +86,10 @@ export const getRoute = createRegistrySelector(
  */
 export const getRoutes = createRegistrySelector(
 	( select ) => ( state, namespace ) => {
-		const hasResolved = select(
-			STORE_KEY
-		).hasFinishedResolution( 'getRoutes', [ namespace ] );
+		const hasResolved = select( STORE_KEY ).hasFinishedResolution(
+			'getRoutes',
+			[ namespace ]
+		);
 		const routes = state.routes[ namespace ];
 		if ( ! routes ) {
 			if ( hasResolved ) {

--- a/assets/js/hocs/test/with-categories.js
+++ b/assets/js/hocs/test/with-categories.js
@@ -18,10 +18,7 @@ jest.mock( '../../base/utils/errors', () => ( {
 	formatError: jest.fn(),
 } ) );
 
-const mockCategories = [
-	{ id: 1, name: 'Clothing' },
-	{ id: 2, name: 'Food' },
-];
+const mockCategories = [ { id: 1, name: 'Clothing' }, { id: 2, name: 'Food' } ];
 const TestComponent = withCategories( ( props ) => {
 	return (
 		<div

--- a/assets/js/hocs/test/with-product-variations.js
+++ b/assets/js/hocs/test/with-product-variations.js
@@ -22,10 +22,7 @@ const mockProducts = [
 	{ id: 1, name: 'Hoodie', variations: [ 3, 4 ] },
 	{ id: 2, name: 'Backpack' },
 ];
-const mockVariations = [
-	{ id: 3, name: 'Blue' },
-	{ id: 4, name: 'Red' },
-];
+const mockVariations = [ { id: 3, name: 'Blue' }, { id: 4, name: 'Red' } ];
 const TestComponent = withProductVariations( ( props ) => {
 	return (
 		<div


### PR DESCRIPTION
Some times, files get pushed to `master` without being formatted by Prettier. This is annoying because when doing changes in those files or doing a merge prettier formats the entire file making your PR get formatting diffs from unrelated changes.

This PR was the result of running `npm run reformat-files` in order to get all files updated.