### PR TITLE
Fix Reviews blocks loading @wordpress/element in the frontend

### DIFF
--- a/assets/js/base/components/block-error-boundary/index.js
+++ b/assets/js/base/components/block-error-boundary/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment } from 'react';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
During the meetup we found out _Reviews_ blocks had `@wordpress/element` as a dependency even though they directly import from `react`. This PR fixes that.

I think we should have an automated way to prevent this kind of issues, ideally a tool that notifies us of any change in the dependencies files so we can be aware when those change. If that sounds interesting, I would open an issue to keep track of that.

### How to test the changes in this Pull Request:

1. Go to `build/reviews-frontend.asset.php` and verify `wp-element` is not in the list.