### PR TITLE
Summary/description consistency update

### DIFF
--- a/assets/js/atomic/blocks/product/button/index.js
+++ b/assets/js/atomic/blocks/product/button/index.js
@@ -13,7 +13,7 @@ import { ProductButton } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 
 const blockConfig = {
-	title: __( 'Product Button', 'woo-gutenberg-products-block' ),
+	title: __( 'Add to Cart Button', 'woo-gutenberg-products-block' ),
 	description: __(
 		'Display a call to action button which either adds the product to the cart, or links to the product page.',
 		'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product/rating/index.js
+++ b/assets/js/atomic/blocks/product/rating/index.js
@@ -12,7 +12,7 @@ import { ProductRating } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 
 const blockConfig = {
-	title: __( 'Product Rating', 'woo-gutenberg-products-block' ),
+	title: __( 'Average Rating', 'woo-gutenberg-products-block' ),
 	description: __(
 		'Display the average rating of a product.',
 		'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product/rating/index.js
+++ b/assets/js/atomic/blocks/product/rating/index.js
@@ -12,7 +12,7 @@ import { ProductRating } from '@woocommerce/atomic-components/product';
 import sharedConfig from '../shared-config';
 
 const blockConfig = {
-	title: __( 'Average Rating', 'woo-gutenberg-products-block' ),
+	title: __( 'Product Rating', 'woo-gutenberg-products-block' ),
 	description: __(
 		'Display the average rating of a product.',
 		'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product/summary/index.js
+++ b/assets/js/atomic/blocks/product/summary/index.js
@@ -14,7 +14,7 @@ import sharedConfig from '../shared-config';
 const blockConfig = {
 	title: __( 'Product Summary', 'woo-gutenberg-products-block' ),
 	description: __(
-		'Display the short description of a product.',
+		'Display a short description about a product.',
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/atomic/components/product/summary/index.js
+++ b/assets/js/atomic/components/product/summary/index.js
@@ -7,7 +7,7 @@ import { useProductLayoutContext } from '@woocommerce/base-context/product-layou
 
 const ProductSummary = ( { className, product } ) => {
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
-	if ( ! product.description ) {
+	if ( ! product.summary ) {
 		return null;
 	}
 
@@ -18,7 +18,7 @@ const ProductSummary = ( { className, product } ) => {
 				`${ layoutStyleClassPrefix }__product-summary`
 			) }
 			dangerouslySetInnerHTML={ {
-				__html: product.description,
+				__html: product.summary,
 			} }
 		/>
 	);

--- a/assets/js/previews/cart-items.js
+++ b/assets/js/previews/cart-items.js
@@ -17,7 +17,13 @@ export const previewCartItems = [
 		id: 1,
 		quantity: 2,
 		name: __( 'Beanie', 'woo-gutenberg-products-block' ),
-		description: __( 'Warm hat for winter' ),
+		summary: __( 'Warm hat for winter', 'woo-gutenberg-products-block' ),
+		short_description: __(
+			'Warm hat for winter',
+			'woo-gutenberg-products-block'
+		),
+		description:
+			'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.',
 		sku: 'woo-beanie',
 		permalink: 'https://example.org',
 		low_stock_remaining: 2,
@@ -61,7 +67,16 @@ export const previewCartItems = [
 		id: 2,
 		quantity: 1,
 		name: __( 'Cap', 'woo-gutenberg-products-block' ),
-		description: __( 'Lightweight baseball cap' ),
+		summary: __(
+			'Lightweight baseball cap',
+			'woo-gutenberg-products-block'
+		),
+		short_description: __(
+			'Lightweight baseball cap',
+			'woo-gutenberg-products-block'
+		),
+		description:
+			'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.',
 		sku: 'woo-cap',
 		permalink: 'https://example.org',
 		images: [

--- a/assets/js/previews/products.js
+++ b/assets/js/previews/products.js
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  */
 import productPicture from './product-image';
 
-const description = __(
+const shortDescription = __(
 	'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
 	'woo-gutenberg-products-block'
 );
@@ -20,9 +20,10 @@ export const previewProducts = [
 		variation: '',
 		permalink: 'https://example.org',
 		sku: 'wp-pennant',
-		summary: description,
-		short_description: description,
-		description,
+		summary: shortDescription,
+		short_description: shortDescription,
+		description:
+			'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.',
 		price: '7.99',
 		price_html:
 			'<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">$</span>7.99</span>',

--- a/assets/js/previews/products.js
+++ b/assets/js/previews/products.js
@@ -15,6 +15,14 @@ export const previewProducts = [
 		variation: '',
 		permalink: 'https://example.org',
 		sku: 'wp-pennant',
+		summary: __(
+			'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
+			'woo-gutenberg-products-block'
+		),
+		short_description: __(
+			'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
+			'woo-gutenberg-products-block'
+		),
 		description: __(
 			'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
 			'woo-gutenberg-products-block'

--- a/assets/js/previews/products.js
+++ b/assets/js/previews/products.js
@@ -8,6 +8,11 @@ import { __ } from '@wordpress/i18n';
  */
 import productPicture from './product-image';
 
+const description = __(
+	'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
+	'woo-gutenberg-products-block'
+);
+
 export const previewProducts = [
 	{
 		id: 1,
@@ -15,18 +20,9 @@ export const previewProducts = [
 		variation: '',
 		permalink: 'https://example.org',
 		sku: 'wp-pennant',
-		summary: __(
-			'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
-			'woo-gutenberg-products-block'
-		),
-		short_description: __(
-			'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
-			'woo-gutenberg-products-block'
-		),
-		description: __(
-			'Fly your WordPress banner with this beauty! Deck out your office space or add it to your kids walls. This banner will spruce up any space it’s hung!',
-			'woo-gutenberg-products-block'
-		),
+		summary: description,
+		short_description: description,
+		description,
 		price: '7.99',
 		price_html:
 			'<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">$</span>7.99</span>',

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -255,20 +255,22 @@ class CartItemSchema extends AbstractSchema {
 	 * @return string
 	 */
 	protected function get_product_summary( \WC_Product $product ) {
-		$description       = $product->get_description();
 		$short_description = $product->get_short_description();
 
-		// Select description based on availability.
-		$source        = \trim( $short_description ? $short_description : $description );
-		$source_length = \strlen( \wp_strip_all_tags( $source ) );
-
-		// Try to extract the first sentence only if the description is too long.
-		if ( 150 < $source_length ) {
-			$source_p = \wpautop( $source );
-			$source   = \strstr( $source_p, '</p>' ) ? \substr( $source_p, 0, \strpos( $source_p, '</p>' ) + 4 ) : \wc_trim_string( $source, 150 );
+		if ( $short_description ) {
+			return \wc_format_content( $short_description );
 		}
 
-		return \wc_format_content( $source );
+		$description = $product->get_description();
+		$length      = \strlen( \wp_strip_all_tags( $description ) );
+
+		// Try to extract the first sentence only if the description is too long.
+		if ( 150 < $length ) {
+			$description_p = \wpautop( $description );
+			$description   = \strstr( $description_p, '</p>' ) ? \substr( $description_p, 0, \strpos( $description_p, '</p>' ) + 4 ) : \wc_trim_string( $description, 150 );
+		}
+
+		return \wc_format_content( $description );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductImages;
+use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductSummary;
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ReserveStock;
 
 /**
@@ -228,7 +229,7 @@ class CartItemSchema extends AbstractSchema {
 			'id'                  => $product->get_id(),
 			'quantity'            => wc_stock_amount( $cart_item['quantity'] ),
 			'name'                => $this->prepare_html_response( $product->get_title() ),
-			'summary'             => $this->prepare_html_response( $this->get_product_summary( $product ) ),
+			'summary'             => $this->prepare_html_response( ( new ProductSummary( $product ) )->get_summary( 150 ) ),
 			'short_description'   => $this->prepare_html_response( wc_format_content( $product->get_short_description() ) ),
 			'description'         => $this->prepare_html_response( wc_format_content( $product->get_description() ) ),
 			'sku'                 => $this->prepare_html_response( $product->get_sku() ),
@@ -246,31 +247,6 @@ class CartItemSchema extends AbstractSchema {
 				]
 			),
 		];
-	}
-
-	/**
-	 * Generate a summary from the product short/full description.
-	 *
-	 * @param \WC_Product $product Product instance.
-	 * @return string
-	 */
-	protected function get_product_summary( \WC_Product $product ) {
-		$short_description = $product->get_short_description();
-
-		if ( $short_description ) {
-			return \wc_format_content( $short_description );
-		}
-
-		$description = $product->get_description();
-		$length      = \strlen( \wp_strip_all_tags( $description ) );
-
-		// Try to extract the first sentence only if the description is too long.
-		if ( 150 < $length ) {
-			$description_p = \wpautop( $description );
-			$description   = \strstr( $description_p, '</p>' ) ? \substr( $description_p, 0, \strpos( $description_p, '</p>' ) + 4 ) : \wc_trim_string( $description, 150 );
-		}
-
-		return \wc_format_content( $description );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -268,6 +268,7 @@ class ProductSchema extends AbstractSchema {
 			),
 		];
 	}
+
 	/**
 	 * Generate a summary from the product short/full description.
 	 *

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductImages;
+use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductSummary;
 
 /**
  * ProductSchema class.
@@ -248,7 +249,7 @@ class ProductSchema extends AbstractSchema {
 			'variation'           => $this->prepare_html_response( $product->is_type( 'variation' ) ? wc_get_formatted_variation( $product, true, true, false ) : '' ),
 			'permalink'           => $product->get_permalink(),
 			'sku'                 => $this->prepare_html_response( $product->get_sku() ),
-			'summary'             => $this->prepare_html_response( $this->get_product_summary( $product ) ),
+			'summary'             => $this->prepare_html_response( ( new ProductSummary( $product ) )->get_summary( 150 ) ),
 			'short_description'   => $this->prepare_html_response( wc_format_content( $product->get_short_description() ) ),
 			'description'         => $this->prepare_html_response( wc_format_content( $product->get_description() ) ),
 			'on_sale'             => $product->is_on_sale(),
@@ -267,31 +268,6 @@ class ProductSchema extends AbstractSchema {
 				]
 			),
 		];
-	}
-
-	/**
-	 * Generate a summary from the product short/full description.
-	 *
-	 * @param \WC_Product $product Product instance.
-	 * @return string
-	 */
-	protected function get_product_summary( \WC_Product $product ) {
-		$short_description = $product->get_short_description();
-
-		if ( $short_description ) {
-			return \wc_format_content( $short_description );
-		}
-
-		$description = $product->get_description();
-		$length      = \strlen( \wp_strip_all_tags( $description ) );
-
-		// Try to extract the first sentence only if the description is too long.
-		if ( 150 < $length ) {
-			$description_p = \wpautop( $description );
-			$description   = \strstr( $description_p, '</p>' ) ? \substr( $description_p, 0, \strpos( $description_p, '</p>' ) + 4 ) : \wc_trim_string( $description, 150 );
-		}
-
-		return \wc_format_content( $description );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -276,20 +276,22 @@ class ProductSchema extends AbstractSchema {
 	 * @return string
 	 */
 	protected function get_product_summary( \WC_Product $product ) {
-		$description       = $product->get_description();
 		$short_description = $product->get_short_description();
 
-		// Select description based on availability.
-		$source        = \trim( $short_description ? $short_description : $description );
-		$source_length = \strlen( \wp_strip_all_tags( $source ) );
-
-		// Try to extract the first sentence only if the description is too long.
-		if ( 150 < $source_length ) {
-			$source_p = \wpautop( $source );
-			$source   = \strstr( $source_p, '</p>' ) ? \substr( $source_p, 0, \strpos( $source_p, '</p>' ) + 4 ) : \wc_trim_string( $source, 150 );
+		if ( $short_description ) {
+			return \wc_format_content( $short_description );
 		}
 
-		return \wc_format_content( $source );
+		$description = $product->get_description();
+		$length      = \strlen( \wp_strip_all_tags( $description ) );
+
+		// Try to extract the first sentence only if the description is too long.
+		if ( 150 < $length ) {
+			$description_p = \wpautop( $description );
+			$description   = \strstr( $description_p, '</p>' ) ? \substr( $description_p, 0, \strpos( $description_p, '</p>' ) + 4 ) : \wc_trim_string( $description, 150 );
+		}
+
+		return \wc_format_content( $description );
 	}
 
 	/**

--- a/src/RestApi/Utilities/ProductSummary.php
+++ b/src/RestApi/Utilities/ProductSummary.php
@@ -68,10 +68,10 @@ final class ProductSummary {
 	 */
 	private function generate_summary( $content, $max_words ) {
 		$content_p = \wpautop( $content );
-		$paragraph = \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : $content_p;
+		$paragraph = \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : $content;
 
 		if ( $this->get_word_count( $paragraph ) > $max_words ) {
-			return \wp_trim_words( $content, $max_words );
+			return \wp_trim_words( $paragraph, $max_words );
 		}
 
 		return $paragraph;

--- a/src/RestApi/Utilities/ProductSummary.php
+++ b/src/RestApi/Utilities/ProductSummary.php
@@ -12,13 +12,13 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Product Summary class.
  */
-class ProductSummary {
+final class ProductSummary {
 	/**
 	 * Original content from the product.
 	 *
 	 * @var string
 	 */
-	protected $content = '';
+	private $content = '';
 
 	/**
 	 * Constructor.
@@ -55,7 +55,7 @@ class ProductSummary {
 	 * @param string $content HTML Content.
 	 * @return int Length
 	 */
-	protected function get_word_count( $content ) {
+	private function get_word_count( $content ) {
 		return \str_word_count( \wp_strip_all_tags( $content ) );
 	}
 
@@ -66,7 +66,7 @@ class ProductSummary {
 	 * @param int    $max_words Maximum allowed words for summary.
 	 * @return string
 	 */
-	protected function generate_summary( $content, $max_words ) {
+	private function generate_summary( $content, $max_words ) {
 		$content_p = \wpautop( $content );
 		$paragraph = \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : $content_p;
 

--- a/src/RestApi/Utilities/ProductSummary.php
+++ b/src/RestApi/Utilities/ProductSummary.php
@@ -14,11 +14,11 @@ defined( 'ABSPATH' ) || exit;
  */
 final class ProductSummary {
 	/**
-	 * Original content from the product.
+	 * Reference to product object.
 	 *
-	 * @var string
+	 * @var \WC_Product
 	 */
-	private $content = '';
+	private $product = '';
 
 	/**
 	 * Constructor.
@@ -26,11 +26,7 @@ final class ProductSummary {
 	 * @param \WC_Product $product The product to generate a summary for.
 	 */
 	public function __construct( \WC_Product $product ) {
-		$this->content = $product->get_short_description();
-
-		if ( ! $this->content ) {
-			$this->content = $product->get_description();
-		}
+		$this->product = $product;
 	}
 
 	/**
@@ -40,7 +36,7 @@ final class ProductSummary {
 	 * @return string
 	 */
 	public function get_summary( $max_words = 25 ) {
-		$summary = $this->content;
+		$summary = $this->get_content_for_summary();
 
 		if ( $max_words && $this->get_word_count( $summary ) > $max_words ) {
 			$summary = $this->generate_summary( $summary, $max_words );
@@ -50,13 +46,45 @@ final class ProductSummary {
 	}
 
 	/**
-	 * Get the word count.
+	 * Get description to base summary on from the product object.
+	 *
+	 * @return string
+	 */
+	private function get_content_for_summary() {
+		$content = $this->product->get_short_description();
+
+		if ( ! $content ) {
+			$content = $this->product->get_description();
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Get the word count. Based on the logic in `wp_trim_words`.
 	 *
 	 * @param string $content HTML Content.
 	 * @return int Length
 	 */
 	private function get_word_count( $content ) {
-		return \str_word_count( \wp_strip_all_tags( $content ) );
+		$content = wp_strip_all_tags( $content );
+
+		/*
+		* translators: If your word count is based on single characters (e.g. East Asian characters),
+		* enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+		* Do not translate into your own language.
+		*/
+		$type = _x( 'words', 'Word count type. Do not translate!' ); // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+
+		if ( strpos( $type, 'characters' ) === 0 && preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) ) ) {
+			$content = trim( preg_replace( "/[\n\r\t ]+/", ' ', $content ), ' ' );
+			preg_match_all( '/./u', $content, $words_array );
+			$words_array = $words_array[0];
+		} else {
+			$words_array = preg_split( "/[\n\r\t ]+/", $content );
+		}
+
+		return count( array_filter( $words_array ) );
 	}
 
 	/**
@@ -68,6 +96,8 @@ final class ProductSummary {
 	 */
 	private function generate_summary( $content, $max_words ) {
 		$content_p = \wpautop( $content );
+
+		// This gets the first paragraph, if <p> tags are found. Otherwise returns the entire string.
 		$paragraph = \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : $content;
 
 		if ( $this->get_word_count( $paragraph ) > $max_words ) {

--- a/src/RestApi/Utilities/ProductSummary.php
+++ b/src/RestApi/Utilities/ProductSummary.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Helper class to format a short summary of content for a product.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\Utilities;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Product Summary class.
+ */
+class ProductSummary {
+	/**
+	 * Original content from the product.
+	 *
+	 * @var string
+	 */
+	protected $content = '';
+
+	/**
+	 * Constructor.
+	 *
+	 * @param \WC_Product $product The product to generate a summary for.
+	 */
+	public function __construct( \WC_Product $product ) {
+		$this->content = $product->get_short_description();
+
+		if ( ! $this->content ) {
+			$this->content = $product->get_description();
+		}
+	}
+
+	/**
+	 * Return the formatted summary.
+	 *
+	 * @param int $allowed_length Maximum allowed characters for summary.
+	 * @return string
+	 */
+	public function get_summary( $allowed_length ) {
+		$summary = $this->content;
+
+		if ( $this->get_length( $summary ) > $allowed_length ) {
+			$summary = $this->get_first_paragraph( $summary );
+		}
+
+		return \wc_format_content( $summary );
+	}
+
+	/**
+	 * Get the character length of some content, ignoring HTML.
+	 *
+	 * @param string $content HTML Content.
+	 * @return int Length
+	 */
+	protected function get_length( $content ) {
+		return \strlen( \wp_strip_all_tags( $content ) );
+	}
+
+	/**
+	 * Get the first paragraph, or a short excerpt, from some content.
+	 *
+	 * @param string $content HTML Content.
+	 * @return string
+	 */
+	protected function get_first_paragraph( $content ) {
+		$content_p = \wpautop( $content );
+
+		return \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : \wc_trim_string( $content, 150 );
+	}
+}

--- a/src/RestApi/Utilities/ProductSummary.php
+++ b/src/RestApi/Utilities/ProductSummary.php
@@ -36,38 +36,44 @@ class ProductSummary {
 	/**
 	 * Return the formatted summary.
 	 *
-	 * @param int $allowed_length Maximum allowed characters for summary.
+	 * @param int $max_words Word limit for summary.
 	 * @return string
 	 */
-	public function get_summary( $allowed_length ) {
+	public function get_summary( $max_words = 25 ) {
 		$summary = $this->content;
 
-		if ( $this->get_length( $summary ) > $allowed_length ) {
-			$summary = $this->get_first_paragraph( $summary );
+		if ( $max_words && $this->get_word_count( $summary ) > $max_words ) {
+			$summary = $this->generate_summary( $summary, $max_words );
 		}
 
 		return \wc_format_content( $summary );
 	}
 
 	/**
-	 * Get the character length of some content, ignoring HTML.
+	 * Get the word count.
 	 *
 	 * @param string $content HTML Content.
 	 * @return int Length
 	 */
-	protected function get_length( $content ) {
-		return \strlen( \wp_strip_all_tags( $content ) );
+	protected function get_word_count( $content ) {
+		return \str_word_count( \wp_strip_all_tags( $content ) );
 	}
 
 	/**
 	 * Get the first paragraph, or a short excerpt, from some content.
 	 *
 	 * @param string $content HTML Content.
+	 * @param int    $max_words Maximum allowed words for summary.
 	 * @return string
 	 */
-	protected function get_first_paragraph( $content ) {
+	protected function generate_summary( $content, $max_words ) {
 		$content_p = \wpautop( $content );
+		$paragraph = \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : $content_p;
 
-		return \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : \wc_trim_string( $content, 150 );
+		if ( $this->get_word_count( $paragraph ) > $max_words ) {
+			return \wp_trim_words( $content, $max_words );
+		}
+
+		return $paragraph;
 	}
 }

--- a/tests/php/RestApi/Utilities/ProductSummary.php
+++ b/tests/php/RestApi/Utilities/ProductSummary.php
@@ -31,6 +31,22 @@ class ProductSummaryTests extends TestCase {
 		$this->assertEquals( "<p>Lorem ipsum dolor&hellip;</p>\n", $class->get_summary( 3 ) );
 		// Should return 1 word.
 		$this->assertEquals( "<p>Lorem&hellip;</p>\n", $class->get_summary( 1 ) );
+
+		// Test for languages where characters are words.
+		add_filter(
+			'gettext_with_context',
+			function( $translated, $text, $context ) {
+				if ( $text === 'words' && $context === 'Word count type. Do not translate!' ) {
+					return 'characters';
+				}
+				return $translated;
+			},
+			10,
+			3
+		);
+		$product->set_description( '<p>我不知道这是否行得通。</p><p>我是用中文写的说明，因此我们可以测试如何修剪产品摘要中的单词。</p>' );
+		$this->assertEquals( "<p>我不知道这是否行得通。</p>\n", $class->get_summary() );
+		$this->assertEquals( "<p>我不知&hellip;</p>\n", $class->get_summary( 3 ) );
 	}
 }
 

--- a/tests/php/RestApi/Utilities/ProductSummary.php
+++ b/tests/php/RestApi/Utilities/ProductSummary.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Utility Tests.
+ *
+ * @package WooCommerce\Blocks\Tests
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\RestApi\Utilities;
+
+use PHPUnit\Framework\TestCase;
+use \WC_Helper_Product as ProductHelper;
+use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductSummary;
+
+/**
+ * ProductSummary Utility Tests.
+ */
+class ProductSummaryTests extends TestCase {
+	/**
+	 * Test that stock is reserved for draft orders.
+	 */
+	public function test_get_summary() {
+		$product = new \WC_Product();
+		$product->set_description( '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p><p>Ut enim ad minim veniam, quis <strong>nostrud</strong> exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p><p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p><p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>' );
+
+		$class = new ProductSummary( $product );
+		// 25 word limit should return 1st para.
+		$this->assertEquals( "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>\n", $class->get_summary() );
+		// Large limit, should return full description.
+		$this->assertEquals( "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>\n<p>Ut enim ad minim veniam, quis <strong>nostrud</strong> exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>\n<p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>\n<p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>\n", $class->get_summary( 1000 ) );
+		// Should return 3 words.
+		$this->assertEquals( "<p>Lorem ipsum dolor&hellip;</p>\n", $class->get_summary( 3 ) );
+		// Should return 1 word.
+		$this->assertEquals( "<p>Lorem&hellip;</p>\n", $class->get_summary( 1 ) );
+	}
+}
+
+
+

--- a/tests/php/RestApi/Utilities/ProductSummary.php
+++ b/tests/php/RestApi/Utilities/ProductSummary.php
@@ -16,6 +16,14 @@ use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductSummary;
  */
 class ProductSummaryTests extends TestCase {
 	/**
+	 * Tear down method.
+	 */
+	public function tearDown() {
+		remove_filter( 'gettext_with_context', array( $this, 'gettext_with_context_callback' ), 10, 3 );
+		parent::tearDown();
+	}
+
+	/**
 	 * Test that stock is reserved for draft orders.
 	 */
 	public function test_get_summary() {
@@ -33,20 +41,26 @@ class ProductSummaryTests extends TestCase {
 		$this->assertEquals( "<p>Lorem&hellip;</p>\n", $class->get_summary( 1 ) );
 
 		// Test for languages where characters are words.
-		add_filter(
-			'gettext_with_context',
-			function( $translated, $text, $context ) {
-				if ( $text === 'words' && $context === 'Word count type. Do not translate!' ) {
-					return 'characters';
-				}
-				return $translated;
-			},
-			10,
-			3
-		);
+		add_filter( 'gettext_with_context', array( $this, 'gettext_with_context_callback' ), 10, 3 );
+
 		$product->set_description( '<p>我不知道这是否行得通。</p><p>我是用中文写的说明，因此我们可以测试如何修剪产品摘要中的单词。</p>' );
 		$this->assertEquals( "<p>我不知道这是否行得通。</p>\n", $class->get_summary() );
 		$this->assertEquals( "<p>我不知&hellip;</p>\n", $class->get_summary( 3 ) );
+	}
+
+	/**
+	 * Adjusts word count type to character based.
+	 *
+	 * @param string $translated Translated string.
+	 * @param string $text Text to translate.
+	 * @param string $context Translation context.
+	 * @return string
+	 */
+	public function gettext_with_context_callback( $translated, $text, $context ) {
+		if ( $text === 'words' && $context === 'Word count type. Do not translate!' ) {
+			return 'characters';
+		}
+		return $translated;
 	}
 }
 


### PR DESCRIPTION
This PR tweaks some atomic block labels and makes summary consistent across the cart item and product APIs.

Changes:
- Changes some atomic block labels and descriptions for clarity. Summary block is left as is but has a slightly revised label so it states it shows "a" description rather than "the" description.
- Returns API fields `summary`, `description`, `short_description` in the product and cart APIs - before the naming was mixed.
- Summary is the short description, or a truncated full description.
- Rather than manually applying filters, make use of the core function `wc_format_content` which handles formatting and shortcodes.

Note: I am aware of some duplication (`get_product_summary` method), however there didn't appear to be an obvious place for an abstraction so to prevent future tech debt I've kept them with their respective endpoints.

Closes #1442

### Screenshots

Atomic blocks with revised names:

![Screenshot 2020-01-23 at 13 05 57](https://user-images.githubusercontent.com/90977/72995537-00ea7700-3df1-11ea-848a-5a8f0b31e3a1.png)

Summaries in all products block:

![Screenshot 2020-01-23 at 14 55 27](https://user-images.githubusercontent.com/90977/72995583-12cc1a00-3df1-11ea-8b55-f42f733d44f0.png)

### How to test the changes in this Pull Request:

1. Edit all products block; insert an atomic block and check labels
2. Confirm summary block shows content

The cart item API doesn't appear to be in used yet so nothing to test that side aside from the API response on `/store/cart/items`