### PR TITLE
Cleanup draft orders 

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -84,10 +84,8 @@ class Library {
 	 * Maybe create cron events.
 	 */
 	public static function maybe_create_cronjobs() {
-		$next_event = wp_get_scheduled_event( 'woocommerce_cleanup_draft_orders' );
-
-		if ( ! $next_event ) {
-			wp_schedule_event( time() + 10, 'daily', 'woocommerce_cleanup_draft_orders' );
+		if ( function_exists( 'as_next_scheduled_action' ) && false === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
+			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'woocommerce_cleanup_draft_orders' );
 		}
 	}
 

--- a/src/Library.php
+++ b/src/Library.php
@@ -21,6 +21,7 @@ class Library {
 		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
 		add_action( 'init', array( __CLASS__, 'define_tables' ) );
 		add_action( 'init', array( __CLASS__, 'maybe_create_tables' ) );
+		add_action( 'init', array( __CLASS__, 'maybe_create_cronjobs' ) );
 		add_filter( 'wc_order_statuses', array( __CLASS__, 'register_draft_order_status' ) );
 		add_filter( 'woocommerce_register_shop_order_post_statuses', array( __CLASS__, 'register_draft_order_post_status' ) );
 	}
@@ -76,6 +77,17 @@ class Library {
 		);
 
 		update_option( 'wc_blocks_db_version', \Automattic\WooCommerce\Blocks\Package::get_version() );
+	}
+
+	/**
+	 * Maybe create cron events.
+	 */
+	public static function maybe_create_cronjobs() {
+		$next_event = wp_get_scheduled_event( 'woocommerce_cleanup_draft_orders' );
+
+		if ( ! $next_event ) {
+			wp_schedule_event( time() + 10, 'daily', 'woocommerce_cleanup_draft_orders' );
+		}
 	}
 
 	/**

--- a/tests/php/Library/DeleteDraftOrders.php
+++ b/tests/php/Library/DeleteDraftOrders.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\Tests\Library;
+
+use PHPUnit\Framework\TestCase;
+use \WC_Order;
+use Automattic\WooCommerce\Blocks\Library;
+
+/**
+ * Tests Delete Draft Orders functionality
+ *
+ * @since $VID:$
+ * @group testing
+ */
+class DeleteDraftOrders extends TestCase {
+	/**
+	 * During setup create some draft orders.
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		global $wpdb;
+
+		$order = new WC_Order();
+		$order->set_status( 'checkout-draft' );
+		$order->save();
+
+		$order = new WC_Order();
+		$order->set_status( 'checkout-draft' );
+		$order->save();
+		$wpdb->update(
+			$wpdb->posts,
+			array(
+				'post_modified'     => date( 'Y-m-d H:i:s', strtotime( '-1 DAY', current_time( 'timestamp' ) ) ),
+				'post_modified_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '-1 DAY' ) )
+			),
+			array(
+				'ID' => $order->get_id()
+			)
+		);
+
+		$order = new WC_Order();
+		$order->set_status( 'checkout-draft' );
+		$order->save();
+		$wpdb->update(
+			$wpdb->posts,
+			array(
+				'post_modified'     => date( 'Y-m-d H:i:s', strtotime( '-2 DAY', current_time( 'timestamp' ) ) ),
+				'post_modified_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '-2 DAY' ) )
+			),
+			array(
+				'ID' => $order->get_id()
+			)
+		);
+	}
+
+	/**
+	 * Delete draft orders older than a day.
+	 *
+	 * Ran on a daily cron schedule.
+	 */
+	public function test_delete_expired_draft_orders() {
+		global $wpdb;
+
+		// Check there are 3 draft orders from our setup before running tests.
+		$this->assertEquals( 3, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-checkout-draft'" ) );
+
+		// Run delete query.
+		Library::delete_expired_draft_orders();
+
+		// Only 1 should remain.
+		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-checkout-draft'" ) );
+	}
+}


### PR DESCRIPTION
Adds a draft order cleanup query (with unit test). Drafts are deleted after 1 day. The cron job runs daily.

Fixes #1542 

### How to test the changes in this Pull Request:

If you have draft orders prior to running this PR, the older ones will be deleted once you switch to this branch and the cron job runs.

Otherwise, unit tests cover the deletion itself.