### PR TITLE
Move default population to class method instead of constructor

### DIFF
--- a/assets/js/filters/block-list-block.js
+++ b/assets/js/filters/block-list-block.js
@@ -17,6 +17,20 @@ const withDefaultAttributes = createHigherOrderComponent(
 			constructor() {
 				super( ...arguments );
 
+				this.getAttributesWithDefaults = this.getAttributesWithDefaults.bind(
+					this
+				);
+			}
+
+			componentDidMount() {
+				const { block, setAttributes } = this.props;
+
+				if ( block.name.startsWith( 'woocommerce/' ) ) {
+					setAttributes( this.getAttributesWithDefaults() );
+				}
+			}
+
+			getAttributesWithDefaults() {
 				const blockType = getBlockType( this.props.block.name );
 				const attributes = Object.assign(
 					{},
@@ -39,22 +53,14 @@ const withDefaultAttributes = createHigherOrderComponent(
 					} );
 				}
 
-				this.attributesWithDefaults = attributes;
-			}
-
-			componentDidMount() {
-				const { block, setAttributes } = this.props;
-
-				if ( block.name.startsWith( 'woocommerce/' ) ) {
-					setAttributes( this.attributesWithDefaults );
-				}
+				return attributes;
 			}
 
 			render() {
 				return (
 					<BlockListBlock
 						{ ...this.props }
-						attributes={ this.attributesWithDefaults }
+						attributes={ this.getAttributesWithDefaults() }
 					/>
 				);
 			}


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1613 introduced a bug where attributes could not longer be changed (sorry!). This was due to running default-population on construct, and using that value for attributes forever. This prevented updates from taking effect.

By moving this logic to a class method, it can run on `render()` and mount to ensure defaults are applied to the current attributes, rather than just the initial attributes.

### How to test the changes in this Pull Request:

1. Check you can edit rows/columns for the all products block
2. Check that when you insert the block for first time, rows and columns are 3 (defaults)