### PR TITLE
Rename the "Align Buttons" option for the All Products Block

### DIFF
--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -264,7 +264,8 @@
 	.wc-block-grid__product-image,
 	.wc-block-grid__product-title,
 	.wc-block-grid__product-price,
-	.wc-block-grid__product-rating {
+	.wc-block-grid__product-rating,
+	.wc-block-grid__product-add-to-cart {
 		margin-top: 0;
 		margin-bottom: $gap-small;
 	}
@@ -276,8 +277,11 @@
 			display: flex;
 			flex-direction: column;
 		}
-		.wc-block-grid__product-add-to-cart {
-			margin-top: auto !important;
+		.wc-block-grid__product > .wc-block-grid__product-title:last-child,
+		.wc-block-grid__product > div:last-child {
+			margin-top: auto;
+			margin-bottom: 0;
+			padding-bottom: $gap-small;
 		}
 	}
 	@for $i from 1 to 9 {

--- a/assets/js/components/grid-layout-control/index.js
+++ b/assets/js/components/grid-layout-control/index.js
@@ -49,15 +49,18 @@ const GridLayoutControl = ( {
 				max={ MAX_ROWS }
 			/>
 			<ToggleControl
-				label={ __( 'Align Buttons', 'woo-gutenberg-products-block' ) }
+				label={ __(
+					'Align Last Block',
+					'woo-gutenberg-products-block'
+				) }
 				help={
 					alignButtons
 						? __(
-								'Buttons are aligned vertically.',
+								'The last inner block will be aligned vertically.',
 								'woo-gutenberg-products-block'
 						  )
 						: __(
-								'Buttons follow content.',
+								'The last inner block will follow other content.',
 								'woo-gutenberg-products-block'
 						  )
 				}


### PR DESCRIPTION
The all products block inherited an option from our old grid blocks labelled "Align Buttons" which seeked to align the "add to cart" button to the bottom of the element. With the introduction of inner blocks however, it is no longer possible to just assume the button will be the final element shown for each list item.

Aligning buttons when not the final element introduces some issues:

1. Technically the flex box layout doesn't cope with this and causes other elements to be misaligned
2. If the button is first for example (#1617), the buttons are already "aligned". It's the content beneath them that follows on. The setting doesn't make much sense in this regard and how it "should" work isn't clear.

We can work around this by stating "last element" instead of "button" so that this works in the same way regardless of used blocks. The final element will be aligned to the bottom with this change, rather than just buttons.

Closes #1617

### Screenshots

Reworded options:

![Screenshot 2020-01-28 at 11 47 06](https://user-images.githubusercontent.com/90977/73261417-ef73e700-41c3-11ea-8918-e8cd2802c8b8.png)

In this example price is the last element:

![Screenshot 2020-01-28 at 11 46 41](https://user-images.githubusercontent.com/90977/73261400-e5ea7f00-41c3-11ea-97e9-fc1a1b2df5ed.png)

### How to test the changes in this Pull Request:

1. Turn on the alignment option.
2. Move elements around and save.
3. Check bottom most element is aligned to the bottom of the list item.

<!-- If you can, add the appropriate labels -->

### Changelog

> Renamed the "all products" align option so it's clear the final element gets alignment, not just buttons.
