### PR TITLE
disable coupon submit if the field is empty

### DIFF
--- a/assets/js/base/components/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/totals/totals-coupon-code-input/index.js
@@ -76,7 +76,7 @@ const TotalsCouponCodeInput = ( {
 						/>
 						<Button
 							className="wc-block-coupon-code__button"
-							disabled={ isLoading }
+							disabled={ isLoading || ! couponValue }
 							onClick={ ( e ) => {
 								e.preventDefault();
 								onSubmit( couponValue );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR disables the add coupon button if the field is empty, this is to prevent weird errors like `"" is already added` or `"" is not a valid coupon`.
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1965


### How to test the changes in this Pull Request:

1. in a cart or checkout block, trying submitting an empty coupon
2. the button shouldn’t work
3. try writing something
4. button is now enabled.