### PR TITLE
Update testPathIgnorePatterns to exclude vendor directory

### DIFF
--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -21,10 +21,12 @@
 	},
 	"setupFiles": [
 		"<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/setup-globals.js",
-		"<rootDir>/tests/js/setup-globals"
+		"<rootDir>/tests/js/setup-globals.js"
 	],
 	"testPathIgnorePatterns": [
-		"<rootDir>/tests/e2e-tests"
+		"<rootDir>/tests/",
+		"<rootDir>/node_modules/",
+		"<rootDir>/vendor/"
 	],
 	"transformIgnorePatterns": [ "node_modules/(?!(simple-html-tokenizer)/)" ],
 	"preset": "@wordpress/jest-preset-default",


### PR DESCRIPTION
We've been seeing Jest tests fail, and noticed that too many tests were being ran. It seemed to have been picking up tests from the vendors directory, possibly related to docker and the e2e-tests.

Adding this exclusion rule prevents the issues. 42 tests run successfully.