### PR TITLE
Improved cart styling for desktop and mobile

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -105,23 +105,16 @@ const CartLineItemRow = ( { lineItem } ) => {
 	) : null;
 
 	return (
-		<tr>
+		<tr className="wc-block-cart-items__row">
+			<td className="wc-block-cart-item__image">
+				<img { ...imageProps } alt={ imageProps.alt } />
+			</td>
 			<td className="wc-block-cart-item__product">
-				<div className="wc-block-cart-item__product-wrapper">
-					<img { ...imageProps } alt={ imageProps.alt } />
-					<div className="wc-block-cart-item__product-details">
-						<div className="wc-block-cart-item__product-name">
-							{ name }
-						</div>
-						{ lowStockBadge }
-						<div className="wc-block-cart-item__product-metadata">
-							{ description }
-							<ProductVariationDetails variation={ variation } />
-						</div>
-						{ quantitySelector(
-							'wc-block-cart-item__quantity-stacked'
-						) }
-					</div>
+				<div className="wc-block-cart-item__product-name">{ name }</div>
+				{ lowStockBadge }
+				<div className="wc-block-cart-item__product-metadata">
+					{ description }
+					<ProductVariationDetails variation={ variation } />
 				</div>
 			</td>
 			<td className="wc-block-cart-item__quantity">
@@ -130,12 +123,12 @@ const CartLineItemRow = ( { lineItem } ) => {
 					<button className="wc-block-cart-item__remove-link">
 						{ __( 'Remove item', 'woo-gutenberg-products-block' ) }
 					</button>
+					<button className="wc-block-cart-item__remove-icon">
+						<IconTrash />
+					</button>
 				</div>
 			</td>
 			<td className="wc-block-cart-item__total">
-				<button className="wc-block-cart-item__remove-icon">
-					<IconTrash />
-				</button>
 				{ fullPrice }
 				<div className="wc-block-cart-item__line-total">
 					<FormattedMonetaryAmount

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -8,6 +8,7 @@ import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import { getCurrency, formatPrice } from '@woocommerce/base-utils';
 import { IconTrash } from '@woocommerce/block-components/icons';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Return the difference between two price amounts, e.g. a discount.
@@ -107,7 +108,10 @@ const CartLineItemRow = ( { lineItem } ) => {
 	return (
 		<tr className="wc-block-cart-items__row">
 			<td className="wc-block-cart-item__image">
-				<img { ...imageProps } alt={ imageProps.alt } />
+				<img
+					{ ...imageProps }
+					alt={ decodeEntities( imageProps.alt ) }
+				/>
 			</td>
 			<td className="wc-block-cart-item__product">
 				<div className="wc-block-cart-item__product-name">{ name }</div>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -118,15 +118,13 @@ const CartLineItemRow = ( { lineItem } ) => {
 				</div>
 			</td>
 			<td className="wc-block-cart-item__quantity">
-				<div>
-					{ quantitySelector() }
-					<button className="wc-block-cart-item__remove-link">
-						{ __( 'Remove item', 'woo-gutenberg-products-block' ) }
-					</button>
-					<button className="wc-block-cart-item__remove-icon">
-						<IconTrash />
-					</button>
-				</div>
+				{ quantitySelector() }
+				<button className="wc-block-cart-item__remove-link">
+					{ __( 'Remove item', 'woo-gutenberg-products-block' ) }
+				</button>
+				<button className="wc-block-cart-item__remove-icon">
+					<IconTrash />
+				</button>
 			</td>
 			<td className="wc-block-cart-item__total">
 				{ fullPrice }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
@@ -18,8 +18,11 @@ const CartLineItemsTable = ( { lineItems = [] } ) => {
 		<table className="wc-block-cart-items">
 			<thead>
 				<tr className="wc-block-cart-items__header">
-					<th className="wc-block-cart-items__header-product">
+					<th className="wc-block-cart-items__header-image">
 						{ __( 'Product', 'woo-gutenberg-products-block' ) }
+					</th>
+					<th className="wc-block-cart-items__header-product">
+						{ __( 'Details', 'woo-gutenberg-products-block' ) }
 					</th>
 					<th className="wc-block-cart-items__header-quantity">
 						{ __( 'Quantity', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -124,63 +124,73 @@ const Cart = () => {
 				<CartLineItemsTitle itemCount={ previewCartItems.length } />
 				<CartLineItemsTable lineItems={ previewCartItems } />
 			</div>
-			<Card className="wc-block-cart__sidebar" isElevated={ true }>
-				<CardBody>
-					<h2 className="wc-block-cart__totals-title">
-						{ __( 'Cart totals', 'woo-gutenberg-products-block' ) }
-					</h2>
-					{ totalRowsConfig.map(
-						( { label, value, description } ) => (
-							<TotalsItem
-								key={ label }
-								currency={ currency }
-								label={ label }
-								value={ value }
-								description={ description }
-							/>
-						)
-					) }
-					<fieldset className="wc-block-cart__shipping-options-fieldset">
-						<legend className="screen-reader-text">
+			<div className="wc-block-cart__sidebar">
+				<Card isElevated={ true }>
+					<CardBody>
+						<h2 className="wc-block-cart__totals-title">
 							{ __(
-								'Choose the shipping method.',
+								'Cart totals',
 								'woo-gutenberg-products-block'
 							) }
-						</legend>
-						<RadioControl
-							className="wc-block-cart__shipping-options"
-							selected={ selectedShippingOption }
-							options={ placeholderShippingMethods.map(
-								( option ) => ( {
-									label: option.label,
-									value: option.value,
-									description: [
-										option.price,
-										option.schedule,
-									]
-										.filter( Boolean )
-										.join( ' — ' ),
-								} )
+						</h2>
+						{ totalRowsConfig.map(
+							( { label, value, description } ) => (
+								<TotalsItem
+									key={ label }
+									currency={ currency }
+									label={ label }
+									value={ value }
+									description={ description }
+								/>
+							)
+						) }
+						<fieldset className="wc-block-cart__shipping-options-fieldset">
+							<legend className="screen-reader-text">
+								{ __(
+									'Choose the shipping method.',
+									'woo-gutenberg-products-block'
+								) }
+							</legend>
+							<RadioControl
+								className="wc-block-cart__shipping-options"
+								selected={ selectedShippingOption }
+								options={ placeholderShippingMethods.map(
+									( option ) => ( {
+										label: option.label,
+										value: option.value,
+										description: [
+											option.price,
+											option.schedule,
+										]
+											.filter( Boolean )
+											.join( ' — ' ),
+									} )
+								) }
+								onChange={ ( newSelectedShippingOption ) =>
+									setSelectedShippingOption(
+										newSelectedShippingOption
+									)
+								}
+							/>
+						</fieldset>
+						{ COUPONS_ENABLED && (
+							<TotalsCouponCodeInput
+								onSubmit={ onActivateCoupon }
+							/>
+						) }
+						<TotalsItem
+							className="wc-block-cart__totals-footer"
+							currency={ currency }
+							label={ __(
+								'Total',
+								'woo-gutenberg-products-block'
 							) }
-							onChange={ ( newSelectedShippingOption ) =>
-								setSelectedShippingOption(
-									newSelectedShippingOption
-								)
-							}
+							value={ parseInt( cartTotals.total_price, 10 ) }
 						/>
-					</fieldset>
-					{ COUPONS_ENABLED && (
-						<TotalsCouponCodeInput onSubmit={ onActivateCoupon } />
-					) }
-					<TotalsItem
-						className="wc-block-cart__totals-footer"
-						currency={ currency }
-						label={ __( 'Total', 'woo-gutenberg-products-block' ) }
-						value={ parseInt( cartTotals.total_price, 10 ) }
-					/>
-					<CheckoutButton />
-				</CardBody>
-			</Card>
+						<CheckoutButton />
+					</CardBody>
+				</Card>
+			</div>
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -44,10 +44,8 @@ table.wc-block-cart-items {
 		}
 	}
 	.wc-block-cart-items__row {
-		.wc-block-cart-item__image {
-			img {
-				width: 100%;
-			}
+		.wc-block-cart-item__image img {
+			width: 100%;
 		}
 		.wc-block-cart-item__product {
 			.wc-block-cart-item__product-name {
@@ -189,6 +187,7 @@ table.wc-block-cart-items {
 		}
 		.wc-block-cart-items__row {
 			display: grid;
+			grid-template-columns: 80px 132px;
 			border-top: 1px solid $core-grey-light-600;
 			padding: $gap 0;
 			position: relative;
@@ -196,22 +195,18 @@ table.wc-block-cart-items {
 			.wc-block-cart-item__image {
 				grid-column-start: 1;
 				grid-row-start: 1;
-				width: auto;
-				max-width: 100px;
 				padding-right: $gap;
 			}
 			.wc-block-cart-item__product {
 				grid-column-start: 2;
 				grid-column-end: 4;
 				grid-row-start: 1;
-				width: auto;
+				justify-self: stretch;
 				padding-bottom: $gap;
 			}
 			.wc-block-cart-item__quantity {
 				grid-column-start: 2;
 				grid-row-start: 2;
-				width: auto;
-				max-width: 132px;
 				vertical-align: bottom;
 				padding-right: $gap;
 
@@ -225,7 +220,6 @@ table.wc-block-cart-items {
 			.wc-block-cart-item__total {
 				grid-column-start: 3;
 				grid-row-start: 2;
-				width: auto;
 				align-self: center;
 
 				.wc-block-cart-item__discount-badge {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,147 +1,139 @@
+table.wc-block-cart-items,
+table.wc-block-cart-items th,
+table.wc-block-cart-items td {
+	// Override Storefront theme gray table background.
+	background: none !important;
+	// Remove borders on default themes.
+	border: 0;
+}
+
+table.wc-block-cart-items {
+	table-layout: fixed;
+	width: 100%;
+	border-bottom: 1px solid $core-grey-light-600;
+
+	th {
+		padding: 0.5rem $gap 0.5rem 0;
+		white-space: nowrap;
+		border-collapse: collapse;
+	}
+	td {
+		border-top: 1px solid $core-grey-light-600;
+		padding: $gap $gap $gap 0;
+		vertical-align: top;
+		border-collapse: collapse;
+	}
+	th:last-child,
+	td:last-child {
+		padding-right: 0;
+	}
+	.wc-block-cart-items__header {
+		text-transform: uppercase;
+		.wc-block-cart-items__header-image {
+			width: 100px;
+		}
+		.wc-block-cart-items__header-product {
+			visibility: hidden;
+		}
+		.wc-block-cart-items__header-quantity {
+			width: 132px;
+		}
+		.wc-block-cart-items__header-total {
+			width: 132px;
+			text-align: right;
+		}
+	}
+	.wc-block-cart-items__row {
+		.wc-block-cart-item__image {
+			img {
+				width: 100%;
+			}
+		}
+		.wc-block-cart-item__product {
+			.wc-block-cart-item__product-name {
+				color: $core-grey-dark-600;
+				font-size: 16px;
+			}
+
+			.wc-block-cart-item__low-stock-badge {
+				display: inline-block;
+
+				background-color: $white;
+				border-radius: 3px;
+				border: 1px solid $black;
+				color: $black;
+				font-size: 12px;
+				padding: 0 1em;
+				text-transform: uppercase;
+				white-space: nowrap;
+			}
+
+			.wc-block-cart-item__product-metadata {
+				color: $core-grey-dark-400;
+				font-size: 12px;
+			}
+		}
+		.wc-block-cart-item__quantity {
+			.wc-block-cart-item__remove-link {
+				@include link-button;
+
+				color: $core-grey-dark-400;
+				font-size: 14px;
+				line-height: 12px;
+				margin-top: 0.5em;
+				// Temporary - this is not yet a link or "link button".
+				// May not be needed when remove is hooked up to API properly.
+				text-decoration: underline;
+			}
+			.wc-block-cart-item__remove-icon {
+				@include link-button;
+
+				color: $core-grey-dark-400;
+				fill: currentColor;
+				position: absolute;
+				top: $gap;
+				right: 0;
+				display: none;
+			}
+		}
+		.wc-block-cart-item__total {
+			text-align: right;
+			font-size: 16px;
+			line-height: 19px;
+
+			.wc-block-cart-item__full-price {
+				color: $core-grey-dark-400;
+				text-decoration: line-through;
+			}
+
+			.wc-block-cart-item__line-total {
+				color: $black;
+				margin-left: 0.5em;
+			}
+
+			.wc-block-cart-item__discount-badge {
+				background-color: $core-grey-dark-600;
+				border-radius: 3px;
+				color: $white;
+				font-size: 12px;
+				padding: 0 1em;
+				text-transform: uppercase;
+				white-space: nowrap;
+				display: inline-block;
+			}
+		}
+	}
+}
+
 .wc-block-cart__sidebar {
 	border: 1px solid $core-grey-light-600;
 	border-width: 1px 0;
 	min-width: 15rem;
 	padding-bottom: $gap-largest;
 }
-
 .wc-block-cart__item-count {
 	float: right;
 }
-
-table.wc-block-cart-items,
-table.wc-block-cart-items th,
-table.wc-block-cart-items td {
-	// Override Storefront theme gray table background.
-	background: none !important;
-	border: 0;
-}
-
-table.wc-block-cart-items th {
-	padding: 0.5rem $gap;
-	white-space: nowrap;
-}
-
-table.wc-block-cart-items td {
-	border-top: 1px solid $core-grey-light-600;
-	padding: $gap;
-}
-table.wc-block-cart-items {
-	border-bottom: 1px solid $core-grey-light-600;
-}
-
-table.wc-block-cart-items th:first-child,
-table.wc-block-cart-items td:first-child {
-	padding-left: 0;
-}
-table.wc-block-cart-items th:last-child,
-table.wc-block-cart-items td:last-child {
-	padding-right: 0;
-}
-
-.wc-block-cart-items__header {
-	display: none;
-	text-transform: uppercase;
-}
-
-.wc-block-cart-items__header-quantity,
-.wc-block-cart-item__quantity {
-	width: 132px;
-}
-
-.wc-block-cart-item__remove-link {
-	@include link-button;
-
-	color: $core-grey-dark-400;
-	font-size: 14px;
-	line-height: 12px;
-	margin-top: 0.5em;
-	// Temporary - this is not yet a link or "link button".
-	// May not be needed when remove is hooked up to API properly.
-	text-decoration: underline;
-}
-
-.wc-block-cart-item__remove-icon {
-	@include link-button;
-
-	color: $core-grey-dark-400;
-	fill: currentColor;
-}
-
-.wc-block-cart-items__header-total,
-.wc-block-cart-item__total {
-	text-align: right;
-}
-
-.wc-block-cart-item__product-wrapper {
-	display: flex;
-	flex-direction: row;
-
-	// Fixes a Safari-specific issue - product images display stretched vertically (full image height).
-	// https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari
-	align-items: flex-start;
-}
-
-.wc-block-cart-item__product img {
-	max-width: $cart-image-width;
-}
-
-.wc-block-cart-item__product-details {
-	margin-left: $gap;
-}
-
-.wc-block-cart-item__product-name {
-	color: $core-grey-dark-600;
-	font-size: 16px;
-}
-
-.wc-block-cart-item__low-stock-badge {
-	display: inline-block;
-
-	background-color: $white;
-	border-radius: 3px;
-	border: 1px solid $black;
-	color: $black;
-	font-size: 12px;
-	padding: 0 1em;
-	text-transform: uppercase;
-	white-space: nowrap;
-}
-
-.wc-block-cart-item__product-metadata {
-	color: $core-grey-dark-400;
-	font-size: 12px;
-}
-
-.wc-block-cart-item__quantity {
-	display: none;
-}
-
-.wc-block-cart-item__total {
-	font-size: 16px;
-	line-height: 19px;
-}
-
-.wc-block-cart-item__full-price {
-	color: $core-grey-dark-400;
-	text-decoration: line-through;
-}
-
-.wc-block-cart-item__line-total {
-	color: $black;
-	margin-left: 0.5em;
-}
-
-.wc-block-cart-item__discount-badge {
-	background-color: $core-grey-dark-600;
-	border-radius: 3px;
-	color: $white;
-	font-size: 12px;
-	padding: 0 1em;
-	text-transform: uppercase;
-	white-space: nowrap;
-}
-
 .wc-block-cart__totals-footer {
 	color: #000;
 	font-size: 1.25em;
@@ -182,132 +174,81 @@ table.wc-block-cart-items td:last-child {
 	}
 }
 
+// Mobile styles.
 @include breakpoint( "<782px" ) {
-	.wc-block-cart-items td {
-		&:first-child {
-			padding-left: 0;
-		}
-		&:last-child {
-			padding-right: 0;
-		}
-	}
-
-	.wc-block-cart-item__remove-link {
-		display: none;
-	}
-
-	.wc-block-cart-item__total {
-		// We position this td cell relative so we can use position: absolute for trash icon at top.
-		position: relative;
-	}
-
-	.wc-block-cart-item__remove-icon {
-		display: inline-block;
-		position: absolute;
-		top: $gap;
-		right: 0;
-	}
-
-	.wc-block-cart__totals-title {
-		display: none;
-	}
-
-	.wc-block-cart-item__line-total,
-	.wc-block-cart-item__full-price {
-		// inline on mobile, so line prices are aligned vertically
-		display: inline-block;
-	}
-
-	.wc-block-cart-item__total {
-		vertical-align: bottom;
-	}
-
-	.wc-block-cart-item__discount-badge {
-		display: none;
-	}
-
 	table.wc-block-cart-items {
 		td {
-			padding: 16px 0;
+			padding: 0;
+			border: 0;
 		}
-		.wc-block-cart-item__product {
-			width: 70%;
-			box-sizing: border-box;
+		.wc-block-cart-items__header {
+			display: none;
+		}
+		.wc-block-cart-item__remove-link {
+			display: none;
+		}
+		.wc-block-cart-items__row {
+			display: grid;
+			border-top: 1px solid $core-grey-light-600;
+			padding: $gap 0;
+			position: relative;
 
-			.wc-block-cart-item__product-wrapper {
-				img {
-					width: 100px;
+			.wc-block-cart-item__image {
+				grid-column-start: 1;
+				grid-row-start: 1;
+				width: auto;
+				max-width: 100px;
+				padding-right: $gap;
+			}
+			.wc-block-cart-item__product {
+				grid-column-start: 2;
+				grid-column-end: 4;
+				grid-row-start: 1;
+				width: auto;
+				padding-bottom: $gap;
+			}
+			.wc-block-cart-item__quantity {
+				grid-column-start: 2;
+				grid-row-start: 2;
+				width: auto;
+				max-width: 132px;
+				vertical-align: bottom;
+				padding-right: $gap;
+
+				.wc-block-cart-item__remove-link {
+					display: none;
+				}
+				.wc-block-cart-item__remove-icon {
+					display: block;
 				}
 			}
-		}
-		.wc-block-cart-item__total {
-			width: 30%;
-			padding-left: 16px;
-			box-sizing: border-box;
+			.wc-block-cart-item__total {
+				grid-column-start: 3;
+				grid-row-start: 2;
+				width: auto;
+				align-self: center;
+
+				.wc-block-cart-item__discount-badge {
+					display: none;
+				}
+			}
 		}
 	}
 }
 
+// Desktop only styles.
 @include breakpoint( ">782px" ) {
 	.wc-block-cart__sidebar {
 		max-width: 374px;
 	}
-
 	.wc-block-cart {
 		display: flex;
 	}
-
 	.wc-block-cart__main {
 		flex-grow: 4;
 		margin-right: 3em;
 	}
-
 	.wc-block-cart__sidebar {
 		flex-grow: 1;
-	}
-
-	.wc-block-cart-items {
-		table-layout: fixed;
-	}
-
-	.wc-block-cart-items__header {
-		display: table-row;
-	}
-
-	.wc-block-cart-items__header-product {
-		width: 60%;
-	}
-
-	.wc-block-cart-item__quantity {
-		display: table-cell;
-	}
-
-	.wc-block-cart-item__quantity-stacked {
-		display: none;
-	}
-
-	.wc-block-cart-item__remove-link {
-		display: block;
-	}
-
-	.wc-block-cart-item__remove-icon {
-		display: none;
-	}
-
-	.wc-block-cart-item__total {
-		vertical-align: top;
-	}
-
-	.wc-block-cart-item__line-total,
-	.wc-block-cart-item__full-price {
-		display: block;
-	}
-
-	.wc-block-cart-item__full-price {
-		margin-right: 0;
-	}
-
-	.wc-block-cart-item__discount-badge {
-		display: inline-block;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,3 +1,60 @@
+.wc-block-cart {
+	display: flex;
+	flex-wrap: wrap;
+	margin: 0 (-$gap) $gap;
+
+	.wc-block-cart__main {
+		margin: 0 $gap;
+		flex: 1 0 500px;
+	}
+	.wc-block-cart__sidebar {
+		flex: 1 1 240px;
+		margin: 0 $gap;
+		border: 1px solid $core-grey-light-600;
+		border-width: 1px 0;
+	}
+	.wc-block-cart__item-count {
+		float: right;
+	}
+	.wc-block-cart__totals-footer {
+		color: #000;
+		font-size: 1.25em;
+
+		> .wc-block-totals-table-item__label {
+			font-weight: normal;
+		}
+	}
+	// Added extra class and label for specificity.
+	fieldset.wc-block-cart__shipping-options-fieldset {
+		background-color: transparent;
+		margin: 0;
+		padding: 0;
+	}
+	.wc-block-cart__shipping-options {
+		.wc-block-radio-control__label {
+			flex-basis: 100%;
+			line-height: 16px;
+		}
+
+		.wc-block-radio-control__description {
+			flex-basis: 100%;
+		}
+
+		.wc-block-radio-control__option {
+			padding-left: $gap-large;
+
+			&:last-child {
+				border-bottom: none;
+			}
+		}
+
+		.wc-block-radio-control__input {
+			left: 0;
+			top: $gap;
+		}
+	}
+}
+
 table.wc-block-cart-items,
 table.wc-block-cart-items th,
 table.wc-block-cart-items td {
@@ -34,12 +91,13 @@ table.wc-block-cart-items {
 		}
 		.wc-block-cart-items__header-product {
 			visibility: hidden;
+			min-width: 300px;
 		}
 		.wc-block-cart-items__header-quantity {
-			width: 132px;
+			width: 116px;
 		}
 		.wc-block-cart-items__header-total {
-			width: 132px;
+			width: 100px;
 			text-align: right;
 		}
 	}
@@ -76,9 +134,11 @@ table.wc-block-cart-items {
 				@include link-button;
 
 				color: $core-grey-dark-400;
-				font-size: 14px;
+				font-size: 12px;
 				line-height: 12px;
 				margin-top: 0.5em;
+				text-transform: none;
+				white-space: nowrap;
 				// Temporary - this is not yet a link or "link button".
 				// May not be needed when remove is hooked up to API properly.
 				text-decoration: underline;
@@ -123,57 +183,20 @@ table.wc-block-cart-items {
 	}
 }
 
-.wc-block-cart__sidebar {
-	border: 1px solid $core-grey-light-600;
-	border-width: 1px 0;
-	min-width: 15rem;
-	padding-bottom: $gap-largest;
-}
-.wc-block-cart__item-count {
-	float: right;
-}
-.wc-block-cart__totals-footer {
-	color: #000;
-	font-size: 1.25em;
-
-	> .wc-block-totals-table-item__label {
-		font-weight: normal;
-	}
-}
-
-// Added extra class and label for specificity.
-.wc-block-cart fieldset.wc-block-cart__shipping-options-fieldset {
-	background-color: transparent;
-	margin: 0;
-	padding: 0;
-}
-
-.wc-block-cart__shipping-options {
-	.wc-block-radio-control__label {
-		flex-basis: 100%;
-		line-height: 16px;
-	}
-
-	.wc-block-radio-control__description {
-		flex-basis: 100%;
-	}
-
-	.wc-block-radio-control__option {
-		padding-left: $gap-large;
-
-		&:last-child {
-			border-bottom: none;
-		}
-	}
-
-	.wc-block-radio-control__input {
-		left: 0;
-		top: $gap;
-	}
-}
-
 // Mobile styles.
 @include breakpoint( "<782px" ) {
+	.wc-block-cart {
+		display: block;
+		margin: 0 0 $gap;
+		.wc-block-cart__main {
+			margin: 0;
+			flex: none;
+		}
+		.wc-block-cart__sidebar {
+			margin: 0;
+			flex: none;
+		}
+	}
 	table.wc-block-cart-items {
 		td {
 			padding: 0;
@@ -227,22 +250,5 @@ table.wc-block-cart-items {
 				}
 			}
 		}
-	}
-}
-
-// Desktop only styles.
-@include breakpoint( ">782px" ) {
-	.wc-block-cart__sidebar {
-		max-width: 374px;
-	}
-	.wc-block-cart {
-		display: flex;
-	}
-	.wc-block-cart__main {
-		flex-grow: 4;
-		margin-right: 3em;
-	}
-	.wc-block-cart__sidebar {
-		flex-grow: 1;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -9,10 +9,12 @@
 	float: right;
 }
 
+table.wc-block-cart-items,
 table.wc-block-cart-items th,
 table.wc-block-cart-items td {
 	// Override Storefront theme gray table background.
 	background: none !important;
+	border: 0;
 }
 
 table.wc-block-cart-items th {
@@ -113,9 +115,6 @@ table.wc-block-cart-items td:last-child {
 
 .wc-block-cart-item__quantity {
 	display: none;
-}
-.wc-block-cart-item__quantity-stacked {
-	display: block;
 }
 
 .wc-block-cart-item__total {
@@ -225,6 +224,27 @@ table.wc-block-cart-items td:last-child {
 
 	.wc-block-cart-item__discount-badge {
 		display: none;
+	}
+
+	table.wc-block-cart-items {
+		td {
+			padding: 16px 0;
+		}
+		.wc-block-cart-item__product {
+			width: 70%;
+			box-sizing: border-box;
+
+			.wc-block-cart-item__product-wrapper {
+				img {
+					width: 100px;
+				}
+			}
+		}
+		.wc-block-cart-item__total {
+			width: 30%;
+			padding-left: 16px;
+			box-sizing: border-box;
+		}
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -4,14 +4,14 @@
 	margin: 0 (-$gap) $gap;
 
 	.wc-block-cart__main {
-		margin: 0 $gap;
-		flex: 1 0 500px;
+		flex: 1 0 60%;
+		margin: 0;
+		padding: 0 $gap;
 	}
 	.wc-block-cart__sidebar {
-		flex: 1 1 240px;
-		margin: 0 $gap;
-		border: 1px solid $core-grey-light-600;
-		border-width: 1px 0;
+		flex: 1 1 40%;
+		margin: 0;
+		padding: 0 $gap;
 	}
 	.wc-block-cart__item-count {
 		float: right;
@@ -29,6 +29,7 @@
 		background-color: transparent;
 		margin: 0;
 		padding: 0;
+		border: 0;
 	}
 	.wc-block-cart__shipping-options {
 		.wc-block-radio-control__label {
@@ -189,11 +190,11 @@ table.wc-block-cart-items {
 		display: block;
 		margin: 0 0 $gap;
 		.wc-block-cart__main {
-			margin: 0;
+			padding: 0;
 			flex: none;
 		}
 		.wc-block-cart__sidebar {
-			margin: 0;
+			padding: 0;
 			flex: none;
 		}
 	}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -4,12 +4,13 @@
 	margin: 0 (-$gap) $gap;
 
 	.wc-block-cart__main {
-		flex: 1 0 60%;
+		flex: 1 0 65%;
 		margin: 0;
 		padding: 0 $gap;
+		min-width: 500px;
 	}
 	.wc-block-cart__sidebar {
-		flex: 1 1 40%;
+		flex: 1 1 35%;
 		margin: 0;
 		padding: 0 $gap;
 	}


### PR DESCRIPTION
This PR fixes the mobile view of the quantity selector (Fixes #1578), and improves mobile styling by:

- Removing duplicate elements from the table
- Using flexbox to make the cart sidebar wrap on narrow themes
- Using CSS Grid to restyle table columns/rows when using mobile, without relying on duplicate elements

### Screenshots

Desktop view:
![Screenshot 2020-01-17 at 16 29 46](https://user-images.githubusercontent.com/90977/72628672-ab245380-3946-11ea-8953-67bb6f0d0486.png)

Mobile view:
![Screenshot 2020-01-16 at 14 45 14](https://user-images.githubusercontent.com/90977/72628677-b1b2cb00-3946-11ea-8acd-0e5d4c3bc1b6.png)

**To test:**
- View cart on desktop
- Shrink window - confirm totals wrap
- Shrink window to mobile size - confirm styling changes to mobile view

Will need testing across themes and browsers but this will be the baseline. Tested under Firefox, Chrome, Safari.
