### PR TITLE
UI for removing cart items (not including hooking up to API)

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -75,3 +75,18 @@
 	margin: unset;
 	overflow: hidden;
 }
+
+// Reset <button> style so we can use link style for action buttons.
+@mixin link-button() {
+	margin: 0;
+	padding: 0;
+	border: 0;
+
+	font-size: inherit;
+	font-weight: normal;
+
+	background: transparent;
+	&:hover {
+		background: transparent;
+	}
+}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -127,15 +127,15 @@ const CartLineItemRow = ( { lineItem } ) => {
 			<td className="wc-block-cart-item__quantity">
 				<div>
 					{ quantitySelector() }
-					<div className="wc-block-cart-item__remove-link">
+					<button className="wc-block-cart-item__remove-link">
 						{ __( 'Remove item', 'woo-gutenberg-products-block' ) }
-					</div>
+					</button>
 				</div>
 			</td>
 			<td className="wc-block-cart-item__total">
-				<div className="wc-block-cart-item__remove-icon">
+				<button className="wc-block-cart-item__remove-icon">
 					<IconTrash />
-				</div>
+				</button>
 				{ fullPrice }
 				<div className="wc-block-cart-item__line-total">
 					<FormattedMonetaryAmount

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import { getCurrency, formatPrice } from '@woocommerce/base-utils';
-import { IconDelete } from '@woocommerce/block-components/icons';
+import { IconTrash } from '@woocommerce/block-components/icons';
 
 /**
  * Return the difference between two price amounts, e.g. a discount.
@@ -134,7 +134,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 			</td>
 			<td className="wc-block-cart-item__total">
 				<div className="wc-block-cart-item__remove-icon">
-					<IconDelete />
+					<IconTrash />
 				</div>
 				<div className="wc-block-cart-item__totals-container">
 					{ fullPrice }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -136,16 +136,14 @@ const CartLineItemRow = ( { lineItem } ) => {
 				<div className="wc-block-cart-item__remove-icon">
 					<IconTrash />
 				</div>
-				<div className="wc-block-cart-item__totals-container">
-					{ fullPrice }
-					<div className="wc-block-cart-item__line-total">
-						<FormattedMonetaryAmount
-							currency={ currency }
-							value={ total }
-						/>
-					</div>
-					{ discountBadge }
+				{ fullPrice }
+				<div className="wc-block-cart-item__line-total">
+					<FormattedMonetaryAmount
+						currency={ currency }
+						value={ total }
+					/>
 				</div>
+				{ discountBadge }
 			</td>
 		</tr>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import { getCurrency, formatPrice } from '@woocommerce/base-utils';
+import { IconDelete } from '@woocommerce/block-components/icons';
 
 /**
  * Return the difference between two price amounts, e.g. a discount.
@@ -132,14 +133,19 @@ const CartLineItemRow = ( { lineItem } ) => {
 				</div>
 			</td>
 			<td className="wc-block-cart-item__total">
-				{ fullPrice }
-				<div className="wc-block-cart-item__line-total">
-					<FormattedMonetaryAmount
-						currency={ currency }
-						value={ total }
-					/>
+				<div className="wc-block-cart-item__remove-icon">
+					<IconDelete />
 				</div>
-				{ discountBadge }
+				<div className="wc-block-cart-item__totals-container">
+					{ fullPrice }
+					<div className="wc-block-cart-item__line-total">
+						<FormattedMonetaryAmount
+							currency={ currency }
+							value={ total }
+						/>
+					</div>
+					{ discountBadge }
+				</div>
 			</td>
 		</tr>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
@@ -2,7 +2,22 @@
 	max-width: $cart-image-width;
 }
 
+.editor-styles-wrapper table.wc-block-cart-items th {
+	padding-bottom: 0.5rem;
+	padding-top: 0.5rem;
+}
+
+.editor-styles-wrapper table.wc-block-cart-items td {
+	border-top: 1px solid $core-grey-light-600;
+}
+
 .editor-styles-wrapper table th.wc-block-cart-items__header-total,
 .editor-styles-wrapper table td.wc-block-cart-item__total {
 	text-align: right;
+}
+
+@include breakpoint( "<782px" ) {
+	.editor-styles-wrapper table td.wc-block-cart-item__total {
+		vertical-align: bottom;
+	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
@@ -2,3 +2,7 @@
 	max-width: $cart-image-width;
 }
 
+.editor-styles-wrapper table th.wc-block-cart-items__header-total,
+.editor-styles-wrapper table td.wc-block-cart-item__total {
+	text-align: right;
+}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -28,6 +28,15 @@ table.wc-block-cart-items {
 	border-bottom: 1px solid $core-grey-light-600;
 }
 
+table.wc-block-cart-items th:first-child,
+table.wc-block-cart-items td:first-child {
+	padding-left: 0;
+}
+table.wc-block-cart-items th:last-child,
+table.wc-block-cart-items td:last-child {
+	padding-right: 0;
+}
+
 .wc-block-cart-items__header {
 	display: none;
 	text-transform: uppercase;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -49,7 +49,7 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__remove-icon {
-	color: $core-grey-light-900;
+	color: $core-grey-dark-400;
 	fill: currentColor;
 }
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -48,6 +48,11 @@ table.wc-block-cart-items {
 	text-decoration: underline;
 }
 
+.wc-block-cart-item__remove-icon {
+	color: $core-grey-light-900;
+	fill: currentColor;
+}
+
 .wc-block-cart-items__header-total,
 .wc-block-cart-item__total {
 	text-align: right;
@@ -101,7 +106,6 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__total {
-	vertical-align: bottom;
 	font-size: 16px;
 	line-height: 19px;
 }
@@ -167,8 +171,29 @@ table.wc-block-cart-items {
 }
 
 @include breakpoint( "<782px" ) {
+	.wc-block-cart-items td {
+		&:first-child {
+			padding-left: 0;
+		}
+		&:last-child {
+			padding-right: 0;
+		}
+	}
+
 	.wc-block-cart-item__remove-link {
 		display: none;
+	}
+
+	.wc-block-cart-item__total {
+		// We position this td cell relative so we can use position: absolute for trash icon at top.
+		position: relative;
+	}
+
+	.wc-block-cart-item__remove-icon {
+		display: inline-block;
+		position: absolute;
+		top: $gap;
+		right: 0;
 	}
 
 	.wc-block-cart__totals-title {
@@ -179,6 +204,10 @@ table.wc-block-cart-items {
 	.wc-block-cart-item__full-price {
 		// inline on mobile, so line prices are aligned vertically
 		display: inline-block;
+	}
+
+	.wc-block-cart-item__total {
+		vertical-align: bottom;
 	}
 
 	.wc-block-cart-item__discount-badge {
@@ -226,6 +255,10 @@ table.wc-block-cart-items {
 
 	.wc-block-cart-item__remove-link {
 		display: block;
+	}
+
+	.wc-block-cart-item__remove-icon {
+		display: none;
 	}
 
 	.wc-block-cart-item__total {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -38,6 +38,16 @@ table.wc-block-cart-items {
 	width: 132px;
 }
 
+.wc-block-cart-item__remove-link {
+	color: $core-grey-dark-400;
+	font-size: 14px;
+	line-height: 12px;
+	margin-top: 0.5em;
+	// Temporary - this is not yet a link or "link button".
+	// May not be needed when remove is hooked up to API properly.
+	text-decoration: underline;
+}
+
 .wc-block-cart-items__header-total,
 .wc-block-cart-item__total {
 	text-align: right;
@@ -157,6 +167,10 @@ table.wc-block-cart-items {
 }
 
 @include breakpoint( "<782px" ) {
+	.wc-block-cart-item__remove-link {
+		display: none;
+	}
+
 	.wc-block-cart__totals-title {
 		display: none;
 	}
@@ -208,6 +222,10 @@ table.wc-block-cart-items {
 
 	.wc-block-cart-item__quantity-stacked {
 		display: none;
+	}
+
+	.wc-block-cart-item__remove-link {
+		display: block;
 	}
 
 	.wc-block-cart-item__total {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -39,6 +39,8 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__remove-link {
+	@include link-button;
+
 	color: $core-grey-dark-400;
 	font-size: 14px;
 	line-height: 12px;
@@ -49,6 +51,8 @@ table.wc-block-cart-items {
 }
 
 .wc-block-cart-item__remove-icon {
+	@include link-button;
+
 	color: $core-grey-dark-400;
 	fill: currentColor;
 }

--- a/assets/js/components/icons/delete.js
+++ b/assets/js/components/icons/delete.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { Icon } from '@wordpress/components';
+
+// This is named `delete` as it is the `delete_outline` icon from Material.
+// https://material.io/resources/icons/?icon=delete_outline&style=baseline
+// We are using it as `trash` or `trashcan` or `remove-item`.
+export default () => (
+	<Icon
+		className="material-icon"
+		icon={
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				width="24"
+				height="24"
+				viewBox="0 0 24 24"
+			>
+				<path d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM8 9h8v10H8V9zm7.5-5l-1-1h-5l-1 1H5v2h14V4z" />
+				<path fill="none" d="M0 0h24v24H0V0z" />
+			</svg>
+		}
+	/>
+);

--- a/assets/js/components/icons/index.js
+++ b/assets/js/components/icons/index.js
@@ -2,6 +2,7 @@
 export { default as IconAllReviews } from './all-reviews';
 export { default as IconCheckChecked } from './checkbox-checked';
 export { default as IconCheckUnchecked } from './checkbox-unchecked';
+export { default as IconDelete } from './delete';
 export { default as IconFolder } from './folder';
 export { default as IconFolderStar } from './folder-star';
 export { default as IconProductOnSale } from './product-on-sale';

--- a/assets/js/components/icons/index.js
+++ b/assets/js/components/icons/index.js
@@ -2,7 +2,7 @@
 export { default as IconAllReviews } from './all-reviews';
 export { default as IconCheckChecked } from './checkbox-checked';
 export { default as IconCheckUnchecked } from './checkbox-unchecked';
-export { default as IconDelete } from './delete';
+export { default as IconTrash } from './trash';
 export { default as IconFolder } from './folder';
 export { default as IconFolderStar } from './folder-star';
 export { default as IconProductOnSale } from './product-on-sale';

--- a/assets/js/components/icons/trash.js
+++ b/assets/js/components/icons/trash.js
@@ -3,7 +3,7 @@
  */
 import { Icon } from '@wordpress/components';
 
-// This is named `delete` as it is the `delete_outline` icon from Material.
+// This uses `delete_outline` icon from Material.
 // https://material.io/resources/icons/?icon=delete_outline&style=baseline
 // We are using it as `trash` or `trashcan` or `remove-item`.
 export default () => (


### PR DESCRIPTION
Fixes #1534

This PR adds and styles UI elements for removing items from the cart. Note that these are not yet functional – we'll need to hook them up as part of #1489 . 

- On larger screens, there's a `Remove item` link under the quantity selector. This is already in master; this PR updates the styling.
- On smaller screens, there's a trashcan icon ([`delete_outline` from Material icons](https://material.io/resources/icons/?icon=delete_outline)), at the top right of the totals column.

#### Accessibility

- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

Note: the color has been darkened to meet this contrast guideline, the design uses a lighter grey (cc @garymurray)

### Screenshots

<img width="851" alt="Screen Shot 2020-01-16 at 3 32 55 PM" src="https://user-images.githubusercontent.com/4167300/72488319-7a281e00-3875-11ea-967b-39e5750197a1.png">
<img width="450" alt="Screen Shot 2020-01-16 at 3 32 23 PM" src="https://user-images.githubusercontent.com/4167300/72488325-7e543b80-3875-11ea-8576-dd7fa519e70c.png">

Note: there's an issue with the quantity selector in these screenshots, logged here: #1578 

### How to test the changes in this Pull Request:

1. Clone this branch.
2. Add cart block to a page and publish. 
3. View the page on the front end and test in a variety of browsers/platforms/screen sizes.
