### PR TITLE
Record a tracks event when merchant toggles cart shipping calculator:

### DIFF
--- a/assets/js/base/utils/index.js
+++ b/assets/js/base/utils/index.js
@@ -1,3 +1,4 @@
 export * from './errors';
 export * from './price';
 export * from './address';
+export * from './tracks';

--- a/assets/js/base/utils/tracks.js
+++ b/assets/js/base/utils/tracks.js
@@ -3,19 +3,17 @@
  */
 import { select } from '@wordpress/data';
 
-function isTracksAvailable() {
-	return typeof window.wcTracks.recordEvent === 'function';
-}
+// Stand-in wcTracks.recordEvent in case tracks is not available (for any reason).
+window.wcTracks = window.wcTracks || {};
+window.wcTracks.recordEvent = window.wcTracks.recordEvent || function() {};
 
 export const recordEditorEvent = function( event, props ) {
-	if ( ! isTracksAvailable() ) {
-		return;
-	}
-
 	// Force prefix - our editor events will be 'wcadmin_blocks_*'.
 	const blocksPrefix = 'blocks_';
 
 	const postData = select( 'core/editor' );
+
+	// If tracks is not available (e.g. opt-out), recordEvent is a no-op.
 	window.wcTracks.recordEvent( blocksPrefix + event, {
 		// Automatically include post id and post type props.
 		post_id: postData.getCurrentPostId(),

--- a/assets/js/base/utils/tracks.js
+++ b/assets/js/base/utils/tracks.js
@@ -8,7 +8,7 @@ function isTracksAvailable() {
 }
 
 export const recordEditorEvent = function( event, props ) {
-	if ( ! isTracksAvailable ) {
+	if ( ! isTracksAvailable() ) {
 		return;
 	}
 

--- a/assets/js/base/utils/tracks.js
+++ b/assets/js/base/utils/tracks.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
+function isTracksAvailable() {
+	return typeof window.wcTracks.recordEvent === 'function';
+}
+
+export const recordEditorEvent = function( event, props ) {
+	if ( ! isTracksAvailable ) {
+		return;
+	}
+
+	// Force prefix - our editor events will be 'wcadmin_blocks_*'.
+	const blocksPrefix = 'blocks_';
+
+	const postData = select( 'core/editor' );
+	window.wcTracks.recordEvent( blocksPrefix + event, {
+		// Automatically include post id and post type props.
+		post_id: postData.getCurrentPostId(),
+		post_type: postData.getCurrentPostType(),
+		...props,
+	} );
+};

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -87,9 +87,12 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 					checked={ isShippingCalculatorEnabled }
 					onChange={ () => {
-						recordEditorEvent( 'cart_shipping_calculator_toggled', {
-							enabled: ! isShippingCalculatorEnabled,
-						} );
+						recordEditorEvent(
+							'cart_settings_shipping_calculator_toggle',
+							{
+								enabled: ! isShippingCalculatorEnabled,
+							}
+						);
 						setAttributes( {
 							isShippingCalculatorEnabled: ! isShippingCalculatorEnabled,
 						} );

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -19,6 +19,7 @@ import { EditorProvider, useEditorContext } from '@woocommerce/base-context';
 import { useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import { getAdminLink } from '@woocommerce/settings';
+import { recordEditorEvent } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -85,11 +86,15 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						'woo-gutenberg-products-block'
 					) }
 					checked={ isShippingCalculatorEnabled }
-					onChange={ () =>
+					onChange={ () => {
+						const newEnabled = ! isShippingCalculatorEnabled;
+						recordEditorEvent( 'cart_shipping_calculator_toggled', {
+							enabled: newEnabled,
+						} );
 						setAttributes( {
-							isShippingCalculatorEnabled: ! isShippingCalculatorEnabled,
-						} )
-					}
+							isShippingCalculatorEnabled: newEnabled,
+						} );
+					} }
 				/>
 				<ToggleControl
 					label={ __(

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -87,12 +87,11 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 					checked={ isShippingCalculatorEnabled }
 					onChange={ () => {
-						const newEnabled = ! isShippingCalculatorEnabled;
 						recordEditorEvent( 'cart_shipping_calculator_toggled', {
-							enabled: newEnabled,
+							enabled: ! isShippingCalculatorEnabled,
 						} );
 						setAttributes( {
-							isShippingCalculatorEnabled: newEnabled,
+							isShippingCalculatorEnabled: ! isShippingCalculatorEnabled,
 						} );
 					} }
 				/>


### PR DESCRIPTION
Related #1273

This PR adds a utility function for triggering tracks events in blocks plugin, specifically for editor events for our blocks. This a wrapper for `window.wcTracks.recordEvent` which adds a standard prefix (so we can easily wrangle blocks events), and some standard props. I've added `post_type` and `post_id` props as an example; we can iterate on what standard props we want as we add events.

I've added one example event `cart_shipping_calculator_toggled`, with a boolean prop for whether the post author is toggling it on or off.

### How to test the changes in this Pull Request:

#### Test `cart_shipping_calculator_toggled` event

1. Enable usage tracking: `WooCommerce > Settings > Advanced > WooCommerce.com`.
2. Add a page and add cart block (or edit page containing cart block). 
3. Open dev tools Network tab, search for `pixel.wp.com` (so you can see events).
2. Toggle the shipping calculator option. You should see a network request for `cart_shipping_calculator_toggled` event; check the props are all correct and sensible.

<img width="637" alt="Screen Shot 2020-03-23 at 5 54 43 PM" src="https://user-images.githubusercontent.com/4167300/77282664-701c1300-6d2f-11ea-9014-e0866b5a312d.png">

Note: screenshot taken with Woo core https://github.com/woocommerce/woocommerce/pull/25977 - so the event also has new standard props `woo_version` and `url`.

#### Test the `recordEditorEvent` interface (optional)
- Try adding an event for some aspect of one of the Woo blocks. 
- Does `recordEditorEvent` work for your use case? 
- What custom props does your event need?
- What default props should we add to all events?

