### PR TITLE
Update/extract prepare total items to utility

### DIFF
--- a/assets/js/base/hooks/payment-methods/index.js
+++ b/assets/js/base/hooks/payment-methods/index.js
@@ -1,2 +1,2 @@
-export * from './use-payment-method-interface';
+export { usePaymentMethodInterface } from './use-payment-method-interface';
 export * from './use-payment-methods';

--- a/assets/js/base/hooks/payment-methods/test/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/test/use-payment-method-interface.js
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import { prepareTotalItems } from '../use-payment-method-interface';
+
+describe( 'prepareTotalItems', () => {
+	const fixture = {
+		total_items: '200',
+		total_items_tax: '20',
+		total_fees: '100',
+		total_fees_tax: '10',
+		total_discount: '350',
+		total_discount_tax: '50',
+		total_shipping: '50',
+		total_shipping_tax: '5',
+		total_tax: '30',
+	};
+	const expected = [
+		{
+			label: 'Subtotal:',
+			value: 200,
+			valueWithTax: 220,
+		},
+		{
+			label: 'Fees:',
+			value: 100,
+			valueWithTax: 110,
+		},
+		{
+			label: 'Discount:',
+			value: 350,
+			valueWithTax: 400,
+		},
+		{
+			label: 'Taxes:',
+			value: 30,
+			valueWithTax: 30,
+		},
+	];
+	const expectedWithShipping = [
+		...expected,
+		{
+			label: 'Shipping:',
+			value: 50,
+			valueWithTax: 55,
+		},
+	];
+	it( 'returns expected values when needsShipping is false', () => {
+		expect( prepareTotalItems( fixture, false ) ).toEqual( expected );
+	} );
+	it( 'returns expected values when needsShipping is true', () => {
+		expect( prepareTotalItems( fixture, true ) ).toEqual(
+			expectedWithShipping
+		);
+	} );
+} );

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -172,7 +172,7 @@ export const usePaymentMethodInterface = () => {
 			// @todo need to pass along the default country set for the site
 			// if it's available.
 			country: '',
-			cartItems: currentCartTotals.current,
+			cartTotalItems: currentCartTotals.current,
 			displayPricesIncludingTax: DISPLAY_CART_PRICES_INCLUDING_TAX,
 			appliedCoupons,
 		},

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -9,6 +9,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import { useEffect, useRef } from '@wordpress/element';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -172,6 +173,7 @@ export const usePaymentMethodInterface = () => {
 			// if it's available.
 			country: '',
 			cartItems: currentCartTotals.current,
+			displayPricesIncludingTax: DISPLAY_CART_PRICES_INCLUDING_TAX,
 			appliedCoupons,
 		},
 		eventRegistration: {

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -22,41 +22,56 @@ import {
 
 /**
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
- * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').CartTotalItem} CartTotalItem
+ * @typedef {import('@woocommerce/type-defs/cart').CartTotalItem} CartTotalItem
  */
 
-// @todo similar logic is done in `blocks/cart-checkout/cart/full-cart/index.js`
-// we should extract this to use in both places so it's consistent.
-// @todo this will need to account for `DISPLAY_PRICES_INCLUDING_TAXES`.
 /**
+ * Prepares the total items into a shape usable for display as passed on to
+ * registered payment methods.
+ *
  * @param {Object} totals Current cart total items
  * @param {boolean} needsShipping Whether or not shipping is needed.
  *
  * @return {CartTotalItem[]}  Array for cart total items prepared for use.
  */
-const prepareTotalItems = ( totals, needsShipping ) => {
+export const prepareTotalItems = ( totals, needsShipping ) => {
 	const newTotals = [];
-	newTotals.push( {
-		label: __( 'Subtotal:', 'woo-gutenberg-products-block' ),
-		value: parseInt( totals.total_items, 10 ),
-	} );
-	newTotals.push( {
-		label: __( 'Fees:', 'woo-gutenberg-products-block' ),
-		value: parseInt( totals.total_fees, 10 ),
-	} );
-	newTotals.push( {
-		label: __( 'Discount:', 'woo-gutenberg-products-block' ),
-		value: parseInt( totals.total_discount, 10 ),
-	} );
+	const factory = ( label, property ) => {
+		const value = parseInt( totals[ property ], 10 );
+		const tax = parseInt( totals[ property + '_tax' ], 10 );
+		return {
+			label,
+			value,
+			valueWithTax: value + tax,
+		};
+	};
+	newTotals.push(
+		factory(
+			__( 'Subtotal:', 'woo-gutenberg-products-block' ),
+			'total_items'
+		)
+	);
+	newTotals.push(
+		factory( __( 'Fees:', 'woo-gutenberg-products-block' ), 'total_fees' )
+	);
+	newTotals.push(
+		factory(
+			__( 'Discount:', 'woo-gutenberg-products-block' ),
+			'total_discount'
+		)
+	);
 	newTotals.push( {
 		label: __( 'Taxes:', 'woo-gutenberg-products-block' ),
 		value: parseInt( totals.total_tax, 10 ),
+		valueWithTax: parseInt( totals.total_tax, 10 ),
 	} );
 	if ( needsShipping ) {
-		newTotals.push( {
-			label: __( 'Shipping:', 'woo-gutenberg-products-block' ),
-			value: parseInt( totals.total_shipping, 10 ),
-		} );
+		newTotals.push(
+			factory(
+				__( 'Shipping:', 'woo-gutenberg-products-block' ),
+				'total_shipping'
+			)
+		);
 	}
 	return newTotals;
 };

--- a/assets/js/type-defs/cart.js
+++ b/assets/js/type-defs/cart.js
@@ -2,9 +2,9 @@
  * @typedef {Object} CartTotalItem
  *
  * @property {string} label        Label for total item
- * @property {number} value        The value of the total item
+ * @property {number} value        The value of the total item (in subunits).
  * @property {number} valueWithTax The value of the total item with tax
- *                                 included.
+ *                                 included (in subunits).
  */
 
 /**
@@ -86,12 +86,15 @@
  *                                                thousands separator.
  * @property {string} line_subtotal               Line subtotal (the price of
  *                                                the product before coupon
- *                                                discounts have been applied).
- * @property {string} line_subtotal_tax           Line subtotal tax.
+ *                                                discounts have been applied
+ *                                                in subunits).
+ * @property {string} line_subtotal_tax           Line subtotal tax (in
+ *                                                subunits).
  * @property {string} line_total                  Line total (the price of the
  *                                                product after coupon
- *                                                discounts have been applied).
- * @property {string} line_total_tax              Line total tax.
+ *                                                discounts have been applied
+ *                                                in subunits).
+ * @property {string} line_total_tax              Line total tax (in subunits).
  */
 
 /**
@@ -122,10 +125,12 @@
  *                                                     decimal separator.
  * @property {string}      currency_thousand_separator The string used for the
  *                                                     thousands separator.
- * @property {string}      price                       Current product price.
- * @property {string}      regular_price               Regular product price.
+ * @property {string}      price                       Current product price
+ *                                                     in subunits.
+ * @property {string}      regular_price               Regular product price
+ *                                                     in subunits.
  * @property {string}      sale_price                  Sale product price, if
- *                                                     applicable.
+ *                                                     applicable (in subunits).
  * @property {CartItemPriceRange|null} price_range     Price range, if
  *                                                     applicable.
  *
@@ -208,24 +213,29 @@
  *                                                which can be used to format
  *                                                returned prices.
  * @property {number} total_items                 Total price of items in the
- *                                                cart.
+ *                                                cart (in subunits).
  * @property {number} total_items_tax             Total tax on items in the
- *                                                cart.
+ *                                                cart (in subunits).
  * @property {number} total_fees                  Total price of any applied
- *                                                fees.
- * @property {number} total_fees_tax              Total tax on fees.
+ *                                                fees (in subunits).
+ * @property {number} total_fees_tax              Total tax on fees (
+ *                                                in subunits).
  * @property {number} total_discount              Total discount from applied
- *                                                coupons.
+ *                                                coupons (in subunits).
  * @property {number} total_discount_tax          Total tax removed due to
- *                                                discount from applied coupons.
- * @property {number} total_shipping              Total price of shipping.
- * @property {number} total_shipping_tax          Total tax on shipping.
+ *                                                discount from applied coupons
+ *                                                (in subunits).
+ * @property {number} total_shipping              Total price of shipping
+ *                                                (in subunits).
+ * @property {number} total_shipping_tax          Total tax on shipping
+ *                                                (in subunits).
  * @property {number} total_price                 Total price the customer will
- *                                                pay.
+ *                                                pay (in subunits).
  * @property {number} total_tax                   Total tax applied to items and
- *                                                shipping.
+ *                                                shipping (in subunits).
  * @property {Array}  tax_lines                   Lines of taxes applied to
- *                                                items and shipping.
+ *                                                items and shipping
+ *                                                (in subunits).
  */
 
 export {};

--- a/assets/js/type-defs/cart.js
+++ b/assets/js/type-defs/cart.js
@@ -1,8 +1,10 @@
 /**
  * @typedef {Object} CartTotalItem
  *
- * @property {string} label  Label for total item
- * @property {number} value  The value of the total item
+ * @property {string} label        Label for total item
+ * @property {number} value        The value of the total item
+ * @property {number} valueWithTax The value of the total item with tax
+ *                                 included.
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -119,20 +119,29 @@
 /**
  * @typedef BillingDataProps
  *
- * @property {CartBillingAddress} billingData    The address used for billing.
- * @property {Function}           setBillingData Used to set the cart billing
- *                                               address.
- * @property {Object}             order          The order object for the
- *                                               purchase.
- * @property {boolean}            orderLoading   True if the order is being
- *                                               loaded.
- * @property {CartTotalItem}      cartTotal      The total item for the cart.
- * @property {SiteCurrency}       currency       Currency object.
- * @property {string}             country        ISO country code for the
- *                                               default country for the site.
- * @property {CartTotalItem[]}    cartItems      The various subtotal amounts.
- * @property {string[]}           appliedCoupons All the coupons that were
- *                                               applied.
+ * @property {CartBillingAddress} billingData               The address used for
+ *                                                          billing.
+ * @property {Function}           setBillingData            Used to set the cart
+ *                                                          billing address.
+ * @property {Object}             order                     The order object for
+ *                                                          the purchase.
+ * @property {boolean}            orderLoading              True if the order is
+ *                                                          being loaded.
+ * @property {CartTotalItem}      cartTotal                 The total item for
+ *                                                          the cart.
+ * @property {SiteCurrency}       currency                  Currency object.
+ * @property {string}             country                   ISO country code
+ *                                                          for the default
+ *                                                          country for the
+ *                                                          site.
+ * @property {CartTotalItem[]}    cartItems                 The various subtotal
+ *                                                          amounts.
+ * @property {boolean}            displayPricesIncludingTax True means that the
+ *                                                          site is configured
+ *                                                          to display prices
+ *                                                          including tax.
+ * @property {string[]}           appliedCoupons            All the coupons that
+ *                                                          were applied.
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -134,7 +134,7 @@
  *                                                          for the default
  *                                                          country for the
  *                                                          site.
- * @property {CartTotalItem[]}    cartItems                 The various subtotal
+ * @property {CartTotalItem[]}    cartTotalItems            The various subtotal
  *                                                          amounts.
  * @property {boolean}            displayPricesIncludingTax True means that the
  *                                                          site is configured


### PR DESCRIPTION
This addresses #1946.

Originally I thought that the logic `prepareTotalItems` was also used in the `FullCart` component but it looks like the logic there changed since I originally created the todo so extracting no longer has value. Instead I've left this as a function in the `use-payment-method-interface` hook file and added tests for it.  It's not exported publicly but is exported for the tests.

In this pull:

`prepareTotalItems` now returns an array of objects where each object is in the shape described by the `CartTotalItem` typedef.  This object has three properties:

- `label`: the label for the total item
- `value`: the value for the total item as a number without taxes applied.
- `valueWithTax`: the value for the total item as a number _with_ taxes applied.

This allows payment methods consuming this to decide how to display the items for their use.

Also added a `displayPricesIncludingTax` property to the billingData exposed on the payment method interface so that payment methods could know what the site is configured for.

## To Test

I added unit tests because there's nothing really user facing to test with this. If the unit tests pass in travis this should be good to go (assuming review passes too).