### PR TITLE
Remove vendors-frontend from Webpack config

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -331,19 +331,6 @@ const getFrontConfig = ( options = {} ) => {
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksJsonp',
 		},
-		optimization: {
-			splitChunks: {
-				minSize: 0,
-				cacheGroups: {
-					vendors: {
-						test: /[\\/]node_modules[\\/]/,
-						name: 'vendors',
-						chunks: 'all',
-						enforce: true,
-					},
-				},
-			},
-		},
 		module: {
 			rules: [
 				{

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
 			},
 			{
 				"path": "./build/cart-frontend.js",
-				"maxSize": "100 kB"
+				"maxSize": "120 kB"
 			},
 			{
 				"path": "./build/*.css",

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -46,8 +46,7 @@ class Cart extends AbstractBlock {
 	public function render( $attributes = array(), $content = '' ) {
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
 			$this->block_name . '-frontend',
-			$this->block_name . '-block-frontend',
-			[ 'wc-vendors-frontend' ]
+			$this->block_name . '-block-frontend'
 		);
 		return $content;
 	}


### PR DESCRIPTION
@nerrad noticed that after #1423 was merged, some blocks stopped working. That seemed to be because of the modified Webpack config. This PR is a temporary fix for it reverting the changes introduced in #1423.

### How to test the changes in this Pull Request:

1. Create a post with several frontend-rendered blocks (_Cart_, _Checkout_, _All Products_, any of _Reviews_ blocks...).
2. Verify all of them render correctly.