### PR TITLE
Add styling to checkboxes

### DIFF
--- a/assets/js/base/components/checkbox-control/index.js
+++ b/assets/js/base/components/checkbox-control/index.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { CheckboxControl as WPCheckboxControl } from 'wordpress-components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Component used to show a checkbox control with styles.
+ */
+const CheckboxControl = ( {
+	checked = [],
+	className,
+	label,
+	onChange = () => {},
+} ) => {
+	return (
+		<WPCheckboxControl
+			checked={ checked }
+			className={ classNames( 'wc-block-checkbox', className ) }
+			label={ label }
+			onChange={ onChange }
+		/>
+	);
+};
+
+CheckboxControl.propTypes = {
+	checked: PropTypes.bool,
+	className: PropTypes.string,
+	label: PropTypes.string,
+	onChange: PropTypes.func,
+};
+
+export default CheckboxControl;

--- a/assets/js/base/components/checkbox-control/index.js
+++ b/assets/js/base/components/checkbox-control/index.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import { CheckboxControl as WPCheckboxControl } from 'wordpress-components';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { CheckboxControl as WPCheckboxControl } from 'wordpress-components';
 
 /**
  * Internal dependencies
@@ -13,27 +13,17 @@ import './style.scss';
 /**
  * Component used to show a checkbox control with styles.
  */
-const CheckboxControl = ( {
-	checked = [],
-	className,
-	label,
-	onChange = () => {},
-} ) => {
+const CheckboxControl = ( { className, ...props } ) => {
 	return (
 		<WPCheckboxControl
-			checked={ checked }
 			className={ classNames( 'wc-block-checkbox', className ) }
-			label={ label }
-			onChange={ onChange }
+			{ ...props }
 		/>
 	);
 };
 
 CheckboxControl.propTypes = {
-	checked: PropTypes.bool,
 	className: PropTypes.string,
-	label: PropTypes.string,
-	onChange: PropTypes.func,
 };
 
 export default CheckboxControl;

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -1,0 +1,10 @@
+.wc-block-checkbox {
+	.components-checkbox-control__input[type="checkbox"]:checked {
+		background: currentColor;
+		border-color: currentColor;
+	}
+	.components-checkbox-control__input[type="checkbox"]:focus {
+		border-color: currentColor;
+		box-shadow: 0 0 2px currentColor;
+	}
+}

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -7,4 +7,7 @@
 		border-color: currentColor;
 		box-shadow: 0 0 2px currentColor;
 	}
+	.components-checkbox-control__label {
+		display: inline;
+	}
 }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -11,7 +11,7 @@ import CheckoutForm from '@woocommerce/base-components/checkout/form';
 import NoShipping from '@woocommerce/base-components/checkout/no-shipping';
 import TextInput from '@woocommerce/base-components/text-input';
 import ShippingRatesControl from '@woocommerce/base-components/shipping-rates-control';
-import { CheckboxControl } from '@wordpress/components';
+import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import CheckoutProvider from '@woocommerce/base-context/checkout-context';

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -132,6 +132,8 @@ const stableMainEntry = {
 	'panel-style': './node_modules/@wordpress/components/src/panel/style.scss',
 	'custom-select-control-style':
 		'./node_modules/@wordpress/components/src/custom-select-control/style.scss',
+	'checkbox-control-style':
+		'./node_modules/@wordpress/components/src/checkbox-control/style.scss',
 	'spinner-style':
 		'./node_modules/@wordpress/components/src/spinner/style.scss',
 };


### PR DESCRIPTION
Fixes #1878.

Unlike radio controls (see #1817), I found checkbox styles were quite easy to reuse from the `<CheckboxControl>` component from `@wordpress/components`, so this PR creates a `<CheckboxControl>` component for WooCommerce Blocks which is basically a wrapper which adds a class with some reset styles.

### Screenshots

_Before:_
![Peek 2020-03-05 12-29](https://user-images.githubusercontent.com/3616980/75977599-0c938800-5edd-11ea-8b6b-03415a246b50.gif)

_After:_
![Peek 2020-03-05 15-20](https://user-images.githubusercontent.com/3616980/75990252-e843a580-5ef4-11ea-9e11-c0ff94fb7980.gif)

### How to test the changes in this Pull Request:

1. Add a _Checkout_ block and view it in the frontend.
2. Try checking/unchecking some checkboxes and verify they look good.
