### PR TITLE
Bump up budget for checkout-frontend.js script

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,10 @@
 				"maxSize": "140 kB"
 			},
 			{
+				"path": "./build/checkout-frontend.js",
+				"maxSize": "140 kB"
+			},
+			{
 				"path": "./build/*.css",
 				"maxSize": "50kB"
 			},


### PR DESCRIPTION
The checkout block is increasing past the default size budget of 60Kb for frontend scripts so this pull bumps it to the same budget we have for the cart.

This is a build utility only, no impact on user facing code so if automated tests pass I'll merge this in.