### PR TITLE
 Make Shipping packages collapsible in Cart page 

### DIFF
--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -18,33 +18,12 @@
 		border-bottom: 0;
 	}
 
-	.wc-block-radio-control__input {
-		appearance: none;
-		background: #fff;
-		border: 2px solid currentColor;
-		border-radius: 50%;
-		display: inline-block;
-		height: 1rem;
-		margin: 0 0 0 -8px;
-		left: $gap-larger;
-		min-height: 16px;
-		min-width: 16px;
-		position: absolute;
-		top: $gap;
-		width: 1rem;
-
-		&:checked::before {
-			background: currentColor;
-			border-radius: 50%;
-			content: "";
-			display: block;
-			height: 8px;
-			left: 50%;
-			margin: 0;
+	.wc-block-radio-control {
+		.wc-block-radio-control__input {
+			margin: 0 0 0 -8px;
+			left: $gap-larger;
 			position: absolute;
-			top: 50%;
-			transform: translate(-50%, -50%);
-			width: 8px;
+			top: $gap;
 		}
 	}
 
@@ -67,5 +46,33 @@
 	.wc-block-radio-control__secondary-label,
 	.wc-block-radio-control__secondary-description {
 		text-align: right;
+	}
+}
+
+@mixin radio-control-input-styles {
+	.wc-block-radio-control__input {
+		appearance: none;
+		background: #fff;
+		border: 2px solid currentColor;
+		border-radius: 50%;
+		display: inline-block;
+		height: 1rem;
+		min-height: 16px;
+		min-width: 16px;
+		width: 1rem;
+
+		&:checked::before {
+			background: currentColor;
+			border-radius: 50%;
+			content: "";
+			display: block;
+			height: 8px;
+			left: 50%;
+			margin: 0;
+			position: absolute;
+			top: 50%;
+			transform: translate(-50%, -50%);
+			width: 8px;
+		}
 	}
 }

--- a/assets/js/base/components/radio-control/editor.scss
+++ b/assets/js/base/components/radio-control/editor.scss
@@ -2,5 +2,5 @@
 
 // We need to increase the styles specificity in the editor, to avoid wp-admin styles taking preference.
 #wpbody .edit-post-visual-editor {
-	@include radio-control-styles;
+	@include radio-control-input-styles;
 }

--- a/assets/js/base/components/radio-control/style.scss
+++ b/assets/js/base/components/radio-control/style.scss
@@ -1,3 +1,4 @@
 @import "./mixin";
 
 @include radio-control-styles;
+@include radio-control-input-styles;

