### PR TITLE
Split Full Cart sidebar totals into several components

### DIFF
--- a/assets/js/base/components/totals/index.js
+++ b/assets/js/base/components/totals/index.js
@@ -1,2 +1,8 @@
+export { default as SubtotalsItem } from './subtotals-item';
 export { default as TotalsCouponCodeInput } from './totals-coupon-code-input';
+export { default as TotalsDiscountItem } from './totals-discount-item';
+export { default as TotalsFeesItem } from './totals-fees-item';
+export { default as TotalsFooterItem } from './totals-footer-item';
 export { default as TotalsItem } from './totals-item';
+export { default as TotalsShippingItem } from './totals-shipping-item';
+export { default as TotalsTaxesItem } from './totals-taxes-item';

--- a/assets/js/base/components/totals/subtotals-item/index.js
+++ b/assets/js/base/components/totals/subtotals-item/index.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import TotalsItem from '../totals-item';
+
+const SubtotalsItem = ( { currency, values } ) => {
+	const { total_items: totalItems, total_items_tax: totalItemsTax } = values;
+	const itemsValue = parseInt( totalItems, 10 );
+	const itemsTaxValue = parseInt( totalItemsTax, 10 );
+
+	return (
+		<TotalsItem
+			currency={ currency }
+			label={ __( 'Subtotal', 'woo-gutenberg-products-block' ) }
+			value={
+				DISPLAY_CART_PRICES_INCLUDING_TAX
+					? itemsValue + itemsTaxValue
+					: itemsValue
+			}
+		/>
+	);
+};
+
+SubtotalsItem.propTypes = {
+	currency: PropTypes.object.isRequired,
+	values: PropTypes.shape( {
+		total_items: PropTypes.string,
+		total_items_tax: PropTypes.string,
+	} ).isRequired,
+};
+
+export default SubtotalsItem;

--- a/assets/js/base/components/totals/totals-discount-item/index.js
+++ b/assets/js/base/components/totals/totals-discount-item/index.js
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
+import LoadingMask from '@woocommerce/base-components/loading-mask';
+import Chip from '@woocommerce/base-components/chip';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import TotalsItem from '../totals-item';
+
+const TotalsDiscountItem = ( {
+	cartCoupons = [],
+	currency,
+	isRemovingCoupon,
+	removeCoupon,
+	values,
+} ) => {
+	const {
+		total_discount: totalDiscount,
+		total_discount_tax: totalDiscountTax,
+	} = values;
+	const discountValue = parseInt( totalDiscount, 10 );
+
+	if ( ! discountValue && cartCoupons.length === 0 ) {
+		return null;
+	}
+
+	const discountTaxValue = parseInt( totalDiscountTax, 10 );
+
+	return (
+		<TotalsItem
+			currency={ currency }
+			description={
+				cartCoupons.length !== 0 && (
+					<LoadingMask
+						screenReaderLabel={ __(
+							'Removing coupon…',
+							'woo-gutenberg-products-block'
+						) }
+						isLoading={ isRemovingCoupon }
+						showSpinner={ false }
+					>
+						<ul className="wc-block-cart-coupon-list">
+							{ cartCoupons.map( ( cartCoupon ) => (
+								<Chip
+									key={ 'coupon-' + cartCoupon.code }
+									className="wc-block-cart-coupon-list__item"
+									text={ cartCoupon.code }
+									screenReaderText={ sprintf(
+										/* Translators: %s Coupon code. */
+										__(
+											'Coupon: %s',
+											'woo-gutenberg-products-block'
+										),
+										cartCoupon.code
+									) }
+									disabled={ isRemovingCoupon }
+									onRemove={ () => {
+										removeCoupon( cartCoupon.code );
+									} }
+									radius="large"
+								/>
+							) ) }
+						</ul>
+					</LoadingMask>
+				)
+			}
+			label={ __( 'Discount', 'woo-gutenberg-products-block' ) }
+			value={
+				( DISPLAY_CART_PRICES_INCLUDING_TAX
+					? discountValue + discountTaxValue
+					: discountValue ) * -1
+			}
+		/>
+	);
+};
+
+TotalsDiscountItem.propTypes = {
+	cartCoupons: PropTypes.arrayOf(
+		PropTypes.shape( {
+			code: PropTypes.string.isRequired,
+		} )
+	),
+	currency: PropTypes.object.isRequired,
+	isRemovingCoupon: PropTypes.bool.isRequired,
+	removeCoupon: PropTypes.func.isRequired,
+	values: PropTypes.shape( {
+		total_discount: PropTypes.string,
+		total_discount_tax: PropTypes.string,
+	} ).isRequired,
+};
+
+export default TotalsDiscountItem;

