### PR TITLE
Change 'country' to 'country / region' label

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -182,7 +182,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 							<InputRow>
 								<ShippingCountryInput
 									label={ __(
-										'Country',
+										'Country / Region',
 										'woo-gutenberg-products-block'
 									) }
 									value={ shippingFields.country }


### PR DESCRIPTION
Same as https://github.com/woocommerce/woocommerce/pull/25530 but for WooCommerce Blocks, so we keep naming consistent. Rationale of the change in https://github.com/woocommerce/woocommerce/pull/24555.

I think that's the only instance of `Country` label we have. There is another one in an [open PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1559/files#diff-137ba2f7c4cf961d3ba840fb0f3ba641R24), but I will address it there.