### PR TITLE
Make TextInput respect prefers-reduced-motion preference

### DIFF
--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -10,9 +10,10 @@
 	font-size: 16px;
 	line-height: 22px;
 	color: $gray-50;
+	transition: all 200ms ease;
 
-	@media screen and (prefers-reduced-motion: no-preference) {
-		transition: all 200ms ease;
+	@media screen and (prefers-reduced-motion: reduce) {
+		transition: none;
 	}
 }
 

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -9,13 +9,15 @@
 	transform-origin: top left;
 	font-size: 16px;
 	line-height: 22px;
-	transition: all 200ms ease;
 	color: $gray-50;
+
+	@media screen and (prefers-reduced-motion: no-preference) {
+		transition: all 200ms ease;
+	}
 }
 
 .wc-block-text-input.is-active label {
 	transform: translateX(#{$gap}) translateY(#{$gap-smallest}) scale(0.75);
-	transition: all 200ms ease;
 }
 .wc-block-text-input input[type="tel"],
 .wc-block-text-input input[type="url"],


### PR DESCRIPTION
Fixes #1584.

#### Accessibility
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)

### Screenshots

![Peek 2020-01-16 15-45](https://user-images.githubusercontent.com/3616980/72534586-5c5bb880-3877-11ea-89e3-5d52c1f64241.gif)

### How to test the changes in this Pull Request:

1. Enable/disable the `reduce` request for `prefers-reduced-motion` in your OS following these steps: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#User_Preferences.
2. Verify label is animated or not depending on the setting.
