### PR TITLE
Fix empty cart inner blocks disabled

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
+import { Disabled, Toolbar } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import TextToolbarButton from '@woocommerce/block-components/text-toolbar-button';
 import PropTypes from 'prop-types';
@@ -49,7 +49,11 @@ const CartEditor = ( { className } ) => {
 	return (
 		<div className={ className }>
 			{ getBlockControls() }
-			{ isFullCartMode && <FullCart /> }
+			{ isFullCartMode && (
+				<Disabled>
+					<FullCart />
+				</Disabled>
+			) }
 			<EmptyCart hidden={ isFullCartMode } />
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { Disabled } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -39,11 +38,7 @@ registerBlockType( 'woocommerce/cart', {
 	 * @param {Object} props Props to pass to block.
 	 */
 	edit( props ) {
-		return (
-			<Disabled>
-				<Editor { ...props } />
-			</Disabled>
-		);
+		return <Editor { ...props } />;
 	},
 
 	/**


### PR DESCRIPTION
Fixes #1433.

### How to test the changes in this Pull Request:

1. Add a _Cart_ block.
2. Switch to the _Empty Cart_ tab.
3. Verify you can add and remove inner blocks.