### PR TITLE
Write the first e2e test

### DIFF
--- a/tests/e2e-tests/specs/backend/__snapshots__/all-products.test.js.snap
+++ b/tests/e2e-tests/specs/backend/__snapshots__/all-products.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`All Products can be created 1`] = `
+"<!-- wp:woocommerce/all-products {\\"columns\\":3,\\"rows\\":3,\\"alignButtons\\":false,\\"contentVisibility\\":{\\"orderBy\\":true},\\"orderby\\":\\"date\\",\\"layoutConfig\\":[[\\"woocommerce/product-image\\"],[\\"woocommerce/product-title\\"],[\\"woocommerce/product-price\\"],[\\"woocommerce/product-rating\\"],[\\"woocommerce/product-button\\"]]} -->
+<div class=\\"wp-block-woocommerce-all-products wc-block-all-products\\" data-attributes=\\"{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}\\"></div>
+<!-- /wp:woocommerce/all-products -->"
+`;

--- a/tests/e2e-tests/specs/backend/all-products.test.js
+++ b/tests/e2e-tests/specs/backend/all-products.test.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import {
+	insertBlock,
+	getEditedPostContent,
+	createNewPost,
+	switchUserToAdmin,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'All Products', () => {
+	beforeEach( async () => {
+		await switchUserToAdmin();
+		await createNewPost();
+	} );
+
+	it( 'can be created', async () => {
+		await insertBlock( 'All Products' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
This PR adds a simple e2e test that inserts the all products block and matches the editor output with a snapshot.

[in the original PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1670), you will find the steps to set up this testing, and to run this test visually, you need to run this command

```
npm run test:e2e-dev ./tests/e2e-tests/specs/backend/all-products.test.js
```