### PR TITLE
Make RadioControl id optional

### DIFF
--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -13,10 +13,13 @@ import './style.scss';
 const RadioControl = ( {
 	className,
 	componentId,
+	id,
 	selected,
 	onChange,
 	options = [],
 } ) => {
+	const radioControlId = id || componentId;
+
 	return (
 		options.length && (
 			<div
@@ -25,7 +28,7 @@ const RadioControl = ( {
 				{ options.map( ( option ) => (
 					<RadioControlOption
 						key={ option.value }
-						name={ `radio-control-${ componentId }` }
+						name={ `radio-control-${ radioControlId }` }
 						checked={ option.value === selected }
 						option={ option }
 						onChange={ onChange }


### PR DESCRIPTION
Implement the same solution from #1560 to the `<RadioControl>`.

It will try to use the `id` from the props, if it's not specified, it will rely on the value from `withComponentId()`.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### How to test the changes in this Pull Request:

1. Create a post with the _Cart_ block.
2. With your browser devtools verify each Shipping option markup makes sense (verify `id`, `name`, `for` and `aria-describedby` refer to valid elements).