### PR TITLE
Handle Cart API errors

### DIFF
--- a/assets/js/base/hooks/use-shipping-rates.js
+++ b/assets/js/base/hooks/use-shipping-rates.js
@@ -6,6 +6,7 @@ import { useReducer, useEffect } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useDebounce } from 'use-debounce';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+
 /**
  * Internal dependencies
  */
@@ -26,7 +27,7 @@ import { pluckAddress } from '../utils';
  *                 - {Object} shippingAddress       An object containing shipping address.
  */
 export const useShippingRates = ( addressFieldsKeys ) => {
-	const { shippingRates } = useStoreCart();
+	const { cartErrors, shippingRates } = useStoreCart();
 	const addressFields = Object.fromEntries(
 		addressFieldsKeys.map( ( key ) => [ key, '' ] )
 	);
@@ -63,5 +64,6 @@ export const useShippingRates = ( addressFieldsKeys ) => {
 		shippingAddress,
 		setShippingAddress,
 		shippingRatesLoading,
+		shippingRatesErrors: cartErrors,
 	};
 };

--- a/assets/js/base/hooks/use-store-cart-coupons.js
+++ b/assets/js/base/hooks/use-store-cart-coupons.js
@@ -22,7 +22,7 @@ import { useStoreCart } from './use-store-cart';
  * store api /cart/coupons endpoint.
  */
 export const useStoreCartCoupons = () => {
-	const { cartCoupons, cartIsLoading } = useStoreCart();
+	const { cartCoupons, cartErrors, cartIsLoading } = useStoreCart();
 	const {
 		addErrorNotice,
 		addSuccessNotice,
@@ -100,6 +100,7 @@ export const useStoreCartCoupons = () => {
 
 	return {
 		appliedCoupons: cartCoupons,
+		cartCouponsErrors: cartErrors,
 		isLoading: cartIsLoading,
 		...results,
 	};

--- a/assets/js/base/hooks/use-store-cart-item-quantity.js
+++ b/assets/js/base/hooks/use-store-cart-item-quantity.js
@@ -7,6 +7,11 @@ import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useDebounce } from 'use-debounce';
 
 /**
+ * Internal dependencies
+ */
+import { useStoreCart } from './use-store-cart';
+
+/**
  * @typedef {import('@woocommerce/type-defs/hooks').StoreCartItemQuantity} StoreCartItemQuantity
  * @typedef {import('@woocommerce/type-defs/cart').CartItem} CartItem
  */
@@ -23,6 +28,7 @@ import { useDebounce } from 'use-debounce';
  *                                 to cart items.
  */
 export const useStoreCartItemQuantity = ( cartItem ) => {
+	const { cartErrors } = useStoreCart();
 	// Store quantity in hook state. This is used to keep the UI
 	// updated while server request is updated.
 	const [ quantity, changeQuantity ] = useState( cartItem.quantity );
@@ -53,5 +59,6 @@ export const useStoreCartItemQuantity = ( cartItem ) => {
 		quantity,
 		changeQuantity,
 		removeItem,
+		cartItemQuantityErrors: cartErrors,
 	};
 };

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -28,12 +28,17 @@ const CartFrontend = ( {
 	isShippingCostHidden,
 } ) => {
 	const {
+		cartErrors,
 		cartItems,
 		cartTotals,
 		cartIsLoading,
 		cartCoupons,
 		shippingRates,
 	} = useStoreCart();
+
+	if ( cartErrors && cartErrors.length > 0 ) {
+		throw new Error( cartErrors[ 0 ].message );
+	}
 
 	return (
 		<StoreNoticesProvider context="wc/cart">

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -57,11 +57,16 @@ const CartLineItemRow = ( { lineItem } ) => {
 	} = lineItem;
 
 	const {
+		cartItemQuantityErrors,
 		quantity,
 		changeQuantity,
 		removeItem,
 		isPending: itemQuantityDisabled,
 	} = useStoreCartItemQuantity( lineItem );
+
+	if ( cartItemQuantityErrors && cartItemQuantityErrors.length > 0 ) {
+		throw new Error( cartItemQuantityErrors[ 0 ].message );
+	}
 
 	const currency = getCurrency( prices );
 	const regularPrice = parseInt( prices.regular_price, 10 ) * quantity;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -95,6 +95,7 @@ const Cart = ( {
 	const defaultAddressFields = [ 'country', 'state', 'city', 'postcode' ];
 	const {
 		shippingAddress,
+		shippingRatesErrors,
 		setShippingAddress,
 		shippingRatesLoading,
 	} = useShippingRates( defaultAddressFields );
@@ -103,7 +104,13 @@ const Cart = ( {
 		removeCoupon,
 		isApplyingCoupon,
 		isRemovingCoupon,
+		cartCouponsErrors,
 	} = useStoreCartCoupons();
+
+	const errors = [ ...shippingRatesErrors, ...cartCouponsErrors ];
+	if ( errors.length > 0 ) {
+		throw new Error( errors[ 0 ].message );
+	}
 
 	const showShippingCosts = Boolean(
 		SHIPPING_ENABLED &&

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -21,7 +21,12 @@ import renderFrontend from '../../../utils/render-frontend.js';
  * @param {Object} props Props for the block.
  */
 const CheckoutFrontend = ( props ) => {
-	const { shippingRates } = useStoreCart();
+	const { cartErrors, shippingRates } = useStoreCart();
+
+	if ( cartErrors && cartErrors.length > 0 ) {
+		throw new Error( cartErrors[ 0 ].message );
+	}
+
 	return (
 		<BlockErrorBoundary
 			header={ __(

--- a/assets/js/hocs/with-store-cart-api-hydration.js
+++ b/assets/js/hocs/with-store-cart-api-hydration.js
@@ -22,6 +22,7 @@ const useStoreCartApiHydration = () => {
 		const { isResolving, hasFinishedResolution } = select( CART_STORE_KEY );
 		const {
 			receiveCart,
+			receiveError,
 			startResolution,
 			finishResolution,
 		} = registry.dispatch( CART_STORE_KEY );
@@ -31,7 +32,11 @@ const useStoreCartApiHydration = () => {
 			! hasFinishedResolution( 'getCartData', [] )
 		) {
 			startResolution( 'getCartData', [] );
-			receiveCart( cartData.current );
+			if ( cartData.current?.code?.includes( 'error' ) ) {
+				receiveError( cartData.current );
+			} else {
+				receiveCart( cartData.current );
+			}
 			finishResolution( 'getCartData', [] );
 		}
 	}, [] );

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -19,24 +19,28 @@
 /**
  * @typedef {Object} StoreCartCoupon
  *
- * @property {Array}    appliedCoupons   Collection of applied coupons from the
- *                                       API.
- * @property {boolean}  isLoading        True when coupon data is being loaded.
- * @property {Function} applyCoupon      Callback for applying a coupon by code.
- * @property {Function} removeCoupon     Callback for removing a coupon by code.
- * @property {boolean}  isApplyingCoupon True when a coupon is being applied.
- * @property {boolean}  isRemovingCoupon True when a coupon is being removed.
+ * @property {Array}    appliedCoupons    Collection of applied coupons from the
+ *                                        API.
+ * @property {boolean}  isLoading         True when coupon data is being loaded.
+ * @property {Function} applyCoupon       Callback for applying a coupon by code.
+ * @property {Function} removeCoupon      Callback for removing a coupon by code.
+ * @property {boolean}  isApplyingCoupon  True when a coupon is being applied.
+ * @property {boolean}  isRemovingCoupon  True when a coupon is being removed.
+ * @property {boolean}  cartCouponsErrors An array of errors thrown by the cart.
  */
 
 /**
  * @typedef {Object} StoreCartItemQuantity
  *
- * @property {number}      quantity        The quantity of the item in the cart.
- * @property {boolean}     isPending       Whether the cart item is updating or
- *                                         not.
- * @property {Function}    changeQuantity  Callback for changing quantity of
- *                                         item in cart.
- * @property {Function}    removeItem      Callback for removing a cart item.
+ * @property {number}   quantity               The quantity of the item in the
+ *                                             cart.
+ * @property {boolean}  isPending              Whether the cart item is updating
+ *                                             or not.
+ * @property {Function} changeQuantity         Callback for changing quantity
+ *                                             of item in cart.
+ * @property {Function} removeItem             Callback for removing a cart item.
+ * @property {Object}   cartItemQuantityErrors An array of errors thrown by
+ *                                             the cart.
  */
 
 export {};


### PR DESCRIPTION
Fixes #1820.

With this PR:
* `useShippingRates` includes a `shippingRatesErrors` property which is an array of errors returned by the API.
* `useStoreCartCoupons` has them in `cartCouponsErrors`.
* `useStoreCartItemQuantity` has them in `cartItemQuantityErrors`.

Errors are in the form:
```JS
{
  "code": "error",
  "message": "Test error",
  "data": {
    "status": 500
  }
}
```

@nerrad error codes related to wrong shipping addresses are:

* `woocommerce_rest_cart_shipping_rates_missing_country`
* `woocommerce_rest_cart_shipping_rates_invalid_country`
* `woocommerce_rest_cart_shipping_rates_invalid_state`

Are these codes ok or should we try to unify them under the same?

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/76232950-bbaac900-6227-11ea-9c84-17e6b29bc8c8.png)

### How to test the changes in this Pull Request:

1. In [Cart.php L383](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/StoreApi/Controllers/Cart.php#L383) add:
```diff
+return new RestError( 'test_error', 'Test error', array( 'status' => 500 ) );
```
2. Visit a page with the _Cart_ block and verify it shows the error boundary with the _Test error_ message.
3. Undo the previous change in Cart.php and in [CartShippingRages.php L168](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/src/RestApi/StoreApi/Controllers/CartShippingRates.php#L168) add the same:
```diff
+return new RestError( 'test_error', 'Test error', array( 'status' => 500 ) );
```
4. Visit the page with the _Cart_ block again and try changing the address in the shipping calculator.
5. Verify the error boundary appears again with the _Test error_ message.