### PR TITLE
Update Attribute Filter strings to ease translation

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -76,11 +76,11 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 						help={
 							showCounts
 								? __(
-										'Product counts are visible.',
+										'Product count is visible.',
 										'woo-gutenberg-products-block'
 								  )
 								: __(
-										'Product counts are hidden.',
+										'Product count is hidden.',
 										'woo-gutenberg-products-block'
 								  )
 						}
@@ -262,7 +262,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		setIsEditing( false );
 		debouncedSpeak(
 			__(
-				'Showing attribute filter block preview.',
+				'Showing Filter Products by Attribute block preview.',
 				'woo-gutenberg-products-block'
 			)
 		);


### PR DESCRIPTION
The other day I was playing with `translate.wordpress.org` and found a couple of strings that could be improved:

* We had two very similar texts: `Product counts are visible/hidden` (Attribute Filter) and `Product count is visible/hidden` (Product Categories). This PR unifies them to the latter, so there are only 2 strings to translate instead of 4.
* I also updated `Showing attribute filter block preview` to `Showing Filter Products by Attribute block preview`. `Filter Products by Attribute` is the name used by that block in the frontend.
