### PR TITLE
Remove style-loader

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -226,7 +226,6 @@ const getMainConfig = ( options = {} ) => {
 				{
 					test: /\.s[c|a]ss$/,
 					use: [
-						'style-loader',
 						MiniCssExtractPlugin.loader,
 						{ loader: 'css-loader', options: { importLoaders: 1 } },
 						'postcss-loader',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18684,28 +18684,6 @@
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
-    "style-loader": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.1.tgz",
-      "integrity": "sha512-oIVF12trRq0od4Yojg7q0K3Lq/O6Ix/AYgVosykrVg+kWxxxUyk8KhKCCmekyGSUiVK1xxlAQymLWWdh6S9lOg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.0.1"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.1.tgz",
-          "integrity": "sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.10.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        }
-      }
-    },
     "style-search": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
 		"request-promise": "4.2.5",
 		"rimraf": "3.0.0",
 		"sass-loader": "7.3.1",
-		"style-loader": "1.1.1",
 		"stylelint": "12.0.0",
 		"stylelint-config-wordpress": "13.1.0",
 		"webpack": "4.41.2",


### PR DESCRIPTION
`style-loader` 1.1.1 was not playing well when used in parallel with `MiniCssExtractPlugin.loader` and builds were failing. A fix was introduced in 1.1.2 but will be removed in next major version.

Actually, we don't seem to need `style-loader` at all, so this PR removes it.

### How to test the changes in this Pull Request:

1. `npm run start` and verify styles load correctly both in the editor and the frontend.
2. Repeat the same running `npm run build`.