### PR TITLE
Default to empty array if no states are found in state-input

### DIFF
--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -27,7 +27,7 @@ const StateInput = ( {
 				key,
 				name: decodeEntities( countryStates[ key ] ),
 		  } ) )
-		: null;
+		: [];
 
 	/**
 	 * Handles state selection onChange events. Finds a matching state by key or value.
@@ -50,40 +50,36 @@ const StateInput = ( {
 		[ onChange, options ]
 	);
 
-	if ( Array.isArray( options ) ) {
+	if ( options.length > 0 ) {
 		return (
-			options.length > 0 && (
-				<>
-					<Select
-						className={ className }
-						label={ label }
-						onChange={ onChangeState }
-						options={ options }
-						value={ options.find(
-							( option ) => option.key === value
-						) }
-						required={ required }
+			<>
+				<Select
+					className={ className }
+					label={ label }
+					onChange={ onChangeState }
+					options={ options }
+					value={ options.find( ( option ) => option.key === value ) }
+					required={ required }
+				/>
+				{ autoComplete !== 'off' && (
+					<input
+						type="text"
+						aria-hidden={ true }
+						autoComplete={ autoComplete }
+						value={ value }
+						onChange={ ( event ) =>
+							onChangeState( event.target.value )
+						}
+						style={ {
+							height: '0',
+							border: '0',
+							padding: '0',
+							position: 'absolute',
+						} }
+						tabIndex={ -1 }
 					/>
-					{ autoComplete !== 'off' && (
-						<input
-							type="text"
-							aria-hidden={ true }
-							autoComplete={ autoComplete }
-							value={ value }
-							onChange={ ( event ) =>
-								onChangeState( event.target.value )
-							}
-							style={ {
-								height: '0',
-								border: '0',
-								padding: '0',
-								position: 'absolute',
-							} }
-							tabIndex={ -1 }
-						/>
-					) }
-				</>
-			)
+				) }
+			</>
 		);
 	}
 	return (


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Previously, `StateInput` sets `options` to `null` if no state was found for this country, this causes other problems down the line because some code assumes that `options` is an array, some other code is guarded by `Array.isArray( options )`.
we could simply guard everything, but to keep behavior consistent, I defaulted `options` to an empty array if nothing was found, removed the `Array.isArray( options )` condition and only used the length as a condition.

<!-- Reference any related issues or PRs here -->
Fixes #1884

### How to test the changes in this Pull Request:

1. in a page with checkout or cart
2. go to state field and type
3. change to a country with known states (US), a select should show up.
4. change to a country with no states (Algeria), a text field should show up.
