### PR TITLE
Add permalink to cart line items

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -48,6 +48,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 	const {
 		name,
 		summary,
+		permalink,
 		images,
 		variation,
 		quantity,
@@ -116,13 +117,20 @@ const CartLineItemRow = ( { lineItem } ) => {
 	return (
 		<tr className="wc-block-cart-items__row">
 			<td className="wc-block-cart-item__image">
-				<img
-					{ ...imageProps }
-					alt={ decodeEntities( imageProps.alt ) }
-				/>
+				<a href={ permalink }>
+					<img
+						{ ...imageProps }
+						alt={ decodeEntities( imageProps.alt ) }
+					/>
+				</a>
 			</td>
 			<td className="wc-block-cart-item__product">
-				<div className="wc-block-cart-item__product-name">{ name }</div>
+				<a
+					className="wc-block-cart-item__product-name"
+					href={ permalink }
+				>
+					{ name }
+				</a>
 				{ lowStockBadge }
 				<div className="wc-block-cart-item__product-metadata">
 					<RawHTML>{ summary }</RawHTML>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -139,6 +139,7 @@ table.wc-block-cart-items {
 			.wc-block-cart-item__product-name {
 				color: $core-grey-dark-600;
 				font-size: 16px;
+				display: block;
 			}
 
 			.wc-block-cart-item__low-stock-badge {


### PR DESCRIPTION
Just a small thing I noticed today; the cart line items did not have permalinks back to product pages. Like core, I've added links on the image and product title to solve this.

### Screenshots

![Screenshot 2020-02-21 at 16 44 38](https://user-images.githubusercontent.com/90977/75053595-79645680-54c9-11ea-8c69-27b8ea6b5ac5.png)

### How to test the changes in this Pull Request:

Add items to the cart and ensure the image and title links through to the product page.