### PR TITLE
fix cart api total_price value

### DIFF
--- a/src/RestApi/StoreApi/Schemas/CartSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartSchema.php
@@ -173,6 +173,8 @@ class CartSchema extends AbstractSchema {
 	public function get_item_response( $cart ) {
 		$cart_coupon_schema = new CartCouponSchema();
 		$cart_item_schema   = new CartItemSchema();
+		$context            = 'edit';
+
 		return [
 			'coupons'        => array_values( array_map( [ $cart_coupon_schema, 'get_item_response' ], array_filter( $cart->get_applied_coupons() ) ) ),
 			'items'          => array_values( array_map( [ $cart_item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
@@ -190,7 +192,9 @@ class CartSchema extends AbstractSchema {
 					'total_discount_tax' => $this->prepare_money_response( $cart->get_discount_tax(), wc_get_price_decimals() ),
 					'total_shipping'     => $this->prepare_money_response( $cart->get_shipping_total(), wc_get_price_decimals() ),
 					'total_shipping_tax' => $this->prepare_money_response( $cart->get_shipping_tax(), wc_get_price_decimals() ),
-					'total_price'        => $this->prepare_money_response( $cart->get_total(), wc_get_price_decimals() ),
+
+					// Explicitly request context='edit'; default ('view') will render total as markup.
+					'total_price'        => $this->prepare_money_response( $cart->get_total( $context ), wc_get_price_decimals() ),
 					'total_tax'          => $this->prepare_money_response( $cart->get_total_tax(), wc_get_price_decimals() ),
 					'tax_lines'          => $this->get_tax_lines( $cart ),
 				]


### PR DESCRIPTION
Fixes #1748

Fixes an issue with the total price value. This was returning the total cart price with "36" prepended, e.g. if the cart total was $225 (`22500` as money value) then the total_price was `3622500`.

The issue was caused by the woo core cart `get_total()` rendering the total to HTML, which was not the format expected by `prepare_money_value`. Fixed by passing `edit` context to `get_total()`.

### How to test the changes in this Pull Request:

1. Add some stuff to cart.
2. Call store cart API, e.g. `http://localhost:8222/index.php?rest_route=%2Fwc%2Fstore%2Fcart&_locale=user`
3. Check total price - should be correct (in "money value" format, i.e. cents if currency is USD).


