### PR TITLE
Fix Attribute Filter not reacting to query changes

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -174,6 +174,14 @@ const AttributeFilterBlock = ( {
 		[ checked, onSubmit ]
 	);
 
+	const checkedQuery = useMemo( () => {
+		return productAttributesQuery
+			.filter(
+				( { attribute } ) => attribute === attributeObject.taxonomy
+			)
+			.flatMap( ( { slug } ) => slug );
+	}, [ productAttributesQuery, attributeObject.taxonomy ] );
+
 	const currentCheckedQuery = useShallowEqual( checkedQuery );
 
 	// Track ATTRIBUTES QUERY changes so the block reflects current filters.
@@ -215,14 +223,6 @@ const AttributeFilterBlock = ( {
 			blockAttributes.queryType === 'or' ? 'in' : 'and'
 		);
 	};
-
-	const checkedQuery = useMemo( () => {
-		return productAttributesQuery
-			.filter(
-				( { attribute } ) => attribute === attributeObject.taxonomy
-			)
-			.flatMap( ( { slug } ) => slug );
-	}, [ productAttributesQuery, attributeObject.taxonomy ] );
 
 	const multiple =
 		blockAttributes.displayStyle !== 'dropdown' ||


### PR DESCRIPTION
Fixes #1522.

It turned out to be an order issue, `checkedQuery` was used before it was defined.

### Screenshots
_Before:_
![Peek 2020-01-09 11-14](https://user-images.githubusercontent.com/3616980/72059028-7888b400-32d1-11ea-8d0f-4d99f2a66d09.gif)

_After:_
![Peek 2020-01-10 10-09](https://user-images.githubusercontent.com/3616980/72140570-55253e00-3391-11ea-8b3c-ea420c7c1e9b.gif)

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_, _Attributes Filter_ and _Active Filters_ blocks.
2. Activate some attribute filters and then remove them using the _Active Filters_ block.
3. Verify the _Attribute Filter_ checkboxes are updated.
