### PR TITLE
All Products: fix variable products subtracting taxes in some configurations

### DIFF
--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -281,12 +281,12 @@ class ProductSchema extends AbstractSchema {
 		$price_function   = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
 
 		if ( $product->is_type( 'variable' ) ) {
-			$prices = $product->get_variation_prices( false );
+			$prices = $product->get_variation_prices( true );
 
 			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
 				return [
-					'min_amount' => $this->prepare_money_response( $price_function( $product, [ 'price' => min( $prices['price'] ) ] ), wc_get_price_decimals() ),
-					'max_amount' => $this->prepare_money_response( $price_function( $product, [ 'price' => max( $prices['price'] ) ] ), wc_get_price_decimals() ),
+					'min_amount' => $this->prepare_money_response( min( $prices['price'] ), wc_get_price_decimals() ),
+					'max_amount' => $this->prepare_money_response( max( $prices['price'] ), wc_get_price_decimals() ),
 				];
 			}
 		}

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -278,7 +278,6 @@ class ProductSchema extends AbstractSchema {
 	 */
 	protected function get_price_range( \WC_Product $product ) {
 		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
-		$price_function   = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
 
 		if ( $product->is_type( 'variable' ) ) {
 			$prices = $product->get_variation_prices( true );
@@ -292,7 +291,8 @@ class ProductSchema extends AbstractSchema {
 		}
 
 		if ( $product->is_type( 'grouped' ) ) {
-			$children = array_filter( array_map( 'wc_get_product', $product->get_children() ), 'wc_products_array_filter_visible_grouped' );
+			$children       = array_filter( array_map( 'wc_get_product', $product->get_children() ), 'wc_products_array_filter_visible_grouped' );
+			$price_function = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
 
 			foreach ( $children as $child ) {
 				if ( '' !== $child->get_price() ) {

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -281,7 +281,7 @@ class ProductSchema extends AbstractSchema {
 		$price_function   = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
 
 		if ( $product->is_type( 'variable' ) ) {
-			$prices = $product->get_variation_prices( true );
+			$prices = $product->get_variation_prices( false );
 
 			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
 				return [


### PR DESCRIPTION
Fixes #1502.

We are showing prices excluding or including taxes depending on this line:
```PHP
$price_function   = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
```

So there was no need to tell `get_variation_prices` to handle tax inclusion, otherwise in some occasions we were excluding taxes twice, making prices to be wrong.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/71893012-bc9d7c80-314a-11ea-8754-a607a0b99d9f.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/71892979-aabbd980-314a-11ea-8688-758230e126bb.png)

### How to test the changes in this Pull Request:

1. Go to _WooCommerce_ > _Settings_ > _Taxes_ and select:
  * _Prices entered with tax_ > _Yes, I will enter prices inclusive of tax_ and
  * _Display prices in the shop_ > _Including Tax_.
2. In a post with the _All Products_ block, notice Variable products are shown excluding taxes.
3. Try different combinations of the two settings above and make sure there are no regressions.

### Changelog

> Fix issue in All Products block that was causing Variable products price to exclude taxes in some cases.