### PR TITLE
Add skeleton markup to the cart block

### DIFF
--- a/assets/js/base/components/store-notices-container/index.js
+++ b/assets/js/base/components/store-notices-container/index.js
@@ -28,6 +28,9 @@ const StoreNoticesContainer = ( { className, notices } ) => {
 	const { removeNotice } = useStoreNoticesContext();
 	const wrapperClass = classnames( className, 'wc-block-components-notices' );
 
+	if ( ! notices.length ) {
+		return null;
+	}
 	return (
 		<div className={ wrapperClass }>
 			{ notices.map( ( props ) => (

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.js
@@ -30,16 +30,24 @@ const CartLineItemsTable = ( { lineItems = [], isLoading = false } ) => {
 			<thead>
 				<tr className="wc-block-cart-items__header">
 					<th className="wc-block-cart-items__header-image">
-						{ __( 'Product', 'woo-gutenberg-products-block' ) }
+						<span>
+							{ __( 'Product', 'woo-gutenberg-products-block' ) }
+						</span>
 					</th>
 					<th className="wc-block-cart-items__header-product">
-						{ __( 'Details', 'woo-gutenberg-products-block' ) }
+						<span>
+							{ __( 'Details', 'woo-gutenberg-products-block' ) }
+						</span>
 					</th>
 					<th className="wc-block-cart-items__header-quantity">
-						{ __( 'Quantity', 'woo-gutenberg-products-block' ) }
+						<span>
+							{ __( 'Quantity', 'woo-gutenberg-products-block' ) }
+						</span>
 					</th>
 					<th className="wc-block-cart-items__header-total">
-						{ __( 'Total', 'woo-gutenberg-products-block' ) }
+						<span>
+							{ __( 'Total', 'woo-gutenberg-products-block' ) }
+						</span>
 					</th>
 				</tr>
 			</thead>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -224,43 +224,6 @@ table.wc-block-cart-items {
 
 // Loading placeholder state.
 .wc-block-cart--is-loading {
-	.wc-block-cart-items {
-		.wc-block-cart-items__row {
-			.wc-block-cart-item__product-name,
-			.wc-block-cart-item__price,
-			.wc-block-cart-item__product-metadata,
-			.wc-block-cart-item__image a,
-			.wc-block-quantity-selector {
-				@include placeholder();
-			}
-			.wc-block-cart-item__product-name {
-				min-width: 50%;
-				display: inline-block;
-				@include force-content();
-			}
-			.wc-block-cart-item__product-metadata {
-				@include force-content();
-			}
-			.wc-block-cart-item__remove-link,
-			.wc-block-cart-item__remove-icon {
-				visibility: hidden;
-			}
-			.wc-block-cart-item__image a {
-				display: block;
-			}
-			.wc-block-cart-item__price {
-				@include force-content();
-			}
-		}
-	}
-	.wc-block-cart__sidebar .components-card {
-		@include placeholder();
-		@include force-content();
-	}
-}
-.wc-block-cart--skeleton {
-	display: none;
-
 	th span,
 	h2 span {
 		@include placeholder();
@@ -271,21 +234,42 @@ table.wc-block-cart-items {
 	h2 span {
 		min-width: 33%;
 	}
-	.wc-block-cart-item__image div,
-	.wc-block-quantity-selector {
-		@include placeholder();
-	}
-	.wc-block-cart-item__product,
-	.wc-block-cart-item__total {
-		div {
-			@include placeholder();
-			@include force-content();
-			min-width: 84px;
-			display: inline-block;
-		}
-		div + div {
-			margin-top: 0.25em;
-			min-width: 8em;
+	.wc-block-cart-items {
+		.wc-block-cart-items__row {
+			.wc-block-cart-item__product-name,
+			.wc-block-cart-item__price,
+			.wc-block-cart-item__product-metadata,
+			.wc-block-cart-item__image > *,
+			.wc-block-quantity-selector {
+				@include placeholder();
+			}
+			.wc-block-cart-item__product-name {
+				@include placeholder();
+				@include force-content();
+				min-width: 84px;
+				display: inline-block;
+			}
+			.wc-block-cart-item__product-metadata {
+				margin-top: 0.25em;
+				min-width: 8em;
+			}
+			.wc-block-cart-item__remove-link,
+			.wc-block-cart-item__remove-icon {
+				visibility: hidden;
+			}
+			.wc-block-cart-item__image a {
+				display: block;
+			}
+			.wc-block-cart-item__total {
+				> span,
+				> div {
+					display: none;
+				}
+				.wc-block-cart-item__price {
+					@include force-content();
+					display: block;
+				}
+			}
 		}
 	}
 	.wc-block-cart__sidebar .components-card {
@@ -293,6 +277,9 @@ table.wc-block-cart-items {
 		@include force-content();
 		min-height: 460px;
 	}
+}
+.wc-block-cart--skeleton {
+	display: none;
 }
 .is-loading + .wc-block-cart--skeleton {
 	display: flex;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -268,6 +268,9 @@ table.wc-block-cart-items {
 		min-width: 84px;
 		display: inline-block;
 	}
+	h2 span {
+		min-width: 33%;
+	}
 	.wc-block-cart-item__image div,
 	.wc-block-quantity-selector {
 		@include placeholder();
@@ -288,7 +291,7 @@ table.wc-block-cart-items {
 	.wc-block-cart__sidebar .components-card {
 		@include placeholder();
 		@include force-content();
-		min-height: 400px;
+		min-height: 460px;
 	}
 }
 .is-loading + .wc-block-cart--skeleton {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -136,6 +136,7 @@ table.wc-block-cart-items {
 	.wc-block-cart-items__row {
 		.wc-block-cart-item__image img {
 			width: 100%;
+			margin: 0;
 		}
 		.wc-block-cart-item__product {
 			.wc-block-cart-item__product-name {
@@ -254,7 +255,44 @@ table.wc-block-cart-items {
 	}
 	.wc-block-cart__sidebar .components-card {
 		@include placeholder();
+		@include force-content();
 	}
+}
+.wc-block-cart--skeleton {
+	display: none;
+
+	th span,
+	h2 span {
+		@include placeholder();
+		@include force-content();
+		min-width: 84px;
+		display: inline-block;
+	}
+	.wc-block-cart-item__image div,
+	.wc-block-quantity-selector {
+		@include placeholder();
+	}
+	.wc-block-cart-item__product,
+	.wc-block-cart-item__total {
+		div {
+			@include placeholder();
+			@include force-content();
+			min-width: 84px;
+			display: inline-block;
+		}
+		div + div {
+			margin-top: 0.25em;
+			min-width: 8em;
+		}
+	}
+	.wc-block-cart__sidebar .components-card {
+		@include placeholder();
+		@include force-content();
+		min-height: 400px;
+	}
+}
+.is-loading + .wc-block-cart--skeleton {
+	display: flex;
 }
 
 // Mobile styles.

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -76,7 +76,7 @@ class Cart extends AbstractBlock {
 	 */
 	protected function get_skeleton() {
 		return '
-			<div class="wc-block-cart wc-block-cart--skeleton" aria-hidden="true">
+			<div class="wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton" aria-hidden="true">
 				<div class="wc-block-cart__main">
 					<h2><span></span></h2>
 					<table class="wc-block-cart-items">
@@ -89,13 +89,13 @@ class Cart extends AbstractBlock {
 							</tr>
 						</thead>
 						<tbody>
-						<tr class="wc-block-cart-items__row">
+							<tr class="wc-block-cart-items__row">
 								<td class="wc-block-cart-item__image">
 									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
 								</td>
 								<td class="wc-block-cart-item__product">
-									<div></div>
-									<div></div>
+									<div class="wc-block-cart-item__product-name"></div>
+									<div class="wc-block-cart-item__product-metadata"></div>
 								</td>
 								<td class="wc-block-cart-item__quantity">
 								<div class="wc-block-quantity-selector">
@@ -105,7 +105,7 @@ class Cart extends AbstractBlock {
 								</div>
 								</td>
 								<td class="wc-block-cart-item__total">
-									<div></div>
+									<div class="wc-block-cart-item__price"></div>
 								</td>
 							</tr>
 							<tr class="wc-block-cart-items__row">
@@ -113,8 +113,8 @@ class Cart extends AbstractBlock {
 									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
 								</td>
 								<td class="wc-block-cart-item__product">
-									<div></div>
-									<div></div>
+									<div class="wc-block-cart-item__product-name">&nbsp;</div>
+									<div class="wc-block-cart-item__product-metadata">&nbsp;</div>
 								</td>
 								<td class="wc-block-cart-item__quantity">
 								<div class="wc-block-quantity-selector">
@@ -124,7 +124,7 @@ class Cart extends AbstractBlock {
 								</div>
 								</td>
 								<td class="wc-block-cart-item__total">
-									<div></div>
+									<div class="wc-block-cart-item__price"></div>
 								</td>
 							</tr>
 							<tr class="wc-block-cart-items__row">
@@ -132,8 +132,8 @@ class Cart extends AbstractBlock {
 									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
 								</td>
 								<td class="wc-block-cart-item__product">
-									<div></div>
-									<div></div>
+									<div class="wc-block-cart-item__product-name"></div>
+									<div class="wc-block-cart-item__product-metadata"></div>
 								</td>
 								<td class="wc-block-cart-item__quantity">
 								<div class="wc-block-quantity-selector">
@@ -143,7 +143,7 @@ class Cart extends AbstractBlock {
 								</div>
 								</td>
 								<td class="wc-block-cart-item__total">
-									<div></div>
+									<div class="wc-block-cart-item__price"></div>
 								</td>
 							</tr>
 						</tbody>

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -78,6 +78,7 @@ class Cart extends AbstractBlock {
 		return '
 			<div class="wc-block-cart wc-block-cart--skeleton" aria-hidden="true">
 				<div class="wc-block-cart__main">
+					<h2><span></span></h2>
 					<table class="wc-block-cart-items">
 						<thead>
 							<tr class="wc-block-cart-items__header">

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -68,6 +68,90 @@ class Cart extends AbstractBlock {
 			$this->block_name . '-frontend',
 			$this->block_name . '-block-frontend'
 		);
-		return $content;
+		return $content . $this->get_skeleton();
+	}
+
+	/**
+	 * Render skeleton markup for the cart block.
+	 */
+	protected function get_skeleton() {
+		return '
+			<div class="wc-block-cart wc-block-cart--skeleton" aria-hidden="true">
+				<div class="wc-block-cart__main">
+					<table class="wc-block-cart-items">
+						<thead>
+							<tr class="wc-block-cart-items__header">
+								<th class="wc-block-cart-items__header-image"><span /></th>
+								<th class="wc-block-cart-items__header-product"><span /></th>
+								<th class="wc-block-cart-items__header-quantity"><span /></th>
+								<th class="wc-block-cart-items__header-total"><span /></th>
+							</tr>
+						</thead>
+						<tbody>
+						<tr class="wc-block-cart-items__row">
+								<td class="wc-block-cart-item__image">
+									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
+								</td>
+								<td class="wc-block-cart-item__product">
+									<div></div>
+									<div></div>
+								</td>
+								<td class="wc-block-cart-item__quantity">
+								<div class="wc-block-quantity-selector">
+									<input class="wc-block-quantity-selector__input" type="number" step="1" min="0" value="1" />
+									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus">－</button>
+									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus">＋</button>
+								</div>
+								</td>
+								<td class="wc-block-cart-item__total">
+									<div></div>
+								</td>
+							</tr>
+							<tr class="wc-block-cart-items__row">
+								<td class="wc-block-cart-item__image">
+									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
+								</td>
+								<td class="wc-block-cart-item__product">
+									<div></div>
+									<div></div>
+								</td>
+								<td class="wc-block-cart-item__quantity">
+								<div class="wc-block-quantity-selector">
+									<input class="wc-block-quantity-selector__input" type="number" step="1" min="0" value="1" />
+									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus">－</button>
+									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus">＋</button>
+								</div>
+								</td>
+								<td class="wc-block-cart-item__total">
+									<div></div>
+								</td>
+							</tr>
+							<tr class="wc-block-cart-items__row">
+								<td class="wc-block-cart-item__image">
+									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
+								</td>
+								<td class="wc-block-cart-item__product">
+									<div></div>
+									<div></div>
+								</td>
+								<td class="wc-block-cart-item__quantity">
+								<div class="wc-block-quantity-selector">
+									<input class="wc-block-quantity-selector__input" type="number" step="1" min="0" value="1" />
+									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus">－</button>
+									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus">＋</button>
+								</div>
+								</td>
+								<td class="wc-block-cart-item__total">
+									<div></div>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div class="wc-block-cart__sidebar">
+					<div class="components-card"></div>
+				</div>
+			</div>
+		';
 	}
 }


### PR DESCRIPTION
With the inclusion of https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1845 there is no longer a delay before the cart is rendered. This kinda makes the placeholder state we added redundant (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1819).

However, what does remain is whilst the page is loaded, before React is available and first block render, then is no content or indication that the cart is there. This is further exaggerated when using throttling in network tools.

This PR adds skeleton markup on the PHP side which is shown via CSS. Once the block is loaded, this markup is hidden.

The question remains (@senadir @Aljullu) if we'd prefer this markup within the `save()` method of the block itself, however that raises concerns due to invalidation if markup changes, and how it conflicts with the InnerBlocks being saved there currently.

#### Accessibility

Skeleton markup is hidden from screen readers.

### Screenshots

![2020-03-04 12 34 27](https://user-images.githubusercontent.com/90977/75881195-7f85fb80-5e16-11ea-9d6d-f5b0912dbfb0.gif)

### How to test the changes in this Pull Request:

1. In browser developer tools, under network, enabling 3g throttling
2. View the cart page
3. Ensure the skeleton markup is hidden once the block loads
