### PR TITLE
Display selected shipping location in cart block

### DIFF
--- a/assets/js/base/components/shipping-location/index.js
+++ b/assets/js/base/components/shipping-location/index.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	SHIPPING_COUNTRIES,
+	SHIPPING_STATES,
+} from '@woocommerce/block-settings';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Shows a formatted shipping location.
+ */
+const ShippingLocation = ( { address } ) => {
+	const formattedCountry =
+		typeof SHIPPING_COUNTRIES[ address.country ] === 'string'
+			? decodeEntities( SHIPPING_COUNTRIES[ address.country ] )
+			: '';
+
+	const formattedState =
+		typeof SHIPPING_STATES[ address.country ] === 'object' &&
+		typeof SHIPPING_STATES[ address.country ][ address.state ] === 'string'
+			? decodeEntities(
+					SHIPPING_STATES[ address.country ][ address.state ]
+			  )
+			: address.state;
+
+	const addressParts = [];
+
+	addressParts.push( address.postcode.toUpperCase() );
+	addressParts.push( address.city );
+	addressParts.push( formattedState );
+	addressParts.push( formattedCountry );
+
+	const formattedLocation = addressParts.filter( Boolean ).join( ', ' );
+
+	return (
+		formattedLocation && (
+			<span className="wc-block-cart__shipping-address">
+				{ sprintf(
+					/* Translators: %s location. */
+					__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
+					formattedLocation
+				) + ' ' }
+			</span>
+		)
+	);
+};
+
+ShippingLocation.propTypes = {
+	address: PropTypes.shape( {
+		city: PropTypes.string,
+		state: PropTypes.string,
+		postcode: PropTypes.string,
+		country: PropTypes.string,
+	} ),
+};
+
+export default ShippingLocation;

