### PR TITLE
Implement browser autocomplete for checkout address fields

### DIFF
--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -15,6 +15,7 @@ const CountryInput = ( {
 	label,
 	onChange,
 	value = '',
+	autoComplete = 'off',
 } ) => {
 	const options = Object.keys( countries ).map( ( key ) => ( {
 		key,
@@ -22,13 +23,27 @@ const CountryInput = ( {
 	} ) );
 
 	return (
-		<Select
-			className={ className }
-			label={ label }
-			onChange={ onChange }
-			options={ options }
-			value={ options.find( ( option ) => option.key === value ) }
-		/>
+		<>
+			<Select
+				className={ className }
+				label={ label }
+				onChange={ onChange }
+				options={ options }
+				value={ options.find( ( option ) => option.key === value ) }
+			/>
+			<input
+				type="text"
+				aria-hidden={ true }
+				autoComplete={ autoComplete }
+				value={ value }
+				onChange={ ( event ) => onChange( event.target.value ) }
+				style={ {
+					height: '0',
+					border: '0',
+					padding: '0',
+				} }
+			/>
+		</>
 	);
 };
 
@@ -38,6 +53,7 @@ CountryInput.propTypes = {
 	className: PropTypes.string,
 	label: PropTypes.string,
 	value: PropTypes.string,
+	autoComplete: PropTypes.string,
 };
 
 export default CountryInput;

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -42,14 +42,13 @@ const CountryInput = ( {
 						const foundOption = options.find(
 							( option ) => option.key === textValue
 						);
-						if ( foundOption ) {
-							onChange( foundOption.key );
-						}
+						onChange( foundOption ? foundOption.key : '' );
 					} }
 					style={ {
 						height: '0',
 						border: '0',
 						padding: '0',
+						position: 'absolute',
 					} }
 				/>
 			) }

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -31,18 +31,28 @@ const CountryInput = ( {
 				options={ options }
 				value={ options.find( ( option ) => option.key === value ) }
 			/>
-			<input
-				type="text"
-				aria-hidden={ true }
-				autoComplete={ autoComplete }
-				value={ value }
-				onChange={ ( event ) => onChange( event.target.value ) }
-				style={ {
-					height: '0',
-					border: '0',
-					padding: '0',
-				} }
-			/>
+			{ autoComplete !== 'off' && (
+				<input
+					type="text"
+					aria-hidden={ true }
+					autoComplete={ autoComplete }
+					value={ value }
+					onChange={ ( event ) => {
+						const textValue = event.target.value;
+						const foundOption = options.find(
+							( option ) => option.key === textValue
+						);
+						if ( foundOption ) {
+							onChange( foundOption.key );
+						}
+					} }
+					style={ {
+						height: '0',
+						border: '0',
+						padding: '0',
+					} }
+				/>
+			) }
 		</>
 	);
 };

--- a/assets/js/base/components/shipping-calculator/address.js
+++ b/assets/js/base/components/shipping-calculator/address.js
@@ -19,7 +19,7 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 	const [ address, setAddress ] = useState( initialAddress );
 
 	return (
-		<div className="wc-block-shipping-calculator-address">
+		<form className="wc-block-shipping-calculator-address">
 			<ShippingCountryInput
 				className="wc-block-shipping-calculator-address__input"
 				label={ __(
@@ -32,7 +32,6 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 					setAddress( {
 						...address,
 						country: newValue,
-						state: '',
 					} )
 				}
 			/>
@@ -80,7 +79,7 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 			>
 				{ __( 'Update', 'woo-gutenberg-products-block' ) }
 			</Button>
-		</div>
+		</form>
 	);
 };
 

--- a/assets/js/base/components/shipping-calculator/address.js
+++ b/assets/js/base/components/shipping-calculator/address.js
@@ -22,7 +22,10 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 		<div className="wc-block-shipping-calculator-address">
 			<ShippingCountryInput
 				className="wc-block-shipping-calculator-address__input"
