### PR TITLE
Use correct count from useStoreCart/API

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -43,6 +43,8 @@ import './editor.scss';
  * Component that renders the Cart block when user has something in cart aka "full".
  */
 const Cart = ( { attributes } ) => {
+	const { isShippingCalculatorEnabled, isShippingCostHidden } = attributes;
+
 	const {
 		cartItems,
 		cartTotals,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -43,8 +43,12 @@ import './editor.scss';
  * Component that renders the Cart block when user has something in cart aka "full".
  */
 const Cart = ( { attributes } ) => {
-	const { cartItems, cartTotals, cartIsLoading } = useStoreCart();
-	const { isShippingCalculatorEnabled, isShippingCostHidden } = attributes;
+	const {
+		cartItems,
+		cartTotals,
+		cartIsLoading,
+		cartItemsCount,
+	} = useStoreCart();
 
 	const {
 		applyCoupon,
@@ -63,7 +67,7 @@ const Cart = ( { attributes } ) => {
 	return (
 		<SidebarLayout className={ cartClassName }>
 			<Main className="wc-block-cart__main">
-				<CartLineItemsTitle itemCount={ cartItems.length } />
+				<CartLineItemsTitle itemCount={ cartItemsCount } />
 				<CartLineItemsTable
 					lineItems={ cartItems }
 					isLoading={ cartIsLoading }

--- a/assets/js/previews/cart.js
+++ b/assets/js/previews/cart.js
@@ -68,6 +68,9 @@ export const previewCart = {
 				price: '800',
 				regular_price: '800',
 				sale_price: '800',
+				line_price: '1600',
+				line_regular_price: '1600',
+				line_sale_price: '1600',
 			},
 			totals: {
 				currency_code: 'USD',
@@ -130,6 +133,9 @@ export const previewCart = {
 				price: '1400',
 				regular_price: '1600',
 				sale_price: '1400',
+				line_price: '1400',
+				line_regular_price: '1600',
+				line_sale_price: '1400',
 			},
 			totals: {
 				currency_code: 'USD',
@@ -146,7 +152,7 @@ export const previewCart = {
 			},
 		},
 	],
-	items_count: 4,
+	items_count: 3,
 	items_weight: 0,
 	needs_shipping: true,
 	totals: {


### PR DESCRIPTION
The API returns the correct item count (sum of all line item quantities) so let's use it.

Fixes #1954

### How to test the changes in this Pull Request:

See #1954

1. Add several items of varying qty to cart 
2. Check the title shows the sum of line item quantities, not the number of line items in the cart