### PR TITLE
Cart and checkout error boundaries

### DIFF
--- a/assets/js/base/components/block-error-boundary/block-error.js
+++ b/assets/js/base/components/block-error-boundary/block-error.js
@@ -13,6 +13,7 @@ const BlockError = ( {
 		'woo-gutenberg-products-block'
 	),
 	errorMessage,
+	errorMessagePrefix = __( 'Error:', 'woo-gutenberg-products-block' ),
 } ) => {
 	return (
 		<div className="wc-block-error">
@@ -30,7 +31,7 @@ const BlockError = ( {
 				{ text && <p className="wc-block-error__text">{ text }</p> }
 				{ errorMessage && (
 					<p className="wc-block-error__message">
-						{ __( 'Error:', 'woo-gutenberg-products-block' ) }{ ' ' }
+						{ errorMessagePrefix ? errorMessagePrefix + ' ' : '' }
 						{ errorMessage }
 					</p>
 				) }
@@ -62,6 +63,10 @@ BlockError.propTypes = {
 	 * If it's not defined, the default text will be used.
 	 */
 	text: PropTypes.node,
+	/**
+	 * Text preceeding the error message.
+	 */
+	errorMessagePrefix: PropTypes.string,
 };
 
 export default BlockError;

--- a/assets/js/base/components/block-error-boundary/block-error.js
+++ b/assets/js/base/components/block-error-boundary/block-error.js
@@ -29,7 +29,10 @@ const BlockError = ( {
 				) }
 				{ text && <p className="wc-block-error__text">{ text }</p> }
 				{ errorMessage && (
-					<p className="wc-block-error__message">{ errorMessage }</p>
+					<p className="wc-block-error__message">
+						{ __( 'Error:', 'woo-gutenberg-products-block' ) }{ ' ' }
+						{ errorMessage }
+					</p>
 				) }
 			</div>
 		</div>
@@ -58,7 +61,7 @@ BlockError.propTypes = {
 	 * If it's `null` or an empty string, nothing will be displayed.
 	 * If it's not defined, the default text will be used.
 	 */
-	text: PropTypes.string,
+	text: PropTypes.node,
 };
 
 export default BlockError;

--- a/assets/js/base/components/block-error-boundary/index.js
+++ b/assets/js/base/components/block-error-boundary/index.js
@@ -73,7 +73,7 @@ BlockErrorBoundary.propTypes = {
 	 * If it's `null` or an empty string, nothing will be displayed.
 	 * If it's not defined, the default text will be used.
 	 */
-	text: PropTypes.string,
+	text: PropTypes.node,
 };
 
 BlockErrorBoundary.defaultProps = {

--- a/assets/js/base/components/block-error-boundary/index.js
+++ b/assets/js/base/components/block-error-boundary/index.js
@@ -33,7 +33,13 @@ class BlockErrorBoundary extends Component {
 	}
 
 	render() {
-		const { header, imageUrl, showErrorMessage, text } = this.props;
+		const {
+			header,
+			imageUrl,
+			showErrorMessage,
+			text,
+			errorMessagePrefix,
+		} = this.props;
 		const { errorMessage, hasError } = this.state;
 
 		if ( hasError ) {
@@ -43,6 +49,7 @@ class BlockErrorBoundary extends Component {
 					header={ header }
 					imageUrl={ imageUrl }
 					text={ text }
+					errorMessagePrefix={ errorMessagePrefix }
 				/>
 			);
 		}
@@ -74,6 +81,10 @@ BlockErrorBoundary.propTypes = {
 	 * If it's not defined, the default text will be used.
 	 */
 	text: PropTypes.node,
+	/**
+	 * Text preceeding the error message.
+	 */
+	errorMessagePrefix: PropTypes.string,
 };
 
 BlockErrorBoundary.defaultProps = {

--- a/assets/js/base/components/block-error-boundary/style.scss
+++ b/assets/js/base/components/block-error-boundary/style.scss
@@ -22,8 +22,6 @@
 }
 .wc-block-error__message {
 	margin: 1em 0 0 0;
-}
-.wc-block-error__message {
 	font-style: italic;
 }
 

--- a/assets/js/base/components/block-error-boundary/style.scss
+++ b/assets/js/base/components/block-error-boundary/style.scss
@@ -17,9 +17,11 @@
 .wc-block-error__image {
 	max-width: 25%;
 }
-.wc-block-error__text,
-.wc-block-error__message {
+.wc-block-error__text {
 	margin: 0;
+}
+.wc-block-error__message {
+	margin: 1em 0 0 0;
 }
 .wc-block-error__message {
 	font-style: italic;

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -13,6 +13,7 @@ import {
 	previewShippingRates,
 } from '@woocommerce/resource-previews';
 import { SHIPPING_ENABLED } from '@woocommerce/block-settings';
+import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Internal dependencies
@@ -95,22 +96,56 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 						{ currentView === 'full' && (
 							<>
 								{ SHIPPING_ENABLED && <BlockSettings /> }
-								<Disabled>
-									<FullCart
-										cartItems={ previewCart.items }
-										cartTotals={ previewCart.totals }
-										isShippingCostHidden={
-											isShippingCostHidden
-										}
-										isShippingCalculatorEnabled={
-											isShippingCalculatorEnabled
-										}
-										shippingRates={ previewShippingRates }
-									/>
-								</Disabled>
+								<BlockErrorBoundary
+									header={ __(
+										'Cart Block Error',
+										'woo-gutenberg-products-block'
+									) }
+									text={ __(
+										'There was an error whilst rendering the cart block. If this problem continues, try re-creating the block.',
+										'woo-gutenberg-products-block'
+									) }
+									showErrorMessage={ true }
+									errorMessagePrefix={ __(
+										'Error message:',
+										'woo-gutenberg-products-block'
+									) }
+								>
+									<Disabled>
+										<FullCart
+											cartItems={ previewCart.items }
+											cartTotals={ previewCart.totals }
+											isShippingCostHidden={
+												isShippingCostHidden
+											}
+											isShippingCalculatorEnabled={
+												isShippingCalculatorEnabled
+											}
+											shippingRates={
+												previewShippingRates
+											}
+										/>
+									</Disabled>
+								</BlockErrorBoundary>
 							</>
 						) }
-						<EmptyCart hidden={ currentView === 'full' } />
+						<BlockErrorBoundary
+							header={ __(
+								'Cart Block Error',
+								'woo-gutenberg-products-block'
+							) }
+							text={ __(
+								'There was an error whilst rendering the cart block. If this problem continues, try re-creating the block.',
+								'woo-gutenberg-products-block'
+							) }
+							showErrorMessage={ true }
+							errorMessagePrefix={ __(
+								'Error message:',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							<EmptyCart hidden={ currentView === 'full' } />
+						</BlockErrorBoundary>
 					</>
 				) }
 			/>

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -75,8 +75,8 @@ const getErrorBoundaryProps = () => {
 			),
 			{
 				a: (
-					// eslint-disable-next-line jsx-a11y/anchor-has-content
-					<a href="." />
+					// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+					<a href="javascript:window.location.reload(true)" />
 				),
 			}
 		),

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -5,10 +5,14 @@ import {
 	withRestApiHydration,
 	withStoreCartApiHydration,
 } from '@woocommerce/block-hocs';
+import { __ } from '@wordpress/i18n';
 import { useStoreCart } from '@woocommerce/base-hooks';
 import { RawHTML } from '@wordpress/element';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
 import StoreNoticesProvider from '@woocommerce/base-context/store-notices-context';
+import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
+import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
+import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 
 /**
  * Internal dependencies
@@ -33,25 +37,48 @@ const CartFrontend = ( {
 	} = useStoreCart();
 
 	return (
-		<StoreNoticesProvider context="wc/cart">
-			{ ! cartIsLoading && ! cartItems.length ? (
-				<RawHTML>{ emptyCart }</RawHTML>
-			) : (
-				<LoadingMask showSpinner={ true } isLoading={ cartIsLoading }>
-					<FullCart
-						cartItems={ cartItems }
-						cartTotals={ cartTotals }
-						cartCoupons={ cartCoupons }
-						isShippingCalculatorEnabled={
-							isShippingCalculatorEnabled
-						}
-						isShippingCostHidden={ isShippingCostHidden }
-						isLoading={ cartIsLoading }
-						shippingRates={ shippingRates }
-					/>
-				</LoadingMask>
+		<BlockErrorBoundary
+			header={ __(
+				'Something went wrong…',
+				'woo-gutenberg-products-block'
 			) }
-		</StoreNoticesProvider>
+			text={ __experimentalCreateInterpolateElement(
+				__(
+					'The cart has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+					'woo-gutenberg-products-block'
+				),
+				{
+					a: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a href="." />
+					),
+				}
+			) }
+			showErrorMessage={ CURRENT_USER_IS_ADMIN }
+		>
+			<StoreNoticesProvider context="wc/cart">
+				{ ! cartIsLoading && ! cartItems.length ? (
+					<RawHTML>{ emptyCart }</RawHTML>
+				) : (
+					<LoadingMask
+						showSpinner={ true }
+						isLoading={ cartIsLoading }
+					>
+						<FullCart
+							cartItems={ cartItems }
+							cartTotals={ cartTotals }
+							cartCoupons={ cartCoupons }
+							isShippingCalculatorEnabled={
+								isShippingCalculatorEnabled
+							}
+							isShippingCostHidden={ isShippingCostHidden }
+							isLoading={ cartIsLoading }
+							shippingRates={ shippingRates }
+						/>
+					</LoadingMask>
+				) }
+			</StoreNoticesProvider>
+		</BlockErrorBoundary>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -10,7 +10,6 @@ import { useStoreCart } from '@woocommerce/base-hooks';
 import { RawHTML } from '@wordpress/element';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
 import StoreNoticesProvider from '@woocommerce/base-context/store-notices-context';
-import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 
@@ -37,48 +36,25 @@ const CartFrontend = ( {
 	} = useStoreCart();
 
 	return (
-		<BlockErrorBoundary
-			header={ __(
-				'Something went wrong…',
-				'woo-gutenberg-products-block'
-			) }
-			text={ __experimentalCreateInterpolateElement(
-				__(
-					'The cart has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
-					'woo-gutenberg-products-block'
-				),
-				{
-					a: (
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						<a href="." />
-					),
-				}
-			) }
-			showErrorMessage={ CURRENT_USER_IS_ADMIN }
-		>
-			<StoreNoticesProvider context="wc/cart">
-				{ ! cartIsLoading && ! cartItems.length ? (
-					<RawHTML>{ emptyCart }</RawHTML>
-				) : (
-					<LoadingMask
-						showSpinner={ true }
+		<StoreNoticesProvider context="wc/cart">
+			{ ! cartIsLoading && ! cartItems.length ? (
+				<RawHTML>{ emptyCart }</RawHTML>
+			) : (
+				<LoadingMask showSpinner={ true } isLoading={ cartIsLoading }>
+					<FullCart
+						cartItems={ cartItems }
+						cartTotals={ cartTotals }
+						cartCoupons={ cartCoupons }
+						isShippingCalculatorEnabled={
+							isShippingCalculatorEnabled
+						}
+						isShippingCostHidden={ isShippingCostHidden }
 						isLoading={ cartIsLoading }
-					>
-						<FullCart
-							cartItems={ cartItems }
-							cartTotals={ cartTotals }
-							cartCoupons={ cartCoupons }
-							isShippingCalculatorEnabled={
-								isShippingCalculatorEnabled
-							}
-							isShippingCostHidden={ isShippingCostHidden }
-							isLoading={ cartIsLoading }
-							shippingRates={ shippingRates }
-						/>
-					</LoadingMask>
-				) }
-			</StoreNoticesProvider>
-		</BlockErrorBoundary>
+						shippingRates={ shippingRates }
+					/>
+				</LoadingMask>
+			) }
+		</StoreNoticesProvider>
 	);
 };
 
@@ -89,8 +65,28 @@ const getProps = ( el ) => ( {
 	isShippingCostHidden: el.dataset.isshippingcosthidden === 'true',
 } );
 
+const getErrorBoundaryProps = () => {
+	return {
+		header: __( 'Something went wrong…', 'woo-gutenberg-products-block' ),
+		text: __experimentalCreateInterpolateElement(
+			__(
+				'The cart has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+				'woo-gutenberg-products-block'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a href="." />
+				),
+			}
+		),
+		showErrorMessage: CURRENT_USER_IS_ADMIN,
+	};
+};
+
 renderFrontend(
 	'.wp-block-woocommerce-cart',
 	withStoreCartApiHydration( withRestApiHydration( CartFrontend ) ),
-	getProps
+	getProps,
+	getErrorBoundaryProps
 );

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -152,15 +152,13 @@ const CheckoutEditor = ( { attributes, setAttributes } ) => {
 					'woo-gutenberg-products-block'
 				) }
 			>
-				<Disabled>
-					<Block
-						attributes={ attributes }
-						isEditor={ true }
-						shippingRates={
-							SHIPPING_METHODS_EXIST ? previewShippingRates : []
-						}
-					/>
-				</Disabled>
+				<Block
+					attributes={ attributes }
+					isEditor={ true }
+					shippingRates={
+						SHIPPING_METHODS_EXIST ? previewShippingRates : []
+					}
+				/>
 			</BlockErrorBoundary>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -11,6 +11,7 @@ import {
 	ToggleControl,
 	CheckboxControl,
 } from '@wordpress/components';
+import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 
 /**
  * Internal dependencies
@@ -28,7 +29,6 @@ const CheckoutEditor = ( { attributes, setAttributes } ) => {
 		requireCompanyField,
 		requirePhoneField,
 	} = attributes;
-	// @todo: wrap Block with Disabled once you finish building the form
 	return (
 		<div className={ className }>
 			<InspectorControls>
@@ -137,13 +137,31 @@ const CheckoutEditor = ( { attributes, setAttributes } ) => {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Block
-				attributes={ attributes }
-				isEditor={ true }
-				shippingRates={
-					SHIPPING_METHODS_EXIST ? previewShippingRates : []
-				}
-			/>
+			<BlockErrorBoundary
+				header={ __(
+					'Checkout Block Error',
+					'woo-gutenberg-products-block'
+				) }
+				text={ __(
+					'There was an error whilst rendering the checkout block. If this problem continues, try re-creating the block.',
+					'woo-gutenberg-products-block'
+				) }
+				showErrorMessage={ true }
+				errorMessagePrefix={ __(
+					'Error message:',
+					'woo-gutenberg-products-block'
+				) }
+			>
+				<Disabled>
+					<Block
+						attributes={ attributes }
+						isEditor={ true }
+						shippingRates={
+							SHIPPING_METHODS_EXIST ? previewShippingRates : []
+						}
+					/>
+				</Disabled>
+			</BlockErrorBoundary>
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -78,8 +78,8 @@ const getErrorBoundaryProps = () => {
 			),
 			{
 				a: (
-					// eslint-disable-next-line jsx-a11y/anchor-has-content
-					<a href="." />
+					// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
+					<a href="javascript:window.location.reload(true)" />
 				),
 			}
 		),

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -1,8 +1,12 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { withRestApiHydration } from '@woocommerce/block-hocs';
 import { useStoreCart } from '@woocommerce/base-hooks';
+import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
+import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
+import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 
 /**
  * Internal dependencies
@@ -12,13 +16,35 @@ import blockAttributes from './attributes';
 import renderFrontend from '../../../utils/render-frontend.js';
 
 /**
- * Wrapper component to supply API data.
+ * Wrapper component for the checkout block.
  *
- * @param {Object} attributes object of key value attributes passed to block.
+ * @param {Object} props Props for the block.
  */
-const CheckoutFrontend = ( attributes ) => {
+const CheckoutFrontend = ( props ) => {
 	const { shippingRates } = useStoreCart();
-	return <Block attributes={ attributes } shippingRates={ shippingRates } />;
+	return (
+		<BlockErrorBoundary
+			header={ __(
+				'Something went wrong…',
+				'woo-gutenberg-products-block'
+			) }
+			text={ __experimentalCreateInterpolateElement(
+				__(
+					'The checkout has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+					'woo-gutenberg-products-block'
+				),
+				{
+					a: (
+						// eslint-disable-next-line jsx-a11y/anchor-has-content
+						<a href="." />
+					),
+				}
+			) }
+			showErrorMessage={ CURRENT_USER_IS_ADMIN }
+		>
+			<Block { ...props } shippingRates={ shippingRates } />
+		</BlockErrorBoundary>
+	);
 };
 
 const getProps = ( el ) => {

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -68,8 +68,28 @@ const getProps = ( el ) => {
 	};
 };
 
+const getErrorBoundaryProps = () => {
+	return {
+		header: __( 'Something went wrong…', 'woo-gutenberg-products-block' ),
+		text: __experimentalCreateInterpolateElement(
+			__(
+				'The checkout has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+				'woo-gutenberg-products-block'
+			),
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-has-content
+					<a href="." />
+				),
+			}
+		),
+		showErrorMessage: CURRENT_USER_IS_ADMIN,
+	};
+};
+
 renderFrontend(
 	'.wp-block-woocommerce-checkout',
 	withRestApiHydration( CheckoutFrontend ),
-	getProps
+	getProps,
+	getErrorBoundaryProps
 );

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -3,6 +3,7 @@
  */
 import { getSetting } from '@woocommerce/settings';
 
+export const CURRENT_USER_IS_ADMIN = getSetting( 'currentUserIsAdmin', false );
 export const REVIEW_RATINGS_ENABLED = getSetting(
 	'reviewRatingsEnabled',
 	true

--- a/assets/js/utils/render-frontend.js
+++ b/assets/js/utils/render-frontend.js
@@ -7,18 +7,27 @@ import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundar
 /**
  * Renders a block component in the place of a specified set of selectors.
  *
- * @param {string}   selector   CSS selector to match the elements to replace.
- * @param {Function} Block      React block to use as a replacement.
- * @param {Function} [getProps] Function to generate the props object for the
- * block.
+ * @param {string}   selector                CSS selector to match the elements
+ * to replace.
+ * @param {Function} Block                   React block to use as a replacement.
+ * @param {Function} [getProps]              Function to generate the props
+ * object for the block.
+ * @param {Function} [getErrorBoundaryProps] Function to generate the props
+ * object for the error boundary.
  */
-export default ( selector, Block, getProps = () => ( {} ) ) => {
+export default (
+	selector,
+	Block,
+	getProps = () => {},
+	getErrorBoundaryProps = () => {}
+) => {
 	const containers = document.querySelectorAll( selector );
 
 	if ( containers.length ) {
 		// Use Array.forEach for IE11 compatibility.
 		Array.prototype.forEach.call( containers, ( el, i ) => {
 			const props = getProps( el, i );
+			const errorBoundaryProps = getErrorBoundaryProps( el, i );
 			const attributes = {
 				...el.dataset,
 				...props.attributes,
@@ -27,7 +36,7 @@ export default ( selector, Block, getProps = () => ( {} ) ) => {
 			el.classList.remove( 'is-loading' );
 
 			render(
-				<BlockErrorBoundary>
+				<BlockErrorBoundary { ...errorBoundaryProps }>
 					<Block { ...props } attributes={ attributes } />
 				</BlockErrorBoundary>,
 				el

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -127,8 +127,8 @@ const stableMainEntry = {
 	'price-filter': './assets/js/blocks/price-filter/index.js',
 	'attribute-filter': './assets/js/blocks/attribute-filter/index.js',
 	'active-filters': './assets/js/blocks/active-filters/index.js',
-	'block-error-boundry':
-		'./assets/js/base/components/block-error-boundry/style.scss',
+	'block-error-boundary':
+		'./assets/js/base/components/block-error-boundary/style.scss',
 	'panel-style': './node_modules/@wordpress/components/src/panel/style.scss',
 	'custom-select-control-style':
 		'./node_modules/@wordpress/components/src/custom-select-control/style.scss',

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -127,8 +127,8 @@ const stableMainEntry = {
 	'price-filter': './assets/js/blocks/price-filter/index.js',
 	'attribute-filter': './assets/js/blocks/attribute-filter/index.js',
 	'active-filters': './assets/js/blocks/active-filters/index.js',
-	'block-error-boundary':
-		'./assets/js/base/components/block-error-boundary/style.scss',
+	'block-error-boundry':
+		'./assets/js/base/components/block-error-boundry/style.scss',
 	'panel-style': './node_modules/@wordpress/components/src/panel/style.scss',
 	'custom-select-control-style':
 		'./node_modules/@wordpress/components/src/custom-select-control/style.scss',

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -106,6 +106,7 @@ class Assets {
 		return array_merge(
 			$settings,
 			[
+				'currentUserIsAdmin'            => is_user_logged_in() && current_user_can( 'manage_woocommerce' ),
 				'min_columns'                   => wc_get_theme_support( 'product_blocks::min_columns', 1 ),
 				'max_columns'                   => wc_get_theme_support( 'product_blocks::max_columns', 6 ),
 				'default_columns'               => wc_get_theme_support( 'product_blocks::default_columns', 3 ),


### PR DESCRIPTION
This PR adds extra error boundaries to the cart and checkout blocks.

Closes #1427
Closes #1426

We already have an error boundary in place for cart and checkout frontend - this PR customises this for cart/checkout usage, adding different messaging, and only showing error messages to admin users who can manage woocommerce. 

### Screenshots

![Screenshot 2020-03-03 at 11 40 18](https://user-images.githubusercontent.com/90977/75772795-880e0180-5d44-11ea-94a9-1230a2c94b0c.png)
![Screenshot 2020-03-03 at 11 40 25](https://user-images.githubusercontent.com/90977/75772798-893f2e80-5d44-11ea-9927-db3bcc47705a.png)

### How to test the changes in this Pull Request:

1. Add this to full-cart or checkout blocks `throw new Error( 'I have fallen over' );`
2. View the cart/checkout page logged in as admin, or as a guest
3. Confirm boundary is displayed