### PR TITLE
Implement __experimentalCreateInterpolateElement for translations.

### DIFF
--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import {
 	Notice,
@@ -36,7 +35,7 @@ export const getBlockControls = ( editMode, setAttributes ) => (
 
 export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 	return (
-		<Fragment>
+		<>
 			<ToggleControl
 				label={ __( 'Product rating', 'woo-gutenberg-products-block' ) }
 				checked={ attributes.showReviewRating }
@@ -108,7 +107,7 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 				}
 			/>
 			{ attributes.showReviewImage && (
-				<Fragment>
+				<>
 					<ToggleButtonControl
 						label={ __(
 							'Review image',
@@ -160,9 +159,9 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 							) }
 						</Notice>
 					) }
-				</Fragment>
+				</>
 			) }
-		</Fragment>
+		</>
 	);
 };
 
@@ -171,7 +170,7 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 	const maxPerPage = 20;
 
 	return (
-		<Fragment>
+		<>
 			<ToggleControl
 				label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
 				checked={ attributes.showOrderby }
@@ -225,6 +224,6 @@ export const getSharedReviewListControls = ( attributes, setAttributes ) => {
 					min={ minPerPage }
 				/>
 			) }
-		</Fragment>
+		</>
 	);
 };

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { Fragment, RawHTML } from '@wordpress/element';
-import { escapeHTML } from '@wordpress/escape-html';
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import {
 	Notice,
 	ToggleControl,
@@ -51,19 +51,24 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 					className="wc-block-reviews__notice"
 					isDismissible={ false }
 				>
-					<RawHTML>
-						{ sprintf(
-							escapeHTML(
-								/* translators: 1: store settings url 2: link attributes */
-								__(
-									'Product rating is disabled in your <a href="%1$s" %2$s>store settings</a>.',
-									'woo-gutenberg-products-block'
-								)
+					{ __experimentalCreateInterpolateElement(
+						__(
+							'Product rating is disabled in your <a>store settings</a>.',
+							'woo-gutenberg-products-block'
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<a
+									href={ getAdminLink(
+										'admin.php?page=wc-settings&tab=products'
+									) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
 							),
-							getAdminLink( 'admin.php?page=wc-settings&tab=products' ),
-							'target="_blank"'
-						) }
-					</RawHTML>
+						}
+					) }
 				</Notice>
 			) }
 			<ToggleControl
@@ -135,19 +140,24 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 							className="wc-block-reviews__notice"
 							isDismissible={ false }
 						>
-							<RawHTML>
-								{ sprintf(
-									escapeHTML(
-										/* translators: 1: discussion settings url 2: link attributes */
-										__(
-											'Reviewer photo is disabled in your <a href="%$1s" %$2s>site settings</a>.',
-											'woo-gutenberg-products-block'
-										)
+							{ __experimentalCreateInterpolateElement(
+								__(
+									'Reviewer photo is disabled in your <a>site settings</a>.',
+									'woo-gutenberg-products-block'
+								),
+								{
+									a: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											href={ getAdminLink(
+												'options-discussion.php'
+											) }
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
 									),
-									getAdminLink( 'options-discussion.php' ),
-									'target="_blank"'
-								) }
-							</RawHTML>
+								}
+							) }
 						</Notice>
 					) }
 				</Fragment>

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -54,16 +54,14 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 					<RawHTML>
 						{ sprintf(
 							escapeHTML(
-								/* translators: A notice that links to WooCommerce settings. */
+								/* translators: 1: store settings url 2: link attributes */
 								__(
-									'Product rating is disabled in your %sstore settings%s.',
+									'Product rating is disabled in your <a href="%1$s" %2$s>store settings</a>.',
 									'woo-gutenberg-products-block'
 								)
 							),
-							`<a href="${ getAdminLink(
-								'admin.php?page=wc-settings&tab=products'
-							) }" target="_blank">`,
-							'</a>'
+							getAdminLink( 'admin.php?page=wc-settings&tab=products' ),
+							'target="_blank"'
 						) }
 					</RawHTML>
 				</Notice>

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -138,16 +138,14 @@ export const getSharedReviewContentControls = ( attributes, setAttributes ) => {
 							<RawHTML>
 								{ sprintf(
 									escapeHTML(
-										/* translators: A notice that links to WordPress settings. */
+										/* translators: 1: discussion settings url 2: link attributes */
 										__(
-											'Reviewer photo is disabled in your %ssite settings%s.',
+											'Reviewer photo is disabled in your <a href="%$1s" %$2s>site settings</a>.',
 											'woo-gutenberg-products-block'
 										)
 									),
-									`<a href="${ getAdminLink(
-										'options-discussion.php'
-									) }" target="_blank">`,
-									'</a>'
+									getAdminLink( 'options-discussion.php' ),
+									'target="_blank"'
 								) }
 							</RawHTML>
 						</Notice>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29642,6 +29642,28 @@
         }
       }
     },
+    "wordpress-element": {
+      "version": "npm:@wordpress/element@2.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
+      "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "@wordpress/escape-html": "^1.7.0",
+        "lodash": "^4.17.15",
+        "react": "^16.9.0",
+        "react-dom": "^16.9.0"
+      },
+      "dependencies": {
+        "@wordpress/escape-html": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.7.0.tgz",
+          "integrity": "sha512-xDOBo0P3Jnbdbb/UypsQaplsD2k4UXgd/EpKhMAKhDa2m20GxWWmEKW9IB3/5bS4Rh2YZjVM9WL4JyWPUo4hEA==",
+          "requires": {
+            "@babel/runtime": "^7.8.3"
+          }
+        }
+      }
+    },
     "wordwrap": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,8 @@
 		"react-number-format": "4.3.1",
 		"trim-html": "0.1.9",
 		"use-debounce": "3.3.0",
-		"wordpress-components": "npm:@wordpress/components@8.5.0"
+		"wordpress-components": "npm:@wordpress/components@8.5.0",
+		"wordpress-element": "npm:@wordpress/element@2.11.0"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
Following on from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1043, this PR implements the new `__experimentalCreateInterpolateElement` from the `wordpress/element` package. It allows us to dynamically insert HTML (in this case anchors) into a translatable string.

For translators, instead of:

> Product rating is disabled in your %sstore settings%s.

They will be able to translate a more obvious:

```Product rating is disabled in your <a>store settings</a>.```

And the link will be inserted. It also means we can avoid using RawHTML and escapeHTML to show string based HTML content.

Since `__experimentalCreateInterpolateElement` is not available in WordPress yet, only Gutenberg master, this pulls in the package via package.json.

