### PR TITLE
Add renovate config to avoid pinning `jetpack-autoloader` package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"minimum-stability": "dev",
 	"require": {
 		"composer/installers": "1.7.0",
-		"automattic/jetpack-autoloader": "^1.3.0"
+		"automattic/jetpack-autoloader": "^1.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "6.5.14",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"minimum-stability": "dev",
 	"require": {
 		"composer/installers": "1.7.0",
-		"automattic/jetpack-autoloader": "1.3.2"
+		"automattic/jetpack-autoloader": "^1.3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "6.5.14",

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
 	"packageRules": [
 		{
 			"packageNames": [ "automattic/jetpack-autoloader" ],
-			"rangeStrategy": "replace"
+			"rangeStrategy": "bump"
 		}
 	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,11 @@
 	"schedule": [ "before 3am on wednesday" ],
 	"composer": {
 		"enabled": false
-	}
+	},
+	"packageRules": [
+		{
+			"packageNames": [ "automattic/jetpack-autoloader" ],
+			"rangeStrategy": "replace"
+		}
+	]
 }


### PR DESCRIPTION
This is a small tweak to renovate config using the options in https://docs.renovatebot.com/configuration-options/

This change prevents the `jetpack-autoloader` being pinned to a specific version which will lessen the likelihood of conflicts when it's pulled into Woo core, if the woo core version or wc-admin version of this package differs from the pin.

The range strategy is `replace`:

```
Replace the range with a newer one if the new version falls outside it, e.g. ^1.0.0 -> ^2.0.0
```

So when this package is bumped to `1.4.0` we should get an update from renovate.

Woo Core already has similar rules in place: https://github.com/woocommerce/woocommerce/blob/master/renovate.json#L5

wc-admin does not (https://github.com/woocommerce/woocommerce-admin/blob/master/renovate.json) so if approved, it should probably be added there too cc @woocommerce/wc-admin

Fixes #1625