### PR TITLE
fix react runtime js error when "link to product" = off in All Products inner blocks editor

### DIFF
--- a/assets/js/atomic/components/product/image/index.js
+++ b/assets/js/atomic/components/product/image/index.js
@@ -88,7 +88,7 @@ const ProductImage = ( {
 					{ renderedSalesAndImage }
 				</a>
 			) : (
-				{ renderedSalesAndImage }
+				renderedSalesAndImage
 			) }
 		</div>
 	);


### PR DESCRIPTION
Fixes #1591

When you edit the inner blocks for All Products, and disable `Link to product`, there's  a js error. There were extra `{}` in the code that wrapped it in an obj and caused React to 😭 

### How to test the changes in this Pull Request:

1. Add an All Products block to a page or post. 
2. Click the pencil in the block tool bar to edit inner blocks.
3. Click the image. 
4. Click `Link to Product Page` to toggle off. (Should not crash here!)
5. Publish, confirm link / don't link works as expected on front end.

### Changelog

Fixed a javascript error when editing All Products inner blocks "Link to Product Page" option.