### PR TITLE
Load core translations for PHP strings that don't have a translation

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -180,3 +180,27 @@ JS;
 }
 
 add_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
+
+/**
+ * Filter translations so we can retrieve translations from Core when the original and the translated
+ * texts are the same (which happens when translations are missing).
+ *
+ * @param string $translation Translated text based on WC Blocks translations.
+ * @param string $text        Text to translate.
+ * @param string $domain      The text domain.
+ * @return string WC Blocks translation. In case it's the same as $text, Core translation.
+ */
+function woocommerce_blocks_get_php_translation_from_core( $translation, $text, $domain ) {
+	if ( 'woo-gutenberg-products-block' !== $domain ) {
+		return $translation;
+	}
+
+	// When translation is the same, that could mean the string is not translated.
+	// In that case, load it from core.
+	if ( $translation === $text ) {
+		return translate( $text, 'woocommerce' ); // phpcs:ignore
+	}
+	return $translation;
+}
+
+add_filter( 'gettext', 'woocommerce_blocks_get_php_translation_from_core', 10, 4 );

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -203,4 +203,4 @@ function woocommerce_blocks_get_php_translation_from_core( $translation, $text, 
 	return $translation;
 }
 
-add_filter( 'gettext', 'woocommerce_blocks_get_php_translation_from_core', 10, 4 );
+add_filter( 'gettext', 'woocommerce_blocks_get_php_translation_from_core', 10, 3 );

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -198,7 +198,7 @@ function woocommerce_blocks_get_php_translation_from_core( $translation, $text, 
 	// When translation is the same, that could mean the string is not translated.
 	// In that case, load it from core.
 	if ( $translation === $text ) {
-		return translate( $text, 'woocommerce' ); // phpcs:ignore
+		return translate( $text, 'woocommerce' ); // phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction, WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.TextDomainMismatch
 	}
 	return $translation;
 }


### PR DESCRIPTION
Fixes #1272.

#1242 made it so we load WooCommerce Core translations when they are missing for WooCommerce Blocks. That worked for JS-rendered strings, but didn't include PHP strings.

This PR is an attempt to extend it to PHP strings.

Tagging @mikejolley and @nerrad for review since you worked on/reviewed #1242, which is kinda related. But anybody else is welcome to take a look.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/73537782-97d6b500-4429-11ea-881a-ea71d5e4e8da.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/73537808-a8872b00-4429-11ea-81d8-971184058972.png)

### How to test the changes in this Pull Request:

1. Create a post:
	* With a _Product Categories List_ block with _Display Style_ set to _Dropdown_.
	* With a _Handpicked Products_ block (or any other PHP-rendered product grid block).
2. Change your site language to `Deustch (Sie)`.
3. Load these translations into (`/wp-content/languages/plugins/`):
	* https://downloads.wordpress.org/translation/plugin/woocommerce/3.9.1/de_DE_formal.zip
	* https://downloads.wordpress.org/translation/plugin/woo-gutenberg-products-block/1.3.1/de_DE_formal.zip
4. Verify `Sale!` and `Select a category` strings appear in German.

### Changelog

> Load WooCommerce Core translations for 'Sale!'  and some other strings if translations are unavailable for WooCommerce Blocks.