### PR TITLE
Only populate default attributes on initial mount of block.

### DIFF
--- a/assets/js/filters/block-list-block.js
+++ b/assets/js/filters/block-list-block.js
@@ -14,23 +14,7 @@ const { addFilter } = wp.hooks;
 const withDefaultAttributes = createHigherOrderComponent(
 	( BlockListBlock ) => {
 		class WrappedComponent extends Component {
-			constructor() {
-				super( ...arguments );
-
-				this.getAttributesWithDefaults = this.getAttributesWithDefaults.bind(
-					this
-				);
-			}
-
-			componentDidMount() {
-				const { block, setAttributes } = this.props;
-
-				if ( block.name.startsWith( 'woocommerce/' ) ) {
-					setAttributes( this.getAttributesWithDefaults() );
-				}
-			}
-
-			getAttributesWithDefaults() {
+			getAttributesWithDefaults = () => {
 				const blockType = getBlockType( this.props.block.name );
 				const attributes = Object.assign(
 					{},
@@ -42,6 +26,45 @@ const withDefaultAttributes = createHigherOrderComponent(
 					typeof blockType.attributes !== 'undefined' &&
 					typeof blockType.defaults !== 'undefined'
 				) {
+					Object.keys( blockType.attributes ).map( ( key ) => {
+						if (
+							typeof attributes[ key ] === 'undefined' &&
+							typeof blockType.defaults[ key ] !== 'undefined'
+						) {
+							attributes[ key ] = blockType.defaults[ key ];
+						}
+						return key;
+					} );
+				}
+
+				return attributes;
+			};
+
+			state = { mounted: false };
+
+			componentDidMount() {
+				const { block, setAttributes } = this.props;
+
+				if ( block.name.startsWith( 'woocommerce/' ) ) {
+					setAttributes( this.getAttributesWithDefaults() );
+				}
+				this.setState( { mounted: true } );
+			}
+
+			getAttributesWithDefaults() {
+				const blockType = getBlockType( this.props.block.name );
+				let attributes = this.props.attributes;
+
+				if (
+					! this.state.mounted &&
+					this.props.block.name.startsWith( 'woocommerce/' ) &&
+					typeof blockType.attributes !== 'undefined' &&
+					typeof blockType.defaults !== 'undefined'
+				) {
+					attributes = Object.assign(
+						{},
+						this.props.attributes || {}
+					);
 					Object.keys( blockType.attributes ).map( ( key ) => {
 						if (
 							typeof attributes[ key ] === 'undefined' &&

--- a/assets/js/filters/block-list-block.js
+++ b/assets/js/filters/block-list-block.js
@@ -14,7 +14,7 @@ const { addFilter } = wp.hooks;
 const withDefaultAttributes = createHigherOrderComponent(
 	( BlockListBlock ) => {
 		class WrappedComponent extends Component {
-			state = { mounted: false };
+			mounted = false;
 
 			componentDidMount() {
 				const { block, setAttributes } = this.props;
@@ -27,9 +27,9 @@ const withDefaultAttributes = createHigherOrderComponent(
 			componentDidUpdate() {
 				if (
 					this.props.block.name.startsWith( 'woocommerce/' ) &&
-					! this.state.mounted
+					! this.mounted
 				) {
-					this.setState( { mounted: true } );
+					this.mounted = true;
 				}
 			}
 
@@ -38,7 +38,7 @@ const withDefaultAttributes = createHigherOrderComponent(
 				let attributes = this.props.attributes;
 
 				if (
-					! this.state.mounted &&
+					! this.mounted &&
 					this.props.block.name.startsWith( 'woocommerce/' ) &&
 					typeof blockType.attributes !== 'undefined' &&
 					typeof blockType.defaults !== 'undefined'

--- a/assets/js/filters/block-list-block.js
+++ b/assets/js/filters/block-list-block.js
@@ -25,7 +25,10 @@ const withDefaultAttributes = createHigherOrderComponent(
 			}
 
 			componentDidUpdate() {
-				if ( ! this.state.mounted ) {
+				if (
+					this.props.block.name.startsWith( 'woocommerce/' ) &&
+					! this.state.mounted
+				) {
 					this.setState( { mounted: true } );
 				}
 			}

--- a/assets/js/filters/block-list-block.js
+++ b/assets/js/filters/block-list-block.js
@@ -14,32 +14,6 @@ const { addFilter } = wp.hooks;
 const withDefaultAttributes = createHigherOrderComponent(
 	( BlockListBlock ) => {
 		class WrappedComponent extends Component {
-			getAttributesWithDefaults = () => {
-				const blockType = getBlockType( this.props.block.name );
-				const attributes = Object.assign(
-					{},
-					this.props.attributes || {}
-				);
-
-				if (
-					this.props.block.name.startsWith( 'woocommerce/' ) &&
-					typeof blockType.attributes !== 'undefined' &&
-					typeof blockType.defaults !== 'undefined'
-				) {
-					Object.keys( blockType.attributes ).map( ( key ) => {
-						if (
-							typeof attributes[ key ] === 'undefined' &&
-							typeof blockType.defaults[ key ] !== 'undefined'
-						) {
-							attributes[ key ] = blockType.defaults[ key ];
-						}
-						return key;
-					} );
-				}
-
-				return attributes;
-			};
-
 			state = { mounted: false };
 
 			componentDidMount() {
@@ -48,7 +22,12 @@ const withDefaultAttributes = createHigherOrderComponent(
 				if ( block.name.startsWith( 'woocommerce/' ) ) {
 					setAttributes( this.getAttributesWithDefaults() );
 				}
-				this.setState( { mounted: true } );
+			}
+
+			componentDidUpdate() {
+				if ( ! this.state.mounted ) {
+					this.setState( { mounted: true } );
+				}
 			}
 
 			getAttributesWithDefaults() {
@@ -75,7 +54,6 @@ const withDefaultAttributes = createHigherOrderComponent(
 						return key;
 					} );
 				}
-
 				return attributes;
 			}
 


### PR DESCRIPTION
This is an alternative to the fix done in #1638. In this pull, 
- we avoid looping through all the attributes to check for defaults every time the component is re-rendered
- we avoid creating a new attribute object every render for woo blocks (which avoids an extra render every time attributes change).
- switch to use class properties.

## To Test

- Verify defaults are applied as expected for pre-existing blocks and new blocks.
- Verify that you can change the rows on existing blocks and it updates as expected.
- Verify attributes (including defaults) are saved with the serialized block content.
