### PR TITLE
All Products & filters accessibility improvements

### DIFF
--- a/assets/js/atomic/components/product/rating/index.js
+++ b/assets/js/atomic/components/product/rating/index.js
@@ -18,6 +18,11 @@ const ProductRating = ( { className, product } ) => {
 		width: ( rating / 5 ) * 100 + '%',
 	};
 
+	const ratingText = sprintf(
+		__( 'Rated %d out of 5', 'woo-gutenberg-products-block' ),
+		rating
+	);
+
 	return (
 		<div
 			className={ classnames(
@@ -28,16 +33,9 @@ const ProductRating = ( { className, product } ) => {
 			<div
 				className={ `${ layoutStyleClassPrefix }__product-rating__stars` }
 				role="img"
+				aria-label={ ratingText }
 			>
-				<span style={ starStyle }>
-					{ sprintf(
-						__(
-							'Rated %d out of 5',
-							'woo-gutenberg-products-block'
-						),
-						rating
-					) }
-				</span>
+				<span style={ starStyle }>{ ratingText }</span>
 			</div>
 		</div>
 	);

--- a/assets/js/atomic/components/product/sale-badge/index.js
+++ b/assets/js/atomic/components/product/sale-badge/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
+import Label from '@woocommerce/base-components/label';
 
 const ProductSaleBadge = ( { className, product, align } ) => {
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
@@ -21,7 +22,13 @@ const ProductSaleBadge = ( { className, product, align } ) => {
 					`${ layoutStyleClassPrefix }__product-onsale`
 				) }
 			>
-				{ __( 'Sale', 'woo-gutenberg-products-block' ) }
+				<Label
+					label={ __( 'Sale', 'woo-gutenberg-products-block' ) }
+					screenReaderLabel={ __(
+						'Product on sale',
+						'woo-gutenberg-products-block'
+					) }
+				/>
 			</div>
 		);
 	}

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -148,7 +148,7 @@ const DropdownSelector = ( {
 							tabIndex={
 								// When it's a single selector and there is one element selected,
 								// we make the input non-focusable with the keyboard because it's
-								// visually hidden. The input is still displayed, though, because it
+								// visually hidden. The input is still rendered, though, because it
 								// must be possible to focus it when pressing the select value chip.
 								! multiple && checked.length > 0 ? '-1' : '0'
 							}

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -145,6 +145,13 @@ const DropdownSelector = ( {
 											attributeLabel
 									  )
 							}
+							tabIndex={
+								// When it's a single selector and there is one element selected,
+								// we make the input non-focusable with the keyboard because it's
+								// visually hidden. The input is still displayed, though, because it
+								// must be possible to focus it when pressing the select value chip.
+								! multiple && checked.length > 0 ? '-1' : '0'
+							}
 							value={ inputValue }
 						/>
 					</DropdownSelectorInputWrapper>

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -6,6 +6,7 @@ const DropdownSelectorInput = ( {
 	onFocus,
 	onRemoveItem,
 	placeholder,
+	tabIndex,
 	value,
 } ) => {
 	return (
@@ -25,6 +26,7 @@ const DropdownSelectorInput = ( {
 					}
 				},
 				placeholder,
+				tabIndex,
 			} ) }
 		/>
 	);

--- a/assets/js/base/components/dropdown-selector/selected-value.js
+++ b/assets/js/base/components/dropdown-selector/selected-value.js
@@ -21,6 +21,7 @@ const DropdownSelectorSelectedValue = ( { onClick, onRemoveItem, option } ) => {
 					onClick( option.value );
 				} }
 				aria-label={ sprintf(
+					/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
 					__(
 						'Replace current %s filter',
 						'woo-gutenberg-products-block'
@@ -41,6 +42,7 @@ const DropdownSelectorSelectedValue = ( { onClick, onRemoveItem, option } ) => {
 					}
 				} }
 				aria-label={ sprintf(
+					/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
 					__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
 					option.name
 				) }

--- a/assets/js/base/components/filter-submit-button/index.js
+++ b/assets/js/base/components/filter-submit-button/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Label from '@woocommerce/base-components/label';
 
 /**
  * Internal dependencies
@@ -21,8 +22,16 @@ const FilterSubmitButton = ( { className, disabled, onClick } ) => {
 			disabled={ disabled }
 			onClick={ onClick }
 		>
-			{ // translators: Submit button text for filters.
-			__( 'Go', 'woo-gutenberg-products-block' ) }
+			<Label
+				label={
+					// translators: Submit button text for filters.
+					__( 'Go', 'woo-gutenberg-products-block' )
+				}
+				screenReaderLabel={ __(
+					'Apply filter',
+					'woo-gutenberg-products-block'
+				) }
+			/>
 		</button>
 	);
 };

--- a/assets/js/base/components/filter-submit-button/index.js
+++ b/assets/js/base/components/filter-submit-button/index.js
@@ -11,7 +11,14 @@ import Label from '@woocommerce/base-components/label';
  */
 import './style.scss';
 
-const FilterSubmitButton = ( { className, disabled, onClick } ) => {
+const FilterSubmitButton = ( {
+	className,
+	disabled,
+	// translators: Submit button text for filters.
+	label = __( 'Go', 'woo-gutenberg-products-block' ),
+	onClick,
+	screenReaderLabel = __( 'Apply filter', 'woo-gutenberg-products-block' ),
+} ) => {
 	return (
 		<button
 			type="submit"
@@ -22,16 +29,7 @@ const FilterSubmitButton = ( { className, disabled, onClick } ) => {
 			disabled={ disabled }
 			onClick={ onClick }
 		>
-			<Label
-				label={
-					// translators: Submit button text for filters.
-					__( 'Go', 'woo-gutenberg-products-block' )
-				}
-				screenReaderLabel={ __(
-					'Apply filter',
-					'woo-gutenberg-products-block'
-				) }
-			/>
+			<Label label={ label } screenReaderLabel={ screenReaderLabel } />
 		</button>
 	);
 };
@@ -46,6 +44,8 @@ FilterSubmitButton.propTypes = {
 	 * On click callback.
 	 */
 	onClick: PropTypes.func.isRequired,
+	label: PropTypes.string,
+	screenReaderLabel: PropTypes.string,
 };
 
 FilterSubmitButton.defaultProps = {

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Label from '@woocommerce/base-components/label';
@@ -83,7 +83,14 @@ const Pagination = ( {
 					onClick={ () => onPageChange( 1 ) }
 					disabled={ currentPage === 1 }
 				>
-					1
+					<Label
+						label={ 1 }
+						screenReaderLabel={ sprintf(
+							/* translators: %d is the page number (1, 2, 3...). */
+							__( 'Page %s', 'woo-gutenberg-products-block' ),
+							1
+						) }
+					/>
 				</button>
 			) }
 			{ showFirstPageEllipsis && (
@@ -109,7 +116,14 @@ const Pagination = ( {
 						}
 						disabled={ currentPage === page }
 					>
-						{ page }
+						<Label
+							label={ page }
+							screenReaderLabel={ sprintf(
+								/* translators: %d is the page number (1, 2, 3...). */
+								__( 'Page %s', 'woo-gutenberg-products-block' ),
+								page
+							) }
+						/>
 					</button>
 				);
 			} ) }
@@ -130,7 +144,14 @@ const Pagination = ( {
 					onClick={ () => onPageChange( totalPages ) }
 					disabled={ currentPage === totalPages }
 				>
-					{ totalPages }
+					<Label
+						label={ totalPages }
+						screenReaderLabel={ sprintf(
+							/* translators: %d is the page number (1, 2, 3...). */
+							__( 'Page %s', 'woo-gutenberg-products-block' ),
+							totalPages
+						) }
+					/>
 				</button>
 			) }
 			{ displayNextAndPreviousArrows && (

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -87,7 +87,7 @@ const Pagination = ( {
 						label={ 1 }
 						screenReaderLabel={ sprintf(
 							/* translators: %d is the page number (1, 2, 3...). */
-							__( 'Page %s', 'woo-gutenberg-products-block' ),
+							__( 'Page %d', 'woo-gutenberg-products-block' ),
 							1
 						) }
 					/>
@@ -120,7 +120,7 @@ const Pagination = ( {
 							label={ page }
 							screenReaderLabel={ sprintf(
 								/* translators: %d is the page number (1, 2, 3...). */
-								__( 'Page %s', 'woo-gutenberg-products-block' ),
+								__( 'Page %d', 'woo-gutenberg-products-block' ),
 								page
 							) }
 						/>
@@ -148,7 +148,7 @@ const Pagination = ( {
 						label={ totalPages }
 						screenReaderLabel={ sprintf(
 							/* translators: %d is the page number (1, 2, 3...). */
-							__( 'Page %s', 'woo-gutenberg-products-block' ),
+							__( 'Page %d', 'woo-gutenberg-products-block' ),
 							totalPages
 						) }
 					/>

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -355,6 +355,10 @@ const PriceSlider = ( {
 						className="wc-block-price-filter__button"
 						disabled={ isLoading || ! hasValidConstraints }
 						onClick={ onSubmit }
+						screenReaderLabel={ __(
+							'Apply price filter',
+							'woo-gutenberg-products-block'
+						) }
 					/>
 				) }
 			</div>

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -241,7 +241,7 @@ const PriceSlider = ( {
 				onFocus={ findClosestRange }
 			>
 				{ hasValidConstraints && (
-					<Fragment>
+					<div aria-hidden={ showInputFields }>
 						<div
 							className="wc-block-price-filter__range-input-progress"
 							style={ progressStyles }
@@ -284,7 +284,7 @@ const PriceSlider = ( {
 							ref={ maxRange }
 							disabled={ isLoading }
 						/>
-					</Fragment>
+					</div>
 				) }
 			</div>
 			<div className="wc-block-price-filter__controls">

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -264,6 +264,7 @@ const PriceSlider = ( {
 							max={ maxConstraint }
 							ref={ minRange }
 							disabled={ isLoading }
+							tabIndex={ showInputFields ? '-1' : '0' }
 						/>
 						<input
 							type="range"
@@ -283,6 +284,7 @@ const PriceSlider = ( {
 							max={ maxConstraint }
 							ref={ maxRange }
 							disabled={ isLoading }
+							tabIndex={ showInputFields ? '-1' : '0' }
 						/>
 					</div>
 				) }

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -333,8 +333,8 @@ const PriceSlider = ( {
 					Number.isFinite( minPrice ) &&
 					Number.isFinite( maxPrice ) && (
 						<div className="wc-block-price-filter__range-text">
-							{ __( 'Price', 'woo-gutenberg-products-block' ) }:
-							&nbsp;
+							{ __( 'Price', 'woo-gutenberg-products-block' ) }
+							: &nbsp;
 							<FormattedMonetaryAmount
 								currency={ currency }
 								displayType="text"

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -16,6 +17,7 @@ import {
 } from '@woocommerce/base-hooks';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -70,6 +72,29 @@ const extractPaginationAndSortAttributes = ( query ) => {
 	return totalQuery;
 };
 
+const announceLoadingCompletion = ( totalProducts ) => {
+	if ( ! Number.isFinite( totalProducts ) ) {
+		return;
+	}
+
+	if ( totalProducts === 0 ) {
+		speak( __( 'No products found', 'woo-gutenberg-products-block' ) );
+	} else {
+		speak(
+			sprintf(
+				// translators: %s is an integer higher than 0 (1, 2, 3...)
+				_n(
+					'%d product found',
+					'%d products found',
+					totalProducts,
+					'woo-gutenberg-products-block'
+				),
+				totalProducts
+			)
+		);
+	}
+};
+
 const ProductList = ( {
 	attributes,
 	currentPage,
@@ -119,6 +144,11 @@ const ProductList = ( {
 		// reset pagination to the first page.
 		if ( ! isPreviousTotalQueryEqual ) {
 			onPageChange( 1 );
+
+			// Make sure there was a previous query, so we don't announce it on page load.
+			if ( previousQueryTotals ) {
+				announceLoadingCompletion( totalProducts );
+			}
 		}
 	}, [ queryState ] );
 

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -108,7 +108,7 @@
 	.wc-block-grid__product-price__regular {
 		font-size: 0.8em;
 		line-height: 1;
-		color: #aaa;
+		color: #555;
 		margin-top: -0.25em;
 		display: block;
 	}

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -181,7 +181,8 @@
 		height: 1.618em;
 		line-height: 1.618;
 		font-size: 1em;
-		font-family: star; /* stylelint-disable-line */
+		/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
+		font-family: star;
 		font-weight: 400;
 		margin: 0 auto;
 		text-align: left;

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -183,7 +183,6 @@
 		font-size: 1em;
 		font-family: star; /* stylelint-disable-line */
 		font-weight: 400;
-		display: -block;
 		margin: 0 auto;
 		text-align: left;
 

--- a/assets/js/blocks/active-filters/active-attribute-filters.js
+++ b/assets/js/blocks/active-filters/active-attribute-filters.js
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
 import { useCollection, useQueryStateByKey } from '@woocommerce/base-hooks';
 import { decodeEntities } from '@wordpress/html-entities';
-import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -37,28 +35,21 @@ const ActiveAttributeFilters = ( { attributeObject = {}, slugs = [] } ) => {
 		const termObject = results.find( ( term ) => {
 			return term.slug === slug;
 		} );
-		const name = decodeEntities( termObject.name || slug );
 
 		return (
 			termObject &&
-			renderRemovableListItem( attributeLabel, name, () => {
-				removeAttributeFilterBySlug(
-					productAttributes,
-					setProductAttributes,
-					attributeObject,
-					slug
-				);
-				speak(
-					sprintf(
-						// translators: %s is a filter value (large, medium, blue, yellow...)
-						__(
-							'%s filter removed',
-							'woo-gutenberg-products-block'
-						),
-						name
-					)
-				);
-			} )
+			renderRemovableListItem(
+				attributeLabel,
+				decodeEntities( termObject.name || slug ),
+				() => {
+					removeAttributeFilterBySlug(
+						productAttributes,
+						setProductAttributes,
+						attributeObject,
+						slug
+					);
+				}
+			)
 		);
 	} );
 };

--- a/assets/js/blocks/active-filters/active-attribute-filters.js
+++ b/assets/js/blocks/active-filters/active-attribute-filters.js
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { useCollection, useQueryStateByKey } from '@woocommerce/base-hooks';
 import { decodeEntities } from '@wordpress/html-entities';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -35,21 +37,28 @@ const ActiveAttributeFilters = ( { attributeObject = {}, slugs = [] } ) => {
 		const termObject = results.find( ( term ) => {
 			return term.slug === slug;
 		} );
+		const name = decodeEntities( termObject.name || slug );
 
 		return (
 			termObject &&
-			renderRemovableListItem(
-				attributeLabel,
-				decodeEntities( termObject.name || slug ),
-				() => {
-					removeAttributeFilterBySlug(
-						productAttributes,
-						setProductAttributes,
-						attributeObject,
-						slug
-					);
-				}
-			)
+			renderRemovableListItem( attributeLabel, name, () => {
+				removeAttributeFilterBySlug(
+					productAttributes,
+					setProductAttributes,
+					attributeObject,
+					slug
+				);
+				speak(
+					sprintf(
+						// translators: %s is a filter value (large, medium, blue, yellow...)
+						__(
+							'%s filter removed',
+							'woo-gutenberg-products-block'
+						),
+						name
+					)
+				);
+			} )
 		);
 	} );
 };

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -38,8 +38,8 @@ const ActiveFiltersBlock = ( {
 			__( 'Price', 'woo-gutenberg-products-block' ),
 			formatPriceRange( minPrice, maxPrice ),
 			() => {
-				setMinPrice( null );
-				setMaxPrice( null );
+				setMinPrice( undefined );
+				setMaxPrice( undefined );
 			}
 		);
 	}, [ minPrice, maxPrice, formatPriceRange ] );
@@ -105,8 +105,8 @@ const ActiveFiltersBlock = ( {
 				<button
 					className="wc-block-active-filters__clear-all"
 					onClick={ () => {
-						setMinPrice( null );
-						setMaxPrice( null );
+						setMinPrice( undefined );
+						setMaxPrice( undefined );
 						setProductAttributes( [] );
 					} }
 				>

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -6,6 +6,7 @@ import { useQueryStateByKey } from '@woocommerce/base-hooks';
 import { useMemo, Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import Label from '@woocommerce/base-components/label';
 
 /**
  * Internal dependencies
@@ -109,7 +110,16 @@ const ActiveFiltersBlock = ( {
 						setProductAttributes( [] );
 					} }
 				>
-					{ __( 'Clear All', 'woo-gutenberg-products-block' ) }
+					<Label
+						label={ __(
+							'Clear All',
+							'woo-gutenberg-products-block'
+						) }
+						screenReaderLabel={ __(
+							'Clear All Filters',
+							'woo-gutenberg-products-block'
+						) }
+					/>
 				</button>
 			</div>
 		</Fragment>

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -7,6 +7,7 @@ import { useMemo, Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -40,6 +41,9 @@ const ActiveFiltersBlock = ( {
 			() => {
 				setMinPrice( undefined );
 				setMaxPrice( undefined );
+				speak(
+					__( 'Price filter removed', 'woo-gutenberg-products-block' )
+				);
 			}
 		);
 	}, [ minPrice, maxPrice, formatPriceRange ] );
@@ -108,6 +112,12 @@ const ActiveFiltersBlock = ( {
 						setMinPrice( undefined );
 						setMaxPrice( undefined );
 						setProductAttributes( [] );
+						speak(
+							__(
+								'Cleared all filters',
+								'woo-gutenberg-products-block'
+							)
+						);
 					} }
 				>
 					<Label

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -7,7 +7,6 @@ import { useMemo, Fragment } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
-import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -41,9 +40,6 @@ const ActiveFiltersBlock = ( {
 			() => {
 				setMinPrice( undefined );
 				setMaxPrice( undefined );
-				speak(
-					__( 'Price filter removed', 'woo-gutenberg-products-block' )
-				);
 			}
 		);
 	}, [ minPrice, maxPrice, formatPriceRange ] );
@@ -112,12 +108,6 @@ const ActiveFiltersBlock = ( {
 						setMinPrice( undefined );
 						setMaxPrice( undefined );
 						setProductAttributes( [] );
-						speak(
-							__(
-								'Cleared all filters',
-								'woo-gutenberg-products-block'
-							)
-						);
 					} }
 				>
 					<Label

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { formatPrice } from '@woocommerce/base-utils';
+import Label from '@woocommerce/base-components/label';
 
 /**
  * Format a min/max price range to display.
@@ -59,7 +60,17 @@ export const renderRemovableListItem = (
 				{ name }
 			</strong>
 			<button onClick={ removeCallback }>
-				{ __( 'Remove', 'woo-gutenberg-products-block' ) }
+				<Label
+					label={ __( 'Remove', 'woo-gutenberg-products-block' ) }
+					screenReaderLabel={ sprintf(
+						/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
+						__(
+							'Remove %s filter',
+							'woo-gutenberg-products-block'
+						),
+						name
+					) }
+				/>
 			</button>
 		</li>
 	);

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { formatPrice } from '@woocommerce/base-utils';
-import Label from '@woocommerce/base-components/label';
 
 /**
  * Format a min/max price range to display.
@@ -60,17 +59,11 @@ export const renderRemovableListItem = (
 				{ name }
 			</strong>
 			<button onClick={ removeCallback }>
-				<Label
-					label={ __( 'Remove', 'woo-gutenberg-products-block' ) }
-					screenReaderLabel={ sprintf(
-						/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
-						__(
-							'Remove %s filter',
-							'woo-gutenberg-products-block'
-						),
-						name
-					) }
-				/>
+				{ sprintf(
+					/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
+					__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
+					name
+				) }
 			</button>
 		</li>
 	);


### PR DESCRIPTION
Part of #1281.

This PR contains several small improvements to _All Products_ and filter blocks accessibility.

For improvements that seemed more complex, I created issues with the label `scope: accessibility`:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues?q=is%3Aissue+is%3Aopen+label%3A%22scope%3A+accessibility%22

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/73288002-7c399780-41fa-11ea-9c1a-dcee5e6f4d6d.png)

### How to test the changes in this Pull Request:

1. Create a page like the one in the screenshot (with the _All Products_ block and filter blocks).
2. With the Axe extension ([Firefox](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd)) analyze the page and verify there are no errors related to the blocks. (Notice there is an issue with the `Sale` badge color contrast, that's Storefront specific and being fixed in https://github.com/woocommerce/storefront/pull/1251).
3. Navigate the page with a screen reader and verify some texts are clearer now (related commits https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1656/commits/86781c1dfb849c2c9b0d7593b6e11a72299b713f, https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1656/commits/96704eb6e671df38baafa546f041a1d22cbbf55f and https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1656/commits/8dad6a2d46be2cae8bafc326ac1eb1c81544bef7):
	* _Sale_ > _Product on Sale_
	* (Filter) _Clear All_ > _Clear All Filters_
	* (Filter) _Remove_ > _Remove X Filter_
	* (Filter) _Go_ > _Apply filter_
	* (Pagination) _2_ > _Page 2_
4. In the _Price Filter_ block, set the _Price Range_ option to _Input_. Navigate the page and verify you can't focus the slider anymore: there is no need to offer two controls for the same value (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1656/commits/b102ae4a4fdf4ef39beda5b0a173bef8a532e684 and https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1656/commits/07246f396815d55e9689bd3712457f808a5ebc4f).
5. In the _Attributes Filter_ block, set the _Query Type_ to _And_ and _Display Style_ > _Dropdown_. Then, navigate the page with the keyboard and verify you can't select the input field. We already have a "Change filter" and "Remove filter" button, so being able to focus the input field is unnecessary and unexpected, because it's visually hidden (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1656/commits/ec35bca895b678b00ead6f4323378ff582e4999c).
6. With a screen reader, enable/disable some filters and verify the number of results is announced. This helps to know the filter was applied and also gives information about how many products were found (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1656/commits/97fe7f04fe47413e57e980ef6cfe83624e359f56).
7. Play around with the page, change block settings, etc. and report any issues you find.

### Changelog

> Accessibility of the All Products block and filter blocks has been improved.