### PR TITLE
Update build-plugin-zip.sh intro text

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -89,7 +89,7 @@ copy_dest_files() {
 	cd "$CURRENT_DIR" || exit
 }
 
-status "💃 Time to release WooCommerce Blocks 🕺"
+status "💃 Time to build a WooCommerce Blocks ZIP 🕺"
 
 if [ -z "$NO_CHECKS" ]; then
 	# Make sure there are no changes in the working tree. Release builds should be


### PR DESCRIPTION
`build-plugin-zip.sh` doesn't do a release but packages the plugin into a ZIP file. This PR updates the text so running the script is less scary now.