### PR TITLE
Create CountyInput component

### DIFF
--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -2,14 +2,12 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import { CustomSelectControl } from 'wordpress-components';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
  */
-import './style.scss';
+import Select from '../select';
 
 const CountryInput = ( {
 	className,
@@ -22,21 +20,20 @@ const CountryInput = ( {
 		key,
 		name: decodeEntities( countries[ key ] ),
 	} ) );
-
-	return (
-		<CustomSelectControl
-			className={ classnames( 'wc-block-country-input', className, {
-				'is-active': value,
-			} ) }
-			label={ label }
-			options={ options }
-			onChange={ ( { selectedItem } ) => {
-				onChange( selectedItem.key );
-			} }
-			value={ {
+	const formattedValue = value
+		? {
 				key: value,
 				name: decodeEntities( countries[ value ] ),
-			} }
+		  }
+		: null;
+
+	return (
+		<Select
+			className={ className }
+			label={ label }
+			onChange={ onChange }
+			options={ options }
+			value={ formattedValue }
 		/>
 	);
 };

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -20,12 +20,6 @@ const CountryInput = ( {
 		key,
 		name: decodeEntities( countries[ key ] ),
 	} ) );
-	const formattedValue = value
-		? {
-				key: value,
-				name: decodeEntities( countries[ value ] ),
-		  }
-		: null;
 
 	return (
 		<Select
@@ -33,7 +27,7 @@ const CountryInput = ( {
 			label={ label }
 			onChange={ onChange }
 			options={ options }
-			value={ formattedValue }
+			value={ options.find( ( option ) => option.key === value ) }
 		/>
 	);
 };

--- a/assets/js/base/components/county-input/billing-county-input.js
+++ b/assets/js/base/components/county-input/billing-county-input.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { ALLOWED_COUNTIES } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import CountyInput from './county-input.js';
+
+const BillingCountyInput = ( props ) => {
+	return <CountyInput counties={ ALLOWED_COUNTIES } { ...props } />;
+};
+
+BillingCountyInput.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	className: PropTypes.string,
+	label: PropTypes.string,
+	value: PropTypes.string,
+};
+
+export default BillingCountyInput;

--- a/assets/js/base/components/county-input/county-input.js
+++ b/assets/js/base/components/county-input/county-input.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import Select from '../select';
+
+const CountyInput = ( {
+	className,
+	counties,
+	country,
+	label,
+	onChange,
+	value = '',
+} ) => {
+	const countryCounties = counties[ country ];
+	if ( ! countryCounties || Object.keys( countryCounties ).length === 0 ) {
+		return null;
+	}
+
+	const options = Object.keys( countryCounties ).map( ( key ) => ( {
+		key,
+		name: decodeEntities( countryCounties[ key ] ),
+	} ) );
+	const formattedValue = countryCounties[ value ]
+		? {
+				key: value,
+				name: decodeEntities( countryCounties[ value ] ),
+		  }
+		: null;
+
+	return (
+		<Select
+			className={ className }
+			label={ label }
+			onChange={ onChange }
+			options={ options }
+			value={ formattedValue }
+		/>
+	);
+};
+
+CountyInput.propTypes = {
+	counties: PropTypes.objectOf(
+		PropTypes.oneOfType( [
+			PropTypes.array,
+			PropTypes.objectOf( PropTypes.string ),
+		] )
+	).isRequired,
+	onChange: PropTypes.func.isRequired,
+	className: PropTypes.string,
+	country: PropTypes.string,
+	label: PropTypes.string,
+	value: PropTypes.string,
+};
+
+export default CountyInput;

--- a/assets/js/base/components/county-input/county-input.js
+++ b/assets/js/base/components/county-input/county-input.js
@@ -34,12 +34,6 @@ const CountyInput = ( {
 		key,
 		name: decodeEntities( countryCounties[ key ] ),
 	} ) );
