### PR TITLE
Default to the first state when selecting a country with states

### DIFF
--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -31,6 +31,7 @@ const StateInput = ( {
 	// @todo: remove this code block when issue https://github.com/woocommerce/woocommerce/issues/25854 is merged
 	// Defaults to the first state when selecting a country with states, this is here
 	// until a bug in Woo core is fixed.
+	// see: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1919
 	useEffect( () => {
 		if ( ! value && options.length ) {
 			onChangeState( options[ 0 ].key );

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -28,7 +28,14 @@ const StateInput = ( {
 				name: decodeEntities( countryStates[ key ] ),
 		  } ) )
 		: [];
-
+	// @todo: remove this code block when issue https://github.com/woocommerce/woocommerce/issues/25854 is merged
+	// Defaults to the first state when selecting a country with states, this is here
+	// until a bug in Woo core is fixed.
+	useEffect( () => {
+		if ( ! value && options.length ) {
+			onChangeState( options[ 0 ].key );
+		}
+	}, [ country ] );
 	/**
 	 * Handles state selection onChange events. Finds a matching state by key or value.
 	 *


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR defaults to the first state when a country with states is selected, it is meant temporarily patch an issue in Woo Core https://github.com/woocommerce/woocommerce/issues/25854
<!-- Reference any related issues or PRs here -->
Fixes #1895
Todo introduced: #1920

### How to test the changes in this Pull Request:

1. select a country with states in Checkout or Cart
2. See first state being selected
