### PR TITLE
Update eslint config to use non-deprecated value for global configuration.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 		'jest/globals': true,
 	},
 	globals: {
-		wcSettings: true,
+		wcSettings: 'readonly',
 	},
 	plugins: [ 'jest', 'woocommerce' ],
 	rules: {


### PR DESCRIPTION
Fixes: #900 

Eslint has a [configuration for specifying globals](https://eslint.org/docs/user-guide/configuring#specifying-globals) and using booleans as the values is deprecated. Also, we don't want to allow mutation of the `wcSettings` global so I've configured it to be `readonly`.  Eslint will warn if it's mutated.