### PR TITLE
Add product name and quantity to cart shipping rates endpoint

### DIFF
--- a/assets/js/base/components/shipping-rates-control/index.js
+++ b/assets/js/base/components/shipping-rates-control/index.js
@@ -9,9 +9,9 @@ import { useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Package from './package';
-import './style.scss';
+import Packages from './packages';
 import LoadingMask from '../loading-mask';
+import './style.scss';
 
 const ShippingRatesControl = ( {
 	address,
@@ -26,24 +26,6 @@ const ShippingRatesControl = ( {
 		shippingRates,
 		( newRates ) => newRates.length > 0
 	);
-
-	const renderPackages = ( rates ) =>
-		rates.map( ( shippingRate, i ) => (
-			<Package
-				key={ Object.keys( shippingRate.items ).join() }
-				className={ className }
-				noResultsMessage={ noResultsMessage }
-				onChange={ ( newShippingRate ) => {
-					const newSelected = [ ...selected ];
-					newSelected[ i ] = newShippingRate;
-					onChange( newSelected );
-				} }
-				renderOption={ renderOption }
-				selected={ selected[ i ] }
-				shippingRate={ shippingRate }
-				showItems={ rates.length > 1 }
-			/>
-		) );
 
 	// Select first item when shipping rates are loaded.
 	useEffect(
@@ -90,12 +72,28 @@ const ShippingRatesControl = ( {
 				) }
 				showSpinner={ true }
 			>
-				{ renderPackages( previousShippingRates || [] ) }
+				<Packages
+					shippingRates={ previousShippingRates || [] }
+					className={ className }
+					noResultsMessage={ noResultsMessage }
+					onChange={ onChange }
+					renderOption={ renderOption }
+					selected={ selected }
+				/>
 			</LoadingMask>
 		);
 	}
 
-	return renderPackages( shippingRates );
+	return (
+		<Packages
+			shippingRates={ shippingRates }
+			className={ className }
+			noResultsMessage={ noResultsMessage }
+			onChange={ onChange }
+			renderOption={ renderOption }
+			selected={ selected }
+		/>
+	);
 };
 
 ShippingRatesControl.propTypes = {

--- a/assets/js/base/components/shipping-rates-control/index.js
+++ b/assets/js/base/components/shipping-rates-control/index.js
@@ -73,12 +73,12 @@ const ShippingRatesControl = ( {
 				showSpinner={ true }
 			>
 				<Packages
-					shippingRates={ previousShippingRates || [] }
 					className={ className }
 					noResultsMessage={ noResultsMessage }
 					onChange={ onChange }
 					renderOption={ renderOption }
 					selected={ selected }
+					shippingRates={ previousShippingRates || [] }
 				/>
 			</LoadingMask>
 		);
@@ -86,12 +86,12 @@ const ShippingRatesControl = ( {
 
 	return (
 		<Packages
-			shippingRates={ shippingRates }
 			className={ className }
 			noResultsMessage={ noResultsMessage }
 			onChange={ onChange }
 			renderOption={ renderOption }
 			selected={ selected }
+			shippingRates={ shippingRates }
 		/>
 	);
 };
@@ -113,3 +113,4 @@ ShippingRatesControl.propTypes = {
 };
 
 export default ShippingRatesControl;
+export { Packages };

--- a/assets/js/base/components/shipping-rates-control/index.js
+++ b/assets/js/base/components/shipping-rates-control/index.js
@@ -30,7 +30,7 @@ const ShippingRatesControl = ( {
 	const renderPackages = ( rates ) =>
 		rates.map( ( shippingRate, i ) => (
 			<Package
-				key={ shippingRate.items.join() }
+				key={ Object.keys( shippingRate.items ).join() }
 				className={ className }
 				noResultsMessage={ noResultsMessage }
 				onChange={ ( newShippingRate ) => {

--- a/assets/js/base/components/shipping-rates-control/package-options.js
+++ b/assets/js/base/components/shipping-rates-control/package-options.js
@@ -52,11 +52,11 @@ const PackageOptions = ( {
 };
 
 PackageOptions.propTypes = {
-	noResultsMessage: PropTypes.string.isRequired,
-	onChange: PropTypes.func.isRequired,
 	options: PropTypes.arrayOf( PropTypes.object ).isRequired,
 	renderOption: PropTypes.func.isRequired,
 	className: PropTypes.string,
+	noResultsMessage: PropTypes.string,
+	onChange: PropTypes.func,
 	selected: PropTypes.string,
 };
 

--- a/assets/js/base/components/shipping-rates-control/package-options.js
+++ b/assets/js/base/components/shipping-rates-control/package-options.js
@@ -52,11 +52,11 @@ const PackageOptions = ( {
 };
 
 PackageOptions.propTypes = {
+	onChange: PropTypes.func.isRequired,
 	options: PropTypes.arrayOf( PropTypes.object ).isRequired,
 	renderOption: PropTypes.func.isRequired,
 	className: PropTypes.string,
 	noResultsMessage: PropTypes.string,
-	onChange: PropTypes.func,
 	selected: PropTypes.string,
 };
 

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -66,8 +66,6 @@ const Package = ( {
 };
 
 Package.propTypes = {
-	noResultsMessage: PropTypes.string.isRequired,
-	onChange: PropTypes.func.isRequired,
 	renderOption: PropTypes.func.isRequired,
 	shippingRate: PropTypes.shape( {
 		shipping_rates: PropTypes.arrayOf( PropTypes.object ).isRequired,
@@ -79,6 +77,8 @@ Package.propTypes = {
 		).isRequired,
 	} ).isRequired,
 	className: PropTypes.string,
+	noResultsMessage: PropTypes.string,
+	onChange: PropTypes.func,
 	selected: PropTypes.string,
 	showItems: PropTypes.bool,
 };

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -3,6 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { Fragment } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -30,11 +31,14 @@ const Package = ( {
 				selected={ selected }
 			/>
 			{ showItems && (
-				<span>
-					{ /* @todo Show product names,
-						see: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1554 */ }
-					{ shippingRate.items.join( ', ' ) }
-				</span>
+				<small>
+					{ Object.values( shippingRate.items )
+						.map(
+							( v ) =>
+								`${ decodeEntities( v.name ) } ×${ v.quantity }`
+						)
+						.join( ', ' ) }
+				</small>
 			) }
 		</Fragment>
 	);
@@ -46,7 +50,12 @@ Package.propTypes = {
 	renderOption: PropTypes.func.isRequired,
 	shippingRate: PropTypes.shape( {
 		shipping_rates: PropTypes.arrayOf( PropTypes.object ).isRequired,
-		items: PropTypes.arrayOf( PropTypes.string ).isRequired,
+		items: PropTypes.objectOf(
+			PropTypes.shape( {
+				name: PropTypes.string.isRequired,
+				quantity: PropTypes.number.isRequired,
+			} ).isRequired
+		).isRequired,
 	} ).isRequired,
 	className: PropTypes.string,
 	selected: PropTypes.string,

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { _n, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import Label from '@woocommerce/base-components/label';
 
 /**
  * Internal dependencies
@@ -32,12 +34,31 @@ const Package = ( {
 			/>
 			{ showItems && (
 				<small>
-					{ Object.values( shippingRate.items )
-						.map(
-							( v ) =>
-								`${ decodeEntities( v.name ) } ×${ v.quantity }`
-						)
-						.join( ', ' ) }
+					{ Object.values( shippingRate.items ).map( ( v, i ) => {
+						const name = decodeEntities( v.name );
+						const quantity = v.quantity;
+						const displayComma =
+							i < Object.values( shippingRate.items ).length - 1;
+						return (
+							<Fragment key={ name }>
+								<Label
+									label={ `${ name } ×${ quantity }` }
+									screenReaderLabel={ sprintf(
+										// translators: %s name of the product (ie: Sunglasses), %d number of units in the current cart package
+										_n(
+											'%s (%d unit)',
+											'%s (%d units)',
+											quantity,
+											'woo-gutenberg-products-block'
+										),
+										name,
+										quantity
+									) }
+								/>
+								{ displayComma && ', ' }
+							</Fragment>
+						);
+					} ) }
 				</small>
 			) }
 		</Fragment>

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -66,6 +66,7 @@ const Package = ( {
 };
 
 Package.propTypes = {
+	onChange: PropTypes.func.isRequired,
 	renderOption: PropTypes.func.isRequired,
 	shippingRate: PropTypes.shape( {
 		shipping_rates: PropTypes.arrayOf( PropTypes.object ).isRequired,
@@ -78,7 +79,6 @@ Package.propTypes = {
 	} ).isRequired,
 	className: PropTypes.string,
 	noResultsMessage: PropTypes.string,
-	onChange: PropTypes.func,
 	selected: PropTypes.string,
 	showItems: PropTypes.bool,
 };

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -33,7 +33,7 @@ const Package = ( {
 				selected={ selected }
 			/>
 			{ showItems && (
-				<small>
+				<small className="wc-block-shipping-rates-control__package-items">
 					{ Object.values( shippingRate.items ).map( ( v, i ) => {
 						const name = decodeEntities( v.name );
 						const quantity = v.quantity;

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -33,14 +33,15 @@ const Package = ( {
 				selected={ selected }
 			/>
 			{ showItems && (
-				<small className="wc-block-shipping-rates-control__package-items">
-					{ Object.values( shippingRate.items ).map( ( v, i ) => {
+				<ul className="wc-block-shipping-rates-control__package-items">
+					{ Object.values( shippingRate.items ).map( ( v ) => {
 						const name = decodeEntities( v.name );
 						const quantity = v.quantity;
-						const displayComma =
-							i < Object.values( shippingRate.items ).length - 1;
 						return (
-							<Fragment key={ name }>
+							<li
+								key={ name }
+								className="wc-block-shipping-rates-control__package-item"
+							>
 								<Label
 									label={ `${ name } ×${ quantity }` }
 									screenReaderLabel={ sprintf(
@@ -55,11 +56,10 @@ const Package = ( {
 										quantity
 									) }
 								/>
-								{ displayComma && ', ' }
-							</Fragment>
+							</li>
 						);
 					} ) }
-				</small>
+				</ul>
 			) }
 		</Fragment>
 	);

--- a/assets/js/base/components/shipping-rates-control/packages.js
+++ b/assets/js/base/components/shipping-rates-control/packages.js
@@ -12,7 +12,7 @@ import './style.scss';
 const Packages = ( {
 	className,
 	noResultsMessage,
-	onChange,
+	onChange = () => {},
 	renderOption,
 	selected = [],
 	shippingRates,

--- a/assets/js/base/components/shipping-rates-control/packages.js
+++ b/assets/js/base/components/shipping-rates-control/packages.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import Package from './package';
+import './style.scss';
+
+const Packages = ( {
+	className,
+	noResultsMessage,
+	onChange,
+	renderOption,
+	selected = [],
+	shippingRates,
+} ) => {
+	return shippingRates.map( ( shippingRate, i ) => (
+		<Package
+			key={ Object.keys( shippingRate.items ).join() }
+			className={ className }
+			noResultsMessage={ noResultsMessage }
+			onChange={ ( newShippingRate ) => {
+				const newSelected = [ ...selected ];
+				newSelected[ i ] = newShippingRate;
+				onChange( newSelected );
+			} }
+			renderOption={ renderOption }
+			selected={ selected[ i ] }
+			shippingRate={ shippingRate }
+			showItems={ shippingRates.length > 1 }
+		/>
+	) );
+};
+
+Packages.propTypes = {
+	noResultsMessage: PropTypes.string.isRequired,
+	onChange: PropTypes.func.isRequired,
+	renderOption: PropTypes.func.isRequired,
+	className: PropTypes.string,
+	selected: PropTypes.arrayOf( PropTypes.string ),
+	shippingRates: PropTypes.arrayOf(
+		PropTypes.shape( {
+			items: PropTypes.object.isRequired,
+		} ).isRequired
+	).isRequired,
+};
+
+export default Packages;

--- a/assets/js/base/components/shipping-rates-control/packages.js
+++ b/assets/js/base/components/shipping-rates-control/packages.js
@@ -36,10 +36,10 @@ const Packages = ( {
 };
 
 Packages.propTypes = {
-	noResultsMessage: PropTypes.string.isRequired,
-	onChange: PropTypes.func.isRequired,
 	renderOption: PropTypes.func.isRequired,
 	className: PropTypes.string,
+	noResultsMessage: PropTypes.string,
+	onChange: PropTypes.func,
 	selected: PropTypes.arrayOf( PropTypes.string ),
 	shippingRates: PropTypes.arrayOf(
 		PropTypes.shape( {

--- a/assets/js/base/components/shipping-rates-control/style.scss
+++ b/assets/js/base/components/shipping-rates-control/style.scss
@@ -3,3 +3,8 @@
 	margin-bottom: 0;
 	padding-bottom: $gap-small;
 }
+
+.wc-block-shipping-rates-control__package-items {
+	display: block;
+	padding-bottom: $gap;
+}

--- a/assets/js/base/components/shipping-rates-control/style.scss
+++ b/assets/js/base/components/shipping-rates-control/style.scss
@@ -6,5 +6,19 @@
 
 .wc-block-shipping-rates-control__package-items {
 	display: block;
-	padding-bottom: $gap;
+	font-size: 75%;
+	list-style: none;
+	margin: 0;
+	padding: 0 0 $gap;
+}
+
+.wc-block-shipping-rates-control__package-item {
+	display: inline-block;
+	margin: 0;
+	padding: 0;
+}
+
+.wc-block-shipping-rates-control__package-item:not(:last-child)::after {
+	content: ", ";
+	white-space: pre;
 }

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -99,13 +99,13 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 									<FullCart
 										cartItems={ previewCart.items }
 										cartTotals={ previewCart.totals }
-										shippingRates={ previewShippingRates }
 										isShippingCostHidden={
 											isShippingCostHidden
 										}
 										isShippingCalculatorEnabled={
 											isShippingCalculatorEnabled
 										}
+										shippingRates={ previewShippingRates }
 									/>
 								</Disabled>
 							</>

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -8,7 +8,10 @@ import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import { withFeedbackPrompt } from '@woocommerce/block-hocs';
 import ViewSwitcher from '@woocommerce/block-components/view-switcher';
-import { previewCart } from '@woocommerce/resource-previews';
+import {
+	previewCart,
+	previewShippingRates,
+} from '@woocommerce/resource-previews';
 import { SHIPPING_ENABLED } from '@woocommerce/block-settings';
 
 /**
@@ -96,6 +99,7 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 									<FullCart
 										cartItems={ previewCart.items }
 										cartTotals={ previewCart.totals }
+										shippingRates={ previewShippingRates }
 										isShippingCostHidden={
 											isShippingCostHidden
 										}

--- a/assets/js/previews/index.js
+++ b/assets/js/previews/index.js
@@ -3,3 +3,4 @@ export { previewCart } from './cart';
 export { previewReviews } from './reviews';
 export { gridBlockPreview } from './grid-block';
 export { previewCategories } from './categories';
+export { previewShippingRates } from './shipping-rates';

--- a/assets/js/previews/shipping-rates.js
+++ b/assets/js/previews/shipping-rates.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const previewShippingRates = [
+	{
+		destination: {},
+		items: {},
+		shipping_rates: [
+			{
+				currency_code: 'USD',
+				currency_symbol: '$',
+				currency_minor_unit: 2,
+				currency_decimal_separator: '.',
+				currency_thousand_separator: ',',
+				currency_prefix: '$',
+				currency_suffix: '',
+				name: __( 'Free shipping', 'woo-gutenberg-products-block' ),
+				description: '',
+				delivery_time: '',
+				price: '200',
+				rate_id: 'free_shipping:1',
+			},
+			{
+				currency_code: 'USD',
+				currency_symbol: '$',
+				currency_minor_unit: 2,
+				currency_decimal_separator: '.',
+				currency_thousand_separator: ',',
+				currency_prefix: '$',
+				currency_suffix: '',
+				name: __( 'Local pickup', 'woo-gutenberg-products-block' ),
+				description: '',
+				delivery_time: '',
+				price: '0',
+				rate_id: 'local_pickup:1',
+			},
+		],
+	},
+];

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -79,7 +79,21 @@ class CartShippingRateSchema extends AbstractSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 				'items'       => [
-					'type' => 'string',
+					'type'       => 'object',
+					'properties' => [
+						'name'     => [
+							'description' => __( 'Name of the item.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'quantity' => [
+							'description' => __( 'Quantity of the item in the current package.', 'woo-gutenberg-products-block' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
 				],
 			],
 			'shipping_rates' => [
@@ -179,6 +193,15 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $package ) {
+		// Add product names and quantities.
+		$items = array();
+		foreach ( $package['contents'] as $item_id => $values ) {
+			$items[ $item_id ] = [
+				'name'     => $values['data']->get_name(),
+				'quantity' => $values['quantity'],
+			];
+		}
+
 		return [
 			'destination'    => (object) $this->prepare_html_response(
 				[
@@ -190,7 +213,7 @@ class CartShippingRateSchema extends AbstractSchema {
 					'country'   => $package['destination']['country'],
 				]
 			),
-			'items'          => array_values( wp_list_pluck( $package['contents'], 'key' ) ),
+			'items'          => $items,
 			'shipping_rates' => array_values( array_map( [ $this, 'get_rate_response' ], $package['rates'] ) ),
 		];
 	}

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -89,7 +89,7 @@ class CartShippingRateSchema extends AbstractSchema {
 						],
 						'quantity' => [
 							'description' => __( 'Quantity of the item in the current package.', 'woo-gutenberg-products-block' ),
-							'type'        => 'integer',
+							'type'        => 'number',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],


### PR DESCRIPTION
Fixes #1554.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/74960864-5ecca780-540d-11ea-9675-55e3091c8cfa.png)

### How to test the changes in this Pull Request:

1. Install [WooCommerce Advanced Shipping Packages](https://woocommerce.com/products/woocommerce-advanced-shipping-packages/) and set up some package rules ([see how](https://docs.woocommerce.com/document/woocommerce-advanced-shipping-packages/)).
2. Add products that will be in different packages to your cart.
3. Check a post with the _Cart_ block.
4. Verify it shows the product names and quantities instead of ids.