### PR TITLE
Add padding zeros to displayed prices

### DIFF
--- a/assets/js/base/components/formatted-monetary-amount/index.js
+++ b/assets/js/base/components/formatted-monetary-amount/index.js
@@ -14,6 +14,7 @@ const currencyToNumberFormat = ( currency ) => {
 		thousandSeparator: currency.thousandSeparator,
 		decimalSeparator: currency.decimalSeparator,
 		decimalScale: currency.minorUnit,
+		fixedDecimalScale: true,
 		prefix: currency.prefix,
 		suffix: currency.suffix,
 		isNumericString: true,


### PR DESCRIPTION
As a part of a fix for the 2.5 branch in #1518, I discovered a configuration for `NumberFormat` that will ensure padding zeros are used for the rendered value.  This pull brings that change into the master branch.

## To Test

All prices displayed via the `AllProducts` block (or content using the `FormattedMonetaryAmount` component should now include padding zeros where needed.

<img width="720" alt="Image 2020-01-08 at 9 57 10 AM" src="https://user-images.githubusercontent.com/1429108/71988144-5cb3de00-31fd-11ea-9672-2f8937c516f0.png">
