### PR TITLE
Load countries in wcSettings only when a block requires them

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -129,8 +129,6 @@ class Assets {
 				'productCount'                => array_sum( (array) $product_counts ),
 				'attributes'                  => array_values( wc_get_attribute_taxonomies() ),
 				'wcBlocksAssetUrl'            => plugins_url( 'assets/', __DIR__ ),
-				'shippingCountries'           => WC()->countries->get_shipping_countries(),
-				'allowedCountries'            => WC()->countries->get_allowed_countries(),
 				'restApiRoutes'               => [
 					'/wc/store' => array_keys( \Automattic\WooCommerce\Blocks\RestApi::get_routes_from_namespace( 'wc/store' ) ),
 				],

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Package;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -44,6 +46,10 @@ class Cart extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
+		$data_registry = Package::container()->get(
+			\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class
+		);
+		$data_registry->add( 'shippingCountries', WC()->countries->get_shipping_countries() );
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
 			$this->block_name . '-frontend',
 			$this->block_name . '-block-frontend'

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Package;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -45,6 +47,11 @@ class Checkout extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
+		$data_registry = Package::container()->get(
+			\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class
+		);
+		$data_registry->add( 'allowedCountries', WC()->countries->get_allowed_countries() );
+		$data_registry->add( 'shippingCountries', WC()->countries->get_shipping_countries() );
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
 		return $content;
 	}


### PR DESCRIPTION
As discussed in #1574, since `shippingCountries` and `availableCountries` will be quite big once they include counties, we want to load them in `wcSettings` only when a block requires them. This PR implements that using the asset data registry.

### How to test the changes in this Pull Request:

1. Create a post with an _All Products_ block. Preview it and run `console.log( wcSettings );` in the console. Verify it doesn't have `shippingCountries` neither `allowedCountries`.
2. Create a post with an _Cart_ block. Preview it and run `console.log( wcSettings );` in the console. Verify it does have `shippingCountries` but doesn't have `allowedCountries`.
3. Create a post with an _Checkout_ block. Preview it and run `console.log( wcSettings );` in the console. Verify it does have both `shippingCountries` and `allowedCountries`.