### PR TITLE
Show grouped products with tax rate

### DIFF
--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -302,8 +302,8 @@ class ProductSchema extends AbstractSchema {
 
 			if ( ! empty( $child_prices ) ) {
 				return [
-					'min_amount' => $this->prepare_money_response( min( $child_prices ), wc_get_price_decimals() ),
-					'max_amount' => $this->prepare_money_response( max( $child_prices ), wc_get_price_decimals() ),
+					'min_amount' => $this->prepare_money_response( $price_function( $product, [ 'price' => min( $child_prices ) ] ), wc_get_price_decimals() ),
+					'max_amount' => $this->prepare_money_response( $price_function( $product, [ 'price' => max( $child_prices ) ] ), wc_get_price_decimals() ),
 				];
 			}
 		}


### PR DESCRIPTION
Fixes #1491.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/71810284-504f4a00-3072-11ea-9527-9dd0e6b9546a.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/71810271-4594b500-3072-11ea-88e6-20fa5f6b7f6b.png)

### How to test the changes in this Pull Request:

1. Go to _WooCommerce_ > _Settings_ > _Tax_ > _Display prices in the shop_ and select _Including Tax_. You might need to create tax rates if you hadn't done it before.
2. Create  post with an _All Products_ block and make sure you have a grouped product created.
3. Go to the frontend and verify the grouped product shows the prices with taxes.

### Changelog

> Grouped products shown in the All Products block now honor the setting whether prices must include taxes.