### PR TITLE
Fix undefined variable in cart items terms

### DIFF
--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -370,7 +370,7 @@ class CartItemSchema extends AbstractSchema {
 			} else {
 				// If this is a custom option slug, get the options name.
 				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $product );
-				$label = wc_attribute_label( str_replace( 'attribute_', '', $name ), $product );
+				$label = wc_attribute_label( str_replace( 'attribute_', '', $key ), $product );
 			}
 
 			$return[] = [


### PR DESCRIPTION
this PR fixes an issue with terms in `CartItemSchema`, it seems a refactor left out an unused variable, causing this error

```
Notice: Undefined variable: name in /var/www/html/wp-content/plugins/woocommerce-gutenberg-products-block/src/RestApi/StoreApi/Schemas/CartItemSchema.php on line 373
```

this PR fixes it.

## How to test
have a product with a local term (something you create within the product page).
go to the cart and observe no errors, also the term should be visible within the product.