### PR TITLE
Fix Cart buttons misalignment in Firefox

### DIFF
--- a/assets/js/components/text-toolbar-button/style.scss
+++ b/assets/js/components/text-toolbar-button/style.scss
@@ -1,4 +1,6 @@
 .wc-block-text-toolbar-button {
+	align-items: center;
+
 	&.is-toggled,
 	&.is-toggled:focus {
 		background: $core-grey-dark-500;


### PR DESCRIPTION
Fixes #1432.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/71510299-b4ae2480-288e-11ea-9595-543dcb1d3c72.png)

### How to test the changes in this Pull Request:

1. First, you will need to merge #1445 to get builds passing: `git merge update/style-loader-broken-build`.
2. Then, add a _Cart_ block to a post using Firefox and verify _Full Cart_ and _Empty Cart_ buttons are aligned.
