### PR TITLE
Default to experimental flag locally when no flag is present

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -136,9 +136,9 @@ const experimentalMainEntry = {
 };
 
 const mainEntry =
-	process.env.WOOCOMMERCE_BLOCKS_PHASE === 'experimental'
-		? { ...stableMainEntry, ...experimentalMainEntry }
-		: stableMainEntry;
+	process.env.WOOCOMMERCE_BLOCKS_PHASE === 'stable'
+		? stableMainEntry
+		: { ...stableMainEntry, ...experimentalMainEntry };
 
 const stableFrontEndEntry = {
 	reviews: './assets/js/blocks/reviews/frontend.js',
@@ -154,9 +154,9 @@ const experimentalFrontEndEntry = {
 };
 
 const frontEndEntry =
-	process.env.WOOCOMMERCE_BLOCKS_PHASE === 'experimental'
-		? { ...stableFrontEndEntry, ...experimentalFrontEndEntry }
-		: stableFrontEndEntry;
+	process.env.WOOCOMMERCE_BLOCKS_PHASE === 'stable'
+		? stableFrontEndEntry
+		: { ...stableFrontEndEntry, ...experimentalFrontEndEntry };
 
 const getEntryConfig = ( main = true, exclude = [] ) => {
 	const entryConfig = main ? mainEntry : frontEndEntry;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #1699 

This PR implements the second solution in the issue

> ### Default to experimental
>We update the `webpack-helpers.js` code to search for the flag stable, if not present, push both experimental and stable.

