### PR TITLE
Fix broken e2e test for Checkout block

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"test:help": "wp-scripts test-unit-js --help",
 		"test:update": "wp-scripts test-unit-js --updateSnapshot --config tests/js/jest.config.json",
 		"test:e2e": "./tests/bin/e2e-test-integration.js",
+		"test:e2e:update": "./tests/bin/e2e-test-integration.js -- --updateSnapshot",
 		"test:e2e-dev": "./tests/bin/e2e-test-integration.js --dev",
 		"test:watch": "npm run test -- --watch",
 		"size-check": "bundlewatch",

--- a/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
+++ b/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Checkout Block can be created 1`] = `
 "<!-- wp:woocommerce/checkout -->
-<div class=\\"wp-block-woocommerce-checkout\\">Checkout block coming soon to store near you</div>
+<div class=\\"wp-block-woocommerce-checkout\\" data-use-shipping-as-billing=\\"true\\">Checkout block coming soon to store near you</div>
 <!-- /wp:woocommerce/checkout -->"
 `;


### PR DESCRIPTION
Recently we merged new snapshot tests for cart & checkout block (#1809). Since then, some markup for the checkout block has changed (well, this must have happened in parallel #1857).

This PR updates the snapshot for the checkout block and adds a `package.json` script for updating e2e snapshots.

### How to test the changes in this Pull Request:
#### Set up e2e locally
- `nvm install --latest-npm` (optional)
- `npm ci` (optional)
- `npm run docker:up`
- `composer install`
- `npm run build:e2e-test`

You should now have a docker container up where the e2e tests run. (`npm run docker:down` to shut it down.)

#### Run e2 tests - should pass
- `npm run test:e2e`

#### Test rebuilding snapshots
- Break a snapshot by editing it directly (`tests/e2e-tests/specs/backend/__snapshots__`).
- OR change the rendered markup for a block with a snapshot test.
- Run tests - they should fail `npm run test:e2e`.
- Run tests & update snapshots - should succeed `npm run test:e2e:update`.
