### PR TITLE
Fix RTL price slider display issues

### DIFF
--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -152,9 +152,14 @@
 
 			&::-webkit-slider-thumb {
 				margin-left: -2px;
+				background-position-x: left;
 			}
 			&::-moz-range-thumb {
+				background-position-x: left;
 				transform: translate(-2px, 4px);
+			}
+			&::-ms-thumb {
+				background-position-x: left;
 			}
 		}
 
@@ -162,15 +167,15 @@
 			z-index: 20;
 
 			&::-webkit-slider-thumb {
-				background-position-x: 26px;
+				background-position-x: right;
 				margin-left: 2px;
 			}
 			&::-moz-range-thumb {
-				background-position-x: 26px;
+				background-position-x: right;
 				transform: translate(2px, 4px);
 			}
 			&::-ms-thumb {
-				background-position-x: 26px;
+				background-position-x: right;
 			}
 		}
 	}

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -66,6 +66,7 @@
 			top: 0;
 			--track-background: linear-gradient(to right, transparent var(--low), var(--range-color) 0, var(--range-color) var(--high), transparent 0) no-repeat 0 100% / 100% 100%;
 			--range-color: #a8739d;
+			/*rtl:ignore*/
 			background: var(--track-background);
 		}
 	}
@@ -196,6 +197,14 @@
 		.wc-block-price-filter__button {
 			animation: none;
 		}
+	}
+}
+
+.rtl {
+	.wc-block-price-filter .wc-block-price-filter__range-input-wrapper .wc-block-price-filter__range-input-progress {
+		--track-background: linear-gradient(to left, transparent var(--low), var(--range-color) 0, var(--range-color) var(--high), transparent 0) no-repeat 0 100% / 100% 100%;
+		--range-color: #a8739d;
+		background: var(--track-background);
 	}
 }
 


### PR DESCRIPTION
Adjusts some styles from px values to left/right so that webpack-rtl generates the correct RTL styles for the price slider.

Also adds some RTL specific styles for the range slider track element.

Fixes #1624

### Screenshots

![Screenshot 2020-01-27 at 13 03 47](https://user-images.githubusercontent.com/90977/73176963-a78e8a80-4105-11ea-8ff1-e1f679729c13.png)

### How to test the changes in this Pull Request:

1. Install https://wordpress.org/plugins/rtl-tester/
2. Switch to RTL when viewing a page with price slider
3. Confirm sliders work as expected

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix display of price slider when using RTL languages.
