### PR TITLE
Hydrate Checkout block with API data

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withRestApiHydration } from '@woocommerce/block-hocs';
+import {
+	withRestApiHydration,
+	withStoreCartApiHydration,
+} from '@woocommerce/block-hocs';
 import { useStoreCart } from '@woocommerce/base-hooks';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
@@ -96,7 +99,7 @@ const getErrorBoundaryProps = () => {
 
 renderFrontend(
 	'.wp-block-woocommerce-checkout',
-	withRestApiHydration( CheckoutFrontend ),
+	withStoreCartApiHydration( withRestApiHydration( CheckoutFrontend ) ),
 	getProps,
 	getErrorBoundaryProps
 );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -62,6 +62,9 @@ class Checkout extends AbstractBlock {
 		if ( ! $data_registry->exists( 'shippingStates' ) ) {
 			$data_registry->add( 'shippingStates', WC()->countries->get_shipping_country_states() );
 		}
+		if ( ! $data_registry->exists( 'cartData' ) ) {
+			$data_registry->add( 'cartData', WC()->api->get_endpoint_data( '/wc/store/cart' ) );
+		}
 		if ( function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 			if ( $screen && $screen->is_block_editor() && ! $data_registry->exists( 'shippingMethodsExist' ) ) {


### PR DESCRIPTION
This PR wraps the _Checkout_ block with `withStoreCartApiHydration()` so it's hydrated on first load. That avoids making a `cart` call on load and makes the shipping rates to be initially loaded. Once we add the _Checkout_ sidebar (see #1921), it will also hydrate the values there.

### How to test the changes in this Pull Request:

1. Load a page with the _Checkout_ block.
3. Verify the shipping rates are initially loaded, so the spinner is not shown. Also make sure there are no API calls to `cart`.