### PR TITLE
add product short description to cart/items api

### DIFF
--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -195,7 +195,9 @@ class CartItemSchema extends AbstractSchema {
 	public function get_item_response( $cart_item ) {
 		$product = $cart_item['data'];
 
-		$short_description = $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description() );
+		$description_char_limit = 75;
+
+		$short_description = $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), $description_char_limit );
 		$short_description = wp_filter_nohtml_kses( $short_description );
 		$short_description = strip_shortcodes( $short_description );
 

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -200,7 +200,7 @@ class CartItemSchema extends AbstractSchema {
 			'id'                => $product->get_id(),
 			'quantity'          => wc_stock_amount( $cart_item['quantity'] ),
 			'name'              => $product->get_title(),
-			'short_description' => apply_filters( 'woocommerce_short_description', $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ),
+			'short_description' => $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description() ),
 			'sku'               => $product->get_sku(),
 			'permalink'         => $product->get_permalink(),
 			'images'            => ( new ProductImages() )->images_to_array( $product ),

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -195,12 +195,16 @@ class CartItemSchema extends AbstractSchema {
 	public function get_item_response( $cart_item ) {
 		$product = $cart_item['data'];
 
+		$short_description = $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description() );
+		$short_description = wp_filter_nohtml_kses( $short_description );
+		$short_description = strip_shortcodes( $short_description );
+
 		return [
 			'key'               => $cart_item['key'],
 			'id'                => $product->get_id(),
 			'quantity'          => wc_stock_amount( $cart_item['quantity'] ),
 			'name'              => $product->get_title(),
-			'short_description' => $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description() ),
+			'short_description' => $short_description,
 			'sku'               => $product->get_sku(),
 			'permalink'         => $product->get_permalink(),
 			'images'            => ( new ProductImages() )->images_to_array( $product ),

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -195,9 +195,7 @@ class CartItemSchema extends AbstractSchema {
 	public function get_item_response( $cart_item ) {
 		$product = $cart_item['data'];
 
-		$description_char_limit = 75;
-
-		$short_description = $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), $description_char_limit );
+		$short_description = apply_filters( 'woocommerce_short_description', $product->get_short_description() ? $product->get_short_description() : $product->get_description(), 400 );
 		$short_description = wp_filter_nohtml_kses( $short_description );
 		$short_description = strip_shortcodes( $short_description );
 		$short_description = normalize_whitespace( $short_description );

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -31,13 +31,13 @@ class CartItemSchema extends AbstractSchema {
 	 */
 	protected function get_properties() {
 		return [
-			'key'       => [
+			'key'               => [
 				'description' => __( 'Unique identifier for the item within the cart.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'id'        => [
+			'id'                => [
 				'description' => __( 'The cart item product or variation ID.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
@@ -47,7 +47,7 @@ class CartItemSchema extends AbstractSchema {
 					'validate_callback' => [ $this, 'product_id_exists' ],
 				],
 			],
-			'quantity'  => [
+			'quantity'          => [
 				'description' => __( 'Quantity of this item in the cart.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
@@ -56,26 +56,32 @@ class CartItemSchema extends AbstractSchema {
 					'sanitize_callback' => 'wc_stock_amount',
 				],
 			],
-			'name'      => [
+			'name'              => [
 				'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'sku'       => [
+			'short_description' => [
+				'description' => __( 'Product short description or excerpt from full description.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'sku'               => [
 				'description' => __( 'Stock keeping unit, if applicable.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'permalink' => [
+			'permalink'         => [
 				'description' => __( 'Product URL.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'format'      => 'uri',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'images'    => [
+			'images'            => [
 				'description' => __( 'List of images.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -111,7 +117,7 @@ class CartItemSchema extends AbstractSchema {
 					],
 				],
 			],
-			'variation' => [
+			'variation'         => [
 				'description' => __( 'Chosen attributes (for variations).', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -131,7 +137,7 @@ class CartItemSchema extends AbstractSchema {
 					],
 				],
 			],
-			'totals'    => [
+			'totals'            => [
 				'description' => __( 'Item total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -190,15 +196,16 @@ class CartItemSchema extends AbstractSchema {
 		$product = $cart_item['data'];
 
 		return [
-			'key'       => $cart_item['key'],
-			'id'        => $product->get_id(),
-			'quantity'  => wc_stock_amount( $cart_item['quantity'] ),
-			'name'      => $product->get_title(),
-			'sku'       => $product->get_sku(),
-			'permalink' => $product->get_permalink(),
-			'images'    => ( new ProductImages() )->images_to_array( $product ),
-			'variation' => $this->format_variation_data( $cart_item['variation'], $product ),
-			'totals'    => array_merge(
+			'key'               => $cart_item['key'],
+			'id'                => $product->get_id(),
+			'quantity'          => wc_stock_amount( $cart_item['quantity'] ),
+			'name'              => $product->get_title(),
+			'short_description' => apply_filters( 'woocommerce_short_description', $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) ),
+			'sku'               => $product->get_sku(),
+			'permalink'         => $product->get_permalink(),
+			'images'            => ( new ProductImages() )->images_to_array( $product ),
+			'variation'         => $this->format_variation_data( $cart_item['variation'], $product ),
+			'totals'            => array_merge(
 				$this->get_store_currency_response(),
 				[
 					'line_subtotal'     => $this->prepare_money_response( $cart_item['line_subtotal'], wc_get_price_decimals() ),

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -200,6 +200,7 @@ class CartItemSchema extends AbstractSchema {
 		$short_description = $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), $description_char_limit );
 		$short_description = wp_filter_nohtml_kses( $short_description );
 		$short_description = strip_shortcodes( $short_description );
+		$short_description = normalize_whitespace( $short_description );
 
 		return [
 			'key'               => $cart_item['key'],


### PR DESCRIPTION
Fixes #1551

The cart block design includes a description under the product title. This PR adds a plain-text product short description to the `cart/items` API endpoint. 

If the product has a short description set, it is used. Otherwise the product description is used, trimmed (to default max 400 chars, consistent with products endpoint) and stripped of markup / shortcodes.

### How to test the changes in this Pull Request:

1. Clone this branch.
2. Add a range of products to your cart.
3. View `/wp-json/wc/store/cart/items` response and ensure product short description is appropriate and correct.

### Screenshot

<img width="448" alt="Screen Shot 2020-01-14 at 10 10 06 AM" src="https://user-images.githubusercontent.com/4167300/72294174-e2320500-36b9-11ea-9991-bf11f36b6be9.png">

