### PR TITLE
Shipping rates: decode entities

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -17,6 +17,7 @@ import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import { Card, CardBody } from 'wordpress-components';
 import { previewCartItems } from '@woocommerce/resource-previews';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -198,7 +199,7 @@ const Cart = () => {
 								) }
 								selected={ selectedShippingRate }
 								renderOption={ ( option ) => ( {
-									label: option.name,
+									label: decodeEntities( option.name ),
 									value: option.rate_id,
 									description: (
 										<Fragment>
@@ -214,7 +215,9 @@ const Cart = () => {
 											option.delivery_time
 												? ' — '
 												: null }
-											{ option.delivery_time }
+											{ decodeEntities(
+												option.delivery_time
+											) }
 										</Fragment>
 									),
 								} ) }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -19,6 +19,7 @@ import {
 	ExpressCheckoutFormControl,
 	PaymentMethods,
 } from '@woocommerce/base-components/payment-methods';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -286,9 +287,11 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 								} )
 							}
 							renderOption={ ( option ) => ( {
-								label: option.name,
+								label: decodeEntities( option.name ),
 								value: option.rate_id,
-								description: option.description,
+								description: decodeEntities(
+									option.description
+								),
 								secondaryLabel: (
 									<FormattedMonetaryAmount
 										currency={ getCurrencyFromPriceResponse(
@@ -297,7 +300,9 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 										value={ option.price }
 									/>
 								),
-								secondaryDescription: option.delivery_time,
+								secondaryDescription: decodeEntities(
+									option.delivery_time
+								),
 							} ) }
 							selected={ shippingMethod.methods }
 						/>


### PR DESCRIPTION
Fixes #1759.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/74719969-49048a00-5235-11ea-81f5-dffb5a0349b9.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/74719909-2ecaac00-5235-11ea-8512-2e8df77b893a.png)

### How to test the changes in this Pull Request:

1. Add a shipping method with special characters e.g. dash, `Flat rate - 'rest of world'`.
2. Add items to cart.
3. Add cart block to a page
4. View cart and select shipping method.
5. Verify shipping method label is decoded.