### PR TITLE
Remove duplicate application of taxes to price display for grouped products

### DIFF
--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -302,8 +302,8 @@ class ProductSchema extends AbstractSchema {
 
 			if ( ! empty( $child_prices ) ) {
 				return [
-					'min_amount' => $this->prepare_money_response( $price_function( $product, [ 'price' => min( $child_prices ) ] ), wc_get_price_decimals() ),
-					'max_amount' => $this->prepare_money_response( $price_function( $product, [ 'price' => max( $child_prices ) ] ), wc_get_price_decimals() ),
+					'min_amount' => $this->prepare_money_response( min( $child_prices ), wc_get_price_decimals() ),
+					'max_amount' => $this->prepare_money_response( max( $child_prices ), wc_get_price_decimals() ),
 				];
 			}
 		}


### PR DESCRIPTION
Introduced in #1493 (and I reviewed and did not catch!) the changes in that pull unnecessarily applied duplicate application of taxes to price display for _grouped products_.  The appropriate tax methods are already being applied to the child prices so there was no need to apply it again.

I already accounted for this when cherrypicking for 2.5.9 release but am assigning this to the milestone as cherrypicked as well so we have record.

I'm concerned my foggy (sick from head cold) brain might be missing something obvious, but testing seems to confirm this fix is appropriate.

## To test

1. Go to WooCommerce > Settings > Tax > Display prices in the shop and select Including Tax. You might need to create tax rates if you hadn't done it before.
2. Create post with an All Products block and make sure you have a grouped product created.
3. Go to the frontend and verify the grouped product shows the prices with taxes.

## Screenshots

The actual product range price for the group (without taxes) is $18 - $45 and taxes on my store setup are 20%

### Grouped Product (Logo Collection) with bug (duplicate taxes applied to prices)
<img width="802" alt="Image 2020-01-07 at 10 24 58 AM" src="https://user-images.githubusercontent.com/1429108/71906397-fe70f780-3137-11ea-8334-dc00cde6f512.png">

### Grouped Product (Logo Collection) with this pull applied

<img width="831" alt="Image 2020-01-07 at 10 26 09 AM" src="https://user-images.githubusercontent.com/1429108/71906473-24969780-3138-11ea-9f20-e05a300f6200.png">
