### PR TITLE
support disabled QuantitySelector [in progress]

### DIFF
--- a/assets/js/base/components/quantity-selector/index.js
+++ b/assets/js/base/components/quantity-selector/index.js
@@ -18,6 +18,7 @@ const QuantitySelector = ( {
 	quantity = 1,
 	onChange = () => null,
 	itemName = '',
+	disabled,
 } ) => {
 	const classes = classNames( 'wc-block-quantity-selector', className );
 	const inputRef = useRef( null );
@@ -63,6 +64,7 @@ const QuantitySelector = ( {
 		<div className={ classes }>
 			<input
 				className="wc-block-quantity-selector__input"
+				disabled={ disabled }
 				type="number"
 				step="1"
 				min="0"
@@ -91,7 +93,7 @@ const QuantitySelector = ( {
 					'woo-gutenberg-products-block'
 				) }
 				className="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus"
-				disabled={ currentValue <= 0 }
+				disabled={ disabled || currentValue <= 0 }
 				onClick={ () => {
 					const newQuantity = currentValue - 1;
 					setCurrentValue( newQuantity );
@@ -114,6 +116,7 @@ const QuantitySelector = ( {
 					'Increase quantity',
 					'woo-gutenberg-products-block'
 				) }
+				disabled={ disabled }
 				className="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus"
 				onClick={ () => {
 					const newQuantity = currentValue + 1;
@@ -141,6 +144,7 @@ QuantitySelector.propTypes = {
 	quantity: PropTypes.number,
 	onChange: PropTypes.func,
 	itemName: PropTypes.string,
+	disabled: PropTypes.bool,
 };
 
 export default QuantitySelector;

--- a/assets/js/base/components/quantity-selector/stories/index.js
+++ b/assets/js/base/components/quantity-selector/stories/index.js
@@ -1,4 +1,9 @@
 /**
+  * External dependencies
+  */
+import { boolean } from '@storybook/addon-knobs';
+
+/**
  * Internal dependencies
  */
 import QuantitySelector from '../';
@@ -10,5 +15,8 @@ export default {
 };
 
 export const Default = () => (
-	<QuantitySelector itemName='widgets'></QuantitySelector>
+	<QuantitySelector
+		disabled={ boolean( 'Disabled', false ) }
+		itemName='widgets'
+	></QuantitySelector>
 );

--- a/assets/js/base/components/quantity-selector/stories/index.js
+++ b/assets/js/base/components/quantity-selector/stories/index.js
@@ -1,6 +1,6 @@
 /**
-  * External dependencies
-  */
+ * External dependencies
+ */
 import { boolean } from '@storybook/addon-knobs';
 
 /**

--- a/assets/js/base/components/quantity-selector/stories/index.js
+++ b/assets/js/base/components/quantity-selector/stories/index.js
@@ -18,5 +18,5 @@ export const Default = () => (
 	<QuantitySelector
 		disabled={ boolean( 'Disabled', false ) }
 		itemName='widgets'
-	></QuantitySelector>
+	/>
 );

--- a/assets/js/base/components/quantity-selector/stories/index.js
+++ b/assets/js/base/components/quantity-selector/stories/index.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+import QuantitySelector from '../';
+import './style.scss';
+
+export default {
+	title: 'WooCommerce Blocks/@base-components/QuantitySelector',
+	component: QuantitySelector,
+};
+
+export const Default = () => (
+	<QuantitySelector itemName='widgets'></QuantitySelector>
+);

--- a/assets/js/base/components/quantity-selector/stories/style.scss
+++ b/assets/js/base/components/quantity-selector/stories/style.scss
@@ -1,0 +1,5 @@
+// Choose a nice width for storybook demo.
+// (QuantitySelector expands to container width.)
+.wc-block-quantity-selector {
+	width: 100px;
+}

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -33,6 +33,9 @@
 			background: $core-grey-light-200;
 			outline: 1px solid $core-grey-dark-100;
 		}
+		&:disabled {
+			color: $core-grey-dark-100;
+		}
 	}
 	input::-webkit-outer-spin-button,
 	input::-webkit-inner-spin-button {


### PR DESCRIPTION
Fixes #1814

Adds `disabled` prop to `QuantitySelector` so it can be globally disabled from client code. Uses existing disabled styling for the up/down buttons and adds a style rule for the number edit. Add to storybook for easier testing while we're here :)

### Screenshots

<img width="1016" alt="Screen Shot 2020-02-27 at 2 47 23 PM" src="https://user-images.githubusercontent.com/4167300/75404682-26c6e680-5970-11ea-8437-342ca768baed.png">

### How to test the changes in this Pull Request:

1. Clone this branch.
2. Launch storybook and test component in isolation in a variety of browsers/devices: `npm run storybook` `http://localhost:6006/`.

For now, to test this in woo blocks context, you'll need to hack the source for cart and force `disabled`. In future can test this in conjunction with #1813 / #1746.

