### PR TITLE
Update renovate to assign `type: dependencies` label for pulls

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
 	"composer": {
 		"enabled": false
 	},
-  "labels": ["type: dependencies"],
+  "labels": ["type: dependencies", "skip-changelog"],
 	"packageRules": [
 		{
 			"packageNames": [ "automattic/jetpack-autoloader" ],

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
 	"composer": {
 		"enabled": false
 	},
+	{
+  "labels": ["type: dependencies"],
 	"packageRules": [
 		{
 			"packageNames": [ "automattic/jetpack-autoloader" ],

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
 	"composer": {
 		"enabled": false
 	},
-	{
   "labels": ["type: dependencies"],
 	"packageRules": [
 		{


### PR DESCRIPTION
As a part of the #1602, the `dependencies` label is being changed to `type: dependencies`.  This pull is to configure renovate to use the new label for any pulls it creates.