### PR TITLE
Tidy cart items mobile layout

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -317,7 +317,7 @@ table.wc-block-cart-items {
 			.wc-block-cart-item__total {
 				grid-column-start: 3;
 				grid-row-start: 2;
-				align-self: center;
+				align-self: flex-end;
 
 				.wc-block-formatted-money-amount {
 					display: inline-block;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -264,6 +264,7 @@ table.wc-block-cart-items {
 		.wc-block-cart__main {
 			padding: 0;
 			flex: none;
+			min-width: 200px;
 		}
 		.wc-block-cart__sidebar {
 			padding: 0;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -317,7 +317,7 @@ table.wc-block-cart-items {
 			.wc-block-cart-item__total {
 				grid-column-start: 3;
 				grid-row-start: 2;
-				align-self: flex-end;
+				align-self: center;
 
 				.wc-block-formatted-money-amount {
 					display: inline-block;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -319,6 +319,10 @@ table.wc-block-cart-items {
 				grid-row-start: 2;
 				align-self: center;
 
+				.wc-block-formatted-money-amount {
+					display: inline-block;
+				}
+
 				.wc-block-cart-item__sale-badge {
 					display: none;
 				}


### PR DESCRIPTION
Fixes #1870

This PR addresses some styling issues with cart item table on mobile.

- Override max width on smaller screens, so the table isn't larger than the screen.
- Makes prices inline on smaller screens, so sale price (if visible) is not stacked vertically with actual price.

Also looked at aligning the price with the bottom of the row, so the margins are consistent... but backed out of that, as the design has the prices aligned with the quantity number (which makes sense now I think about it).

### Screenshots

<img width="377" alt="Screen Shot 2020-03-05 at 5 55 31 PM" src="https://user-images.githubusercontent.com/4167300/75949494-4aa7a080-5f0b-11ea-9121-2d9c69b4b028.png">

(Pay no attention to the low stock badge!! #1874)

### How to test the changes in this Pull Request:
2. Ensure you have some products on sale.
1. Publish a page with cart block, add some stuff to cart (including some sale items).
3. View cart in a range of browsers, screen sizes & devices. Should look better on mobile, and shopper should be able to wrangle items (see info & prices, change quantity, remove item etc) on any device :)