--- a/assets/js/base/components/totals/totals-fees-item/index.js
+++ b/assets/js/base/components/totals/totals-fees-item/index.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	DISPLAY_CART_PRICES_INCLUDING_TAX,
+	SHIPPING_ENABLED,
+} from '@woocommerce/block-settings';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import TotalsItem from '../totals-item';
+
+const TotalsFeesItem = ( { currency, values } ) => {
+	if ( ! SHIPPING_ENABLED ) {
+		return null;
+	}
+	const { total_fees: totalFees, total_fees_tax: totalFeesTax } = values;
+	const feesValue = parseInt( totalFees, 10 );
+
+	if ( ! feesValue ) {
+		return null;
+	}
+
+	const feesTaxValue = parseInt( totalFeesTax, 10 );
+
+	return (
+		<TotalsItem
+			currency={ currency }
+			label={ __( 'Fees', 'woo-gutenberg-products-block' ) }
+			value={
+				DISPLAY_CART_PRICES_INCLUDING_TAX
+					? feesValue + feesTaxValue
+					: feesValue
+			}
+		/>
+	);
+};
+
+TotalsFeesItem.propTypes = {
+	currency: PropTypes.object.isRequired,
+	values: PropTypes.shape( {
+		total_fees: PropTypes.string,
+		total_fees_tax: PropTypes.string,
+	} ).isRequired,
+};
+
+export default TotalsFeesItem;

--- a/assets/js/base/components/totals/totals-footer-item/index.js
+++ b/assets/js/base/components/totals/totals-footer-item/index.js
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
+import { __experimentalCreateInterpolateElement } from 'wordpress-element';
+import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import TotalsItem from '../totals-item';
+import './style.scss';
+
+const TotalsFooterItem = ( { currency, values } ) => {
+	const { total_price: totalPrice, total_tax: totalTax } = values;
+
+	return (
+		<TotalsItem
+			className="wc-block-totals-footer-item"
+			currency={ currency }
+			label={ __( 'Total', 'woo-gutenberg-products-block' ) }
+			value={ parseInt( totalPrice, 10 ) }
+			description={
+				DISPLAY_CART_PRICES_INCLUDING_TAX && (
+					<p className="wc-block-totals-footer-item-tax">
+						{ __experimentalCreateInterpolateElement(
+							__(
+								'Including <TaxAmount/> in taxes',
+								'woo-gutenberg-products-block'
+							),
+							{
+								TaxAmount: (
+									<FormattedMonetaryAmount
+										className="wc-block-totals-footer-item-tax-value"
+										currency={ currency }
+										displayType="text"
+										value={ parseInt( totalTax, 10 ) }
+									/>
+								),
+							}
+						) }
+					</p>
+				)
+			}
+		/>
+	);
+};
+
+TotalsFooterItem.propTypes = {
+	currency: PropTypes.object.isRequired,
+	values: PropTypes.shape( {
+		total_price: PropTypes.string,
+		total_tax: PropTypes.string,
+	} ).isRequired,
+};
+
+export default TotalsFooterItem;

--- a/assets/js/base/components/totals/totals-footer-item/style.scss
+++ b/assets/js/base/components/totals/totals-footer-item/style.scss
@@ -1,0 +1,15 @@
+.wc-block-totals-footer-item {
+	.wc-block-totals-table-item__value,
+	.wc-block-totals-table-item__label {
+		color: #000;
+		font-size: 1.25em;
+	}
+
+	.wc-block-totals-table-item__label {
+		font-weight: normal;
+	}
+
+	.wc-block-totals-footer-item-tax {
+		margin-bottom: 0;
+	}
+}

