### PR TITLE
fix issue when user re-selects same attr when setting up filter block:

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -271,6 +271,10 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 
 	const onChange = useCallback(
 		( selected ) => {
+			if ( ! selected || ! selected.length ) {
+				return;
+			}
+
 			const selectedId = selected[ 0 ].id;
 			const productAttribute = find( ATTRIBUTES, [
 				'attribute_id',


### PR DESCRIPTION
Fixes #1595

Fixes a js error in the onChange handler when user re-selects same attribute in `Filter Products by Attribute` block. Fix is to check the `selected` arg before accessing it.

### How to test the changes in this Pull Request:

1. Set up at least 2 product attributes.
2. Edit a page or post and add `Filter Products by Attribute` block.
1. Select an attribute. Don't click "done".
2. Click the same attribute again. See JS error in console/dev tools.

### Changelog

Fixes a js error in editor when user re-selects same attribute in Filter Products by Attribute block.