### PR TITLE
Always filter attribute filters based on price filter

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -66,7 +66,7 @@ const AttributeFilterBlock = ( {
 		shouldSelect: blockAttributes.attributeId > 0,
 	} );
 
-	const filterAvailableFilters =
+	const filterAvailableTerms =
 		blockAttributes.displayStyle !== 'dropdown' &&
 		blockAttributes.queryType === 'and';
 	const {
@@ -77,7 +77,10 @@ const AttributeFilterBlock = ( {
 			taxonomy: attributeObject.taxonomy,
 			queryType: blockAttributes.queryType,
 		},
-		queryState: filterAvailableFilters ? queryState : null,
+		queryState: {
+			...queryState,
+			attributes: filterAvailableTerms ? queryState.attributes : null,
+		},
 	} );
 
 	/**


### PR DESCRIPTION
Fixes #1380.

### Screenshots

![Peek 2019-12-16 12-00](https://user-images.githubusercontent.com/3616980/70901767-b90b4f80-1ffb-11ea-953b-fa4decaead54.gif)

### How to test the changes in this Pull Request:

1. Create a post with _All Products_ + _Price Filter_ + _Attribute Filter_ (with `OR` as query type).
2. Verify when you select attributes filters, others don't disappear (so there are no regressions since #1339).
3. Verify when you update the price slider, attribute filters update and the ones not matching disappear.

### Changelog

> Fix: Attribute filters were not updating based on changes in the Price filter when query type was set to OR.