### PR TITLE
remove all Fragments and their import and change to <>

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ module.exports = {
 		'@wordpress/dependency-group': 'off',
 		'woocommerce/dependency-group': 'error',
 		'woocommerce/feature-flag': 'error',
+		'react/jsx-fragments': [ 'error', 'syntax' ],
 		'valid-jsdoc': 'off',
 		radix: 'error',
 		yoda: [ 'error', 'never' ],

--- a/assets/js/atomic/blocks/product/image/index.js
+++ b/assets/js/atomic/blocks/product/image/index.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, image } from '@woocommerce/icons';
-import { Fragment } from '@wordpress/element';
 import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import ToggleButtonControl from '@woocommerce/block-components/toggle-button-control';
@@ -49,7 +48,7 @@ const blockConfig = {
 		const { productLink, showSaleBadge, saleBadgeAlign } = attributes;
 
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody
 						title={ __(
@@ -134,7 +133,7 @@ const blockConfig = {
 						saleBadgeAlign={ saleBadgeAlign }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	},
 };

--- a/assets/js/atomic/blocks/product/title/index.js
+++ b/assets/js/atomic/blocks/product/title/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { Fragment } from 'react';
 import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ProductTitle } from '@woocommerce/atomic-components/product';
@@ -50,7 +49,7 @@ const blockConfig = {
 		const { headingLevel, productLink } = attributes;
 
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody
 						title={ __(
@@ -93,7 +92,7 @@ const blockConfig = {
 						product={ attributes.product }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	},
 };

--- a/assets/js/atomic/components/product/image/index.js
+++ b/assets/js/atomic/components/product/image/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import classnames from 'classnames';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/block-settings';
 import { useProductLayoutContext } from '@woocommerce/base-context/product-layout-context';
@@ -25,7 +25,7 @@ const Image = ( { layoutPrefix, loaded, image, onLoad } ) => {
 	} );
 	const { thumbnail, srcset, sizes, alt } = image || {};
 	return (
-		<Fragment>
+		<>
 			{ image && (
 				<img
 					className={ cssClass }
@@ -44,7 +44,7 @@ const Image = ( { layoutPrefix, loaded, image, onLoad } ) => {
 					alt=""
 				/>
 			) }
-		</Fragment>
+		</>
 	);
 };
 
@@ -61,7 +61,7 @@ const ProductImage = ( {
 		product.images && product.images.length ? product.images[ 0 ] : null;
 
 	const renderedSalesAndImage = (
-		<Fragment>
+		<>
 			<SaleBadge
 				product={ product }
 				saleBadgeAlign={ saleBadgeAlign }
@@ -73,7 +73,7 @@ const ProductImage = ( {
 				image={ image }
 				onLoad={ () => setImageLoaded( true ) }
 			/>
-		</Fragment>
+		</>
 	);
 
 	return (

--- a/assets/js/base/components/block-error-boundary/index.js
+++ b/assets/js/base/components/block-error-boundary/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
+import { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -20,10 +20,10 @@ class BlockErrorBoundary extends Component {
 		) {
 			return {
 				errorMessage: (
-					<Fragment>
+					<>
 						<strong>{ error.status }</strong>:&nbsp;
 						{ error.statusText }
-					</Fragment>
+					</>
 				),
 				hasError: true,
 			};

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -100,7 +100,7 @@ const CheckboxList = ( {
 		const optionCount = options.length;
 		const shouldTruncateOptions = optionCount > limit + 5;
 		return (
-			<Fragment>
+			<>
 				{ options.map( ( option, index ) => (
 					<Fragment key={ option.value }>
 						<li
@@ -128,7 +128,7 @@ const CheckboxList = ( {
 					</Fragment>
 				) ) }
 				{ shouldTruncateOptions && renderedShowLess }
-			</Fragment>
+			</>
 		);
 	}, [
 		options,

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Fragment } from 'react';
 import classNames from 'classnames';
+import React from 'react';
 
 /**
  * Component used to render an accessible text given a label and/or a
@@ -35,7 +35,7 @@ const Label = ( {
 		return <Wrapper { ...wrapperProps }>{ screenReaderLabel }</Wrapper>;
 	}
 
-	Wrapper = wrapperElement || Fragment;
+	Wrapper = wrapperElement || React.Fragment;
 
 	if ( hasLabel && hasScreenReaderLabel && label !== screenReaderLabel ) {
 		return (

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	Fragment,
 	useState,
 	useEffect,
 	useCallback,
@@ -291,7 +290,7 @@ const PriceSlider = ( {
 			</div>
 			<div className="wc-block-price-filter__controls">
 				{ showInputFields && (
-					<Fragment>
+					<>
 						<FormattedMonetaryAmount
 							currency={ currency }
 							displayType="input"
@@ -328,7 +327,7 @@ const PriceSlider = ( {
 							disabled={ isLoading || ! hasValidConstraints }
 							value={ maxPriceInput }
 						/>
-					</Fragment>
+					</>
 				) }
 				{ ! showInputFields &&
 					! isLoading &&

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,7 +19,7 @@ const Package = ( {
 	showItems,
 } ) => {
 	return (
-		<Fragment>
+		<>
 			<PackageOptions
 				className={ className }
 				noResultsMessage={ noResultsMessage }
@@ -36,7 +35,7 @@ const Package = ( {
 					{ shippingRate.items.join( ', ' ) }
 				</span>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/base/hocs/with-scroll-to-top/index.js
+++ b/assets/js/base/hocs/with-scroll-to-top/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Component, createRef, Fragment } from 'react';
+import { Component, createRef } from 'react';
 
 /**
  * Internal dependencies
@@ -54,7 +54,7 @@ const withScrollToTop = ( OriginalComponent ) => {
 
 		render() {
 			return (
-				<Fragment>
+				<>
 					<div
 						className="with-scroll-to-top__scroll-point"
 						ref={ this.scrollPointRef }
@@ -64,7 +64,7 @@ const withScrollToTop = ( OriginalComponent ) => {
 						{ ...this.props }
 						scrollToTop={ this.scrollToTop }
 					/>
-				</Fragment>
+				</>
 			);
 		}
 	}

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useQueryStateByKey } from '@woocommerce/base-hooks';
-import { useMemo, Fragment } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
@@ -79,14 +79,14 @@ const ActiveFiltersBlock = ( {
 	} );
 
 	return (
-		<Fragment>
+		<>
 			{ ! isEditor && blockAttributes.heading && (
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
 			<div className="wc-block-active-filters">
 				<ul className={ listClasses }>
 					{ isEditor ? (
-						<Fragment>
+						<>
 							{ renderRemovableListItem( {
 								type: __(
 									'Size',
@@ -107,12 +107,12 @@ const ActiveFiltersBlock = ( {
 									'woo-gutenberg-products-block'
 								),
 							} ) }
-						</Fragment>
+						</>
 					) : (
-						<Fragment>
+						<>
 							{ activePriceFilters }
 							{ activeAttributeFilters }
-						</Fragment>
+						</>
 					) }
 				</ul>
 				<button
@@ -135,7 +135,7 @@ const ActiveFiltersBlock = ( {
 					/>
 				</button>
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { formatPrice } from '@woocommerce/base-utils';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Format a min/max price range to display.
@@ -64,11 +63,11 @@ export const renderRemovableListItem = ( {
 			) }
 			<span className="wc-block-active-filters__list-item-name">
 				{ prefix ? (
-					<Fragment>
+					<>
 						{ prefix }
 						&nbsp;
 						{ name }
-					</Fragment>
+					</>
 				) : (
 					name
 				) }

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -10,13 +10,7 @@ import {
 	useCollectionData,
 	useShallowEqual,
 } from '@woocommerce/base-hooks';
-import {
-	useCallback,
-	Fragment,
-	useEffect,
-	useState,
-	useMemo,
-} from '@wordpress/element';
+import { useCallback, useEffect, useState, useMemo } from '@wordpress/element';
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
 import DropdownSelector from '@woocommerce/base-components/dropdown-selector';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
@@ -323,7 +317,7 @@ const AttributeFilterBlock = ( {
 	const isDisabled = ! blockAttributes.isPreview && filteredCountsLoading;
 
 	return (
-		<Fragment>
+		<>
 			{ ! isEditor && blockAttributes.heading && (
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
@@ -357,7 +351,7 @@ const AttributeFilterBlock = ( {
 					/>
 				) }
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Fragment, useState, useCallback } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import {
 	Placeholder,
@@ -380,7 +380,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	return Object.keys( ATTRIBUTES ).length === 0 ? (
 		noAttributesPlaceholder()
 	) : (
-		<Fragment>
+		<>
 			{ getBlockControls() }
 			{ getInspectorControls() }
 			{ isEditing ? (
@@ -399,7 +399,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 					</Disabled>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/attribute-filter/label.js
+++ b/assets/js/blocks/attribute-filter/label.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import Label from '@woocommerce/base-components/label';
 
 /**
@@ -10,7 +9,7 @@ import Label from '@woocommerce/base-components/label';
  */
 const AttributeFilterLabel = ( { name, count } ) => {
 	return (
-		<Fragment>
+		<>
 			{ name }
 			{ Number.isFinite( count ) && (
 				<Label
@@ -31,7 +30,7 @@ const AttributeFilterLabel = ( { name, count } ) => {
 					} }
 				/>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Disabled } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { withFeedbackPrompt } from '@woocommerce/block-hocs';
 import ViewSwitcher from '@woocommerce/block-components/view-switcher';
@@ -37,14 +36,14 @@ const CartEditor = ( { className } ) => {
 				] }
 				defaultView={ 'full' }
 				render={ ( currentView ) => (
-					<Fragment>
+					<>
 						{ currentView === 'full' && (
 							<Disabled>
 								<FullCart />
 							</Disabled>
 						) }
 						<EmptyCart hidden={ currentView === 'full' } />
-					</Fragment>
+					</>
 				) }
 			/>
 		</div>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/checkout-button/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/checkout-button/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import Button from '@woocommerce/base-components/button';
 import { CHECKOUT_URL } from '@woocommerce/block-settings';
 
@@ -18,7 +17,7 @@ import { MastercardLogo, VisaLogo } from './payment-logos'; // @todo we want to 
  */
 const CheckoutButton = () => {
 	return (
-		<Fragment>
+		<>
 			<Button
 				className="wc-block-cart__submit-button"
 				href={ CHECKOUT_URL }
@@ -30,7 +29,7 @@ const CheckoutButton = () => {
 				<AmericanExpressLogo />
 				<VisaLogo />
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, Fragment } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	TotalsCouponCodeInput,
 	TotalsItem,
@@ -118,7 +118,7 @@ const Cart = () => {
 				? totalShipping + totalShippingTax
 				: totalShipping,
 			description: (
-				<Fragment>
+				<>
 					{ __(
 						'Shipping to location',
 						'woo-gutenberg-products-block'
@@ -127,7 +127,7 @@ const Cart = () => {
 						address={ shippingCalculatorAddress }
 						setAddress={ setShippingCalculatorAddress }
 					/>
-				</Fragment>
+				</>
 			),
 		} );
 
@@ -201,7 +201,7 @@ const Cart = () => {
 									label: option.name,
 									value: option.rate_id,
 									description: (
-										<Fragment>
+										<>
 											{ option.price && (
 												<FormattedMonetaryAmount
 													currency={ getCurrencyFromPriceResponse(
@@ -215,7 +215,7 @@ const Cart = () => {
 												? ' — '
 												: null }
 											{ option.delivery_time }
-										</Fragment>
+										</>
 									),
 								} ) }
 								onChange={ ( newSelectedShippingOption ) =>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import FormStep from '@woocommerce/base-components/checkout/form-step';
 import CheckoutForm from '@woocommerce/base-components/checkout/form';
@@ -51,7 +51,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 					) }
 					stepNumber={ 1 }
 					stepHeadingContent={ () => (
-						<Fragment>
+						<>
 							{ __(
 								'Already have an account? ',
 								'woo-gutenberg-products-block'
@@ -62,7 +62,7 @@ const Block = ( { shippingMethods = [], isEditor = false } ) => {
 									'woo-gutenberg-products-block'
 								) }
 							</a>
-						</Fragment>
+						</>
 					) }
 				>
 					<TextInput

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -27,7 +27,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import classnames from 'classnames';
-import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { MIN_HEIGHT } from '@woocommerce/block-settings';
@@ -146,7 +145,7 @@ const FeaturedCategory = ( {
 					] }
 				>
 					{ !! url && (
-						<Fragment>
+						<>
 							<RangeControl
 								label={ __(
 									'Background Opacity',
@@ -170,7 +169,7 @@ const FeaturedCategory = ( {
 									}
 								/>
 							) }
-						</Fragment>
+						</>
 					) }
 				</PanelColorSettings>
 			</InspectorControls>
@@ -362,11 +361,11 @@ const FeaturedCategory = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls() }
 			{ getInspectorControls() }
 			{ category ? renderCategory() : renderNoCategory() }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -27,7 +27,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import classnames from 'classnames';
-import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -82,7 +81,7 @@ const FeaturedProduct = ( {
 		};
 
 		return (
-			<Fragment>
+			<>
 				{ getBlockControls() }
 				<Placeholder
 					icon={ <Icon srcElement={ star } /> }
@@ -114,7 +113,7 @@ const FeaturedProduct = ( {
 						</Button>
 					</div>
 				</Placeholder>
-			</Fragment>
+			</>
 		);
 	};
 
@@ -217,7 +216,7 @@ const FeaturedProduct = ( {
 					] }
 				>
 					{ !! url && (
-						<Fragment>
+						<>
 							<RangeControl
 								label={ __(
 									'Background Opacity',
@@ -241,7 +240,7 @@ const FeaturedProduct = ( {
 									}
 								/>
 							) }
-						</Fragment>
+						</>
 					) }
 				</PanelColorSettings>
 			</InspectorControls>
@@ -405,11 +404,11 @@ const FeaturedProduct = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls() }
 			{ getInspectorControls() }
 			{ product ? renderProduct() : renderNoProduct() }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -17,7 +17,7 @@ import {
 	withSpokenMessages,
 	ToggleControl,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { MAX_COLUMNS, MIN_COLUMNS } from '@woocommerce/block-settings';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
@@ -165,7 +165,7 @@ class ProductsBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar
 						controls={ [
@@ -190,7 +190,7 @@ class ProductsBlock extends Component {
 						/>
 					</Disabled>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -6,7 +6,7 @@ import {
 	useQueryStateByContext,
 	useCollectionData,
 } from '@woocommerce/base-hooks';
-import { Fragment, useCallback, useState, useEffect } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import PriceSlider from '@woocommerce/base-components/price-slider';
 import { useDebouncedCallback } from 'use-debounce';
 import PropTypes from 'prop-types';
@@ -107,7 +107,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 	const TagName = `h${ attributes.headingLevel }`;
 
 	return (
-		<Fragment>
+		<>
 			{ ! isEditor && attributes.heading && (
 				<TagName>{ attributes.heading }</TagName>
 			) }
@@ -125,7 +125,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 					isLoading={ isLoading }
 				/>
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Placeholder,
@@ -153,7 +152,7 @@ export default function( { attributes, setAttributes } ) {
 	);
 
 	return (
-		<Fragment>
+		<>
 			{ PRODUCT_COUNT === 0 ? (
 				noProductsPlaceholder()
 			) : (
@@ -171,6 +170,6 @@ export default function( { attributes, setAttributes } ) {
 					</Disabled>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 }

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
@@ -81,7 +81,7 @@ class ProductBestSellersBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -89,7 +89,7 @@ class ProductBestSellersBlock extends Component {
 						attributes={ attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
@@ -145,14 +144,14 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	};
 
 	return (
-		<Fragment>
+		<>
 			{ getInspectorControls() }
 			<ServerSideRender
 				block={ name }
 				attributes={ attributes }
 				EmptyResponsePlaceholder={ EmptyPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -15,7 +15,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
@@ -282,7 +282,7 @@ class ProductByCategoryBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar
 						controls={ [
@@ -300,7 +300,7 @@ class ProductByCategoryBlock extends Component {
 				</BlockControls>
 				{ this.getInspectorControls() }
 				{ isEditing ? this.renderEditMode() : this.renderViewMode() }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
@@ -81,7 +81,7 @@ class ProductNewestBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -89,7 +89,7 @@ class ProductNewestBlock extends Component {
 						attributes={ attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody, Placeholder } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
@@ -106,7 +106,7 @@ class ProductOnSaleBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -115,7 +115,7 @@ class ProductOnSaleBlock extends Component {
 						EmptyResponsePlaceholder={ EmptyPlaceholder }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { InspectorControls } from '@wordpress/editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { Icon, search } from '@woocommerce/icons';
 /**
  * Internal dependencies
@@ -82,7 +81,7 @@ registerBlockType( 'woocommerce/product-search', {
 		const { attributes, setAttributes } = props;
 		const { hasLabel } = attributes;
 		return (
-			<Fragment>
+			<>
 				<InspectorControls key="inspector">
 					<PanelBody
 						title={ __(
@@ -115,7 +114,7 @@ registerBlockType( 'woocommerce/product-search', {
 					</PanelBody>
 				</InspectorControls>
 				<Block { ...props } isEditor={ true } />
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -15,7 +15,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { HAS_TAGS } from '@woocommerce/block-settings';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
@@ -264,9 +264,9 @@ class ProductsByTagBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ HAS_TAGS ? (
-					<Fragment>
+					<>
 						<BlockControls>
 							<Toolbar
 								controls={ [
@@ -286,7 +286,7 @@ class ProductsByTagBlock extends Component {
 						{ isEditing
 							? this.renderEditMode()
 							: this.renderViewMode() }
-					</Fragment>
+					</>
 				) : (
 					<Placeholder
 						icon={
@@ -307,7 +307,7 @@ class ProductsByTagBlock extends Component {
 						) }
 					</Placeholder>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls, ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
@@ -81,7 +81,7 @@ class ProductTopRatedBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -89,7 +89,7 @@ class ProductTopRatedBlock extends Component {
 						attributes={ attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -15,7 +15,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Icon, tags } from '@woocommerce/icons';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
@@ -165,7 +165,7 @@ class ProductsByAttributeBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar
 						controls={ [
@@ -190,7 +190,7 @@ class ProductsByAttributeBlock extends Component {
 						/>
 					</Disabled>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/reviews/all-reviews/edit.js
+++ b/assets/js/blocks/reviews/all-reviews/edit.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { Icon, discussion } from '@woocommerce/icons';
 
@@ -58,7 +57,7 @@ const AllReviewsEditor = ( { attributes, setAttributes } ) => {
 	};
 
 	return (
-		<Fragment>
+		<>
 			{ getInspectorControls() }
 			<EditorContainerBlock
 				attributes={ attributes }
@@ -72,7 +71,7 @@ const AllReviewsEditor = ( { attributes, setAttributes } ) => {
 				name={ __( 'All Reviews', 'woo-gutenberg-products-block' ) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { REVIEW_RATINGS_ENABLED } from '@woocommerce/block-settings';
 import LoadMoreButton from '@woocommerce/base-components/load-more-button';
@@ -27,7 +26,7 @@ const FrontendBlock = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ attributes.showOrderby !== 'false' && REVIEW_RATINGS_ENABLED && (
 				<ReviewSortSelect
 					defaultValue={ orderby }
@@ -45,7 +44,7 @@ const FrontendBlock = ( {
 						) }
 					/>
 				) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -11,7 +11,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/components';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import ProductCategoryControl from '@woocommerce/block-components/product-category-control';
 import { Icon, review } from '@woocommerce/icons';
@@ -168,7 +167,7 @@ const ReviewsByCategoryEditor = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls( editMode, setAttributes ) }
 			{ getInspectorControls() }
 			<EditorContainerBlock
@@ -186,7 +185,7 @@ const ReviewsByCategoryEditor = ( {
 				) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -10,7 +10,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/components';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import ProductControl from '@woocommerce/block-components/product-control';
 import { Icon, comment } from '@woocommerce/icons';
@@ -156,7 +155,7 @@ const ReviewsByProductEditor = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls( editMode, setAttributes ) }
 			{ getInspectorControls() }
 			<EditorContainerBlock
@@ -174,7 +173,7 @@ const ReviewsByProductEditor = ( {
 				) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/components/error-placeholder/index.js
+++ b/assets/js/components/error-placeholder/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { Icon, notice } from '@woocommerce/icons';
 import classNames from 'classnames';
@@ -25,7 +24,7 @@ const ErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 	>
 		<ErrorMessage error={ error } />
 		{ onRetry && (
-			<Fragment>
+			<>
 				{ isLoading ? (
 					<Spinner />
 				) : (
@@ -33,7 +32,7 @@ const ErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 						{ __( 'Retry', 'woo-gutenberg-products-block' ) }
 					</Button>
 				) }
-			</Fragment>
+			</>
 		) }
 	</Placeholder>
 );

--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { ToggleControl } from '@wordpress/components';
 
@@ -12,7 +11,7 @@ import { ToggleControl } from '@wordpress/components';
 const GridContentControl = ( { onChange, settings } ) => {
 	const { button, price, rating, title } = settings;
 	return (
-		<Fragment>
+		<>
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
 				help={
@@ -80,7 +79,7 @@ const GridContentControl = ( { onChange, settings } ) => {
 				checked={ button }
 				onChange={ () => onChange( { ...settings, button: ! button } ) }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/components/grid-layout-control/index.js
+++ b/assets/js/components/grid-layout-control/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { clamp, isNaN } from 'lodash';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { RangeControl, ToggleControl } from '@wordpress/components';
 import {
@@ -23,7 +22,7 @@ const GridLayoutControl = ( {
 	alignButtons,
 } ) => {
 	return (
-		<Fragment>
+		<>
 			<RangeControl
 				label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
 				value={ columns }
@@ -69,7 +68,7 @@ const GridLayoutControl = ( {
 					setAttributes( { alignButtons: ! alignButtons } )
 				}
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/components/product-attribute-term-control/index.js
+++ b/assets/js/components/product-attribute-term-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -132,7 +131,7 @@ const ProductAttributeTermControl = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			<SearchListControl
 				className="woocommerce-product-attributes"
 				list={ currentList }
@@ -182,7 +181,7 @@ const ProductAttributeTermControl = ( {
 					/>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/components/product-category-control/index.js
+++ b/assets/js/components/product-category-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -127,7 +126,7 @@ const ProductCategoryControl = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			<SearchListControl
 				className="woocommerce-product-categories"
 				list={ categories }
@@ -178,7 +177,7 @@ const ProductCategoryControl = ( {
 					/>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/components/product-tag-control/index.js
+++ b/assets/js/components/product-tag-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { debounce, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -122,7 +122,7 @@ class ProductTagControl extends Component {
 		};
 
 		return (
-			<Fragment>
+			<>
 				<SearchListControl
 					className="woocommerce-product-tags"
 					list={ list }
@@ -173,7 +173,7 @@ class ProductTagControl extends Component {
 						/>
 					</div>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/components/view-switcher/index.js
+++ b/assets/js/components/view-switcher/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ButtonGroup, Button } from '@wordpress/components';
-import { useState, Fragment } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import withComponentId from '@woocommerce/base-hocs/with-component-id';
 
 /**
@@ -26,7 +26,7 @@ const ViewSwitcher = ( {
 	const htmlId = 'wc-block-view-switch-control-' + componentId;
 
 	return (
-		<Fragment>
+		<>
 			<div className={ classes }>
 				<label
 					htmlFor={ htmlId }
@@ -51,7 +51,7 @@ const ViewSwitcher = ( {
 				</ButtonGroup>
 			</div>
 			{ render( currentView ) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/hocs/with-feedback-prompt/index.js
+++ b/assets/js/hocs/with-feedback-prompt/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
@@ -27,12 +26,12 @@ const withFeedbackPrompt = ( content ) =>
 	 */
 	createHigherOrderComponent( ( BlockEdit ) => {
 		return ( props ) => (
-			<Fragment>
+			<>
 				<BlockEdit { ...props } />
 				<InspectorControls>
 					<FeedbackPrompt text={ content } />
 				</InspectorControls>
-			</Fragment>
+			</>
 		);
 	}, 'withFeedbackPrompt' );
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR removes all `Fragment` instances and uses `<>`, there are a couple of edge cases that we can’t use `<>`;

1. Reassignment
```js
Wrapper = wrapperElement || React.Fragment;
```

2. Fragment with keys, happens inside loops.
```js
<Fragment key={ option.value }>

</Fragment>
```

In both edge cases, I import either the Fragment from wordpress/element or from React directly.

In theory, importing from `@wordpress/element` or `react` should have no effect on our bundle size whatsoever, however, this is yet to be proven I guess, we should dig more to understand why bundle change in our case.
See [example here](https://babeljs.io/en/repl#?browsers=&build=&builtIns=false&spec=false&loose=false&code_lz=JYWwDg9gTgLgBAJQKYEMDG8BmUIjgcilQ3wG4AoctCAOwGd4BhAeTgF44AKASnYD4u5ADzJ0MAHQAxKCgDmIJDRh9ycOEJVqhAehU7RGKTPmLl5bkA&debug=false&forceAllTransforms=false&shippedProposals=false&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=es2016%2Creact%2Cstage-2&prettier=true&targets=&version=7.8.4&externalPlugins=)

This uses `'react/jsx-fragments': [ 'error', 'syntax' ],`, but this can’t detect fragments imported from `wordpress/element` so I had to run some regex magic.

everything in this PR was done by a couple of regex search replaces, edges cases got fixed manually, the rest was deleted by eslint `--fix` function.

<!-- Reference any related issues or PRs here -->
Fixes #1761 


