### PR TITLE
Fix broken atomic blocks in the All Products Block

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 	],
 	"sideEffects": [
 		"*.css",
-		"*.scss"
+		"*.scss",
+		"./assets/js/atomic/blocks/product/**"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Fixes #1398 

In #1363 I introduced a configuration to the `package.json` that enabled tree-shaking for our builds.  Unfortunately, what I didn't realize (or forgot) is that the atomic blocks used with the All Products block are [imported directly into the all products entry point](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/515b386601eb508cf7f7a196fd475031c1491196/assets/js/blocks/products/all-products/index.js#L15).  Webpack will _drop_ these imports from final builds unless they are explicitly marked as an exclusion in the `package.json` configuration for `sideEffects`.  This pull does that.

I also did a search to make sure there are no other direct imports anywhere that should be handled as well.

## To test

You can reproduce this issue on master by simply running `npm run build` and testing the with the built bundle.  If you do the same on this branch you will not see any errors with editing the inner block template for the All Products block.

**Note**:  This does increase the bundle size of the `all-products.js` file but I think that's okay for the admin side.  The frontend build remains unaffected.