### PR TITLE
show product details in cart line items: attributes (variations), product short description

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -8,8 +8,16 @@ import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import { getCurrency } from '@woocommerce/base-utils';
 
+const ProductVariationDetails = ( { variation } ) => {
+	const variationsText = variation
+		.map( ( v ) => `${ v.attribute }: ${ v.value }` )
+		.join( ' / ' );
+
+	return <div>{ variationsText }</div>;
+};
+
 const CartLineItemRow = ( { lineItem } ) => {
-	const { name, images, quantity, totals } = lineItem;
+	const { name, images, variation, quantity, totals } = lineItem;
 	const { line_total: total, line_subtotal: subtotal } = totals;
 
 	const imageProps = {};
@@ -48,7 +56,12 @@ const CartLineItemRow = ( { lineItem } ) => {
 				<div className="wc-block-cart-item__product-wrapper">
 					<img { ...imageProps } alt={ imageProps.alt } />
 					<div className="wc-block-cart-item__product-details">
-						{ name }
+						<div className="wc-block-cart-item__product-name">
+							{ name }
+						</div>
+						<div className="wc-block-cart-item__product-metadata">
+							<ProductVariationDetails variation={ variation } />
+						</div>
 						{ quantitySelector(
 							'wc-block-cart-item__quantity-stacked'
 						) }
@@ -79,6 +92,12 @@ CartLineItemRow.propTypes = {
 		name: PropTypes.string.isRequired,
 		images: PropTypes.array.isRequired,
 		quantity: PropTypes.number.isRequired,
+		variation: PropTypes.arrayOf(
+			PropTypes.shape( {
+				attribute: PropTypes.string.isRequired,
+				value: PropTypes.string.isRequired,
+			} )
+		).isRequired,
 		totals: PropTypes.shape( {
 			line_subtotal: PropTypes.string.isRequired,
 			line_total: PropTypes.string.isRequired,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -17,7 +17,7 @@ const ProductVariationDetails = ( { variation } ) => {
 };
 
 const CartLineItemRow = ( { lineItem } ) => {
-	const { name, images, variation, quantity, totals } = lineItem;
+	const { name, description, images, variation, quantity, totals } = lineItem;
 	const { line_total: total, line_subtotal: subtotal } = totals;
 
 	const imageProps = {};
@@ -60,6 +60,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 							{ name }
 						</div>
 						<div className="wc-block-cart-item__product-metadata">
+							{ description }
 							<ProductVariationDetails variation={ variation } />
 						</div>
 						{ quantitySelector(
@@ -90,6 +91,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 CartLineItemRow.propTypes = {
 	lineItem: PropTypes.shape( {
 		name: PropTypes.string.isRequired,
+		description: PropTypes.string.isRequired,
 		images: PropTypes.array.isRequired,
 		quantity: PropTypes.number.isRequired,
 		variation: PropTypes.arrayOf(

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -13,7 +13,11 @@ const ProductVariationDetails = ( { variation } ) => {
 		.map( ( v ) => `${ v.attribute }: ${ v.value }` )
 		.join( ' / ' );
 
-	return <div>{ variationsText }</div>;
+	return (
+		<div className="wc-block-cart-item__product-attributes">
+			{ variationsText }
+		</div>
+	);
 };
 
 const CartLineItemRow = ( { lineItem } ) => {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -54,6 +54,16 @@ table.wc-block-cart-items {
 	margin-left: $gap;
 }
 
+.wc-block-cart-item__product-name {
+	color: $core-grey-dark-600;
+	font-size: 16px;
+}
+
+.wc-block-cart-item__product-metadata {
+	color: $core-grey-dark-400;
+	font-size: 12px;
+}
+
 .wc-block-cart-item__quantity {
 	display: none;
 }

--- a/assets/js/previews/cart-items.js
+++ b/assets/js/previews/cart-items.js
@@ -17,6 +17,7 @@ export const previewCartItems = [
 		id: 1,
 		quantity: 2,
 		name: __( 'Beanie', 'woo-gutenberg-products-block' ),
+		description: __( 'Warm hat for winter' ),
 		sku: 'woo-beanie',
 		permalink: 'https://example.org',
 		images: [
@@ -59,6 +60,7 @@ export const previewCartItems = [
 		id: 2,
 		quantity: 1,
 		name: __( 'Cap', 'woo-gutenberg-products-block' ),
+		description: __( 'Lightweight baseball cap' ),
 		sku: 'woo-cap',
 		permalink: 'https://example.org',
 		images: [

--- a/assets/js/previews/cart-items.js
+++ b/assets/js/previews/cart-items.js
@@ -30,7 +30,16 @@ export const previewCartItems = [
 				alt: '',
 			},
 		],
-		variation: [],
+		variation: [
+			{
+				attribute: 'Color',
+				value: 'Yellow',
+			},
+			{
+				attribute: 'Size',
+				value: 'Small',
+			},
+		],
 		totals: {
 			currency_code: 'USD',
 			currency_symbol: '$',
@@ -63,7 +72,12 @@ export const previewCartItems = [
 				alt: '',
 			},
 		],
-		variation: [],
+		variation: [
+			{
+				attribute: 'Color',
+				value: 'Orange',
+			},
+		],
 		totals: {
 			currency_code: 'USD',
 			currency_symbol: '$',


### PR DESCRIPTION
Fixes #1532

Adds product attributes and description to cart line items. Note that the API doesn't currently return a description – this has been added to test data in this PR, and there's [a follow up issue for the API](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1552).

#### Accessibility

- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="540" alt="Screen Shot 2020-01-13 at 2 45 16 PM" src="https://user-images.githubusercontent.com/4167300/72229593-b3ae1e80-3614-11ea-8c38-f5708b769484.png">

### How to test the changes in this Pull Request:

1. Clone this branch.
2. Add the cart block to a page and publish.
3. Test the cart front-end with a variety of browsers and screen sizes.
4. Edit test data in [`previews/cart-items.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/previews/cart-items.js) to test a variety of products with different descriptions & variations.
