### PR TITLE
Make TextInput id optional

### DIFF
--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
+import withComponentId from '@woocommerce/base-hocs/with-component-id';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import './style.scss';
 
 const TextInput = ( {
 	className,
+	componentId,
 	id,
 	type = 'text',
 	ariaLabel,
@@ -25,6 +27,8 @@ const TextInput = ( {
 } ) => {
 	const [ isActive, setIsActive ] = useState( false );
 	const onChangeValue = ( event ) => onChange( event.target.value );
+	const textInputId = id || componentId;
+
 	return (
 		<div
 			className={ classnames( 'wc-block-text-input', className, {
@@ -36,23 +40,28 @@ const TextInput = ( {
 				screenReaderLabel={ screenReaderLabel || label }
 				wrapperElement="label"
 				wrapperProps={ {
-					htmlFor: id,
+					htmlFor: textInputId,
 				} }
-				htmlFor={ id }
+				htmlFor={ textInputId }
 			/>
 			<input
 				type={ type }
-				id={ id }
+				id={ textInputId }
 				value={ value }
 				onChange={ onChangeValue }
 				onFocus={ () => setIsActive( true ) }
 				onBlur={ () => setIsActive( false ) }
 				aria-label={ ariaLabel || label }
 				disabled={ disabled }
-				aria-describedby={ !! help ? id + '__help' : undefined }
+				aria-describedby={
+					!! help ? textInputId + '__help' : undefined
+				}
 			/>
 			{ !! help && (
-				<p id={ id + '__help' } className="wc-block-text-input__help">
+				<p
+					id={ textInputId + '__help' }
+					className="wc-block-text-input__help"
+				>
 					{ help }
 				</p>
 			) }
@@ -71,4 +80,4 @@ TextInput.propTypes = {
 	help: PropTypes.string,
 };
 
-export default TextInput;
+export default withComponentId( TextInput );

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -126,7 +126,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 						>
 							<InputRow>
 								<TextInput
-									id="shipping-first-name"
 									label={ __(
 										'First name',
 										'woo-gutenberg-products-block'
@@ -140,7 +139,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 									}
 								/>
 								<TextInput
-									id="shipping-last-name"
 									label={ __(
 										'Surname',
 										'woo-gutenberg-products-block'
@@ -155,7 +153,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								/>
 							</InputRow>
 							<TextInput
-								id="shipping-street-address"
 								label={ __(
 									'Street address',
 									'woo-gutenberg-products-block'
@@ -169,7 +166,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								}
 							/>
 							<TextInput
-								id="shipping-apartment"
 								label={ __(
 									'Apartment, suite, etc.',
 									'woo-gutenberg-products-block'
@@ -184,7 +180,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 							/>
 							<InputRow>
 								<TextInput
-									id="shipping-country"
 									label={ __(
 										'Country',
 										'woo-gutenberg-products-block'
@@ -198,7 +193,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 									}
 								/>
 								<TextInput
-									id="shipping-city"
 									label={ __(
 										'City',
 										'woo-gutenberg-products-block'
@@ -214,7 +208,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 							</InputRow>
 							<InputRow>
 								<TextInput
-									id="shipping-county"
 									label={ __(
 										'County',
 										'woo-gutenberg-products-block'
@@ -228,7 +221,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 									}
 								/>
 								<TextInput
-									id="shipping-postal-code"
 									label={ __(
 										'Postal code',
 										'woo-gutenberg-products-block'
@@ -243,7 +235,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								/>
 							</InputRow>
 							<TextInput
-								id="shipping-phone"
 								type="tel"
 								label={ __(
 									'Phone',


### PR DESCRIPTION
For the `<TextInput>` component we can rely on the `withComponentId()` HOC so we don't need to specify the `id` every time.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### How to test the changes in this Pull Request:

1. Create a post with a _Checkout_ block and modify [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/blocks/cart-checkout/checkout/block.js#L112) so input fields appear:
```diff
-{ shippingMethods.length > 0 && (
+{ true && (
```
2. With your browser devtools, check that input field ids match the label `for` attributes.
3. Create a post with a _Cart_ block and verify the coupon code input field still has a custom id (should be something like `wc-block-coupon-code__input-0`).