### PR TITLE
If product is changed for featured product block, update the link in the button.

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -61,6 +61,7 @@ const FeaturedProduct = ( {
 	product,
 	setAttributes,
 	setOverlayColor,
+	triggerUrlUpdate = () => void null,
 } ) => {
 	const renderApiError = () => (
 		<ErrorPlaceholder
@@ -108,6 +109,7 @@ const FeaturedProduct = ( {
 									mediaId: 0,
 									mediaSrc: '',
 								} );
+								triggerUrlUpdate();
 							} }
 						/>
 						<Button isDefault onClick={ onDone }>
@@ -447,6 +449,7 @@ FeaturedProduct.propTypes = {
 	setOverlayColor: PropTypes.func.isRequired,
 	// from withSpokenMessages
 	debouncedSpeak: PropTypes.func.isRequired,
+	triggerUrlUpdate: PropTypes.func,
 };
 
 export default compose( [
@@ -470,6 +473,9 @@ export default compose( [
 	} ),
 	createHigherOrderComponent( ( ProductComponent ) => {
 		class WrappedComponent extends Component {
+			state = {
+				doUrlUpdate: false,
+			};
 			componentDidUpdate() {
 				const {
 					attributes,
@@ -478,6 +484,7 @@ export default compose( [
 					product,
 				} = this.props;
 				if (
+					this.state.doUrlUpdate &&
 					! attributes.editMode &&
 					product?.permalink &&
 					currentButtonAttributes?.url &&
@@ -487,10 +494,19 @@ export default compose( [
 						...currentButtonAttributes,
 						url: product.permalink,
 					} );
+					this.setState( { doUrlUpdate: false } );
 				}
 			}
+			triggerUrlUpdate = () => {
+				this.setState( { doUrlUpdate: true } );
+			};
 			render() {
-				return <ProductComponent { ...this.props } />;
+				return (
+					<ProductComponent
+						triggerUrlUpdate={ this.triggerUrlUpdate }
+						{ ...this.props }
+					/>
+				);
 			}
 		}
 		return WrappedComponent;


### PR DESCRIPTION
This fixes #1889.

This is a tricky one because the button is generated by inner blocks which will retain what was saved as post content and keep that after initial persistence. In order to update the button url, the parent block needs to grab the clientId of the inner button block and update the `attributes.url` for it if it differs from the `product.permalink` of the parent.

While this fixes the issue (and I think the expectation we should have here), it should be noted that editing an existing block to a different product _will also erase_ any custom url the merchant might have set for the button. I still think that's okay though, because it's more than likely the merchant would need to change the url anyways.

I implemented the changes using "legacy" methods so we retain the minimum version requirements for this specific block.

## To Test

- verify existing featured product blocks in content do not error when updated to this branch.
- verify if you edit a feature block and change the product, the button url will update as well.

**NOTE: I just knocked this off in some spare time over the weekend. The risk of this going stale is minimal so do not prioritize this for code review. It's okay if it sits for a while.**