### PR TITLE
Fix select rates when multiple packages exists

### DIFF
--- a/assets/js/base/components/shipping-rates-control/packages.js
+++ b/assets/js/base/components/shipping-rates-control/packages.js
@@ -20,19 +20,20 @@ const Packages = ( {
 	const { selectShippingRate, selectedShippingRates } = useSelectShippingRate(
 		shippingRates
 	);
+	/* eslint-disable camelcase */
 	return (
 		<div className="wc-block-shipping-rates-control">
-			{ shippingRates.map( ( shippingRate, i ) => (
+			{ shippingRates.map( ( { package_id, ...shippingRate } ) => (
 				<Package
-					key={ shippingRate.package_id }
+					key={ package_id }
 					className={ className }
 					collapsible={ collapsible }
 					noResultsMessage={ noResultsMessage }
 					onChange={ ( newShippingRate ) => {
-						selectShippingRate( newShippingRate, i );
+						selectShippingRate( newShippingRate, package_id );
 					} }
 					renderOption={ renderOption }
-					selected={ selectedShippingRates[ i ] }
+					selected={ selectedShippingRates[ package_id ] }
 					shippingRate={ shippingRate }
 					showItems={ shippingRates.length > 1 }
 					title={
@@ -42,6 +43,7 @@ const Packages = ( {
 			) ) }
 		</div>
 	);
+	/* eslint-enable */
 };
 
 Packages.propTypes = {

--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -17,17 +17,25 @@ See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tr
  * locally by a state and updated optimistically.
  */
 export const useSelectShippingRate = ( shippingRates ) => {
-	const initiallySelectedRates = shippingRates.map(
-		// the API responds with those keys.
-		// eslint-disable-next-line camelcase
-		( p ) => p.shipping_rates.find( ( rate ) => rate.selected )?.rate_id
+	const initiallySelectedRates = Object.fromEntries(
+		shippingRates.map(
+			// the API responds with those keys.
+			( p, i ) => [
+				i,
+				// eslint-disable-next-line camelcase
+				p.shipping_rates.find( ( rate ) => rate.selected )?.rate_id,
+			]
+		)
 	);
 	const [ selectedShippingRates, setSelectedShipping ] = useState(
 		initiallySelectedRates
 	);
 	const { selectShippingRate } = useDispatch( storeKey );
 	const setRate = ( newShippingRate, packageId ) => {
-		setSelectedShipping( [ newShippingRate ] );
+		setSelectedShipping( {
+			...selectedShippingRates,
+			[ packageId ]: newShippingRate,
+		} );
 		selectShippingRate( newShippingRate, packageId );
 	};
 	return {

--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -13,20 +13,19 @@ See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tr
  * @return {Object} This hook will return an object with two properties:
  * - selectShippingRate    A function that immediately returns the selected
  * rate and dispatches an action generator.
- * - selectedShippingRates An array of selected shipping rates, maintained
+ * - selectedShippingRates An object of selected shipping rates and package id as key, maintained
  * locally by a state and updated optimistically.
  */
 export const useSelectShippingRate = ( shippingRates ) => {
 	const initiallySelectedRates = Object.fromEntries(
 		shippingRates.map(
 			// the API responds with those keys.
+			/* eslint-disable camelcase */
 			( p ) => [
-				/* eslint-disable camelcase */
 				p.package_id,
-				// eslint-disable-next-line camelcase
 				p.shipping_rates.find( ( rate ) => rate.selected )?.rate_id,
-				/* eslint-enable */
 			]
+			/* eslint-enable */
 		)
 	);
 	const [ selectedShippingRates, setSelectedShipping ] = useState(

--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -20,10 +20,12 @@ export const useSelectShippingRate = ( shippingRates ) => {
 	const initiallySelectedRates = Object.fromEntries(
 		shippingRates.map(
 			// the API responds with those keys.
-			( p, i ) => [
-				i,
+			( p ) => [
+				/* eslint-disable camelcase */
+				p.package_id,
 				// eslint-disable-next-line camelcase
 				p.shipping_rates.find( ( rate ) => rate.selected )?.rate_id,
+				/* eslint-enable */
 			]
 		)
 	);

--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -17,8 +17,8 @@ See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tr
  * locally by a state and updated optimistically.
  */
 export const useSelectShippingRate = ( shippingRates ) => {
-	const initiallySelectedRates = Object.fromEntries(
-		shippingRates.map(
+	const initiallySelectedRates = shippingRates
+		.map(
 			// the API responds with those keys.
 			/* eslint-disable camelcase */
 			( p ) => [
@@ -27,7 +27,12 @@ export const useSelectShippingRate = ( shippingRates ) => {
 			]
 			/* eslint-enable */
 		)
-	);
+		// A fromEntries ponyfill, creates an object from an array of arrays.
+		.reduce( ( obj, [ key, val ] ) => {
+			obj[ key ] = val;
+			return obj;
+		}, {} );
+
 	const [ selectedShippingRates, setSelectedShipping ] = useState(
 		initiallySelectedRates
 	);

--- a/assets/js/base/hooks/shipping/use-shipping-rates.js
+++ b/assets/js/base/hooks/shipping/use-shipping-rates.js
@@ -28,13 +28,9 @@ import { pluckAddress } from '../../utils';
  */
 export const useShippingRates = ( addressFieldsKeys ) => {
 	const { cartErrors, shippingRates } = useStoreCart();
-	const addressFields = addressFieldsKeys
-		.map( ( key ) => [ key, '' ] )
-		// A fromEntries ponyfill, creates an object from an array of arrays.
-		.reduce( ( obj, [ key, val ] ) => {
-			obj[ key ] = val;
-			return obj;
-		}, {} );
+	const addressFields = Object.fromEntries(
+		addressFieldsKeys.map( ( key ) => [ key, '' ] )
+	);
 	const derivedAddress = shippingRates[ 0 ]?.destination;
 	const initialAddress = { ...addressFields, ...derivedAddress };
 	const shippingAddressReducer = ( state, address ) => ( {

--- a/assets/js/base/hooks/shipping/use-shipping-rates.js
+++ b/assets/js/base/hooks/shipping/use-shipping-rates.js
@@ -28,9 +28,13 @@ import { pluckAddress } from '../../utils';
  */
 export const useShippingRates = ( addressFieldsKeys ) => {
 	const { cartErrors, shippingRates } = useStoreCart();
-	const addressFields = Object.fromEntries(
-		addressFieldsKeys.map( ( key ) => [ key, '' ] )
-	);
+	const addressFields = addressFieldsKeys
+		.map( ( key ) => [ key, '' ] )
+		// A fromEntries ponyfill, creates an object from an array of arrays.
+		.reduce( ( obj, [ key, val ] ) => {
+			obj[ key ] = val;
+			return obj;
+		}, {} );
 	const derivedAddress = shippingRates[ 0 ]?.destination;
 	const initialAddress = { ...addressFields, ...derivedAddress };
 	const shippingAddressReducer = ( state, address ) => ( {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR changes the shape of selected shipping rates to an object so that we can maintain keys, it also changes to using package_id instead of the index for better stability, and it fixes an issue with updating state (I didn’t use the previous values + new 🤦‍♀️)
<!-- Reference any related issues or PRs here -->
Fixes #1901

### How to test the changes in this Pull Request:

1. Following instructions in #1901 to create packages.
2. try selecting rates in both packages.
3. it should persist and prices should update and reloading should maintain the same value.
