### PR TITLE
Make checkout button sticky footer on mobile

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/checkout-button/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/checkout-button/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import Button from '@woocommerce/base-components/button';
 import { CHECKOUT_URL } from '@woocommerce/block-settings';
 
@@ -18,7 +17,7 @@ import { MastercardLogo, VisaLogo } from './payment-logos'; // @todo we want to 
  */
 const CheckoutButton = () => {
 	return (
-		<Fragment>
+		<div className="wc-block-cart__submit-container">
 			<Button
 				className="wc-block-cart__submit-button"
 				href={ CHECKOUT_URL }
@@ -30,7 +29,7 @@ const CheckoutButton = () => {
 				<AmericanExpressLogo />
 				<VisaLogo />
 			</div>
-		</Fragment>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -416,8 +416,9 @@ table.wc-block-cart-items {
 		width: 100%;
 		z-index: 1;
 	}
-	// temporary hack so we can put checkout button at bottom on mobile
-	.storefront-handheld-footer-bar {
+	// Hide the Storefront sticky footer on cart & checkout page, so it doesn't clash with sticky submit.
+	// Note - this will only work on woo "Cart" page.
+	.woocommerce-page.woocommerce-cart.theme-storefront .storefront-handheld-footer-bar {
 		display: none;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -404,6 +404,21 @@ table.wc-block-cart-items {
 			}
 		}
 	}
+
+	// Submit button is sticky to bottom of screen on mobile.
+	.wc-block-cart__submit-container {
+		background: $white;
+		bottom: 0;
+		box-shadow: 0 -10px 20px 10px transparentize($core-grey-light-700, 0.5);
+		left: 0;
+		padding: $gap;
+		position: fixed;
+		width: 100%;
+	}
+	// temporary hack so we can put checkout button at bottom on mobile
+	.storefront-handheld-footer-bar {
+		display: none;
+	}
 }
 .wc-block-cart-coupon-list {
 	list-style: none;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -414,6 +414,7 @@ table.wc-block-cart-items {
 		padding: $gap;
 		position: fixed;
 		width: 100%;
+		z-index: 1;
 	}
 	// temporary hack so we can put checkout button at bottom on mobile
 	.storefront-handheld-footer-bar {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -416,11 +416,6 @@ table.wc-block-cart-items {
 		width: 100%;
 		z-index: 1;
 	}
-	// Hide the Storefront sticky footer on cart & checkout page, so it doesn't clash with sticky submit.
-	// Note - this will only work on woo "Cart" page.
-	.woocommerce-page.woocommerce-cart.theme-storefront .storefront-handheld-footer-bar {
-		display: none;
-	}
 }
 .wc-block-cart-coupon-list {
 	list-style: none;


### PR DESCRIPTION
Fixes #1873

This PR adds a class to the the CTA / checkout button component, and adds styling so that displays as a fixed footer with shadow on smaller screens.

There's a mobile footer in storefront, which has icon links to account / search / cart. This PR also includes a style tweak to hide this footer on the cart page (on mobile only), so it doesn't interfere with the cart button. It's not needed and is potentially distracting to show these other links on the cart page.

### Screenshots

Here's a screenshot, with theme _Galleria_ (child theme of _Storefront_):

<img width="376" alt="Screen Shot 2020-03-10 at 4 22 25 PM" src="https://user-images.githubusercontent.com/4167300/76276688-66d08680-62eb-11ea-989a-ec8bb8f5cbe0.png">

Here's a screenshot on iPhone with [_Neve_](https://wordpress.org/themes/neve/) from WPORG themes:

![IMG_E17A4D61B5B9-1](https://user-images.githubusercontent.com/4167300/76276793-b6af4d80-62eb-11ea-9774-25b6a61338ed.jpeg)

(For fun I tested this with a few different themes.)

### How to test the changes in this Pull Request:

1. Add the cart block to a page, publish.
2. Set that page as the cart page in `WooCommerce > Settings > Advanced`. 
3. Add some items to cart.
6. Test the cart page on various devices / browsers / screen sizes. The cart should work correctly, and on smaller screens, the checkout button should be prominent and easy to find :)
