### PR TITLE
Add missing alias for tsconfig and re-order alphabetically

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,15 +25,16 @@
 			"@woocommerce/base-hooks/*": [ "assets/js/base/hooks" ],
 			"@woocommerce/base-utils": [ "assets/js/base/utils" ],
 			"@woocommerce/block-components/*": [ "assets/js/components/*" ],
+			"@woocommerce/block-data": [ "assets/js/data" ],
 			"@woocommerce/block-hocs/*": [ "assets/js/hocs/*" ],
 			"@woocommerce/blocks-registry/*": [ "assets/js/blocks-registry/*" ],
-			"@woocommerce/settings": [ "assets/js/settings/shared" ],
 			"@woocommerce/block-settings": [ "assets/js/settings/blocks" ],
-			"@woocommerce/icons": [ "assets/js/icons" ],
-			"@woocommerce/resource-previews": [ "assets/js/previews" ],
 			"@woocommerce/e2e-tests": [
 				"node_modules/woocommerce/tests/e2e-tests"
 			],
+			"@woocommerce/icons": [ "assets/js/icons" ],
+			"@woocommerce/resource-previews": [ "assets/js/previews" ],
+			"@woocommerce/settings": [ "assets/js/settings/shared" ],
 			"@woocommerce/type-defs/*": [ "assets/js/type-defs/*" ]
 		}
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
 			"@woocommerce/base-components/*": [ "assets/js/base/components/*" ],
 			"@woocommerce/base-context/*": [ "assets/js/base/context/*" ],
 			"@woocommerce/base-hocs/*": [ "assets/js/base/hocs/*" ],
-			"@woocommerce/base-hooks/*": [ "assets/js/base/hooks" ],
+			"@woocommerce/base-hooks": [ "assets/js/base/hooks" ],
 			"@woocommerce/base-utils": [ "assets/js/base/utils" ],
 			"@woocommerce/block-components/*": [ "assets/js/components/*" ],
 			"@woocommerce/block-data": [ "assets/js/data" ],


### PR DESCRIPTION
I missed adding the `@woocommerce/block-data` alias to the tsconfig for imports. There was also a fix needed for the `@woocommerce/base-hooks` alias. 

This will fix any places typescript is complaining about missing modules. So testing is just making sure that it's fixed - will have no impact on built code.