### PR TITLE
All Products: fix 'Add to Cart' in IE11

### DIFF
--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -81,7 +81,7 @@ const useAddToCart = ( productId ) => {
 	};
 };
 
-const Event = window.Event || {};
+const Event = window.Event || null;
 
 const ProductButton = ( { product, className } ) => {
 	const {

--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -31,9 +31,9 @@ import { decodeEntities } from '@wordpress/html-entities';
  * @return {Object} Returns an object with the following properties:
  *    @type {number}   cartQuantity  The quantity of the product currently in
  *                                   the cart.
- *    @type {boolean}     addingToCart  Whether the product is currently being
+ *    @type {boolean}  addingToCart  Whether the product is currently being
  *                                   added to the cart (true).
- *    @type {boolean}     cartIsLoading Whether the cart is being loaded.
+ *    @type {boolean}  cartIsLoading Whether the cart is being loaded.
  *    @type {Function} addToCart     An action dispatcher for adding a single
  *                                   quantity of the product to the cart.
  *                                   Receives no arguments, it operates on the
@@ -125,8 +125,8 @@ const ProductButton = ( { product, className } ) => {
 			firstMount.current = false;
 			return;
 		}
-		// Test if we have our Event defined
-		if ( Object.entries( Event ).length !== 0 ) {
+		// In IE, Event is an object and can't be instantiated with `new Event()`.
+		if ( typeof Event === 'function' ) {
 			const event = new Event( 'wc_fragment_refresh', {
 				bubbles: true,
 				cancelable: true,


### PR DESCRIPTION
Fixes #1641.

### Screenshots

GIF of the error (without this PR):
![Peek 2020-01-23 17-10](https://user-images.githubusercontent.com/3616980/73001801-4f087600-3e03-11ea-938d-d093753a9a72.gif)

### How to test the changes in this Pull Request:
1. Create a post with the _All Products_ block and open it with IE 11.
2. Add a product to your cart.
3. Verify everything is working as expected (the block doesn't crash, it doesn't show an error in the console, etc.).

### Changelog

> Fix error with the All Products block and Internet Explorer 11 when adding products to the cart.