### PR TITLE
Fix failing travis e2e tests (environment caused)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ jobs:
               - WOOCOMMERCE_BLOCKS_PHASE=experimental
         - name: E2E Tests
           script:
-              - npm install
+              - npm ci
               - npm run docker:up
               - composer install
               - npm run build:e2e-test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5130,7 +5130,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.10.0.tgz",
       "integrity": "sha512-CedhhFfcubM/lsluY7JPC49VG0/Ee0chOBJ1vyDEvIJmQk0bM3sLfgt5qVK773yivVOqD9blQMO+JihnaMXF8w==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@wordpress/escape-html": "^1.6.0",
@@ -5203,7 +5202,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
       "integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "gettext-parser": "^1.3.1",
@@ -5243,7 +5241,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.7.0.tgz",
       "integrity": "sha512-fRHTAivQlWOQVn8wu8NHM8D5sacSvY6upJ+MgWSu1Q7pqy51zaCPE2T9lhym3GC1QzABus6VjDctR8jwfNfd/g==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
@@ -29607,39 +29604,28 @@
             "@wordpress/is-shallow-equal": "^1.8.0",
             "lodash": "^4.17.15",
             "mousetrap": "^1.6.2"
-          }
-        },
-        "@wordpress/element": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-          "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-          "requires": {
-            "@babel/runtime": "^7.8.3",
-            "@wordpress/escape-html": "^1.7.0",
-            "lodash": "^4.17.15",
-            "react": "^16.9.0",
-            "react-dom": "^16.9.0"
-          }
-        },
-        "@wordpress/i18n": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-          "integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-          "requires": {
-            "@babel/runtime": "^7.8.3",
-            "gettext-parser": "^1.3.1",
-            "lodash": "^4.17.15",
-            "memize": "^1.0.5",
-            "sprintf-js": "^1.1.1",
-            "tannin": "^1.1.0"
-          }
-        },
-        "@wordpress/is-shallow-equal": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-          "integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-          "requires": {
-            "@babel/runtime": "^7.8.3"
+          },
+          "dependencies": {
+            "@wordpress/element": {
+              "version": "2.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
+              "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
+              "requires": {
+                "@babel/runtime": "^7.8.3",
+                "@wordpress/escape-html": "^1.7.0",
+                "lodash": "^4.17.15",
+                "react": "^16.9.0",
+                "react-dom": "^16.9.0"
+              }
+            },
+            "@wordpress/is-shallow-equal": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
+              "integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
+              "requires": {
+                "@babel/runtime": "^7.8.3"
+              }
+            }
           }
         },
         "@wordpress/keycodes": {
@@ -29650,6 +29636,21 @@
             "@babel/runtime": "^7.8.3",
             "@wordpress/i18n": "^3.9.0",
             "lodash": "^4.17.15"
+          },
+          "dependencies": {
+            "@wordpress/i18n": {
+              "version": "3.9.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
+              "integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
+              "requires": {
+                "@babel/runtime": "^7.8.3",
+                "gettext-parser": "^1.3.1",
+                "lodash": "^4.17.15",
+                "memize": "^1.0.5",
+                "sprintf-js": "^1.1.1",
+                "tannin": "^1.1.0"
+              }
+            }
           }
         },
         "downshift": {


### PR DESCRIPTION
Recently it looks like the e2e tests travis job started failing (an [example fail](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block/jobs/293446516)). I am able to run the tests locally without issue so this appears to be environment caused.  I'll use this pull for troubleshooting.

Initially, I noticed the `package-lock.json` got updated locally when I ran `npm install`, since travis builds _from_ the package lock (via `npm ci`) that's the first suspect, so I'm trying a fresh push of that to see if it fixes.