### PR TITLE
Add type="submit" to the Shipping Calculator button

### DIFF
--- a/assets/js/base/components/shipping-calculator/address.js
+++ b/assets/js/base/components/shipping-calculator/address.js
@@ -77,6 +77,7 @@ const ShippingCalculatorAddress = ( { address: initialAddress, onUpdate } ) => {
 				className="wc-block-shipping-calculator-address__button"
 				disabled={ isShallowEqual( address, initialAddress ) }
 				onClick={ () => onUpdate( address ) }
+				type="submit"
 			>
 				{ __( 'Update', 'woo-gutenberg-products-block' ) }
 			</Button>


### PR DESCRIPTION
Add `type="submit"` to the Shipping Calculator form button, so it's possible to submit the form pressing <kbd>Enter</kbd>.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### How to test the changes in this Pull Request:

1. Create a post with a _Cart_ block and view it in the frontend.
2. Click on _Change address_ to open the Shipping Calculator form.
3. Make a change and press <kbd>Enter</kbd>.
4. Verify the form was submitted.