-				label={ __( 'Country', 'woo-gutenberg-products-block' ) }
+				label={ __(
+					'Country / Region',
+					'woo-gutenberg-products-block'
+				) }
 				value={ address.country }
 				autoComplete="country"
 				onChange={ ( newValue ) =>

--- a/assets/js/base/components/shipping-calculator/address.js
+++ b/assets/js/base/components/shipping-calculator/address.js
@@ -22,11 +22,9 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 		<div className="wc-block-shipping-calculator-address">
 			<ShippingCountryInput
 				className="wc-block-shipping-calculator-address__input"
-				label={ __(
-					'Country / Region',
-					'woo-gutenberg-products-block'
-				) }
+				label={ __( 'Country', 'woo-gutenberg-products-block' ) }
 				value={ address.country }
+				autoComplete="country"
 				onChange={ ( newValue ) =>
 					setAddress( {
 						...address,
@@ -40,6 +38,7 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 				country={ address.country }
 				label={ __( 'State / County', 'woo-gutenberg-products-block' ) }
 				value={ address.state }
+				autoComplete="address-level1"
 				onChange={ ( newValue ) =>
 					setAddress( {
 						...address,
@@ -51,6 +50,7 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 				className="wc-block-shipping-calculator-address__input"
 				label={ __( 'City', 'woo-gutenberg-products-block' ) }
 				value={ address.city }
+				autoComplete="address-level2"
 				onChange={ ( newValue ) =>
 					setAddress( {
 						...address,
@@ -62,6 +62,7 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 				className="wc-block-shipping-calculator-address__input"
 				label={ __( 'Postal code', 'woo-gutenberg-products-block' ) }
 				value={ address.postcode }
+				autoComplete="postal-code"
 				onChange={ ( newValue ) =>
 					setAddress( {
 						...address,

--- a/assets/js/base/components/shipping-calculator/address.js
+++ b/assets/js/base/components/shipping-calculator/address.js
@@ -32,6 +32,7 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 					setAddress( {
 						...address,
 						country: newValue,
+						state: '',
 					} )
 				}
 			/>

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -50,24 +50,15 @@ const StateInput = ( {
 		[ onChange, options ]
 	);
 
-	return (
+	return options.length > 0 ? (
 		<>
-			{ options.length > 0 ? (
-				<Select
-					className={ className }
-					label={ label }
-					onChange={ onChangeState }
-					options={ options }
-					value={ options.find( ( option ) => option.key === value ) }
-				/>
-			) : (
-				<TextInput
-					className={ className }
-					label={ label }
-					onChange={ onChangeState }
-					value={ value }
-				/>
-			) }
+			<Select
+				className={ className }
+				label={ label }
+				onChange={ onChangeState }
+				options={ options }
+				value={ options.find( ( option ) => option.key === value ) }
+			/>
 			{ autoComplete !== 'off' && (
 				<input
 					type="text"
@@ -86,6 +77,14 @@ const StateInput = ( {
 				/>
 			) }
 		</>
+	) : (
+		<TextInput
+			className={ className }
+			label={ label }
+			onChange={ onChangeState }
+			autoComplete={ autoComplete }
+			value={ value }
+		/>
 	);
 };
 

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -16,6 +16,7 @@ const StateInput = ( {
 	country,
 	label,
 	onChange,
+	autoComplete = 'off',
 	value = '',
 } ) => {
 	const countryCounties = counties[ country ];
@@ -25,6 +26,7 @@ const StateInput = ( {
 				className={ className }
 				label={ label }
 				onChange={ onChange }
+				autoComplete={ autoComplete }
 				value={ value }
 			/>
 		);
@@ -41,6 +43,7 @@ const StateInput = ( {
 			label={ label }
 			onChange={ onChange }
 			options={ options }
+			autoComplete={ autoComplete }
 			value={ options.find( ( option ) => option.key === value ) }
 		/>
 	);
@@ -54,6 +57,7 @@ StateInput.propTypes = {
 		] )
 	).isRequired,
 	onChange: PropTypes.func.isRequired,
+	autoComplete: PropTypes.string,
 	className: PropTypes.string,
 	country: PropTypes.string,
 	label: PropTypes.string,

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,32 +21,70 @@ const StateInput = ( {
 	value = '',
 } ) => {
 	const countryCounties = counties[ country ];
-	if ( ! countryCounties || Object.keys( countryCounties ).length === 0 ) {
-		return (
-			<TextInput
-				className={ className }
-				label={ label }
-				onChange={ onChange }
-				autoComplete={ autoComplete }
-				value={ value }
-			/>
-		);
-	}
+	const options =
+		countryCounties && Object.keys( countryCounties ).length > 0
+			? Object.keys( countryCounties ).map( ( key ) => ( {
+					key,
+					name: decodeEntities( countryCounties[ key ] ),
+			  } ) )
+			: [];
 
-	const options = Object.keys( countryCounties ).map( ( key ) => ( {
-		key,
-		name: decodeEntities( countryCounties[ key ] ),
-	} ) );
+	/**
+	 * Handles state selection onChange events. Finds a matching state by key or value.
+	 *
+	 * @param {Object} event event data.
+	 */
+	const onChangeState = useCallback(
+		( stateValue ) => {
+			if ( options.length > 0 ) {
+				const foundOption = options.find(
+					( option ) =>
+						option.key === stateValue || option.name === stateValue
+				);
+
+				onChange( foundOption ? foundOption.key : '' );
+				return;
+			}
+			onChange( stateValue );
+		},
+		[ onChange, options ]
+	);
 
 	return (
-		<Select
-			className={ className }
-			label={ label }
-			onChange={ onChange }
-			options={ options }
-			autoComplete={ autoComplete }
-			value={ options.find( ( option ) => option.key === value ) }
-		/>
+		<>
+			{ options.length > 0 ? (
+				<Select
+					className={ className }
+					label={ label }
+					onChange={ onChangeState }
+					options={ options }
+					value={ options.find( ( option ) => option.key === value ) }
+				/>
+			) : (
+				<TextInput
+					className={ className }
+					label={ label }
+					onChange={ onChangeState }
+					value={ value }
+				/>
+			) }
+			{ autoComplete !== 'off' && (
+				<input
+					type="text"
+					aria-hidden={ true }
+					autoComplete={ autoComplete }
+					value={ value }
+					onChange={ ( event ) =>
+						onChangeState( event.target.value )
+					}
+					style={ {
+						height: '0',
+						border: '0',
+						padding: '0',
+					} }
+				/>
+			) }
+		</>
 	);
 };
 

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -81,6 +81,7 @@ const StateInput = ( {
 						height: '0',
 						border: '0',
 						padding: '0',
+						position: 'absolute',
 					} }
 				/>
 			) }

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -36,15 +36,6 @@ const TextInput = ( {
 				'is-active': isActive || value,
 			} ) }
 		>
-			<Label
-				label={ label }
-				screenReaderLabel={ screenReaderLabel || label }
-				wrapperElement="label"
-				wrapperProps={ {
-					htmlFor: textInputId,
-				} }
-				htmlFor={ textInputId }
-			/>
 			<input
 				type={ type }
 				id={ textInputId }
@@ -58,6 +49,15 @@ const TextInput = ( {
 				aria-describedby={
 					!! help ? textInputId + '__help' : undefined
 				}
+			/>
+			<Label
+				label={ label }
+				screenReaderLabel={ screenReaderLabel || label }
+				wrapperElement="label"
+				wrapperProps={ {
+					htmlFor: textInputId,
+				} }
+				htmlFor={ textInputId }
 			/>
 			{ !! help && (
 				<p

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -28,7 +28,7 @@ const TextInput = ( {
 } ) => {
 	const [ isActive, setIsActive ] = useState( false );
 	const onChangeValue = ( event ) => onChange( event.target.value );
-	const textInputId = id || componentId;
+	const textInputId = id || 'textinput-' + componentId;
 
 	return (
 		<div

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -80,6 +80,7 @@ TextInput.propTypes = {
 	screenReaderLabel: PropTypes.string,
 	disabled: PropTypes.bool,
 	help: PropTypes.string,
+	autoComplete: PropTypes.string,
 };
 
 export default withComponentId( TextInput );

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -22,6 +22,7 @@ const TextInput = ( {
 	screenReaderLabel,
 	disabled,
 	help,
+	autoComplete = 'off',
 	value = '',
 	onChange,
 } ) => {
@@ -48,6 +49,7 @@ const TextInput = ( {
 				type={ type }
 				id={ textInputId }
 				value={ value }
+				autoComplete={ autoComplete }
 				onChange={ onChangeValue }
 				onFocus={ () => setIsActive( true ) }
 				onBlur={ () => setIsActive( false ) }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -6,6 +6,7 @@
 .wc-block-text-input label {
 	position: absolute;
 	transform: translateY(#{$gap-small});
+	left: 0;
 	transform-origin: top left;
 	font-size: 16px;
 	line-height: 22px;
@@ -20,7 +21,9 @@
 		transition: none;
 	}
 }
-
+.wc-block-text-input input:-webkit-autofill + label {
+	transform: translateY(#{$gap-smallest}) scale(0.75);
+}
 .wc-block-text-input.is-active label {
 	transform: translateY(#{$gap-smallest}) scale(0.75);
 }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -72,6 +72,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 							'woo-gutenberg-products-block'
 						) }
 						value={ contactFields.email }
+						autoComplete="email"
 						onChange={ ( newValue ) =>
 							setContactFields( {
 								...contactFields,
@@ -114,6 +115,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							value={ shippingFields.firstName }
+							autoComplete="given-name"
 							onChange={ ( newValue ) =>
 								setShippingFields( {
 									...shippingFields,
@@ -127,6 +129,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							value={ shippingFields.lastName }
+							autoComplete="family-name"
 							onChange={ ( newValue ) =>
 								setShippingFields( {
 									...shippingFields,
@@ -141,6 +144,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 							'woo-gutenberg-products-block'
 						) }
 						value={ shippingFields.streetAddress }
+						autoComplete="address-line1"
 						onChange={ ( newValue ) =>
 							setShippingFields( {
 								...shippingFields,
@@ -154,6 +158,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 							'woo-gutenberg-products-block'
 						) }
 						value={ shippingFields.apartment }
+						autoComplete="address-line2"
 						onChange={ ( newValue ) =>
 							setShippingFields( {
 								...shippingFields,
@@ -164,10 +169,11 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 					<InputRow>
 						<ShippingCountryInput
 							label={ __(
-								'Country / Region',
+								'Country',
 								'woo-gutenberg-products-block'
 							) }
 							value={ shippingFields.country }
+							autoComplete="country"
 							onChange={ ( newValue ) =>
 								setShippingFields( {
 									...shippingFields,
@@ -182,6 +188,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							value={ shippingFields.city }
+							autoComplete="address-level2"
 							onChange={ ( newValue ) =>
 								setShippingFields( {
 									...shippingFields,
@@ -198,6 +205,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							value={ shippingFields.state }
+							autoComplete="address-level1"
 							onChange={ ( newValue ) =>
 								setShippingFields( {
 									...shippingFields,
@@ -211,6 +219,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							value={ shippingFields.postcode }
+							autoComplete="postal-code"
 							onChange={ ( newValue ) =>
 								setShippingFields( {
 									...shippingFields,
@@ -223,6 +232,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 						type="tel"
 						label={ __( 'Phone', 'woo-gutenberg-products-block' ) }
 						value={ shippingFields.phone }
+						autoComplete="tel"
 						onChange={ ( newValue ) =>
 							setShippingFields( {
 								...shippingFields,

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -178,6 +178,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								setShippingFields( {
 									...shippingFields,
 									country: newValue,
+									state: '',
 								} )
 							}
 						/>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -169,7 +169,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 					<InputRow>
 						<ShippingCountryInput
 							label={ __(
-								'Country',
+								'Country / Region',
 								'woo-gutenberg-products-block'
 							) }
 							value={ shippingFields.country }
@@ -178,7 +178,6 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								setShippingFields( {
 									...shippingFields,
 									country: newValue,
-									state: '',
 								} )
 							}
 						/>


### PR DESCRIPTION
This PR adds autocomplete attributes to address inputs on the checkout and shipping calculator forms.

The select fields (country and state) needed special handling due to them not using real form inputs. I made a 'hidden' input which can have the autocomplete value set which triggers an onChange event to set the correct value. These cannot be totally hidden because browser autocomplete does not work on hidden fields.

Fixes #1562

### How to test the changes in this Pull Request:

1. Go to block checkout in chrome
2. Double click an address field, then choose a saved address. 
3. Fields should auto-fill

Note the values do overlap the labels somewhat due to the overfancy label CSS there. This might be fixable in a follow up but I'm not sure how possible, and having autofill working IMO is more important.
