### PR TITLE
Add support for image for product categories block

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -30,7 +30,7 @@ const EmptyPlaceholder = () => (
  */
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	const getInspectorControls = () => {
-		const { hasCount, hasEmpty, isDropdown, isHierarchical } = attributes;
+		const { hasCount, hasImage, hasEmpty, isDropdown, isHierarchical } = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -57,6 +57,27 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 						checked={ hasCount }
 						onChange={ () =>
 							setAttributes( { hasCount: ! hasCount } )
+						}
+					/>
+                    <ToggleControl
+						label={ __(
+							'Show category image',
+							'woo-gutenberg-products-block'
+						) }
+						help={
+							hasImage
+								? __(
+										'Category image is visible.',
+										'woo-gutenberg-products-block'
+								  )
+								: __(
+										'Category image is hidden.',
+										'woo-gutenberg-products-block'
+								  )
+						}
+						checked={ hasImage }
+						onChange={ () =>
+							setAttributes( { hasImage: ! hasImage } )
 						}
 					/>
 					<ToggleControl

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -30,7 +30,13 @@ const EmptyPlaceholder = () => (
  */
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	const getInspectorControls = () => {
-		const { hasCount, hasImage, hasEmpty, isDropdown, isHierarchical } = attributes;
+		const {
+			hasCount,
+			hasImage,
+			hasEmpty,
+			isDropdown,
+			isHierarchical,
+		} = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -59,19 +65,19 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							setAttributes( { hasCount: ! hasCount } )
 						}
 					/>
-                    <ToggleControl
+					<ToggleControl
 						label={ __(
-							'Show category image',
+							'Show category images',
 							'woo-gutenberg-products-block'
 						) }
 						help={
 							hasImage
 								? __(
-										'Category image is visible.',
+										'Category images are visible.',
 										'woo-gutenberg-products-block'
 								  )
 								: __(
-										'Category image is hidden.',
+										'Category images are hidden.',
 										'woo-gutenberg-products-block'
 								  )
 						}

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -41,6 +41,42 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 		return (
 			<InspectorControls key="inspector">
 				<PanelBody
+					title={ __(
+						'List Settings',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen
+				>
+					<ToggleButtonControl
+						label={ __(
+							'Display style',
+							'woo-gutenberg-products-block'
+						) }
+						value={ isDropdown ? 'dropdown' : 'list' }
+						options={ [
+							{
+								label: __(
+									'List',
+									'woo-gutenberg-products-block'
+								),
+								value: 'list',
+							},
+							{
+								label: __(
+									'Dropdown',
+									'woo-gutenberg-products-block'
+								),
+								value: 'dropdown',
+							},
+						] }
+						onChange={ ( value ) =>
+							setAttributes( {
+								isDropdown: value === 'dropdown',
+							} )
+						}
+					/>
+				</PanelBody>
+				<PanelBody
 					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
 					initialOpen
 				>
@@ -65,27 +101,29 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							setAttributes( { hasCount: ! hasCount } )
 						}
 					/>
-					<ToggleControl
-						label={ __(
-							'Show category images',
-							'woo-gutenberg-products-block'
-						) }
-						help={
-							hasImage
-								? __(
-										'Category images are visible.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Category images are hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
-						checked={ hasImage }
-						onChange={ () =>
-							setAttributes( { hasImage: ! hasImage } )
-						}
-					/>
+					{ ! isDropdown && (
+						<ToggleControl
+							label={ __(
+								'Show category images',
+								'woo-gutenberg-products-block'
+							) }
+							help={
+								hasImage
+									? __(
+											'Category images are visible.',
+											'woo-gutenberg-products-block'
+									  )
+									: __(
+											'Category images are hidden.',
+											'woo-gutenberg-products-block'
+									  )
+							}
+							checked={ hasImage }
+							onChange={ () =>
+								setAttributes( { hasImage: ! hasImage } )
+							}
+						/>
+					) }
 					<ToggleControl
 						label={ __(
 							'Show hierarchy',
@@ -128,42 +166,6 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 						checked={ hasEmpty }
 						onChange={ () =>
 							setAttributes( { hasEmpty: ! hasEmpty } )
-						}
-					/>
-				</PanelBody>
-				<PanelBody
-					title={ __(
-						'List Settings',
-						'woo-gutenberg-products-block'
-					) }
-					initialOpen
-				>
-					<ToggleButtonControl
-						label={ __(
-							'Display style',
-							'woo-gutenberg-products-block'
-						) }
-						value={ isDropdown ? 'dropdown' : 'list' }
-						options={ [
-							{
-								label: __(
-									'List',
-									'woo-gutenberg-products-block'
-								),
-								value: 'list',
-							},
-							{
-								label: __(
-									'Dropdown',
-									'woo-gutenberg-products-block'
-								),
-								value: 'dropdown',
-							},
-						] }
-						onChange={ ( value ) =>
-							setAttributes( {
-								isDropdown: value === 'dropdown',
-							} )
 						}
 					/>
 				</PanelBody>

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -31,7 +31,7 @@ registerBlockType( 'woocommerce/product-categories', {
 	example: {
 		attributes: {
 			hasCount: true,
-			hasImage: true,
+			hasImage: false,
 		},
 	},
 	attributes: {

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -31,6 +31,7 @@ registerBlockType( 'woocommerce/product-categories', {
 	example: {
 		attributes: {
 			hasCount: true,
+            hasImage: true,
 		},
 	},
 	attributes: {
@@ -40,6 +41,14 @@ registerBlockType( 'woocommerce/product-categories', {
 		hasCount: {
 			type: 'boolean',
 			default: true,
+		},
+
+        /**
+		 * Whether to show the category image in each category.
+		 */
+		hasImage: {
+			type: 'boolean',
+			default: false,
 		},
 
 		/**
@@ -78,6 +87,13 @@ registerBlockType( 'woocommerce/product-categories', {
 					selector: 'div',
 					attribute: 'data-has-count',
 				},
+                hasImage: {
+					type: 'boolean',
+					default: false,
+					source: 'attribute',
+					selector: 'div',
+					attribute: 'data-has-image',
+				},
 				hasEmpty: {
 					type: 'boolean',
 					default: false,
@@ -106,6 +122,7 @@ registerBlockType( 'woocommerce/product-categories', {
 			save( props ) {
 				const {
 					hasCount,
+					hasImage,
 					hasEmpty,
 					isDropdown,
 					isHierarchical,
@@ -113,6 +130,9 @@ registerBlockType( 'woocommerce/product-categories', {
 				const data = {};
 				if ( hasCount ) {
 					data[ 'data-has-count' ] = true;
+				}
+                if ( hasImage ) {
+					data[ 'data-has-image' ] = true;
 				}
 				if ( hasEmpty ) {
 					data[ 'data-has-empty' ] = true;

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -31,7 +31,7 @@ registerBlockType( 'woocommerce/product-categories', {
 	example: {
 		attributes: {
 			hasCount: true,
-            hasImage: true,
+			hasImage: true,
 		},
 	},
 	attributes: {
@@ -43,7 +43,7 @@ registerBlockType( 'woocommerce/product-categories', {
 			default: true,
 		},
 
-        /**
+		/**
 		 * Whether to show the category image in each category.
 		 */
 		hasImage: {
@@ -87,13 +87,6 @@ registerBlockType( 'woocommerce/product-categories', {
 					selector: 'div',
 					attribute: 'data-has-count',
 				},
-                hasImage: {
-					type: 'boolean',
-					default: false,
-					source: 'attribute',
-					selector: 'div',
-					attribute: 'data-has-image',
-				},
 				hasEmpty: {
 					type: 'boolean',
 					default: false,
@@ -122,7 +115,6 @@ registerBlockType( 'woocommerce/product-categories', {
 			save( props ) {
 				const {
 					hasCount,
-					hasImage,
 					hasEmpty,
 					isDropdown,
 					isHierarchical,
@@ -130,9 +122,6 @@ registerBlockType( 'woocommerce/product-categories', {
 				const data = {};
 				if ( hasCount ) {
 					data[ 'data-has-count' ] = true;
-				}
-                if ( hasImage ) {
-					data[ 'data-has-image' ] = true;
 				}
 				if ( hasEmpty ) {
 					data[ 'data-has-empty' ] = true;

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -27,11 +27,18 @@
 		max-width: 50px;
 		display: inline-block;
 		position: relative;
+		padding: 0;
+		margin: 0;
 		margin-right: 0.5em;
 		margin-left: -60px;
 		position: relative;
 		vertical-align: middle;
 		border: 1px solid #eee;
+
+		img {
+			margin: 0;
+			padding: 0;
+		}
 	}
 }
 

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -10,6 +10,31 @@
 	}
 }
 
+.wc-block-product-categories-list--has-images {
+	list-style: none outside;
+
+	.wc-block-product-categories-list-item {
+		margin: 4px 0 4px 60px;
+		list-style: none outside;
+		clear: both;
+
+		ul {
+			margin: 4px 0 0;
+		}
+	}
+
+	.wc-block-product-categories-list-item__image {
+		max-width: 50px;
+		display: inline-block;
+		position: relative;
+		margin-right: 0.5em;
+		margin-left: -60px;
+		position: relative;
+		vertical-align: middle;
+		border: 1px solid #eee;
+	}
+}
+
 .wc-block-product-categories-list-item-count::before {
 	content: " (";
 }

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -28,6 +28,7 @@ class ProductCategories extends AbstractDynamicBlock {
 	 */
 	protected $defaults = array(
 		'hasCount'       => true,
+		'hasImage'       => false,
 		'hasEmpty'       => false,
 		'isDropdown'     => false,
 		'isHierarchical' => true,
@@ -44,6 +45,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			array(
 				'className'      => $this->get_schema_string(),
 				'hasCount'       => $this->get_schema_boolean( true ),
+				'hasImage'       => $this->get_schema_boolean( false ),
 				'hasEmpty'       => $this->get_schema_boolean( false ),
 				'isDropdown'     => $this->get_schema_boolean( false ),
 				'isHierarchical' => $this->get_schema_boolean( true ),
@@ -256,12 +258,13 @@ class ProductCategories extends AbstractDynamicBlock {
 	 */
 	protected function renderListItems( $categories, $attributes, $uid, $depth = 0 ) {
 		$output = '';
+        $image_size = 'large';
 
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
 					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">
-						' . esc_html( $category->name ) . '
+						' . $this->get_image_html( $category, $image_size ) . esc_html( $category->name ) . '
 					</a>
 					' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
@@ -270,6 +273,24 @@ class ProductCategories extends AbstractDynamicBlock {
 		}
 
 		return $output;
+	}
+
+    /**
+	 * Returns the category image html
+	 *
+	 * @param \WP_Term $category Term object.
+	 * @param string   $size    Image size, defaults to 'full'.
+	 * @return string
+	 */
+	public function get_image_html( $category, $size = 'full' ) {
+		$image_html    = '';
+		$image_id = get_term_meta( $category->term_id, 'thumbnail_id', true );
+
+		if ( $image_id ) {
+			$image_html = wp_get_attachment_image( $image_id, $size );
+		}
+
+		return $image_html;
 	}
 
 	/**

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -264,14 +264,13 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return string Rendered output.
 	 */
 	protected function renderListItems( $categories, $attributes, $uid, $depth = 0 ) {
-		$output     = '';
-		$image_size = 'large';
+		$output = '';
 
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
 					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">
-						' . $this->get_image_html( $category, $attributes, $image_size ) . esc_html( $category->name ) . '
+						' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '
 					</a>
 					' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -242,7 +242,14 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return string Rendered output.
 	 */
 	protected function renderList( $categories, $attributes, $uid, $depth = 0 ) {
-		$output = '<ul class="wc-block-product-categories-list wc-block-product-categories-list--depth-' . absint( $depth ) . '">' . $this->renderListItems( $categories, $attributes, $uid, $depth ) . '</ul>';
+		$classes = [
+			'wc-block-product-categories-list',
+			'wc-block-product-categories-list--depth-' . absint( $depth ),
+		];
+		if ( ! empty( $attributes['hasImage'] ) ) {
+			$classes[] = 'wc-block-product-categories-list--has-images';
+		}
+		$output = '<ul class="' . esc_attr( implode( ' ', $classes ) ) . '">' . $this->renderListItems( $categories, $attributes, $uid, $depth ) . '</ul>';
 
 		return $output;
 	}
@@ -257,14 +264,14 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return string Rendered output.
 	 */
 	protected function renderListItems( $categories, $attributes, $uid, $depth = 0 ) {
-		$output = '';
-        $image_size = 'large';
+		$output     = '';
+		$image_size = 'large';
 
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
 					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">
-						' . $this->get_image_html( $category, $image_size ) . esc_html( $category->name ) . '
+						' . $this->get_image_html( $category, $attributes, $image_size ) . esc_html( $category->name ) . '
 					</a>
 					' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
@@ -275,22 +282,26 @@ class ProductCategories extends AbstractDynamicBlock {
 		return $output;
 	}
 
-    /**
+	/**
 	 * Returns the category image html
 	 *
 	 * @param \WP_Term $category Term object.
-	 * @param string   $size    Image size, defaults to 'full'.
+	 * @param array    $attributes Block attributes. Default empty array.
+	 * @param string   $size Image size, defaults to 'woocommerce_thumbnail'.
 	 * @return string
 	 */
-	public function get_image_html( $category, $size = 'full' ) {
-		$image_html    = '';
-		$image_id = get_term_meta( $category->term_id, 'thumbnail_id', true );
-
-		if ( $image_id ) {
-			$image_html = wp_get_attachment_image( $image_id, $size );
+	public function get_image_html( $category, $attributes, $size = 'woocommerce_thumbnail' ) {
+		if ( empty( $attributes['hasImage'] ) ) {
+			return '';
 		}
 
-		return $image_html;
+		$image_id = get_term_meta( $category->term_id, 'thumbnail_id', true );
+
+		if ( ! $image_id ) {
+			return '<span class="wc-block-product-categories-list-item__image wc-block-product-categories-list-item__image--placeholder">' . wc_placeholder_img( 'woocommerce_thumbnail' ) . '</span>';
+		}
+
+		return '<span class="wc-block-product-categories-list-item__image">' . wp_get_attachment_image( $image_id, 'woocommerce_thumbnail' ) . '</span>';
 	}
 
 	/**


### PR DESCRIPTION
This is a refresh/rework of https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1190 that resolves feedback and makes some improvements.

On the frontend, I've made it use thumbnail size, added some CSS styling to improve appearance, and included placeholders for categories with no image. It looks like this compared to no-image view:

![Screenshot 2020-02-14 at 16 39 48](https://user-images.githubusercontent.com/90977/74550632-9c32c000-4f49-11ea-87d5-d4f503747ef5.png)

For the option itself, it only works with lists not drop-downs so I've made it appear conditionally like so:

![Screenshot 2020-02-14 at 16 44 27](https://user-images.githubusercontent.com/90977/74550556-7b6a6a80-4f49-11ea-8200-71bd33fbe7be.png)
![Screenshot 2020-02-14 at 16 44 33](https://user-images.githubusercontent.com/90977/74550562-7d342e00-4f49-11ea-9eaf-c81c3417d8db.png)

## How to test the changes in this Pull Request:

- Select a Product Categories List block in Gutenberg editor.
- Notice the new option 'Show category image' (disabled by default).
- Toggle the option, notice how the image is added and shown/not shown per category item.

## Changelog

> Add option for showing category image for Product Categories List block.

kudos @strarsis