### PR TITLE
Fix layout issues after merges

### DIFF
--- a/assets/js/base/components/cart-checkout/button/style.scss
+++ b/assets/js/base/components/cart-checkout/button/style.scss
@@ -2,14 +2,16 @@
 .wc-block-cart,
 .wc-block-checkout {
 	.button.wc-block-button {
+		align-items: center;
 		background-color: #000 !important;
 		color: #fff !important;
-		display: block;
+		display: flex;
 		font-size: inherit;
 		font-weight: bold;
 		height: 48px; // same height as text-input
+		justify-content: center;
 		line-height: 1;
-		padding: $gap-small;
+		padding: 0 $gap-small;
 		text-align: center;
 		text-decoration: none;
 		text-transform: none;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,4 +1,5 @@
 .wc-block-select {
+	height: 48px;
 	position: relative;
 	margin-top: $gap;
 

--- a/assets/js/base/components/totals/totals-shipping-item/index.js
+++ b/assets/js/base/components/totals/totals-shipping-item/index.js
@@ -15,6 +15,7 @@ import { useShippingRates } from '@woocommerce/base-hooks';
 import TotalsItem from '../totals-item';
 import ShippingRateSelector from './shipping-rate-selector';
 import hasShippingRate from './has-shipping-rate';
+import './style.scss';
 
 /**
  * Renders the shipping totals row, rates, and calculator if enabled.
@@ -22,6 +23,7 @@ import hasShippingRate from './has-shipping-rate';
 const TotalsShippingItem = ( {
 	currency,
 	values,
+	isCheckout = false,
 	showCalculator = true,
 	showRatesWithoutAddress = false,
 } ) => {
@@ -44,14 +46,14 @@ const TotalsShippingItem = ( {
 	const showingRates = showRatesWithoutAddress || hasShippingAddress;
 
 	// If we have no rates, and an address is needed.
-	if ( ! hasRates && ! hasShippingAddress ) {
+	if ( ! hasRates && ! hasShippingAddress && ! isCheckout ) {
 		return (
 			<TotalsItem
 				label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
 				value={
 					showCalculator ? (
 						<button
-							className="wc-block-cart__change-address-button"
+							className="wc-block-totals__change-address-button"
 							onClick={ () => {
 								setIsShippingCalculatorOpen(
 									! isShippingCalculatorOpen
@@ -100,7 +102,7 @@ const TotalsShippingItem = ( {
 						<ShippingLocation address={ shippingAddress } />{ ' ' }
 						{ showCalculator && (
 							<button
-								className="wc-block-cart__change-address-button"
+								className="wc-block-totals__change-address-button"
 								onClick={ () => {
 									setIsShippingCalculatorOpen(
 										! isShippingCalculatorOpen
@@ -127,19 +129,11 @@ const TotalsShippingItem = ( {
 				}
 				currency={ currency }
 			/>
-			{ showingRates && (
-				<fieldset className="wc-block-cart__shipping-options-fieldset">
-					<legend className="screen-reader-text">
-						{ __(
-							'Choose a shipping method',
-							'woo-gutenberg-products-block'
-						) }
-					</legend>
-					<ShippingRateSelector
-						shippingRates={ shippingRates }
-						shippingRatesLoading={ shippingRatesLoading }
-					/>
-				</fieldset>
+			{ ! isCheckout && showingRates && (
+				<ShippingRateSelector
+					shippingRates={ shippingRates }
+					shippingRatesLoading={ shippingRatesLoading }
+				/>
 			) }
 		</>
 	);
@@ -151,6 +145,7 @@ TotalsShippingItem.propTypes = {
 		total_shipping: PropTypes.string,
 		total_shipping_tax: PropTypes.string,
 	} ).isRequired,
+	isCheckout: PropTypes.bool,
 	showCalculator: PropTypes.bool,
 	showRatesWithoutAddress: PropTypes.bool,
 };

--- a/assets/js/base/components/totals/totals-shipping-item/shipping-rate-selector.js
+++ b/assets/js/base/components/totals/totals-shipping-item/shipping-rate-selector.js
@@ -26,15 +26,15 @@ const renderShippingRatesControlOption = ( option ) => ( {
 
 const ShippingRateSelector = ( { shippingRates, shippingRatesLoading } ) => {
 	return (
-		<fieldset className="wc-block-cart__shipping-options-fieldset">
+		<fieldset className="wc-block-totals__shipping-options-fieldset">
 			<legend className="screen-reader-text">
 				{ __(
-					'Choose the shipping method.',
+					'Choose a shipping method',
 					'woo-gutenberg-products-block'
 				) }
 			</legend>
 			<ShippingRatesControl
-				className="wc-block-cart__shipping-options"
+				className="wc-block-totals__shipping-options"
 				collapsibleWhenMultiple={ true }
 				noResultsMessage={ __(
 					'No shipping options were found.',

--- a/assets/js/base/components/totals/totals-shipping-item/style.scss
+++ b/assets/js/base/components/totals/totals-shipping-item/style.scss
@@ -1,0 +1,56 @@
+// Added extra class and label for specificity.
+fieldset.wc-block-totals__shipping-options-fieldset {
+	background-color: transparent;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.wc-block-totals__shipping-options {
+	.wc-block-radio-control__label,
+	.wc-block-radio-control__description,
+	.wc-block-radio-control__secondary-label,
+	.wc-block-radio-control__secondary-description {
+		flex-basis: 100%;
+		text-align: left;
+	}
+
+	.wc-block-radio-control__option {
+		padding-left: $gap-large;
+
+		&:last-child {
+			border-bottom: none;
+		}
+	}
+
+	.wc-block-radio-control__input {
+		left: 0;
+		margin: 0;
+	}
+}
+
+
+.wc-block-totals__change-address-button {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	box-shadow: none;
+	color: inherit;
+	font-family: inherit;
+	font-weight: inherit;
+	display: inline;
+	font-weight: inherit;
+	letter-spacing: inherit;
+	margin: 0;
+	padding: 0;
+	text-decoration: underline;
+	text-transform: none;
+	vertical-align: middle;
+
+	&:hover,
+	&:focus,
+	&:active {
+		background: transparent;
+		opacity: 0.8;
+	}
+}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -7,59 +7,6 @@
 	.wc-block-cart__shipping-calculator {
 		white-space: nowrap;
 	}
-	.wc-block-cart__change-address-button {
-		background: transparent;
-		border: 0;
-		border-radius: 0;
-		box-shadow: none;
-		color: inherit;
-		font-family: inherit;
-		font-weight: inherit;
-		display: inline;
-		font-weight: inherit;
-		letter-spacing: inherit;
-		margin: 0;
-		padding: 0;
-		text-decoration: underline;
-		text-transform: none;
-		vertical-align: middle;
-
-		&:hover,
-		&:focus,
-		&:active {
-			background: transparent;
-			opacity: 0.8;
-		}
-	}
-	// Added extra class and label for specificity.
-	fieldset.wc-block-cart__shipping-options-fieldset {
-		background-color: transparent;
-		margin: 0;
-		padding: 0;
-		border: 0;
-	}
-	.wc-block-cart__shipping-options {
-		.wc-block-radio-control__label,
-		.wc-block-radio-control__description,
-		.wc-block-radio-control__secondary-label,
-		.wc-block-radio-control__secondary-description {
-			flex-basis: 100%;
-			text-align: left;
-		}
-
-		.wc-block-radio-control__option {
-			padding-left: $gap-large;
-
-			&:last-child {
-				border-bottom: none;
-			}
-		}
-
-		.wc-block-radio-control__input {
-			left: 0;
-			margin: 0;
-		}
-	}
 }
 
 table.wc-block-cart-items,

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -332,7 +332,6 @@ const Block = ( {
 						cartCoupons={ cartCoupons }
 						cartItems={ cartItems }
 						cartTotals={ cartTotals }
-						shippingRates={ shippingRates }
 					/>
 				</Sidebar>
 			</SidebarLayout>

--- a/assets/js/blocks/cart-checkout/checkout/sidebar.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar.js
@@ -26,7 +26,6 @@ const CheckoutSidebar = ( {
 	cartCoupons = [],
 	cartItems = [],
 	cartTotals = {},
-	shippingRates,
 } ) => {
 	const {
 		applyCoupon,
@@ -34,7 +33,6 @@ const CheckoutSidebar = ( {
 		isApplyingCoupon,
 		isRemovingCoupon,
 	} = useStoreCartCoupons();
-	const shippingAddress = shippingRates[ 0 ]?.destination;
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
 
 	return (
@@ -51,7 +49,9 @@ const CheckoutSidebar = ( {
 			/>
 			<TotalsShippingItem
 				currency={ totalsCurrency }
-				shippingAddress={ shippingAddress }
+				noResultsMessage={ null }
+				isCheckout={ true }
+				showCalculator={ false }
 				values={ cartTotals }
 			/>
 			{ ! DISPLAY_CART_PRICES_INCLUDING_TAX && (


### PR DESCRIPTION
Fixes some issues we found after the recent merges.

* 5445e707b127596ff798adb7598b2b49ae26eb6f fixes a misalignment in the address form which was introduced in #1941. I think we initially missed it because it was only reproducible in Chrome.
* 8be46078d1e9257d3fd797f0b4f6b91775f5dbc7 prevents the Shipping Calculator from appearing in the _Checkout_ sidebar. I think we merged two PRs in parallel and they both conflicted in the way `<TotalsShippingItem />` was used.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/76646256-f29c1a00-655a-11ea-9e85-f5eaf2ef23d6.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/76645391-342bc580-6559-11ea-98cd-42a9a2bded9c.png)

### How to test the changes in this Pull Request:

1. In a post with the _Checkout_ block.
2. Verify there is no button to _Change address_ in the sidebar neither the list of shipping rates.
3. With a Chromium-based browser, verify the address form doesn't break into several rows.