### PR TITLE
Link shipping form fields to shipping rates to load them.

### DIFF
--- a/assets/js/base/components/shipping-rates-control/index.js
+++ b/assets/js/base/components/shipping-rates-control/index.js
@@ -50,18 +50,12 @@ const ShippingRatesControl = ( {
 };
 
 ShippingRatesControl.propTypes = {
-	address: PropTypes.shape( {
-		address_1: PropTypes.string,
-		address_2: PropTypes.string,
-		city: PropTypes.string,
-		state: PropTypes.string,
-		postcode: PropTypes.string,
-		country: PropTypes.string,
-	} ),
 	noResultsMessage: PropTypes.string.isRequired,
 	renderOption: PropTypes.func.isRequired,
 	className: PropTypes.string,
 	collapsibleWhenMultiple: PropTypes.bool,
+	shippingRates: PropTypes.array,
+	shippingRatesLoading: PropTypes.bool,
 };
 
 export default ShippingRatesControl;

--- a/assets/js/base/hooks/test/use-shipping-rates.js
+++ b/assets/js/base/hooks/test/use-shipping-rates.js
@@ -19,11 +19,13 @@ describe( 'useShippingRates', () => {
 	let registry, mocks, renderer;
 	const getProps = ( testRenderer ) => {
 		const {
-			shippingRates,
+			shippingAddress,
+			setShippingAddress,
 			shippingRatesLoading,
 		} = testRenderer.root.findByType( 'div' ).props;
 		return {
-			shippingRates,
+			shippingAddress,
+			setShippingAddress,
 			shippingRatesLoading,
 		};
 	};
@@ -34,8 +36,14 @@ describe( 'useShippingRates', () => {
 		</RegistryProvider>
 	);
 
+	const defaultFieldsConfig = {
+		country: '',
+		state: '',
+		city: '',
+		postcode: '',
+	};
 	const getTestComponent = () => () => {
-		const items = useShippingRates();
+		const items = useShippingRates( defaultFieldsConfig );
 		return <div { ...items } />;
 	};
 
@@ -45,7 +53,16 @@ describe( 'useShippingRates', () => {
 		itemsCount: 123,
 		itemsWeight: 123,
 		needsShipping: false,
-		shippingRates: { foo: 'bar' },
+		shippingRates: [
+			{
+				destination: {
+					country: '',
+					state: '',
+					city: '',
+					postcode: '',
+				},
+			},
+		],
 	};
 
 	const setUpMocks = () => {
@@ -70,22 +87,25 @@ describe( 'useShippingRates', () => {
 		renderer = null;
 		setUpMocks();
 	} );
-	it( 'should return expected shipping rates provided by the store', () => {
+	it( 'should return expected address provided by the store', () => {
 		const TestComponent = getTestComponent();
 		act( () => {
 			renderer = TestRenderer.create(
 				getWrappedComponents( TestComponent )
 			);
 		} );
-		const { shippingRates } = getProps( renderer );
-		expect( shippingRates ).toBe( mockCartData.shippingRates );
+
+		const { shippingAddress } = getProps( renderer );
+		expect( shippingAddress ).toStrictEqual(
+			mockCartData.shippingRates[ 0 ].destination
+		);
 		// rerender
 		act( () => {
 			renderer.update( getWrappedComponents( TestComponent ) );
 		} );
-		// re-render should result in same shippingRates object.
-		const { shippingRates: newShippingRates } = getProps( renderer );
-		expect( newShippingRates ).toBe( shippingRates );
+		// re-render should result in same shippingAddress object.
+		const { shippingAddress: newShippingAddress } = getProps( renderer );
+		expect( newShippingAddress ).toStrictEqual( shippingAddress );
 		renderer.unmount();
 	} );
 } );

--- a/assets/js/base/hooks/test/use-shipping-rates.js
+++ b/assets/js/base/hooks/test/use-shipping-rates.js
@@ -19,11 +19,13 @@ describe( 'useShippingRates', () => {
 	let registry, mocks, renderer;
 	const getProps = ( testRenderer ) => {
 		const {
+			shippingRates,
 			shippingAddress,
 			setShippingAddress,
 			shippingRatesLoading,
 		} = testRenderer.root.findByType( 'div' ).props;
 		return {
+			shippingRates,
 			shippingAddress,
 			setShippingAddress,
 			shippingRatesLoading,
@@ -36,12 +38,7 @@ describe( 'useShippingRates', () => {
 		</RegistryProvider>
 	);
 
-	const defaultFieldsConfig = {
-		country: '',
-		state: '',
-		city: '',
-		postcode: '',
-	};
+	const defaultFieldsConfig = [ 'country', 'state', 'city', 'postcode' ];
 	const getTestComponent = () => () => {
 		const items = useShippingRates( defaultFieldsConfig );
 		return <div { ...items } />;
@@ -55,6 +52,7 @@ describe( 'useShippingRates', () => {
 		needsShipping: false,
 		shippingRates: [
 			{
+				shippingRates: [ { foo: 'bar' } ],
 				destination: {
 					country: '',
 					state: '',
@@ -106,6 +104,26 @@ describe( 'useShippingRates', () => {
 		// re-render should result in same shippingAddress object.
 		const { shippingAddress: newShippingAddress } = getProps( renderer );
 		expect( newShippingAddress ).toStrictEqual( shippingAddress );
+		renderer.unmount();
+	} );
+
+	it( 'should return expected shipping rates provided by the store', () => {
+		const TestComponent = getTestComponent();
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent )
+			);
+		} );
+
+		const { shippingRates } = getProps( renderer );
+		expect( shippingRates ).toStrictEqual( mockCartData.shippingRates );
+		// rerender
+		act( () => {
+			renderer.update( getWrappedComponents( TestComponent ) );
+		} );
+		// re-render should result in same shippingAddress object.
+		const { shippingRates: newShippingRates } = getProps( renderer );
+		expect( newShippingRates ).toStrictEqual( shippingRates );
 		renderer.unmount();
 	} );
 } );

--- a/assets/js/base/hooks/use-shipping-rates.js
+++ b/assets/js/base/hooks/use-shipping-rates.js
@@ -12,18 +12,18 @@ import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useStoreCart } from './use-store-cart';
 import { pluckAddress } from '../utils';
 /**
- * This is a custom hook that is wired up to the `wc/store/collections` data
-store for the `wc/store/cart/shipping-rates` route. Given a query object, this
-will ensure a component is kept up to date with the shipping rates matching that
-query in the store state.
+ * This is a custom hook that is wired up to the `wc/store/cart/shipping-rates` route.
+ * Given a a set of default fields keys, this will handle shipping form state and load
+ * new rates when certain fields change.
+ *
+ * @param addressFields an object containing default fields keys.
  *
  * @return {Object} This hook will return an object with three properties:
- * - {Boolean} shippingRatesLoading A boolean indicating whether the shipping
- * rates are still loading or not.
- * - {Function} setShippingAddress  An function that optimistically update shipping address and
- * dispatches async rate fetching.
- * - {Object} shippingAddress       An object containing shipping address.
- * @param addressFields
+ *                 - {Boolean} shippingRatesLoading A boolean indicating whether the shipping
+ *                   rates are still loading or not.
+ *                 - {Function} setShippingAddress  An function that optimistically
+ *                   update shipping address and dispatches async rate fetching.
+ *                 - {Object} shippingAddress       An object containing shipping address.
  */
 export const useShippingRates = ( addressFields ) => {
 	const { shippingRates } = useStoreCart();

--- a/assets/js/base/hooks/use-shipping-rates.js
+++ b/assets/js/base/hooks/use-shipping-rates.js
@@ -56,8 +56,9 @@ export const useShippingRates = ( addressFields ) => {
 		}
 	}, [ debouncedShippingAddress ] );
 	return {
+		shippingRates,
 		shippingAddress,
-		shippingRatesLoading,
 		setShippingAddress,
+		shippingRatesLoading,
 	};
 };

--- a/assets/js/base/hooks/use-shipping-rates.js
+++ b/assets/js/base/hooks/use-shipping-rates.js
@@ -1,40 +1,63 @@
 /**
  * External dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useReducer, useEffect } from '@wordpress/element';
+import isShallowEqual from '@wordpress/is-shallow-equal';
+import { useDebounce } from 'use-debounce';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 /**
  * Internal dependencies
  */
 import { useStoreCart } from './use-store-cart';
-
+import { pluckAddress } from '../utils';
 /**
  * This is a custom hook that is wired up to the `wc/store/collections` data
- * store for the `wc/store/cart/shipping-rates` route. Given a query object, this
- * will ensure a component is kept up to date with the shipping rates matching that
- * query in the store state.
+store for the `wc/store/cart/shipping-rates` route. Given a query object, this
+will ensure a component is kept up to date with the shipping rates matching that
+query in the store state.
  *
  * @return {Object} This hook will return an object with three properties:
- *                  - shippingRates        An array of shipping rate objects.
- *                  - shippingRatesLoading A boolean indicating whether the shipping
- *                                         rates are still loading or not.
- *                  - updateShipping       An action dispatcher to update the shipping address.
+ * - {Boolean} shippingRatesLoading A boolean indicating whether the shipping
+ * rates are still loading or not.
+ * - {Function} setShippingAddress  An function that optimistically update shipping address and
+ * dispatches async rate fetching.
+ * - {Object} shippingAddress       An object containing shipping address.
+ * @param addressFields
  */
-export const useShippingRates = () => {
+export const useShippingRates = ( addressFields ) => {
 	const { shippingRates } = useStoreCart();
-	const results = useSelect( ( select, { dispatch } ) => {
-		const store = select( storeKey );
-		const shippingRatesLoading = store.areShippingRatesLoading();
-		const { updateShippingAddress } = dispatch( storeKey );
+	const derivedAddress = shippingRates[ 0 ]?.destination;
+	const initialAddress = { ...addressFields, ...derivedAddress };
+	const shippingAddressReducer = ( state, address ) => ( {
+		...state,
+		...address,
+	} );
+	const [ shippingAddress, setShippingAddress ] = useReducer(
+		shippingAddressReducer,
+		initialAddress
+	);
+	const [ debouncedShippingAddress ] = useDebounce( shippingAddress, 400 );
+	const shippingRatesLoading = useSelect(
+		( select ) => select( storeKey ).areShippingRatesLoading(),
+		[]
+	);
+	const { updateShippingAddress } = useDispatch( storeKey );
 
-		return {
-			shippingRatesLoading,
-			updateShippingAddress,
-		};
-	}, [] );
-
+	useEffect( () => {
+		if (
+			! isShallowEqual(
+				pluckAddress( debouncedShippingAddress ),
+				pluckAddress( initialAddress )
+			) &&
+			debouncedShippingAddress.country
+		) {
+			updateShippingAddress( debouncedShippingAddress );
+		}
+	}, [ debouncedShippingAddress ] );
 	return {
-		shippingRates,
-		...results,
+		shippingAddress,
+		shippingRatesLoading,
+		setShippingAddress,
 	};
 };

--- a/assets/js/base/hooks/use-shipping-rates.js
+++ b/assets/js/base/hooks/use-shipping-rates.js
@@ -16,7 +16,7 @@ import { pluckAddress } from '../utils';
  * Given a a set of default fields keys, this will handle shipping form state and load
  * new rates when certain fields change.
  *
- * @param addressFields an object containing default fields keys.
+ * @param {Array} addressFieldsKeys an array containing default fields keys.
  *
  * @return {Object} This hook will return an object with three properties:
  *                 - {Boolean} shippingRatesLoading A boolean indicating whether the shipping
@@ -25,8 +25,11 @@ import { pluckAddress } from '../utils';
  *                   update shipping address and dispatches async rate fetching.
  *                 - {Object} shippingAddress       An object containing shipping address.
  */
-export const useShippingRates = ( addressFields ) => {
+export const useShippingRates = ( addressFieldsKeys ) => {
 	const { shippingRates } = useStoreCart();
+	const addressFields = Object.fromEntries(
+		addressFieldsKeys.map( ( key ) => [ key, '' ] )
+	);
 	const derivedAddress = shippingRates[ 0 ]?.destination;
 	const initialAddress = { ...addressFields, ...derivedAddress };
 	const shippingAddressReducer = ( state, address ) => ( {

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -1,0 +1,14 @@
+/**
+ * pluckAddress takes a full address object and returns relevant fields for calculating
+ * shipping, so we can track when one of them change to update rates.
+ *
+ * @param {Object} address          An object containing all address information
+ *
+ * @return {Object} pluckedAddress  An object containing shipping address that are needed to fetch an address.
+ */
+export const pluckAddress = ( { country, state, city, postcode } ) => ( {
+	country,
+	state,
+	city,
+	postcode,
+} );

--- a/assets/js/base/utils/index.js
+++ b/assets/js/base/utils/index.js
@@ -1,2 +1,3 @@
 export * from './errors';
 export * from './price';
+export * from './address';

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -56,7 +56,6 @@ const renderShippingRatesControlOption = ( option ) => ( {
 const ShippingCalculatorOptions = ( {
 	shippingRates,
 	shippingRatesLoading,
-	shippingAddress,
 } ) => {
 	return (
 		<fieldset className="wc-block-cart__shipping-options-fieldset">
@@ -68,16 +67,6 @@ const ShippingCalculatorOptions = ( {
 			</legend>
 			<ShippingRatesControl
 				className="wc-block-cart__shipping-options"
-				address={
-					shippingAddress
-						? {
-								city: shippingAddress.city,
-								state: shippingAddress.state,
-								postcode: shippingAddress.postcode,
-								country: shippingAddress.country,
-						  }
-						: null
-				}
 				collapsibleWhenMultiple={ true }
 				noResultsMessage={ __(
 					'No shipping options were found.',
@@ -182,7 +171,6 @@ const Cart = ( {
 									shippingRatesLoading={
 										shippingRatesLoading
 									}
-									shippingAddress={ shippingAddress }
 								/>
 							</fieldset>
 						) }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -103,8 +103,12 @@ const Cart = ( {
 	shippingRates,
 	isLoading = false,
 } ) => {
-	const { updateShippingAddress, shippingRatesLoading } = useShippingRates();
-	const shippingAddress = shippingRates[ 0 ]?.destination;
+	const defaultAddressFields = [ 'country', 'state', 'city', 'postcode' ];
+	const {
+		shippingAddress,
+		setShippingAddress,
+		shippingRatesLoading,
+	} = useShippingRates( defaultAddressFields );
 	const {
 		applyCoupon,
 		removeCoupon,
@@ -161,7 +165,7 @@ const Cart = ( {
 							<TotalsShippingItem
 								currency={ totalsCurrency }
 								shippingAddress={ shippingAddress }
-								updateShippingAddress={ updateShippingAddress }
+								updateShippingAddress={ setShippingAddress }
 								values={ cartTotals }
 							/>
 						) }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -76,11 +76,7 @@ const Block = ( { attributes, isEditor = false, shippingRates = [] } ) => {
 		shippingRatesLoading,
 		shippingAddress: shippingFields,
 		setShippingAddress: setShippingFields,
-	} = useShippingRates(
-		Object.fromEntries(
-			Object.entries( addressFields ).map( ( [ key ] ) => [ key, '' ] )
-		)
-	);
+	} = useShippingRates( Object.keys( addressFields ) );
 
 	return (
 		<CheckoutProvider>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -32,11 +32,9 @@ import './style.scss';
 import '../../../payment-methods-demo';
 
 const Block = ( { attributes, isEditor = false, shippingRates = [] } ) => {
-	const { shippingRatesLoading } = useShippingRates();
 	const [ selectedShippingRate, setSelectedShippingRate ] = useState( {} );
 	const [ contactFields, setContactFields ] = useState( {} );
 	const [ shouldSavePayment, setShouldSavePayment ] = useState( true );
-	const [ shippingFields, setShippingFields ] = useState( {} );
 	const [ billingFields, setBillingFields ] = useState( {} );
 	const [ useShippingAsBilling, setUseShippingAsBilling ] = useState(
 		attributes.useShippingAsBilling
@@ -73,6 +71,16 @@ const Block = ( { attributes, isEditor = false, shippingRates = [] } ) => {
 			hidden: ! attributes.showAddress2Field,
 		},
 	};
+
+	const {
+		shippingRatesLoading,
+		shippingAddress: shippingFields,
+		setShippingAddress: setShippingFields,
+	} = useShippingRates(
+		Object.fromEntries(
+			Object.entries( addressFields ).map( ( [ key ] ) => [ key, '' ] )
+		)
+	);
 
 	return (
 		<CheckoutProvider>

--- a/package.json
+++ b/package.json
@@ -173,6 +173,10 @@
 				"maxSize": "60 kB"
 			},
 			{
+				"path": "./build/cart.js",
+				"maxSize": "70 kB"
+			},
+			{
 				"path": "./build/cart-frontend.js",
 				"maxSize": "140 kB"
 			},


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR is a continuation from yesterday's mega PR, it fixes the problem with shipping rates not updating when you change a value, it now works fine, and is debounced, there are some updates to how `useShippingRates` work now, it is required that you pass the shape of your fields for them to be watched and updated accordingly. 
<!-- Reference any related issues or PRs here -->
Fixes #1883

### How to test the changes in this Pull Request:

1. go to a page/post with Cart or Checkout block, and a sit with shipping rates.
2. enter your shipping informations.
3. watch that changing first name, last name and street address does not trigger a rate update.
4. changing country, state, city or postcode will trigger an update.
5. updates are debounced.
