### PR TITLE
Add style to radio control

### DIFF
--- a/assets/js/base/components/radio-control/style.scss
+++ b/assets/js/base/components/radio-control/style.scss
@@ -20,9 +20,32 @@
 }
 
 .wc-block-radio-control__input {
+	appearance: none;
+	background: #fff;
+	border: 2px solid currentColor;
+	border-radius: 50%;
+	display: inline-block;
+	height: 1rem;
+	margin: 0 0 0 -8px;
+	left: $gap-larger;
+	min-height: 16px;
+	min-width: 16px;
 	position: absolute;
-	left: $gap-large;
-	top: $gap-large;
+	top: $gap;
+	width: 1rem;
+
+	&:checked::before {
+		background: currentColor;
+		border-radius: 50%;
+		content: "";
+		display: block;
+		height: 8px;
+		left: 50%;
+		position: absolute;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		width: 8px;
+	}
 }
 
 .wc-block-radio-control__label,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -61,13 +61,12 @@
 		border: 0;
 	}
 	.wc-block-cart__shipping-options {
-		.wc-block-radio-control__label {
+		.wc-block-radio-control__label,
+		.wc-block-radio-control__description,
+		.wc-block-radio-control__secondary-label,
+		.wc-block-radio-control__secondary-description {
 			flex-basis: 100%;
-			line-height: 16px;
-		}
-
-		.wc-block-radio-control__description {
-			flex-basis: 100%;
+			text-align: left;
 		}
 
 		.wc-block-radio-control__option {
@@ -80,7 +79,7 @@
 
 		.wc-block-radio-control__input {
 			left: 0;
-			top: $gap;
+			margin: 0;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1556.

This PR makes the radio control look good no matter if the label associated to it is one or two lines long. That was not initially possible because depending on the device & browser radio inputs might have different dimensions, so this PR also adds a consistent style to radio inputs based on the designs.

I also investigated whether it made sense using the `<RadioControl>` component from Gutenberg, but it relies on some specific wp-admin styles and global resets, so importing it was not straight-forward and we would have needed to bring some CSS from wp-admin to the frontend. In addition to that, the style from Gutenberg's radios is different from the style on our designs. All of this made me discard using Gutenberg's radio control.

### Screenshots

_Checkout_
![imatge](https://user-images.githubusercontent.com/3616980/75048127-4f5e6480-54c8-11ea-8e5f-2263d5a9af13.png)

_Cart_
![imatge](https://user-images.githubusercontent.com/3616980/75048312-9b110e00-54c8-11ea-959b-4d97724e35f5.png)

### How to test the changes in this Pull Request:

1. Create posts with the _Cart_ and _Checkout_ blocks and make sure you have products in your cart and there are shipping methods created.
2. Verify the radio controls in the shipping methods sections look like in the screenshots above.