### PR TITLE
Checkout: Fix city input field showing country value (II)

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -197,11 +197,11 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 										'City',
 										'woo-gutenberg-products-block'
 									) }
-									value={ shippingFields.country }
+									value={ shippingFields.city }
 									onChange={ ( newValue ) =>
 										setShippingFields( {
 											...shippingFields,
-											country: newValue,
+											city: newValue,
 										} )
 									}
 								/>


### PR DESCRIPTION
Same PR as #1467, I guess those changes were probably lost in a merge.

> Small PR: city input field was using `shippingFields.country` instead of `shippingFields.city`.