### PR TITLE
Fix typedef errors related to `StoreCartItem`

### DIFF
--- a/assets/js/base/hooks/use-store-cart-item.js
+++ b/assets/js/base/hooks/use-store-cart-item.js
@@ -1,4 +1,4 @@
-/** @typedef { import('@woocommerce/type-defs/hooks').StoreCartItems } StoreCartItems */
+/** @typedef { import('@woocommerce/type-defs/hooks').StoreCartItem } StoreCartItem */
 
 /**
  * External dependencies
@@ -14,10 +14,11 @@ import { useStoreCart } from './use-store-cart';
 /**
  * This is a custom hook for loading the Store API /cart/ endpoint and
  * actions for removing or changing item quantity.
- * See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/master/src/RestApi/StoreApi
+ *
+ * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/master/src/RestApi/StoreApi
  *
  * @param {string} cartItemKey Key for a cart item.
- * @return {StoreCartItems} An object exposing data and actions relating to cart items.
+ * @return {StoreCartItem} An object exposing data and actions relating to cart items.
  */
 export const useStoreCartItem = ( cartItemKey ) => {
 	const { cartItems, cartIsLoading } = useStoreCart();

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('./cart').CartData} CartData
+ */
+
+/**
  * @typedef {Object} StoreCart
  *
  * @property {Array}   cartCoupons       An array of coupons applied to the cart.
@@ -24,14 +28,15 @@
  */
 
 /**
- * @typedef {Object} StoreCartItems
+ * @typedef {Object} StoreCartItem
  *
- * @property {boolean}  isLoading             True when cart items are being loaded.
- * @property {Array}    cartItems             An array of items in the cart.
- * @property {Function} isItemQuantityPending Callback for determining if a cart item
- *                                            is currently updating (i.e. remoe / change
- *                                            quantity).
- * @property {Function} removeItemFromCart    Callback for removing a cart item.
+ * @property {boolean}  isLoading             True when cart items are being
+ *                                            loaded.
+ * @property {CartData} cartData              A cart item from the data store.
+ * @property {Function} isPending             Callback for determining if a cart
+ *                                            item is currently updating (i.e.
+ *                                            remove / change quantity).
+ * @property {Function} removeItem            Callback for removing a cart item.
  */
 
- export {};
+export {};


### PR DESCRIPTION
See [this comment](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1813#issuecomment-592275088) for background.

I decided to go ahead and do this now so any usage of `StoreCartItems` for in progress code is using the right type (reduces chances for conflicts happening in multiple pulls as well that might fix this).

I'm going to merge without review because it doesn't affect any builds and minimal change.