### PR TITLE
Fix incorrect property name for price format

### DIFF
--- a/assets/js/base/utils/price.js
+++ b/assets/js/base/utils/price.js
@@ -13,7 +13,7 @@ import { CURRENCY } from '@woocommerce/settings';
  */
 export const formatPrice = (
 	value,
-	priceFormat = CURRENCY.price_format,
+	priceFormat = CURRENCY.priceFormat,
 	currencySymbol = CURRENCY.symbol
 ) => {
 	const formattedNumber = parseInt( value, 10 );

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -118,7 +118,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 					maxPrice={ max }
 					step={ 10 }
 					currencySymbol={ CURRENCY.symbol }
-					priceFormat={ CURRENCY.price_format }
+					priceFormat={ CURRENCY.priceFormat }
 					showInputFields={ attributes.showInputFields }
 					showFilterButton={ attributes.showFilterButton }
 					onChange={ onChange }


### PR DESCRIPTION
Fixes: #1396 

See #1396 for background.  The reason why the active filter block was not showing the price values is because the default for the price format argument was `CURRENCY.price_format` instead of `CURRENCY.priceFormat`.  We never noticed this before because until #1292 was merged, we were always loading the backwards compatible version of `wcSettings` which included both `price_format` and `priceFormat` in the currency values.  

## To Test

- Verify the active filters block correctly shows the selected price from the price filters.