### PR TITLE
Product grid blocks: display rating stars in the editor

### DIFF
--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -173,7 +173,8 @@
 .wc-block-grid__product-rating {
 	display: block;
 
-	.wc-block-grid__product-rating__stars {
+	.wc-block-grid__product-rating__stars,
+	.star-rating {
 		overflow: hidden;
 		position: relative;
 		width: 5.3em;


### PR DESCRIPTION
Fixes #1646.

### Screenshots

#### Editor
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/73170695-5f6c6980-40ff-11ea-9180-c8aa2f1e6f74.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/73170740-7f039200-40ff-11ea-9cc9-68fab7d7cca9.png)

#### Frontend
Notice stars style changes in the frontend (purple to black in Storefront):

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/73170850-b83c0200-40ff-11ea-91bf-ce0e9813812f.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/73170893-d144b300-40ff-11ea-86b8-7c5d4a19fc1c.png)

In the past they were using the theme style while after this change, they rely on the _All Products_ block style. I think it's an acceptable change and that will make it more reliable to future changes, so all our blocks use the same star style. But wanted to point it out so it's not unexpected. :slightly_smiling_face: 

### How to test the changes in this Pull Request:

1. Add a product grid block (for example, the _Top Rated Products_ block).
2. In the editor, verify the rating appears as star images instead of text (see screenshots above).

### Changelog

> Fix ratings appearing as text in the editor instead.