--- a/assets/js/base/components/totals/totals-shipping-item/index.js
+++ b/assets/js/base/components/totals/totals-shipping-item/index.js
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	DISPLAY_CART_PRICES_INCLUDING_TAX,
+	SHIPPING_ENABLED,
+} from '@woocommerce/block-settings';
+import ShippingCalculator from '@woocommerce/base-components/shipping-calculator';
+import ShippingLocation from '@woocommerce/base-components/shipping-location';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import TotalsItem from '../totals-item';
+
+const TotalsShippingItem = ( {
+	currency,
+	shippingAddress,
+	updateShippingAddress,
+	values,
+} ) => {
+	if ( ! SHIPPING_ENABLED ) {
+		return null;
+	}
+	const {
+		total_shipping: totalShipping,
+		total_shipping_tax: totalShippingTax,
+	} = values;
+	const shippingValue = parseInt( totalShipping, 10 );
+	const shippingTaxValue = parseInt( totalShippingTax, 10 );
+
+	return (
+		<TotalsItem
+			currency={ currency }
+			description={
+				<>
+					<ShippingLocation address={ shippingAddress } />
+					<ShippingCalculator
+						address={ shippingAddress }
+						setAddress={ updateShippingAddress }
+					/>
+				</>
+			}
+			label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
+			value={
+				DISPLAY_CART_PRICES_INCLUDING_TAX
+					? shippingValue + shippingTaxValue
+					: shippingValue
+			}
+		/>
+	);
+};
+
+TotalsShippingItem.propTypes = {
+	currency: PropTypes.object.isRequired,
+	shippingAddress: PropTypes.object,
+	updateShippingAddress: PropTypes.func,
+	values: PropTypes.shape( {
+		total_shipping: PropTypes.string,
+		total_shipping_tax: PropTypes.string,
+	} ).isRequired,
+};
+
+export default TotalsShippingItem;

--- a/assets/js/base/components/totals/totals-taxes-item/index.js
+++ b/assets/js/base/components/totals/totals-taxes-item/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import TotalsItem from '../totals-item';
+
+const TotalsTaxesItem = ( { currency, values } ) => {
+	const { total_tax: totalTax } = values;
+
+	return (
+		<TotalsItem
+			currency={ currency }
+			label={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
+			value={ parseInt( totalTax, 10 ) }
+		/>
+	);
+};
+
+TotalsTaxesItem.propTypes = {
+	currency: PropTypes.object.isRequired,
+	values: PropTypes.shape( {
+		total_tax: PropTypes.string,
+	} ).isRequired,
+};
+
+export default TotalsTaxesItem;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -45,21 +45,6 @@
 			opacity: 0.8;
 		}
 	}
-	.wc-block-cart__totals-footer {
-		.wc-block-totals-table-item__value,
-		.wc-block-totals-table-item__label {
-			color: #000;
-			font-size: 1.25em;
-		}
-
-		.wc-block-totals-table-item__label {
-			font-weight: normal;
-		}
-
-		.wc-block-cart__totals-footer-tax {
-			margin-bottom: 0;
-		}
-	}
 	// Added extra class and label for specificity.
 	fieldset.wc-block-cart__shipping-options-fieldset {
 		background-color: transparent;


### PR DESCRIPTION
I started to work on the _Checkout_ block sidebar (see #1304), but quickly found out it was a bit difficult to reuse the logic from the _Cart_ block sidebar because it was all contained inside a function (`getTotalRowsConfig()`). This PR is just a refactor to remove that function and instead move all its logic into smaller components.

This PR doesn't add any new functionality, so everything should be working as it was.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/76016193-b2b2b280-5f1c-11ea-9098-3549351dcd5b.png)

### How to test the changes in this Pull Request:

1. Create a post with a _Cart_ block and preview it in the frontend.
2. In the sidebar of the _Full Cart_ mode, verify everything is working as usual: each row shows the correct values, you can add coupons, etc.