### PR TITLE
Add aria labels for category list product counts

### DIFF
--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -168,6 +168,10 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return string Rendered output.
 	 */
 	protected function renderDropdown( $categories, $attributes, $uid ) {
+		$aria_label = empty( $attributes['hasCount'] ) ?
+			__( 'List of categories', 'woo-gutenberg-products-block' ) :
+			__( 'List of categories with their product counts', 'woo-gutenberg-products-block' );
+
 		$output = '
 			<div class="wc-block-product-categories__dropdown">
 				<label
@@ -176,7 +180,7 @@ class ProductCategories extends AbstractDynamicBlock {
 				>
 					' . esc_html__( 'Select a category', 'woo-gutenberg-products-block' ) . '
 				</label>
-				<select id="' . esc_attr( $uid ) . '-select">
+				<select aria-label="' . esc_attr( $aria_label ) . '" id="' . esc_attr( $uid ) . '-select">
 					<option value="false" hidden>
 						' . esc_html__( 'Select a category', 'woo-gutenberg-products-block' ) . '
 					</option>
@@ -314,6 +318,20 @@ class ProductCategories extends AbstractDynamicBlock {
 		if ( empty( $attributes['hasCount'] ) ) {
 			return '';
 		}
-		return $attributes['isDropdown'] ? '(' . absint( $category->count ) . ')' : '<span class="wc-block-product-categories-list-item-count">' . absint( $category->count ) . '</span>';
+
+		if ( $attributes['isDropdown'] ) {
+			return '(' . absint( $category->count ) . ')';
+		}
+
+		$screen_reader_text = sprintf(
+			/* translators: %s number of products in cart. */
+			_n( '%d product', '%d products', absint( $category->count ), 'woo-gutenberg-products-block' ),
+			absint( $category->count )
+		);
+
+		return '<span class="wc-block-product-categories-list-item-count">'
+			. '<span aria-hidden="true">' . absint( $category->count ) . '</span>'
+			. '<span class="screen-reader-text">' . esc_html( $screen_reader_text ) . '</span>'
+		. '</span>';
 	}
 }


### PR DESCRIPTION
Adds screen reader text to the product categories list.

For lists, it adds additional screen-reader-text stating what each count is for e.g. 1 product.

For dropdowns, it adds an additional label to the select element itself stating what is contained (options cannot have their own labels).

Fixes #1674

### How to test the changes in this Pull Request:

1. Insert 2 product category list blocks; one list, one dropdown
2. Start screenreader
3. Selects counts in the list and confirm it says "X Products"
4. Tab to select input. Ensure it says that it contains "Categories with their product counts".

<!-- If you can, add the appropriate labels -->

### Changelog

> Added screen reader text to product counts in the product category list block
