### PR TITLE
Add extra block attribute escaping

### DIFF
--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -64,7 +64,7 @@ class FeaturedCategory extends AbstractDynamicBlock {
 			wc_format_content( $category->description )
 		);
 
-		$output = sprintf( '<div class="%1$s" style="%2$s">', $this->get_classes( $attributes ), $this->get_styles( $attributes, $category ) );
+		$output = sprintf( '<div class="%1$s" style="%2$s">', esc_attr( $this->get_classes( $attributes ) ), esc_attr( $this->get_styles( $attributes, $category ) ) );
 
 		$output .= $title;
 		if ( $attributes['showDesc'] ) {

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -77,7 +77,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 			$product->get_price_html()
 		);
 
-		$output = sprintf( '<div class="%1$s" style="%2$s">', $this->get_classes( $attributes ), $this->get_styles( $attributes, $product ) );
+		$output = sprintf( '<div class="%1$s" style="%2$s">', esc_attr( $this->get_classes( $attributes ) ), esc_attr( $this->get_styles( $attributes, $product ) ) );
 
 		$output .= $title;
 		if ( $attributes['showDesc'] ) {


### PR DESCRIPTION
This adds some extra attribute escaping around a couple blocks.

This impacts the `FeaturedCategory` and `FeaturedProduct` blocks. 

## To Test

- Verify the above blocks continue to function as before and that there are no validation errors  with existing blocks on this branch.