### PR TITLE
Sort states in Cart and Checkout blocks

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -39,6 +39,20 @@ class Cart extends AbstractBlock {
 	}
 
 	/**
+	 * Given an array of country keys and their states, order the list of states alphabetically.
+	 *
+	 * @param array $states Array containing the states per each country key.
+	 * @return array Same array but with states ordered alphabetically.
+	 */
+	private function sort_states( $states ) {
+		foreach ( $states as $country_key => $states_per_country ) {
+			uasort( $states_per_country, 'wc_ascii_uasort_comparison' );
+			$states[ $country_key ] = $states_per_country;
+		}
+		return $states;
+	}
+
+	/**
 	 * Append frontend scripts when rendering the Cart block.
 	 *
 	 * @param array  $attributes Block attributes. Default empty array.
@@ -53,7 +67,7 @@ class Cart extends AbstractBlock {
 			$data_registry->add( 'shippingCountries', WC()->countries->get_shipping_countries() );
 		}
 		if ( ! $data_registry->exists( 'shippingStates' ) ) {
-			$data_registry->add( 'shippingStates', WC()->countries->get_shipping_country_states() );
+			$data_registry->add( 'shippingStates', $this->sort_states( WC()->countries->get_shipping_country_states() ) );
 		}
 		if ( ! $data_registry->exists( 'countryLocale' ) ) {
 			$data_registry->add( 'countryLocale', WC()->countries->get_country_locale() );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -40,6 +40,20 @@ class Checkout extends AbstractBlock {
 	}
 
 	/**
+	 * Given an array of country keys and their states, order the list of states alphabetically.
+	 *
+	 * @param array $states Array containing the states per each country key.
+	 * @return array Same array but with states ordered alphabetically.
+	 */
+	private function sort_states( $states ) {
+		foreach ( $states as $country_key => $states_per_country ) {
+			uasort( $states_per_country, 'wc_ascii_uasort_comparison' );
+			$states[ $country_key ] = $states_per_country;
+		}
+		return $states;
+	}
+
+	/**
 	 * Append frontend scripts when rendering the block.
 	 *
 	 * @param array  $attributes Block attributes. Default empty array.
@@ -57,10 +71,10 @@ class Checkout extends AbstractBlock {
 			$data_registry->add( 'shippingCountries', WC()->countries->get_shipping_countries() );
 		}
 		if ( ! $data_registry->exists( 'allowedStates' ) ) {
-			$data_registry->add( 'allowedStates', WC()->countries->get_allowed_country_states() );
+			$data_registry->add( 'allowedStates', $this->sort_states( WC()->countries->get_allowed_country_states() ) );
 		}
 		if ( ! $data_registry->exists( 'shippingStates' ) ) {
-			$data_registry->add( 'shippingStates', WC()->countries->get_shipping_country_states() );
+			$data_registry->add( 'shippingStates', $this->sort_states( WC()->countries->get_shipping_country_states() ) );
 		}
 		if ( function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();


### PR DESCRIPTION
Fixes #1902.

### Screenshots

_Before (incorrect order):_
![imatge](https://user-images.githubusercontent.com/3616980/76101861-61173000-5fcf-11ea-852b-37f7fde3b749.png)

_After (correct):_
![imatge](https://user-images.githubusercontent.com/3616980/76101894-6e341f00-5fcf-11ea-812f-5bc89cd7793a.png)

### How to test the changes in this Pull Request:

I'm not pretty sure in how many locales/countries this is reproducible, but at least I found one combination.

1. Set your site language to _Catalan_ and make sure you allow shipping to _Spain_ (or all countries).
2. Open a page with the _Checkout_ block and select Spain (_Espanya_) as your country.
3. In the _State_ dropdown, verify _Illes Balears_ is correctly sorted after _Huelva_ instead of after _Badajoz_ (see screenshots above).

### Todo
While this mostly works. It seems to sort accented names incorrectly. You can see it with _Ávila_ (it should be after _Astúries_ but with this patch it goes to the top):

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/76207883-e3d20200-61fe-11ea-9cee-b23513e8d484.png)

_After (incorrect):_
![imatge](https://user-images.githubusercontent.com/3616980/76207858-d9b00380-61fe-11ea-8578-7875c4a5761f.png)

That's because `wc_ascii_uasort_comparison` [converts strings from UTF-8 to ASCII](https://github.com/woocommerce/woocommerce/blob/master/includes/wc-core-functions.php#L1623-L1624) to remove accents and special characters, but that doesn't work with states because they are already in ASCII.

I tried several other ways to remove accents from state names, but with no luck yet.