### PR TITLE
Update filter blocks descriptions to explain they only work with the All Products block

### DIFF
--- a/assets/js/blocks/active-filters/index.js
+++ b/assets/js/blocks/active-filters/index.js
@@ -20,7 +20,7 @@ registerBlockType( 'woocommerce/active-filters', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a list of active product filters.',
+		'Display a list of active product filters. Works in combination with the Filter Products by Price and Filter Products by Attribute blocks.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -20,7 +20,7 @@ registerBlockType( 'woocommerce/attribute-filter', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a list of filters based on a chosen product attribute.',
+		'Display a list of filters based on a chosen product attribute. Works in combination with the All Products block.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -20,7 +20,7 @@ registerBlockType( 'woocommerce/price-filter', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a slider to filter products in your store by price.',
+		'Display a slider to filter products in your store by price. Works in combination with the All Products block.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/readme.txt
+++ b/readme.txt
@@ -67,7 +67,7 @@ Display a slider to filter products in your store by price. Works in combination
 Display a list of filters based on a chosen product attribute. Works in combination with the _All Products_ block. Requires WordPress 5.3.
 
 **Active Product Filters**
-Display a list of active product filters. Works in combination with the _Filter Products by Price_ and _Filter Products by Attribute_ block. Requires WordPress 5.3.
+Display a list of active product filters. Works in combination with the _Filter Products by Price_ and _Filter Products by Attribute_ blocks. Requires WordPress 5.3.
 
 We've also improved the category selection filter. If you select two or more categories, you can now chose to show products that include ANY or ALL selected categories.
 


### PR DESCRIPTION
Fixes #1416 

Updates the _Active Filters_, _Filter by Price_ and _Filter by Attribute_ descriptions. In #1416 I proposed a different wording, but instead I copied the descriptions we have in the `README` to keep it consistent.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/71169703-d50c2c80-2259-11ea-9570-e80e52561222.png)
