### PR TITLE
Decouple changelog from our project

### DIFF
--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -6,11 +6,11 @@ const requestPromise = require( 'request-promise' );
 const chalk = require( 'chalk' );
 const octokit = require( '@octokit/rest' )();
 const promptly = require( 'promptly' );
-const pkg = require( '../pacakge.json' );
+const pkg = require( '../package.json' );
 
 const REPO = pkg.repository.url
 	// remove https://github.com:
-	.split( ':' )[ 1 ]
+	.split( ':' )[ 2 ]
 	// remove the .git ending.
 	.slice( 0, -4 );
 
@@ -182,7 +182,7 @@ const makeChangelog = async ( version ) => {
 		console.log( '' );
 		console.log(
 			chalk.yellow( 'Write it as it appears in the milestones page: ' ) +
-				'https://github.com/woocommerce/woocommerce-gutenberg-products-block/milestones'
+				`https://github.com/${REPO}/milestones`
 		);
 		console.log( '' );
 		const version = await promptly.prompt( 'Version number: ' );
@@ -190,7 +190,7 @@ const makeChangelog = async ( version ) => {
 		console.log(
 			chalk.green(
 				'Here is the generated changelog. Be sure to remove entries ' +
-					'not intended for a WooCommerce Blocks release.'
+					`not intended for a ${pkg.title} release.`
 			)
 		);
 		console.log( '' );

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -6,20 +6,19 @@ const requestPromise = require( 'request-promise' );
 const chalk = require( 'chalk' );
 const octokit = require( '@octokit/rest' )();
 const promptly = require( 'promptly' );
-const pkg = require('../pacakge.json');
-
+const pkg = require( '../pacakge.json' );
 
 const REPO = pkg.repository.url
 	// remove https://github.com:
-	.split(":")[1]
+	.split( ':' )[ 1 ]
 	// remove the .git ending.
-	.slice(0, -4);
+	.slice( 0, -4 );
 
 if ( pkg.changelog === undefined ) {
 	pkg.changelog = {
-		"LabelPrefix": "type:",
-		"skipLabel": "no-changelog",
-		"defaultPrefix": "dev"
+		LabelPrefix: 'type:',
+		skipLabel: 'no-changelog',
+		defaultPrefix: 'dev',
 	};
 }
 const headers = {
@@ -36,12 +35,14 @@ const getPullRequestType = ( labels ) => {
 	if ( ! typeLabel ) {
 		return pkg.changelog.defaultPrefix;
 	}
-	return typeLabel.name.replace( `${pkg.changelog.LabelPrefix} `, '' );
+	return typeLabel.name.replace( `${ pkg.changelog.LabelPrefix } `, '' );
 };
 
 const isCollaborator = async ( username ) => {
 	return requestPromise( {
-		url: `https://api.github.com/orgs/${ REPO.split( '/' )[0] }/members/${ username }`,
+		url: `https://api.github.com/orgs/${
+			REPO.split( '/' )[ 0 ]
+		}/members/${ username }`,
 		headers,
 		resolveWithFullResponse: true,
 	} )
@@ -102,12 +103,13 @@ const getEntry = async ( data ) => {
 	} else {
 		title = `${ type }: ${ data.title }`;
 	}
-	return `- ${ title } [#${ data.number }](https://github.com/${REPO}/${ data.number })`;
+	return `- ${ title } [#${ data.number }](https://github.com/${ REPO }/${
+		data.number
+	})`;
 };
 
 const makeChangelog = async ( version ) => {
-
-	const fetchAllPages = async (page = 1) => {
+	const fetchAllPages = async ( page = 1 ) => {
 		const results = await octokit.search.issuesAndPullRequests( {
 			q: `milestone:"${ version }"+type:pr+repo:${ REPO }`,
 			sort: 'reactions',
@@ -115,13 +117,13 @@ const makeChangelog = async ( version ) => {
 			page,
 		} );
 
-		if (results.data.items < 100) {
+		if ( results.data.items < 100 ) {
 			return results.data.items;
 		}
 
-		const nextResults = await fetchAllPages(page+1);
-		return results.data.items.concat(nextResults);
-	}
+		const nextResults = await fetchAllPages( page + 1 );
+		return results.data.items.concat( nextResults );
+	};
 
 	const rawEntries = await fetchAllPages();
 	const entries = await Promise.all(

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -182,7 +182,7 @@ const makeChangelog = async ( version ) => {
 		console.log( '' );
 		console.log(
 			chalk.yellow( 'Write it as it appears in the milestones page: ' ) +
-				`https://github.com/${REPO}/milestones`
+				`https://github.com/${ REPO }/milestones`
 		);
 		console.log( '' );
 		const version = await promptly.prompt( 'Version number: ' );
@@ -190,7 +190,7 @@ const makeChangelog = async ( version ) => {
 		console.log(
 			chalk.green(
 				'Here is the generated changelog. Be sure to remove entries ' +
-					`not intended for a ${pkg.title} release.`
+					`not intended for a ${ pkg.title } release.`
 			)
 		);
 		console.log( '' );

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -144,7 +144,7 @@ const makeChangelog = async ( version ) => {
 		);
 		return;
 	}
-
+	filteredEntries.sort();
 	console.log( filteredEntries.join( '\n' ) );
 };
 

--- a/package.json
+++ b/package.json
@@ -155,6 +155,11 @@
 			"composer run-script phpcs"
 		]
 	},
+	"changelog": {
+		"LabelPrefix": "type:",
+		"skipLabel": "no-changelog",
+		"defaultPrefix": "dev"
+	},
 	"files": [
 		"assets/**/*.{js,scss,php}",
 		"build/**/*.{js,json,css}",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Work in progress.
* Removes hardcoded mentions to WooCommerce Blocks.
* Fixes an issue where using non-numeric milestone names crashes the script (e.g Gutenberg 7.2).
* Moves some WooCommerce Blocks specific options to package.json so other projects can add their own options.
* Read repo directly from package file.
* Loops pages if there is more than 100 PR (latest Gutenberg release had 176 PR).
* links PR number now to the actual PR instead of just the number.