### PR TITLE
show active filters block with "no filters" message when no filters are set

### DIFF
--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -66,15 +66,28 @@ const ActiveFiltersBlock = ( {
 		);
 	};
 
-	if ( ! hasFilters() && ! isEditor ) {
-		return null;
-	}
-
 	const TagName = `h${ blockAttributes.headingLevel }`;
 	const listClasses = classnames( 'wc-block-active-filters-list', {
 		'wc-block-active-filters-list--chips':
 			blockAttributes.displayStyle === 'chips',
 	} );
+
+	const clearAllButton = (
+		<button
+			className="wc-block-active-filters__clear-all"
+			onClick={ () => {
+				setMinPrice( null );
+				setMaxPrice( null );
+				setProductAttributes( [] );
+			} }
+		>
+			{ __( 'Clear All', 'woo-gutenberg-products-block' ) }
+		</button>
+	);
+	const noFiltersLabel = __(
+		'No filters enabled.',
+		'woo-gutenberg-products-block'
+	);
 
 	return (
 		<Fragment>
@@ -101,16 +114,7 @@ const ActiveFiltersBlock = ( {
 						</Fragment>
 					) }
 				</ul>
-				<button
-					className="wc-block-active-filters__clear-all"
-					onClick={ () => {
-						setMinPrice( null );
-						setMaxPrice( null );
-						setProductAttributes( [] );
-					} }
-				>
-					{ __( 'Clear All', 'woo-gutenberg-products-block' ) }
-				</button>
+				{ hasFilters() ? clearAllButton : noFiltersLabel }
 			</div>
 		</Fragment>
 	);


### PR DESCRIPTION
Fixes #1435

This PR changes the Active Filters block so it is always visible on the front end, even if the user has no filters enabled. A (new) message is displayed to make it clear that no filters are set - `No filters enabled.`.

cc @garymurray - This is a tweak to the UX for All Products, keen for your thoughts on this and the new string. 

#### Accessibility

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="438" alt="Screen Shot 2020-01-21 at 4 20 48 PM" src="https://user-images.githubusercontent.com/4167300/72772837-ff427700-3c69-11ea-9e6a-e1660ceef88e.png">

### How to test the changes in this Pull Request:

1. Clone this branch. Publish a page/post with All Products, some filter blocks and Active Filters block. 
2. View page on front end, confirm Active Filters block is visible and useful with no filters.
3. Tweak filters (price, attributes etc) and confirm correct Active Filters behaviour: shows filters, filters can be removed.

### Changelog

> Improvement: Always show the Active Filters block, even if customer has no filters enabled.
