### PR TITLE
Add Shipping settings to Cart block

### DIFF
--- a/assets/js/base/components/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/totals/totals-coupon-code-input/index.js
@@ -33,7 +33,7 @@ const TotalsCouponCodeInput = ( { componentId, onSubmit } ) => {
 					htmlFor={ `wc-block-coupon-code__input-${ componentId }` }
 				/>
 			}
-			initialOpen={ false }
+			initialOpen={ true }
 		>
 			<PanelRow className="wc-block-coupon-code__row">
 				<TextInput

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -4,15 +4,12 @@
 import { __ } from '@wordpress/i18n';
 
 import { InspectorControls } from '@wordpress/block-editor';
-import {
-	Disabled,
-	PanelBody,
-	ToggleControl,
-} from '@wordpress/components';
+import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { withFeedbackPrompt } from '@woocommerce/block-hocs';
 import ViewSwitcher from '@woocommerce/block-components/view-switcher';
 import { previewCart } from '@woocommerce/resource-previews';
+import { SHIPPING_ENABLED } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -94,13 +91,17 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 					<>
 						{ currentView === 'full' && (
 							<>
-								<BlockSettings />
+								{ SHIPPING_ENABLED && <BlockSettings /> }
 								<Disabled>
 									<FullCart
 										cartItems={ previewCart.items }
 										cartTotals={ previewCart.totals }
-										isShippingCostHidden={ isShippingCostHidden }
-										isShippingCalculatorEnabled={ isShippingCalculatorEnabled }
+										isShippingCostHidden={
+											isShippingCostHidden
+										}
+										isShippingCalculatorEnabled={
+											isShippingCalculatorEnabled
+										}
 									/>
 								</Disabled>
 							</>

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -40,7 +40,7 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 						'woo-gutenberg-products-block'
 					) }
 					help={ __(
-						'Allow customers to estimate shipping',
+						'Allow customers to estimate shipping.',
 						'woo-gutenberg-products-block'
 					) }
 					checked={ isShippingCalculatorEnabled }
@@ -56,7 +56,7 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 						'woo-gutenberg-products-block'
 					) }
 					help={ __(
-						'Hides this shipping costs until an address is entered',
+						'Hide shipping costs until an address is entered.',
 						'woo-gutenberg-products-block'
 					) }
 					checked={ isShippingCostHidden }

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -50,22 +50,24 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 						} )
 					}
 				/>
-				<ToggleControl
-					label={ __(
-						'Hide shipping costs',
-						'woo-gutenberg-products-block'
-					) }
-					help={ __(
-						'Hide shipping costs until an address is entered.',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ isShippingCostHidden }
-					onChange={ () =>
-						setAttributes( {
-							isShippingCostHidden: ! isShippingCostHidden,
-						} )
-					}
-				/>
+				{ isShippingCalculatorEnabled && (
+					<ToggleControl
+						label={ __(
+							'Hide shipping costs',
+							'woo-gutenberg-products-block'
+						) }
+						help={ __(
+							'Hide shipping costs until an address is entered.',
+							'woo-gutenberg-products-block'
+						) }
+						checked={ isShippingCostHidden }
+						onChange={ () =>
+							setAttributes( {
+								isShippingCostHidden: ! isShippingCostHidden,
+							} )
+						}
+					/>
+				) }
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -2,8 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Disabled } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
+
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+	Disabled,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { withFeedbackPrompt } from '@woocommerce/block-hocs';
 import ViewSwitcher from '@woocommerce/block-components/view-switcher';
@@ -18,7 +23,53 @@ import EmptyCart from './empty-cart';
 /**
  * Component to handle edit mode of "Cart Block".
  */
