### PR TITLE
Implement error handling for shipping rates and selected shipping rates.

### DIFF
--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -60,7 +60,6 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 			if ( isEditor ) {
 				return {
 					cartCoupons: previewCart.coupons,
-					shippingRates: previewCart.shipping_rates,
 					cartItems: previewCart.items,
 					cartItemsCount: previewCart.items_count,
 					cartItemsWeight: previewCart.items_weight,
@@ -68,6 +67,13 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 					cartTotals: previewCart.totals,
 					cartIsLoading: false,
 					cartErrors: [],
+					shippingRates: previewCart.shipping_rates,
+					shippingAddress: {
+						country: '',
+						state: '',
+						city: '',
+						postcode: '',
+					},
 				};
 			}
 

--- a/assets/js/base/hooks/index.js
+++ b/assets/js/base/hooks/index.js
@@ -11,3 +11,4 @@ export * from './use-shallow-equal';
 export * from './use-store-products';
 export * from './use-store-notices';
 export * from './use-query-state';
+export * from './use-throw-error';

--- a/assets/js/base/hooks/shipping/constants.js
+++ b/assets/js/base/hooks/shipping/constants.js
@@ -1,0 +1,5 @@
+export const shippingErrorCodes = {
+	INVALID_COUNTRY: 'woocommerce_rest_cart_shipping_rates_invalid_country',
+	MISSING_COUNTRY: 'woocommerce_rest_cart_shipping_rates_missing_country',
+	INVALID_STATE: 'woocommerce_rest_cart_shipping_rates_invalid_state',
+};

--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -4,6 +4,7 @@
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { useThrowError } from '@woocommerce/base-hooks';
 
 /**
  * This is a custom hook for loading the selected shipping rate from the cart store and actions for selecting a rate.
@@ -17,6 +18,7 @@ See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tr
  * locally by a state and updated optimistically.
  */
 export const useSelectShippingRate = ( shippingRates ) => {
+	const throwError = useThrowError();
 	const initiallySelectedRates = shippingRates
 		.map(
 			// the API responds with those keys.
@@ -42,7 +44,11 @@ export const useSelectShippingRate = ( shippingRates ) => {
 			...selectedShippingRates,
 			[ packageId ]: newShippingRate,
 		} );
-		selectShippingRate( newShippingRate, packageId );
+		selectShippingRate( newShippingRate, packageId ).catch( ( error ) => {
+			// we throw this error because an error on selecting a rate
+			// is problematic.
+			throwError( error );
+		} );
 	};
 	return {
 		selectShippingRate: setRate,

--- a/assets/js/base/hooks/shipping/use-shipping-address.js
+++ b/assets/js/base/hooks/shipping/use-shipping-address.js
@@ -11,6 +11,7 @@ import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
  * Internal dependencies
  */
 import { useStoreCart } from '../cart/use-store-cart';
+import { useThrowError } from '../use-throw-error';
 import { pluckAddress } from '../../utils';
 
 const shouldUpdateStore = ( oldAddress, newAddress ) =>
@@ -21,6 +22,7 @@ export const useShippingAddress = () => {
 	const [ shippingAddress, setShippingAddress ] = useState( initialAddress );
 	const [ debouncedShippingAddress ] = useDebounce( shippingAddress, 400 );
 	const { updateShippingAddress } = useDispatch( storeKey );
+	const throwError = useThrowError();
 
 	// Note, we're intentionally not using initialAddress as a dependency here
 	// so that the stale (previous) value is being used for comparison.
@@ -29,7 +31,12 @@ export const useShippingAddress = () => {
 			debouncedShippingAddress.country &&
 			shouldUpdateStore( initialAddress, debouncedShippingAddress )
 		) {
-			updateShippingAddress( debouncedShippingAddress );
+			updateShippingAddress( debouncedShippingAddress ).catch(
+				( error ) => {
+					// error is non-recoverable so throw
+					throwError( error );
+				}
+			);
 		}
 	}, [ debouncedShippingAddress ] );
 	return {

--- a/assets/js/base/hooks/shipping/use-shipping-rates.js
+++ b/assets/js/base/hooks/shipping/use-shipping-rates.js
@@ -3,7 +3,6 @@
  */
 import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/assets/js/base/hooks/shipping/use-shipping-rates.js
+++ b/assets/js/base/hooks/shipping/use-shipping-rates.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/assets/js/base/hooks/use-collection.js
+++ b/assets/js/base/hooks/use-collection.js
@@ -3,7 +3,8 @@
  */
 import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect } from '@wordpress/data';