--- a/assets/js/base/components/state-input/billing-state-input.js
+++ b/assets/js/base/components/state-input/billing-state-input.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { ALLOWED_COUNTIES } from '@woocommerce/block-settings';
+import { ALLOWED_STATES } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -10,7 +10,7 @@ import { ALLOWED_COUNTIES } from '@woocommerce/block-settings';
 import StateInput from './state-input.js';
 
 const BillingStateInput = ( props ) => {
-	return <StateInput counties={ ALLOWED_COUNTIES } { ...props } />;
+	return <StateInput states={ ALLOWED_STATES } { ...props } />;
 };
 
 BillingStateInput.propTypes = {

--- a/assets/js/base/components/state-input/shipping-state-input.js
+++ b/assets/js/base/components/state-input/shipping-state-input.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { SHIPPING_COUNTIES } from '@woocommerce/block-settings';
+import { SHIPPING_STATES } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -10,7 +10,7 @@ import { SHIPPING_COUNTIES } from '@woocommerce/block-settings';
 import StateInput from './state-input.js';
 
 const ShippingStateInput = ( props ) => {
-	return <StateInput counties={ SHIPPING_COUNTIES } { ...props } />;
+	return <StateInput states={ SHIPPING_STATES } { ...props } />;
 };
 
 ShippingStateInput.propTypes = {

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -13,19 +13,19 @@ import Select from '../select';
 
 const StateInput = ( {
 	className,
-	counties,
+	states,
 	country,
 	label,
 	onChange,
 	autoComplete = 'off',
 	value = '',
 } ) => {
-	const countryCounties = counties[ country ];
+	const countryStates = states[ country ];
 	const options =
-		countryCounties && Object.keys( countryCounties ).length > 0
-			? Object.keys( countryCounties ).map( ( key ) => ( {
+		countryStates && Object.keys( countryStates ).length > 0
+			? Object.keys( countryStates ).map( ( key ) => ( {
 					key,
-					name: decodeEntities( countryCounties[ key ] ),
+					name: decodeEntities( countryStates[ key ] ),
 			  } ) )
 			: [];
 
@@ -89,7 +89,7 @@ const StateInput = ( {
 };
 
 StateInput.propTypes = {
-	counties: PropTypes.objectOf(
+	states: PropTypes.objectOf(
 		PropTypes.oneOfType( [
 			PropTypes.array,
 			PropTypes.objectOf( PropTypes.string ),

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -2,14 +2,15 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { __, sprintf } from '@wordpress/i18n';
-import { useState, Fragment, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
 import {
 	TotalsCouponCodeInput,
 	TotalsItem,
 } from '@woocommerce/base-components/totals';
 import ShippingRatesControl from '@woocommerce/base-components/shipping-rates-control';
 import ShippingCalculator from '@woocommerce/base-components/shipping-calculator';
+import ShippingLocation from '@woocommerce/base-components/shipping-location';
 import {
 	COUPONS_ENABLED,
 	SHIPPING_ENABLED,
@@ -82,7 +83,6 @@ const Cart = ( {
 	 * Given an API response with cart totals, generates an array of rows to display in the Cart block.
 	 *
 	 * @return {Object[]} Values to display in the cart block.
-	 * @param cartTotals
 	 */
 	const getTotalRowsConfig = () => {
 		const totalItems = parseInt( cartTotals.total_items, 10 );
@@ -137,16 +137,15 @@ const Cart = ( {
 					? totalShipping + totalShippingTax
 					: totalShipping,
 				description: (
-					<Fragment>
-						{ __(
-							'Shipping to location',
-							'woo-gutenberg-products-block'
-						) + ' ' }
+					<>
+						<ShippingLocation
+							address={ shippingCalculatorAddress }
+						/>
 						<ShippingCalculator
 							address={ shippingCalculatorAddress }
 							setAddress={ setShippingCalculatorAddress }
 						/>
-					</Fragment>
+					</>
 				),
 			} );
 		}
@@ -176,22 +175,16 @@ const Cart = ( {
 						  }
 						: null
 				}
-				noResultsMessage={ sprintf(
-					// translators: %s shipping destination.
-					__(
-						'No shipping options were found for %s.',
-						'woo-gutenberg-products-block'
-					),
-					// @todo Should display destination name,
-					// see: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1606
-					'location'
+				noResultsMessage={ __(
+					'No shipping options were found.',
+					'woo-gutenberg-products-block'
 				) }
 				selected={ selectedShippingRate }
 				renderOption={ ( option ) => ( {
 					label: decodeEntities( option.name ),
 					value: option.rate_id,
 					description: (
-						<Fragment>
+						<>
 							{ option.price && (
 								<FormattedMonetaryAmount
 									currency={ getCurrencyFromPriceResponse(
@@ -204,7 +197,7 @@ const Cart = ( {
 								? ' — '
 								: null }
 							{ decodeEntities( option.delivery_time ) }
-						</Fragment>
+						</>
 					),
 				} ) }
 				onChange={ ( newSelectedShippingOption ) =>

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -44,5 +44,5 @@ export const IS_SHIPPING_COST_HIDDEN = getSetting(
 export const WC_BLOCKS_ASSET_URL = getSetting( 'wcBlocksAssetUrl', '' );
 export const SHIPPING_COUNTRIES = getSetting( 'shippingCountries', {} );
 export const ALLOWED_COUNTRIES = getSetting( 'allowedCountries', {} );
-export const SHIPPING_COUNTIES = getSetting( 'shippingCounties', {} );
-export const ALLOWED_COUNTIES = getSetting( 'allowedCounties', {} );
+export const SHIPPING_STATES = getSetting( 'shippingStates', {} );
+export const ALLOWED_STATES = getSetting( 'allowedStates', {} );

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -50,7 +50,7 @@ class Cart extends AbstractBlock {
 			\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class
 		);
 		$data_registry->add( 'shippingCountries', WC()->countries->get_shipping_countries() );
-		$data_registry->add( 'shippingCounties', WC()->countries->get_shipping_country_states() );
+		$data_registry->add( 'shippingStates', WC()->countries->get_shipping_country_states() );
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
 			$this->block_name . '-frontend',
 			$this->block_name . '-block-frontend'

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -52,8 +52,8 @@ class Checkout extends AbstractBlock {
 		);
 		$data_registry->add( 'allowedCountries', WC()->countries->get_allowed_countries() );
 		$data_registry->add( 'shippingCountries', WC()->countries->get_shipping_countries() );
-		$data_registry->add( 'allowedCounties', WC()->countries->get_allowed_country_states() );
-		$data_registry->add( 'shippingCounties', WC()->countries->get_shipping_country_states() );
+		$data_registry->add( 'allowedStates', WC()->countries->get_allowed_country_states() );
+		$data_registry->add( 'shippingStates', WC()->countries->get_shipping_country_states() );
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
 		return $content;
 	}


### PR DESCRIPTION
This PR introduces a simple component that is passed the currency address state which it then formats into an appropriate string of HTML.

If no address is provided, nothing is displayed. Once we have a default location state for the customer (pulling from profile) this should be less common. Right now there is no initial state on page load.

Fixes #1606

#1606 suggested we output the location twice, however, the 2nd address string is probably redundant so I opted to generalise the 2nd "no shipping method" message instead of repeating the same data.

This PR renames county to state for clarity.

### Screenshots

![Screenshot 2020-02-18 at 12 48 29](https://user-images.githubusercontent.com/90977/74737744-65142580-524d-11ea-820d-bb7790cf5f94.png)

### How to test the changes in this Pull Request:

1. On the cart page, enter an address using the shipping calculator.
2. The location should be displayed, comma separating each address part.