### PR TITLE
Add `isLoading` property to `LoadingMask` component

### DIFF
--- a/assets/js/base/components/loading-mask/index.js
+++ b/assets/js/base/components/loading-mask/index.js
@@ -16,7 +16,13 @@ const LoadingMask = ( {
 	className,
 	screenReaderLabel,
 	showSpinner = false,
+	isLoading = true,
 } ) => {
+	// If nothing is loading, just pass through the children.
+	if ( ! isLoading ) {
+		return children;
+	}
+
 	return (
 		<div className={ classNames( className, 'wc-block-loading-mask' ) }>
 			{ showSpinner && <Spinner /> }
@@ -38,6 +44,7 @@ LoadingMask.propTypes = {
 	className: PropTypes.string,
 	screenReaderLabel: PropTypes.string,
 	showSpinner: PropTypes.bool,
+	isLoading: PropTypes.bool,
 };
 
 export default LoadingMask;


### PR DESCRIPTION
Adds an `isLoading` property (defaulting to true) to `LoadingMask` enabling developers to wrap components that may load without duplicating logic. If `isLoading`  is false, child elements are simply rendered as normal without spinners or wrapping mask divs.

### How to test the changes in this Pull Request:

1. Wrap components in `<LoadingMask isLoading={ false }>`
2. Check child components are rendered correctly.
3. Wrap components in `<LoadingMask isLoading={ true }>`
4. Check child components are rendered correctly but are masked.