### PR TITLE
Update `reserved stock` class to handle concurrent requests

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -72,6 +72,7 @@ class Library {
 				`product_id` bigint(20) NOT NULL,
 				`stock_quantity` double NOT NULL DEFAULT 0,
 				`timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				`expires` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
 				PRIMARY KEY  (`order_id`, `product_id`)
 			) $collate;
 			"

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -11,7 +11,6 @@ defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductImages;
 use Automattic\WooCommerce\Blocks\RestApi\Utilities\ProductSummary;
-use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ReserveStock;
 
 /**
  * CartItemSchema class.
@@ -335,8 +334,15 @@ class CartItemSchema extends AbstractSchema {
 			return null;
 		}
 
-		$draft_order     = WC()->session->get( 'store_api_draft_order' );
-		$reserve_stock   = new ReserveStock();
+		$draft_order = WC()->session->get( 'store_api_draft_order' );
+
+		// @todo Remove once min support for WC reaches 4.0.0.
+		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {
+			$reserve_stock = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
+		} else {
+			$reserve_stock = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ReserveStock();
+		}
+
 		$reserved_stock  = $reserve_stock->get_reserved_stock( $product, isset( $draft_order['id'] ) ? $draft_order['id'] : 0 );
 		$remaining_stock = $product->get_stock_quantity() - $reserved_stock;
 

--- a/src/RestApi/StoreApi/Utilities/ReserveStock.php
+++ b/src/RestApi/StoreApi/Utilities/ReserveStock.php
@@ -118,6 +118,14 @@ final class ReserveStock {
 
 		$query_for_stock          = $this->get_query_for_stock( $product_id );
 		$query_for_reserved_stock = $this->get_query_for_reserved_stock( $product_id, $order->get_id() );
+		$required_stock           = $stock_quantity;
+
+		// Deals with legacy stock reservations from woo core.
+		$support_legacy_held_stock = ! \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) && absint( get_option( 'woocommerce_hold_stock_minutes', 0 ) ) > 0;
+
+		if ( $support_legacy_held_stock ) {
+			$required_stock += wc_get_held_stock_quantity( wc_get_product( $product_id ) );
+		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 		$result = $wpdb->query(
@@ -131,7 +139,7 @@ final class ReserveStock {
 				$product_id,
 				$stock_quantity,
 				$minutes,
-				$stock_quantity
+				$required_stock
 			)
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared

--- a/src/RestApi/StoreApi/Utilities/ReserveStock.php
+++ b/src/RestApi/StoreApi/Utilities/ReserveStock.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Helper class to handle product stock reservation.
+ * Handle product stock reservation during checkout.
  *
  * @package WooCommerce/Blocks
  */
@@ -9,132 +9,187 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities;
 
 defined( 'ABSPATH' ) || exit;
 
-use \WP_Error;
-
 /**
  * Stock Reservation class.
  */
-class ReserveStock {
-	/**
-	 * Put a temporary hold on stock for an order if enough is available.
-	 *
-	 * @param \WC_Order $order Order object.
-	 * @return bool|WP_Error
-	 */
-	public function reserve_stock_for_order( \WC_Order $order ) {
-		$stock_to_reserve = [];
-		$items            = array_filter(
-			$order->get_items(),
-			function( $item ) {
-				return $item->is_type( 'line_item' ) && $item->get_product() instanceof \WC_Product;
-			}
-		);
-
-		foreach ( $items as $item ) {
-			$product = $item->get_product();
-
-			if ( ! $product->is_in_stock() ) {
-				return new WP_Error(
-					'product_out_of_stock',
-					sprintf(
-						/* translators: %s: product name */
-						__( '%s is out of stock and cannot be purchased.', 'woo-gutenberg-products-block' ),
-						$product->get_name()
-					),
-					[ 'status' => 403 ]
-				);
-			}
-
-			// If stock management is off, no need to reserve any stock here.
-			if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
-				continue;
-			}
-
-			$product_id                      = $product->get_stock_managed_by_id();
-			$stock_to_reserve[ $product_id ] = isset( $stock_to_reserve[ $product_id ] ) ? $stock_to_reserve[ $product_id ] : 0;
-			$reserved_stock                  = $this->get_reserved_stock( $product, $order->get_id() );
-
-			if ( ( $product->get_stock_quantity() - $reserved_stock - $stock_to_reserve[ $product_id ] ) < $item->get_quantity() ) {
-				return new WP_Error(
-					'product_not_enough_stock',
-					sprintf(
-						/* translators: %s: product name */
-						__( 'Not enough units of %s are available in stock to fulfil this order.', 'woo-gutenberg-products-block' ),
-						$product->get_name()
-					),
-					[ 'status' => 403 ]
-				);
-			}
-
-			// Queue for later DB insertion.
-			$stock_to_reserve[ $product_id ] += $item->get_quantity();
-		}
-
-		$this->reserve_stock( $stock_to_reserve, $order->get_id() );
-
-		return true;
-	}
-
-	/**
-	 * Reserve stock by inserting rows into the DB.
-	 *
-	 * @param array   $stock_to_reserve Array of Product ID => Qty pairs.
-	 * @param integer $order_id Order ID for which to reserve stock.
-	 */
-	protected function reserve_stock( $stock_to_reserve, $order_id ) {
-		global $wpdb;
-
-		$stock_to_reserve = array_filter( $stock_to_reserve );
-
-		if ( ! $stock_to_reserve ) {
-			return;
-		}
-
-		$stock_to_reserve_rows = [];
-
-		foreach ( $stock_to_reserve as $product_id => $stock_quantity ) {
-			$stock_to_reserve_rows[] = '(' . esc_sql( $order_id ) . ',"' . esc_sql( $product_id ) . '","' . esc_sql( $stock_quantity ) . '")';
-		}
-
-		$values = implode( ',', $stock_to_reserve_rows );
-
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query( "REPLACE INTO {$wpdb->wc_reserved_stock} ( order_id, product_id, stock_quantity ) VALUES {$values};" );
-	}
-
+final class ReserveStock {
 	/**
 	 * Query for any existing holds on stock for this item.
 	 *
-	 * - Can ignore reserved stock for a specific order.
-	 * - Ignores stock for orders which are no longer drafts (assuming real stock reduction was performed).
-	 * - Ignores stock reserved over 10 mins ago.
-	 *
 	 * @param \WC_Product $product Product to get reserved stock for.
 	 * @param integer     $exclude_order_id Optional order to exclude from the results.
+	 *
 	 * @return integer Amount of stock already reserved.
 	 */
 	public function get_reserved_stock( \WC_Product $product, $exclude_order_id = 0 ) {
 		global $wpdb;
 
-		$reserved_stock = $wpdb->get_var(
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		return (int) $wpdb->get_var( $this->get_query_for_reserved_stock( $product->get_stock_managed_by_id(), $exclude_order_id ) );
+	}
+
+	/**
+	 * Put a temporary hold on stock for an order if enough is available.
+	 *
+	 * @throws ReserveStockException If stock cannot be reserved.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param int       $minutes How long to reserve stock in minutes. Defaults to woocommerce_hold_stock_minutes.
+	 */
+	public function reserve_stock_for_order( \WC_Order $order, $minutes = 0 ) {
+		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
+
+		if ( ! $minutes ) {
+			return;
+		}
+
+		try {
+			$items = array_filter(
+				$order->get_items(),
+				function( $item ) {
+					return $item->is_type( 'line_item' ) && $item->get_product() instanceof \WC_Product && $item->get_quantity() > 0;
+				}
+			);
+			$rows  = [];
+
+			foreach ( $items as $item ) {
+				$product = $item->get_product();
+
+				if ( ! $product->is_in_stock() ) {
+					throw new ReserveStockException(
+						'product_out_of_stock',
+						sprintf(
+							/* translators: %s: product name */
+							__( '%s is out of stock and cannot be purchased.', 'woo-gutenberg-products-block' ),
+							$product->get_name()
+						),
+						403
+					);
+				}
+
+				// If stock management is off, no need to reserve any stock here.
+				if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+					continue;
+				}
+
+				$managed_by_id          = $product->get_stock_managed_by_id();
+				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item->get_quantity() : $item->get_quantity();
+			}
+
+			if ( ! empty( $rows ) ) {
+				foreach ( $rows as $product_id => $quantity ) {
+					$this->reserve_stock_for_product( $product_id, $quantity, $order, $minutes );
+				}
+			}
+		} catch ( ReserveStockException $e ) {
+			$this->release_stock_for_order( $order );
+			throw $e;
+		}
+	}
+
+	/**
+	 * Release a temporary hold on stock for an order.
+	 *
+	 * @param \WC_Order $order Order object.
+	 */
+	public function release_stock_for_order( \WC_Order $order ) {
+		global $wpdb;
+
+		$wpdb->delete(
+			$wpdb->wc_reserved_stock,
+			[
+				'order_id' => $order->get_id(),
+			]
+		);
+	}
+
+	/**
+	 * Reserve stock for a product by inserting rows into the DB.
+	 *
+	 * @throws ReserveStockException If a row cannot be inserted.
+	 *
+	 * @param int       $product_id Product ID which is having stock reserved.
+	 * @param int       $stock_quantity Stock amount to reserve.
+	 * @param \WC_Order $order Order object which contains the product.
+	 * @param int       $minutes How long to reserve stock in minutes.
+	 */
+	private function reserve_stock_for_product( $product_id, $stock_quantity, \WC_Order $order, $minutes ) {
+		global $wpdb;
+
+		$query_for_stock          = $this->get_query_for_stock( $product_id );
+		$query_for_reserved_stock = $this->get_query_for_reserved_stock( $product_id, $order->get_id() );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->query(
 			$wpdb->prepare(
 				"
-				SELECT SUM( stock_table.`stock_quantity` ) FROM $wpdb->wc_reserved_stock stock_table
-				LEFT JOIN $wpdb->posts posts ON stock_table.`order_id` = posts.ID
-				WHERE stock_table.`product_id` = %d
-				AND posts.post_status = 'wc-checkout-draft'
-				AND stock_table.`order_id` != %d
-				AND stock_table.`timestamp` > ( NOW() - INTERVAL 10 MINUTE )
+				REPLACE INTO {$wpdb->wc_reserved_stock} ( order_id, product_id, stock_quantity, expires )
+				SELECT %d, %d, %d, ( NOW() + INTERVAL %d MINUTE ) from DUAL
+				WHERE ( $query_for_stock FOR UPDATE ) - ( $query_for_reserved_stock FOR UPDATE ) >= %d
 				",
-				$product->get_stock_managed_by_id(),
-				$exclude_order_id
+				$order->get_id(),
+				$product_id,
+				$stock_quantity,
+				$minutes,
+				$stock_quantity
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 
-		// Deals with legacy stock reservation which the core Woo checkout performs.
-		$hold_stock_minutes = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
-		$reserved_stock    += ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product ) : 0;
+		if ( ! $result ) {
+			$product = wc_get_product( $product_id );
+			throw new ReserveStockException(
+				'product_not_enough_stock',
+				sprintf(
+					/* translators: %s: product name */
+					__( 'Not enough units of %s are available in stock to fulfil this order.', 'woo-gutenberg-products-block' ),
+					$product ? $product->get_name() : '#' . $product_id
+				),
+				403
+			);
+		}
+	}
 
-		return $reserved_stock;
+	/**
+	 * Returns query statement for getting current `_stock` of a product.
+	 *
+	 * @todo Once merged to woo core data store, this method can be removed.
+	 * @internal MAX function below is used to make sure result is a scalar.
+	 * @param int $product_id Product ID.
+	 * @return string|void Query statement.
+	 */
+	private function get_query_for_stock( $product_id ) {
+		global $wpdb;
+		return $wpdb->prepare(
+			"
+			SELECT COALESCE ( MAX( meta_value ), 0 ) FROM $wpdb->postmeta as meta_table
+			WHERE meta_table.meta_key = '_stock'
+			AND meta_table.post_id = %d
+			",
+			$product_id
+		);
+	}
+
+	/**
+	 * Returns query statement for getting reserved stock of a product.
+	 *
+	 * @param int     $product_id Product ID.
+	 * @param integer $exclude_order_id Optional order to exclude from the results.
+	 * @return string|void Query statement.
+	 */
+	private function get_query_for_reserved_stock( $product_id, $exclude_order_id = 0 ) {
+		global $wpdb;
+		return $wpdb->prepare(
+			"
+			SELECT COALESCE( SUM( stock_table.`stock_quantity` ), 0 ) FROM $wpdb->wc_reserved_stock stock_table
+			LEFT JOIN $wpdb->posts posts ON stock_table.`order_id` = posts.ID
+			WHERE posts.post_status IN ( 'wc-checkout-draft', 'wc-pending' )
+			AND stock_table.`expires` > NOW()
+			AND stock_table.`product_id` = %d
+			AND stock_table.`order_id` != %d
+			",
+			$product_id,
+			$exclude_order_id
+		);
 	}
 }

--- a/src/RestApi/StoreApi/Utilities/ReserveStockException.php
+++ b/src/RestApi/StoreApi/Utilities/ReserveStockException.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Exceptions for stock reservation.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities;
+
+/**
+ * ReserveStockException class.
+ */
+class ReserveStockException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	protected $error_code;
+
+	/**
+	 * Error extra data.
+	 *
+	 * @var array
+	 */
+	protected $error_data;
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $code             Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param string $message          User-friendly translated error message, e.g. 'Product ID is invalid'.
+	 * @param int    $http_status_code Proper HTTP status code to respond with, e.g. 400.
+	 * @param array  $data             Extra error data.
+	 */
+	public function __construct( $code, $message, $http_status_code = 400, $data = array() ) {
+		$this->error_code = $code;
+		$this->error_data = array_merge( array( 'status' => $http_status_code ), $data );
+
+		parent::__construct( $message, $http_status_code );
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns error data.
+	 *
+	 * @return array
+	 */
+	public function getErrorData() {
+		return $this->error_data;
+	}
+}

--- a/tests/php/RestApi/StoreApi/Utilities/ReserveStock.php
+++ b/tests/php/RestApi/StoreApi/Utilities/ReserveStock.php
@@ -32,8 +32,7 @@ class ReserveStockTests extends TestCase {
 		$order->set_status( 'checkout-draft' );
 		$order->save();
 
-		$result = $class->reserve_stock_for_order( $order );
-		$this->assertTrue( $result );
+		$class->reserve_stock_for_order( $order );
 		$this->assertEquals( 4, $this->get_reserved_stock_by_product_id( $product->get_stock_managed_by_id() ) );
 
 		// Repeat.
@@ -41,17 +40,38 @@ class ReserveStockTests extends TestCase {
 		$order->set_status( 'checkout-draft' );
 		$order->save();
 
-		$result = $class->reserve_stock_for_order( $order );
-		$this->assertTrue( $result );
+		$class->reserve_stock_for_order( $order );
 		$this->assertEquals( 8, $this->get_reserved_stock_by_product_id( $product->get_stock_managed_by_id() ) );
+	}
 
-		// Repeat again - should not be enough stock for this.
-		$order = OrderHelper::create_order( 1, $product );
+	/**
+	 * Test that stock is reserved for draft orders.
+	 *
+	 * @expectedException Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ReserveStockException
+	 */
+	public function test_reserve_stock_for_order_throws_exception() {
+		$class = new ReserveStock();
+
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock( 10 );
+		$product->save();
+
+		$order = OrderHelper::create_order( 1, $product ); // Note this adds 4 to the order.
 		$order->set_status( 'checkout-draft' );
 		$order->save();
 
-		$result = $class->reserve_stock_for_order( $order );
-		$this->assertTrue( is_wp_error( $result ) );
+		$order2 = OrderHelper::create_order( 1, $product );
+		$order2->set_status( 'checkout-draft' );
+		$order2->save();
+
+		$order3 = OrderHelper::create_order( 1, $product );
+		$order3->set_status( 'checkout-draft' );
+		$order3->save();
+
+		$class->reserve_stock_for_order( $order );
+		$class->reserve_stock_for_order( $order2 );
+		$class->reserve_stock_for_order( $order3 );
 	}
 
 	/**

--- a/tests/php/RestApi/StoreApi/Utilities/ReserveStock.php
+++ b/tests/php/RestApi/StoreApi/Utilities/ReserveStock.php
@@ -45,7 +45,7 @@ class ReserveStockTests extends TestCase {
 	}
 
 	/**
-	 * Test that stock is reserved for draft orders.
+	 * Test that trying to reserve stock too much throws an exception.
 	 *
 	 * @expectedException Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ReserveStockException
 	 */

--- a/tests/php/RestApi/Utilities/ProductSummary.php
+++ b/tests/php/RestApi/Utilities/ProductSummary.php
@@ -24,7 +24,7 @@ class ProductSummaryTests extends TestCase {
 	}
 
 	/**
-	 * Test that stock is reserved for draft orders.
+	 * Test that we can get a valid summary.
 	 */
 	public function test_get_summary() {
 		$product = new \WC_Product();


### PR DESCRIPTION
These changes solve the concurrency issue by borrowing certain code changes from https://github.com/woocommerce/woocommerce/pull/25172

The main changes are the atomic 'replace' to prevent stock being reserved for 2 orders at the same time, and the introduction of an `expires` column in the DB table.

Since this solution should ultimately be used in core too, I've created a core PR for the same class here https://github.com/woocommerce/woocommerce/pull/25708 Our version will be used during the transition to this (when we support wc 4.0+).

Fixes #1652 

### How to test the changes in this Pull Request:

Since the DB table changed, you'll need to do a little messing about in the DB. This hasn't shipped to users yet so no issues there.

1. Delete `wc_blocks_db_version` from your wp_options table.
2. Reactivate blocks.

This will ensure the `expires` column is added to your `wc_reserved_stock` table.

Then to test, follow the testing instructions in https://github.com/woocommerce/woocommerce/pull/25708, and on the Blocks side, create an order via the API 

- Add some items to your cart whilst logged in
- Basic auth to API for the same user.
- Do a post to /store/cart/order.
 - Check response.

The original issue has more details if needed https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1425