### PR TITLE
Update shipping/cart endpoints

### DIFF
--- a/assets/js/base/components/shipping-rates-control/packages.js
+++ b/assets/js/base/components/shipping-rates-control/packages.js
@@ -19,7 +19,7 @@ const Packages = ( {
 } ) => {
 	return shippingRates.map( ( shippingRate, i ) => (
 		<Package
-			key={ Object.keys( shippingRate.items ).join() }
+			key={ shippingRate.package_id }
 			className={ className }
 			noResultsMessage={ noResultsMessage }
 			onChange={ ( newShippingRate ) => {

--- a/src/RestApi/StoreApi/Controllers/Cart.php
+++ b/src/RestApi/StoreApi/Controllers/Cart.php
@@ -105,6 +105,61 @@ class Cart extends RestController {
 		);
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base . '/update-shipping',
+			[
+				[
+					'methods'  => 'POST',
+					'callback' => [ $this, 'update_shipping' ],
+					'args'     => [
+						'address_1' => array(
+							'description'       => __( 'First line of the address being shipped to.', 'woo-gutenberg-products-block' ),
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'wc_clean',
+							'validate_callback' => 'rest_validate_request_arg',
+						),
+						'address_2' => [
+							'description'       => __( 'Second line of the address being shipped to.', 'woo-gutenberg-products-block' ),
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'wc_clean',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+						'city'      => [
+							'description'       => __( 'City of the address being shipped to.', 'woo-gutenberg-products-block' ),
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'wc_clean',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+						'state'     => [
+							'description'       => __( 'ISO code, or name, for the state, province, or district of the address being shipped to.', 'woo-gutenberg-products-block' ),
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'wc_clean',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+						'postcode'  => [
+							'description'       => __( 'Zip or Postcode of the address being shipped to.', 'woo-gutenberg-products-block' ),
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'wc_clean',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+						'country'   => [
+							'description'       => __( 'ISO code for the country of the address being shipped to.', 'woo-gutenberg-products-block' ),
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'wc_clean',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/select-shipping-rate/(?P<package_id>[\d]+)',
 			[
 				'args'   => [
@@ -235,6 +290,52 @@ class Cart extends RestController {
 	}
 
 	/**
+	 * Given an address, gets updated shipping rates for the cart.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	public function update_shipping( $request ) {
+		if ( ! wc_shipping_enabled() ) {
+			return new RestError( 'woocommerce_rest_shipping_disabled', __( 'Shipping is disabled.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+		}
+
+		$controller = new CartController();
+		$cart       = $controller->get_cart_instance();
+
+		if ( ! $cart || ! $cart instanceof \WC_Cart ) {
+			return new RestError( 'woocommerce_rest_cart_error', __( 'Unable to retrieve cart.', 'woo-gutenberg-products-block' ), array( 'status' => 500 ) );
+		}
+
+		$request = $this->validate_shipping_address( $request );
+
+		if ( is_wp_error( $request ) ) {
+			return $request;
+		}
+
+		// Update customer session.
+		WC()->customer->set_props(
+			array(
+				'shipping_country'   => isset( $request['country'] ) ? $request['country'] : null,
+				'shipping_state'     => isset( $request['state'] ) ? $request['state'] : null,
+				'shipping_postcode'  => isset( $request['postcode'] ) ? $request['postcode'] : null,
+				'shipping_city'      => isset( $request['city'] ) ? $request['city'] : null,
+				'shipping_address_1' => isset( $request['address_1'] ) ? $request['address_1'] : null,
+				'shipping_address_2' => isset( $request['address_2'] ) ? $request['address_2'] : null,
+			)
+		);
+		WC()->customer->save();
+
+		$cart->calculate_shipping();
+		$cart->calculate_totals();
+
+		$data     = $this->prepare_item_for_response( $cart, $request );
+		$response = rest_ensure_response( $data );
+
+		return $response;
+	}
+
+	/**
 	 * Get the cart.
 	 *
 	 * @param \WP_REST_Request $request Full details about the request.
@@ -272,5 +373,76 @@ class Cart extends RestController {
 	 */
 	public function prepare_item_for_response( $cart, $request ) {
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+	}
+
+	/**
+	 * Format the request address.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 * @return \WP_Error|\WP_REST_Response
+	 */
+	protected function validate_shipping_address( $request ) {
+		$valid_countries = WC()->countries->get_shipping_countries();
+
+		if ( empty( $request['country'] ) ) {
+			return new RestError(
+				'woocommerce_rest_cart_shipping_rates_missing_country',
+				sprintf(
+					/* translators: 1: valid country codes */
+					__( 'No destination country code was given. Please provide one of the following: %s', 'woo-gutenberg-products-block' ),
+					implode( ', ', array_keys( $valid_countries ) )
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$request['country'] = wc_strtoupper( $request['country'] );
+
+		if (
+			is_array( $valid_countries ) &&
+			count( $valid_countries ) > 0 &&
+			! array_key_exists( $request['country'], $valid_countries )
+		) {
+			return new RestError(
+				'woocommerce_rest_cart_shipping_rates_invalid_country',
+				sprintf(
+					/* translators: 1: valid country codes */
+					__( 'Destination country code is not valid. Please enter one of the following: %s', 'woo-gutenberg-products-block' ),
+					implode( ', ', array_keys( $valid_countries ) )
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$request['postcode'] = $request['postcode'] ? wc_format_postcode( $request['postcode'], $request['country'] ) : null;
+
+		if ( ! empty( $request['state'] ) ) {
+			$valid_states = WC()->countries->get_states( $request['country'] );
+
+			if ( is_array( $valid_states ) && count( $valid_states ) > 0 ) {
+				$valid_state_values = array_map( 'wc_strtoupper', array_flip( array_map( 'wc_strtoupper', $valid_states ) ) );
+				$request['state']   = wc_strtoupper( $request['state'] );
+
+				if ( isset( $valid_state_values[ $request['state'] ] ) ) {
+					// With this part we consider state value to be valid as well,
+					// convert it to the state key for the valid_states check below.
+					$request['state'] = $valid_state_values[ $request['state'] ];
+				}
+
+				if ( ! in_array( $request['state'], $valid_state_values, true ) ) {
+					return new RestError(
+						'woocommerce_rest_cart_shipping_rates_invalid_state',
+						sprintf(
+							/* translators: 1: valid states */
+							__( 'Destination state is not valid. Please enter one of the following: %s', 'woo-gutenberg-products-block' ),
+							implode( ', ', $valid_states )
+						),
+						[ 'status' => 400 ]
+					);
+				}
+			}
+		}
+
+		return $request;
 	}
 }

--- a/src/RestApi/StoreApi/Controllers/Cart.php
+++ b/src/RestApi/StoreApi/Controllers/Cart.php
@@ -271,8 +271,6 @@ class Cart extends RestController {
 	 * @return \WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $cart, $request ) {
-		$data = $this->schema->get_item_response( $cart );
-
-		return rest_ensure_response( $data );
+		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
 	}
 }

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -122,7 +122,8 @@ class CartShippingRates extends RestController {
 		$response = [];
 
 		foreach ( $packages as $package_id => $package ) {
-			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package, $request, $package_id ) );
+			$package['package_id'] = $package_id;
+			$response[]            = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package, $request ) );
 		}
 
 		return rest_ensure_response( $response );
@@ -182,11 +183,10 @@ class CartShippingRates extends RestController {
 	 *
 	 * @param array            $package Shipping package complete with rates from WooCommerce.
 	 * @param \WP_REST_Request $request Request object.
-	 * @param int              $package_id ID of the package.
 	 * @return \WP_REST_Response $response Response data.
 	 */
-	public function prepare_item_for_response( $package, $request, $package_id ) {
-		return rest_ensure_response( $this->schema->get_item_response( $package, $package_id ) );
+	public function prepare_item_for_response( $package, $request ) {
+		return rest_ensure_response( $this->schema->get_item_response( $package ) );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -75,6 +75,10 @@ class CartShippingRates extends RestController {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public function get_items( $request ) {
+		if ( ! wc_shipping_enabled() ) {
+			return new RestError( 'woocommerce_rest_shipping_disabled', __( 'Shipping is disabled.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+		}
+
 		$controller = new CartController();
 		$cart       = $controller->get_cart_instance();
 
@@ -82,91 +86,18 @@ class CartShippingRates extends RestController {
 			return new RestError( 'woocommerce_rest_cart_error', __( 'Unable to retrieve cart.', 'woo-gutenberg-products-block' ), array( 'status' => 500 ) );
 		}
 
-		if ( ! empty( $request['country'] ) ) {
-			$valid_countries = WC()->countries->get_shipping_countries();
-
-			if (
-				is_array( $valid_countries ) &&
-				count( $valid_countries ) > 0 &&
-				! array_key_exists( $request['country'], $valid_countries )
-			) {
-				return new RestError(
-					'woocommerce_rest_cart_shipping_rates_invalid_country',
-					sprintf(
-						/* translators: 1: valid country codes */
-						__( 'Destination country code is not valid. Please enter one of the following: %s', 'woo-gutenberg-products-block' ),
-						implode( ', ', array_keys( $valid_countries ) )
-					),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		$request = $this->validate_shipping_address( $request );
-
-		if ( is_wp_error( $request ) ) {
-			return $request;
-		}
-
-		$cart_items = $controller->get_cart_items(
-			function( $item ) {
-				return ! empty( $item['data'] ) && $item['data']->needs_shipping();
-			}
-		);
-
-		if ( empty( $cart_items ) ) {
+		if ( ! $cart->needs_shipping() ) {
 			return rest_ensure_response( [] );
 		}
 
-		$packages = $this->get_shipping_packages( $request );
+		$packages = $controller->get_shipping_packages();
 		$response = [];
 
-		foreach ( $packages as $package_id => $package ) {
-			$package['package_id'] = $package_id;
-			$response[]            = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package, $request ) );
+		foreach ( $packages as $package ) {
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package, $request ) );
 		}
 
 		return rest_ensure_response( $response );
-	}
-
-	/**
-	 * Format the request address.
-	 *
-	 * @param \WP_REST_Request $request Full details about the request.
-	 * @return \WP_Error|\WP_REST_Response
-	 */
-	protected function validate_shipping_address( $request ) {
-		$request['country']  = wc_strtoupper( $request['country'] );
-		$request['postcode'] = $request['postcode'] ? wc_format_postcode( $request['postcode'], $request['country'] ) : null;
-
-		if ( ! empty( $request['state'] ) ) {
-			$valid_states = WC()->countries->get_states( $request['country'] );
-
-			if ( is_array( $valid_states ) && count( $valid_states ) > 0 ) {
-				$valid_state_values = array_map( 'wc_strtoupper', array_flip( array_map( 'wc_strtoupper', $valid_states ) ) );
-				$request['state']   = wc_strtoupper( $request['state'] );
-
-				if ( isset( $valid_state_values[ $request['state'] ] ) ) {
-					// With this part we consider state value to be valid as well,
-					// convert it to the state key for the valid_states check below.
-					$request['state'] = $valid_state_values[ $request['state'] ];
-				}
-
-				if ( ! in_array( $request['state'], $valid_state_values, true ) ) {
-					return new RestError(
-						'woocommerce_rest_cart_shipping_rates_invalid_state',
-						sprintf(
-							/* translators: 1: valid states */
-							__( 'Destination state is not valid. Please enter one of the following: %s', 'woo-gutenberg-products-block' ),
-							implode( ', ', $valid_states )
-						),
-						[ 'status' => 400 ]
-					);
-				}
-			}
-		}
-
-		return $request;
 	}
 
 	/**
@@ -187,96 +118,5 @@ class CartShippingRates extends RestController {
 	 */
 	public function prepare_item_for_response( $package, $request ) {
 		return rest_ensure_response( $this->schema->get_item_response( $package ) );
-	}
-
-	/**
-	 * Get the query params available for this endpoint.
-	 *
-	 * @return array
-	 */
-	public function get_collection_params() {
-		$params                       = array();
-		$params['context']            = $this->get_context_param();
-		$params['context']['default'] = 'view';
-
-		$params['address_1'] = array(
-			'description'       => __( 'First line of the address being shipped to.', 'woo-gutenberg-products-block' ),
-			'type'              => 'string',
-			'default'           => '',
-			'sanitize_callback' => 'wc_clean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		$params['address_2'] = array(
-			'description'       => __( 'Second line of the address being shipped to.', 'woo-gutenberg-products-block' ),
-			'type'              => 'string',
-			'default'           => '',
-			'sanitize_callback' => 'wc_clean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		$params['city'] = array(
-			'description'       => __( 'City of the address being shipped to.', 'woo-gutenberg-products-block' ),
-			'type'              => 'string',
-			'default'           => '',
-			'sanitize_callback' => 'wc_clean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		$params['state'] = array(
-			'description'       => __( 'ISO code, or name, for the state, province, or district of the address being shipped to.', 'woo-gutenberg-products-block' ),
-			'type'              => 'string',
-			'default'           => '',
-			'sanitize_callback' => 'wc_clean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		$params['postcode'] = array(
-			'description'       => __( 'Zip or Postcode of the address being shipped to.', 'woo-gutenberg-products-block' ),
-			'type'              => 'string',
-			'default'           => '',
-			'sanitize_callback' => 'wc_clean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		$params['country'] = array(
-			'description'       => __( 'ISO code for the country of the address being shipped to.', 'woo-gutenberg-products-block' ),
-			'type'              => 'string',
-			'default'           => '',
-			'sanitize_callback' => 'wc_clean',
-			'validate_callback' => 'rest_validate_request_arg',
-		);
-
-		return $params;
-	}
-
-	/**
-	 * Get packages with calculated shipping.
-	 *
-	 * Based on WC_Cart::get_shipping_packages but allows the destination to be
-	 * customised based on passed params.
-	 *
-	 * @param \WP_REST_Request $request Request object.
-	 * @return array of cart items
-	 */
-	protected function get_shipping_packages( $request ) {
-		$packages = WC()->cart->get_shipping_packages();
-
-		if ( $request['country'] ) {
-			foreach ( $packages as $key => $package ) {
-				$packages[ $key ]['destination'] = [
-					'address_1' => $request['address_1'],
-					'address_2' => $request['address_2'],
-					'city'      => $request['city'],
-					'state'     => $request['state'],
-					'postcode'  => $request['postcode'],
-					'country'   => $request['country'],
-				];
-			}
-		}
-
-		$packages = WC()->shipping()->calculate_shipping( $packages );
-
-		return $packages;
 	}
 }

--- a/src/RestApi/StoreApi/Controllers/CartShippingRates.php
+++ b/src/RestApi/StoreApi/Controllers/CartShippingRates.php
@@ -121,8 +121,8 @@ class CartShippingRates extends RestController {
 		$packages = $this->get_shipping_packages( $request );
 		$response = [];
 
-		foreach ( $packages as $package ) {
-			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package, $request ) );
+		foreach ( $packages as $package_id => $package ) {
+			$response[] = $this->prepare_response_for_collection( $this->prepare_item_for_response( $package, $request, $package_id ) );
 		}
 
 		return rest_ensure_response( $response );
@@ -182,10 +182,11 @@ class CartShippingRates extends RestController {
 	 *
 	 * @param array            $package Shipping package complete with rates from WooCommerce.
 	 * @param \WP_REST_Request $request Request object.
+	 * @param int              $package_id ID of the package.
 	 * @return \WP_REST_Response $response Response data.
 	 */
-	public function prepare_item_for_response( $package, $request ) {
-		return rest_ensure_response( $this->schema->get_item_response( $package ) );
+	public function prepare_item_for_response( $package, $request, $package_id ) {
+		return rest_ensure_response( $this->schema->get_item_response( $package, $package_id ) );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Schemas/CartSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartSchema.php
@@ -45,7 +45,21 @@ class CartSchema extends AbstractSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 				'items'       => [
-					'type' => 'string',
+					'type'       => 'object',
+					'properties' => [
+						'package_id' => [
+							'description' => __( 'The ID of the package being shipped.', 'woo-gutenberg-products-block' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'rate_id'    => [
+							'description' => __( 'ID of the shipping rate.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
 				],
 			],
 			'items'                   => [
@@ -238,6 +252,21 @@ class CartSchema extends AbstractSchema {
 	 * @return array
 	 */
 	protected function get_selected_shipping_rates() {
-		return WC()->session->get( 'chosen_shipping_methods', array() );
+		$selected_shipping_rates = [];
+		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods', array() );
+
+		// Core stores chosen rates in an indexed array where the index matches the package ids.
+		foreach ( $chosen_shipping_methods as $key => $value ) {
+			// Core sets rates to false when they are not set. Normalize to a string for the API response.
+			if ( false === $value ) {
+				$value = '';
+			}
+			$selected_shipping_rates[] = [
+				'package_id' => $key,
+				'rate_id'    => $value,
+			];
+		}
+
+		return $selected_shipping_rates;
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -202,10 +202,9 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * Convert a shipping rate from WooCommerce into a valid response.
 	 *
 	 * @param array $package Shipping package complete with rates from WooCommerce.
-	 * @param int   $package_id ID of the package.
 	 * @return array
 	 */
-	public function get_item_response( $package, $package_id ) {
+	public function get_item_response( $package ) {
 		// Add product names and quantities.
 		$items = array();
 		foreach ( $package['contents'] as $item_id => $values ) {
@@ -217,7 +216,7 @@ class CartShippingRateSchema extends AbstractSchema {
 		}
 
 		return [
-			'package_id'     => $package_id,
+			'package_id'     => $package['package_id'],
 			'destination'    => (object) $this->prepare_html_response(
 				[
 					'address_1' => $package['destination']['address_1'],

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -74,13 +74,19 @@ class CartShippingRateSchema extends AbstractSchema {
 				],
 			],
 			'items'          => [
-				'description' => __( 'List of cart items (keys) the returned shipping rates apply to.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'List of cart items the returned shipping rates apply to.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 				'items'       => [
 					'type'       => 'object',
 					'properties' => [
+						'key'      => [
+							'description' => __( 'Unique identifier for the item within the cart.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
 						'name'     => [
 							'description' => __( 'Name of the item.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
@@ -190,13 +196,15 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * Convert a shipping rate from WooCommerce into a valid response.
 	 *
 	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @param int   $package_id ID of the package.
 	 * @return array
 	 */
-	public function get_item_response( $package ) {
+	public function get_item_response( $package, $package_id ) {
 		// Add product names and quantities.
 		$items = array();
 		foreach ( $package['contents'] as $item_id => $values ) {
-			$items[ $item_id ] = [
+			$items[] = [
+				'key'      => $item_id,
 				'name'     => $values['data']->get_name(),
 				'quantity' => $values['quantity'],
 			];

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -29,6 +29,12 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	protected function get_properties() {
 		return [
+			'package_id'     => [
+				'description' => __( 'The ID of the package the shipping rates belong to.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
 			'destination'    => [
 				'description' => __( 'Shipping destination address.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
@@ -211,6 +217,7 @@ class CartShippingRateSchema extends AbstractSchema {
 		}
 
 		return [
+			'package_id'     => $package_id,
 			'destination'    => (object) $this->prepare_html_response(
 				[
 					'address_1' => $package['destination']['address_1'],

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -250,7 +250,7 @@ class CartShippingRateSchema extends AbstractSchema {
 		$selected_rate  = isset( $chosen_shipping_methods[ $package['package_id'] ] ) ? $chosen_shipping_methods[ $package['package_id'] ] : '';
 
 		if ( empty( $selected_rate ) && ! empty( $package['rates'] ) ) {
-			$selected_rate = $package['rates'][0]->get_rate_prop( $rate, 'id' );
+			$selected_rate = wc_get_chosen_shipping_method_for_package( $package['package_id'], $package );
 		}
 
 		$response = [];

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -212,19 +212,15 @@ class CartController {
 	/**
 	 * Selects a shipping rate.
 	 *
-	 * @param array $rate_ids Shipping rate ids.
+	 * @param int    $package_id ID of the package to choose a rate for.
+	 * @param string $rate_id ID of the rate being chosen.
 	 */
-	public function select_shipping_rate( $rate_ids ) {
-		$cart                    = $this->get_cart_instance();
-		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' ) ? WC()->session->get( 'chosen_shipping_methods' ) : array();
-		$posted_shipping_methods = $rate_ids ? wc_clean( wp_unslash( $rate_ids ) ) : array();
+	public function select_shipping_rate( $package_id, $rate_id ) {
+		$cart                        = $this->get_cart_instance();
+		$session_data                = WC()->session->get( 'chosen_shipping_methods' ) ? WC()->session->get( 'chosen_shipping_methods' ) : [];
+		$session_data[ $package_id ] = $rate_id;
 
-		if ( empty( $posted_shipping_methods ) ) {
-			$chosen_shipping_methods = array();
-		} else {
-			$chosen_shipping_methods = array_merge( $chosen_shipping_methods, $posted_shipping_methods );
-		}
-		WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
+		WC()->session->set( 'chosen_shipping_methods', $session_data );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -210,6 +210,24 @@ class CartController {
 	}
 
 	/**
+	 * Get shipping packages from the cart and format as required.
+	 *
+	 * @param bool $calculate_rates Should rates for the packages also be returned.
+	 * @return array
+	 */
+	public function get_shipping_packages( $calculate_rates = true ) {
+		$cart     = $this->get_cart_instance();
+		$packages = $cart->get_shipping_packages();
+
+		// Add package ID to array.
+		foreach ( $packages as $key => $package ) {
+			$packages[ $key ]['package_id'] = $key;
+		}
+
+		return $calculate_rates ? WC()->shipping()->calculate_shipping( $packages ) : $packages;
+	}
+
+	/**
 	 * Selects a shipping rate.
 	 *
 	 * @param int    $package_id ID of the package to choose a rate for.


### PR DESCRIPTION
@senadir Will be some more work to do here such as updating tests, testing, and checking each response/request works for our use case, but this PR implements some of what we chatted about.

1. /cart/shipping-rates no longer quotes for a given address. It uses the session data.
2. /cart/ returns an array of shipping-rates for convenience
3. shipping-rates have a `selected` property much like you did originally (sorry)
4. /cart/update-shipping takes an address, updates customer session, and returns new rates
5. /cart/select-shipping-rate/<packageID> lets you set a rate id for a package by POSTing