### PR TITLE
Check for instance of WooCommerce and WP_Error before initializing session and cart in `rest_authentication_errors` callback.

### DIFF
--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -19,7 +19,7 @@ class RestApi {
 	 */
 	public static function init() {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ), 10 );
-		add_filter( 'rest_authentication_errors', array( __CLASS__, 'maybe_init_cart_session' ), 1, 2 );
+		add_filter( 'rest_authentication_errors', array( __CLASS__, 'maybe_init_cart_session' ), 1 );
 	}
 
 	/**
@@ -61,12 +61,13 @@ class RestApi {
 	 *
 	 * @todo check compat < WC 3.6. Make specific to cart endpoint.
 	 * @param mixed $return Value being filtered.
-	 * @param array $request Request data.
 	 * @return mixed
 	 */
-	public static function maybe_init_cart_session( $return, $request = false ) {
+	public static function maybe_init_cart_session( $return ) {
 		$wc_instance = wc();
-		if ( ! $wc_instance instanceof \WooCommerce ) {
+		// if WooCommerce instance isn't available or already have an
+		// authentication error, just return.
+		if ( ! $wc_instance instanceof \WooCommerce || \is_wp_error( $return ) ) {
 			return $return;
 		}
 		$wc_instance->frontend_includes();

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -65,15 +65,14 @@ class RestApi {
 	 * @return mixed
 	 */
 	public static function maybe_init_cart_session( $return, $request = false ) {
-		// Pass through other errors.
-		if ( ! empty( $error ) ) {
-			return $error;
+		$wc_instance = wc();
+		if ( ! $wc_instance instanceof \WooCommerce ) {
+			return $return;
 		}
-
-		wc()->frontend_includes();
-		wc()->initialize_session();
-		wc()->initialize_cart();
-		wc()->cart->get_cart();
+		$wc_instance->frontend_includes();
+		$wc_instance->initialize_session();
+		$wc_instance->initialize_cart();
+		$wc_instance->cart->get_cart();
 
 		return $return;
 	}

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -67,7 +67,7 @@ class RestApi {
 		$wc_instance = wc();
 		// if WooCommerce instance isn't available or already have an
 		// authentication error, just return.
-		if ( ! $wc_instance instanceof \WooCommerce || \is_wp_error( $return ) ) {
+		if ( ! method_exists( $wc_instance, 'initialize_session' ) || \is_wp_error( $return ) ) {
 			return $return;
 		}
 		$wc_instance->frontend_includes();


### PR DESCRIPTION
Fixes: #1697 

While the report from 1697 doesn't describe the conditions for reproducing this bug, it's still fairly clear that there is potential for the fatal to happen based on the current logic.  In this pull:

- The condition checking for `$error` was odd because `$error` is never defined. It looked like this might be some copy pasta. I assumed what was _being_ checked for was whether the authentication already had an error (indicated by the presence of a `WP_Error` object) so I added that instead.
- To prevent the potential for `wc()` not returning an instance of `\WooCommerce` I did a defensive check for that as well.
- The filter being used (`rest_authentication_errors`) [only has one argument for it's signature](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-includes/rest-api/class-wp-rest-server.php#L143). Thus the existing callback didn't make sense and is fixed in this pull.

## To Test

I'm not quite sure how this would be tested other than to make sure the new Cart endpoints work okay? While this is released as a part of the 2.5 branch, we're not actively using the cart endpoints anywhere.

cc @mikejolley It was introduced as a part of #1046 so I've assigned to you for review given you probably have more insight into the specific needs of this and how to verify I haven't borked anything with this change.  I've currently queued up for the 2.5.12 milestone since it is in that branch but feel free to move if you don't think we need to cherry-pick it.