### PR TITLE
Add ESLint radix rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
 		'@wordpress/dependency-group': 'off',
 		'woocommerce/dependency-group': 'error',
 		'valid-jsdoc': 'off',
+		radix: 'error',
 		yoda: [ 'error', 'never' ],
 	},
 };

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -83,7 +83,7 @@ const ProductList = ( {
 	);
 	const results = useStoreProducts( queryState );
 	const { products, productsLoading } = results;
-	const totalProducts = parseInt( results.totalProducts );
+	const totalProducts = parseInt( results.totalProducts, 10 );
 
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const totalQuery = extractPaginationAndSortAttributes( queryState );

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -299,7 +299,7 @@ const FeaturedCategory = ( {
 		}
 
 		const onResizeStop = ( event, direction, elt ) => {
-			setAttributes( { height: parseInt( elt.style.height ) } );
+			setAttributes( { height: parseInt( elt.style.height, 10 ) } );
 		};
 
 		return (

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -284,7 +284,7 @@ const FeaturedProduct = ( {
 		}
 
 		const onResizeStop = ( event, direction, elt ) => {
-			setAttributes( { height: parseInt( elt.style.height ) } );
+			setAttributes( { height: parseInt( elt.style.height, 10 ) } );
 		};
 
 		return (


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1411#discussion_r363711412 we discussed adding the [`radix` rule](https://eslint.org/docs/rules/radix) to our eslint config. This PR takes care of it.