### PR TITLE
Do not allow focus on Country and State input hidden fields

### DIFF
--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -52,6 +52,7 @@ const CountryInput = ( {
 						padding: '0',
 						position: 'absolute',
 					} }
+					tabIndex={ -1 }
 				/>
 			) }
 		</>

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -79,6 +79,7 @@ const StateInput = ( {
 								padding: '0',
 								position: 'absolute',
 							} }
+							tabIndex={ -1 }
 						/>
 					) }
 				</>


### PR DESCRIPTION
Small PR to add `tabIndex="-1"` to the hidden inputs of `CountryInput` and `StateInput`.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)

### Screenshots

_Before:_
![Peek 2020-03-02 13-44](https://user-images.githubusercontent.com/3616980/75677583-15414f80-5c8c-11ea-8461-abd41cddf873.gif)

_After:_
![Peek 2020-03-02 13-45](https://user-images.githubusercontent.com/3616980/75677575-12def580-5c8c-11ea-914c-dc8bb1628573.gif)

### How to test the changes in this Pull Request:

1. Create a post with a _Checkout_ block and navigate through the fields with the keyboard.
2. Verify you can't focus the hidden input fields of `CountryInput` and `StateInput`.