### PR TITLE
Fix ESLint error when commiting bin/webpack-helpers.js

### DIFF
--- a/bin/eslint-plugin-woocommerce/rules/feature-flag.js
+++ b/bin/eslint-plugin-woocommerce/rules/feature-flag.js
@@ -154,17 +154,19 @@ function testIsUsedInStrictBinaryExpression( node, context ) {
 		}
 	}
 
-	context.report( {
-		node,
-		loc: providedFlag.loc,
-		messageId: 'whiteListedFlag',
-		data: {
-			flags: flags.join( ', ' ),
-		},
-		fix( fixer ) {
-			return fixer.replaceText( providedFlag, "'experimental'" );
-		},
-	} );
+	if ( providedFlag && providedFlag.loc ) {
+		context.report( {
+			node,
+			loc: providedFlag.loc,
+			messageId: 'whiteListedFlag',
+			data: {
+				flags: flags.join( ', ' ),
+			},
+			fix( fixer ) {
+				return fixer.replaceText( providedFlag, "'experimental'" );
+			},
+		} );
+	}
 }
 
 /**

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -327,6 +327,7 @@ const getMainConfig = ( options = {} ) => {
 			new DefinePlugin( {
 				// Inject the `WOOCOMMERCE_BLOCKS_PHASE` global, used for feature flagging.
 				'process.env.WOOCOMMERCE_BLOCKS_PHASE': JSON.stringify(
+					// eslint-disable-next-line woocommerce/feature-flag
 					process.env.WOOCOMMERCE_BLOCKS_PHASE || 'experimental'
 				),
 			} ),
@@ -428,6 +429,7 @@ const getFrontConfig = ( options = {} ) => {
 			new DefinePlugin( {
 				// Inject the `WOOCOMMERCE_BLOCKS_PHASE` global, used for feature flagging.
 				'process.env.WOOCOMMERCE_BLOCKS_PHASE': JSON.stringify(
+					// eslint-disable-next-line woocommerce/feature-flag
 					process.env.WOOCOMMERCE_BLOCKS_PHASE || 'experimental'
 				),
 			} ),

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"lint:php": "composer run-script phpcs ./src",
 		"lint:css": "stylelint 'assets/**/*.scss'",
 		"lint:css-fix": "stylelint 'assets/**/*.scss' --fix",
-		"lint:js": "eslint assets/js --ext=js,jsx",
+		"lint:js": "eslint assets/js bin --ext=js,jsx",
 		"lint:js-fix": "eslint assets/js --ext=js,jsx --fix",
 		"package-plugin": "./bin/build-plugin-zip.sh",
 		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",


### PR DESCRIPTION
Fixes #1728.

I'm not 100% sure why, but when committing a change in `bin/webpack-helpers.js`, it was running ESLint on that file. That was making the new `feature-flag` rule to fail.

This PR fixes the rule error and adds `bin` to `npm run lint:js` list of paths, so running it will output errors that otherwise are only reproducible when committing a file.

### How to test the changes in this Pull Request:

1. Make a dummy change in `bin/webpack-helpers.js`. For example modifying a comma in a comment.
2. Commit it.
3. Verify there are no errors and the commit works.