### PR TITLE
update all block one-line descriptions to match documentation

### DIFF
--- a/assets/js/blocks/active-filters/index.js
+++ b/assets/js/blocks/active-filters/index.js
@@ -20,7 +20,7 @@ registerBlockType( 'woocommerce/active-filters', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a list of active product filters. Works in combination with the Filter Products by Price and Filter Products by Attribute blocks.',
+		'Show the currently active product filters. Works in combination with the All Products and filters blocks.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -20,7 +20,7 @@ registerBlockType( 'woocommerce/attribute-filter', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a list of filters based on a chosen product attribute. Works in combination with the All Products block.',
+		'Allow customers to filter the grid by product attribute, such as color. Works in combination with the All Products block.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -20,7 +20,7 @@ registerBlockType( 'woocommerce/price-filter', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a slider to filter products in your store by price. Works in combination with the All Products block.',
+		'Allow customers to filter the products by choosing a lower or upper price limit. Works in combination with the All Products block.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -21,7 +21,7 @@ registerBlockType( 'woocommerce/product-categories', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Show your product categories as a list or dropdown.',
+		'Show all product categories as a list or dropdown.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/product-on-sale/index.js
+++ b/assets/js/blocks/product-on-sale/index.js
@@ -24,7 +24,7 @@ registerBlockType( 'woocommerce/product-on-sale', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a grid of on sale products.',
+		'Display a grid of products currently on sale.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -23,7 +23,7 @@ registerBlockType( 'woocommerce/product-search', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Help visitors find your products.',
+		'A search box to allow customers to search for products by keyword.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -24,7 +24,7 @@ registerBlockType( 'woocommerce/product-tag', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a grid of products from your selected tags.',
+		'Display a grid of products with selected tags.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -24,7 +24,7 @@ registerBlockType( blockTypeName, {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display a grid of products from your selected attributes.',
+		'Display a grid of products with selected attributes.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/products/all-products/index.js
+++ b/assets/js/blocks/products/all-products/index.js
@@ -23,7 +23,7 @@ const blockSettings = {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display all products from your store as a grid.',
+		'Display products from your store in a grid layout.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/reviews/all-reviews/index.js
+++ b/assets/js/blocks/reviews/all-reviews/index.js
@@ -27,7 +27,7 @@ registerBlockType( 'woocommerce/all-reviews', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Shows a list of all product reviews.',
+		'Show a list of all product reviews.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/reviews/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews/reviews-by-product/index.js
@@ -25,7 +25,7 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Show reviews of your product to build trust.',
+		'Show reviews of your products to build trust.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {


### PR DESCRIPTION
This PR updates the description for each block (used in block inserter) to match the description used in the [documentation](https://docs.woocommerce.com/document/woocommerce-blocks/). ~~Also the old inline docs in readme.txt have been removed, and replaced with a link to official documentation.~~ See #1758 

See also #1749