### PR TITLE
Fix double 'yet yet'

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -233,7 +233,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		>
 			<p>
 				{ __(
-					"Attributes are needed for filtering your products. You haven't created any attributes yet yet.",
+					"Attributes are needed for filtering your products. You haven't created any attributes yet.",
 					'woo-gutenberg-products-block'
 				) }
 			</p>


### PR DESCRIPTION
Found during translation of WooCommerce 
Permalink - https://translate.wordpress.org/projects/wp-plugins/woocommerce/dev/en-ca/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=8771164&filters%5Btranslation_id%5D=68202906
