### PR TITLE
Switch lint:js command to use wp-scripts and address errors.

### DIFF
--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -39,11 +39,13 @@ export const formatPriceRange = ( minPrice, maxPrice ) => {
 /**
  * Render a removable item in the active filters block list.
  *
- * @param {string} type Type string.
- * @param {string} name Name string.
- * @param {string} prefix Prefix shown before item name.
- * @param {Function} removeCallback Callback to remove item.
- * @param {boolean} [showLabel=true] Should the label be shown for this item?
+ * @param {Object}   listItem                  The removable item to render.
+ * @param {string}   listItem.type             Type string.
+ * @param {string}   listItem.name             Name string.
+ * @param {string}   listItem.prefix           Prefix shown before item name.
+ * @param {Function} listItem.removeCallback   Callback to remove item.
+ * @param {boolean}  [listItem.showLabel=true] Should the label be shown for
+ *                                             this item?
  */
 export const renderRemovableListItem = ( {
 	type,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"lint:php": "composer run-script phpcs ./src",
 		"lint:css": "stylelint 'assets/**/*.scss'",
 		"lint:css-fix": "stylelint 'assets/**/*.scss' --fix",
-		"lint:js": "eslint assets/js bin --ext=js,jsx",
+		"lint:js": "wp-scripts lint-js",
 		"lint:js-fix": "eslint assets/js --ext=js,jsx --fix",
 		"package-plugin": "./bin/build-plugin-zip.sh",
 		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",

--- a/tests/bin/e2e-test-integration.js
+++ b/tests/bin/e2e-test-integration.js
@@ -21,7 +21,7 @@ if ( program.dev ) {
 
 const envVars = Object.assign( {}, process.env, testEnvVars );
 
-let jestProcess = spawnSync(
+const jestProcess = spawnSync(
 	'jest',
 	[
 		'--maxWorkers=1',
@@ -36,6 +36,7 @@ let jestProcess = spawnSync(
 	}
 );
 
+// eslint-disable-next-line no-console
 console.log( 'Jest exit code: ' + jestProcess.status );
 
 // Pass Jest exit code to npm

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,6 +88,7 @@ const CoreConfig = {
 		new DefinePlugin( {
 			// Inject the `WOOCOMMERCE_BLOCKS_PHASE` global, used for feature flagging.
 			'process.env.WOOCOMMERCE_BLOCKS_PHASE': JSON.stringify(
+				// eslint-disable-next-line woocommerce/feature-flag
 				process.env.WOOCOMMERCE_BLOCKS_PHASE || 'experimental'
 			),
 		} ),
@@ -96,8 +97,10 @@ const CoreConfig = {
 			// file name
 			fileName: 'blocks.ini',
 			// content of the file
-			content: `woocommerce_blocks_phase = ${ process.env
-				.WOOCOMMERCE_BLOCKS_PHASE || 'experimental' }`,
+			content: `woocommerce_blocks_phase = ${
+				// eslint-disable-next-line woocommerce/feature-flag
+				process.env.WOOCOMMERCE_BLOCKS_PHASE || 'experimental'
+			}`,
 		} ),
 	],
 };


### PR DESCRIPTION
While working on #1780 I noticed that our linting command doesn't use `wp-scripts` and when I switched there were additional errors that popped up (because of the widened linting checks on files previously excluded).  It's important to continue using wp-scripts for the lint command to ensure we get any improvements brought in by that.

Since the changes don't impact any existing code and is verifiable via travis, I'll merge once Travis passes.