### PR TITLE
mobile layout fixes for cart totals 

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -318,7 +318,7 @@ table.wc-block-cart-items {
 
 // Mobile styles.
 @include breakpoint( "<782px" ) {
-	.wp-block-woocommerce-cart > .wc-block-cart {
+	.wc-block-cart:not(.wc-block-cart--is-loading):not(.wc-block-cart--skeleton) {
 		display: block;
 		margin: 0 0 $gap;
 		.wc-block-cart__main {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -329,6 +329,21 @@ table.wc-block-cart-items {
 		.wc-block-cart__sidebar {
 			padding: 0;
 			flex: none;
+			max-width: 100%;
+
+			.wc-block-cart__totals-title {
+				display: none;
+			}
+
+			// Reset (remove) totals "card" styling on mobile.
+			.components-card {
+				box-shadow: none;
+				border: none;
+			}
+			.components-card__body {
+				border: none;
+				padding: 0;
+			}
 		}
 	}
 	table.wc-block-cart-items {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -318,7 +318,7 @@ table.wc-block-cart-items {
 
 // Mobile styles.
 @include breakpoint( "<782px" ) {
-	.wc-block-cart {
+	.wp-block-woocommerce-cart > .wc-block-cart {
 		display: block;
 		margin: 0 0 $gap;
 		.wc-block-cart__main {


### PR DESCRIPTION
Fixes #1872

This PR updates styles for the cart totals area so the layout is correct - no card border/styling/padding, hide title, use full width. Also tweaks styles to ensure the skeleton loading cart (#1866 grey boxes) hides correctly after load.

### Screenshots

<img width="365" alt="Screen Shot 2020-03-09 at 3 52 46 PM" src="https://user-images.githubusercontent.com/4167300/76178942-07587500-621e-11ea-9e03-29e5b27d5842.png">

Note in the above screenshot I'm using Storefront and I've customised the text colour (greenish). Some checkout elements use theme colour, others use black. Logged this in another issue [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1539#issuecomment-596309704).

### How to test the changes in this Pull Request:

1. Add a page with cart block, publish, add stuff to your cart, view on various devices & screen sizes.
2. Cart totals area should look good and work well.
3. Test a wide range of stuff in the cart, test coupons.
4. Test to ensure cart works correctly on desktop. (No regressions)

