### PR TITLE
Add comma before 'etc.' in address 2 label

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -81,7 +81,7 @@ const CheckoutEditor = ( { attributes, setAttributes } ) => {
 					) }
 					<ToggleControl
 						label={ __(
-							'Apartment, suite, unit etc',
+							'Apartment, suite, unit, etc',
 							'woo-gutenberg-products-block'
 						) }
 						checked={ showAddress2Field }


### PR DESCRIPTION
Tiny PR to keep this string in sync with the last changes in Core. See: https://github.com/woocommerce/woocommerce/pull/25825.