### PR TITLE
Remove minor unit from price filter

### DIFF
--- a/assets/js/blocks/price-filter/test/use-price-constraints.js
+++ b/assets/js/blocks/price-filter/test/use-price-constraints.js
@@ -11,8 +11,8 @@ import { ROUND_UP, ROUND_DOWN } from '../constants';
 
 describe( 'usePriceConstraints', () => {
 	const TestComponent = ( { price } ) => {
-		const maxPriceConstraint = usePriceConstraint( price, 2, ROUND_UP );
-		const minPriceConstraint = usePriceConstraint( price, 2, ROUND_DOWN );
+		const maxPriceConstraint = usePriceConstraint( price, ROUND_UP );
+		const minPriceConstraint = usePriceConstraint( price, ROUND_DOWN );
 		return (
 			<div
 				minPriceConstraint={ minPriceConstraint }
@@ -22,61 +22,61 @@ describe( 'usePriceConstraints', () => {
 	};
 
 	it( 'max price constraint should be updated when new price is set', () => {
-		const renderer = TestRenderer.create( <TestComponent price={ 1000 } /> );
+		const renderer = TestRenderer.create( <TestComponent price={ 10 } /> );
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.maxPriceConstraint ).toBe( 1000 );
+		expect( container.props.maxPriceConstraint ).toBe( 10 );
 
-		renderer.update( <TestComponent price={ 2000 } /> );
+		renderer.update( <TestComponent price={ 20 } /> );
 
-		expect( container.props.maxPriceConstraint ).toBe( 2000 );
+		expect( container.props.maxPriceConstraint ).toBe( 20 );
 	} );
 
 	it( 'min price constraint should be updated when new price is set', () => {
-		const renderer = TestRenderer.create( <TestComponent price={ 1000 } /> );
+		const renderer = TestRenderer.create( <TestComponent price={ 10 } /> );
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.minPriceConstraint ).toBe( 1000 );
+		expect( container.props.minPriceConstraint ).toBe( 10 );
 
-		renderer.update( <TestComponent price={ 2000 } /> );
+		renderer.update( <TestComponent price={ 20 } /> );
 
-		expect( container.props.minPriceConstraint ).toBe( 2000 );
+		expect( container.props.minPriceConstraint ).toBe( 20 );
 	} );
 
 	it( 'previous price constraint should be preserved when new price is not a infinite number', () => {
-		const renderer = TestRenderer.create( <TestComponent price={ 1000 } /> );
+		const renderer = TestRenderer.create( <TestComponent price={ 10 } /> );
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.maxPriceConstraint ).toBe( 1000 );
+		expect( container.props.maxPriceConstraint ).toBe( 10 );
 
 		renderer.update( <TestComponent price={ Infinity } /> );
 
-		expect( container.props.maxPriceConstraint ).toBe( 1000 );
+		expect( container.props.maxPriceConstraint ).toBe( 10 );
 	} );
 
 	it( 'max price constraint should be higher if the price is decimal', () => {
 		const renderer = TestRenderer.create(
-			<TestComponent price={ 1099 } />
+			<TestComponent price={ 10.99 } />
 		);
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.maxPriceConstraint ).toBe( 2000 );
+		expect( container.props.maxPriceConstraint ).toBe( 20 );
 
-		renderer.update( <TestComponent price={ 1999 } /> );
+		renderer.update( <TestComponent price={ 19.99 } /> );
 
-		expect( container.props.maxPriceConstraint ).toBe( 2000 );
+		expect( container.props.maxPriceConstraint ).toBe( 20 );
 	} );
 
 	it( 'min price constraint should be lower if the price is decimal', () => {
 		const renderer = TestRenderer.create(
-			<TestComponent price={ 999 } />
+			<TestComponent price={ 9.99 } />
 		);
 		const container = renderer.root.findByType( 'div' );
 
 		expect( container.props.minPriceConstraint ).toBe( 0 );
 
-		renderer.update( <TestComponent price={ 1999 } /> );
+		renderer.update( <TestComponent price={ 19.99 } /> );
 
-		expect( container.props.minPriceConstraint ).toBe( 1000 );
+		expect( container.props.minPriceConstraint ).toBe( 10 );
 	} );
 } );

--- a/assets/js/blocks/price-filter/use-price-constraints.js
+++ b/assets/js/blocks/price-filter/use-price-constraints.js
@@ -12,20 +12,18 @@ import { ROUND_UP, ROUND_DOWN } from './constants';
  * Return the price constraint.
  *
  * @param {number} price Price in minor unit, e.g. cents.
- * @param {number} minorUnit Price minor unit (number of digits after the decimal separator).
  * @param {ROUND_UP|ROUND_DOWN} direction Rounding flag whether we round up or down.
  */
-export const usePriceConstraint = ( price, minorUnit, direction ) => {
-	const step = 10 * 10 ** minorUnit;
+export const usePriceConstraint = ( price, direction ) => {
 	let currentConstraint;
 	if ( direction === ROUND_UP ) {
 		currentConstraint = isNaN( price )
 			? null
-			: Math.ceil( parseFloat( price, 10 ) / step ) * step;
+			: Math.ceil( parseFloat( price, 10 ) / 10 ) * 10;
 	} else if ( direction === ROUND_DOWN ) {
 		currentConstraint = isNaN( price )
 			? null
-			: Math.floor( parseFloat( price, 10 ) / step ) * step;
+			: Math.floor( parseFloat( price, 10 ) / 10 ) * 10;
 	}
 
 	const previousConstraint = usePrevious( currentConstraint, ( val ) =>
@@ -36,9 +34,9 @@ export const usePriceConstraint = ( price, minorUnit, direction ) => {
 		: previousConstraint;
 };
 
-export default ( { minPrice, maxPrice, minorUnit } ) => {
+export default ( { minPrice, maxPrice } ) => {
 	return {
-		minConstraint: usePriceConstraint( minPrice, minorUnit, ROUND_DOWN ),
-		maxConstraint: usePriceConstraint( maxPrice, minorUnit, ROUND_UP ),
+		minConstraint: usePriceConstraint( minPrice, ROUND_DOWN ),
+		maxConstraint: usePriceConstraint( maxPrice, ROUND_UP ),
 	};
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes an issue of Price filter not working because of the inconsistency of PRs that have been merged, `price-filter/block.js` in 2.5.7 would only call for min_price and max_price while `price-filter/use-constraints.js` would expect minorUnit.
This happened because of two PRs that get merged at the same time targeting the same files. 
This PR should only be merged against 2.5 since those features should be present at master 

### Changelog

> Fixed a bug where Filter by Price didn’t show up.