### PR TITLE
Focus on Full Cart mode after inserting

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -4,8 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
 import { Disabled, Toolbar } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import TextToolbarButton from '@woocommerce/block-components/text-toolbar-button';
 import PropTypes from 'prop-types';
 import { withFeedbackPrompt } from '@woocommerce/block-hocs';
@@ -19,14 +18,8 @@ import EmptyCart from './empty-cart';
 /**
  * Component to handle edit mode of "Cart Block".
  */
-const CartEditor = ( { className, clientId } ) => {
+const CartEditor = ( { className } ) => {
 	const [ isFullCartMode, setFullCartMode ] = useState( true );
-
-	const { selectBlock } = useDispatch( 'core/block-editor' );
-
-	useEffect( () => {
-		selectBlock( clientId );
-	}, [ clientId ] );
 
 	const toggleFullCartMode = () => {
 		setFullCartMode( ! isFullCartMode );

--- a/assets/js/blocks/cart-checkout/cart/empty-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart/index.js
@@ -25,6 +25,7 @@ const EmptyCart = ( { hidden } ) => {
 	return (
 		<div hidden={ hidden }>
 			<InnerBlocks
+				templateInsertUpdatesSelection={ false }
 				template={ [
 					[
 						'core/image',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This solution feels like a bandaid, hoping there is something better we can do. cc @nerrad 
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1581