### PR TITLE
Make price slider accurately represent the selected price independently from step

### DIFF
--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -78,21 +78,16 @@ const PriceSlider = ( {
 			};
 		}
 
-		// Normalize to whatever is the closest step (because range input will
-		// only jump to the closest step in the range).
-		const min = Math.round( minPrice / stepValue ) * stepValue;
-		const max = Math.round( maxPrice / stepValue ) * stepValue;
-
 		const low =
 			Math.round(
 				100 *
-					( ( min - minConstraint ) /
+					( ( minPrice - minConstraint ) /
 						( maxConstraint - minConstraint ) )
 			) - 0.5;
 		const high =
 			Math.round(
 				100 *
-					( ( max - minConstraint ) /
+					( ( maxPrice - minConstraint ) /
 						( maxConstraint - minConstraint ) )
 			) + 0.5;
 
@@ -160,8 +155,14 @@ const PriceSlider = ( {
 			);
 			const targetValue = event.target.value;
 			const currentValues = isMin
-				? [ targetValue, maxPrice ]
-				: [ minPrice, targetValue ];
+				? [
+						Math.round( targetValue / stepValue ) * stepValue,
+						maxPrice,
+				  ]
+				: [
+						minPrice,
+						Math.round( targetValue / stepValue ) * stepValue,
+				  ];
 			const values = constrainRangeSliderValues(
 				currentValues,
 				minConstraint,
@@ -227,6 +228,11 @@ const PriceSlider = ( {
 		! hasValidConstraints && 'is-disabled'
 	);
 
+	const minRangeStep =
+		minRange && document.activeElement === minRange.current ? stepValue : 1;
+	const maxRangeStep =
+		maxRange && document.activeElement === maxRange.current ? stepValue : 1;
+
 	return (
 		<div className={ classes }>
 			<div
@@ -249,7 +255,7 @@ const PriceSlider = ( {
 							) }
 							value={ minPrice || 0 }
 							onChange={ rangeInputOnChange }
-							step={ stepValue }
+							step={ minRangeStep }
 							min={ minConstraint }
 							max={ maxConstraint }
 							ref={ minRange }
@@ -264,7 +270,7 @@ const PriceSlider = ( {
 							) }
 							value={ maxPrice || 0 }
 							onChange={ rangeInputOnChange }
-							step={ stepValue }
+							step={ maxRangeStep }
 							min={ minConstraint }
 							max={ maxConstraint }
 							ref={ maxRange }


### PR DESCRIPTION
Fixes #1431

### Screenshots
![Peek 2019-12-30 15-52](https://user-images.githubusercontent.com/3616980/71587023-74fc6c80-2b1c-11ea-9bfe-c4026974140b.gif)

### How to test the changes in this Pull Request:

1. Create a post with _All Products_ and _Price Slider_ blocks.
2. Modify the _Price Filter_ input fields and adds numbers which are not on the allowed steps.
3. Verify the price slider updates accordingly, instead of being rounded to the closest step.

### Changelog

> Make price slider accurately represent the selected price