### PR TITLE
Fix Product Title by not inheriting it from div

### DIFF
--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -91,7 +91,6 @@
 	font-weight: 700;
 	padding: 0;
 	color: inherit;
-	font-size: inherit;
 	display: block;
 
 	.is-loading &::before {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes an issue where product title would inherit it size from the parent div, making it always the same size regardless of what heading level it is

<!-- Reference any related issues or PRs here -->
partially Fixes #1451 since the issue is with Themes and not fully on the plugin

### Changelog

> Fix bug where product title didn’t change size when heading level is changed
