### PR TITLE
Fix IE11 issues with the Checkout block

### DIFF
--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -12,9 +12,10 @@
 		margin-top: -24px;
 		margin-left: $gap-small;
 		margin-bottom: $gap-small;
-		width: fit-content;
 		color: $black;
 		font-weight: bold;
+		display: inline-block;
+		vertical-align: middle;
 	}
 
 	.wc-block-component-express-checkout__content {

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -11,6 +11,7 @@
 			padding: $gap-small $gap;
 			color: $black;
 			outline-offset: -1px;
+			text-align: center;
 			transition: box-shadow 0.1s linear;
 			&.is-active {
 				box-shadow: inset 0 -3px $black;
@@ -24,8 +25,7 @@
 			}
 			.wc-component__tab-item-content {
 				width: fit-content;
-				display: block;
-				margin: auto;
+				display: inline-block;
 			}
 		}
 	}

--- a/assets/js/base/hooks/shipping/use-shipping-rates.js
+++ b/assets/js/base/hooks/shipping/use-shipping-rates.js
@@ -28,11 +28,10 @@ import { pluckAddress } from '../../utils';
  */
 export const useShippingRates = ( addressFieldsKeys ) => {
 	const { cartErrors, shippingRates } = useStoreCart();
-	const addressFields = Object.fromEntries(
-		addressFieldsKeys.map( ( key ) => [ key, '' ] )
-	);
-	const derivedAddress = shippingRates[ 0 ]?.destination;
-	const initialAddress = { ...addressFields, ...derivedAddress };
+	const initialAddress = shippingRates[ 0 ]?.destination || {};
+	addressFieldsKeys.forEach( ( key ) => {
+		initialAddress[ key ] = initialAddress[ key ] || '';
+	} );
 	const shippingAddressReducer = ( state, address ) => ( {
 		...state,
 		...address,

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -8,15 +8,33 @@
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {
 		.wc-block-address-form {
-			display: grid;
-			grid-template-columns: 1fr 1fr;
-			grid-column-gap: $gap-small;
-		}
+			margin-left: #{-$gap-small / 2};
+			margin-right: #{-$gap-small / 2};
 
-		.wc-block-address-form__company,
-		.wc-block-address-form__address_1,
-		.wc-block-address-form__address_2 {
-			grid-column-start: span 2;
+			&::after {
+				content: "";
+				clear: both;
+				display: block;
+			}
+
+			.wc-block-text-input,
+			.wc-block-select {
+				float: left;
+				margin-left: #{$gap-small / 2};
+				margin-right: #{$gap-small / 2};
+				position: relative;
+				width: calc(50% - #{$gap-small});
+			}
+
+			.wc-block-address-form__company,
+			.wc-block-address-form__address_1,
+			.wc-block-address-form__address_2 {
+				width: calc(100% - #{$gap-small});
+			}
+
+			.wc-block-checkbox {
+				clear: both;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes several issues with the _Checkout_ block in IE11.

CSS code became much complex, I thought about creating `ie11.scss` files to separate IE11 CSS fixes from the base CSS, but after thinking about it twice, I think it's better to have all CSS shared between browsers, even if that makes our base CSS more complex. This way we don't need to maintain different CSS for IE11, which will increase the maintenance cost.

There is an issue in the _Cart_ block where the sidebar overflows, but I would prefer fixing it after #1921 is merged to avoid re-doing the fix twice.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/76424320-5e8a5100-63a8-11ea-9516-22ddcf5713ba.png)

### How to test the changes in this Pull Request:

1. With IE11 (you can use Browserstack for this), visit a page with the _Checkout_ block.
2. Verify it renders and it looks good.