### PR TITLE
Update several blocks so they don't support HTML editing

### DIFF
--- a/assets/js/blocks/active-filters/index.js
+++ b/assets/js/blocks/active-filters/index.js
@@ -24,6 +24,7 @@ registerBlockType( 'woocommerce/active-filters', {
 		'woo-gutenberg-products-block'
 	),
 	supports: {
+		html: false,
 		multiple: false,
 	},
 	example: {

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -23,7 +23,9 @@ registerBlockType( 'woocommerce/attribute-filter', {
 		'Display a list of filters based on a chosen product attribute.',
 		'woo-gutenberg-products-block'
 	),
-	supports: {},
+	supports: {
+		html: false,
+	},
 	example: {
 		attributes: {
 			isPreview: true,

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -24,6 +24,7 @@ registerBlockType( 'woocommerce/price-filter', {
 		'woo-gutenberg-products-block'
 	),
 	supports: {
+		html: false,
 		multiple: false,
 	},
 	example: {},

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -26,6 +26,7 @@ registerBlockType( 'woocommerce/product-categories', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
+		html: false,
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/reviews/all-reviews/index.js
+++ b/assets/js/blocks/reviews/all-reviews/index.js
@@ -30,6 +30,9 @@ registerBlockType( 'woocommerce/all-reviews', {
 		'Shows a list of all product reviews.',
 		'woo-gutenberg-products-block'
 	),
+	supports: {
+		html: false,
+	},
 	example: {
 		...example,
 		attributes: {

--- a/assets/js/blocks/reviews/reviews-by-category/index.js
+++ b/assets/js/blocks/reviews/reviews-by-category/index.js
@@ -29,6 +29,9 @@ registerBlockType( 'woocommerce/reviews-by-category', {
 		'Show product reviews from specific categories.',
 		'woo-gutenberg-products-block'
 	),
+	supports: {
+		html: false,
+	},
 	example: {
 		...example,
 		attributes: {

--- a/assets/js/blocks/reviews/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews/reviews-by-product/index.js
@@ -29,6 +29,9 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 		'Show reviews of your product to build trust.',
 		'woo-gutenberg-products-block'
 	),
+	supports: {
+		html: false,
+	},
 	example: {
 		...example,
 		attributes: {


### PR DESCRIPTION
After #1384 I wanted to review all other blocks whether they should support HTML editing or not and I think it makes sense disabling it in several of them.

After this PR, only the _Product Search_ would allow HTML editing.

### How to test the changes in this Pull Request:

Add all filter blocks, reviews blocks and _Product List_ block in a post and verify you can't modify their HTML in the editor.

### Changelog

> HTML edition is no longer supported in several blocks.