-const CartEditor = ( { className } ) => {
+const CartEditor = ( { className, attributes, setAttributes } ) => {
+	const { isShippingCalculatorEnabled, isShippingCostHidden } = attributes;
+
+	const BlockSettings = () => (
+		<InspectorControls>
+			<PanelBody
+				title={ __(
+					'Shipping calculations',
+					'woo-gutenberg-products-block'
+				) }
+			>
+				<ToggleControl
+					label={ __(
+						'Shipping calculator',
+						'woo-gutenberg-products-block'
+					) }
+					help={ __(
+						'Allow customers to estimate shipping',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ isShippingCalculatorEnabled }
+					onChange={ () =>
+						setAttributes( {
+							isShippingCalculatorEnabled: ! isShippingCalculatorEnabled,
+						} )
+					}
+				/>
+				<ToggleControl
+					label={ __(
+						'Hide shipping costs',
+						'woo-gutenberg-products-block'
+					) }
+					help={ __(
+						'Hides this shipping costs until an address is entered',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ isShippingCostHidden }
+					onChange={ () =>
+						setAttributes( {
+							isShippingCostHidden: ! isShippingCostHidden,
+						} )
+					}
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+
 	return (
 		<div className={ className }>
 			<ViewSwitcher
@@ -38,17 +89,22 @@ const CartEditor = ( { className } ) => {
 				] }
 				defaultView={ 'full' }
 				render={ ( currentView ) => (
-					<Fragment>
+					<>
 						{ currentView === 'full' && (
-							<Disabled>
-								<FullCart
-									cartItems={ previewCart.items }
-									cartTotals={ previewCart.totals }
-								/>
-							</Disabled>
+							<>
+								<BlockSettings />
+								<Disabled>
+									<FullCart
+										cartItems={ previewCart.items }
+										cartTotals={ previewCart.totals }
+										isShippingCostHidden={ isShippingCostHidden }
+										isShippingCalculatorEnabled={ isShippingCalculatorEnabled }
+									/>
+								</Disabled>
+							</>
 						) }
 						<EmptyCart hidden={ currentView === 'full' } />
-					</Fragment>
+					</>
 				) }
 			/>
 		</div>

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -21,16 +21,8 @@ const CartFrontend = ( { emptyCart } ) => {
 		return null;
 	}
 
-const cartItems = cartData.items;
-const isCartEmpty = cartItems.length <= 0;
-if ( ! isCartEmpty ) {
-	const getProps = ( el ) => {
-		return {
-			isShippingCalculatorEnabled:
-				el.dataset.isShippingCalculatorEnabled === 'true',
-			isShippingCostHidden: el.dataset.isShippingCostHidden === 'true',
-		};
-	};
+	const cartItems = cartData.items;
+	const isCartEmpty = cartItems.length <= 0;
 
 	return isCartEmpty ? (
 		<RawHTML>{ emptyCart }</RawHTML>
@@ -41,6 +33,9 @@ if ( ! isCartEmpty ) {
 
 const getProps = ( el ) => ( {
 	emptyCart: el.innerHTML,
+	isShippingCalculatorEnabled:
+		el.dataset.isshippingcalculatorenabled === 'true',
+	isShippingCostHidden: el.dataset.isshippingcosthidden === 'true',
 } );
 
 renderFrontend(

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -21,8 +21,16 @@ const CartFrontend = ( { emptyCart } ) => {
 		return null;
 	}
 
-	const cartItems = cartData.items;
-	const isCartEmpty = cartItems.length <= 0;
+const cartItems = cartData.items;
+const isCartEmpty = cartItems.length <= 0;
+if ( ! isCartEmpty ) {
+	const getProps = ( el ) => {
+		return {
+			isShippingCalculatorEnabled:
+				el.dataset.isShippingCalculatorEnabled === 'true',
+			isShippingCostHidden: el.dataset.isShippingCostHidden === 'true',
+		};
+	};
 
 	return isCartEmpty ? (
 		<RawHTML>{ emptyCart }</RawHTML>

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -14,7 +14,11 @@ import renderFrontend from '../../../utils/render-frontend.js';
 /**
  * Wrapper component to supply API data and show empty cart view as needed.
  */
-const CartFrontend = ( { emptyCart } ) => {
+const CartFrontend = ( {
+	emptyCart,
+	isShippingCalculatorEnabled,
+	isShippingCostHidden,
+} ) => {
 	const { cartData, isLoading } = useStoreCart();
 
 	if ( isLoading ) {
@@ -27,7 +31,12 @@ const CartFrontend = ( { emptyCart } ) => {
 	return isCartEmpty ? (
 		<RawHTML>{ emptyCart }</RawHTML>
 	) : (
-		<FullCart cartItems={ cartItems } cartTotals={ cartData.totals } />
+		<FullCart
+			cartItems={ cartItems }
+			cartTotals={ cartData.totals }
+			isShippingCalculatorEnabled={ isShippingCalculatorEnabled }
+			isShippingCostHidden={ isShippingCostHidden }
+		/>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -61,11 +61,7 @@ const Cart = ( {
 	useEffect( () => {
 		if ( isShippingCalculatorEnabled ) {
 			if ( isShippingCostHidden ) {
-				if (
-					Object.values( shippingCalculatorAddress ).filter(
-						( v ) => ! v
-					).length === 0
-				) {
+				if ( shippingCalculatorAddress.country ) {
 					return setShowShippingCosts( true );
 				}
 			} else {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -42,7 +42,7 @@ const Cart = ( {
 	cartItems = [],
 	cartTotals = {},
 	isShippingCalculatorEnabled,
-	isShippingCostHidden
+	isShippingCostHidden,
 } ) => {
 	const [ selectedShippingRate, setSelectedShippingRate ] = useState();
 	const [
@@ -61,7 +61,7 @@ const Cart = ( {
 	 * @return {Object[]} Values to display in the cart block.
 	 * @param cartTotals
 	 */
-	const getTotalRowsConfig = ( cartTotals ) => {
+	const getTotalRowsConfig = () => {
 		const totalItems = parseInt( cartTotals.total_items, 10 );
 		const totalItemsTax = parseInt( cartTotals.total_items_tax, 10 );
 		const totalRowsConfig = [
@@ -130,8 +130,8 @@ const Cart = ( {
 		return totalRowsConfig;
 	};
 
-	const totalsCurrency = getCurrencyFromPriceResponse( fetchedCartTotals );
-	const totalRowsConfig = getTotalRowsConfig( fetchedCartTotals );
+	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
+	const totalRowsConfig = getTotalRowsConfig( cartTotals );
 
 	const ShippingCalculatorOptions = () => (
 		<fieldset className="wc-block-cart__shipping-options-fieldset">
@@ -232,10 +232,7 @@ const Cart = ( {
 								'Total',
 								'woo-gutenberg-products-block'
 							) }
-							value={ parseInt(
-								fetchedCartTotals.total_price,
-								10
-							) }
+							value={ parseInt( cartTotals.total_price, 10 ) }
 						/>
 						<CheckoutButton />
 					</CardBody>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -38,7 +38,12 @@ const onActivateCoupon = ( couponCode ) => {
 /**
  * Component that renders the Cart block when user has something in cart aka "full".
  */
-const Cart = ( { cartItems = [], cartTotals = {} } ) => {
+const Cart = ( {
+	cartItems = [],
+	cartTotals = {},
+	isShippingCalculatorEnabled,
+	isShippingCostHidden
+} ) => {
 	const [ selectedShippingRate, setSelectedShippingRate ] = useState();
 	const [
 		shippingCalculatorAddress,
@@ -96,27 +101,28 @@ const Cart = ( { cartItems = [], cartTotals = {} } ) => {
 				value: totalTax,
 			} );
 		}
-		const totalShipping = parseInt( cartTotals.total_shipping, 10 );
-		const totalShippingTax = parseInt( cartTotals.total_shipping_tax, 10 );
-		totalRowsConfig.push( {
-			label: __( 'Shipping:', 'woo-gutenberg-products-block' ),
-			value: DISPLAY_PRICES_INCLUDING_TAXES
-				? totalShipping + totalShippingTax
-				: totalShipping,
-			description: (
-				<Fragment>
-					{ __(
-						'Shipping to location',
-						'woo-gutenberg-products-block'
-					) + ' ' }
-					<ShippingCalculator
-						address={ shippingCalculatorAddress }
-						setAddress={ setShippingCalculatorAddress }
-					/>
-				</Fragment>
-			),
-		} );
-
+		if ( ! isShippingCostHidden ) {
+			const totalShipping = parseInt( cartTotals.total_shipping, 10 );
+			const totalShippingTax = parseInt( cartTotals.total_shipping_tax, 10 );
+			totalRowsConfig.push( {
+				label: __( 'Shipping:', 'woo-gutenberg-products-block' ),
+				value: DISPLAY_PRICES_INCLUDING_TAXES
+					? totalShipping + totalShippingTax
+					: totalShipping,
+				description: (
+					<Fragment>
+						{ __(
+							'Shipping to location',
+							'woo-gutenberg-products-block'
+						) + ' ' }
+						<ShippingCalculator
+							address={ shippingCalculatorAddress }
+							setAddress={ setShippingCalculatorAddress }
+						/>
+					</Fragment>
+				),
+			} );
+		}
 		return totalRowsConfig;
 	};
 
@@ -149,16 +155,17 @@ const Cart = ( { cartItems = [], cartTotals = {} } ) => {
 								/>
 							)
 						) }
-						<fieldset className="wc-block-cart__shipping-options-fieldset">
-							<legend className="screen-reader-text">
-								{ __(
+						{ isShippingCalculatorEnabled && (
+							<fieldset className="wc-block-cart__shipping-options-fieldset">
+								<legend className="screen-reader-text">
+									{ __(
 									'Choose the shipping method.',
 									'woo-gutenberg-products-block'
 								) }
-							</legend>
-							<ShippingRatesControl
-								className="wc-block-cart__shipping-options"
-								address={
+								</legend>
+								<ShippingRatesControl
+									className="wc-block-cart__shipping-options"
+									address={
 									shippingCalculatorAddress.country
 										? {
 												city:
@@ -172,7 +179,7 @@ const Cart = ( { cartItems = [], cartTotals = {} } ) => {
 										  }
 										: null
 								}
-								noResultsMessage={ sprintf(
+									noResultsMessage={ sprintf(
 									// translators: %s shipping destination.
 									__(
 										'No shipping options were found for %s.',
@@ -182,8 +189,8 @@ const Cart = ( { cartItems = [], cartTotals = {} } ) => {
 									// see: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1606
 									'location'
 								) }
-								selected={ selectedShippingRate }
-								renderOption={ ( option ) => ( {
+									selected={ selectedShippingRate }
+									renderOption={ ( option ) => ( {
 									label: decodeEntities( option.name ),
 									value: option.rate_id,
 									description: (
@@ -206,13 +213,14 @@ const Cart = ( { cartItems = [], cartTotals = {} } ) => {
 										</Fragment>
 									),
 								} ) }
-								onChange={ ( newSelectedShippingOption ) =>
+									onChange={ ( newSelectedShippingOption ) =>
 									setSelectedShippingRate(
 										newSelectedShippingOption
 									)
 								}
 							/>
-						</fieldset>
+							</fieldset>
+						) }
 						{ COUPONS_ENABLED && (
 							<TotalsCouponCodeInput
 								onSubmit={ onActivateCoupon }
@@ -225,7 +233,7 @@ const Cart = ( { cartItems = [], cartTotals = {} } ) => {
 								'Total',
 								'woo-gutenberg-products-block'
 							) }
-							value={ parseInt( cartTotals.total_price, 10 ) }
+							value={ parseInt( fetchedCartTotals.total_price, 10 ) }
 						/>
 						<CheckoutButton />
 					</CardBody>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -12,6 +12,7 @@ import ShippingRatesControl from '@woocommerce/base-components/shipping-rates-co
 import ShippingCalculator from '@woocommerce/base-components/shipping-calculator';
 import {
 	COUPONS_ENABLED,
+	SHIPPING_ENABLED,
 	DISPLAY_PRICES_INCLUDING_TAXES,
 } from '@woocommerce/block-settings';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
@@ -59,6 +60,9 @@ const Cart = ( {
 		! isShippingCostHidden
 	);
 	useEffect( () => {
+		if ( ! SHIPPING_ENABLED ) {
+			return setShowShippingCosts( false );
+		}
 		if ( isShippingCalculatorEnabled ) {
 			if ( isShippingCostHidden ) {
 				if ( shippingCalculatorAddress.country ) {
@@ -121,7 +125,7 @@ const Cart = ( {
 				value: totalTax,
 			} );
 		}
-		if ( isShippingCalculatorEnabled ) {
+		if ( SHIPPING_ENABLED && isShippingCalculatorEnabled ) {
 			const totalShipping = parseInt( cartTotals.total_shipping, 10 );
 			const totalShippingTax = parseInt(
 				cartTotals.total_shipping_tax,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -61,8 +61,8 @@ const Cart = ( {
 	 * @return {Object[]} Values to display in the cart block.
 	 */
 	const getTotalRowsConfig = () => {
-		const totalItems = parseInt( cartTotals.total_items, 10 );
-		const totalItemsTax = parseInt( cartTotals.total_items_tax, 10 );
+		const totalItems = parseInt( fetchedCartTotals.total_items, 10 );
+		const totalItemsTax = parseInt( fetchedCartTotals.total_items_tax, 10 );
 		const totalRowsConfig = [
 			{
 				label: __( 'List items:', 'woo-gutenberg-products-block' ),
@@ -71,9 +71,9 @@ const Cart = ( {
 					: totalItems,
 			},
 		];
-		const totalFees = parseInt( cartTotals.total_fees, 10 );
+		const totalFees = parseInt( fetchedCartTotals.total_fees, 10 );
 		if ( totalFees > 0 ) {
-			const totalFeesTax = parseInt( cartTotals.total_fees_tax, 10 );
+			const totalFeesTax = parseInt( fetchedCartTotals.total_fees_tax, 10 );
 			totalRowsConfig.push( {
 				label: __( 'Fees:', 'woo-gutenberg-products-block' ),
 				value: DISPLAY_PRICES_INCLUDING_TAXES
@@ -81,10 +81,10 @@ const Cart = ( {
 					: totalFees,
 			} );
 		}
-		const totalDiscount = parseInt( cartTotals.total_discount, 10 );
+		const totalDiscount = parseInt( fetchedCartTotals.total_discount, 10 );
 		if ( totalDiscount > 0 ) {
 			const totalDiscountTax = parseInt(
-				cartTotals.total_discount_tax,
+				fetchedCartTotals.total_discount_tax,
 				10
 			);
 			totalRowsConfig.push( {
@@ -95,15 +95,15 @@ const Cart = ( {
 			} );
 		}
 		if ( ! DISPLAY_PRICES_INCLUDING_TAXES ) {
-			const totalTax = parseInt( cartTotals.total_tax, 10 );
+			const totalTax = parseInt( fetchedCartTotals.total_tax, 10 );
 			totalRowsConfig.push( {
 				label: __( 'Taxes:', 'woo-gutenberg-products-block' ),
 				value: totalTax,
 			} );
 		}
 		if ( isShippingCalculatorEnabled ) {
-			const totalShipping = parseInt( cartTotals.total_shipping, 10 );
-			const totalShippingTax = parseInt( cartTotals.total_shipping_tax, 10 );
+			const totalShipping = parseInt( fetchedCartTotals.total_shipping, 10 );
+			const totalShippingTax = parseInt( fetchedCartTotals.total_shipping_tax, 10 );
 			totalRowsConfig.push( {
 				label: __( 'Shipping:', 'woo-gutenberg-products-block' ),
 				value: DISPLAY_PRICES_INCLUDING_TAXES
@@ -126,8 +126,8 @@ const Cart = ( {
 		return totalRowsConfig;
 	};
 
-	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
-	const totalRowsConfig = getTotalRowsConfig( cartTotals );
+	const totalsCurrency = getCurrencyFromPriceResponse( fetchedCartTotals );
+	const totalRowsConfig = getTotalRowsConfig( fetchedCartTotals );
 
 	return (
 		<div className="wc-block-cart">
@@ -155,7 +155,8 @@ const Cart = ( {
 								/>
 							)
 						) }
-						{ isShippingCalculatorEnabled && (
+						{ isShippingCalculatorEnabled &&
+							! isShippingCostHidden && (
 							<fieldset className="wc-block-cart__shipping-options-fieldset">
 								<legend className="screen-reader-text">
 									{ __(
@@ -196,13 +197,15 @@ const Cart = ( {
 									description: (
 										<Fragment>
 											{ option.price && (
-												<FormattedMonetaryAmount
-													currency={ getCurrencyFromPriceResponse(
-														option
+											<FormattedMonetaryAmount
+												currency={ getCurrencyFromPriceResponse(
+																option
+															) }
+												value={
+																option.price
+															}
+														/>
 													) }
-													value={ option.price }
-												/>
-											) }
 											{ option.price &&
 											option.delivery_time
 												? ' — '
@@ -211,19 +214,23 @@ const Cart = ( {
 												option.delivery_time
 											) }
 										</Fragment>
-									),
-								} ) }
-									onChange={ ( newSelectedShippingOption ) =>
-									setSelectedShippingRate(
-										newSelectedShippingOption
-									)
-								}
-							/>
-							</fieldset>
-						) }
+											),
+										} ) }
+									onChange={ (
+											newSelectedShippingOption
+										) =>
+											setSelectedShippingRate(
+												newSelectedShippingOption
+											)
+										}
+									/>
+								</fieldset>
+							) }
 						{ COUPONS_ENABLED && (
-						<TotalsCouponCodeInput onSubmit={ onActivateCoupon } />
-					) }
+							<TotalsCouponCodeInput
+								onSubmit={ onActivateCoupon }
+							/>
+						) }
 						<TotalsItem
 							className="wc-block-cart__totals-footer"
 							currency={ totalsCurrency }
@@ -231,8 +238,11 @@ const Cart = ( {
 								'Total',
 								'woo-gutenberg-products-block'
 							) }
-							value={ parseInt( fetchedCartTotals.total_price, 10 ) }
-					/>
+							value={ parseInt(
+								fetchedCartTotals.total_price,
+								10
+							) }
+						/>
 						<CheckoutButton />
 					</CardBody>
 				</Card>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, Fragment } from '@wordpress/element';
+import { useState, Fragment, useEffect } from '@wordpress/element';
 import {
 	TotalsCouponCodeInput,
 	TotalsItem,
@@ -55,6 +55,29 @@ const Cart = ( {
 		country: '',
 	} );
 
+	const [ showShippingCosts, setShowShippingCosts ] = useState(
+		! isShippingCostHidden
+	);
+	useEffect( () => {
+		if ( isShippingCalculatorEnabled ) {
+			if ( isShippingCostHidden ) {
+				if (
+					Object.values( shippingCalculatorAddress ).filter(
+						( v ) => ! v
+					).length === 0
+				) {
+					return setShowShippingCosts( true );
+				}
+			} else {
+				return setShowShippingCosts( true );
+			}
+		}
+		return setShowShippingCosts( false );
+	}, [
+		isShippingCalculatorEnabled,
+		isShippingCostHidden,
+		shippingCalculatorAddress,
+	] );
 	/**
 	 * Given an API response with cart totals, generates an array of rows to display in the Cart block.
 	 *
@@ -216,10 +239,7 @@ const Cart = ( {
 								/>
 							)
 						) }
-						{ isShippingCalculatorEnabled &&
-							! isShippingCostHidden && (
-								<ShippingCalculatorOptions />
-							) }
+						{ showShippingCosts && <ShippingCalculatorOptions /> }
 						{ COUPONS_ENABLED && (
 							<TotalsCouponCodeInput
 								onSubmit={ onActivateCoupon }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -101,7 +101,7 @@ const Cart = ( {
 				value: totalTax,
 			} );
 		}
-		if ( ! isShippingCostHidden ) {
+		if ( isShippingCalculatorEnabled ) {
 			const totalShipping = parseInt( cartTotals.total_shipping, 10 );
 			const totalShippingTax = parseInt( cartTotals.total_shipping_tax, 10 );
 			totalRowsConfig.push( {
@@ -222,10 +222,8 @@ const Cart = ( {
 							</fieldset>
 						) }
 						{ COUPONS_ENABLED && (
-							<TotalsCouponCodeInput
-								onSubmit={ onActivateCoupon }
-							/>
-						) }
+						<TotalsCouponCodeInput onSubmit={ onActivateCoupon } />
+					) }
 						<TotalsItem
 							className="wc-block-cart__totals-footer"
 							currency={ totalsCurrency }
@@ -234,7 +232,7 @@ const Cart = ( {
 								'woo-gutenberg-products-block'
 							) }
 							value={ parseInt( fetchedCartTotals.total_price, 10 ) }
-						/>
+					/>
 						<CheckoutButton />
 					</CardBody>
 				</Card>

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -66,8 +66,8 @@ const settings = {
 			isShippingCostHidden,
 		} = attributes;
 		const data = {
-			'data-is-shipping-calculator-enabled': isShippingCalculatorEnabled,
-			'data-is-shipping-cost-hidden': isShippingCostHidden,
+			'data-isshippingcalculatorenabled': isShippingCalculatorEnabled,
+			'data-isshippingcosthidden': isShippingCostHidden,
 		};
 		return (
 			<div

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -31,7 +31,16 @@ const settings = {
 		multiple: false,
 	},
 	example,
-	attributes: {},
+	attributes: {
+		isShippingCalculatorEnabled: {
+			type: 'boolean',
+			default: true,
+		},
+		isShippingCostHidden: {
+			type: 'boolean',
+			default: false,
+		},
+	},
 
 	/**
 	 * Renders the edit view for a block.

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -2,9 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, cart } from '@woocommerce/icons';
+import {
+	ENABLE_SHIPPING_CALCULATION,
+	HIDE_SHIPPING_COST,
+} from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -34,11 +39,11 @@ const settings = {
 	attributes: {
 		isShippingCalculatorEnabled: {
 			type: 'boolean',
-			default: true,
+			default: ENABLE_SHIPPING_CALCULATION,
 		},
 		isShippingCostHidden: {
 			type: 'boolean',
-			default: false,
+			default: HIDE_SHIPPING_COST,
 		},
 	},
 
@@ -52,11 +57,23 @@ const settings = {
 	},
 
 	/**
-	 * Block content is rendered in PHP, not via save function.
+	 * Save the props to post content.
 	 */
-	save() {
+	save( { attributes } ) {
+		const {
+			className,
+			isShippingCalculatorEnabled,
+			isShippingCostHidden,
+		} = attributes;
+		const data = {
+			'data-is-shipping-calculator-enabled': isShippingCalculatorEnabled,
+			'data-is-shipping-cost-hidden': isShippingCostHidden,
+		};
 		return (
-			<div className="is-loading">
+			<div
+				className={ classNames( 'is-loading', className ) }
+				{ ...data }
+			>
 				<InnerBlocks.Content />
 			</div>
 		);

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -7,8 +7,8 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, cart } from '@woocommerce/icons';
 import {
-	ENABLE_SHIPPING_CALCULATION,
-	HIDE_SHIPPING_COST,
+	IS_SHIPPING_CALCULATOR_ENABLED,
+	IS_SHIPPING_COST_HIDDEN,
 } from '@woocommerce/block-settings';
 
 /**
@@ -39,11 +39,11 @@ const settings = {
 	attributes: {
 		isShippingCalculatorEnabled: {
 			type: 'boolean',
-			default: ENABLE_SHIPPING_CALCULATION,
+			default: IS_SHIPPING_CALCULATOR_ENABLED,
 		},
 		isShippingCostHidden: {
 			type: 'boolean',
-			default: HIDE_SHIPPING_COST,
+			default: IS_SHIPPING_COST_HIDDEN,
 		},
 	},
 

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -26,6 +26,7 @@ export const HOME_URL = getSetting( 'homeUrl', '' );
 export const SHOP_URL = getSetting( 'shopUrl', '' );
 export const CHECKOUT_URL = getSetting( 'checkoutUrl', '' );
 export const COUPONS_ENABLED = getSetting( 'couponsEnabled', true );
+export const SHIPPING_ENABLED = getSetting( 'shippingEnabled', true );
 export const DISPLAY_PRICES_INCLUDING_TAXES = getSetting(
 	'displayPricesIncludingTaxes',
 	false

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -32,6 +32,11 @@ export const DISPLAY_PRICES_INCLUDING_TAXES = getSetting(
 );
 export const PRODUCT_COUNT = getSetting( 'productCount', 0 );
 export const ATTRIBUTES = getSetting( 'attributes', [] );
+export const ENABLE_SHIPPING_CALCULATION = getSetting(
+	'isShippingCalculatorEnabled',
+	true
+);
+export const HIDE_SHIPPING_COST = getSetting( 'isShippingCostHidden', false );
 export const WC_BLOCKS_ASSET_URL = getSetting( 'wcBlocksAssetUrl', '' );
 export const SHIPPING_COUNTRIES = getSetting( 'shippingCountries', {} );
 export const ALLOWED_COUNTRIES = getSetting( 'allowedCountries', {} );

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -32,11 +32,14 @@ export const DISPLAY_PRICES_INCLUDING_TAXES = getSetting(
 );
 export const PRODUCT_COUNT = getSetting( 'productCount', 0 );
 export const ATTRIBUTES = getSetting( 'attributes', [] );
-export const ENABLE_SHIPPING_CALCULATION = getSetting(
+export const IS_SHIPPING_CALCULATOR_ENABLED = getSetting(
 	'isShippingCalculatorEnabled',
 	true
 );
-export const HIDE_SHIPPING_COST = getSetting( 'isShippingCostHidden', false );
+export const IS_SHIPPING_COST_HIDDEN = getSetting(
+	'isShippingCostHidden',
+	false
+);
 export const WC_BLOCKS_ASSET_URL = getSetting( 'wcBlocksAssetUrl', '' );
 export const SHIPPING_COUNTRIES = getSetting( 'shippingCountries', {} );
 export const ALLOWED_COUNTRIES = getSetting( 'allowedCountries', {} );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -123,6 +123,7 @@ class Assets {
 				'shopUrl'                     => get_permalink( wc_get_page_id( 'shop' ) ),
 				'checkoutUrl'                 => get_permalink( wc_get_page_id( 'checkout' ) ),
 				'couponsEnabled'              => wc_coupons_enabled(),
+				'shippingEnabled'             => wc_shipping_enabled(),
 				'displayPricesIncludingTaxes' => 'incl' === get_option( 'woocommerce_tax_display_shop' ),
 				'showAvatars'                 => '1' === get_option( 'show_avatars' ),
 				'reviewRatingsEnabled'        => wc_review_ratings_enabled(),

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -128,6 +128,8 @@ class Assets {
 				'reviewRatingsEnabled'        => wc_review_ratings_enabled(),
 				'productCount'                => array_sum( (array) $product_counts ),
 				'attributes'                  => array_values( wc_get_attribute_taxonomies() ),
+				'isShippingCalculatorEnabled' => 'yes' === get_option( 'woocommerce_enable_shipping_calc' ),
+				'isShippingCostHidden'        => 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ),
 				'wcBlocksAssetUrl'            => plugins_url( 'assets/', __DIR__ ),
 				'restApiRoutes'               => [
 					'/wc/store' => array_keys( \Automattic\WooCommerce\Blocks\RestApi::get_routes_from_namespace( 'wc/store' ) ),

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -128,8 +128,8 @@ class Assets {
 				'reviewRatingsEnabled'        => wc_review_ratings_enabled(),
 				'productCount'                => array_sum( (array) $product_counts ),
 				'attributes'                  => array_values( wc_get_attribute_taxonomies() ),
-				'isShippingCalculatorEnabled' => 'yes' === get_option( 'woocommerce_enable_shipping_calc' ),
-				'isShippingCostHidden'        => 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ),
+				'isShippingCalculatorEnabled' => filter_var( get_option( 'woocommerce_enable_shipping_calc' ), FILTER_VALIDATE_BOOLEAN ),
+				'isShippingCostHidden'        => filter_var( get_option( 'woocommerce_shipping_cost_requires_address' ), FILTER_VALIDATE_BOOLEAN ),
 				'wcBlocksAssetUrl'            => plugins_url( 'assets/', __DIR__ ),
 				'restApiRoutes'               => [
 					'/wc/store' => array_keys( \Automattic\WooCommerce\Blocks\RestApi::get_routes_from_namespace( 'wc/store' ) ),


### PR DESCRIPTION
Fixes #1488.

- I've added two toggle options, show calculator and hide costs.
- I've also moved `getTotalRowsConfig` inside `FullCart` since it depends on an attribute passed from the above block, we can keep it out and just add an extra param to `getTotalRowsConfig`.
- Hide the options on Empty cart mode.
- Render those changes to the frontend
### Screenshots
![image](https://user-images.githubusercontent.com/6165348/72364267-833eb100-36f6-11ea-8b48-af613402df8d.png)
![image](https://user-images.githubusercontent.com/6165348/72364280-8a65bf00-36f6-11ea-801a-5765522d4cd9.png)
![image](https://user-images.githubusercontent.com/6165348/72364293-92256380-36f6-11ea-9b83-6be63d74ac0f.png)
![image](https://user-images.githubusercontent.com/6165348/72364412-c4cf5c00-36f6-11ea-95a7-675cd0e22309.png)



