### PR TITLE
Remove extra colon in active filter block

### DIFF
--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -34,7 +34,7 @@ const ActiveFiltersBlock = ( {
 			return null;
 		}
 		return renderRemovableListItem(
-			__( 'Price:', 'woo-gutenberg-products-block' ),
+			__( 'Price', 'woo-gutenberg-products-block' ),
 			formatPriceRange( minPrice, maxPrice ),
 			() => {
 				setMinPrice( null );


### PR DESCRIPTION
Fix extracted from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1394. Filter blocks automatically add a colon to the filter name, e.g. `Price` becomes `Price:`, therefore we should not pass `Price:` to `renderRemovableListItem`.

### How to test the changes in this Pull Request:

1. Filter by price with active filters block active
2. Check block label

cc @Aljullu 

### Changelog

> Remove double colon on active filter block price label.
