### PR TITLE
Suggest using `git cherry-pick` instead of `hub am -3` in release docs

### DIFF
--- a/docs/releases/readme.md
+++ b/docs/releases/readme.md
@@ -47,9 +47,9 @@ _Outcome_: **Team is aware of release and in agreement about what fixes & featur
 -   Ensure your local checkout is updated to the tip of the release branch.
 -   For _patch_ releases, cherry pick relevant PRs into the release branch:
     -   If PR is already labelled `status: cherry-picked 🍒` then continue to next PR.
-    -   Use git to cherry pick the PR - `git cherry-pick {PR_COMMIT_HASH}`.
+    -   Ideally, use GitHub Hub to cherry pick the PR - `hub cherry-pick {PR-COMMIT-URL}`.
     -   If there are serious conflicts or extensive differences between `master` and release branch, you may need to take more care:
-        -   Use GitHub Hub to cherry pick the PR commit-by-commit - `hub am -3 {http://URL-TO-PR}`.
+        -   Manually cherry pick individual commits using git - `git cherry-pick {COMMIT-HASH}`.
         -   Or in some cases, manually craft a new PR with appropriate changes, targeting release branch.
     -   Push the release branch to origin (so changes are in GitHub repo).
     -   Label the PR: `status: cherry-picked 🍒`.

--- a/docs/releases/readme.md
+++ b/docs/releases/readme.md
@@ -47,9 +47,9 @@ _Outcome_: **Team is aware of release and in agreement about what fixes & featur
 -   Ensure your local checkout is updated to the tip of the release branch.
 -   For _patch_ releases, cherry pick relevant PRs into the release branch:
     -   If PR is already labelled `status: cherry-picked 🍒` then continue to next PR.
-    -   Ideally, use GitHub Hub to cherry pick the PR - `hub am -3 {http://URL-TO-PR}`.
+    -   Use git to cherry pick the PR - `git cherry-pick {PR_COMMIT_HASH}`.
     -   If there are serious conflicts or extensive differences between `master` and release branch, you may need to take more care:
-        -   Manually cherry pick individual commits using git - `git cherry-pick {COMMIT-HASH}`.
+        -   Use GitHub Hub to cherry pick the PR commit-by-commit - `hub am -3 {http://URL-TO-PR}`.
         -   Or in some cases, manually craft a new PR with appropriate changes, targeting release branch.
     -   Push the release branch to origin (so changes are in GitHub repo).
     -   Label the PR: `status: cherry-picked 🍒`.


### PR DESCRIPTION
In PRs, we use `squash and merge` to keep history clean, but in release notes we were suggesting to use `hub am -3`, which does exactly the opposite and cherry-picks PRs commit-by-commit.

I noticed it when importing #1841 to `release/2.5`:
* `hub am -3 https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1841` was adding 3 commits.
* `git cherry-pick 51fbff74c7ed04a61658055ebf9d61720eaee586` was adding 1 commit with the same title and description as it has in `master`.

I think we should try to keep the release branches history as similar to master as possible so it's easy to track which PR added each change.