### PR TITLE
Replace three dots with an ellipsis in Product Search placeholder

### DIFF
--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -59,7 +59,7 @@ registerBlockType( 'woocommerce/product-search', {
 		 */
 		placeholder: {
 			type: 'string',
-			default: __( 'Search products...', 'woo-gutenberg-products-block' ),
+			default: __( 'Search products…', 'woo-gutenberg-products-block' ),
 			source: 'attribute',
 			selector: 'input.wc-block-product-search__field',
 			attribute: 'placeholder',


### PR DESCRIPTION
It might depend on the screen reader, but at least in Linux `...` was read as `dot dot dot`. Replacing it with the ellipsis character (`…`) fixes it.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/73366638-90d76780-42ae-11ea-8566-60a4b78c894f.png)
_(on top the old placeholder with `...` and below the new placeholder `…` – they look almost the same but make a difference with a screen reader)_

### How to test the changes in this Pull Request:

1. In `master` create a post with a _Product Search_ block.
2. `git co fix/product-search-ellipsis`
3. Reload the post in the editor and verify the block didn't get invalidated.
4. Add a new _Product Search_ block.
5. In the frontend, navigate those blocks with a screen reader and verify the placeholder of the new block is read properly.
	Notice this PR doesn't change blocks already added.

### Changelog

> Added correct ellipsis character in Product Search block