### PR TITLE
Fix errors caused by demo payment methods

### DIFF
--- a/assets/js/payment-methods-demo/express-payment/index.js
+++ b/assets/js/payment-methods-demo/express-payment/index.js
@@ -4,6 +4,6 @@
 import { applePayImage } from './apple-pay';
 import { paypalImage } from './paypal';
 
-export const expressApplePay = <img src={ applePayImage } alt="" />;
+export const ExpressApplePay = () => <img src={ applePayImage } alt="" />;
 
-export const expressPaypal = <img src={ paypalImage } alt="" />;
+export const ExpressPaypal = () => <img src={ paypalImage } alt="" />;

--- a/assets/js/payment-methods-demo/index.js
+++ b/assets/js/payment-methods-demo/index.js
@@ -9,14 +9,14 @@ import {
 /**
  * Internal dependencies
  */
-import { expressApplePay, expressPaypal } from './express-payment';
+import { ExpressApplePay, ExpressPaypal } from './express-payment';
 import { paypalPaymentMethod, ccPaymentMethod } from './payment-methods';
 
 registerExpressPaymentMethod(
 	( Config ) =>
 		new Config( {
 			id: 'applepay',
-			activeContent: expressApplePay,
+			activeContent: <ExpressApplePay />,
 			canMakePayment: Promise.resolve( true ),
 		} )
 );
@@ -24,7 +24,7 @@ registerExpressPaymentMethod(
 	( Config ) =>
 		new Config( {
 			id: 'paypal',
-			activeContent: expressPaypal,
+			activeContent: <ExpressPaypal />,
 			canMakePayment: Promise.resolve( true ),
 		} )
 );

--- a/assets/js/payment-methods-demo/payment-methods/index.js
+++ b/assets/js/payment-methods-demo/payment-methods/index.js
@@ -4,15 +4,27 @@
 import { paypalSvg } from './paypal';
 import { ccSvg } from './cc';
 
+const PaypalActivePaymentMethod = () => {
+	return (
+		<div>
+			<p>This is where paypal payment method stuff would be.</p>
+		</div>
+	);
+};
+
+const CreditCardActivePaymentMethod = () => {
+	return (
+		<div>
+			<p>This is where cc payment method stuff would be.</p>
+		</div>
+	);
+};
+
 export const paypalPaymentMethod = {
 	id: 'paypal',
 	label: <img src={ paypalSvg } alt="" />,
 	stepContent: <div>Billing steps</div>,
-	activeContent: (
-		<div>
-			<p>This is where paypal payment method stuff would be.</p>
-		</div>
-	),
+	activeContent: <PaypalActivePaymentMethod />,
 	canMakePayment: Promise.resolve( true ),
 	ariaLabel: 'paypal payment method',
 };
@@ -21,11 +33,7 @@ export const ccPaymentMethod = {
 	id: 'cc',
 	label: <img src={ ccSvg } alt="" />,
 	stepContent: null,
-	activeContent: (
-		<div>
-			<p>This is where cc payment method stuff would be.</p>
-		</div>
-	),
+	activeContent: <CreditCardActivePaymentMethod />,
 	canMakePayment: Promise.resolve( true ),
 	ariaLabel: 'credit-card-payment-method',
 };


### PR DESCRIPTION
This was introduced in #1349 .  The way the demo payment method registration was setup, the react nodes were root native dom elements (`<div>`, `<img />`) so when `React.cloneElement` was called on them to pass in the checkout props, these props were then applied to the native nodes which in turn caused the React warnings due to camel-case props (`isActive`, `checkoutData` etc).  The solution was to modify the demo elements so that they were custom react nodes (which is what actual payment methods will be doing anyways).

## To Test

View the console for the checkout block in the editor or on the frontend and there should be no warnings in the console.