### PR TITLE
Price filter: allow negative numbers in input fields

### DIFF
--- a/assets/js/base/components/formatted-monetary-amount/index.js
+++ b/assets/js/base/components/formatted-monetary-amount/index.js
@@ -35,7 +35,7 @@ const FormattedMonetaryAmount = ( {
 } ) => {
 	const priceValue = value / 10 ** currency.minorUnit;
 
-	if ( ! Number.isFinite( priceValue ) ) {
+	if ( ! Number.isFinite( priceValue ) && priceValue === '-' ) {
 		return null;
 	}
 

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -247,7 +247,11 @@ const PriceSlider = ( {
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
 							) }
-							value={ minPrice || 0 }
+							value={
+								Number.isFinite( minPrice )
+									? minPrice
+									: minConstraint
+							}
 							onChange={ rangeInputOnChange }
 							step={ stepValue }
 							min={ minConstraint }
@@ -262,7 +266,11 @@ const PriceSlider = ( {
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
 							) }
-							value={ maxPrice || 0 }
+							value={
+								Number.isFinite( maxPrice )
+									? maxPrice
+									: maxConstraint
+							}
 							onChange={ rangeInputOnChange }
 							step={ stepValue }
 							min={ minConstraint }

--- a/assets/js/base/components/price-slider/test/constrain-range-slider-values.js
+++ b/assets/js/base/components/price-slider/test/constrain-range-slider-values.js
@@ -5,17 +5,25 @@ import { constrainRangeSliderValues } from '../constrain-range-slider-values';
 
 describe( 'constrainRangeSliderValues', () => {
 	test.each`
-		values            | min     | max     | step  | isMin    | expected
-		${[ 20, 60 ]}     | ${0}    | ${70}   | ${10} | ${true}  | ${[ 20, 60 ]}
-		${[ 20, 60 ]}     | ${20}   | ${60}   | ${10} | ${true}  | ${[ 20, 60 ]}
-		${[ 20, 60 ]}     | ${30}   | ${50}   | ${10} | ${true}  | ${[ 30, 50 ]}
-		${[ 50, 50 ]}     | ${20}   | ${60}   | ${10} | ${true}  | ${[ 50, 60 ]}
-		${[ 50, 50 ]}     | ${20}   | ${60}   | ${10} | ${false} | ${[ 40, 50 ]}
-		${[ 20, 60 ]}     | ${null} | ${null} | ${10} | ${true}  | ${[ 20, 60 ]}
-		${[ null, null ]} | ${20}   | ${60}   | ${10} | ${true}  | ${[ 20, 60 ]}
-		${[ '20', '60' ]} | ${30}   | ${50}   | ${10} | ${true}  | ${[ 30, 50 ]}
+		values              | min     | max     | step  | isMin    | expected
+		${[ 20, 60 ]}       | ${0}    | ${70}   | ${10} | ${true}  | ${[ 20, 60 ]}
+		${[ 20, 60 ]}       | ${20}   | ${60}   | ${10} | ${true}  | ${[ 20, 60 ]}
+		${[ 20, 60 ]}       | ${30}   | ${50}   | ${10} | ${true}  | ${[ 30, 50 ]}
+		${[ 50, 50 ]}       | ${20}   | ${60}   | ${10} | ${true}  | ${[ 50, 60 ]}
+		${[ 50, 50 ]}       | ${20}   | ${60}   | ${10} | ${false} | ${[ 40, 50 ]}
+		${[ 20, 60 ]}       | ${null} | ${null} | ${10} | ${true}  | ${[ 20, 60 ]}
+		${[ null, null ]}   | ${20}   | ${60}   | ${10} | ${true}  | ${[ 20, 60 ]}
+		${[ '20', '60' ]}   | ${30}   | ${50}   | ${10} | ${true}  | ${[ 30, 50 ]}
+		${[ -60, -20 ]}     | ${-70}  | ${0}    | ${10} | ${true}  | ${[ -60, -20 ]}
+		${[ -60, -20 ]}     | ${-60}  | ${-20}  | ${10} | ${true}  | ${[ -60, -20 ]}
+		${[ -60, -20 ]}     | ${-50}  | ${-30}  | ${10} | ${true}  | ${[ -50, -30 ]}
+		${[ -50, -50 ]}     | ${-60}  | ${-20}  | ${10} | ${true}  | ${[ -50, -40 ]}
+		${[ -50, -50 ]}     | ${-60}  | ${-20}  | ${10} | ${false} | ${[ -60, -50 ]}
+		${[ -60, -20 ]}     | ${null} | ${null} | ${10} | ${true}  | ${[ -60, -20 ]}
+		${[ null, null ]}   | ${-60}  | ${-20}  | ${10} | ${true}  | ${[ -60, -20 ]}
+		${[ '-60', '-20' ]} | ${-50}  | ${-30}  | ${10} | ${true}  | ${[ -50, -30 ]}
 	`(
-		`correctly sets prices to its constraints with arguments $values, $min, $max, $step, $isMin`,
+		`correctly sets prices to its constraints with arguments values: $values, min: $min, max: $max, step: $step and isMin: $isMin`,
 		( { values, min, max, step, isMin, expected } ) => {
 			const constrainedValues = constrainRangeSliderValues(
 				values,

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -61,7 +61,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 		setMaxPriceQuery( maxPrice === maxConstraint ? undefined : maxPrice );
 	}, [ minPrice, maxPrice, minConstraint, maxConstraint ] );
 
-	// Callback when slider is changed.
+	// Callback when slider or input fields are changed.
 	const onChange = useCallback(
 		( prices ) => {
 			if ( prices[ 0 ] !== minPrice ) {

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -105,14 +105,6 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 	}
 
 	const TagName = `h${ attributes.headingLevel }`;
-	const min = Math.max(
-		Number.isFinite( minPrice ) ? minPrice : -Infinity,
-		Number.isFinite( minConstraint ) ? minConstraint : -Infinity
-	);
-	const max = Math.min(
-		Number.isFinite( maxPrice ) ? maxPrice : Infinity,
-		Number.isFinite( maxConstraint ) ? maxConstraint : Infinity
-	);
 
 	return (
 		<Fragment>
@@ -123,8 +115,8 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 				<PriceSlider
 					minConstraint={ minConstraint }
 					maxConstraint={ maxConstraint }
-					minPrice={ min }
-					maxPrice={ max }
+					minPrice={ minPrice }
+					maxPrice={ maxPrice }
 					currency={ currency }
 					showInputFields={ attributes.showInputFields }
 					showFilterButton={ attributes.showFilterButton }


### PR DESCRIPTION
Build on top of #1457 so I could add tests and avoid conflicts.

Fixes #1456.

Per https://github.com/woocommerce/woocommerce/issues/25037#issuecomment-554072804, negative prices are a legit case we want to account for. I think price slider doesn't support them yet, but this PR adds support to the input fields and fixes #1456.

### Screenshots

![Peek 2019-12-31 09-46](https://user-images.githubusercontent.com/3616980/71615633-7aa49180-2bb2-11ea-90a1-a073637ec557.gif)

### How to test the changes in this Pull Request:

1. Create a post with a _Price Filter_ block.
2. Enter negative numbers in the input fields.
3. Verify input fields don't disappear.

### Changelog

> Price filter input fields no longer disappear when pressing the minus key.