### PR TITLE
Update payment registration config to include `edit` components

### DIFF
--- a/assets/js/base/components/payment-methods/express-payment-methods.js
+++ b/assets/js/base/components/payment-methods/express-payment-methods.js
@@ -6,10 +6,12 @@ import {
 	usePaymentEvents,
 	useExpressPaymentMethods,
 } from '@woocommerce/base-hooks';
-import { cloneElement } from '@wordpress/element';
+import { cloneElement, isValidElement } from '@wordpress/element';
+import { useCheckoutContext } from '@woocommerce/base-context';
 
 const ExpressPaymentMethods = () => {
 	const [ checkoutData ] = useCheckoutData();
+	const { isEditor } = useCheckoutContext();
 	const { dispatch, select } = usePaymentEvents();
 	// not implementing isInitialized here because it's utilized further
 	// up in the tree for express payment methods. We won't even get here if
@@ -19,17 +21,18 @@ const ExpressPaymentMethods = () => {
 	const content =
 		paymentMethodSlugs.length > 0 ? (
 			paymentMethodSlugs.map( ( slug ) => {
-				const expressPaymentMethod =
-					paymentMethods[ slug ].activeContent;
+				const expressPaymentMethod = isEditor
+					? paymentMethods[ slug ].edit
+					: paymentMethods[ slug ].activeContent;
 				const paymentEvents = { dispatch, select };
-				return (
+				return isValidElement( expressPaymentMethod ) ? (
 					<li key={ slug } id={ `express-payment-method-${ slug }` }>
 						{ cloneElement( expressPaymentMethod, {
 							checkoutData,
 							paymentEvents,
 						} ) }
 					</li>
-				);
+				) : null;
 			} )
 		) : (
 			<li key="noneRegistered">No registered Payment Methods</li>

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -7,8 +7,14 @@ import {
 	useActivePaymentMethod,
 	usePaymentMethods,
 } from '@woocommerce/base-hooks';
-import { useCallback, cloneElement } from '@wordpress/element';
+import {
+	useCallback,
+	cloneElement,
+	useRef,
+	useEffect,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useCheckoutContext } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -38,20 +44,48 @@ const createTabs = ( paymentMethods ) => {
 		: [ noPaymentMethodTab() ];
 };
 
+/**
+ * Returns a payment method for the given context.
+ *
+ * @param {string} id The payment method slug to return.
+ * @param {Object} paymentMethods The current registered payment methods
+ * @param {boolean} isEditor Whether in the editor context (true) or not (false).
+ *
+ * @return The payment method matching the id for the given context.
+ */
+const getPaymentMethod = ( id, paymentMethods, isEditor ) => {
+	let paymentMethod = paymentMethods[ id ] || null;
+	if ( paymentMethod ) {
+		paymentMethod = isEditor
+			? paymentMethod.edit
+			: paymentMethod.activeContent;
+	}
+	return paymentMethod;
+};
+
 const PaymentMethods = () => {
 	const [ checkoutData ] = useCheckoutData();
+	const { isEditor } = useCheckoutContext();
 	const { dispatch, select } = usePaymentEvents();
 	const { isInitialized, paymentMethods } = usePaymentMethods();
+	const currentPaymentMethods = useRef( paymentMethods );
+
+	// update ref on changes
+	useEffect( () => {
+		currentPaymentMethods.current = paymentMethods;
+	}, [ paymentMethods ] );
+
 	const {
 		activePaymentMethod,
 		setActivePaymentMethod,
 	} = useActivePaymentMethod();
 	const getRenderedTab = useCallback(
 		() => ( selectedTab ) => {
-			const paymentMethod =
-				( paymentMethods[ selectedTab ] &&
-					paymentMethods[ selectedTab ].activeContent ) ||
-				null;
+			const paymentMethod = getPaymentMethod(
+				currentPaymentMethods.current,
+				selectedTab,
+				isEditor
+			);
 			const paymentEvents = { dispatch, select };
 			return paymentMethod
 				? cloneElement( paymentMethod, {
@@ -61,7 +95,7 @@ const PaymentMethods = () => {
 				  } )
 				: null;
 		},
-		[ checkoutData, dispatch, select ]
+		[ checkoutData, dispatch, select, isEditor ]
 	);
 	if (
 		! isInitialized ||

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -51,7 +51,7 @@ const createTabs = ( paymentMethods ) => {
  * @param {Object} paymentMethods The current registered payment methods
  * @param {boolean} isEditor Whether in the editor context (true) or not (false).
  *
- * @return The payment method matching the id for the given context.
+ * @return {Object} The payment method matching the id for the given context.
  */
 const getPaymentMethod = ( id, paymentMethods, isEditor ) => {
 	let paymentMethod = paymentMethods[ id ] || null;
@@ -82,8 +82,8 @@ const PaymentMethods = () => {
 	const getRenderedTab = useCallback(
 		() => ( selectedTab ) => {
 			const paymentMethod = getPaymentMethod(
-				currentPaymentMethods.current,
 				selectedTab,
+				currentPaymentMethods.current,
 				isEditor
 			);
 			const paymentEvents = { dispatch, select };

--- a/assets/js/base/context/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/index.js
@@ -75,11 +75,14 @@ export const useCheckoutContext = () => {
  *                                            submit.
  * @param {string}  props.submitLabel         What will be used for the checkout
  *                                            submit button label.
+ * @param {boolean} props.isEditor            Whether the checkout is in the
+ *                                            editor context or not.
  */
 export const CheckoutProvider = ( {
 	children,
 	activePaymentMethod: initialActivePaymentMethod,
 	redirectUrl,
+	isEditor,
 	submitLabel = __( 'Place Order', 'woo-gutenberg-product-block' ),
 } ) => {
 	// note, this is done intentionally so that the default state now has
@@ -180,6 +183,7 @@ export const CheckoutProvider = ( {
 		onCheckoutCompleteError,
 		onCheckoutProcessing,
 		dispatchActions,
+		isEditor,
 	};
 	return (
 		<CheckoutContext.Provider value={ checkoutData }>

--- a/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
@@ -9,17 +9,19 @@ export default class ExpressPaymentMethodConfig {
 		ExpressPaymentMethodConfig.assertValidConfig( config );
 		this.id = config.id;
 		this.activeContent = config.activeContent;
+		this.edit = config.edit;
 		this.canMakePayment = config.canMakePayment;
 	}
 
 	static assertValidConfig = ( config ) => {
-		assertConfigHasProperties( config, [ 'id', 'activeContent' ] );
+		assertConfigHasProperties( config, [ 'id', 'activeContent', 'edit' ] );
 		if ( typeof config.id !== 'string' ) {
 			throw new TypeError(
 				'The id for the express payment method must be a string'
 			);
 		}
 		assertValidElement( config.activeContent, 'activeContent' );
+		assertValidElement( config.edit, 'edit' );
 		if ( ! ( config.canMakePayment instanceof Promise ) ) {
 			throw new TypeError(
 				'The canMakePayment property for the express payment method must be a promise.'

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -9,9 +9,9 @@ export default class PaymentMethodConfig {
 		PaymentMethodConfig.assertValidConfig( config );
 		this.id = config.id;
 		this.label = config.label;
-		this.stepContent = config.stepContent;
 		this.ariaLabel = config.ariaLabel;
 		this.activeContent = config.activeContent;
+		this.edit = config.edit;
 		this.canMakePayment = config.canMakePayment;
 	}
 
@@ -22,6 +22,7 @@ export default class PaymentMethodConfig {
 			'stepContent',
 			'ariaLabel',
 			'activeContent',
+			'edit',
 			'canMakePayment',
 		] );
 		if ( typeof config.id !== 'string' ) {
@@ -30,6 +31,7 @@ export default class PaymentMethodConfig {
 		assertValidElement( config.label, 'label' );
 		assertValidElement( config.stepContent, 'stepContent' );
 		assertValidElement( config.activeContent, 'activeContent' );
+		assertValidElement( config.edit, 'edit' );
 		if ( typeof config.ariaLabel !== 'string' ) {
 			throw new TypeError(
 				'The ariaLabel for the payment method must be a string'

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -79,7 +79,7 @@ const Block = ( { attributes, isEditor = false, shippingRates = [] } ) => {
 	} = useShippingRates( Object.keys( addressFields ) );
 
 	return (
-		<CheckoutProvider>
+		<CheckoutProvider isEditor={ isEditor }>
 			<ExpressCheckoutFormControl />
 			<CheckoutForm>
 				<FormStep

--- a/assets/js/payment-methods-demo/index.js
+++ b/assets/js/payment-methods-demo/index.js
@@ -17,6 +17,7 @@ registerExpressPaymentMethod(
 		new Config( {
 			id: 'applepay',
 			activeContent: <ExpressApplePay />,
+			edit: <ExpressApplePay />,
 			canMakePayment: Promise.resolve( true ),
 		} )
 );
@@ -25,6 +26,7 @@ registerExpressPaymentMethod(
 		new Config( {
 			id: 'paypal',
 			activeContent: <ExpressPaypal />,
+			edit: <ExpressPaypal />,
 			canMakePayment: Promise.resolve( true ),
 		} )
 );

--- a/assets/js/payment-methods-demo/payment-methods/index.js
+++ b/assets/js/payment-methods-demo/payment-methods/index.js
@@ -25,6 +25,7 @@ export const paypalPaymentMethod = {
 	label: <img src={ paypalSvg } alt="" />,
 	stepContent: <div>Billing steps</div>,
 	activeContent: <PaypalActivePaymentMethod />,
+	edit: <PaypalActivePaymentMethod />,
 	canMakePayment: Promise.resolve( true ),
 	ariaLabel: 'paypal payment method',
 };
@@ -34,6 +35,7 @@ export const ccPaymentMethod = {
 	label: <img src={ ccSvg } alt="" />,
 	stepContent: null,
 	activeContent: <CreditCardActivePaymentMethod />,
+	edit: <CreditCardActivePaymentMethod />,
 	canMakePayment: Promise.resolve( true ),
 	ariaLabel: 'credit-card-payment-method',
 };

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -201,6 +201,9 @@
  *                                                        can be dispatched for
  *                                                        the checkout context
  *                                                        data.
+ * @property {boolean}                 isEditor           Indicates whether in
+ *                                                        the editor context
+ *                                                        (true) or not (false).
  */
 
 export {};


### PR DESCRIPTION
This extracts payment method registration configuration changes from #1780. 

We won't want to load payment methods fully in the editor context because that will include unnecessary weight for the page when full payment functionality is not required. So payment method registration includes a configuration for `edit` that allows payment methods to registry components that are only loaded in the editor context.

This allows for things like:

- testing for requirements and ensuring they are setup.
- potentially embedding/modifying configuration for payment methods right in the editor context (as opposed to a separate page)
- previewing what a setup payment method looks like.

In this pull I implemented the configuration changes including updating our demos and the the checkout payment method components.

I also included updating the `CheckoutContextProvider` so it receives (and exposes) an `isEditor` prop for indicating context in which the checkout is used. This, then will allow any child component to read this value from the checkout context and use it for determining alternative behaviour. In this particular pull, this is used to choose which payment method component is loaded from registered payment method configurations.

## To test

There is no new user facing functionality in this pull. It is all developer side focused. Testing simply verifies there are no errors when loading the checkout block in the frontend or the backend.