### PR TITLE
follow up fixes on cart low stock warning badge

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -41,7 +41,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 		images,
 		variation,
 		quantity,
-		lowStockRemaining,
+		low_stock_remaining: lowStockRemaining,
 		totals,
 	} = lineItem;
 	const { line_total: total, line_subtotal: subtotal } = totals;
@@ -152,7 +152,7 @@ CartLineItemRow.propTypes = {
 		description: PropTypes.string.isRequired,
 		images: PropTypes.array.isRequired,
 		quantity: PropTypes.number.isRequired,
-		lowStockRemaining: PropTypes.number,
+		low_stock_remaining: PropTypes.number,
 		variation: PropTypes.arrayOf(
 			PropTypes.shape( {
 				attribute: PropTypes.string.isRequired,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -94,13 +94,11 @@ const CartLineItemRow = ( { lineItem } ) => {
 
 	const lowStockBadge = lowStockRemaining ? (
 		<div className="wc-block-cart-item__low-stock-badge">
-			<span>
-				{ sprintf(
-					/* translators: %s stock amount (number of items in stock for product) */
-					__( '%s left in stock', 'woo-gutenberg-products-block' ),
-					lowStockRemaining
-				) }
-			</span>
+			{ sprintf(
+				/* translators: %s stock amount (number of items in stock for product) */
+				__( '%s left in stock', 'woo-gutenberg-products-block' ),
+				lowStockRemaining
+			) }
 		</div>
 	) : null;
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
@@ -10,18 +10,8 @@ import PropTypes from 'prop-types';
 import CartLineItemRow from './cart-line-item-row';
 
 const CartLineItemsTable = ( { lineItems = [] } ) => {
-	const products = lineItems.map( ( lineItemRaw ) => {
-		// convert low stock prop into camelCase
-		const {
-			low_stock_remaining: lowStockRemaining,
-			...lineItem
-		} = lineItemRaw;
-		return (
-			<CartLineItemRow
-				key={ lineItem.key }
-				lineItem={ { lowStockRemaining, ...lineItem } }
-			/>
-		);
+	const products = lineItems.map( ( lineItem ) => {
+		return <CartLineItemRow key={ lineItem.key } lineItem={ lineItem } />;
 	} );
 
 	return (

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -60,16 +60,16 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__low-stock-badge {
-	span {
-		background-color: $white;
-		border-radius: 3px;
-		border: 1px solid $black;
-		color: $black;
-		font-size: 12px;
-		padding: 0 1em;
-		text-transform: uppercase;
-		white-space: nowrap;
-	}
+	display: inline-block;
+
+	background-color: $white;
+	border-radius: 3px;
+	border: 1px solid $black;
+	color: $black;
+	font-size: 12px;
+	padding: 0 1em;
+	text-transform: uppercase;
+	white-space: nowrap;
 }
 
 .wc-block-cart-item__product-metadata {


### PR DESCRIPTION
There were some fixes needed on PR #1557 (issue #1533) which I missed when I (accidentally) merged the PR. This PR is to address that feedback.

- Don't create a new object to get around `low_stock_remaining` variable name (to avoid extra renders)
- Switch badge styling to match simpler approach (no extra `span` element needed), consistent with #1548 

#### Accessibility

- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="831" alt="Screen Shot 2020-01-15 at 12 53 17 PM" src="https://user-images.githubusercontent.com/4167300/72392873-03682380-3796-11ea-9b9a-268fe0543812.png">


### How to test the changes in this Pull Request:

1. Clone this branch.
2. Add a cart block to a page and publish.
3. View the cart on front end in a variety of browsers and contexts.
13. Hack [`cart-items.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/previews/cart-items.js) to test a variety of stock scenarios.

