### PR TITLE
decode html entities in product attr values, so they render correctly

### DIFF
--- a/src/RestApi/StoreApi/Schemas/TermSchema.php
+++ b/src/RestApi/StoreApi/Schemas/TermSchema.php
@@ -71,7 +71,9 @@ class TermSchema extends AbstractSchema {
 	public function get_item_response( $term ) {
 		return [
 			'id'          => (int) $term->term_id,
-			'name'        => $term->name,
+			// Attribute values (aka taxonomy terms) are stored in database with chars like '&' encoded.
+			// We decode them so the API response can be rendered in UI.
+			'name'        => wp_specialchars_decode( $term->name ),
 			'description' => $term->description,
 			'slug'        => $term->slug,
 			'count'       => (int) $term->count,


### PR DESCRIPTION
Fixes #1586

Fixes a render issue for product attribute values with ampersands (or other special chars). 

Product attributes are stored as taxonomy terms, which are stored in the database with special chars encoded as html entities. The fix was to decode these entities when preparing the API response.

Our APIs typically return strings without encoded values, so this PR makes the `store/products/attributes` API consistent with this approach.

### Screenshots

<img width="745" alt="Screen Shot 2020-01-17 at 11 35 27 AM" src="https://user-images.githubusercontent.com/4167300/72568642-78199a00-391d-11ea-9b0d-e54b6015ad73.png">

### How to test the changes in this Pull Request:

0. Edit products so you have special chars in interesting places, in particular, a product attribute value with ampersand.
1. Edit a page or post and add All Products, Filter Products by Attribute and Active Filters blocks.
2. Set up the filter by attr block so it's using your attribute (with at least one value with special char).
3. Publish the page.
4. Test front end and editor and ensure that everything renders as it should and there's no encoded stuff rendered on screen.

### Changelog

Fixed a render issue for product attribute values with ampersands (or other special chars). 
