### PR TITLE
Fix PropTypes warning for CartLineItem component

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -48,7 +48,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 	const {
 		name,
 		summary,
-		low_stock_remaining: lowStockRemaining,
+		low_stock_remaining: lowStockRemaining = null,
 		backorders_allowed: backOrdersAllowed,
 		permalink,
 		images,
@@ -147,7 +147,10 @@ CartLineItemRow.propTypes = {
 		name: PropTypes.string.isRequired,
 		summary: PropTypes.string.isRequired,
 		images: PropTypes.array.isRequired,
-		low_stock_remaining: PropTypes.number.isRequired,
+		low_stock_remaining: PropTypes.oneOfType( [
+			PropTypes.number,
+			PropTypes.oneOf( [ null ] ),
+		] ),
 		backorders_allowed: PropTypes.bool.isRequired,
 		sold_individually: PropTypes.bool.isRequired,
 		variation: PropTypes.arrayOf(

--- a/assets/js/previews/cart.js
+++ b/assets/js/previews/cart.js
@@ -31,6 +31,8 @@ export const previewCart = {
 			sku: 'woo-beanie',
 			permalink: 'https://example.org',
 			low_stock_remaining: 2,
+			backorders_allowed: false,
+			sold_individually: false,
 			images: [
 				{
 					id: 10,
@@ -95,6 +97,8 @@ export const previewCart = {
 				'Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.',
 			sku: 'woo-cap',
 			permalink: 'https://example.org',
+			backorders_allowed: false,
+			sold_individually: false,
 			images: [
 				{
 					id: 11,

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -310,7 +310,7 @@ class CartItemSchema extends AbstractSchema {
 			'description'         => $this->prepare_html_response( wc_format_content( $product->get_description() ) ),
 			'sku'                 => $this->prepare_html_response( $product->get_sku() ),
 			'low_stock_remaining' => $this->get_low_stock_remaining( $product ),
-			'backorders_allowed'  => $product->backorders_allowed(),
+			'backorders_allowed'  => (bool) $product->backorders_allowed(),
 			'sold_individually'   => $product->is_sold_individually(),
 			'permalink'           => $product->get_permalink(),
 			'images'              => ( new ProductImages() )->images_to_array( $product ),


### PR DESCRIPTION
In [his comment](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1915#pullrequestreview-371929723) in #1915 about a couple bugs he noticed in the Editor:

```
Warning: Failed prop type: The prop `lineItem.backorders_allowed` is marked as required in `CartLineItemRow`, but its value is `undefined`.
```

 and a 404 request that fires

```
index.js:75 POST http://192.168.0.188:8889/wp-json/wc/store/cart/update-item?_locale=user
```

The latter is fixed in #1925. The former is fixed in this pull (previews needed updated).

Also in this pull is a fix for an error I was getting in the frontend for the cart block:

```
Warning: Failed prop type: The prop `lineItem.backorders_allowed` is marked as required in `CartLineItemRow`, but its value is `undefined`. 
```

## To test

- Load the cart block in the editor, you should only see the 404 request errors in the console.
- Load the cart block in the frontend, you should not see any errors in the console.