### PR TITLE
Fix Product Search block in last Gutenberg release

### DIFF
--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -4,9 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { PlainText } from '@wordpress/editor';
 import { HOME_URL } from '@woocommerce/block-settings';
-import withComponentId from '@woocommerce/base-hocs/with-component-id';
 
 /**
  * Internal dependencies
@@ -19,66 +17,12 @@ import './style.scss';
  */
 const ProductSearchBlock = ( {
 	attributes: { label, placeholder, formId, className, hasLabel, align },
-	instanceId,
-	isEditor,
-	setAttributes,
 } ) => {
 	const classes = classnames(
 		'wc-block-product-search',
 		align ? 'align' + align : '',
 		className
 	);
-
-	if ( isEditor ) {
-		if ( ! formId ) {
-			setAttributes( {
-				formId: `wc-block-product-search-${ instanceId }`,
-			} );
-		}
-
-		return (
-			<div className={ classes }>
-				{ !! hasLabel && (
-					<PlainText
-						className="wc-block-product-search__label"
-						value={ label }
-						onChange={ ( value ) =>
-							setAttributes( { label: value } )
-						}
-					/>
-				) }
-				<div className="wc-block-product-search__fields">
-					<PlainText
-						className="wc-block-product-search__field input-control"
-						value={ placeholder }
-						onChange={ ( value ) =>
-							setAttributes( { placeholder: value } )
-						}
-					/>
-					<button
-						type="submit"
-						className="wc-block-product-search__button"
-						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
-						onClick={ ( e ) => e.preventDefault() }
-						tabIndex="-1"
-					>
-						<svg
-							aria-hidden="true"
-							role="img"
-							focusable="false"
-							className="dashicon dashicons-arrow-right-alt2"
-							xmlns="http://www.w3.org/2000/svg"
-							width="20"
-							height="20"
-							viewBox="0 0 20 20"
-						>
-							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
-						</svg>
-					</button>
-				</div>
-			</div>
-		);
-	}
 
 	return (
 		<div className={ classes }>
@@ -131,18 +75,6 @@ ProductSearchBlock.propTypes = {
 	 * The attributes for this block.
 	 */
 	attributes: PropTypes.object.isRequired,
-	/**
-	 * A unique ID for identifying the label for the select dropdown.
-	 */
-	componentId: PropTypes.number,
-	/**
-	 * Whether it's in the editor or frontend display.
-	 */
-	isEditor: PropTypes.bool,
-	/**
-	 * A callback to update attributes.
-	 */
-	setAttributes: PropTypes.func,
 };
 
-export default withComponentId( ProductSearchBlock );
+export default ProductSearchBlock;

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { PlainText } from '@wordpress/editor';
 import { HOME_URL } from '@woocommerce/block-settings';
@@ -18,92 +17,22 @@ import './style.scss';
 /**
  * Component displaying a product search form.
  */
-class ProductSearchBlock extends Component {
-	renderView() {
-		const {
-			attributes: {
-				label,
-				placeholder,
-				formId,
-				className,
-				hasLabel,
-				align,
-			},
-		} = this.props;
-		const classes = classnames(
-			'wc-block-product-search',
-			align ? 'align' + align : '',
-			className
-		);
+const ProductSearchBlock = ( {
+	attributes: { label, placeholder, formId, className, hasLabel, align },
+	instanceId,
+	isEditor,
+	setAttributes,
+} ) => {
+	const classes = classnames(
+		'wc-block-product-search',
+		align ? 'align' + align : '',
+		className
+	);
 
-		return (
-			<div className={ classes }>
-				<form role="search" method="get" action={ HOME_URL }>
-					<label
-						htmlFor={ formId }
-						className={
-							hasLabel
-								? 'wc-block-product-search__label'
-								: 'wc-block-product-search__label screen-reader-text'
-						}
-					>
-						{ label }
-					</label>
-					<div className="wc-block-product-search__fields">
-						<input
-							type="search"
-							id={ formId }
-							className="wc-block-product-search__field"
-							placeholder={ placeholder }
-							name="s"
-						/>
-						<input type="hidden" name="post_type" value="product" />
-						<button
-							type="submit"
-							className="wc-block-product-search__button"
-							label={ __(
-								'Search',
-								'woo-gutenberg-products-block'
-							) }
-						>
-							<svg
-								aria-hidden="true"
-								role="img"
-								focusable="false"
-								className="dashicon dashicons-arrow-right-alt2"
-								xmlns="http://www.w3.org/2000/svg"
-								width="20"
-								height="20"
-								viewBox="0 0 20 20"
-							>
-								<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
-							</svg>
-						</button>
-					</div>
-				</form>
-			</div>
-		);
-	}
-
-	renderEdit() {
-		const { attributes, componentId, setAttributes } = this.props;
-		const {
-			label,
-			placeholder,
-			formId,
-			className,
-			hasLabel,
-			align,
-		} = attributes;
-		const classes = classnames(
-			'wc-block-product-search',
-			align ? 'align' + align : '',
-			className
-		);
-
+	if ( isEditor ) {
 		if ( ! formId ) {
 			setAttributes( {
-				formId: `wc-block-product-search-${ componentId }`,
+				formId: `wc-block-product-search-${ instanceId }`,
 			} );
 		}
 
@@ -151,14 +80,51 @@ class ProductSearchBlock extends Component {
 		);
 	}
 
-	render() {
-		if ( this.props.isEditor ) {
-			return this.renderEdit();
-		}
-
-		return this.renderView();
-	}
-}
+	return (
+		<div className={ classes }>
+			<form role="search" method="get" action={ HOME_URL }>
+				<label
+					htmlFor={ formId }
+					className={
+						hasLabel
+							? 'wc-block-product-search__label'
+							: 'wc-block-product-search__label screen-reader-text'
+					}
+				>
+					{ label }
+				</label>
+				<div className="wc-block-product-search__fields">
+					<input
+						type="search"
+						id={ formId }
+						className="wc-block-product-search__field"
+						placeholder={ placeholder }
+						name="s"
+					/>
+					<input type="hidden" name="post_type" value="product" />
+					<button
+						type="submit"
+						className="wc-block-product-search__button"
+						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
+					>
+						<svg
+							aria-hidden="true"
+							role="img"
+							focusable="false"
+							className="dashicon dashicons-arrow-right-alt2"
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 20 20"
+						>
+							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
+						</svg>
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+};
 
 ProductSearchBlock.propTypes = {
 	/**

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -5,9 +5,9 @@ import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
-import { withInstanceId, compose } from '@wordpress/compose';
 import { PlainText } from '@wordpress/editor';
 import { HOME_URL } from '@woocommerce/block-settings';
+import withComponentId from '@woocommerce/base-hocs/with-component-id';
 
 /**
  * Internal dependencies
@@ -86,7 +86,7 @@ class ProductSearchBlock extends Component {
 	}
 
 	renderEdit() {
-		const { attributes, setAttributes, instanceId } = this.props;
+		const { attributes, componentId, setAttributes } = this.props;
 		const {
 			label,
 			placeholder,
@@ -103,7 +103,7 @@ class ProductSearchBlock extends Component {
 
 		if ( ! formId ) {
 			setAttributes( {
-				formId: `wc-block-product-search-${ instanceId }`,
+				formId: `wc-block-product-search-${ componentId }`,
 			} );
 		}
 
@@ -168,7 +168,7 @@ ProductSearchBlock.propTypes = {
 	/**
 	 * A unique ID for identifying the label for the select dropdown.
 	 */
-	instanceId: PropTypes.number,
+	componentId: PropTypes.number,
 	/**
 	 * Whether it's in the editor or frontend display.
 	 */
@@ -179,4 +179,4 @@ ProductSearchBlock.propTypes = {
 	setAttributes: PropTypes.func,
 };
 
-export default compose( [ withInstanceId ] )( ProductSearchBlock );
+export default withComponentId( ProductSearchBlock );

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -1,0 +1,130 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { InspectorControls, PlainText } from '@wordpress/editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import './style.scss';
+
+/**
+ * Component displaying a product search form.
+ */
+const Edit = ( {
+	attributes: { label, placeholder, formId, className, hasLabel, align },
+	instanceId,
+	setAttributes,
+} ) => {
+	const classes = classnames(
+		'wc-block-product-search',
+		align ? 'align' + align : '',
+		className
+	);
+
+	if ( ! formId ) {
+		setAttributes( {
+			formId: `wc-block-product-search-${ instanceId }`,
+		} );
+	}
+
+	return (
+		<>
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<ToggleControl
+						label={ __(
+							'Show search field label',
+							'woo-gutenberg-products-block'
+						) }
+						help={
+							hasLabel
+								? __(
+										'Label is visible.',
+										'woo-gutenberg-products-block'
+								  )
+								: __(
+										'Label is hidden.',
+										'woo-gutenberg-products-block'
+								  )
+						}
+						checked={ hasLabel }
+						onChange={ () =>
+							setAttributes( { hasLabel: ! hasLabel } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div className={ classes }>
+				{ !! hasLabel && (
+					<PlainText
+						className="wc-block-product-search__label"
+						value={ label }
+						onChange={ ( value ) =>
+							setAttributes( { label: value } )
+						}
+					/>
+				) }
+				<div className="wc-block-product-search__fields">
+					<PlainText
+						className="wc-block-product-search__field input-control"
+						value={ placeholder }
+						onChange={ ( value ) =>
+							setAttributes( { placeholder: value } )
+						}
+					/>
+					<button
+						type="submit"
+						className="wc-block-product-search__button"
+						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
+						onClick={ ( e ) => e.preventDefault() }
+						tabIndex="-1"
+					>
+						<svg
+							aria-hidden="true"
+							role="img"
+							focusable="false"
+							className="dashicon dashicons-arrow-right-alt2"
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 20 20"
+						>
+							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
+						</svg>
+					</button>
+				</div>
+			</div>
+		</>
+	);
+};
+
+Edit.propTypes = {
+	/**
+	 * The attributes for this block.
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * A unique ID for identifying the label for the select dropdown.
+	 */
+	instanceId: PropTypes.number,
+	/**
+	 * Whether it's in the editor or frontend display.
+	 */
+	isEditor: PropTypes.bool,
+	/**
+	 * A callback to update attributes.
+	 */
+	setAttributes: PropTypes.func,
+};
+
+export default withInstanceId( Edit );

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -3,9 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { InspectorControls } from '@wordpress/editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { Icon, search } from '@woocommerce/icons';
 /**
  * Internal dependencies
@@ -13,6 +10,7 @@ import { Icon, search } from '@woocommerce/icons';
 import './style.scss';
 import './editor.scss';
 import Block from './block.js';
+import edit from './edit.js';
 
 registerBlockType( 'woocommerce/product-search', {
 	title: __( 'Product Search', 'woo-gutenberg-products-block' ),
@@ -73,51 +71,7 @@ registerBlockType( 'woocommerce/product-search', {
 		},
 	},
 
-	/**
-	 * Renders and manages the block.
-	 *
-	 * @param {Object} props Props to pass to block.
-	 */
-	edit( props ) {
-		const { attributes, setAttributes } = props;
-		const { hasLabel } = attributes;
-		return (
-			<Fragment>
-				<InspectorControls key="inspector">
-					<PanelBody
-						title={ __(
-							'Content',
-							'woo-gutenberg-products-block'
-						) }
-						initialOpen
-					>
-						<ToggleControl
-							label={ __(
-								'Show search field label',
-								'woo-gutenberg-products-block'
-							) }
-							help={
-								hasLabel
-									? __(
-											'Label is visible.',
-											'woo-gutenberg-products-block'
-									  )
-									: __(
-											'Label is hidden.',
-											'woo-gutenberg-products-block'
-									  )
-							}
-							checked={ hasLabel }
-							onChange={ () =>
-								setAttributes( { hasLabel: ! hasLabel } )
-							}
-						/>
-					</PanelBody>
-				</InspectorControls>
-				<Block { ...props } isEditor={ true } />
-			</Fragment>
-		);
-	},
+	edit,
 
 	/**
 	 * Save the props to post content.


### PR DESCRIPTION
Fixes #1825.

It took me a while to understand what was going on in #1825 and I don't fully understand everything yet. What I found out is that using React hooks inside the render function doesn't play well with Gutenberg and makes it crash.

In fact, we were not directly using React hooks in the render function, but we used `withInstanceId`, which was updated recently to use hooks (see https://github.com/WordPress/gutenberg/pull/19091).

In order to fix this, and considering we only need the `instanceId` in the editor, this PR splits `ProductSearchBlock` into two components: one for the save function and another one for the editor, as we do for most of the other blocks.

Note: if it's difficult to merge this PR into `release/2.5`, e101b0c9cfc709ba263d9ab333954c53ceda4a1c is a quick work-around that switches `withInstanceId` from Gutenberg for our `withComponentId`, which doesn't use hooks internally so it doesn't make the block crash. But that is not a future-proof solution because if we ever changed `withComponentId` to use hooks, the issue would appear again. So at least in `master` we should merge this PR entirely.

### How to test the changes in this Pull Request:

1. In `master` with Gutenberg disabled create a post or page with a _Product Search_ block.
2. Reload the post and notice everything works.
3. Enable Gutenberg or switch to WP 5.4 dev versions.
4. Reload the post and notice it crashes when loading.
5. Check out this branch and reload the post again.
6. Verify it loads and you can add more _Product Search_ blocks and reload as many times as you want.
7. Preview the post in the frontend and verify the block appears.

### Changelog

> Product Search block is now compatible with WordPress 5.4 and the last versions of Gutenberg.