--- a/assets/js/base/components/shipping-rates-control/index.js
+++ b/assets/js/base/components/shipping-rates-control/index.js
@@ -16,6 +16,7 @@ const ShippingRatesControl = ( {
 	shippingRates,
 	shippingRatesLoading,
 	className,
+	collapsibleWhenMultiple = false,
 	noResultsMessage,
 	renderOption,
 } ) => {
@@ -23,6 +24,8 @@ const ShippingRatesControl = ( {
 		shippingRates,
 		( newRates ) => newRates.length > 0
 	);
+
+	const shippingRatesToDisplay = previousShippingRates || shippingRates;
 
 	return (
 		<LoadingMask
@@ -35,9 +38,12 @@ const ShippingRatesControl = ( {
 		>
 			<Packages
 				className={ className }
+				collapsible={
+					shippingRatesToDisplay.length > 1 && collapsibleWhenMultiple
+				}
 				noResultsMessage={ noResultsMessage }
 				renderOption={ renderOption }
-				shippingRates={ previousShippingRates || shippingRates }
+				shippingRates={ shippingRatesToDisplay }
 			/>
 		</LoadingMask>
 	);
@@ -55,6 +61,7 @@ ShippingRatesControl.propTypes = {
 	noResultsMessage: PropTypes.string.isRequired,
 	renderOption: PropTypes.func.isRequired,
 	className: PropTypes.string,
+	collapsibleWhenMultiple: PropTypes.bool,
 };
 
 export default ShippingRatesControl;

--- a/assets/js/base/components/shipping-rates-control/package.js
+++ b/assets/js/base/components/shipping-rates-control/package.js
@@ -6,6 +6,7 @@ import { _n, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import Label from '@woocommerce/base-components/label';
 import classNames from 'classnames';
+import { PanelBody, PanelRow } from 'wordpress-components';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import './style.scss';
 
 const Package = ( {
 	className,
+	collapsible = false,
 	noResultsMessage,
 	onChange,
 	renderOption,
@@ -23,13 +25,8 @@ const Package = ( {
 	showItems,
 	title,
 } ) => {
-	return (
-		<div
-			className={ classNames(
-				'wc-block-shipping-rates-control__package',
-				className
-			) }
-		>
+	const header = (
+		<>
 			{ title && (
 				<div className="wc-block-shipping-rates-control__package-title">
 					{ title }
@@ -64,14 +61,38 @@ const Package = ( {
 					} ) }
 				</ul>
 			) }
-			<PackageOptions
-				className={ className }
-				noResultsMessage={ noResultsMessage }
-				onChange={ onChange }
-				options={ shippingRate.shipping_rates }
-				renderOption={ renderOption }
-				selected={ selected }
-			/>
+		</>
+	);
+	const body = (
+		<PackageOptions
+			className={ className }
+			noResultsMessage={ noResultsMessage }
+			onChange={ onChange }
+			options={ shippingRate.shipping_rates }
+			renderOption={ renderOption }
+			selected={ selected }
+		/>
+	);
+	if ( collapsible ) {
+		return (
+			<PanelBody
+				className="wc-block-shipping-rates-control__package"
+				title={ header }
+				initialOpen={ true }
+			>
+				<PanelRow>{ body }</PanelRow>
+			</PanelBody>
+		);
+	}
+	return (
+		<div
+			className={ classNames(
+				'wc-block-shipping-rates-control__package',
+				className
+			) }
+		>
+			{ header }
+			{ body }
 		</div>
 	);
 };
@@ -90,6 +111,7 @@ Package.propTypes = {
 		).isRequired,
 	} ).isRequired,
 	className: PropTypes.string,
+	collapsible: PropTypes.bool,
 	noResultsMessage: PropTypes.string,
 	selected: PropTypes.string,
 	showItems: PropTypes.bool,

--- a/assets/js/base/components/shipping-rates-control/packages.js
+++ b/assets/js/base/components/shipping-rates-control/packages.js
@@ -12,6 +12,7 @@ import './style.scss';
 
 const Packages = ( {
 	className,
+	collapsible = false,
 	noResultsMessage,
 	renderOption,
 	shippingRates = [],
@@ -19,26 +20,34 @@ const Packages = ( {
 	const { selectShippingRate, selectedShippingRates } = useSelectShippingRate(
 		shippingRates
 	);
-	return shippingRates.map( ( shippingRate, i ) => (
-		<Package
-			key={ shippingRate.package_id }
-			className={ className }
-			noResultsMessage={ noResultsMessage }
-			onChange={ ( newShippingRate ) => {
-				selectShippingRate( newShippingRate, i );
-			} }
-			renderOption={ renderOption }
-			selected={ selectedShippingRates[ i ] }
-			shippingRate={ shippingRate }
-			showItems={ shippingRates.length > 1 }
-			title={ shippingRates.length > 1 ? shippingRate.name : null }
-		/>
-	) );
+	return (
+		<div className="wc-block-shipping-rates-control">
+			{ shippingRates.map( ( shippingRate, i ) => (
+				<Package
+					key={ shippingRate.package_id }
+					className={ className }
+					collapsible={ collapsible }
+					noResultsMessage={ noResultsMessage }
+					onChange={ ( newShippingRate ) => {
+						selectShippingRate( newShippingRate, i );
+					} }
+					renderOption={ renderOption }
+					selected={ selectedShippingRates[ i ] }
+					shippingRate={ shippingRate }
+					showItems={ shippingRates.length > 1 }
+					title={
+						shippingRates.length > 1 ? shippingRate.name : null
+					}
+				/>
+			) ) }
+		</div>
+	);
 };
 
 Packages.propTypes = {
 	renderOption: PropTypes.func.isRequired,
 	className: PropTypes.string,
+	collapsible: PropTypes.bool,
 	noResultsMessage: PropTypes.string,
 	shippingRates: PropTypes.arrayOf(
 		PropTypes.shape( {

--- a/assets/js/base/components/shipping-rates-control/style.scss
+++ b/assets/js/base/components/shipping-rates-control/style.scss
@@ -7,6 +7,7 @@
 }
 
 .wc-block-shipping-rates-control__package-items {
+	color: $core-grey-dark-400;
 	display: block;
 	font-size: 0.875em;
 	list-style: none;
@@ -27,4 +28,46 @@
 
 .wc-block-shipping-rates-control__no-results {
 	margin-bottom: 0;
+}
+
+// Resets when it's inside a panel.
+.wc-block-shipping-rates-control {
+	.wc-block-shipping-rates-control__package.components-panel__body {
+		border-bottom: none;
+
+		&,
+		&.is-opened {
+			padding-bottom: 0;
+
+			.components-panel__body-title {
+				margin-bottom: 0;
+			}
+		}
+
+		.components-panel__body-toggle {
+			padding-bottom: 14px;
+			padding-top: 14px;
+		}
+
+		.wc-block-shipping-rates-control__package-title {
+			font-weight: normal;
+		}
+
+		.wc-block-shipping-rates-control__package-items {
+			margin: 0;
+		}
+
+		.wc-block-radio-control {
+			width: 100%;
+		}
+
+		.wc-block-radio-control__option {
+			margin-right: 0;
+			max-width: none;
+
+			&:first-child {
+				border-top: 1px solid $core-grey-light-600;
+			}
+		}
+	}
 }

--- a/assets/js/base/components/shipping-rates-control/style.scss
+++ b/assets/js/base/components/shipping-rates-control/style.scss
@@ -38,10 +38,10 @@
 		&,
 		&.is-opened {
 			padding-bottom: 0;
+		}
 
-			.components-panel__body-title {
-				margin-bottom: 0;
-			}
+		.components-panel__body-title {
+			margin-bottom: 0;
 		}
 
 		.components-panel__body-toggle {

--- a/assets/js/base/components/totals/totals-coupon-code-input/style.scss
+++ b/assets/js/base/components/totals/totals-coupon-code-input/style.scss
@@ -1,49 +1,17 @@
-.wc-block-coupon-code {
-	// Extra class for specificity
-	&.components-panel__body {
-		&.is-opened {
-			padding-left: 0;
-			padding-right: 0;
+.wc-block-coupon-code__form {
+	display: flex;
+	margin-bottom: 0;
+}
 
-			> .components-panel__body-title {
-				margin-left: 0;
-				margin-right: 0;
-			}
-		}
+.wc-block-coupon-code__input {
+	margin-top: 0;
+	flex-grow: 1;
+}
 
-		> .components-panel__body-title,
-		.components-panel__body-toggle {
-			&,
-			&:hover,
-			&:focus,
-			&:active {
-				background-color: transparent;
-			}
-		}
-
-		.components-panel__body-toggle {
-			font-weight: normal;
-			font-size: inherit;
-			padding-left: 0;
-			padding-right: 0;
-		}
-	}
-
-	.wc-block-coupon-code__form {
-		display: flex;
-		margin-bottom: 0;
-	}
-
-	.wc-block-coupon-code__input {
-		margin-top: 0;
-		flex-grow: 1;
-	}
-
-	.wc-block-coupon-code__button {
-		height: 48px;
-		margin-left: $gap;
-		padding-left: $gap-large;
-		padding-right: $gap-large;
-		white-space: nowrap;
-	}
+.wc-block-coupon-code__button {
+	height: 48px;
+	margin-left: $gap;
+	padding-left: $gap-large;
+	padding-right: $gap-large;
+	white-space: nowrap;
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -79,6 +79,7 @@ const ShippingCalculatorOptions = ( {
 						  }
 						: null
 				}
+				collapsibleWhenMultiple={ true }
 				noResultsMessage={ __(
 					'No shipping options were found.',
 					'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,4 +1,5 @@
 .wc-block-cart {
+	color: $core-grey-dark-600;
 	display: flex;
 	flex-wrap: wrap;
 	margin: 0 (-$gap) $gap;
@@ -78,6 +79,10 @@
 
 		.wc-block-radio-control__option {
 			padding-left: $gap-large;
+
+			&:last-child {
+				border-bottom: none;
+			}
 		}
 
 		.wc-block-radio-control__input {
@@ -283,6 +288,47 @@ table.wc-block-cart-items {
 }
 .is-loading + .wc-block-cart--skeleton {
 	display: flex;
+}
+
+// Reset Gutenberg <Panel> styles when used in the sidebar.
+.wc-block-cart__sidebar {
+	.components-panel__body {
+		border-top: 1px solid $core-grey-light-600;
+		border-bottom: 1px solid $core-grey-light-600;
+
+		&.is-opened {
+			padding-left: 0;
+			padding-right: 0;
+
+			> .components-panel__body-title {
+				margin-left: 0;
+				margin-right: 0;
+			}
+		}
+
+		> .components-panel__body-title,
+		.components-panel__body-toggle {
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				background-color: transparent;
+				color: inherit;
+			}
+		}
+
+		.components-panel__body-toggle {
+			font-weight: normal;
+			font-size: inherit;
+			padding-left: 0;
+			padding-right: 36px;
+
+			&.components-button,
+			&.components-button:focus:not(:disabled):not([aria-disabled="true"]) {
+				color: inherit;
+			}
+		}
+	}
 }
 
 // Mobile styles.


### PR DESCRIPTION
Fixes #1810.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
<img src="https://user-images.githubusercontent.com/3616980/75894024-e960ce00-5e33-11ea-81c7-6473d08d0f49.gif" alt="Screenshot" width="343" />

### How to test the changes in this Pull Request:

1. Install [WooCommerce Advanced Shipping Packages](https://woocommerce.com/products/woocommerce-advanced-shipping-packages/) and set up some package rules ([see how](https://docs.woocommerce.com/document/woocommerce-advanced-shipping-packages/)).
2. Add products that will be in different packages to your cart.
3. Create a page with a _Cart_ block and view it in the frontend.
4. Verify the packages are collapsible like in the GIF above.
5. Verify there are no regressions in the _Checkout_ block and when there is only one package.