### PR TITLE
Update changelog script.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ This document outlines the process of releasing new versions of the blocks plugi
 - Install & set up [GitHub hub](https://hub.github.com) tools.
 - Configure a GitHub token for release scripts to use.
   - https://github.com/settings/tokens
-  - Select the following permissions: 
+  - Select the following permissions:
     - `admin:org`
     - `public_repo`
     - `read:user`
@@ -42,7 +42,7 @@ _Outcome_: __Team is aware of release and in agreement about what fixes & featur
 - Ensure your local checkout is updated to the tip of the release branch.
 - For _patch_ releases, cherry pick relevant PRs into the release branch:
   - If PR is already labelled `status: cherry-picked 🍒` then continue to next PR.
-  - Ideally, use GitHub Hub to cherry pick the PR - `hub am -3 {http://URL-TO-PR}`. 
+  - Ideally, use GitHub Hub to cherry pick the PR - `hub am -3 {http://URL-TO-PR}`.
   - If there are serious conflicts or extensive differences between `master` and release branch, you may need to take more care:
     - Manually cherry pick individual commits using git - `git cherry-pick {COMMIT-HASH}`.
     - Or in some cases, manually craft a new PR with appropriate changes, targeting release branch.
@@ -54,9 +54,11 @@ _Outcome_: __Release branch has all relevant changes merged & pushed.__
 ### Prepare release
 #### Ensure release branch readme is up to date
 - Run changelog script `npm run changelog` to get changelog txt for readme. Changelog content will be output to screen by script.
+  - The above script will automatically generate changelog entries from a milestone (you will be asked about the milestone name in the script).
+  - If you want to pull changelog entries from a Zenhub release instead, use `npm run changelog:zenhub` and follow instructions.
 - Add changelog section for release, e.g. [`= 2.5.11 - 2020-01-20 =`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/74a41881bfa456a2167a52aaeb4871352255e328).
 - Copy-paste the changelog content into `readme.txt`.
-- Make any other changes to readme as needed - e.g. support versions changing, new blocks. 
+- Make any other changes to readme as needed - e.g. support versions changing, new blocks.
 - Push readme changes to release branch on origin repo.
   - Note: you can push your readme changes directly to branch – no need for a PR & review process.
 
@@ -80,7 +82,7 @@ _Outcome_: __Confident that source code is ready for release: intended fixes are
 
 ### Release!
 #### Tag release on GitHub
-- Prepare tagged release on github `npm run deploy`. 
+- Prepare tagged release on github `npm run deploy`.
   - Note: the script automatically updates version numbers (commits on your behalf).
 - Edit release, add changelog info to Github release notes.
 - Check release repo tag is correct - checkout, smoke test/confidence check.
@@ -112,7 +114,7 @@ _Outcome_: __Customers can install/update via WPORG; WPORG plugin page is up to 
 - For _major_ & _minor_ releases - tbc
 
 ## Appendix: Versions
-We have _major_, _minor_ and _patch_ releases. 
+We have _major_, _minor_ and _patch_ releases.
 
 For example:
 
@@ -126,7 +128,7 @@ For example:
 
 There are some differences to our release process for each kind of release - these are detailed in the steps above.
 
-## Appendix: updating a specific file on WPORG 
+## Appendix: updating a specific file on WPORG
 
 Sometimes, we need to update a single file in WordPress.org without wanting to do a full release, for example, updating the `readme.txt` versions or descriptions. In order to do that, refer to the _[Editing Existing Files](https://developer.wordpress.org/plugins/wordpress-org/how-to-use-subversion/#editing-existing-files)_ section of the Subversion guide in developer.wordpress.org or follow these steps:
 

--- a/bin/changelog/README.md
+++ b/bin/changelog/README.md
@@ -28,15 +28,25 @@ The following configuration options can be set for the changelog script. **Note:
 
 `package.json` configuration should be added on a top level `changelog` property.
 
-| package.json | environment variable | command line arg | description |
-| ---- | ---- | ---- | ---- |
-| labelPrefix | LABEL_PREFIX | labelPrefix | Any labels prefixed with this string will be used to derive the "type" of change (defaults to `type:`). |
-| skipLabel | SKIP_LABEL | skipLabel | Any pull having this label will be skipped for the changelog (defaults to `no-changelog`). |
-| defaultPrefix | DEFAULT_PREFIX | defaultPrefix | When there is no label with the `labelPrefix` on a pull, this is the default type that will be used for the changelog entry (defaults to `dev`). |
-| changelogSrcType | CHANGELOG_SRC_TYPE | changelogSrcType | Either "MILESTONE" (default) or "ZENHUB_RELEASE". This determines what will serve as the source for the changelog entries.
-| devNoteLabel | DEV_NOTE_LABEL | devNoteLabel | If a pull has this label then `[DN]` will be appended to the end of the changelog. It's a good way to indicate what entries have (or will have) dev notes.
-| ghApiToken | GH_API_TOKEN | ghApiToken | You can pass your github api token to the script. NOTE: Strongly recommend you use environment variable for this. |
-| zhApiKey | ZH_API_KEY | zhApiKey | You can pass your zenhub api key to the script using this config. NOTE: Strongly recommend you use environment variable for this. |
+The 'variable' in the following table can be used in `package.json` or as a cli arg.
+
+| variable | description |
+| ---- | ---- |
+| labelPrefix | Any labels prefixed with this string will be used to derive the "type" of change (defaults to `type:`). |
+| skipLabel |  Any pull having this label will be skipped for the changelog (defaults to `no-changelog`). |
+| defaultPrefix |  When there is no label with the `labelPrefix` on a pull, this is the default type that will be used for the changelog entry (defaults to `dev`). |
+| changelogSrcType |  Either "MILESTONE" (default) or "ZENHUB_RELEASE". This determines what will serve as the source for the changelog entries.
+| devNoteLabel |  If a pull has this label then `[DN]` will be appended to the end of the changelog. It's a good way to indicate what entries have (or will have) dev notes.
+| repo | This is the namespace for the github repository used as the source for pulls used in the changelog entries. Example: `'woocommerce/woocommerce-gutenberg-products-block'`
+| ghApiToken |  You can pass your github api token to the script. NOTE: Strongly recommend you use environment variable for this. |
+| zhApiKey | You can pass your zenhub api key to the script using this config. NOTE: Strongly recommend you use environment variable for this. |
+
+The two environment variables you can use are:
+
+| Environment Variable | Description |
+| -------------------- | ----------  |
+| GH_API_TOKEN | Github API token for authorizing on the github API. |
+| ZH_API_KEY   | Zenhub api key used for authorizing against the zenhub API. |
 
 ### Examples:
 
@@ -45,19 +55,20 @@ The following configuration options can be set for the changelog script. **Note:
 ```json
 {
   "changelog": {
-		"labelPrefix": "type:",
-		"skipLabel": "skip-changelog",
-		"defaultPrefix": "dev"
-	},
+    "labelPrefix": "type:",
+    "skipLabel": "skip-changelog",
+    "defaultPrefix": "dev",
+    "repo": "woocommerce/woocommerce-gutenberg-products-block"
+  },
 }
 ```
 
 **Environment Variable**
 ```bash
-LABEL_PREFIX="type:" SKIP_LABEL="skip-changelog" DEFAULT_PREFIX="dev" node ./bin/changelog
+GH_API_TOKEN="1343ASDFQWER13241REASD" node ./bin/changelog
 ```
 
 **Command Line**
 ```bash
-node ./bin/changelog --labelPrefix="type:" --skipLabel="skip-changelog" --defaultPrefix="dev"
+node ./bin/changelog --labelPrefix="type:" --skipLabel="skip-changelog" --defaultPrefix="dev" --repo="woocommerce/woocommerce-gutenberg-products-block" --ghApiToken="1343ASDFQWER13241REASD"
 ```

--- a/bin/changelog/README.md
+++ b/bin/changelog/README.md
@@ -4,7 +4,15 @@ This folder contains the logic for a changelog script that can be used for gener
 
 ## Usage:
 
-You can implement the script in you `package.json` in the simplest form by adding the following to the `"scripts"` property (assuming it is installed in `./bin`):
+By default, changelog entries will use the title of pull requests. However, you can also customize the changelog entry by adding to the description of the pull custom text in the following format.
+
+```md
+### Changelog
+
+> Fix bug in Safari and other Webkit browsers.
+```
+
+You can implement the script in your `package.json` in the simplest form by adding the following to the `"scripts"` property (assuming it is installed in `./bin`):
 
 ```json
 {

--- a/bin/changelog/README.md
+++ b/bin/changelog/README.md
@@ -46,7 +46,7 @@ The two environment variables you can use are:
 | Environment Variable | Description |
 | -------------------- | ----------  |
 | GH_API_TOKEN | Github API token for authorizing on the github API. |
-| ZH_API_KEY   | Zenhub api key used for authorizing against the zenhub API. |
+| ZH_API_TOKEN   | Zenhub api token used for authorizing against the zenhub API. |
 
 ### Examples:
 

--- a/bin/changelog/README.md
+++ b/bin/changelog/README.md
@@ -1,0 +1,55 @@
+# Changelog Script
+
+This folder contains the logic for a changelog script that can be used for generating changelog entries from either pull requests added to a Github milestone, or pull requests that are part of a Zenhub release.
+
+## Usage:
+
+You can implement the script in you `package.json` in the simplest form by adding the following to the `"scripts"` property (assuming it is installed in `./bin`):
+
+```json
+{
+  "scripts": {
+    "changelog": "node ./bin/changelog",
+  }
+}
+```
+
+## Configuration
+
+The following configuration options can be set for the changelog script. **Note:** you can use all of these options but environment variables overwrite `package.json` config and command line arguments overwrite environment variables.
+
+`package.json` configuration should be added on a top level `changelog` property.
+
+| package.json | environment variable | command line arg | description |
+| ---- | ---- | ---- | ---- |
+| labelPrefix | LABEL_PREFIX | labelPrefix | Any labels prefixed with this string will be used to derive the "type" of change (defaults to `type:`). |
+| skipLabel | SKIP_LABEL | skipLabel | Any pull having this label will be skipped for the changelog (defaults to `no-changelog`). |
+| defaultPrefix | DEFAULT_PREFIX | defaultPrefix | When there is no label with the `labelPrefix` on a pull, this is the default type that will be used for the changelog entry (defaults to `dev`). |
+| changelogSrcType | CHANGELOG_SRC_TYPE | changelogSrcType | Either "MILESTONE" (default) or "ZENHUB_RELEASE". This determines what will serve as the source for the changelog entries.
+| devNoteLabel | DEV_NOTE_LABEL | devNoteLabel | If a pull has this label then `[DN]` will be appended to the end of the changelog. It's a good way to indicate what entries have (or will have) dev notes.
+| ghApiToken | GH_API_TOKEN | ghApiToken | You can pass your github api token to the script. NOTE: Strongly recommend you use environment variable for this. |
+| zhApiKey | ZH_API_KEY | zhApiKey | You can pass your zenhub api key to the script using this config. NOTE: Strongly recommend you use environment variable for this. |
+
+### Examples:
+
+**package.json**:
+
+```json
+{
+  "changelog": {
+		"labelPrefix": "type:",
+		"skipLabel": "skip-changelog",
+		"defaultPrefix": "dev"
+	},
+}
+```
+
+**Environment Variable**
+```bash
+LABEL_PREFIX="type:" SKIP_LABEL="skip-changelog" DEFAULT_PREFIX="dev" node ./bin/changelog
+```
+
+**Command Line**
+```bash
+node ./bin/changelog --labelPrefix="type:" --skipLabel="skip-changelog" --defaultPrefix="dev"
+```

--- a/bin/changelog/common/get-entry.js
+++ b/bin/changelog/common/get-entry.js
@@ -7,7 +7,7 @@ const { pkg, REPO } = require( '../config' );
 /* eslint no-console: 0 */
 
 const headers = {
-	authorization: `token ${ process.env.GH_API_TOKEN }`,
+	authorization: `token ${ pkg.changelog.ghApiToken }`,
 	'user-agent': 'changelog-tool',
 };
 

--- a/bin/changelog/common/get-entry.js
+++ b/bin/changelog/common/get-entry.js
@@ -23,6 +23,13 @@ const getPullRequestType = ( labels ) => {
 	return typeLabel.name.replace( `${ pkg.changelog.labelPrefix } `, '' );
 };
 
+const devNoteSuffix = ( labels ) => {
+	const noteLabel = labels.find( ( label ) =>
+		label.name.includes( pkg.changelog.devNoteLabel )
+	);
+	return noteLabel ? ' [DN]' : '';
+};
+
 const isCollaborator = async ( username ) => {
 	return requestPromise( {
 		url: `https://api.github.com/orgs/${
@@ -54,6 +61,7 @@ const getEntry = async ( pullRequest ) => {
 	const collaborator = await isCollaborator( pullRequest.author.login );
 	const type = getPullRequestType( pullRequest.labels.nodes );
 	const authorTag = collaborator ? '' : `👏 @${ pullRequest.author.login }`;
+	const devNote = devNoteSuffix( pullRequest.labels.nodes );
 	let title;
 	if ( /### Changelog\r\n\r\n> /.test( pullRequest.body ) ) {
 		const bodyParts = pullRequest.body.split( '### Changelog\r\n\r\n> ' );
@@ -71,7 +79,7 @@ const getEntry = async ( pullRequest ) => {
 	} else {
 		title = `${ type }: ${ pullRequest.title }`;
 	}
-	return `- ${ title } [#${ pullRequest.number }](${ pullRequest.url }) ${ authorTag }`;
+	return `- ${ title } [#${ pullRequest.number }](${ pullRequest.url })${ devNote } ${ authorTag }`;
 };
 
 module.exports = {

--- a/bin/changelog/config.js
+++ b/bin/changelog/config.js
@@ -25,7 +25,7 @@ pkg.changelog = pkg.changelog || DEFAULTS;
 
 config.merge( { ...DEFAULTS, ...pkg.changelog } );
 config.env( [ 'GH_API_TOKEN', 'ZH_API_KEY' ] );
-config.argv( Object.keys( pkg.changelog ) );
+config.argv( Object.keys( DEFAULTS ) );
 
 const REPO = config.get( 'repo' );
 

--- a/bin/changelog/config.js
+++ b/bin/changelog/config.js
@@ -29,15 +29,7 @@ const DEFAULTS = {
 pkg.changelog = pkg.changelog || DEFAULTS;
 
 config.merge( { ...DEFAULTS, ...pkg.changelog } );
-config.env( [
-	'LABEL_PREFIX',
-	'SKIP_LABEL',
-	'DEFAULT_PREFIX',
-	'DEV_NOTE_LABEL',
-	'CHANGELOG_SRC_TYPE',
-	'GH_API_TOKEN',
-	'ZH_API_KEY',
-] );
+config.env( [ 'GH_API_TOKEN', 'ZH_API_KEY' ] );
 config.argv( Object.keys( pkg.changelog ) );
 
 //merge in command-line arguments

--- a/bin/changelog/config.js
+++ b/bin/changelog/config.js
@@ -1,6 +1,14 @@
 'use strict';
 
 const pkg = require( '../../package.json' );
+const Config = require( 'merge-config' );
+
+const config = new Config();
+
+const changelogSrcTypes = {
+	MILESTONE: 'MILESTONE',
+	ZENHUB: 'ZENHUB_RELEASE',
+};
 
 const REPO = pkg.repository.url
 	// remove https://github.com:
@@ -8,16 +16,37 @@ const REPO = pkg.repository.url
 	// remove the .git ending.
 	.slice( 0, -4 );
 
-if ( pkg.changelog === undefined ) {
-	pkg.changelog = {
-		labelPrefix: 'type:',
-		skipLabel: 'no-changelog',
-		defaultPrefix: 'dev',
-		zenhub: false,
-	};
-}
+const DEFAULTS = {
+	labelPrefix: 'type:',
+	skipLabel: 'no-changelog',
+	defaultPrefix: 'dev',
+	changelogSrcType: changelogSrcTypes.MILESTONE,
+	devNoteLabel: 'dev-note',
+	ghApiToken: '',
+	zhApiKey: '',
+};
+
+pkg.changelog = pkg.changelog || DEFAULTS;
+
+config.merge( { ...DEFAULTS, ...pkg.changelog } );
+config.env( [
+	'LABEL_PREFIX',
+	'SKIP_LABEL',
+	'DEFAULT_PREFIX',
+	'DEV_NOTE_LABEL',
+	'CHANGELOG_SRC_TYPE',
+	'GH_API_TOKEN',
+	'ZH_API_KEY',
+] );
+config.argv( Object.keys( pkg.changelog ) );
+
+//merge in command-line arguments
 
 module.exports = {
-	pkg,
+	pkg: {
+		...pkg,
+		changelog: config.get(),
+	},
 	REPO,
+	changelogSrcTypes,
 };

--- a/bin/changelog/config.js
+++ b/bin/changelog/config.js
@@ -10,18 +10,13 @@ const changelogSrcTypes = {
 	ZENHUB: 'ZENHUB_RELEASE',
 };
 
-const REPO = pkg.repository.url
-	// remove https://github.com:
-	.split( ':' )[ 2 ]
-	// remove the .git ending.
-	.slice( 0, -4 );
-
 const DEFAULTS = {
 	labelPrefix: 'type:',
 	skipLabel: 'no-changelog',
 	defaultPrefix: 'dev',
 	changelogSrcType: changelogSrcTypes.MILESTONE,
 	devNoteLabel: 'dev-note',
+	repo: '',
 	ghApiToken: '',
 	zhApiKey: '',
 };
@@ -32,7 +27,14 @@ config.merge( { ...DEFAULTS, ...pkg.changelog } );
 config.env( [ 'GH_API_TOKEN', 'ZH_API_KEY' ] );
 config.argv( Object.keys( pkg.changelog ) );
 
-//merge in command-line arguments
+const REPO = config.get( 'repo' );
+
+if ( ! REPO ) {
+	throw new Error(
+		"The 'repo' configuration value is not set. This script requires the\n" +
+			'repository namespace used as the source for the changelog entries.'
+	);
+}
 
 module.exports = {
 	pkg: {

--- a/bin/changelog/config.js
+++ b/bin/changelog/config.js
@@ -18,13 +18,13 @@ const DEFAULTS = {
 	devNoteLabel: 'dev-note',
 	repo: '',
 	ghApiToken: '',
-	zhApiKey: '',
+	zhApiToken: '',
 };
 
 pkg.changelog = pkg.changelog || DEFAULTS;
 
 config.merge( { ...DEFAULTS, ...pkg.changelog } );
-config.env( [ 'GH_API_TOKEN', 'ZH_API_KEY' ] );
+config.env( [ 'GH_API_TOKEN', 'ZH_API_TOKEN' ] );
 config.argv( Object.keys( DEFAULTS ) );
 
 const REPO = config.get( 'repo' );

--- a/bin/changelog/github/make-change-log.js
+++ b/bin/changelog/github/make-change-log.js
@@ -6,28 +6,34 @@ const { make } = require( '../common' );
 const { fetchAllPullRequests } = require( './requests' );
 
 /* eslint no-console: 0 */
+let ready = false;
 
 const makeChangeLog = async () => {
-	console.log(
-		chalk.yellow(
-			'This program requires an api token. You can create one here: '
-		) + 'https://github.com/settings/tokens'
-	);
-	console.log( '' );
-	console.log(
-		chalk.yellow(
-			'Token scope will require read permissions on public_repo, admin:org, and user.'
-		)
-	);
-	console.log( '' );
-	console.log(
-		chalk.yellow(
-			'Export the token as variable called GH_API_TOKEN from your bash profile.'
-		)
-	);
-	console.log( '' );
+	if ( ! pkg.changelog.ghApiToken ) {
+		console.log(
+			chalk.yellow(
+				'This program requires an api token. You can create one here: '
+			) + 'https://github.com/settings/tokens'
+		);
+		console.log( '' );
+		console.log(
+			chalk.yellow(
+				'Token scope will require read permissions on public_repo, admin:org, and user.'
+			)
+		);
+		console.log( '' );
+		console.log(
+			chalk.yellow(
+				'Export the token as variable called GH_API_TOKEN from your bash profile.'
+			)
+		);
+		console.log( '' );
 
-	const ready = await promptly.confirm( 'Are you ready to continue? ' );
+		ready = await promptly.confirm( 'Are you ready to continue? ' );
+	} else {
+		console.log( chalk.green( 'Detected GH_API_TOKEN is set.' ) );
+		ready = true;
+	}
 
 	if ( ready ) {
 		console.log( '' );

--- a/bin/changelog/index.js
+++ b/bin/changelog/index.js
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 'use strict';
+/* eslint no-console: 0 */
+const chalk = require( 'chalk' );
 
-const { makeChangeLog: githubMake } = require( './github' );
-const { makeChangeLog: zenhubMake } = require( './zenhub' );
-const { pkg, changelogSrcTypes } = require( './config' );
+try {
+	const { makeChangeLog: githubMake } = require( './github' );
+	const { makeChangeLog: zenhubMake } = require( './zenhub' );
+	const { pkg, changelogSrcTypes } = require( './config' );
 
-const makeChangeLog =
-	pkg.changelogSrcType === changelogSrcTypes.ZENHUB ? zenhubMake : githubMake;
+	const makeChangeLog =
+		pkg.changelogSrcType === changelogSrcTypes.ZENHUB
+			? zenhubMake
+			: githubMake;
 
-makeChangeLog();
+	makeChangeLog();
+} catch ( error ) {
+	console.log( chalk.red( error.message ) );
+}

--- a/bin/changelog/index.js
+++ b/bin/changelog/index.js
@@ -3,8 +3,9 @@
 
 const { makeChangeLog: githubMake } = require( './github' );
 const { makeChangeLog: zenhubMake } = require( './zenhub' );
-const { pkg } = require( './config' );
+const { pkg, changelogSrcTypes } = require( './config' );
 
-const makeChangeLog = pkg.changelog.zenhub ? zenhubMake : githubMake;
+const makeChangeLog =
+	pkg.changelogSrcType === changelogSrcTypes.ZENHUB ? zenhubMake : githubMake;
 
 makeChangeLog();

--- a/bin/changelog/index.js
+++ b/bin/changelog/index.js
@@ -9,7 +9,7 @@ try {
 	const { pkg, changelogSrcTypes } = require( './config' );
 
 	const makeChangeLog =
-		pkg.changelogSrcType === changelogSrcTypes.ZENHUB
+		pkg.changelog.changelogSrcType === changelogSrcTypes.ZENHUB
 			? zenhubMake
 			: githubMake;
 

--- a/bin/changelog/zenhub/make-change-log.js
+++ b/bin/changelog/zenhub/make-change-log.js
@@ -10,12 +10,29 @@ let ready = false;
 
 const makeChangeLog = async () => {
 	if ( ! pkg.changelog.zhApiKey || ! pkg.changelog.ghApiToken ) {
+		const zenhubSet = pkg.changelog.zhApiKey
+			? chalk.green( 'set' )
+			: chalk.red( 'not set' );
+		const githubSet = pkg.changelog.ghApiToken
+			? chalk.green( 'set' )
+			: chalk.red( 'not set' );
+		console.log( `${ chalk.yellow( 'Zenhub Key:' ) } ${ zenhubSet }` );
+		console.log( `${ chalk.yellow( 'Github Token:' ) } ${ githubSet }` );
+		console.log( '' );
 		console.log(
 			chalk.yellow(
-				'This program requires an api token from Github and Zenhub. You can create one here: '
-			) +
-				'https://github.com/settings/tokens' +
-				' and https://app.zenhub.com/dashboard/tokens'
+				'This program requires an api token from Github and Zenhub.'
+			)
+		);
+		console.log(
+			chalk.yellow(
+				'You can create and get a Github token here: https://github.com/settings/tokens'
+			)
+		);
+		console.log(
+			chalk.yellow(
+				'You can create and get a Zenhub key here: https://app.zenhub.com/dashboard/tokens'
+			)
 		);
 		console.log( '' );
 		console.log(
@@ -35,7 +52,7 @@ const makeChangeLog = async () => {
 	} else {
 		console.log(
 			chalk.green(
-				'Detected ZH_API_KEY and GH_API_TOKEN values are set.'
+				'Detected that ZH_API_KEY and GH_API_TOKEN values are set.'
 			)
 		);
 		ready = true;

--- a/bin/changelog/zenhub/make-change-log.js
+++ b/bin/changelog/zenhub/make-change-log.js
@@ -16,7 +16,7 @@ const makeChangeLog = async () => {
 		const githubSet = pkg.changelog.ghApiToken
 			? chalk.green( 'set' )
 			: chalk.red( 'not set' );
-		console.log( `${ chalk.yellow( 'Zenhub Key:' ) } ${ zenhubSet }` );
+		console.log( `${ chalk.yellow( 'Zenhub Token:' ) } ${ zenhubSet }` );
 		console.log( `${ chalk.yellow( 'Github Token:' ) } ${ githubSet }` );
 		console.log( '' );
 		console.log(
@@ -31,7 +31,7 @@ const makeChangeLog = async () => {
 		);
 		console.log(
 			chalk.yellow(
-				'You can create and get a Zenhub key here: https://app.zenhub.com/dashboard/tokens'
+				'You can create and get a Zenhub token here: https://app.zenhub.com/dashboard/tokens'
 			)
 		);
 		console.log( '' );
@@ -43,7 +43,7 @@ const makeChangeLog = async () => {
 		console.log( '' );
 		console.log(
 			chalk.yellow(
-				'Export the github token as variable called GH_API_TOKEN and the Zenhub token as a variable called ZH_API_KEY from your bash profile.'
+				'Export the github token as variable called GH_API_TOKEN and the Zenhub token as a variable called ZH_API_TOKEN from your bash profile.'
 			)
 		);
 		console.log( '' );
@@ -52,7 +52,7 @@ const makeChangeLog = async () => {
 	} else {
 		console.log(
 			chalk.green(
-				'Detected that ZH_API_KEY and GH_API_TOKEN values are set.'
+				'Detected that ZH_API_TOKEN and GH_API_TOKEN values are set.'
 			)
 		);
 		ready = true;

--- a/bin/changelog/zenhub/make-change-log.js
+++ b/bin/changelog/zenhub/make-change-log.js
@@ -6,30 +6,40 @@ const { make } = require( '../common' );
 const { fetchAllPullRequests } = require( './requests' );
 
 /* eslint no-console: 0 */
+let ready = false;
 
 const makeChangeLog = async () => {
-	console.log(
-		chalk.yellow(
-			'This program requires an api token from Github and Zenhub. You can create one here: '
-		) +
-			'https://github.com/settings/tokens' +
-			' and https://app.zenhub.com/dashboard/tokens'
-	);
-	console.log( '' );
-	console.log(
-		chalk.yellow(
-			'Token scope for Github will require read permissions on public_repo, admin:org, and user.'
-		)
-	);
-	console.log( '' );
-	console.log(
-		chalk.yellow(
-			'Export the github token as variable called GH_API_TOKEN and the Zenhub token as a variable called ZH_API_KEY from your bash profile.'
-		)
-	);
-	console.log( '' );
+	if ( ! pkg.changelog.zhApiKey || ! pkg.changelog.ghApiToken ) {
+		console.log(
+			chalk.yellow(
+				'This program requires an api token from Github and Zenhub. You can create one here: '
+			) +
+				'https://github.com/settings/tokens' +
+				' and https://app.zenhub.com/dashboard/tokens'
+		);
+		console.log( '' );
+		console.log(
+			chalk.yellow(
+				'Token scope for Github will require read permissions on public_repo, admin:org, and user.'
+			)
+		);
+		console.log( '' );
+		console.log(
+			chalk.yellow(
+				'Export the github token as variable called GH_API_TOKEN and the Zenhub token as a variable called ZH_API_KEY from your bash profile.'
+			)
+		);
+		console.log( '' );
 
-	const ready = await promptly.confirm( 'Are you ready to continue? ' );
+		ready = await promptly.confirm( 'Are you ready to continue? ' );
+	} else {
+		console.log(
+			chalk.green(
+				'Detected ZH_API_KEY and GH_API_TOKEN values are set.'
+			)
+		);
+		ready = true;
+	}
 
 	if ( ready ) {
 		console.log( '' );

--- a/bin/changelog/zenhub/make-change-log.js
+++ b/bin/changelog/zenhub/make-change-log.js
@@ -9,8 +9,8 @@ const { fetchAllPullRequests } = require( './requests' );
 let ready = false;
 
 const makeChangeLog = async () => {
-	if ( ! pkg.changelog.zhApiKey || ! pkg.changelog.ghApiToken ) {
-		const zenhubSet = pkg.changelog.zhApiKey
+	if ( ! pkg.changelog.zhApiToken || ! pkg.changelog.ghApiToken ) {
+		const zenhubSet = pkg.changelog.zhApiToken
 			? chalk.green( 'set' )
 			: chalk.red( 'not set' );
 		const githubSet = pkg.changelog.ghApiToken

--- a/bin/changelog/zenhub/requests.js
+++ b/bin/changelog/zenhub/requests.js
@@ -3,11 +3,11 @@
 /* eslint no-console: 0 */
 
 const ZenHub = require( 'zenhub-api' );
-const { REPO } = require( '../config' );
+const { REPO, pkg } = require( '../config' );
 const { authedGraphql } = require( '../common' );
 const { pull } = require( 'lodash' );
 
-const api = new ZenHub( process.env.ZH_API_KEY );
+const api = new ZenHub( pkg.changelog.zhApiToken );
 
 const getQuery = ( before ) => {
 	const [ owner, repo ] = REPO.split( '/' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6537,6 +6537,16 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
+    "camel-case": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.2.2.tgz",
+      "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
+      "dev": true,
+      "requires": {
+        "sentence-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -6660,6 +6670,30 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "change-case": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-2.3.1.tgz",
+      "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
+      "dev": true,
+      "requires": {
+        "camel-case": "^1.1.1",
+        "constant-case": "^1.1.0",
+        "dot-case": "^1.1.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "param-case": "^1.1.0",
+        "pascal-case": "^1.1.0",
+        "path-case": "^1.1.0",
+        "sentence-case": "^1.1.1",
+        "snake-case": "^1.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^1.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "character-entities": {
@@ -7201,6 +7235,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/consolidated-events/-/consolidated-events-2.0.2.tgz",
       "integrity": "sha512-2/uRVMdRypf5z/TW/ncD/66l75P5hH2vM/GR8Jf8HLc2xnfJtmina6F6du8+v4Z2vTrMo7jC+W1tmEEuuELgkQ=="
+    },
+    "constant-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-1.1.2.tgz",
+      "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
+      "dev": true,
+      "requires": {
+        "snake-case": "^1.1.0",
+        "upper-case": "^1.1.1"
+      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -8267,6 +8311,15 @@
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
+      }
+    },
+    "dot-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-1.1.2.tgz",
+      "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
+      "dev": true,
+      "requires": {
+        "sentence-case": "^1.1.2"
       }
     },
     "dot-prop": {
@@ -10965,6 +11018,12 @@
         "value-equal": "^1.0.1"
       }
     },
+    "hjson": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/hjson/-/hjson-1.8.4.tgz",
+      "integrity": "sha1-C8j/sCGY0hjEm1iZGxH2BIUBHTY=",
+      "dev": true
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -11782,6 +11841,15 @@
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
     },
+    "is-lower-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-1.1.3.tgz",
+      "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.0"
+      }
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -11937,6 +12005,15 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-upper-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-1.1.2.tgz",
+      "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.0"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -13587,6 +13664,12 @@
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -13831,6 +13914,21 @@
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lower-case-first": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case-first/-/lower-case-first-1.0.2.tgz",
+      "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.2"
       }
     },
     "lru-cache": {
@@ -14082,6 +14180,268 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "merge-config": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-config/-/merge-config-2.0.0.tgz",
+      "integrity": "sha1-ek7GSj/tIGcu5JgSFsreq1pS+Cg=",
+      "dev": true,
+      "requires": {
+        "change-case": "^2.2.0",
+        "hjson": "^1.6.1",
+        "js-yaml": "3.5.3",
+        "lodash": "^4.5.0",
+        "therror": "^0.2.0",
+        "yargs": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "esprima": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.3.tgz",
+          "integrity": "sha1-6e5ggrBld3DkNG368qWMWZIlH3Y=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.2",
+            "esprima": "^2.6.0"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          }
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+          "dev": true,
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
           }
         }
       }
@@ -15384,6 +15744,15 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "param-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-1.1.2.tgz",
+      "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
+      "dev": true,
+      "requires": {
+        "sentence-case": "^1.1.2"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15449,6 +15818,16 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
+    "pascal-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.2.tgz",
+      "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
+      "dev": true,
+      "requires": {
+        "camel-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
+      }
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -15460,6 +15839,15 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
       "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
+    },
+    "path-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/path-case/-/path-case-1.1.2.tgz",
+      "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
+      "dev": true,
+      "requires": {
+        "sentence-case": "^1.1.2"
+      }
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -18039,6 +18427,15 @@
         }
       }
     },
+    "sentence-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.3.tgz",
+      "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "serialize-javascript": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
@@ -18231,6 +18628,15 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snake-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-1.1.2.tgz",
+      "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
+      "dev": true,
+      "requires": {
+        "sentence-case": "^1.1.2"
       }
     },
     "snapdragon": {
@@ -19485,6 +19891,16 @@
         }
       }
     },
+    "swap-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/swap-case/-/swap-case-1.1.2.tgz",
+      "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -19595,6 +20011,12 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "therror": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/therror/-/therror-0.2.0.tgz",
+      "integrity": "sha1-g0L/I55OhDwoel9TlW+w3HtgX+4=",
+      "dev": true
+    },
     "thread-loader": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-2.1.3.tgz",
@@ -19687,6 +20109,16 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+    },
+    "title-case": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/title-case/-/title-case-1.1.2.tgz",
+      "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
+      "dev": true,
+      "requires": {
+        "sentence-case": "^1.1.1",
+        "upper-case": "^1.0.3"
+      }
     },
     "tmp": {
       "version": "0.0.33",
@@ -20176,6 +20608,21 @@
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
       "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
       "dev": true
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
+    "upper-case-first": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.2.tgz",
+      "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
+      "dev": true,
+      "requires": {
+        "upper-case": "^1.1.1"
+      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -20803,6 +21250,12 @@
           }
         }
       }
+    },
+    "window-size": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "dev": true
     },
     "windows-release": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"test:update": "wp-scripts test-unit-js --updateSnapshot --config tests/js/jest.config.json",
 		"test:watch": "npm run test -- --watch",
 		"size-check": "bundlewatch",
-		"changelog": "node ./bin/changelog"
+		"changelog": "node ./bin/changelog",
+		"changelog:zenhub": "node ./bin/changelog --changelogSrcType:'MILESTONE'"
 	},
 	"devDependencies": {
 		"@babel/core": "7.8.3",
@@ -163,8 +164,7 @@
 	"changelog": {
 		"labelPrefix": "type:",
 		"skipLabel": "skip-changelog",
-		"defaultPrefix": "dev",
-		"devNoteLabel": ""
+		"defaultPrefix": "dev"
 	},
 	"files": [
 		"assets/**/*.{js,scss,php}",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"labelPrefix": "type:",
 		"skipLabel": "skip-changelog",
 		"defaultPrefix": "dev",
-		"zenhub": true
+		"devNoteLabel": ""
 	},
 	"files": [
 		"assets/**/*.{js,scss,php}",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
 		"husky": "2.4.1",
 		"ignore-loader": "0.1.2",
 		"lint-staged": "9.5.0",
+		"merge-config": "^2.0.0",
 		"mini-css-extract-plugin": "0.9.0",
 		"node-sass": "4.13.1",
 		"postcss-loader": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -164,7 +164,8 @@
 	"changelog": {
 		"labelPrefix": "type:",
 		"skipLabel": "skip-changelog",
-		"defaultPrefix": "dev"
+		"defaultPrefix": "dev",
+		"repo": "woocommerce/woocommerce-gutenberg-products-block"
 	},
 	"files": [
 		"assets/**/*.{js,scss,php}",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"test:watch": "npm run test -- --watch",
 		"size-check": "bundlewatch",
 		"changelog": "node ./bin/changelog",
-		"changelog:zenhub": "node ./bin/changelog --changelogSrcType:'MILESTONE'"
+		"changelog:zenhub": "node ./bin/changelog --changelogSrcType='ZENHUB_RELEASE'"
 	},
 	"devDependencies": {
 		"@babel/core": "7.8.3",


### PR DESCRIPTION
This pull request updates the changelog script with the following enhancements:

- remove zenhub option from package.json
- install and implement `merge-config` package. This allows for usage of environment variables and command line variables along with `package.json` configuration for the changelog generation.
- implement new variable: `devNoteLabel` for indicating what label indicates the pull has (or requires) a devnote. Pull Requests with this label will have `[DN]` appended to the changelog entry.
- add new variable: `changelogSrcType` for indicating what source to use for generating changelogs (can be `MILESTONE` or `ZENHUB_RELEASE`). Implemented detection of this in code, defaults to `MILESTONE`.
- Modify initial setup text so if user already has api key(s) setup, then we don't give instructions again.
- Update package.json with changelog script variation for running it with zenhub release as the source.
- Update `RELEASE.md` docs to clarify changelog script options
- Add a `README.md` doc for the changelog script.

## To Test

* [ ] execute `npm run changelog` with an existing milestone and verify this works as expected.
* [ ] execute `npm run changelog:zenhub` with an existing zenhub release id and verify this works as expected.