### PR TITLE
show discount on cart line items & price styling 

### DIFF
--- a/assets/js/base/components/formatted-monetary-amount/index.js
+++ b/assets/js/base/components/formatted-monetary-amount/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import NumberFormat from 'react-number-format';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ const currencyToNumberFormat = ( currency ) => {
  * @param {Object} props Component props.
  */
 const FormattedMonetaryAmount = ( {
+	className,
 	value,
 	currency,
 	onValueChange,
@@ -45,6 +47,7 @@ const FormattedMonetaryAmount = ( {
 		return null;
 	}
 
+	const classes = classNames( 'wc-block-formatted-money-amount', className );
 	const numberFormatProps = {
 		displayType: 'text',
 		...props,
@@ -64,7 +67,7 @@ const FormattedMonetaryAmount = ( {
 
 	return (
 		<NumberFormat
-			className="wc-block-formatted-money-amount"
+			className={ classes }
 			{ ...numberFormatProps }
 			value={ priceValue }
 			onValueChange={ onValueChangeWrapper }

--- a/assets/js/base/components/formatted-monetary-amount/index.js
+++ b/assets/js/base/components/formatted-monetary-amount/index.js
@@ -4,6 +4,11 @@
 import NumberFormat from 'react-number-format';
 
 /**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
  * Formats currency data into the expected format for NumberFormat.
  *
  * @param {Object} currency Currency data.
@@ -59,6 +64,7 @@ const FormattedMonetaryAmount = ( {
 
 	return (
 		<NumberFormat
+			className="wc-block-formatted-money-amount"
 			{ ...numberFormatProps }
 			value={ priceValue }
 			onValueChange={ onValueChangeWrapper }

--- a/assets/js/base/components/formatted-monetary-amount/style.scss
+++ b/assets/js/base/components/formatted-monetary-amount/style.scss
@@ -1,0 +1,3 @@
+.wc-block-formatted-money-amount {
+	white-space: nowrap;
+}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -2,11 +2,25 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
-import { getCurrency } from '@woocommerce/base-utils';
+import { getCurrency, formatPrice } from '@woocommerce/base-utils';
+
+/**
+ * Return the difference between two price amounts, e.g. a discount.
+ *
+ * @param {string} subtotal Currency value in minor unit, e.g. cents.
+ * @param {string} total Currency value in minor unit, e.g. cents.
+ * @return {number} The difference (discount).
+ */
+const calcPriceDifference = ( subtotal, total ) => {
+	const subtotalValue = parseInt( subtotal, 10 );
+	const totalValue = parseInt( total, 10 );
+
+	return subtotalValue - totalValue;
+};
 
 const CartLineItemRow = ( { lineItem } ) => {
 	const { name, images, quantity, totals } = lineItem;
@@ -23,12 +37,28 @@ const CartLineItemRow = ( { lineItem } ) => {
 	const [ lineQuantity, setLineQuantity ] = useState( quantity );
 	const currency = getCurrency();
 
-	const isDiscounted = subtotal !== total;
-	const fullPrice = isDiscounted ? (
-		<div className="wc-block-cart-item__full-price">
-			<FormattedMonetaryAmount currency={ currency } value={ subtotal } />
-		</div>
-	) : null;
+	const discountAmount = calcPriceDifference( subtotal, total );
+	let fullPrice = null,
+		discountBadge = null;
+	if ( discountAmount > 0 ) {
+		fullPrice = (
+			<div className="wc-block-cart-item__full-price">
+				<FormattedMonetaryAmount
+					currency={ currency }
+					value={ subtotal }
+				/>
+			</div>
+		);
+		discountBadge = (
+			<div className="wc-block-cart-item__discount-badge">
+				{ sprintf(
+					/* translators: %s discount amount */
+					__( 'Save %s!', 'woo-gutenberg-products-block' ),
+					formatPrice( discountAmount, currency )
+				) }
+			</div>
+		);
+	}
 
 	// We use this in two places so we can stack the quantity selector under
 	// product info on smaller screens.
@@ -69,6 +99,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 					currency={ currency }
 					value={ total }
 				/>
+				{ discountBadge }
 			</td>
 		</tr>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -51,11 +51,13 @@ const CartLineItemRow = ( { lineItem } ) => {
 		);
 		discountBadge = (
 			<div className="wc-block-cart-item__discount-badge">
-				{ sprintf(
-					/* translators: %s discount amount */
-					__( 'Save %s!', 'woo-gutenberg-products-block' ),
-					formatPrice( discountAmount, currency )
-				) }
+				<span>
+					{ sprintf(
+						/* translators: %s discount amount */
+						__( 'Save %s!', 'woo-gutenberg-products-block' ),
+						formatPrice( discountAmount, currency )
+					) }
+				</span>
 			</div>
 		);
 	}
@@ -96,6 +98,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 			<td className="wc-block-cart-item__total">
 				{ fullPrice }
 				<FormattedMonetaryAmount
+					className="wc-block-cart-item__line-total"
 					currency={ currency }
 					value={ total }
 				/>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -51,13 +51,11 @@ const CartLineItemRow = ( { lineItem } ) => {
 		);
 		discountBadge = (
 			<div className="wc-block-cart-item__discount-badge">
-				<span>
-					{ sprintf(
-						/* translators: %s discount amount */
-						__( 'Save %s!', 'woo-gutenberg-products-block' ),
-						formatPrice( discountAmount, currency )
-					) }
-				</span>
+				{ sprintf(
+					/* translators: %s discount amount */
+					__( 'Save %s!', 'woo-gutenberg-products-block' ),
+					formatPrice( discountAmount, currency )
+				) }
 			</div>
 		);
 	}
@@ -97,11 +95,12 @@ const CartLineItemRow = ( { lineItem } ) => {
 			</td>
 			<td className="wc-block-cart-item__total">
 				{ fullPrice }
-				<FormattedMonetaryAmount
-					className="wc-block-cart-item__line-total"
-					currency={ currency }
-					value={ total }
-				/>
+				<div className="wc-block-cart-item__line-total">
+					<FormattedMonetaryAmount
+						currency={ currency }
+						value={ total }
+					/>
+				</div>
 				{ discountBadge }
 			</td>
 		</tr>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -68,6 +68,10 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__full-price {
+	// inline on mobile, so line prices are aligned vertically
+	display: inline-block;
+	margin-right: 0.5em;
+
 	color: $core-grey-dark-400;
 	text-decoration: line-through;
 }
@@ -180,6 +184,11 @@ table.wc-block-cart-items {
 
 	.wc-block-cart-item__total {
 		vertical-align: top;
+	}
+
+	.wc-block-cart-item__full-price {
+		display: block;
+		margin-right: 0;
 	}
 
 	.wc-block-cart-item__discount-badge {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -85,6 +85,7 @@ table.wc-block-cart-items {
 		font-size: 12px;
 		padding: 0 1em;
 		text-transform: uppercase;
+		white-space: nowrap;
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -68,10 +68,6 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__full-price {
-	// inline on mobile, so line prices are aligned vertically
-	display: inline-block;
-	margin-right: 0.5em;
-
 	color: $core-grey-dark-400;
 	text-decoration: line-through;
 }
@@ -81,9 +77,6 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__discount-badge {
-	// hidden on mobile
-	display: none;
-
 	span {
 		background-color: $core-grey-dark-600;
 		border-radius: 3px;
@@ -136,6 +129,16 @@ table.wc-block-cart-items {
 
 @include breakpoint( "<782px" ) {
 	.wc-block-cart__totals-title {
+		display: none;
+	}
+
+	.wc-block-cart-item__full-price {
+		// inline on mobile, so line prices are aligned vertically
+		display: inline-block;
+		margin-right: 0.5em;
+	}
+
+	.wc-block-cart-item__discount-badge {
 		display: none;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -63,11 +63,31 @@ table.wc-block-cart-items {
 
 .wc-block-cart-item__total {
 	vertical-align: bottom;
+	font-size: 16px;
+	line-height: 19px;
 }
 
 .wc-block-cart-item__full-price {
-	color: $core-grey-light-800;
+	color: $core-grey-dark-400;
 	text-decoration: line-through;
+}
+
+.wc-block-cart-item__line-total {
+	color: $black;
+}
+
+.wc-block-cart-item__discount-badge {
+	// hidden on mobile
+	display: none;
+
+	span {
+		background-color: $core-grey-dark-600;
+		border-radius: 3px;
+		color: $white;
+		font-size: 12px;
+		padding: 0 1em;
+		text-transform: uppercase;
+	}
 }
 
 .wc-block-cart__totals-footer {
@@ -160,5 +180,9 @@ table.wc-block-cart-items {
 
 	.wc-block-cart-item__total {
 		vertical-align: top;
+	}
+
+	.wc-block-cart-item__discount-badge {
+		display: block;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -78,15 +78,13 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__discount-badge {
-	span {
-		background-color: $core-grey-dark-600;
-		border-radius: 3px;
-		color: $white;
-		font-size: 12px;
-		padding: 0 1em;
-		text-transform: uppercase;
-		white-space: nowrap;
-	}
+	background-color: $core-grey-dark-600;
+	border-radius: 3px;
+	color: $white;
+	font-size: 12px;
+	padding: 0 1em;
+	text-transform: uppercase;
+	white-space: nowrap;
 }
 
 .wc-block-cart__totals-footer {
@@ -134,6 +132,7 @@ table.wc-block-cart-items {
 		display: none;
 	}
 
+	.wc-block-cart-item__line-total,
 	.wc-block-cart-item__full-price {
 		// inline on mobile, so line prices are aligned vertically
 		display: inline-block;
@@ -190,12 +189,16 @@ table.wc-block-cart-items {
 		vertical-align: top;
 	}
 
+	.wc-block-cart-item__line-total,
 	.wc-block-cart-item__full-price {
 		display: block;
+	}
+
+	.wc-block-cart-item__full-price {
 		margin-right: 0;
 	}
 
 	.wc-block-cart-item__discount-badge {
-		display: block;
+		display: inline-block;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -74,6 +74,7 @@ table.wc-block-cart-items {
 
 .wc-block-cart-item__line-total {
 	color: $black;
+	margin-left: 0.5em;
 }
 
 .wc-block-cart-item__discount-badge {
@@ -135,7 +136,6 @@ table.wc-block-cart-items {
 	.wc-block-cart-item__full-price {
 		// inline on mobile, so line prices are aligned vertically
 		display: inline-block;
-		margin-right: 0.5em;
 	}
 
 	.wc-block-cart-item__discount-badge {


### PR DESCRIPTION
Fixes #1535

This PR adds a discount badge to cart line items price area (if there is a discount). Also in this PR, the font sizes, line height, mobile layout and colors of the price column are tweaked to align with the design.

#### Accessibility

- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

Desktop:
<img width="534" alt="Screen Shot 2020-01-13 at 10 59 40 AM" src="https://user-images.githubusercontent.com/4167300/72226247-d1b75700-35f3-11ea-8648-00beef16dfa2.png">

Mobile:
<img width="483" alt="Screen Shot 2020-01-13 at 10 59 10 AM" src="https://user-images.githubusercontent.com/4167300/72226249-d2e88400-35f3-11ea-866f-bfa2bd24f5db.png">

### How to test the changes in this Pull Request:

1. Clone this branch. 
2. Add a cart block to a page & publish
3. Confirm cart discounts are correctly displayed on front end.
4. Edit test data in [`previews/cart-items.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/previews/cart-items.js) to test a variety of price/discount scenarios.
5. Test in a variety of browsers and screen sizes :)

