### PR TITLE
show low stock warning badge on cart line items

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
@@ -21,7 +21,15 @@ const ProductVariationDetails = ( { variation } ) => {
 };
 
 const CartLineItemRow = ( { lineItem } ) => {
-	const { name, description, images, variation, quantity, totals } = lineItem;
+	const {
+		name,
+		description,
+		images,
+		variation,
+		quantity,
+		lowStockRemaining,
+		totals,
+	} = lineItem;
 	const { line_total: total, line_subtotal: subtotal } = totals;
 
 	const imageProps = {};
@@ -54,6 +62,18 @@ const CartLineItemRow = ( { lineItem } ) => {
 		);
 	};
 
+	const lowStockBadge = lowStockRemaining ? (
+		<div className="wc-block-cart-item__low-stock-badge">
+			<span>
+				{ sprintf(
+					/* translators: %s stock amount (number of items in stock for product) */
+					__( '%s left in stock', 'woo-gutenberg-products-block' ),
+					lowStockRemaining
+				) }
+			</span>
+		</div>
+	) : null;
+
 	return (
 		<tr>
 			<td className="wc-block-cart-item__product">
@@ -63,6 +83,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 						<div className="wc-block-cart-item__product-name">
 							{ name }
 						</div>
+						{ lowStockBadge }
 						<div className="wc-block-cart-item__product-metadata">
 							{ description }
 							<ProductVariationDetails variation={ variation } />
@@ -98,6 +119,7 @@ CartLineItemRow.propTypes = {
 		description: PropTypes.string.isRequired,
 		images: PropTypes.array.isRequired,
 		quantity: PropTypes.number.isRequired,
+		lowStockRemaining: PropTypes.number,
 		variation: PropTypes.arrayOf(
 			PropTypes.shape( {
 				attribute: PropTypes.string.isRequired,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
@@ -10,9 +10,19 @@ import PropTypes from 'prop-types';
 import CartLineItemRow from './cart-line-item-row';
 
 const CartLineItemsTable = ( { lineItems = [] } ) => {
-	const products = lineItems.map( ( lineItem ) => (
-		<CartLineItemRow key={ lineItem.key } lineItem={ lineItem } />
-	) );
+	const products = lineItems.map( ( lineItemRaw ) => {
+		// convert low stock prop into camelCase
+		const {
+			low_stock_remaining: lowStockRemaining,
+			...lineItem
+		} = lineItemRaw;
+		return (
+			<CartLineItemRow
+				key={ lineItem.key }
+				lineItem={ { lowStockRemaining, ...lineItem } }
+			/>
+		);
+	} );
 
 	return (
 		<table className="wc-block-cart-items">

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -59,6 +59,19 @@ table.wc-block-cart-items {
 	font-size: 16px;
 }
 
+.wc-block-cart-item__low-stock-badge {
+	span {
+		background-color: $white;
+		border-radius: 3px;
+		border: 1px solid $black;
+		color: $black;
+		font-size: 12px;
+		padding: 0 1em;
+		text-transform: uppercase;
+		white-space: nowrap;
+	}
+}
+
 .wc-block-cart-item__product-metadata {
 	color: $core-grey-dark-400;
 	font-size: 12px;

--- a/assets/js/previews/cart-items.js
+++ b/assets/js/previews/cart-items.js
@@ -20,6 +20,7 @@ export const previewCartItems = [
 		description: __( 'Warm hat for winter' ),
 		sku: 'woo-beanie',
 		permalink: 'https://example.org',
+		low_stock_remaining: 2,
 		images: [
 			{
 				id: 10,


### PR DESCRIPTION
Fixes #1533 

Adds a low-stock warning badge to cart line items, underneath the product name.

Note 1: the cart line items API doesn't currently return low stock info, though [there's `low_stock_remaining` in the products API](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/22ef67938b3275a0c18bfdad99bc6ac78e58976a/src/RestApi/StoreApi/Schemas/ProductSchema.php#L183). This PR has fake data in the (sample) line items data for now; @mikejolley @nerrad should we add an issue for this, or are we expecting to hook this up to products API (as well as line items)?

Note 2: this has quite similar styling to the [discount badge](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1548). I haven't built a "badge" component or shared any styles in these PRs, but that might be worth looking at later. We'd need more use cases and design input to implement that well. For example, do we have props for colors, named style variations, how do we allow themes (core vs. storefront) to override colors etc. To me, this seems like a relatively simple component, that might be useful in other places in the Woo UI, and captures the complexity of supporting theming while providing a consistent look & feel. FYI @garymurray 

#### Accessibility

- [ ] I've tested using a screen reader
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="795" alt="Screen Shot 2020-01-14 at 5 04 49 PM" src="https://user-images.githubusercontent.com/4167300/72313424-1fb18500-36f0-11ea-8e65-ed58c82d1e62.png">

### How to test the changes in this Pull Request:

1. Clone this branch.
2. Add a cart block to a page and publish.
3. View the cart on front end in a variety of browsers and contexts.
13. Hack [`cart-items.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/previews/cart-items.js) to test a variety of stock scenarios.

