### PR TITLE
Fix prices showing two currencies in some occasions

### DIFF
--- a/assets/js/base/utils/price.js
+++ b/assets/js/base/utils/price.js
@@ -58,14 +58,27 @@ export const getCurrencyFromPriceResponse = ( currencyData ) => {
 	if ( ! currencyData || typeof currencyData !== 'object' ) {
 		return siteCurrencySettings;
 	}
+
+	const {
+		currency_code: code,
+		currency_symbol: symbol,
+		currency_thousand_separator: thousandSeparator,
+		currency_decimal_separator: decimalSeparator,
+		currency_minor_unit: minorUnit,
+		currency_prefix: prefix,
+		currency_suffix: suffix,
+	} = currencyData;
+
 	return {
-		code: currencyData.currency_code || 'USD',
-		symbol: currencyData.currency_symbol || '$',
-		thousandSeparator: currencyData.currency_thousand_separator || ',',
-		decimalSeparator: currencyData.currency_decimal_separator || '.',
-		minorUnit: currencyData.currency_minor_unit || 2,
-		prefix: currencyData.currency_prefix || '$',
-		suffix: currencyData.currency_suffix || '',
+		code: code || 'USD',
+		symbol: symbol || '$',
+		thousandSeparator:
+			typeof thousandSeparator === 'string' ? thousandSeparator : ',',
+		decimalSeparator:
+			typeof decimalSeparator === 'string' ? decimalSeparator : '.',
+		minorUnit: Number.isFinite( minorUnit ) ? minorUnit : 2,
+		prefix: typeof prefix === 'string' ? prefix : '$',
+		suffix: typeof suffix === 'string' ? suffix : '',
 	};
 };
 


### PR DESCRIPTION
Fixes #1514.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/71975262-bf17d900-3213-11ea-9dc7-e367ebab04c9.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/71975565-947a5000-3214-11ea-91ce-edd9d631e977.png)


### How to test the changes in this Pull Request:

1. Go to _WooCommerce_ > _Settings_ > _Currency options_ > _Currency position_ and select _Right with space_.
2. In a post with a _Price Filter_ or an _All Products_ block, verify prices are shown with only one symbol after the price.