### PR TITLE
Give Woo Icon special treatment by making it a component

### DIFF
--- a/assets/js/icons/icon/index.js
+++ b/assets/js/icons/icon/index.js
@@ -16,7 +16,7 @@ function Icon( { srcElement, size = 24, ...props } ) {
 	);
 }
 
-Icon.PropTypes = {
+Icon.propTypes = {
 	srcElement: PropTypes.oneOfType( [
 		PropTypes.instanceOf( SVG ),
 		// HTMLImageElement is a global interface

--- a/assets/js/icons/library/woo.js
+++ b/assets/js/icons/library/woo.js
@@ -2,9 +2,15 @@
  * External dependencies
  */
 import { SVG } from '@wordpress/components';
-
-const woo = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 245 145">
+import classnames from 'classnames';
+const woo = ( { className, size } ) => (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 245 145"
+		className={ classnames( 'woo-icon', className ) }
+		width={ Math.floor( size * 1.67 ) }
+		height={ size }
+	>
 		<path
 			fill="#96588A"
 			d="M22.76 0h199.1a22.77 22.77 0 0 1 22.8 22.76v75.92a22.77 22.77 0 0 1-22.78 22.78h-71.41l9.77 24-43.13-24H22.76C10.1946 121.449.011 111.2654 0 98.7V22.76C.011 10.1946 10.1946.011 22.76 0z"

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -19,13 +19,15 @@ setCategories( [
 	{
 		slug: 'woocommerce',
 		title: __( 'WooCommerce', 'woo-gutenberg-products-block' ),
-		icon: (
-			<Icon
-				icon={ woo }
-				width={ Math.floor( 20 * 1.67 ) }
-				height={ 20 }
-				className="woo-icon"
-			/>
-		),
+		icon: {
+			src: (
+				<Icon
+					icon={ woo }
+					width={ Math.floor( 20 * 1.67 ) }
+					height={ 20 }
+					className="woo-icon"
+				/>
+			),
+		},
 	},
 ] );

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,7 +3,7 @@
  */
 import { getCategories, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { Icon, woo } from '@woocommerce/icons';
+import { woo as Icon } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -19,15 +19,6 @@ setCategories( [
 	{
 		slug: 'woocommerce',
 		title: __( 'WooCommerce', 'woo-gutenberg-products-block' ),
-		icon: {
-			src: (
-				<Icon
-					icon={ woo }
-					width={ Math.floor( 20 * 1.67 ) }
-					height={ 20 }
-					className="woo-icon"
-				/>
-			),
-		},
+		icon: <Icon />,
 	},
 ] );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Due to the nature of how GB categories handle icons, most props like class and so end up redefined at the main icon, this PR seeks to treat Woo icon as a component and not an element, this is done by moving the props and logic to the icon.

it also fixes a typo in `Icon` propType
<!-- Reference any related issues or PRs here -->
Fixes #1701

### Screenshots
![image](https://user-images.githubusercontent.com/6165348/73598715-060b9c80-453c-11ea-94d6-2f340c96a983.png)
