### PR TITLE
Preserve query key order in All Products

### DIFF
--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -5,6 +5,7 @@ import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { useQueryStateContext } from '@woocommerce/base-context/query-state-context';
+import { assign } from 'lodash';
 
 /**
  * Internal dependencies
@@ -122,10 +123,7 @@ export const useSynchronizedQueryState = ( synchronizedQuery, context ) => {
 	const isInitialized = useRef( false );
 	// update queryState anytime incoming synchronizedQuery changes
 	useEffect( () => {
-		setQueryState( {
-			...queryState,
-			...currentSynchronizedQuery,
-		} );
+		setQueryState( assign( {}, queryState, currentSynchronizedQuery ) );
 		isInitialized.current = true;
 	}, [ currentSynchronizedQuery ] );
 	return isInitialized.current


### PR DESCRIPTION
Fixes #1609.

#### tl;dr

Running this code snippet in your browser console:
```JS
var products1 = { a: 'WordPress', b: 'Jetpack', c: 'WooCommerce' };
var products2 = { b: 'Tumblr', d: 'Akismet' };
console.log( { ...products1, ...products2 } );
```
Outputs a different result depending on the browser:
* Safari & other Webkit browsers: `{a: "WordPress", c: "WooCommerce", b: "Tumblr", d: "Akismet"}`.
* Firefox & Chrome: `{ a: "WordPress", b: "Tumblr", c: "WooCommerce", d: "Akismet" }`.

That was the cause of #1609: Firefox & Chrome preserve key order when doing a merge while Webkit, doesn't.

In the _All Products_ block, when changing the sort select, we are [updating the query merging two objects](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/hooks/use-query-state.js#L125-L128) and later we [stringify the `query` object](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/data/collections/selectors.js#L23) and use that stringified-query to know [if that query is already in the store state](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/data/collections/selectors.js#L24).

So, when the query is updated (for example, when changing the order), the attributes change their order in Webkit, making the default query never to be matched again and, because of that, returning 0 results.

One solution would have been to migrate the query data structure to a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map), which preserves key order. But that required a big refactor that I don't think we want in a point release. So for now I relied on using lodash's `assign` method that allows merging objects while preserving key order.

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block.
2. In a Webkit browser (Safari, for example), change the sort select to something different and then go back to the initial order.
3. Verify results appear, instead of the _No results_ message.

### Changelog

> Fix bug in Safari and other Webkit browsers that was causing the All Products block to show 0 results when resetting the sort value.