### PR TITLE
Change PropType validation for Icon component

### DIFF
--- a/assets/js/icons/icon/index.js
+++ b/assets/js/icons/icon/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { cloneElement, isValidElement } from '@wordpress/element';
-import { SVG } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
 function Icon( { srcElement, size = 24, ...props } ) {
@@ -17,12 +16,7 @@ function Icon( { srcElement, size = 24, ...props } ) {
 }
 
 Icon.propTypes = {
-	srcElement: PropTypes.oneOfType( [
-		PropTypes.instanceOf( SVG ),
-		// HTMLImageElement is a global interface
-		// eslint-disable-next-line no-undef
-		PropTypes.instanceOf( HTMLImageElement ),
-	] ),
+	srcElement: PropTypes.element,
 	size: PropTypes.number,
 };
 


### PR DESCRIPTION
I was seeing console errors due to the PropTypes validation. My icon was an `object` that did not match the SVG or image element being validated.

Changing the validation to `PropTypes.element` (a react element) should satisfy both, and removes the error for exported icon types.

cc @senadir 