### PR TITLE
Add catalog visibility arg to product query attributes

### DIFF
--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -52,7 +52,7 @@ const generateQuery = ( { sortValue, currentPage, attributes } ) => {
 	};
 	return {
 		...getSortArgs( sortValue ),
-		catalog_visibility: 'visible',
+		catalog_visibility: 'catalog',
 		per_page: columns * rows,
 		page: currentPage,
 	};

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -52,6 +52,7 @@ const generateQuery = ( { sortValue, currentPage, attributes } ) => {
 	};
 	return {
 		...getSortArgs( sortValue ),
+		catalog_visibility: 'visible',
 		per_page: columns * rows,
 		page: currentPage,
 	};


### PR DESCRIPTION
All Products block was showing "hidden" products in the results and in the product filters. We can define `catalog_visibility` to work around this since it's already supported in the API.

Fixes #1720

### How to test the changes in this Pull Request:

1. Create a very expensive product (way higher than other products) that is hidden (ref #1720)
2. See frontend shows this upper range in price filter, and the product is visible in results
3. Apply this PR. The upper price in price filter will not include this product, and this product will not be in the result set any longer.

<!-- If you can, add the appropriate labels -->

### Changelog

> Respect hidden products in All Products block.
