### PR TITLE
Convert variable product prices to float

### DIFF
--- a/assets/js/atomic/components/product/price/index.js
+++ b/assets/js/atomic/components/product/price/index.js
@@ -13,6 +13,7 @@ const ProductPrice = ( { className, product } ) => {
 		thousandSeparator: prices.thousand_separator,
 		decimalSeparator: prices.decimal_separator,
 		decimalScale: prices.decimals,
+		fixedDecimalScale: true,
 		prefix: prices.price_prefix,
 		suffix: prices.price_suffix,
 	};
@@ -22,6 +23,8 @@ const ProductPrice = ( { className, product } ) => {
 		prices.price_range.min_amount &&
 		prices.price_range.max_amount
 	) {
+		const minAmount = parseFloat( prices.price_range.min_amount );
+		const maxAmount = parseFloat( prices.price_range.max_amount );
 		return (
 			<div
 				className={ classnames(
@@ -32,15 +35,9 @@ const ProductPrice = ( { className, product } ) => {
 				<span
 					className={ `${ layoutStyleClassPrefix }__product-price__value` }
 				>
-					<NumberFormat
-						value={ prices.price_range.min_amount }
-						{ ...numberFormatArgs }
-					/>
+					<NumberFormat value={ minAmount } { ...numberFormatArgs } />
 					&nbsp;&mdash;&nbsp;
-					<NumberFormat
-						value={ prices.price_range.max_amount }
-						{ ...numberFormatArgs }
-					/>
+					<NumberFormat value={ maxAmount } { ...numberFormatArgs } />
 				</span>
 			</div>
 		);

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -333,8 +333,8 @@ class ProductSchema extends AbstractSchema {
 
 			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
 				return [
-					'min_amount' => min( $prices['price'] ),
-					'max_amount' => max( $prices['price'] ),
+					'min_amount' => floatval( min( $prices['price'] ) ),
+					'max_amount' => floatval( max( $prices['price'] ) ),
 				];
 			}
 		}

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -333,8 +333,8 @@ class ProductSchema extends AbstractSchema {
 
 			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
 				return [
-					'min_amount' => floatval( min( $prices['price'] ) ),
-					'max_amount' => floatval( max( $prices['price'] ) ),
+					'min_amount' => min( $prices['price'] ),
+					'max_amount' => max( $prices['price'] ),
 				];
 			}
 		}


### PR DESCRIPTION
Fixes #1516.

Notice this bug doesn't affect `master` because prices from the API are wrapped with [`prepare_money_response`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/StoreApi/Schemas/AbstractSchema.php#L170) there, which already handles converting to an int and to a string afterwards.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/71976554-df956280-3216-11ea-85f7-0e9fe7406a04.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/71979976-4c145f80-321f-11ea-9f3c-661c00b6761c.png)

### How to test the changes in this Pull Request:

1. Make sure you have a variable product whose variations have different prices.
2. Create an _All Products_ block.
3. Switch pages (or use filters) until that variable product is visible and verify prices have the correct format.

### Changelog

> All Products block: fix wrong price format for variable products with certain currency settings