### PR TITLE
Translator string feedback

### DIFF
--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -40,6 +40,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 								value: 'list',
 							},
 							{
+								/* translators: "Chips" is a tag-like display style for chosen attributes. */
 								label: __(
 									'Chips',
 									'woo-gutenberg-products-block'

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -12,8 +12,8 @@ import { formatPrice } from '@woocommerce/base-utils';
  */
 export const formatPriceRange = ( minPrice, maxPrice ) => {
 	if ( Number.isFinite( minPrice ) && Number.isFinite( maxPrice ) ) {
-		/* translators: %s min price, %s max price */
 		return sprintf(
+			/* translators: %s min price, %s max price */
 			__( 'Between %s and %s', 'woo-gutenberg-products-block' ),
 			formatPrice( minPrice ),
 			formatPrice( maxPrice )
@@ -21,15 +21,15 @@ export const formatPriceRange = ( minPrice, maxPrice ) => {
 	}
 
 	if ( Number.isFinite( minPrice ) ) {
-		/* translators: %s min price */
 		return sprintf(
+			/* translators: %s min price */
 			__( 'From %s', 'woo-gutenberg-products-block' ),
 			formatPrice( minPrice )
 		);
 	}
 
-	/* translators: %s max price */
 	return sprintf(
+		/* translators: %s max price */
 		__( 'Up to %s', 'woo-gutenberg-products-block' ),
 		formatPrice( maxPrice )
 	);


### PR DESCRIPTION
Addresses some issues raised by the Global team/translators.

- Translator comments must immediately precede a line with placeholders/translation strings otherwise they won't be picked up. In this case, extra line breaks may have been added after the fact.
- "Chips" was causing confusion as it has no context. We don't display potato snacks so I've added a little extra description. 