### PR TITLE
Add and/or labelling to active filters block

### DIFF
--- a/assets/js/blocks/active-filters/active-attribute-filters.js
+++ b/assets/js/blocks/active-filters/active-attribute-filters.js
@@ -3,7 +3,8 @@
  */
 import { useCollection, useQueryStateByKey } from '@woocommerce/base-hooks';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -43,19 +44,16 @@ const ActiveAttributeFilters = ( {
 
 		let name = decodeEntities( termObject.name || slug );
 
-		if ( index > 0 ) {
-			name =
-				operator === 'in'
-					? sprintf(
-							// Translators: %s attribute name.
-							__( 'or %s', 'woo-gutenberg-products-block' ),
-							name
-					  )
-					: sprintf(
-							// Translators: %s attribute name.
-							__( 'and %s', 'woo-gutenberg-products-block' ),
-							name
-					  );
+		if ( index > 0 && operator === 'and' ) {
+			name = (
+				<Fragment>
+					<span className="wc-block-active-filters-list-item__operator">
+						{ __( 'and', 'woo-gutenberg-products-block' ) }
+					</span>
+					&nbsp;
+					{ name }
+				</Fragment>
+			);
 		}
 
 		return (

--- a/assets/js/blocks/active-filters/active-attribute-filters.js
+++ b/assets/js/blocks/active-filters/active-attribute-filters.js
@@ -4,7 +4,6 @@
 import { useCollection, useQueryStateByKey } from '@woocommerce/base-hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -37,42 +36,49 @@ const ActiveAttributeFilters = ( {
 
 	const attributeLabel = attributeObject.label;
 
-	return slugs.map( ( slug, index ) => {
-		const termObject = results.find( ( term ) => {
-			return term.slug === slug;
-		} );
+	return (
+		<li>
+			<span className="wc-block-active-filters__list-item-type">
+				{ attributeLabel }:
+			</span>
+			<ul>
+				{ slugs.map( ( slug, index ) => {
+					const termObject = results.find( ( term ) => {
+						return term.slug === slug;
+					} );
 
-		let name = decodeEntities( termObject.name || slug );
+					if ( ! termObject ) {
+						return null;
+					}
 
-		if ( index > 0 && operator === 'and' ) {
-			name = (
-				<Fragment>
-					<span className="wc-block-active-filters-list-item__operator">
-						{ __( 'and', 'woo-gutenberg-products-block' ) }
-					</span>
-					&nbsp;
-					{ name }
-				</Fragment>
-			);
-		}
+					let prefix = '';
 
-		return (
-			termObject &&
-			renderRemovableListItem( {
-				type: attributeLabel,
-				name,
-				removeCallback: () => {
-					removeAttributeFilterBySlug(
-						productAttributes,
-						setProductAttributes,
-						attributeObject,
-						slug
-					);
-				},
-				showLabel: index === 0,
-			} )
-		);
-	} );
+					if ( index > 0 && operator === 'and' ) {
+						prefix = (
+							<span className="wc-block-active-filters__list-item-operator">
+								{ __( 'and', 'woo-gutenberg-products-block' ) }
+							</span>
+						);
+					}
+
+					return renderRemovableListItem( {
+						type: attributeLabel,
+						name: decodeEntities( termObject.name || slug ),
+						prefix,
+						removeCallback: () => {
+							removeAttributeFilterBySlug(
+								productAttributes,
+								setProductAttributes,
+								attributeObject,
+								slug
+							);
+						},
+						showLabel: false,
+					} );
+				} ) }
+			</ul>
+		</li>
+	);
 };
 
 export default ActiveAttributeFilters;

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -34,14 +34,14 @@ const ActiveFiltersBlock = ( {
 		if ( ! Number.isFinite( minPrice ) && ! Number.isFinite( maxPrice ) ) {
 			return null;
 		}
-		return renderRemovableListItem(
-			__( 'Price', 'woo-gutenberg-products-block' ),
-			formatPriceRange( minPrice, maxPrice ),
-			() => {
+		return renderRemovableListItem( {
+			type: __( 'Price', 'woo-gutenberg-products-block' ),
+			name: formatPriceRange( minPrice, maxPrice ),
+			removeCallback: () => {
 				setMinPrice( undefined );
 				setMaxPrice( undefined );
-			}
-		);
+			},
+		} );
 	}, [ minPrice, maxPrice, formatPriceRange ] );
 
 	const activeAttributeFilters = useMemo( () => {
@@ -54,6 +54,7 @@ const ActiveFiltersBlock = ( {
 					attributeObject={ attributeObject }
 					slugs={ attribute.slug }
 					key={ attribute.attribute }
+					operator={ attribute.operator }
 				/>
 			);
 		} );
@@ -86,14 +87,26 @@ const ActiveFiltersBlock = ( {
 				<ul className={ listClasses }>
 					{ isEditor ? (
 						<Fragment>
-							{ renderRemovableListItem(
-								__( 'Size', 'woo-gutenberg-products-block' ),
-								__( 'Small', 'woo-gutenberg-products-block' )
-							) }
-							{ renderRemovableListItem(
-								__( 'Color', 'woo-gutenberg-products-block' ),
-								__( 'Blue', 'woo-gutenberg-products-block' )
-							) }
+							{ renderRemovableListItem( {
+								type: __(
+									'Size',
+									'woo-gutenberg-products-block'
+								),
+								name: __(
+									'Small',
+									'woo-gutenberg-products-block'
+								),
+							} ) }
+							{ renderRemovableListItem( {
+								type: __(
+									'Color',
+									'woo-gutenberg-products-block'
+								),
+								name: __(
+									'Blue',
+									'woo-gutenberg-products-block'
+								),
+							} ) }
 						</Fragment>
 					) : (
 						<Fragment>

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -73,8 +73,8 @@ const ActiveFiltersBlock = ( {
 	}
 
 	const TagName = `h${ blockAttributes.headingLevel }`;
-	const listClasses = classnames( 'wc-block-active-filters-list', {
-		'wc-block-active-filters-list--chips':
+	const listClasses = classnames( 'wc-block-active-filters__list', {
+		'wc-block-active-filters__list--chips':
 			blockAttributes.displayStyle === 'chips',
 	} );
 

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -22,10 +22,16 @@
 
 		li {
 			margin: 0 0 $gap-smallest;
-			padding: 0 16px 0 0;
+			padding: 0;
 			list-style: none outside;
 			clear: both;
-			position: relative;
+
+			.wc-block-active-filters-list-item__name {
+				font-weight: bold;
+				display: block;
+				position: relative;
+				padding: 0 16px 0 0;
+			}
 		}
 
 		button {

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -90,6 +90,9 @@
 				.wc-block-active-filters__list-item-type {
 					display: none;
 				}
+				.wc-block-active-filters__list-item-name {
+					padding: 0;
+				}
 			}
 			li.wc-block-active-filters__list-item {
 				background: #c4c4c4;

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -15,7 +15,7 @@
 			background: transparent none;
 		}
 	}
-	.wc-block-active-filters-list {
+	.wc-block-active-filters__list {
 		margin: 0 0 $gap-smallest;
 		list-style: none outside;
 		clear: both;
@@ -26,7 +26,13 @@
 			list-style: none outside;
 			clear: both;
 
-			.wc-block-active-filters-list-item__type {
+			ul {
+				margin: 0;
+				padding: 0;
+				list-style: none outside;
+			}
+
+			.wc-block-active-filters__list-item-type {
 				text-transform: uppercase;
 				font-size: 0.7em;
 				letter-spacing: 0.1em;
@@ -34,12 +40,12 @@
 				display: block;
 			}
 
-			.wc-block-active-filters-list-item__operator {
+			.wc-block-active-filters__list-item-operator {
 				font-weight: normal;
 				font-style: italic;
 			}
 
-			.wc-block-active-filters-list-item__name {
+			.wc-block-active-filters__list-item-name {
 				font-weight: bold;
 				display: block;
 				position: relative;
@@ -47,7 +53,7 @@
 			}
 
 			&:first-child {
-				.wc-block-active-filters-list-item__type {
+				.wc-block-active-filters__list-item-type {
 					margin: 0;
 				}
 			}
@@ -77,18 +83,20 @@
 			}
 		}
 
-		&.wc-block-active-filters-list--chips {
+		&.wc-block-active-filters__list--chips {
 			li {
 				display: inline-block;
+
+				.wc-block-active-filters__list-item-type {
+					display: none;
+				}
+			}
+			li.wc-block-active-filters__list-item {
 				background: #c4c4c4;
 				border-radius: 4px;
 				padding: 4px 8px;
 				margin: 0 6px 6px 0;
 				color: #24292d;
-
-				.wc-block-active-filters-list-item__type {
-					display: none;
-				}
 			}
 			button {
 				float: none;

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -21,16 +21,35 @@
 		clear: both;
 
 		li {
-			margin: 0 0 $gap-smallest;
+			margin: 0;
 			padding: 0;
 			list-style: none outside;
 			clear: both;
+
+			.wc-block-active-filters-list-item__type {
+				text-transform: uppercase;
+				font-size: 0.7em;
+				letter-spacing: 0.1em;
+				margin: $gap 0 0;
+				display: block;
+			}
+
+			.wc-block-active-filters-list-item__operator {
+				font-weight: normal;
+				font-style: italic;
+			}
 
 			.wc-block-active-filters-list-item__name {
 				font-weight: bold;
 				display: block;
 				position: relative;
 				padding: 0 16px 0 0;
+			}
+
+			&:first-child {
+				.wc-block-active-filters-list-item__type {
+					margin: 0;
+				}
 			}
 		}
 

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { formatPrice } from '@woocommerce/base-utils';
+import { Fragment } from '@wordpress/element';
 
 /**
  * Format a min/max price range to display.
@@ -40,27 +41,37 @@ export const formatPriceRange = ( minPrice, maxPrice ) => {
  *
  * @param {string} type Type string.
  * @param {string} name Name string.
+ * @param {string} prefix Prefix shown before item name.
  * @param {Function} removeCallback Callback to remove item.
  * @param {boolean} [showLabel=true] Should the label be shown for this item?
  */
 export const renderRemovableListItem = ( {
 	type,
 	name,
+	prefix,
 	removeCallback = () => {},
 	showLabel = true,
 } ) => {
 	return (
 		<li
-			className="wc-block-active-filters-list-item"
+			className="wc-block-active-filters__list-item"
 			key={ type + ':' + name }
 		>
 			{ showLabel && (
-				<span className="wc-block-active-filters-list-item__type">
+				<span className="wc-block-active-filters__list-item-type">
 					{ type + ': ' }
 				</span>
 			) }
-			<span className="wc-block-active-filters-list-item__name">
-				{ name }
+			<span className="wc-block-active-filters__list-item-name">
+				{ prefix ? (
+					<Fragment>
+						{ prefix }
+						&nbsp;
+						{ name }
+					</Fragment>
+				) : (
+					name
+				) }
 				<button onClick={ removeCallback }>
 					{ sprintf(
 						/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -41,7 +41,7 @@ export const formatPriceRange = ( minPrice, maxPrice ) => {
  * @param {string} type Type string.
  * @param {string} name Name string.
  * @param {Function} removeCallback Callback to remove item.
- * @param {boolean} showLabel Should the label be shown for this item?
+ * @param {boolean} [showLabel=true] Should the label be shown for this item?
  */
 export const renderRemovableListItem = ( {
 	type,

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -41,30 +41,37 @@ export const formatPriceRange = ( minPrice, maxPrice ) => {
  * @param {string} type Type string.
  * @param {string} name Name string.
  * @param {Function} removeCallback Callback to remove item.
+ * @param {boolean} showLabel Should the label be shown for this item?
  */
-export const renderRemovableListItem = (
+export const renderRemovableListItem = ( {
 	type,
 	name,
-	removeCallback = () => {}
-) => {
+	removeCallback = () => {},
+	showLabel = true,
+} ) => {
 	return (
 		<li
 			className="wc-block-active-filters-list-item"
 			key={ type + ':' + name }
 		>
-			<span className="wc-block-active-filters-list-item__type">
-				{ type + ': ' }
-			</span>
-			<strong className="wc-block-active-filters-list-item__name">
+			{ showLabel && (
+				<span className="wc-block-active-filters-list-item__type">
+					{ type + ': ' }
+				</span>
+			) }
+			<span className="wc-block-active-filters-list-item__name">
 				{ name }
-			</strong>
-			<button onClick={ removeCallback }>
-				{ sprintf(
-					/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
-					__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
-					name
-				) }
-			</button>
+				<button onClick={ removeCallback }>
+					{ sprintf(
+						/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
+						__(
+							'Remove %s filter',
+							'woo-gutenberg-products-block'
+						),
+						name
+					) }
+				</button>
+			</span>
 		</li>
 	);
 };


### PR DESCRIPTION
Shows when a query is "and" based in the active filters block.

Closes #1341

The problem we had was active filters listed individual filters, but not the relationship between them. Blocks can be setup to query "all" or "any" matches.

### Screenshots

![Screenshot 2020-01-28 at 16 27 20](https://user-images.githubusercontent.com/90977/73283552-2f01f980-41eb-11ea-96be-c3b6264cb887.png)

### How to test the changes in this Pull Request:

1. Setup filter blocks and set some to 'any' filtering and some to 'all' filtering
2. Setup active filters block
3. Filter on the frontend

<!-- If you can, add the appropriate labels -->

### Changelog

> Show relationship between terms in the active filters block.