-	const formattedValue = countryCounties[ value ]
-		? {
-				key: value,
-				name: decodeEntities( countryCounties[ value ] ),
-		  }
-		: null;
 
 	return (
 		<Select
@@ -47,7 +41,7 @@ const CountyInput = ( {
 			label={ label }
 			onChange={ onChange }
 			options={ options }
-			value={ formattedValue }
+			value={ options.find( ( option ) => option.key === value ) }
 		/>
 	);
 };

--- a/assets/js/base/components/county-input/county-input.js
+++ b/assets/js/base/components/county-input/county-input.js
@@ -7,6 +7,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import TextInput from '../text-input';
 import Select from '../select';
 
 const CountyInput = ( {
@@ -19,7 +20,14 @@ const CountyInput = ( {
 } ) => {
 	const countryCounties = counties[ country ];
 	if ( ! countryCounties || Object.keys( countryCounties ).length === 0 ) {
-		return null;
+		return (
+			<TextInput
+				className={ className }
+				label={ label }
+				onChange={ onChange }
+				value={ value }
+			/>
+		);
 	}
 
 	const options = Object.keys( countryCounties ).map( ( key ) => ( {

--- a/assets/js/base/components/county-input/index.js
+++ b/assets/js/base/components/county-input/index.js
@@ -1,0 +1,3 @@
+export { default as CountyInput } from './county-input';
+export { default as BillingCountyInput } from './billing-county-input';
+export { default as ShippingCountyInput } from './shipping-county-input';

--- a/assets/js/base/components/county-input/shipping-county-input.js
+++ b/assets/js/base/components/county-input/shipping-county-input.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { SHIPPING_COUNTIES } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import CountyInput from './county-input.js';
+
+const ShippingCountyInput = ( props ) => {
+	return <CountyInput counties={ SHIPPING_COUNTIES } { ...props } />;
+};
+
+ShippingCountyInput.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	className: PropTypes.string,
+	label: PropTypes.string,
+	value: PropTypes.string,
+};
+
+export default ShippingCountyInput;

--- a/assets/js/base/components/input-row/style.scss
+++ b/assets/js/base/components/input-row/style.scss
@@ -3,7 +3,7 @@
 	flex-wrap: wrap;
 	justify-content: space-between;
 
-	> .wc-block-country-input,
+	> .wc-block-select,
 	> .wc-block-text-input {
 		margin-right: $gap-small;
 		flex-basis: 0;

--- a/assets/js/base/components/select/index.js
+++ b/assets/js/base/components/select/index.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { CustomSelectControl } from 'wordpress-components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const Select = ( { className, label, onChange, options, value } ) => {
+	return (
+		<CustomSelectControl
+			className={ classnames( 'wc-block-select', className, {
+				'is-active': value,
+			} ) }
+			label={ label }
+			onChange={ ( { selectedItem } ) => {
+				onChange( selectedItem.key );
+			} }
+			options={ options }
+			value={ value }
+		/>
+	);
+};
+
+Select.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	options: PropTypes.arrayOf(
+		PropTypes.shape( {
+			key: PropTypes.string.isRequired,
+			name: PropTypes.string.isRequired,
+		} ).isRequired
+	).isRequired,
+	className: PropTypes.string,
+	label: PropTypes.string,
+	value: PropTypes.shape( {
+		key: PropTypes.string.isRequired,
+		name: PropTypes.string.isRequired,
+	} ),
+};
+
+export default Select;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,4 +1,4 @@
-.wc-block-country-input {
+.wc-block-select {
 	position: relative;
 	margin-top: $gap;
 

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -49,4 +49,8 @@
 		margin-left: 0;
 		padding-left: $gap;
 	}
+
+	.components-custom-select-control__item-icon {
+		display: none;
+	}
 }

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -23,17 +23,23 @@
 
 	.components-custom-select-control__button {
 		background-color: #fff;
+		box-shadow: none;
+		color: $input-text-active;
+		font-family: inherit;
 		font-size: 16px;
 		font-weight: normal;
 		height: 100%;
+		letter-spacing: inherit;
 		line-height: 1;
 		padding: $gap-large $gap $gap-smallest;
+		text-transform: none;
 		width: 100%;
 
 		&:hover,
 		&:focus,
 		&:active {
 			background-color: #fff;
+			text-decoration: none;
 		}
 	}
 

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -8,6 +8,7 @@ import CheckoutForm from '@woocommerce/base-components/checkout/form';
 import NoShipping from '@woocommerce/base-components/checkout/no-shipping';
 import TextInput from '@woocommerce/base-components/text-input';
 import { ShippingCountryInput } from '@woocommerce/base-components/country-input';
+import { ShippingCountyInput } from '@woocommerce/base-components/county-input';
 import ShippingRatesControl from '@woocommerce/base-components/shipping-rates-control';
 import InputRow from '@woocommerce/base-components/input-row';
 import { CheckboxControl } from '@wordpress/components';
@@ -189,7 +190,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 						/>
 					</InputRow>
 					<InputRow>
-						<TextInput
+						<ShippingCountyInput
 							label={ __(
 								'County',
 								'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -172,6 +172,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								setShippingFields( {
 									...shippingFields,
 									country: newValue,
+									county: '',
 								} )
 							}
 						/>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -192,6 +192,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 					</InputRow>
 					<InputRow>
 						<ShippingCountyInput
+							country={ shippingFields.country }
 							label={ __(
 								'County',
 								'woo-gutenberg-products-block'

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -35,3 +35,5 @@ export const ATTRIBUTES = getSetting( 'attributes', [] );
 export const WC_BLOCKS_ASSET_URL = getSetting( 'wcBlocksAssetUrl', '' );
 export const SHIPPING_COUNTRIES = getSetting( 'shippingCountries', {} );
 export const ALLOWED_COUNTRIES = getSetting( 'allowedCountries', {} );
+export const SHIPPING_COUNTIES = getSetting( 'shippingCounties', {} );
+export const ALLOWED_COUNTIES = getSetting( 'allowedCounties', {} );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -52,6 +52,8 @@ class Checkout extends AbstractBlock {
 		);
 		$data_registry->add( 'allowedCountries', WC()->countries->get_allowed_countries() );
 		$data_registry->add( 'shippingCountries', WC()->countries->get_shipping_countries() );
+		$data_registry->add( 'allowedCounties', WC()->countries->get_allowed_country_states() );
+		$data_registry->add( 'shippingCounties', WC()->countries->get_shipping_country_states() );
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
 		return $content;
 	}


### PR DESCRIPTION
Part of #1575.

Built on top of #1726.

In a follow-up I will make the word _County_ change depending on the country (sometimes it must be _State_, _Province_, _District_, etc.).

### Screenshots

![Peek 2020-02-13 12-09](https://user-images.githubusercontent.com/3616980/74428625-ab3a4500-4e59-11ea-9245-46565e08ba7e.gif)

### How to test the changes in this Pull Request:
1. Create a post with a _Checkout_ block and modify [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/blocks/cart-checkout/checkout/block.js#L113) so input fields appear:
```diff
-{ shippingMethods.length > 0 && (
+{ true && (
```
2. Select a country with counties (_United States_ or _Spain_ for example), and verify the county input appears.
3. Try selecting a country with no counties (_Andorra_, for example), and verify the county input is hidden.
