### PR TITLE
Ensure travis is using php 7.3 for the linting job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
           script:
               - phpunit
         - name: PHP Linting Check
-          php: 7.1
+          php: 7.3
           env:
               - WP_TRAVISCI=phpcs
               - WOOCOMMERCE_BLOCKS_PHASE=experimental
@@ -69,19 +69,19 @@ jobs:
               - npm install
               - npm run test
           env:
-            - WOOCOMMERCE_BLOCKS_PHASE=experimental
+              - WOOCOMMERCE_BLOCKS_PHASE=experimental
         - name: Javascript/CSS Lint and Bundle Size Check
           script:
               - npm install
               - npm run build:ci
           env:
-            - WOOCOMMERCE_BLOCKS_PHASE=experimental
+              - WOOCOMMERCE_BLOCKS_PHASE=experimental
         - name: E2E Tests
           script:
-            - npm install
-            - npm run docker:up
-            - composer install
-            - npm run build:e2e-test
-            - npm run test:e2e
+              - npm install
+              - npm run docker:up
+              - composer install
+              - npm run build:e2e-test
+              - npm run test:e2e
           env:
-            - WOOCOMMERCE_BLOCKS_PHASE=experimental
+              - WOOCOMMERCE_BLOCKS_PHASE=experimental


### PR DESCRIPTION
We started experiencing failures on the php lint job for travis with the following error:

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Installation request for phpdocumentor/reflection-docblock 5.0.0 -> satisfiable by phpdocumentor/reflection-docblock[5.0.0].
    - phpdocumentor/reflection-docblock 5.0.0 requires php ^7.2 -> your PHP version (7.1.11) does not satisfy that requirement.
  Problem 2
    - phpspec/prophecy v1.10.2 requires phpdocumentor/reflection-docblock ^2.0|^3.0.2|^4.0|^5.0 -> satisfiable by phpdocumentor/reflection-docblock[5.0.0].
    - phpspec/prophecy v1.10.2 requires phpdocumentor/reflection-docblock ^2.0|^3.0.2|^4.0|^5.0 -> satisfiable by phpdocumentor/reflection-docblock[5.0.0].
    - phpdocumentor/reflection-docblock 5.0.0 requires php ^7.2 -> your PHP version (7.1.11) does not satisfy that requirement.
    - Installation request for phpspec/prophecy v1.10.2 -> satisfiable by phpspec/prophecy[v1.10.2].
```

In order to fix this we need to update the php version being used for the php lint checks.