### PR TITLE
Updated `store/cart` endpoint coupon formatting and handling

### DIFF
--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -79,8 +79,11 @@ export function* applyCoupon( couponCode ) {
 
 	try {
 		const result = yield apiFetch( {
-			path: '/wc/store/cart/apply-coupon/' + couponCode,
+			path: '/wc/store/cart/apply-coupon',
 			method: 'POST',
+			data: {
+				code: couponCode,
+			},
 			cache: 'no-store',
 		} );
 
@@ -105,8 +108,11 @@ export function* removeCoupon( couponCode ) {
 
 	try {
 		const result = yield apiFetch( {
-			path: '/wc/store/cart/remove-coupon/' + couponCode,
+			path: '/wc/store/cart/remove-coupon',
 			method: 'POST',
+			data: {
+				code: couponCode,
+			},
 			cache: 'no-store',
 		} );
 

--- a/src/RestApi/StoreApi/Controllers/Cart.php
+++ b/src/RestApi/StoreApi/Controllers/Cart.php
@@ -71,34 +71,34 @@ class Cart extends RestController {
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/apply-coupon/(?P<code>[\w-]+)',
+			'/' . $this->rest_base . '/apply-coupon',
 			[
-				'args'   => [
-					'code' => [
-						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
-						'type'        => 'string',
-					],
-				],
 				[
 					'methods'  => 'POST',
 					'callback' => [ $this, 'apply_coupon' ],
+					'args'     => [
+						'code' => [
+							'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+						],
+					],
 				],
 				'schema' => [ $this, 'get_public_item_schema' ],
 			]
 		);
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/remove-coupon/(?P<code>[\w-]+)',
+			'/' . $this->rest_base . '/remove-coupon',
 			[
-				'args'   => [
-					'code' => [
-						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
-						'type'        => 'string',
-					],
-				],
 				[
 					'methods'  => 'POST',
 					'callback' => [ $this, 'remove_coupon' ],
+					'args'     => [
+						'code' => [
+							'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+						],
+					],
 				],
 				'schema' => [ $this, 'get_public_item_schema' ],
 			]

--- a/src/RestApi/StoreApi/Controllers/Cart.php
+++ b/src/RestApi/StoreApi/Controllers/Cart.php
@@ -118,15 +118,16 @@ class Cart extends RestController {
 			return new RestError( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
 		}
 
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
+		$controller  = new CartController();
+		$cart        = $controller->get_cart_instance();
+		$coupon_code = wc_format_coupon_code( $request['code'] );
 
 		if ( ! $cart || ! $cart instanceof \WC_Cart ) {
 			return new RestError( 'woocommerce_rest_cart_error', __( 'Unable to retrieve cart.', 'woo-gutenberg-products-block' ), array( 'status' => 500 ) );
 		}
 
 		try {
-			$controller->apply_coupon( $request['code'] );
+			$controller->apply_coupon( $coupon_code );
 		} catch ( RestException $e ) {
 			return new RestError( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
@@ -150,19 +151,20 @@ class Cart extends RestController {
 			return new RestError( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
 		}
 
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
+		$controller  = new CartController();
+		$cart        = $controller->get_cart_instance();
+		$coupon_code = wc_format_coupon_code( $request['code'] );
 
 		if ( ! $cart || ! $cart instanceof \WC_Cart ) {
 			return new RestError( 'woocommerce_rest_cart_error', __( 'Unable to retrieve cart.', 'woo-gutenberg-products-block' ), array( 'status' => 500 ) );
 		}
 
-		if ( ! $controller->has_coupon( $request['code'] ) ) {
+		if ( ! $controller->has_coupon( $coupon_code ) ) {
 			return new RestError( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
 		}
 
 		$cart = $controller->get_cart_instance();
-		$cart->remove_coupon( $request['code'] );
+		$cart->remove_coupon( $coupon_code );
 		$cart->calculate_totals();
 
 		$data     = $this->prepare_item_for_response( $cart, $request );

--- a/tests/php/RestApi/StoreApi/Controllers/Cart.php
+++ b/tests/php/RestApi/StoreApi/Controllers/Cart.php
@@ -101,6 +101,30 @@ class Cart extends TestCase {
 		$data     = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( '100', $data['totals']->total_discount );
+
+		// Test coupons with different case.
+		$newcoupon = CouponHelper::create_coupon( 'testCoupon' );
+		$request = new WP_REST_Request( 'POST', '/wc/store/cart/apply-coupon' );
+		$request->set_body_params(
+			array(
+				'code' => 'testCoupon',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Test coupons with special chars in the code.
+		$newcoupon = CouponHelper::create_coupon( '$5 off' );
+		$request = new WP_REST_Request( 'POST', '/wc/store/cart/apply-coupon' );
+		$request->set_body_params(
+			array(
+				'code' => '$5 off',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	/**

--- a/tests/php/RestApi/StoreApi/Controllers/Cart.php
+++ b/tests/php/RestApi/StoreApi/Controllers/Cart.php
@@ -91,7 +91,13 @@ class Cart extends TestCase {
 	public function test_apply_coupon() {
 		wc()->cart->remove_coupon( $this->coupon->get_code() );
 
-		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/store/cart/apply-coupon/' . $this->coupon->get_code() ) );
+		$request = new WP_REST_Request( 'POST', '/wc/store/cart/apply-coupon' );
+		$request->set_body_params(
+			array(
+				'code' => $this->coupon->get_code(),
+			)
+		);
+		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( '100', $data['totals']->total_discount );
@@ -102,12 +108,24 @@ class Cart extends TestCase {
 	 */
 	public function test_remove_coupon() {
 		// Invalid coupon.
-		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/store/cart/remove-coupon/doesnotexist' ) );
+		$request = new WP_REST_Request( 'POST', '/wc/store/cart/remove-coupon' );
+		$request->set_body_params(
+			array(
+				'code' => 'doesnotexist',
+			)
+		);
+		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals( 404, $response->get_status() );
 
 		// Applied coupon.
-		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/store/cart/remove-coupon/' . $this->coupon->get_code() ) );
+		$request = new WP_REST_Request( 'POST', '/wc/store/cart/remove-coupon' );
+		$request->set_body_params(
+			array(
+				'code' => $this->coupon->get_code(),
+			)
+		);
+		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( '0', $data['totals']->total_discount );


### PR DESCRIPTION
This PR fixes 2 issues with the coupon handling under the `store/cart` endpoint.

1. Moves the coupon from the URL to the body of the request. This avoids issues with URL encoding of coupons and coupons containing special characters. For example, `$5 off` would 404 due to the `$` in the URL.

2. Applies `wc_format_coupon_code` to the passed in code to ensure codes are normalised. This isn't a problem on the `/store/cart/coupons` endpoint because `wc_format_coupon_code` is defined in the schema, but that schema isn't used here so we need to apply it manually.

cc @nerrad 

### How to test the changes in this Pull Request:

1. Create a coupon called `$5 off` and one called `testCoupon`.
2. On the cart block page apply both coupons as typed above.
3. Ensure coupons are applied to cart.

Added unit tests for the 2 cases above.