### PR TITLE
Fix Attribute Fiter count misalignment

### DIFF
--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -16,7 +16,10 @@
 		li {
 			text-decoration: underline;
 
-			label,
+			label {
+				cursor: pointer;
+			}
+
 			input {
 				cursor: pointer;
 				display: inline-block;


### PR DESCRIPTION
Small CSS issue I introduced in #1332. Notice it doesn't affect `release/2.5`.

## Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/70902206-93327a80-1ffc-11ea-873f-65881c2f7a0d.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/70902142-78600600-1ffc-11ea-81b0-3206ebfaa419.png)

### How to test the changes in this Pull Request:

Add an Attribute Filter block and verify counts are aligned to the right.
