### PR TITLE
Fix invalid coupon thrown error and form not connected console warning.

### DIFF
--- a/assets/js/base/components/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/totals/totals-coupon-code-input/index.js
@@ -76,7 +76,8 @@ const TotalsCouponCodeInput = ( {
 						<Button
 							className="wc-block-coupon-code__button"
 							disabled={ isLoading }
-							onClick={ () => {
+							onClick={ ( e ) => {
+								e.preventDefault();
 								onSubmit( couponValue );
 							} }
 							type="submit"

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -28,17 +28,12 @@ const CartFrontend = ( {
 	isShippingCostHidden,
 } ) => {
 	const {
-		cartErrors,
 		cartItems,
 		cartTotals,
 		cartIsLoading,
 		cartCoupons,
 		shippingRates,
 	} = useStoreCart();
-
-	if ( cartErrors && cartErrors.length > 0 ) {
-		throw new Error( cartErrors[ 0 ].message );
-	}
 
 	return (
 		<StoreNoticesProvider context="wc/cart">

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -57,16 +57,11 @@ const CartLineItemRow = ( { lineItem } ) => {
 	} = lineItem;
 
 	const {
-		cartItemQuantityErrors,
 		quantity,
 		changeQuantity,
 		removeItem,
 		isPending: itemQuantityDisabled,
 	} = useStoreCartItemQuantity( lineItem );
-
-	if ( cartItemQuantityErrors && cartItemQuantityErrors.length > 0 ) {
-		throw new Error( cartItemQuantityErrors[ 0 ].message );
-	}
 
 	const currency = getCurrency( prices );
 	const regularPrice = parseInt( prices.regular_price, 10 ) * quantity;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -95,7 +95,6 @@ const Cart = ( {
 	const defaultAddressFields = [ 'country', 'state', 'city', 'postcode' ];
 	const {
 		shippingAddress,
-		shippingRatesErrors,
 		setShippingAddress,
 		shippingRatesLoading,
 	} = useShippingRates( defaultAddressFields );
@@ -104,13 +103,7 @@ const Cart = ( {
 		removeCoupon,
 		isApplyingCoupon,
 		isRemovingCoupon,
-		cartCouponsErrors,
 	} = useStoreCartCoupons();
-
-	const errors = [ ...shippingRatesErrors, ...cartCouponsErrors ];
-	if ( errors.length > 0 ) {
-		throw new Error( errors[ 0 ].message );
-	}
 
 	const showShippingCosts = Boolean(
 		SHIPPING_ENABLED &&


### PR DESCRIPTION
Fixes: #1951 

Also in this pull I addressed this console warning when clicking the APPLY button for coupons:

<img width="717" alt="Image 2020-03-11 at 3 06 26 PM" src="https://user-images.githubusercontent.com/1429108/76457117-90061b00-63ae-11ea-875b-3e9efdd06134.png">

The reason why invalid coupon application was triggering the error boundary is because a number of components were _throwing_ an error anytime errors existed in state for various things. Added in #1907, this is too aggressive because it assumes that any error in the cart state is blocking. Instead, similar to how coupon application was being handled, errors should only be thrown if it's blocking for the customer and they are unable to do anything to fix.

We can continue work on surfacing these errors to customers in subsequent pulls (I'll create an issue touching this pull).