### PR TITLE
Store API: Add customer endpoints

### DIFF
--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -95,11 +95,12 @@ class RestApi {
 			'store-cart'                    => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\Cart',
 			'store-cart-items'              => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\CartItems',
 			'store-cart-coupons'            => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\CartCoupons',
+			'store-cart-shipping-rates'     => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\CartShippingRates',
+			'store-customer'                => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\Customer',
 			'store-products'                => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\Products',
 			'store-product-collection-data' => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductCollectionData',
 			'store-product-attributes'      => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductAttributes',
 			'store-product-attribute-terms' => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\ProductAttributeTerms',
-			'store-cart-shipping-rates'     => __NAMESPACE__ . '\RestApi\StoreApi\Controllers\CartShippingRates',
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Controllers/Customer.php
+++ b/src/RestApi/StoreApi/Controllers/Customer.php
@@ -103,6 +103,7 @@ class Customer extends RestController {
 	 */
 	public function update_item( $request ) {
 		$customer = wc()->cart->get_customer();
+		$schema   = $this->get_item_schema();
 
 		if ( ! $customer || ! $customer instanceof CustomerObject ) {
 			return new RestError(
@@ -114,14 +115,14 @@ class Customer extends RestController {
 
 		try {
 			if ( isset( $request['billing'] ) ) {
-				$allowed_billing_values = array_intersect_key( $request['billing'], ( $this->get_item_schema() )['properties']['billing']['properties'] );
+				$allowed_billing_values = array_intersect_key( $request['billing'], $schema['properties']['billing']['properties'] );
 				foreach ( $allowed_billing_values as $key => $value ) {
 					$customer->{"set_billing_$key"}( $value );
 				}
 			}
 
 			if ( isset( $request['shipping'] ) ) {
-				$allowed_shipping_values = array_intersect_key( $request['shipping'], ( $this->get_item_schema() )['properties']['shipping']['properties'] );
+				$allowed_shipping_values = array_intersect_key( $request['shipping'], $schema['properties']['shipping']['properties'] );
 				foreach ( $allowed_shipping_values as $key => $value ) {
 					$customer->{"set_shipping_$key"}( $value );
 				}

--- a/src/RestApi/StoreApi/Controllers/Customer.php
+++ b/src/RestApi/StoreApi/Controllers/Customer.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Customer controller.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers;
+
+defined( 'ABSPATH' ) || exit;
+
+use \WP_Error as RestError;
+use \WP_REST_Server as RestServer;
+use \WP_REST_Controller as RestController;
+use \WC_Customer as CustomerObject;
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CustomerSchema;
+
+/**
+ * Customer API.
+ */
+class Customer extends RestController {
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/store';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'customer';
+
+	/**
+	 * Schema class instance.
+	 *
+	 * @var object
+	 */
+	protected $schema;
+
+	/**
+	 * Setup API class.
+	 */
+	public function __construct() {
+		$this->schema = new CustomerSchema();
+	}
+
+	/**
+	 * Register routes.
+	 *
+	 * @todo /session
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'  => RestServer::READABLE,
+					'callback' => [ $this, 'get_item' ],
+					'args'     => [
+						'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Get the current customer.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$customer = wc()->cart->get_customer();
+
+		if ( ! $customer || ! $customer instanceof CustomerObject ) {
+			return new RestError(
+				'woocommerce_rest_customer_error',
+				__( 'Unable to retrieve customer.', 'woo-gutenberg-products-block' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return $this->prepare_item_for_response( $customer, $request );
+	}
+
+	/**
+	 * Customer item schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		return $this->schema->get_item_schema();
+	}
+
+	/**
+	 * Prepares a single item output for response.
+	 *
+	 * @param CustomerObject   $customer    Customer Object.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $customer, $request ) {
+		return rest_ensure_response( $this->schema->get_item_response( $customer ) );
+	}
+}

--- a/src/RestApi/StoreApi/README.md
+++ b/src/RestApi/StoreApi/README.md
@@ -1011,6 +1011,101 @@ Example response:
 ]
 ```
 
+## Customer API
+
+### Get data for the current customer
+
+```http
+GET /cart/customer
+```
+
+There are no parameters required for this endpoint.
+
+```http
+curl "https://example-store.com/wp-json/wc/store/customer"
+```
+
+Example response:
+
+```json
+{
+  "id": 0,
+  "billing": {
+    "first_name": "Margaret",
+    "last_name": "Thatchcroft",
+    "company": "",
+    "address_1": "123 South Street",
+    "address_2": "Apt 1",
+    "city": "Philadelphia",
+    "state": "PA",
+    "postcode": "19123",
+    "country": "US",
+    "email": "test@test.com",
+    "phone": ""
+  },
+  "shipping": {
+    "first_name": "Margaret",
+    "last_name": "Thatchcroft",
+    "company": "",
+    "address_1": "123 South Street",
+    "address_2": "Apt 1",
+    "city": "Philadelphia",
+    "state": "PA",
+    "postcode": "19123",
+    "country": "US"
+  }
+}
+```
+
+### Edit data for the current customer
+
+Edit current customer data, such as billing and shipping addresses.
+
+```http
+PUT /cart/customer
+```
+
+| Attribute  | Type    | Required | Description                        |
+| :--------- | :------ | :------: | :--------------------------------- |
+| `billing`  | object  |   No     | Billing address properties.        |
+| `shipping` | object  |   No     | Shipping address properties.       |
+
+```http
+curl --request PUT https://example-store.com/wp-json/wc/store/cart/customer?billing[company]=Test
+```
+
+Example response:
+
+```json
+{
+  "id": 0,
+  "billing": {
+    "first_name": "Margaret",
+    "last_name": "Thatchcroft",
+    "company": "Test",
+    "address_1": "123 South Street",
+    "address_2": "Apt 1",
+    "city": "Philadelphia",
+    "state": "PA",
+    "postcode": "19123",
+    "country": "US",
+    "email": "test@test.com",
+    "phone": ""
+  },
+  "shipping": {
+    "first_name": "Margaret",
+    "last_name": "Thatchcroft",
+    "company": "",
+    "address_1": "123 South Street",
+    "address_2": "Apt 1",
+    "city": "Philadelphia",
+    "state": "PA",
+    "postcode": "19123",
+    "country": "US"
+  }
+}
+```
+
 ## Product Attributes API
 
 ```http

--- a/src/RestApi/StoreApi/Schemas/CustomerSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CustomerSchema.php
@@ -165,7 +165,7 @@ class CustomerSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $object ) {
 		return [
-			'id'       => is_user_logged_in() ? $object->get_id() : 0,
+			'id'       => $object->get_id(),
 			'billing'  => [
 				'first_name' => $object->get_billing_first_name(),
 				'last_name'  => $object->get_billing_last_name(),

--- a/src/RestApi/StoreApi/Schemas/CustomerSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CustomerSchema.php
@@ -29,150 +29,126 @@ class CustomerSchema extends AbstractSchema {
 	 */
 	protected function get_properties() {
 		return [
-			'id'         => [
-				'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+			'id'       => [
+				'description' => __( 'Customer ID. Will return 0 if the customer is logged out.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'username'   => [
-				'description' => __( 'Customer login name.', 'woo-gutenberg-products-block' ),
-				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
-				'readonly'    => true,
-			],
-			'first_name' => [
-				'description' => __( 'Customer first name.', 'woo-gutenberg-products-block' ),
-				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
-				'arg_options' => [
-					'sanitize_callback' => 'sanitize_text_field',
-				],
-			],
-			'last_name'  => [
-				'description' => __( 'Customer last name.', 'woo-gutenberg-products-block' ),
-				'type'        => 'string',
-				'context'     => [ 'view', 'edit' ],
-				'arg_options' => [
-					'sanitize_callback' => 'sanitize_text_field',
-				],
-			],
-			'email'      => [
-				'description' => __( 'The email address for the customer.', 'woo-gutenberg-products-block' ),
-				'type'        => 'string',
-				'format'      => 'email',
-				'context'     => [ 'view', 'edit' ],
-			],
-			'billing'    => [
+			'billing'  => [
 				'description' => __( 'List of billing address data.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
 				'properties'  => [
 					'first_name' => [
-						'description' => __( 'First name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'First name of the customer for the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'last_name'  => [
-						'description' => __( 'Last name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Last name of the customer for the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'company'    => [
-						'description' => __( 'Company name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Company name for the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'address_1'  => [
-						'description' => __( 'Address line 1', 'woo-gutenberg-products-block' ),
+						'description' => __( 'First line of the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'address_2'  => [
-						'description' => __( 'Address line 2', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Second line of the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'city'       => [
-						'description' => __( 'City name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'City of the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'state'      => [
-						'description' => __( 'ISO code or name of the state, province or district.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'ISO code, or name, for the state, province, or district of the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'postcode'   => [
-						'description' => __( 'Postal code.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Zip or Postcode of the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'country'    => [
-						'description' => __( 'ISO code of the country.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'ISO country code for the billing address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'email'      => [
-						'description' => __( 'Email address.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'The billing email address of the customer.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'format'      => 'email',
 						'context'     => [ 'view', 'edit' ],
+						'arg_options' => [
+							'sanitize_callback' => 'sanitize_email',
+							'validate_callback' => 'is_email',
+						],
 					],
 					'phone'      => [
-						'description' => __( 'Phone number.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'The billing contact number of the customer.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 				],
 			],
-			'shipping'   => [
+			'shipping' => [
 				'description' => __( 'List of shipping address data.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
 				'properties'  => [
 					'first_name' => [
-						'description' => __( 'First name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'First name of the customer for the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'last_name'  => [
-						'description' => __( 'Last name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Last name of the customer for the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'company'    => [
-						'description' => __( 'Company name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Company name for the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'address_1'  => [
-						'description' => __( 'Address line 1', 'woo-gutenberg-products-block' ),
+						'description' => __( 'First line of the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'address_2'  => [
-						'description' => __( 'Address line 2', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Second line of the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'city'       => [
-						'description' => __( 'City name.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'City of the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'state'      => [
-						'description' => __( 'ISO code or name of the state, province or district.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'ISO code, or name, for the state, province, or district of the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'postcode'   => [
-						'description' => __( 'Postal code.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Zip or Postcode of the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
 					'country'    => [
-						'description' => __( 'ISO code of the country.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'ISO country code for the shipping address.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'context'     => [ 'view', 'edit' ],
 					],
@@ -189,12 +165,8 @@ class CustomerSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $object ) {
 		return [
-			'id'         => $object->get_id(),
-			'username'   => $object->get_username(),
-			'first_name' => $object->get_first_name(),
-			'last_name'  => $object->get_last_name(),
-			'email'      => $object->get_email(),
-			'billing'    => [
+			'id'       => is_user_logged_in() ? $object->get_id() : 0,
+			'billing'  => [
 				'first_name' => $object->get_billing_first_name(),
 				'last_name'  => $object->get_billing_last_name(),
 				'company'    => $object->get_billing_company(),
@@ -207,7 +179,7 @@ class CustomerSchema extends AbstractSchema {
 				'email'      => $object->get_billing_email(),
 				'phone'      => $object->get_billing_phone(),
 			],
-			'shipping'   => [
+			'shipping' => [
 				'first_name' => $object->get_shipping_first_name(),
 				'last_name'  => $object->get_shipping_last_name(),
 				'company'    => $object->get_shipping_company(),

--- a/src/RestApi/StoreApi/Schemas/CustomerSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CustomerSchema.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Customer schema.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
+
+defined( 'ABSPATH' ) || exit;
+
+use \WC_Customer as CustomerObject;
+
+/**
+ * CustomerSchema class.
+ */
+class CustomerSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'customer';
+
+	/**
+	 * Customer schema properties.
+	 *
+	 * @return array
+	 */
+	protected function get_properties() {
+		return [
+			'id'         => [
+				'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'username'   => [
+				'description' => __( 'Customer login name.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'first_name' => [
+				'description' => __( 'Customer first name.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'arg_options' => [
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			],
+			'last_name'  => [
+				'description' => __( 'Customer last name.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'arg_options' => [
+					'sanitize_callback' => 'sanitize_text_field',
+				],
+			],
+			'email'      => [
+				'description' => __( 'The email address for the customer.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'format'      => 'email',
+				'context'     => [ 'view', 'edit' ],
+			],
+			'billing'    => [
+				'description' => __( 'List of billing address data.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => [
+					'first_name' => [
+						'description' => __( 'First name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'last_name'  => [
+						'description' => __( 'Last name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'company'    => [
+						'description' => __( 'Company name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'address_1'  => [
+						'description' => __( 'Address line 1', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'address_2'  => [
+						'description' => __( 'Address line 2', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'city'       => [
+						'description' => __( 'City name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'state'      => [
+						'description' => __( 'ISO code or name of the state, province or district.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'postcode'   => [
+						'description' => __( 'Postal code.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'country'    => [
+						'description' => __( 'ISO code of the country.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'email'      => [
+						'description' => __( 'Email address.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'format'      => 'email',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'phone'      => [
+						'description' => __( 'Phone number.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+				],
+			],
+			'shipping'   => [
+				'description' => __( 'List of shipping address data.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => [
+					'first_name' => [
+						'description' => __( 'First name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'last_name'  => [
+						'description' => __( 'Last name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'company'    => [
+						'description' => __( 'Company name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'address_1'  => [
+						'description' => __( 'Address line 1', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'address_2'  => [
+						'description' => __( 'Address line 2', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'city'       => [
+						'description' => __( 'City name.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'state'      => [
+						'description' => __( 'ISO code or name of the state, province or district.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'postcode'   => [
+						'description' => __( 'Postal code.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+					'country'    => [
+						'description' => __( 'ISO code of the country.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+						'context'     => [ 'view', 'edit' ],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Convert a woo customer into an object suitable for the response.
+	 *
+	 * @param CustomerObject $object Customer object.
+	 * @return array
+	 */
+	public function get_item_response( $object ) {
+		return [
+			'id'         => $object->get_id(),
+			'username'   => $object->get_username(),
+			'first_name' => $object->get_first_name(),
+			'last_name'  => $object->get_last_name(),
+			'email'      => $object->get_email(),
+			'billing'    => [
+				'first_name' => $object->get_billing_first_name(),
+				'last_name'  => $object->get_billing_last_name(),
+				'company'    => $object->get_billing_company(),
+				'address_1'  => $object->get_billing_address_1(),
+				'address_2'  => $object->get_billing_address_2(),
+				'city'       => $object->get_billing_city(),
+				'state'      => $object->get_billing_state(),
+				'postcode'   => $object->get_billing_postcode(),
+				'country'    => $object->get_billing_country(),
+				'email'      => $object->get_billing_email(),
+				'phone'      => $object->get_billing_phone(),
+			],
+			'shipping'   => [
+				'first_name' => $object->get_shipping_first_name(),
+				'last_name'  => $object->get_shipping_last_name(),
+				'company'    => $object->get_shipping_company(),
+				'address_1'  => $object->get_shipping_address_1(),
+				'address_2'  => $object->get_shipping_address_2(),
+				'city'       => $object->get_shipping_city(),
+				'state'      => $object->get_shipping_state(),
+				'postcode'   => $object->get_shipping_postcode(),
+				'country'    => $object->get_shipping_country(),
+			],
+		];
+	}
+}

--- a/tests/php/RestApi/StoreApi/Controllers/Customer.php
+++ b/tests/php/RestApi/StoreApi/Controllers/Customer.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Controller Tests.
+ *
+ * @package WooCommerce\Blocks\Tests
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\RestApi\StoreApi\Controllers;
+
+use \WP_REST_Request;
+use \WC_REST_Unit_Test_Case as TestCase;
+use \WC_Helper_Product as ProductHelper;
+
+/**
+ * Customer Controller Tests.
+ */
+class Customer extends TestCase {
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+		$this->assertArrayHasKey( '/wc/store/customer', $routes );
+	}
+
+	/**
+	 * Test getting customer data.
+	 */
+	public function test_get_item() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/customer' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'billing', $data );
+		$this->assertArrayHasKey( 'shipping', $data );
+	}
+
+	/**
+	 * Test updating customer data.
+	 */
+	public function test_update_item() {
+		$request = new WP_REST_Request( 'POST', '/wc/store/customer' );
+		$request->set_body_params(
+			[
+				'billing' => [
+					'address_1' => '123 South Street',
+					'address_2' => 'Apt 1',
+					'city'      => 'Philadelphia',
+					'state'     => 'PA',
+					'postcode'  => '19123',
+					'country'   => 'US',
+				],
+			]
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( '123 South Street', $data['billing']['address_1'] );
+		$this->assertEquals( 'Apt 1', $data['billing']['address_2'] );
+		$this->assertEquals( 'Philadelphia', $data['billing']['city'] );
+		$this->assertEquals( 'PA', $data['billing']['state'] );
+		$this->assertEquals( '19123', $data['billing']['postcode'] );
+		$this->assertEquals( 'US', $data['billing']['country'] );
+
+		// Invalid email.
+		$request = new WP_REST_Request( 'POST', '/wc/store/customer' );
+		$request->set_body_params(
+			[
+				'billing' => [
+					'email' => 'not-an-email',
+				],
+			]
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+	/**
+	 * Test delete customer data.
+	 */
+	public function test_delete_items() {
+		$request  = new WP_REST_Request( 'DELETE', '/wc/store/cart/items' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( [], $data );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart/items' ) );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 0, count( $data ) );
+	}
+
+	/**
+	 * Test schema retrieval.
+	 */
+	public function test_get_item_schema() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\Customer();
+		$schema     = $controller->get_item_schema();
+
+		$this->assertArrayHasKey( 'id', $schema['properties'] );
+		$this->assertArrayHasKey( 'billing', $schema['properties'] );
+		$this->assertArrayHasKey( 'shipping', $schema['properties'] );
+	}
+
+	/**
+	 * Test conversion of customer data to rest response.
+	 */
+	public function test_prepare_item_for_response() {
+		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Controllers\Customer();
+		$customer   = new \WC_Customer();
+
+		$customer->set_billing_first_name( 'Name' );
+		$customer->set_billing_last_name( 'Surname' );
+		$customer->set_billing_email( 'test@test.com' );
+		$customer->set_billing_phone( '+44 01010101011' );
+		$customer->set_billing_address_1( '123 South Street' );
+		$customer->set_billing_address_2( 'Apt 1' );
+		$customer->set_billing_city( 'Philadelphia' );
+		$customer->set_billing_state( 'PA' );
+		$customer->set_billing_postcode( '19123' );
+		$customer->set_billing_country( 'US' );
+
+		$customer->set_shipping_first_name( 'Name' );
+		$customer->set_shipping_last_name( 'Surname' );
+		$customer->set_shipping_address_1( '123 South Street' );
+		$customer->set_shipping_address_2( 'Apt 1' );
+		$customer->set_shipping_city( 'Philadelphia' );
+		$customer->set_shipping_state( 'PA' );
+		$customer->set_shipping_postcode( '19123' );
+		$customer->set_shipping_country( 'US' );
+
+		$response = $controller->prepare_item_for_response( $customer, [] );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'Name', $data['billing']['first_name'] );
+		$this->assertEquals( 'Surname', $data['billing']['last_name'] );
+		$this->assertEquals( '123 South Street', $data['billing']['address_1'] );
+		$this->assertEquals( 'Apt 1', $data['billing']['address_2'] );
+		$this->assertEquals( 'Philadelphia', $data['billing']['city'] );
+		$this->assertEquals( 'PA', $data['billing']['state'] );
+		$this->assertEquals( '19123', $data['billing']['postcode'] );
+		$this->assertEquals( 'US', $data['billing']['country'] );
+
+		$this->assertEquals( 'Name', $data['shipping']['first_name'] );
+		$this->assertEquals( 'Surname', $data['shipping']['last_name'] );
+		$this->assertEquals( '123 South Street', $data['shipping']['address_1'] );
+		$this->assertEquals( 'Apt 1', $data['shipping']['address_2'] );
+		$this->assertEquals( 'Philadelphia', $data['shipping']['city'] );
+		$this->assertEquals( 'PA', $data['shipping']['state'] );
+		$this->assertEquals( '19123', $data['shipping']['postcode'] );
+		$this->assertEquals( 'US', $data['shipping']['country'] );
+	}
+}

--- a/tests/php/RestApi/StoreApi/Controllers/Customer.php
+++ b/tests/php/RestApi/StoreApi/Controllers/Customer.php
@@ -80,24 +80,6 @@ class Customer extends TestCase {
 	}
 
 	/**
-	 * Test delete customer data.
-	 */
-	public function test_delete_items() {
-		$request  = new WP_REST_Request( 'DELETE', '/wc/store/cart/items' );
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( [], $data );
-
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart/items' ) );
-		$data     = $response->get_data();
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 0, count( $data ) );
-	}
-
-	/**
 	 * Test schema retrieval.
 	 */
 	public function test_get_item_schema() {


### PR DESCRIPTION
Adds endpoints to get and update customer session data (addresses) from the Store API.

Closes #1320

Readme is updated. This endpoint allows the cart and checkout to update and retrieve addresses which will be useful for populating defaults on the checkout form.

There were a few questions in the issue, so to answer those:

> Since this API requires no authentication, do we require additional mechanisms in place to ensure requests only come from the store?

This API should only ever expose the "current" customer. So be it a logged in user or a guest. The only data exposed is addresses, since those can be updated by the customer themselves.

> How do we surface address fields for extensions to extend/add to?

It's not clear if or what is needed for this yet, and there are places in core which need extending too. We should get feedback before making a decision here. If needed, we can make schemas filterable and expose the get/update routines.

> What validation is needed for addresses etc?

Validation is being left for the customer class. Email however does have some basic prop validation via REST API args in the schema.

> Are we happy with /customer or would it make more sense to expose /session and include all session data from the server?

Some session data might be private, and it shouldn't really be editable by a user. Because of this, we're just exposing addresses.

**How to test the changes in this Pull Request:**

- Check `wc/store/customer` lists address data. If you have a user account with saved addresses, you can test the response by enabling basic auth and logging in whilst making the request.
- Try to update some address by doing a PUT request to `wc/store/customer`.


