### PR TITLE
Add Empty Placeholder for the on-sale product block

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -9,7 +9,7 @@ import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
 import { IconFolder } from '@woocommerce/block-components/icons';
 import ToggleButtonControl from '@woocommerce/block-components/toggle-button-control';
 
-const EmptyPlaceHolder = () => (
+const EmptyPlaceholder = () => (
 	<Placeholder
 		icon={ <IconFolder /> }
 		label={ __(
@@ -150,7 +150,7 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 			<ServerSideRender
 				block={ name }
 				attributes={ attributes }
-				EmptyResponsePlaceholder={ EmptyPlaceHolder }
+				EmptyResponsePlaceholder={ EmptyPlaceholder }
 			/>
 		</Fragment>
 	);

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -13,7 +13,7 @@ import ProductOrderbyControl from '@woocommerce/block-components/product-orderby
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { IconProductOnSale } from '@woocommerce/block-components/icons';
 
-const EmptyPlaceHolder = () => (
+const EmptyPlaceholder = () => (
 	<Placeholder
 		icon={ <IconProductOnSale /> }
 		label={ __( 'On Sale Products', 'woo-gutenberg-products-block' ) }
@@ -112,7 +112,7 @@ class ProductOnSaleBlock extends Component {
 					<ServerSideRender
 						block={ name }
 						attributes={ attributes }
-						EmptyResponsePlaceholder={ EmptyPlaceHolder }
+						EmptyResponsePlaceholder={ EmptyPlaceholder }
 					/>
 				</Disabled>
 			</Fragment>

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
-import { Disabled, PanelBody } from '@wordpress/components';
+import { Disabled, PanelBody, Placeholder } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
@@ -11,6 +11,23 @@ import GridLayoutControl from '@woocommerce/block-components/grid-layout-control
 import ProductCategoryControl from '@woocommerce/block-components/product-category-control';
 import ProductOrderbyControl from '@woocommerce/block-components/product-orderby-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
+import { IconProductOnSale } from '@woocommerce/block-components/icons';
+
+const EmptyPlaceHolder = () => (
+	<Placeholder
+		icon={ <IconProductOnSale /> }
+		label={ __(
+			'On Sale Products',
+			'woo-gutenberg-products-block'
+		) }
+		className="wc-block-product-on-sale"
+	>
+		{ __(
+			"This block shows on-sale products. There are currently no discounted products in your store.",
+			'woo-gutenberg-products-block'
+		) }
+	</Placeholder>
+);
 
 /**
  * Component to handle edit mode of "On Sale Products".
@@ -98,6 +115,7 @@ class ProductOnSaleBlock extends Component {
 					<ServerSideRender
 						block={ name }
 						attributes={ attributes }
+						EmptyResponsePlaceholder={ EmptyPlaceHolder }
 					/>
 				</Disabled>
 			</Fragment>

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -16,14 +16,11 @@ import { IconProductOnSale } from '@woocommerce/block-components/icons';
 const EmptyPlaceHolder = () => (
 	<Placeholder
 		icon={ <IconProductOnSale /> }
-		label={ __(
-			'On Sale Products',
-			'woo-gutenberg-products-block'
-		) }
+		label={ __( 'On Sale Products', 'woo-gutenberg-products-block' ) }
 		className="wc-block-product-on-sale"
 	>
 		{ __(
-			"This block shows on-sale products. There are currently no discounted products in your store.",
+			'This block shows on-sale products. There are currently no discounted products in your store.',
 			'woo-gutenberg-products-block'
 		) }
 	</Placeholder>

--- a/assets/js/blocks/product-on-sale/editor.scss
+++ b/assets/js/blocks/product-on-sale/editor.scss
@@ -1,0 +1,6 @@
+.wc-block-product-on-sale {
+	.components-placeholder__label svg {
+		margin-right: 1ch;
+		fill: currentColor;
+	}
+}

--- a/assets/js/blocks/product-on-sale/index.js
+++ b/assets/js/blocks/product-on-sale/index.js
@@ -10,6 +10,7 @@ import { IconProductOnSale } from '@woocommerce/block-components/icons';
  * Internal dependencies
  */
 import Block from './block';
+import './editor.scss';
 import { deprecatedConvertToShortcode } from '../../utils/deprecations';
 import sharedAttributes, {
 	sharedAttributeBlockTypes,


### PR DESCRIPTION
Some of the SSR blocks we have make use of `EmptyResponsePlaceholder` when no content is returned from the server. Since sale products might more commonly return no results (because it depends on a product having a sale price), we should add a placeholder to avoid showing a error message.

Fixes #1498

### Screenshots

Before:

![71819595-9fa27400-308c-11ea-9091-ca76d2d37358](https://user-images.githubusercontent.com/90977/71984438-bed20a80-3220-11ea-9977-41d92e3df8ce.png)

After:

![Screenshot 2020-01-08 at 14 06 47](https://user-images.githubusercontent.com/90977/71984453-c2fe2800-3220-11ea-9b6e-fd3c9ca2ece2.png)

### How to test the changes in this Pull Request:

1. Remove sale prices from all products.
2. Insert products on-sale block.
3. Check placeholder is shown.

Nothing is shown on the frontend of the store which is intentional.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add placeholder to the on-sale products block when no results are found.
