### PR TITLE
Fix minor issues with TextInput component

### DIFF
--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -21,7 +21,7 @@ const TextInput = ( {
 	disabled,
 	help,
 	value = '',
-	onChange,
+	onChange = () => null,
 } ) => {
 	const [ isActive, setIsActive ] = useState( false );
 	const onChangeValue = ( event ) => onChange( event.target.value );

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -21,7 +21,7 @@ const TextInput = ( {
 	disabled,
 	help,
 	value = '',
-	onChange = () => null,
+	onChange,
 } ) => {
 	const [ isActive, setIsActive ] = useState( false );
 	const onChangeValue = ( event ) => onChange( event.target.value );
@@ -61,9 +61,9 @@ const TextInput = ( {
 };
 
 TextInput.propTypes = {
+	onChange: PropTypes.func.isRequired,
 	id: PropTypes.string,
 	value: PropTypes.string,
-	onChange: PropTypes.func,
 	ariaLabel: PropTypes.string,
 	label: PropTypes.string,
 	screenReaderLabel: PropTypes.string,

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -63,7 +63,7 @@ const TextInput = ( {
 TextInput.propTypes = {
 	id: PropTypes.string,
 	value: PropTypes.string,
-	onChangeValue: PropTypes.func,
+	onChange: PropTypes.func,
 	ariaLabel: PropTypes.string,
 	label: PropTypes.string,
 	screenReaderLabel: PropTypes.string,

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -20,7 +20,7 @@ const TextInput = ( {
 	screenReaderLabel,
 	disabled,
 	help,
-	value,
+	value = '',
 	onChange,
 } ) => {
 	const [ isActive, setIsActive ] = useState( false );

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -6,6 +6,7 @@
 .wc-block-text-input label {
 	position: absolute;
 	transform: translateX(#{$gap}) translateY(#{$gap-small});
+	transform-origin: top left;
 	font-size: 16px;
 	line-height: 22px;
 	transition: all 200ms ease;
@@ -13,7 +14,7 @@
 }
 
 .wc-block-text-input.is-active label {
-	transform: translateX(#{$gap - $gap-small}) translateY(#{$gap-smallest}) scale(0.75);
+	transform: translateX(#{$gap}) translateY(#{$gap-smallest}) scale(0.75);
 	transition: all 200ms ease;
 }
 .wc-block-text-input input[type="tel"],


### PR DESCRIPTION
Several improvements to the `<TextInput>` component:
- Set default `value` to an empty string, otherwise in some occasions React was considering the form element to go from being uncontrolled to controlled and was showing a console warning (https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/5c9572ad3b3244c12ce86b644edcd56d2e9f462a).
- Set label transition origin in CSS, otherwise depending on the label length it was positioned in a different position when the input was filled (https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/95fa7fed406166d11a158e5be6250bd3256ad691).
- Set default `onChange` function prop to noop: just in case at some point the component is used without definning the `onChange` prop (https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/81095388505b23c5df0fbca964f45751c9e73a9d).
- Fix wrong `propType` name: the prop was named `onChange` but in the propTypes definition it was named `onChangeValue` (https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/3e6b59328fa3e628e8a8e2a1dae72d17dc689a0c).