### PR TITLE
Hide package name when there is only one

### DIFF
--- a/assets/js/base/components/shipping-rates-control/packages.js
+++ b/assets/js/base/components/shipping-rates-control/packages.js
@@ -31,7 +31,7 @@ const Packages = ( {
 			selected={ selected[ i ] }
 			shippingRate={ shippingRate }
 			showItems={ shippingRates.length > 1 }
-			title={ shippingRate.name }
+			title={ shippingRates.length > 1 ? shippingRate.name : null }
 		/>
 	) );
 };


### PR DESCRIPTION
Issue introduced in #1806.

When there is only one package, we don't want to show the package name. This PR addresses it.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/75770785-ee951e80-5d48-11ea-8221-4efa205d3cf6.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/75770556-70d11300-5d48-11ea-9cd1-09b7814a6588.png)


### How to test the changes in this Pull Request:

1. Disable _WooCommerce Advanced Shipping Packages_ if you have it installed (or set up your cart so you only have products from one package).
2. Go to the _Cart_ and verify the package name doesn't appear.