### PR TITLE
Add basic tests for Cart & Checkout blocks - snapshot, can only add one instance

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -33,7 +33,6 @@ const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
-		multiple: false,
 	},
 	example,
 	attributes: {

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -33,6 +33,7 @@ const settings = {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
+		multiple: false,
 	},
 	example,
 	attributes: {

--- a/tests/e2e-tests/specs/backend/__snapshots__/cart.test.js.snap
+++ b/tests/e2e-tests/specs/backend/__snapshots__/cart.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cart Block can be created 1`] = `
+"<!-- wp:woocommerce/cart -->
+<div class=\\"wp-block-woocommerce-cart is-loading\\" data-isshippingcalculatorenabled=\\"true\\" data-isshippingcosthidden=\\"false\\"><!-- wp:image {\\"align\\":\\"center\\",\\"sizeSlug\\":\\"small\\"} -->
+<div class=\\"wp-block-image\\"><figure class=\\"aligncenter size-small\\"><img src=\\"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzgiIGhlaWdodD0iMzgiIHZpZXdCb3g9IjAgMCAzOCAzOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTE5IDBDOC41MDQwMyAwIDAgOC41MDQwMyAwIDE5QzAgMjkuNDk2IDguNTA0MDMgMzggMTkgMzhDMjkuNDk2IDM4IDM4IDI5LjQ5NiAzOCAxOUMzOCA4LjUwNDAzIDI5LjQ5NiAwIDE5IDBaTTI1LjEyOSAxMi44NzFDMjYuNDg1MSAxMi44NzEgMjcuNTgwNiAxMy45NjY1IDI3LjU4MDYgMTUuMzIyNkMyNy41ODA2IDE2LjY3ODYgMjYuNDg1MSAxNy43NzQyIDI1LjEyOSAxNy43NzQyQzIzLjc3MyAxNy43NzQyIDIyLjY3NzQgMTYuNjc4NiAyMi42Nzc0IDE1LjMyMjZDMjIuNjc3NCAxMy45NjY1IDIzLjc3MyAxMi44NzEgMjUuMTI5IDEyLjg3MVpNMTEuNjQ1MiAzMS4yNTgxQzkuNjE0OTIgMzEuMjU4MSA3Ljk2Nzc0IDI5LjY0OTIgNy45Njc3NCAyNy42NTczQzcuOTY3NzQgMjYuMTI1IDEwLjE1MTIgMjMuMDI5OCAxMS4xNTQ4IDIxLjY5NjhDMTEuNCAyMS4zNjczIDExLjg5MDMgMjEuMzY3MyAxMi4xMzU1IDIxLjY5NjhDMTMuMTM5MSAyMy4wMjk4IDE1LjMyMjYgMjYuMTI1IDE1LjMyMjYgMjcuNjU3M0MxNS4zMjI2IDI5LjY0OTIgMTMuNjc1NCAzMS4yNTgxIDExLjY0NTIgMzEuMjU4MVpNMTIuODcxIDE3Ljc3NDJDMTEuNTE0OSAxNy43NzQyIDEwLjQxOTQgMTYuNjc4NiAxMC40MTk0IDE1LjMyMjZDMTAuNDE5NCAxMy45NjY1IDExLjUxNDkgMTIuODcxIDEyLjg3MSAxMi44NzFDMTQuMjI3IDEyLjg3MSAxNS4zMjI2IDEzLjk2NjUgMTUuMzIyNiAxNS4zMjI2QzE1LjMyMjYgMTYuNjc4NiAxNC4yMjcgMTcuNzc0MiAxMi44NzEgMTcuNzc0MlpNMjUuOTEwNSAyOS41ODc5QzI0LjE5NDQgMjcuNTM0NyAyMS42NzM4IDI2LjM1NDggMTkgMjYuMzU0OEMxNy4zNzU4IDI2LjM1NDggMTcuMzc1OCAyMy45MDMyIDE5IDIzLjkwMzJDMjIuNDAxNiAyMy45MDMyIDI1LjYxMTcgMjUuNDA0OCAyNy43ODc1IDI4LjAyNUMyOC44NDQ4IDI5LjI4MTUgMjYuOTI5NCAzMC44MjE0IDI1LjkxMDUgMjkuNTg3OVoiIGZpbGw9ImJsYWNrIi8+Cjwvc3ZnPgo=\\" alt=\\"\\"/></figure></div>
+<!-- /wp:image -->
+
+<!-- wp:heading {\\"align\\":\\"center\\",\\"className\\":\\"wc-block-cart__empty-cart__title\\"} -->
+<h2 class=\\"has-text-align-center wc-block-cart__empty-cart__title\\">Your cart is currently empty!</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {\\"align\\":\\"center\\"} -->
+<p class=\\"has-text-align-center\\"><a href=\\"false\\">Browse store</a>.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator {\\"className\\":\\"is-style-dots\\"} -->
+<hr class=\\"wp-block-separator is-style-dots\\"/>
+<!-- /wp:separator -->
+
+<!-- wp:heading {\\"align\\":\\"center\\"} -->
+<h2 class=\\"has-text-align-center\\">New in store</h2>
+<!-- /wp:heading -->
+
+<!-- wp:woocommerce/product-new {\\"rows\\":1} /--></div>
+<!-- /wp:woocommerce/cart -->"
+`;

--- a/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
+++ b/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Checkout Block can be created 1`] = `
+"<!-- wp:woocommerce/checkout -->
+<div class=\\"wp-block-woocommerce-checkout\\">Checkout block coming soon to store near you</div>
+<!-- /wp:woocommerce/checkout -->"
+`;

--- a/tests/e2e-tests/specs/backend/cart.test.js
+++ b/tests/e2e-tests/specs/backend/cart.test.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import {
+	insertBlock,
+	getEditedPostContent,
+	getAllBlocks,
+	createNewPost,
+	switchUserToAdmin,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Cart Block', () => {
+	beforeEach( async () => {
+		await switchUserToAdmin();
+		await createNewPost();
+	} );
+
+	it( 'can be created', async () => {
+		await insertBlock( 'Cart' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'can only be inserted once', async () => {
+		await insertBlock( 'Cart' );
+		expect( await getAllBlocks() ).toHaveLength( 1 );
+
+		await insertBlock( 'Cart' );
+		expect( await getAllBlocks() ).toHaveLength( 1 );
+	} );
+} );

--- a/tests/e2e-tests/specs/backend/checkout.test.js
+++ b/tests/e2e-tests/specs/backend/checkout.test.js
@@ -9,22 +9,22 @@ import {
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
 
-describe( 'Cart Block', () => {
+describe( 'Checkout Block', () => {
 	beforeEach( async () => {
 		await switchUserToAdmin();
 		await createNewPost();
 	} );
 
 	it( 'can be created', async () => {
-		await insertBlock( 'Cart' );
+		await insertBlock( 'Checkout' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
 	it( 'can only be inserted once', async () => {
-		await insertBlock( 'Cart' );
+		await insertBlock( 'Checkout' );
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 
-		await insertBlock( 'Cart' );
+		await insertBlock( 'Checkout' );
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );
 } );


### PR DESCRIPTION
Adds some very basic tests for cart and checkout blocks. Same tests for each block.

- Test adding a block succeeds, and compares the generated markup to a snapshot.
- Test that it's not possible to add more than one cart or checkout block.

### How to test the changes in this Pull Request:

1. Clone this branch. 
2. Run tests `npm run test:e2e`. (If necessary, build test containers with `npm run docker:up:build`)
3. Tests should succeed :)