-import { useRef, useState } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
+import { useThrowError } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -60,7 +61,7 @@ export const useCollection = ( options ) => {
 	// ensure we feed the previous reference if it's equivalent
 	const currentQuery = useShallowEqual( query );
 	const currentResourceValues = useShallowEqual( resourceValues );
-	const [ , setState ] = useState();
+	const throwError = useThrowError();
 	const results = useSelect(
 		( select ) => {
 			if ( ! shouldSelect ) {
@@ -76,12 +77,7 @@ export const useCollection = ( options ) => {
 			const error = store.getCollectionError( ...args );
 
 			if ( error ) {
-				// Is there an error? If so, throw an exception.
-				// This uses setState because useCollection is a hook.
-				// See https://github.com/facebook/react/issues/14981
-				setState( () => {
-					throw error;
-				} );
+				throwError( error );
 			}
 
 			return {

--- a/assets/js/base/hooks/use-throw-error.js
+++ b/assets/js/base/hooks/use-throw-error.js
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Helper method for throwing an error in a React Hook.
+ *
+ * @see https://github.com/facebook/react/issues/14981
+ *
+ * @return {function(Object)} A function receiving the error that will be thrown.
+ */
+export const useThrowError = () => {
+	const [ , setState ] = useState();
+	return ( error ) =>
+		setState( () => {
+			throw error;
+		} );
+};

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -42,21 +42,15 @@ import './editor.scss';
  * Component that renders the Cart block when user has something in cart aka "full".
  */
 const Cart = ( { isShippingCalculatorEnabled, isShippingCostHidden } ) => {
-	const { cartItems, cartTotals, cartIsLoading, cartErrors } = useStoreCart();
+	const { cartItems, cartTotals, cartIsLoading } = useStoreCart();
 
 	const {
 		applyCoupon,
 		removeCoupon,
 		isApplyingCoupon,
 		isRemovingCoupon,
-		cartCoupons,
-		cartCouponsErrors,
+		appliedCoupons,
 	} = useStoreCartCoupons();
-
-	const errors = [ ...cartErrors, ...cartCouponsErrors ];
-	if ( errors.length > 0 ) {
-		throw new Error( errors[ 0 ].message );
-	}
 
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
 
@@ -91,7 +85,7 @@ const Cart = ( { isShippingCalculatorEnabled, isShippingCostHidden } ) => {
 							values={ cartTotals }
 						/>
 						<TotalsDiscountItem
-							cartCoupons={ cartCoupons }
+							cartCoupons={ appliedCoupons }
 							currency={ totalsCurrency }
 							isRemovingCoupon={ isRemovingCoupon }
 							removeCoupon={ removeCoupon }

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -7,6 +7,7 @@ import {
 	withStoreCartApiHydration,
 } from '@woocommerce/block-hocs';
 import { useStoreCart } from '@woocommerce/base-hooks';
+import { StoreNoticesProvider } from '@woocommerce/base-context';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
@@ -27,14 +28,9 @@ const CheckoutFrontend = ( props ) => {
 	const {
 		cartCoupons,
 		cartItems,
-		cartErrors,
 		cartTotals,
 		shippingRates,
 	} = useStoreCart();
-
-	if ( cartErrors && cartErrors.length > 0 ) {
-		throw new Error( cartErrors[ 0 ].message );
-	}
 
 	return (
 		<BlockErrorBoundary
@@ -56,13 +52,15 @@ const CheckoutFrontend = ( props ) => {
 			) }
 			showErrorMessage={ CURRENT_USER_IS_ADMIN }
 		>
-			<Block
-				{ ...props }
-				cartCoupons={ cartCoupons }
-				cartItems={ cartItems }
-				cartTotals={ cartTotals }
-				shippingRates={ shippingRates }
-			/>
+			<StoreNoticesProvider context="wc/checkout">
+				<Block
+					{ ...props }
+					cartCoupons={ cartCoupons }
+					cartItems={ cartItems }
+					cartTotals={ cartTotals }
+					shippingRates={ shippingRates }
+				/>
+			</StoreNoticesProvider>
 		</BlockErrorBoundary>
 	);
 };

--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -308,6 +308,10 @@ export function* updateShippingAddress( address ) {
 		}
 	} catch ( error ) {
 		yield receiveError( error );
+		yield shippingRatesAreResolving( false );
+		// rethrow error.
+		throw error;
 	}
 	yield shippingRatesAreResolving( false );
+	return true;
 }

--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -268,7 +268,10 @@ export function* selectShippingRate( rateId, packageId = 0 ) {
 		}
 	} catch ( error ) {
 		yield receiveError( error );
+		// Re-throw the error.
+		throw error;
 	}
+	return true;
 }
 
 /**


### PR DESCRIPTION
Fixes: #1953

This pull adds some error handling for the shipping rates requests and select shipping rate requests.

Currently this will correctly throw errors for non-recoverable states. A couple of follow-up issues are open for validating and improving validation signals to customers: #1969, and #1966 

All errors will trigger something like this:

<img width="1213" alt="Image 2020-03-12 at 12 00 58 PM" src="https://user-images.githubusercontent.com/1429108/76540893-2db62480-6459-11ea-8c31-8b538473cde2.png">

In this pull:

- Added a `useThrowError` hook that is the workaround currently needed for throwing errors in hook callbacks that get caught by error boundaries (replaced existing logic in `useCollection` with this too).
- update error handling for `useSelectShippingRate` and `useShippingAddress`.

## To Test

This impacts coupon handling (invalid and valid coupons), shipping rate calculations and selecting shipping rates.

- First test that existing behaviour for the above works as expected.
- To test errors with shipping rates and selected shipping rates, you'll need to tweak the endpoints temporarily manually directly in the code to trigger an error on the rest api responses.

In polish work after we get the blocks done, I want to add tests for this error handling. Adding tests at this point extends how long it will take to get this pull merged (a number of mocks will be needed) so not doing now.