### PR TITLE
Rename wc-blocks to wc-block classname prefix

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -347,7 +347,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 					<PaymentMethods />
 					{ /*@todo this should be something the payment method controls*/ }
 					<CheckboxControl
-						className="wc-blocks-checkout__save-card-info"
+						className="wc-block-checkout__save-card-info"
 						label={ __(
 							'Save payment information to my account for future purchases.',
 							'woo-gutenberg-products-block'


### PR DESCRIPTION
In #1449 we decided to rename `wc-blocks-` classnames prefix to `wc-block-`, but some PRs got merged in parallel and in one of them there was `wc-blocks-`. This PR fixes this last instance of `wc-blocks- `.
