### PR TITLE
Add screen reader text to sale badge for SSR rendered blocks

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -427,7 +427,10 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			return;
 		}
 
-		return '<span class="wc-block-grid__product-onsale">' . esc_html__( 'Sale!', 'woo-gutenberg-products-block' ) . '</span>';
+		return '<span class="wc-block-grid__product-onsale">
+			<span aria-hidden="true">' . esc_html__( 'Sale!', 'woo-gutenberg-products-block' ) . '</span>
+			<span class="screen-reader-text">' . esc_html__( 'Product on sale', 'woo-gutenberg-products-block' ) . '</span>
+		</span>';
 	}
 
 	/**


### PR DESCRIPTION
Adds screenreader text to the sale badge which reads "Product on sale" rather than the default text of just "Sale!".

Fixes #1686

### How to test the changes in this Pull Request:

1. Enable voiceover, visit the handpicked products block on a page in chrome
2. Highlight the sale badge with cursor
3. Voiceover should read "Product on sale".

--also--

Ensure the text "product on sale" is not visible.

<!-- If you can, add the appropriate labels -->

### Changelog

> Added screenreader alternative text to the sale badge.
