### PR TITLE
Add "or continue below" separator to checkout block

### DIFF
--- a/assets/js/base/components/payment-methods/express-checkout.js
+++ b/assets/js/base/components/payment-methods/express-checkout.js
@@ -13,14 +13,19 @@ import './style.scss';
 
 const ExpressCheckoutContainer = ( { children } ) => {
 	return (
-		<div className="wc-block-component-express-checkout">
-			<div className="wc-block-component-express-checkout__title">
-				{ __( 'Express checkout', 'woo-gutenberg-products-block' ) }
+		<>
+			<div className="wc-block-component-express-checkout">
+				<div className="wc-block-component-express-checkout__title">
+					{ __( 'Express checkout', 'woo-gutenberg-products-block' ) }
+				</div>
+				<div className="wc-block-component-express-checkout__content">
+					{ children }
+				</div>
 			</div>
-			<div className="wc-block-component-express-checkout__content">
-				{ children }
+			<div className="wc-block-component-express-checkout-continue-rule">
+				{ __( 'Or continue below', 'woo-gutenberg-products-block' ) }
 			</div>
-		</div>
+		</>
 	);
 };
 

--- a/assets/js/base/components/payment-methods/express-checkout.js
+++ b/assets/js/base/components/payment-methods/express-checkout.js
@@ -13,13 +13,13 @@ import './style.scss';
 
 const ExpressCheckoutContainer = ( { children } ) => {
 	return (
-		<div className="wc-component__checkout-container wc-component__container-with-border">
-			<div className="wc-component__text-overlay-on-border">
-				<strong>
-					{ __( 'Express checkout', 'woo-gutenberg-products-block' ) }
-				</strong>
+		<div className="wc-block-component-express-checkout">
+			<div className="wc-block-component-express-checkout__title">
+				{ __( 'Express checkout', 'woo-gutenberg-products-block' ) }
 			</div>
-			<div className="wc-component__container-content">{ children }</div>
+			<div className="wc-block-component-express-checkout__content">
+				{ children }
+			</div>
 		</div>
 	);
 };

--- a/assets/js/base/components/payment-methods/express-payment-methods.js
+++ b/assets/js/base/components/payment-methods/express-payment-methods.js
@@ -35,7 +35,7 @@ const ExpressPaymentMethods = () => {
 			<li key="noneRegistered">No registered Payment Methods</li>
 		);
 	return (
-		<ul className="wc-component__express-payment-event-buttons">
+		<ul className="wc-block-component-express-checkout-payment-event-buttons">
 			{ content }
 		</ul>
 	);

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -3,7 +3,6 @@
 	border: 2px solid $black;
 	border-radius: 5px;
 	padding: 10px;
-	margin-bottom: $gap-large;
 
 	.wc-block-component-express-checkout__title {
 		position: relative;
@@ -44,5 +43,25 @@
 		> li:nth-child(odd) {
 			padding-right: $gap-smaller;
 		}
+	}
+}
+.wc-block-component-express-checkout-continue-rule {
+	display: flex;
+	align-items: center;
+	text-align: center;
+	padding: 0 ($gap-large+14px);
+	margin: $gap-large 0;
+
+	&::before {
+		margin-right: 10px;
+	}
+	&::after {
+		margin-left: 10px;
+	}
+	&::before,
+	&::after {
+		content: " ";
+		flex: 1;
+		border-bottom: 1px solid $core-grey-light-600;
 	}
 }

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -1,11 +1,11 @@
-.wc-component__container-with-border {
+.wc-block-component-express-checkout {
 	margin: auto;
 	border: 2px solid $black;
 	border-radius: 5px;
 	padding: 10px;
 	margin-bottom: $gap-large;
 
-	.wc-component__text-overlay-on-border {
+	.wc-block-component-express-checkout__title {
 		position: relative;
 		top: -24px;
 		background-color: $white;
@@ -13,16 +13,17 @@
 		padding-right: $gap-small;
 		width: fit-content;
 		color: $black;
+		font-weight: bold;
 	}
 
-	.wc-component__container-content {
+	.wc-block-component-express-checkout__content {
 		margin-top: -15px;
 		padding-left: $gap-large;
 		padding-right: $gap-large;
 		padding-bottom: $gap;
 	}
 
-	.wc-component__express-payment-event-buttons {
+	.wc-block-component-express-checkout-payment-event-buttons {
 		list-style: none;
 		display: flex;
 		flex-direction: row;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -7,20 +7,19 @@
 
 	.wc-block-component-express-checkout__title {
 		position: relative;
-		top: -24px;
 		background-color: $white;
 		padding-left: $gap-small;
 		padding-right: $gap-small;
+		margin-top: -24px;
+		margin-left: $gap-small;
+		margin-bottom: $gap-small;
 		width: fit-content;
 		color: $black;
 		font-weight: bold;
 	}
 
 	.wc-block-component-express-checkout__content {
-		margin-top: -15px;
-		padding-left: $gap-large;
-		padding-right: $gap-large;
-		padding-bottom: $gap;
+		padding: 0 $gap-large;
 	}
 
 	.wc-block-component-express-checkout-payment-event-buttons {
@@ -30,10 +29,20 @@
 		flex-wrap: wrap;
 		width: 100%;
 		padding: 0;
-		margin: 0;
+		margin: 0 0 $gap;
+		overflow: hidden;
 		> li {
 			display: inline-block;
 			width: 50%;
+			> img {
+				width: 100%;
+			}
+		}
+		> li:nth-child(even) {
+			padding-left: $gap-smaller;
+		}
+		> li:nth-child(odd) {
+			padding-right: $gap-smaller;
 		}
 	}
 }


### PR DESCRIPTION
Add the continue rule/separator to the checkout block.

Whilst working in this component I also took the liberty of more closely matching the comps, and making classnames match our coding standards doc (`wc-block-component-x` prefixes).

Fixes #1504

### Screenshots

Before:
![Screenshot 2020-03-09 at 15 00 05](https://user-images.githubusercontent.com/90977/76227421-31f2ff80-6217-11ea-9aef-5d5229a75391.png)

After: 
![Screenshot 2020-03-09 at 15 01 47](https://user-images.githubusercontent.com/90977/76227411-30293c00-6217-11ea-8a6c-c013d576969f.png)

### How to test the changes in this Pull Request:

View the checkout block :)
