### PR TITLE
Switch Add to Cart buttons to useStoreCart

### DIFF
--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -186,6 +186,34 @@ export function receiveRemovedItem( cartItemKey ) {
 }
 
 /**
+ * Adds an item to the cart:
+ * - Calls API to add item.
+ * - If successful, yields action to add item from store.
+ * - If error, yields action to store error.
+ * - Sets cart item as pending while API request is in progress.
+ *
+ * @param {number} productId Product ID to add to cart.
+ * @param {number} quantity Number of product ID being added to cart.
+ */
+export function* addItemToCart( productId, quantity = 1 ) {
+	try {
+		const cart = yield apiFetch( {
+			path: `/wc/store/cart/add-item`,
+			method: 'POST',
+			data: {
+				id: productId,
+				quantity,
+			},
+			cache: 'no-store',
+		} );
+
+		yield receiveCart( cart );
+	} catch ( error ) {
+		yield receiveError( error );
+	}
+}
+
+/**
  * Removes specified item from the cart:
  * - Calls API to remove item.
  * - If successful, yields action to remove item from store.

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -43,6 +43,19 @@
  */
 
 /**
+ * @typedef {Object} StoreCartItemAddToCart
+ *
+ * @property {number}   quantity               The quantity of the item in the
+ *                                             cart.
+ * @property {boolean}  addingToCart           Whether the cart item is still
+ *                                             being added or not.
+ * @property {boolean}  isLoading              Whether the cart is being loaded.
+ * @property {Function} addToCart              Callback for adding a cart item.
+ * @property {Object}   addToCartErrors        An array of errors thrown by
+ *                                             the cart.
+ */
+
+/**
  * @typedef {Object} StoreCartItemQuantity
  *
  * @property {number}   quantity               The quantity of the item in the

--- a/src/RestApi/StoreApi/Routes/CartAddItem.php
+++ b/src/RestApi/StoreApi/Routes/CartAddItem.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Cart add item route.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
+
+/**
+ * CartAddItem class.
+ */
+class CartAddItem extends AbstractRoute {
+	/**
+	 * Get the namespace for this route.
+	 *
+	 * @return string
+	 */
+	public function get_namespace() {
+		return 'wc/store';
+	}
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return '/cart/add-item';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'  => \WP_REST_Server::CREATABLE,
+				'callback' => [ $this, 'get_response' ],
+				'args'     => $this->schema->item_schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
+			],
+			'schema' => [ $this->schema->item_schema, 'get_public_item_schema' ],
+		];
+	}
+
+	/**
+	 * Handle the request and return a valid response for this endpoint.
+	 *
+	 * @throws RouteException On error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_post_response( \WP_REST_Request $request ) {
+		// Do not allow key to be specified during creation.
+		if ( ! empty( $request['key'] ) ) {
+			throw new RouteException( 'woocommerce_rest_cart_item_exists', __( 'Cannot create an existing cart item.', 'woo-gutenberg-products-block' ), 400 );
+		}
+
+		$controller = new CartController();
+		$cart       = $controller->get_cart_instance();
+		$result     = $controller->add_to_cart(
+			[
+				'id'        => $request['id'],
+				'quantity'  => $request['quantity'],
+				'variation' => $request['variation'],
+			]
+		);
+
+		$response = rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		$response->set_status( 201 );
+		return $response;
+	}
+}

--- a/src/RestApi/StoreApi/RoutesController.php
+++ b/src/RestApi/StoreApi/RoutesController.php
@@ -32,6 +32,7 @@ class RoutesController {
 
 		$routes = [
 			new Routes\Cart( $schemas['cart'] ),
+			new Routes\CartAddItem( $schemas['cart'] ),
 			new Routes\CartApplyCoupon( $schemas['cart'] ),
 			new Routes\CartCoupons( $schemas['coupon'] ),
 			new Routes\CartCouponsByCode( $schemas['coupon'] ),

--- a/src/RestApi/StoreApi/Schemas/AbstractSchema.php
+++ b/src/RestApi/StoreApi/Schemas/AbstractSchema.php
@@ -54,13 +54,13 @@ abstract class AbstractSchema {
 	}
 
 	/**
-	 * Retrieves an array of endpoint arguments from the item schema for the controller.
+	 * Retrieves an array of endpoint arguments from schema.
 	 *
+	 * @param array  $schema The array of schema data.
 	 * @param string $method Optional. HTTP method of the request.
 	 * @return array Endpoint arguments.
 	 */
-	public function get_endpoint_args_for_item_schema( $method = \WP_REST_Server::CREATABLE ) {
-		$schema            = $this->get_item_schema();
+	protected function get_endpoint_args_from_schema( $schema, $method = \WP_REST_Server::CREATABLE ) {
 		$schema_properties = ! empty( $schema['properties'] ) ? $schema['properties'] : array();
 		$endpoint_args     = array();
 
@@ -113,6 +113,16 @@ abstract class AbstractSchema {
 		}
 
 		return $endpoint_args;
+	}
+
+	/**
+	 * Retrieves an array of endpoint arguments from the item schema for the controller.
+	 *
+	 * @param string $method Optional. HTTP method of the request.
+	 * @return array Endpoint arguments.
+	 */
+	public function get_endpoint_args_for_item_schema( $method = \WP_REST_Server::CREATABLE ) {
+		return $this->get_endpoint_args_from_schema( $this->get_item_schema(), $method );
 	}
 
 	/**


### PR DESCRIPTION
@nerrad I did this thinking it would allow us to track cart changes from the Empty Cart state (add to cart->updates cart store). But we're using the old blocks...

Discard or polish/keep? I think it still might be a useful refactor.