### PR TITLE
Add `low_stock_remaining` field to cart items API

### DIFF
--- a/tests/php/RestApi/StoreApi/Controllers/CartItems.php
+++ b/tests/php/RestApi/StoreApi/Controllers/CartItems.php
@@ -212,7 +212,9 @@ class CartItems extends TestCase {
 		$this->assertArrayHasKey( 'id', $schema['properties'] );
 		$this->assertArrayHasKey( 'quantity', $schema['properties'] );
 		$this->assertArrayHasKey( 'name', $schema['properties'] );
+		$this->assertArrayHasKey( 'short_description', $schema['properties'] );
 		$this->assertArrayHasKey( 'sku', $schema['properties'] );
+		$this->assertArrayHasKey( 'low_stock_remaining', $schema['properties'] );
 		$this->assertArrayHasKey( 'permalink', $schema['properties'] );
 		$this->assertArrayHasKey( 'images', $schema['properties'] );
 		$this->assertArrayHasKey( 'totals', $schema['properties'] );
@@ -237,6 +239,8 @@ class CartItems extends TestCase {
 		$this->assertArrayHasKey( 'images', $data );
 		$this->assertArrayHasKey( 'totals', $data );
 		$this->assertArrayHasKey( 'variation', $data );
+		$this->assertArrayHasKey( 'low_stock_remaining', $data );
+		$this->assertArrayHasKey( 'short_description', $data );
 	}
 
 	/**


### PR DESCRIPTION
Adds a `low_stock_remaining` field to the `cart/item` API.

Unlike the product API, this one takes reserved stock into account so the values on the cart page are current and accurate.

Fixes #1565

### How to test the changes in this Pull Request:

1. Add items to cart.
2. GET from `wc/store/cart/items` via Rest client