### PR TITLE
Add Checkout form validation

### DIFF
--- a/assets/js/base/components/address-form/index.js
+++ b/assets/js/base/components/address-form/index.js
@@ -3,7 +3,7 @@
  */
 import { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import TextInput from '@woocommerce/base-components/text-input';
+import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
 import {
 	BillingCountryInput,
 	ShippingCountryInput,
@@ -162,7 +162,7 @@ const AddressForm = ( {
 				}
 
 				return (
-					<TextInput
+					<ValidatedTextInput
 						key={ field.key }
 						className={ `wc-block-address-form__${ field.key }` }
 						label={

--- a/assets/js/base/components/address-form/index.js
+++ b/assets/js/base/components/address-form/index.js
@@ -32,7 +32,7 @@ const validateShippingCountry = (
 	if (
 		! hasValidationError &&
 		! values.country &&
-		Object.values( values ).some( ( value ) => value !== '' )
+		( values.city || values.state || values.postcode )
 	) {
 		setValidationErrors( {
 			'shipping-missing-country': {

--- a/assets/js/base/components/address-form/index.js
+++ b/assets/js/base/components/address-form/index.js
@@ -11,38 +11,12 @@ import {
 	BillingStateInput,
 	ShippingStateInput,
 } from '@woocommerce/base-components/state-input';
-import { useValidationContext } from '@woocommerce/base-context';
-import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import defaultAddressFields from './default-address-fields';
 import countryAddressFields from './country-address-fields';
-
-const validateCountry = (
-	values,
-	setValidationErrors,
-	clearValidationError,
-	hasValidationError
-) => {
-	if (
-		! hasValidationError &&
-		! values.country &&
-		Object.values( values ).some( ( value ) => value !== '' )
-	) {
-		setValidationErrors( {
-			country: __(
-				'Please select a country to calculate rates.',
-				'woo-gutenberg-products-block'
-			),
-		} );
-	}
-	if ( hasValidationError && values.country ) {
-		clearValidationError( 'country' );
-	}
-};
 
 /**
  * Checkout address form.
@@ -54,35 +28,16 @@ const AddressForm = ( {
 	type = 'shipping',
 	values,
 } ) => {
-	const {
-		getValidationError,
-		setValidationErrors,
-		clearValidationError,
-	} = useValidationContext();
 	const countryLocale = countryAddressFields[ values.country ] || {};
 	const addressFields = fields.map( ( field ) => ( {
 		key: field,
 		...defaultAddressFields[ field ],
-		...fieldConfig[ field ],
 		...countryLocale[ field ],
+		...fieldConfig[ field ],
 	} ) );
 	const sortedAddressFields = addressFields.sort(
 		( a, b ) => a.index - b.index
 	);
-	const countryValidationError = getValidationError( 'country' );
-	useEffect( () => {
-		validateCountry(
-			values,
-			setValidationErrors,
-			clearValidationError,
-			!! countryValidationError
-		);
-	}, [
-		values,
-		countryValidationError,
-		setValidationErrors,
-		clearValidationError,
-	] );
 	return (
 		<div className="wc-block-address-form">
 			{ sortedAddressFields.map( ( field ) => {
@@ -114,6 +69,7 @@ const AddressForm = ( {
 									postcode: '',
 								} )
 							}
+							errorMessage={ field.errorMessage }
 							required={ field.required }
 						/>
 					);
@@ -141,6 +97,7 @@ const AddressForm = ( {
 									state: newValue,
 								} )
 							}
+							errorMessage={ field.errorMessage }
 							required={ field.required }
 						/>
 					);
@@ -161,6 +118,7 @@ const AddressForm = ( {
 								[ field.key ]: newValue,
 							} )
 						}
+						errorMessage={ field.errorMessage }
 						required={ field.required }
 					/>
 				);

--- a/assets/js/base/components/address-form/index.js
+++ b/assets/js/base/components/address-form/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
 import {
@@ -107,29 +106,32 @@ const AddressForm = ( {
 							? ShippingCountryInput
 							: BillingCountryInput;
 					return (
-						<Fragment key={ field.key }>
-							<Tag
-								label={
-									field.required
-										? field.label
-										: field.optionalLabel
-								}
-								value={ values.country }
-								autoComplete={ field.autocomplete }
-								onChange={ ( newValue ) =>
-									onChange( {
-										...values,
-										country: newValue,
-										state: '',
-										city: '',
-										postcode: '',
-									} )
-								}
-								errorId="shipping-missing-country"
-								errorMessage={ field.errorMessage }
-								required={ field.required }
-							/>
-						</Fragment>
+						<Tag
+							key={ field.key }
+							label={
+								field.required
+									? field.label
+									: field.optionalLabel
+							}
+							value={ values.country }
+							autoComplete={ field.autocomplete }
+							onChange={ ( newValue ) =>
+								onChange( {
+									...values,
+									country: newValue,
+									state: '',
+									city: '',
+									postcode: '',
+								} )
+							}
+							errorId={
+								type === 'shipping'
+									? 'shipping-missing-country'
+									: null
+							}
+							errorMessage={ field.errorMessage }
+							required={ field.required }
+						/>
 					);
 				}
 

--- a/assets/js/base/components/cart-checkout/place-order-button/index.js
+++ b/assets/js/base/components/cart-checkout/place-order-button/index.js
@@ -2,23 +2,33 @@
  * External dependencies
  */
 import { useCheckoutContext } from '@woocommerce/base-context';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 
-const PlaceOrderButton = () => {
+const PlaceOrderButton = ( { validateSubmit } ) => {
 	const { submitLabel, onSubmit } = useCheckoutContext();
 
 	return (
 		<Button
 			className="wc-block-components-checkout-place-order-button"
-			onClick={ onSubmit }
+			onClick={ () => {
+				const isValid = validateSubmit();
+				if ( isValid ) {
+					onSubmit();
+				}
+			} }
 		>
 			{ submitLabel }
 		</Button>
 	);
+};
+
+PlaceOrderButton.propTypes = {
+	validateSubmit: PropTypes.func.isRequired,
 };
 
 export default PlaceOrderButton;

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import Select from '../select';
+import { ValidatedSelect } from '../select';
 
 const CountryInput = ( {
 	className,
@@ -32,7 +32,7 @@ const CountryInput = ( {
 
 	return (
 		<div className={ classnames( className, 'wc-block-country-input' ) }>
-			<Select
+			<ValidatedSelect
 				label={ label }
 				onChange={ onChange }
 				options={ options }

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useValidationContext } from '@woocommerce/base-context';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Select from '../select';
-import { ValidationInputError } from '../validation';
 
 const CountryInput = ( {
 	className,
@@ -20,13 +19,15 @@ const CountryInput = ( {
 	value = '',
 	autoComplete = 'off',
 	required = false,
+	errorMessage = __(
+		'Please select a country.',
+		'woo-gutenberg-products-block'
+	),
 } ) => {
 	const options = Object.keys( countries ).map( ( key ) => ( {
 		key,
 		name: decodeEntities( countries[ key ] ),
 	} ) );
-	const { getValidationError } = useValidationContext();
-	const errorMessage = getValidationError( 'country' );
 
 	return (
 		<div className={ classnames( className, 'wc-block-country-input' ) }>
@@ -35,8 +36,8 @@ const CountryInput = ( {
 				onChange={ onChange }
 				options={ options }
 				value={ options.find( ( option ) => option.key === value ) }
+				errorMessage={ errorMessage }
 				required={ required }
-				hasError={ !! errorMessage }
 			/>
 			{ autoComplete !== 'off' && (
 				<input
@@ -61,7 +62,6 @@ const CountryInput = ( {
 					tabIndex={ -1 }
 				/>
 			) }
-			<ValidationInputError errorMessage={ errorMessage } />
 		</div>
 	);
 };
@@ -73,6 +73,7 @@ CountryInput.propTypes = {
 	label: PropTypes.string,
 	value: PropTypes.string,
 	autoComplete: PropTypes.string,
+	errorMessage: PropTypes.string,
 };
 
 export default CountryInput;

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -19,6 +19,7 @@ const CountryInput = ( {
 	value = '',
 	autoComplete = 'off',
 	required = false,
+	errorId,
 	errorMessage = __(
 		'Please select a country.',
 		'woo-gutenberg-products-block'
@@ -36,6 +37,7 @@ const CountryInput = ( {
 				onChange={ onChange }
 				options={ options }
 				value={ options.find( ( option ) => option.key === value ) }
+				errorId={ errorId }
 				errorMessage={ errorMessage }
 				required={ required }
 			/>
@@ -73,6 +75,7 @@ CountryInput.propTypes = {
 	label: PropTypes.string,
 	value: PropTypes.string,
 	autoComplete: PropTypes.string,
+	errorId: PropTypes.string,
 	errorMessage: PropTypes.string,
 };
 

--- a/assets/js/base/components/select/index.js
+++ b/assets/js/base/components/select/index.js
@@ -24,12 +24,14 @@ const Select = ( {
 	value,
 	instanceId,
 	required,
+	errorId,
 	errorMessage = __(
 		'Please select a value.',
 		'woo-gutenberg-products-block'
 	),
 } ) => {
 	const selectId = id || 'select-' + instanceId;
+	errorId = errorId || selectId;
 	const {
 		getValidationError,
 		setValidationErrors,
@@ -37,10 +39,10 @@ const Select = ( {
 	} = useValidationContext();
 	const validateSelect = () => {
 		if ( ! required || value ) {
-			clearValidationError( selectId );
+			clearValidationError( errorId );
 		} else {
 			setValidationErrors( {
-				[ selectId ]: {
+				[ errorId ]: {
 					message: errorMessage,
 					hidden: true,
 				},
@@ -52,7 +54,7 @@ const Select = ( {
 		validateSelect();
 	}, [ value ] );
 
-	const error = getValidationError( selectId ) || {};
+	const error = getValidationError( errorId ) || {};
 
 	return (
 		<div
@@ -70,7 +72,7 @@ const Select = ( {
 				options={ options }
 				value={ value }
 			/>
-			<ValidationInputError propertyName={ selectId } />
+			<ValidationInputError propertyName={ errorId } />
 		</div>
 	);
 };
@@ -84,6 +86,7 @@ Select.propTypes = {
 		} ).isRequired
 	).isRequired,
 	className: PropTypes.string,
+	errorId: PropTypes.string,
 	errorMessage: PropTypes.string,
 	id: PropTypes.string,
 	label: PropTypes.string,

--- a/assets/js/base/components/select/index.js
+++ b/assets/js/base/components/select/index.js
@@ -4,7 +4,6 @@
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { CustomSelectControl } from 'wordpress-components';
-import { withInstanceId } from 'wordpress-compose';
 
 /**
  * Internal dependencies
@@ -58,5 +57,5 @@ Select.propTypes = {
 	} ),
 };
 
-export default withInstanceId( Select );
+export default Select;
 export { default as ValidatedSelect } from './validated';

--- a/assets/js/base/components/select/index.js
+++ b/assets/js/base/components/select/index.js
@@ -1,9 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useEffect } from 'react';
-import { useValidationContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { CustomSelectControl } from 'wordpress-components';
@@ -12,56 +9,22 @@ import { withInstanceId } from 'wordpress-compose';
 /**
  * Internal dependencies
  */
-import { ValidationInputError } from '../validation';
 import './style.scss';
 
 const Select = ( {
 	className,
+	feedback,
 	id,
 	label,
 	onChange,
 	options,
 	value,
-	instanceId,
-	required,
-	errorId,
-	errorMessage = __(
-		'Please select a value.',
-		'woo-gutenberg-products-block'
-	),
 } ) => {
-	const selectId = id || 'select-' + instanceId;
-	errorId = errorId || selectId;
-	const {
-		getValidationError,
-		setValidationErrors,
-		clearValidationError,
-	} = useValidationContext();
-	const validateSelect = () => {
-		if ( ! required || value ) {
-			clearValidationError( errorId );
-		} else {
-			setValidationErrors( {
-				[ errorId ]: {
-					message: errorMessage,
-					hidden: true,
-				},
-			} );
-		}
-	};
-
-	useEffect( () => {
-		validateSelect();
-	}, [ value ] );
-
-	const error = getValidationError( errorId ) || {};
-
 	return (
 		<div
-			id={ selectId }
+			id={ id }
 			className={ classnames( 'wc-block-select', className, {
 				'is-active': value,
-				'has-error': error.message && ! error.hidden,
 			} ) }
 		>
 			<CustomSelectControl
@@ -72,7 +35,7 @@ const Select = ( {
 				options={ options }
 				value={ value }
 			/>
-			<ValidationInputError propertyName={ errorId } />
+			{ feedback }
 		</div>
 	);
 };
@@ -86,11 +49,9 @@ Select.propTypes = {
 		} ).isRequired
 	).isRequired,
 	className: PropTypes.string,
-	errorId: PropTypes.string,
-	errorMessage: PropTypes.string,
+	feedback: PropTypes.node,
 	id: PropTypes.string,
 	label: PropTypes.string,
-	required: PropTypes.bool,
 	value: PropTypes.shape( {
 		key: PropTypes.string.isRequired,
 		name: PropTypes.string.isRequired,
@@ -98,3 +59,4 @@ Select.propTypes = {
 };
 
 export default withInstanceId( Select );
+export { default as ValidatedSelect } from './validated';

--- a/assets/js/base/components/select/index.js
+++ b/assets/js/base/components/select/index.js
@@ -1,29 +1,77 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { useValidationContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { CustomSelectControl } from 'wordpress-components';
+import { withInstanceId } from 'wordpress-compose';
 
 /**
  * Internal dependencies
  */
+import { ValidationInputError } from '../validation';
 import './style.scss';
 
-const Select = ( { className, label, onChange, options, value, hasError } ) => {
+const Select = ( {
+	className,
+	id,
+	label,
+	onChange,
+	options,
+	value,
+	instanceId,
+	required,
+	errorMessage = __(
+		'Please select a value.',
+		'woo-gutenberg-products-block'
+	),
+} ) => {
+	const selectId = id || 'select-' + instanceId;
+	const {
+		getValidationError,
+		setValidationErrors,
+		clearValidationError,
+	} = useValidationContext();
+	const validateSelect = () => {
+		if ( ! required || value ) {
+			clearValidationError( selectId );
+		} else {
+			setValidationErrors( {
+				[ selectId ]: {
+					message: errorMessage,
+					hidden: true,
+				},
+			} );
+		}
+	};
+
+	useEffect( () => {
+		validateSelect();
+	}, [ value ] );
+
+	const error = getValidationError( selectId ) || {};
+
 	return (
-		<CustomSelectControl
+		<div
+			id={ selectId }
 			className={ classnames( 'wc-block-select', className, {
 				'is-active': value,
-				'has-error': hasError,
+				'has-error': error.message && ! error.hidden,
 			} ) }
-			label={ label }
-			onChange={ ( { selectedItem } ) => {
-				onChange( selectedItem.key );
-			} }
-			options={ options }
-			value={ value }
-		/>
+		>
+			<CustomSelectControl
+				label={ label }
+				onChange={ ( { selectedItem } ) => {
+					onChange( selectedItem.key );
+				} }
+				options={ options }
+				value={ value }
+			/>
+			<ValidationInputError propertyName={ selectId } />
+		</div>
 	);
 };
 
@@ -36,11 +84,14 @@ Select.propTypes = {
 		} ).isRequired
 	).isRequired,
 	className: PropTypes.string,
+	errorMessage: PropTypes.string,
+	id: PropTypes.string,
 	label: PropTypes.string,
+	required: PropTypes.bool,
 	value: PropTypes.shape( {
 		key: PropTypes.string.isRequired,
 		name: PropTypes.string.isRequired,
 	} ),
 };
 
-export default Select;
+export default withInstanceId( Select );

--- a/assets/js/base/components/select/validated.js
+++ b/assets/js/base/components/select/validated.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { useValidationContext } from '@woocommerce/base-context';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { withInstanceId } from 'wordpress-compose';
+
+/**
+ * Internal dependencies
+ */
+import { ValidationInputError } from '../validation';
+import Select from './index';
+import './style.scss';
+
+const ValidatedSelect = ( {
+	className,
+	id,
+	value,
+	instanceId,
+	required,
+	errorId,
+	errorMessage = __(
+		'Please select a value.',
+		'woo-gutenberg-products-block'
+	),
+	...rest
+} ) => {
+	const selectId = id || 'select-' + instanceId;
+	errorId = errorId || selectId;
+	const {
+		getValidationError,
+		setValidationErrors,
+		clearValidationError,
+	} = useValidationContext();
+	const validateSelect = () => {
+		if ( ! required || value ) {
+			clearValidationError( errorId );
+		} else {
+			setValidationErrors( {
+				[ errorId ]: {
+					message: errorMessage,
+					hidden: true,
+				},
+			} );
+		}
+	};
+
+	useEffect( () => {
+		validateSelect();
+	}, [ value ] );
+
+	const error = getValidationError( errorId ) || {};
+
+	return (
+		<Select
+			id={ selectId }
+			className={ classnames( className, {
+				'has-error': error.message && ! error.hidden,
+			} ) }
+			feedback={ <ValidationInputError propertyName={ errorId } /> }
+			value={ value }
+			{ ...rest }
+		/>
+	);
+};
+
+ValidatedSelect.propTypes = {
+	className: PropTypes.string,
+	errorId: PropTypes.string,
+	errorMessage: PropTypes.string,
+	id: PropTypes.string,
+	required: PropTypes.bool,
+	value: PropTypes.shape( {
+		key: PropTypes.string.isRequired,
+		name: PropTypes.string.isRequired,
+	} ),
+};
+
+export default withInstanceId( ValidatedSelect );

--- a/assets/js/base/components/shipping-calculator/address.js
+++ b/assets/js/base/components/shipping-calculator/address.js
@@ -21,13 +21,13 @@ const ShippingCalculatorAddress = ( {
 } ) => {
 	const [ address, setAddress ] = useState( initialAddress );
 	const {
-		areThereValidationErrors,
+		hasValidationErrors,
 		showAllValidationErrors,
 	} = useValidationContext();
 
 	const validateSubmit = () => {
 		showAllValidationErrors();
-		if ( areThereValidationErrors() ) {
+		if ( hasValidationErrors() ) {
 			return false;
 		}
 		return true;

--- a/assets/js/base/components/shipping-calculator/address.js
+++ b/assets/js/base/components/shipping-calculator/address.js
@@ -20,24 +20,56 @@ const ShippingCalculatorAddress = ( {
 	addressFields,
 } ) => {
 	const [ address, setAddress ] = useState( initialAddress );
-	const { getValidationError } = useValidationContext();
+	const {
+		areThereValidationErrors,
+		showAllValidationErrors,
+	} = useValidationContext();
+
+	const validateSubmit = () => {
+		showAllValidationErrors();
+		if ( areThereValidationErrors() ) {
+			return false;
+		}
+		return true;
+	};
+
+	// Make all fields optional except 'country'.
+	const fieldConfig = {};
+	addressFields.forEach( ( field ) => {
+		if ( field === 'country' ) {
+			fieldConfig[ field ] = {
+				...fieldConfig[ field ],
+				errorMessage: __(
+					'Please select a country to calculate rates.',
+					'woo-gutenberg-products-block'
+				),
+				required: true,
+			};
+		} else {
+			fieldConfig[ field ] = {
+				...fieldConfig[ field ],
+				required: false,
+			};
+		}
+	} );
 
 	return (
 		<form className="wc-block-shipping-calculator-address">
 			<AddressForm
 				fields={ addressFields }
+				fieldConfig={ fieldConfig }
 				onChange={ setAddress }
 				values={ address }
 			/>
 			<Button
 				className="wc-block-shipping-calculator-address__button"
-				disabled={
-					isShallowEqual( address, initialAddress ) ||
-					getValidationError( 'country' )
-				}
+				disabled={ isShallowEqual( address, initialAddress ) }
 				onClick={ ( e ) => {
 					e.preventDefault();
-					return onUpdate( address );
+					const isAddressValid = validateSubmit();
+					if ( isAddressValid ) {
+						return onUpdate( address );
+					}
 				} }
 				type="submit"
 			>

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -21,6 +21,7 @@ const StateInput = ( {
 	autoComplete = 'off',
 	value = '',
 	required = false,
+	errorId,
 	errorMessage = __(
 		'Please select a state.',
 		'woo-gutenberg-products-block'
@@ -72,6 +73,7 @@ const StateInput = ( {
 					onChange={ onChangeState }
 					options={ options }
 					value={ options.find( ( option ) => option.key === value ) }
+					errorId={ errorId }
 					errorMessage={ errorMessage }
 					required={ required }
 				/>
@@ -120,6 +122,7 @@ StateInput.propTypes = {
 	autoComplete: PropTypes.string,
 	className: PropTypes.string,
 	country: PropTypes.string,
+	errorId: PropTypes.string,
 	errorMessage: PropTypes.string,
 	label: PropTypes.string,
 	value: PropTypes.string,

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -9,8 +9,8 @@ import { useCallback, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import TextInput from '../text-input';
-import Select from '../select';
+import { ValidatedTextInput } from '../text-input';
+import { ValidatedSelect } from '../select';
 
 const StateInput = ( {
 	className,
@@ -67,7 +67,7 @@ const StateInput = ( {
 	if ( options.length > 0 ) {
 		return (
 			<>
-				<Select
+				<ValidatedSelect
 					className={ className }
 					label={ label }
 					onChange={ onChangeState }
@@ -100,7 +100,7 @@ const StateInput = ( {
 		);
 	}
 	return (
-		<TextInput
+		<ValidatedTextInput
 			className={ className }
 			label={ label }
 			onChange={ onChangeState }

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useCallback, useEffect } from '@wordpress/element';
@@ -20,6 +21,10 @@ const StateInput = ( {
 	autoComplete = 'off',
 	value = '',
 	required = false,
+	errorMessage = __(
+		'Please select a state.',
+		'woo-gutenberg-products-block'
+	),
 } ) => {
 	const countryStates = states[ country ];
 	const options = countryStates
@@ -67,6 +72,7 @@ const StateInput = ( {
 					onChange={ onChangeState }
 					options={ options }
 					value={ options.find( ( option ) => option.key === value ) }
+					errorMessage={ errorMessage }
 					required={ required }
 				/>
 				{ autoComplete !== 'off' && (
@@ -114,6 +120,7 @@ StateInput.propTypes = {
 	autoComplete: PropTypes.string,
 	className: PropTypes.string,
 	country: PropTypes.string,
+	errorMessage: PropTypes.string,
 	label: PropTypes.string,
 	value: PropTypes.string,
 };

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -21,11 +21,6 @@ const StateInput = ( {
 	autoComplete = 'off',
 	value = '',
 	required = false,
-	errorId,
-	errorMessage = __(
-		'Please select a state.',
-		'woo-gutenberg-products-block'
-	),
 } ) => {
 	const countryStates = states[ country ];
 	const options = countryStates
@@ -73,8 +68,10 @@ const StateInput = ( {
 					onChange={ onChangeState }
 					options={ options }
 					value={ options.find( ( option ) => option.key === value ) }
-					errorId={ errorId }
-					errorMessage={ errorMessage }
+					errorMessage={ __(
+						'Please select a state.',
+						'woo-gutenberg-products-block'
+					) }
 					required={ required }
 				/>
 				{ autoComplete !== 'off' && (
@@ -122,8 +119,6 @@ StateInput.propTypes = {
 	autoComplete: PropTypes.string,
 	className: PropTypes.string,
 	country: PropTypes.string,
-	errorId: PropTypes.string,
-	errorMessage: PropTypes.string,
 	label: PropTypes.string,
 	value: PropTypes.string,
 };

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -1,14 +1,10 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { useRef, useEffect } from 'react';
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
-import { withInstanceId } from 'wordpress-compose';
-import { useValidationContext } from '@woocommerce/base-context';
-import { ValidationInputError } from '@woocommerce/base-components/validation';
 
 /**
  * Internal dependencies
@@ -16,118 +12,84 @@ import { ValidationInputError } from '@woocommerce/base-components/validation';
 import Label from '../label';
 import './style.scss';
 
-const TextInput = ( {
-	className,
-	instanceId,
-	id,
-	type = 'text',
-	ariaLabel,
-	ariaDescribedBy,
-	label,
-	screenReaderLabel,
-	disabled,
-	help,
-	autoComplete = 'off',
-	value = '',
-	onChange,
-	required = false,
-	errorId,
-	validateOnMount = true,
-	showError = true,
-} ) => {
-	const [ isActive, setIsActive ] = useState( false );
-	const inputRef = useRef();
-	const {
-		getValidationError,
-		hideValidationError,
-		setValidationErrors,
-		clearValidationError,
-		getValidationErrorId,
-	} = useValidationContext();
+const TextInput = forwardRef(
+	(
+		{
+			className,
+			id,
+			type = 'text',
+			ariaLabel,
+			ariaDescribedBy,
+			label,
+			screenReaderLabel,
+			disabled,
+			help,
+			autoComplete = 'off',
+			value = '',
+			onChange,
+			required = false,
+			onBlur = () => {},
+			feedback,
+		},
+		ref
+	) => {
+		const [ isActive, setIsActive ] = useState( false );
 
-	const textInputId = id || 'textinput-' + instanceId;
-	errorId = errorId || textInputId;
-	const validateInput = ( errorsHidden = true ) => {
-		if ( inputRef.current.checkValidity() ) {
-			clearValidationError( errorId );
-		} else {
-			setValidationErrors( {
-				[ errorId ]: {
-					message:
-						inputRef.current.validationMessage ||
-						__( 'Invalid value.', 'woo-gutenberg-products-block' ),
-					hidden: errorsHidden,
-				},
-			} );
-		}
-	};
-
-	useEffect( () => {
-		if ( validateOnMount ) {
-			validateInput();
-		}
-	}, [ validateOnMount ] );
-
-	const errorMessage = getValidationError( errorId ) || {};
-	const hasError = errorMessage.message && ! errorMessage.hidden;
-	let describedBy =
-		!! help && ! ariaDescribedBy ? textInputId + '__help' : ariaDescribedBy;
-	if ( showError && hasError ) {
-		describedBy = getValidationErrorId( textInputId );
+		return (
+			<div
+				className={ classnames( 'wc-block-text-input', className, {
+					'is-active': isActive || value,
+				} ) }
+			>
+				<input
+					type={ type }
+					id={ id }
+					value={ value }
+					ref={ ref }
+					autoComplete={ autoComplete }
+					onChange={ ( event ) => {
+						onChange( event.target.value );
+					} }
+					onFocus={ () => setIsActive( true ) }
+					onBlur={ () => {
+						onBlur();
+						setIsActive( false );
+					} }
+					aria-label={ ariaLabel || label }
+					disabled={ disabled }
+					aria-describedby={
+						!! help && ! ariaDescribedBy
+							? id + '__help'
+							: ariaDescribedBy
+					}
+					required={ required }
+				/>
+				<Label
+					label={ label }
+					screenReaderLabel={ screenReaderLabel || label }
+					wrapperElement="label"
+					wrapperProps={ {
+						htmlFor: id,
+					} }
+					htmlFor={ id }
+				/>
+				{ !! help && (
+					<p
+						id={ id + '__help' }
+						className="wc-block-text-input__help"
+					>
+						{ help }
+					</p>
+				) }
+				{ feedback }
+			</div>
+		);
 	}
-
-	return (
-		<div
-			className={ classnames( 'wc-block-text-input', className, {
-				'is-active': isActive || value,
-				'has-error': hasError,
-			} ) }
-		>
-			<input
-				type={ type }
-				id={ textInputId }
-				value={ value }
-				ref={ inputRef }
-				autoComplete={ autoComplete }
-				onChange={ ( event ) => {
-					hideValidationError( errorId );
-					onChange( event.target.value );
-				} }
-				onFocus={ () => setIsActive( true ) }
-				onBlur={ () => {
-					validateInput( false );
-					setIsActive( false );
-				} }
-				aria-label={ ariaLabel || label }
-				disabled={ disabled }
-				aria-describedby={ describedBy }
-				required={ required }
-			/>
-			<Label
-				label={ label }
-				screenReaderLabel={ screenReaderLabel || label }
-				wrapperElement="label"
-				wrapperProps={ {
-					htmlFor: textInputId,
-				} }
-				htmlFor={ textInputId }
-			/>
-			{ !! help && (
-				<p
-					id={ textInputId + '__help' }
-					className="wc-block-text-input__help"
-				>
-					{ help }
-				</p>
-			) }
-			{ showError && <ValidationInputError propertyName={ errorId } /> }
-		</div>
-	);
-};
+);
 
 TextInput.propTypes = {
+	id: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,
-	id: PropTypes.string,
 	value: PropTypes.string,
 	ariaLabel: PropTypes.string,
 	ariaDescribedBy: PropTypes.string,
@@ -142,4 +104,5 @@ TextInput.propTypes = {
 	showError: PropTypes.bool,
 };
 
-export default withInstanceId( TextInput );
+export default TextInput;
+export { default as ValidatedTextInput } from './validated';

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -99,9 +99,6 @@ TextInput.propTypes = {
 	help: PropTypes.string,
 	autoComplete: PropTypes.string,
 	required: PropTypes.bool,
-	errorId: PropTypes.string,
-	validateOnMount: PropTypes.bool,
-	showError: PropTypes.bool,
 };
 
 export default TextInput;

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -3,13 +3,64 @@
 	margin-bottom: $gap-large;
 	white-space: nowrap;
 
+	label {
+		position: absolute;
+		transform: translateY(#{$gap-small});
+		left: 0;
+		transform-origin: top left;
+		font-size: 16px;
+		line-height: 22px;
+		color: $gray-50;
+		transition: transform 200ms ease;
+		margin: 0 $gap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: calc(100% - #{  2 * $gap });
+
+		@media screen and (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+	}
+
+	input:-webkit-autofill + label {
+		transform: translateY(#{$gap-smallest}) scale(0.75);
+	}
+
+	&.is-active label {
+		transform: translateY(#{$gap-smallest}) scale(0.75);
+	}
+
+	input[type="tel"],
+	input[type="url"],
+	input[type="text"],
+	input[type="email"] {
+		background-color: #fff;
+		padding: $gap-small $gap;
+		border-radius: 4px;
+		border: 1px solid $input-border-gray;
+		width: 100%;
+		font-size: 16px;
+		line-height: 22px;
+		font-family: inherit;
+		margin: 0;
+		box-sizing: border-box;
+		height: 48px;
+		color: $input-text-active;
+
+		&:focus {
+			background-color: #fff;
+		}
+	}
+
+	&.is-active input[type="tel"],
+	&.is-active input[type="url"],
+	&.is-active input[type="text"],
+	&.is-active input[type="email"] {
+		padding: $gap-large $gap $gap-smallest;
+	}
+
 	&.has-error input {
-		/**
-		 *  This is needed because of the input[type="*"] rules later in this
-		 *  file (and in themes like storefront) have higher specificity for
-		 *  border
-		 */
-		border-color: $error-red !important;
+		border-color: $error-red;
 		&:focus {
 			outline-color: $error-red;
 		}
@@ -18,56 +69,4 @@
 	&.has-error label {
 		color: $error-red;
 	}
-}
-
-.wc-block-text-input label {
-	position: absolute;
-	transform: translateY(#{$gap-small});
-	left: 0;
-	transform-origin: top left;
-	font-size: 16px;
-	line-height: 22px;
-	color: $gray-50;
-	transition: transform 200ms ease;
-	margin: 0 $gap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	max-width: calc(100% - #{  2 * $gap });
-
-	@media screen and (prefers-reduced-motion: reduce) {
-		transition: none;
-	}
-}
-.wc-block-text-input input:-webkit-autofill + label {
-	transform: translateY(#{$gap-smallest}) scale(0.75);
-}
-.wc-block-text-input.is-active label {
-	transform: translateY(#{$gap-smallest}) scale(0.75);
-}
-.wc-block-text-input input[type="tel"],
-.wc-block-text-input input[type="url"],
-.wc-block-text-input input[type="text"],
-.wc-block-text-input input[type="email"] {
-	background-color: #fff;
-	padding: $gap-small $gap;
-	border-radius: 4px;
-	border: 1px solid $input-border-gray;
-	width: 100%;
-	font-size: 16px;
-	line-height: 22px;
-	font-family: inherit;
-	margin: 0;
-	box-sizing: border-box;
-	height: 48px;
-	color: $input-text-active;
-
-	&:focus {
-		background-color: #fff;
-	}
-}
-.wc-block-text-input.is-active input[type="tel"],
-.wc-block-text-input.is-active input[type="url"],
-.wc-block-text-input.is-active input[type="text"],
-.wc-block-text-input.is-active input[type="email"] {
-	padding: $gap-large $gap $gap-smallest;
 }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -28,7 +28,7 @@
 	font-size: 16px;
 	line-height: 22px;
 	color: $gray-50;
-	transition: all 200ms ease;
+	transition: transform 200ms ease;
 	margin: 0 $gap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import { useValidationContext } from '@woocommerce/base-context';
+import { ValidationInputError } from '@woocommerce/base-components/validation';
+import { withInstanceId } from 'wordpress-compose';
+
+/**
+ * Internal dependencies
+ */
+import TextInput from './index';
+import './style.scss';
+
+const ValidatedTextInput = ( {
+	className,
+	instanceId,
+	id,
+	ariaDescribedBy,
+	help,
+	value = '',
+	errorId,
+	validateOnMount = true,
+	onChange,
+	showError = true,
+	...rest
+} ) => {
+	const inputRef = useRef();
+	const {
+		getValidationError,
+		hideValidationError,
+		setValidationErrors,
+		clearValidationError,
+		getValidationErrorId,
+	} = useValidationContext();
+
+	const textInputId = id || 'textinput-' + instanceId;
+	errorId = errorId || textInputId;
+	const validateInput = ( errorsHidden = true ) => {
+		if ( inputRef.current.checkValidity() ) {
+			clearValidationError( errorId );
+		} else {
+			setValidationErrors( {
+				[ errorId ]: {
+					message:
+						inputRef.current.validationMessage ||
+						__( 'Invalid value.', 'woo-gutenberg-products-block' ),
+					hidden: errorsHidden,
+				},
+			} );
+		}
+	};
+
+	useEffect( () => {
+		if ( validateOnMount ) {
+			validateInput();
+		}
+	}, [ validateOnMount ] );
+
+	const errorMessage = getValidationError( errorId ) || {};
+	const hasError = errorMessage.message && ! errorMessage.hidden;
+	let describedBy =
+		!! help && ! ariaDescribedBy ? textInputId + '__help' : ariaDescribedBy; // @todo can be removed?
+	if ( showError && hasError ) {
+		describedBy = getValidationErrorId( textInputId );
+	}
+
+	return (
+		<TextInput
+			className={ classnames( className, {
+				'has-error': hasError,
+			} ) }
+			id={ textInputId }
+			onBlur={ () => {
+				validateInput( false );
+			} }
+			feedback={
+				showError && <ValidationInputError propertyName={ errorId } />
+			}
+			value={ value }
+			ref={ inputRef }
+			onChange={ ( val ) => {
+				hideValidationError( errorId );
+				onChange( val );
+			} }
+			ariaDescribedBy={ describedBy }
+			{ ...rest }
+		/>
+	);
+};
+
+ValidatedTextInput.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	id: PropTypes.string,
+	value: PropTypes.string,
+	ariaLabel: PropTypes.string,
+	ariaDescribedBy: PropTypes.string,
+	label: PropTypes.string,
+	screenReaderLabel: PropTypes.string,
+	disabled: PropTypes.bool,
+	help: PropTypes.string,
+	autoComplete: PropTypes.string,
+	required: PropTypes.bool,
+	errorId: PropTypes.string,
+	validateOnMount: PropTypes.bool,
+	showError: PropTypes.bool,
+};
+
+export default withInstanceId( ValidatedTextInput );

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -20,8 +20,6 @@ const ValidatedTextInput = ( {
 	instanceId,
 	id,
 	ariaDescribedBy,
-	help,
-	value = '',
 	errorId,
 	validateOnMount = true,
 	onChange,
@@ -62,11 +60,10 @@ const ValidatedTextInput = ( {
 
 	const errorMessage = getValidationError( errorId ) || {};
 	const hasError = errorMessage.message && ! errorMessage.hidden;
-	let describedBy =
-		!! help && ! ariaDescribedBy ? textInputId + '__help' : ariaDescribedBy; // @todo can be removed?
-	if ( showError && hasError ) {
-		describedBy = getValidationErrorId( textInputId );
-	}
+	const describedBy =
+		showError && hasError
+			? getValidationErrorId( textInputId )
+			: ariaDescribedBy;
 
 	return (
 		<TextInput
@@ -80,7 +77,6 @@ const ValidatedTextInput = ( {
 			feedback={
 				showError && <ValidationInputError propertyName={ errorId } />
 			}
-			value={ value }
 			ref={ inputRef }
 			onChange={ ( val ) => {
 				hideValidationError( errorId );
@@ -96,14 +92,7 @@ ValidatedTextInput.propTypes = {
 	onChange: PropTypes.func.isRequired,
 	id: PropTypes.string,
 	value: PropTypes.string,
-	ariaLabel: PropTypes.string,
 	ariaDescribedBy: PropTypes.string,
-	label: PropTypes.string,
-	screenReaderLabel: PropTypes.string,
-	disabled: PropTypes.bool,
-	help: PropTypes.string,
-	autoComplete: PropTypes.string,
-	required: PropTypes.bool,
 	errorId: PropTypes.string,
 	validateOnMount: PropTypes.bool,
 	showError: PropTypes.bool,

--- a/assets/js/base/components/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/totals/totals-coupon-code-input/index.js
@@ -10,7 +10,6 @@ import Label from '@woocommerce/base-components/label';
 import { ValidationInputError } from '@woocommerce/base-components/validation';
 import PropTypes from 'prop-types';
 import { withInstanceId } from 'wordpress-compose';
-import classnames from 'classnames';
 import { useValidationContext } from '@woocommerce/base-context';
 
 /**
@@ -27,21 +26,18 @@ const TotalsCouponCodeInput = ( {
 } ) => {
 	const [ couponValue, setCouponValue ] = useState( '' );
 	const currentIsLoading = useRef( false );
-	const {
-		getValidationError,
-		clearValidationError,
-		getValidationErrorId,
-	} = useValidationContext();
-	const validationMessage = getValidationError( 'coupon' );
+	const { getValidationError, getValidationErrorId } = useValidationContext();
+
+	const validationError = getValidationError( 'coupon' );
 
 	useEffect( () => {
 		if ( currentIsLoading.current !== isLoading ) {
-			if ( ! isLoading && couponValue && ! validationMessage ) {
+			if ( ! isLoading && couponValue && ! validationError ) {
 				setCouponValue( '' );
 			}
 			currentIsLoading.current = isLoading;
 		}
-	}, [ isLoading, couponValue, validationMessage ] );
+	}, [ isLoading, couponValue, validationError ] );
 
 	const textInputId = `wc-block-coupon-code__input-${ instanceId }`;
 
@@ -75,12 +71,8 @@ const TotalsCouponCodeInput = ( {
 					<form className="wc-block-coupon-code__form">
 						<TextInput
 							id={ textInputId }
-							className={ classnames(
-								'wc-block-coupon-code__input',
-								{
-									'has-error': !! validationMessage,
-								}
-							) }
+							errorId="coupon"
+							className="wc-block-coupon-code__input"
 							label={ __(
 								'Enter code',
 								'woo-gutenberg-products-block'
@@ -91,8 +83,9 @@ const TotalsCouponCodeInput = ( {
 							) }
 							onChange={ ( newCouponValue ) => {
 								setCouponValue( newCouponValue );
-								clearValidationError( 'coupon' );
 							} }
+							validateOnMount={ false }
+							showError={ false }
 						/>
 						<Button
 							className="wc-block-coupon-code__button"
@@ -106,11 +99,11 @@ const TotalsCouponCodeInput = ( {
 							{ __( 'Apply', 'woo-gutenberg-products-block' ) }
 						</Button>
 					</form>
+					<ValidationInputError
+						propertyName="coupon"
+						elementId={ textInputId }
+					/>
 				</PanelRow>
-				<ValidationInputError
-					errorMessage={ validationMessage }
-					elementId={ textInputId }
-				/>
 			</LoadingMask>
 		</PanelBody>
 	);

--- a/assets/js/base/components/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/totals/totals-coupon-code-input/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { PanelBody, PanelRow } from 'wordpress-components';
 import { Button } from '@woocommerce/base-components/cart-checkout';
-import TextInput from '@woocommerce/base-components/text-input';
+import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
 import Label from '@woocommerce/base-components/label';
 import { ValidationInputError } from '@woocommerce/base-components/validation';
 import PropTypes from 'prop-types';
@@ -69,7 +69,7 @@ const TotalsCouponCodeInput = ( {
 			>
 				<PanelRow className="wc-block-coupon-code__row">
 					<form className="wc-block-coupon-code__form">
-						<TextInput
+						<ValidatedTextInput
 							id={ textInputId }
 							errorId="coupon"
 							className="wc-block-coupon-code__input"

--- a/assets/js/base/components/totals/totals-coupon-code-input/style.scss
+++ b/assets/js/base/components/totals/totals-coupon-code-input/style.scss
@@ -3,6 +3,7 @@
 	margin-bottom: 0;
 
 	.wc-block-coupon-code__input {
+		margin-bottom: 0;
 		margin-top: 0;
 		flex-grow: 1;
 	}
@@ -14,5 +15,15 @@
 		padding-left: $gap-large;
 		padding-right: $gap-large;
 		white-space: nowrap;
+	}
+}
+
+.wc-block-coupon-code__row {
+	flex-direction: column;
+
+	.wc-block-form-input-validation-error {
+		margin-top: $gap-smaller;
+		position: relative;
+		width: 100%;
 	}
 }

--- a/assets/js/base/components/validation/style.scss
+++ b/assets/js/base/components/validation/style.scss
@@ -1,13 +1,18 @@
 .wc-block-form-input-validation-error {
 	color: $error-red;
 	@include font-size(12);
-	margin-top: -$gap-large;
-	padding-top: $gap-smallest;
-	display: block;
+	max-width: 100%;
+	position: absolute;
+	top: calc(100% - 1px);
+	white-space: normal;
 
 	> p {
-		padding: 0;
+		align-items: center;
+		display: flex;
+		line-height: 12px; // This allows two lines in a 24px bottom margin.
 		margin: 0;
+		min-height: 24px;
+		padding: 0;
 	}
 }
 

--- a/assets/js/base/components/validation/validation-input-error.js
+++ b/assets/js/base/components/validation/validation-input-error.js
@@ -15,10 +15,15 @@ export const ValidationInputError = ( {
 	elementId = '',
 } ) => {
 	const { getValidationError, getValidationErrorId } = useValidationContext();
-	if ( ! errorMessage && ! propertyName ) {
-		return null;
+	if ( ! errorMessage ) {
+		const error = getValidationError( propertyName ) || {};
+		if ( error.message && ! error.hidden ) {
+			errorMessage = error.message;
+		} else {
+			return null;
+		}
 	}
-	errorMessage = errorMessage || getValidationError( propertyName );
+
 	return (
 		<div className="wc-block-form-input-validation-error" role="alert">
 			<p id={ getValidationErrorId( elementId ) }>{ errorMessage }</p>

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -38,11 +38,11 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *
 	 * @param {string} property The property the error message is for.
 	 *
-	 * @return {string} Either the error message for the given property or an
-	 *                  empty string.
+	 * @return {Object} The error object for the given property.
 	 */
-	const getValidationError = ( property ) =>
-		validationErrors[ property ] || '';
+	const getValidationError = ( property ) => {
+		return validationErrors[ property ];
+	};
 
 	/**
 	 * Clears any validation error that exists in state for the given property
@@ -73,11 +73,80 @@ export const ValidationContextProvider = ( { children } ) => {
 		// all values must be a string.
 		newErrors = pickBy(
 			newErrors,
-			( message ) => typeof message === 'string'
+			( { message } ) => typeof message === 'string'
 		);
 		if ( Object.values( newErrors ).length > 0 ) {
-			updateValidationErrors( { ...validationErrors, ...newErrors } );
+			updateValidationErrors( ( prevErrors ) => ( {
+				...prevErrors,
+				...newErrors,
+			} ) );
 		}
+	};
+
+	const updateValidationError = ( property, newError ) => {
+		updateValidationErrors( ( prevErrors ) => {
+			if ( ! prevErrors.hasOwnProperty( property ) ) {
+				return prevErrors;
+			}
+			return {
+				...prevErrors,
+				[ property ]: {
+					...prevErrors[ property ],
+					...newError,
+				},
+			};
+		} );
+	};
+
+	/**
+	 * Given a property name and if an associated error exists, it sets its
+	 * `hidden` value to true.
+	 *
+	 * @param {string} property  The name of the property to set the `hidden`
+	 *                           value to true.
+	 */
+	const hideValidationError = ( property ) => {
+		updateValidationError( property, {
+			hidden: true,
+		} );
+	};
+
+	/**
+	 * Given a property name and if an associated error exists, it sets its
+	 * `hidden` value to false.
+	 *
+	 * @param {string} property  The name of the property to set the `hidden`
+	 *                           value to false.
+	 */
+	const showValidationError = ( property ) => {
+		updateValidationError( property, {
+			hidden: false,
+		} );
+	};
+
+	/**
+	 * Sets the `hidden` value of all errors to `false`.
+	 */
+	const showAllValidationErrors = () => {
+		updateValidationErrors( ( prevErrors ) => {
+			const newErrors = {};
+			Object.keys( prevErrors ).forEach( ( property ) => {
+				newErrors[ property ] = {
+					...prevErrors[ property ],
+					hidden: false,
+				};
+			} );
+			return newErrors;
+		} );
+	};
+
+	/**
+	 * Allows checking if the current context has at least one validation error.
+	 *
+	 * @return {boolean} Whether there is at least one error.
+	 */
+	const areThereValidationErrors = () => {
+		return Object.keys( validationErrors ).length > 0;
 	};
 
 	/**
@@ -98,6 +167,10 @@ export const ValidationContextProvider = ( { children } ) => {
 		clearValidationError,
 		clearAllValidationErrors,
 		getValidationErrorId,
+		hideValidationError,
+		showValidationError,
+		showAllValidationErrors,
+		areThereValidationErrors,
 	};
 	return (
 		<ValidationContext.Provider value={ context }>

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -143,7 +143,7 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *
 	 * @return {boolean} Whether there is at least one error.
 	 */
-	const areThereValidationErrors = () => {
+	const hasValidationErrors = () => {
 		return Object.keys( validationErrors ).length > 0;
 	};
 
@@ -168,7 +168,7 @@ export const ValidationContextProvider = ( { children } ) => {
 		hideValidationError,
 		showValidationError,
 		showAllValidationErrors,
-		areThereValidationErrors,
+		hasValidationErrors,
 	};
 	return (
 		<ValidationContext.Provider value={ context }>

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -40,9 +40,7 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *
 	 * @return {Object} The error object for the given property.
 	 */
-	const getValidationError = ( property ) => {
-		return validationErrors[ property ];
-	};
+	const getValidationError = ( property ) => validationErrors[ property ];
 
 	/**
 	 * Clears any validation error that exists in state for the given property

--- a/assets/js/base/hooks/cart/use-store-cart-coupons.js
+++ b/assets/js/base/hooks/cart/use-store-cart-coupons.js
@@ -58,7 +58,9 @@ export const useStoreCartCoupons = () => {
 						}
 					} )
 					.catch( ( error ) => {
-						setValidationErrors( { coupon: error.message } );
+						setValidationErrors( {
+							coupon: { message: error.message, hidden: false },
+						} );
 						// Finished handling the coupon.
 						receiveApplyingCoupon( '' );
 					} );

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -22,7 +22,7 @@ import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import {
 	CheckoutProvider,
-	ValidationContextProvider,
+	useValidationContext,
 } from '@woocommerce/base-context';
 import {
 	ExpressCheckoutFormControl,
@@ -37,6 +37,7 @@ import {
 	Main,
 } from '@woocommerce/base-components/sidebar-layout';
 import { getSetting } from '@woocommerce/settings';
+import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 
 /**
  * Internal dependencies
@@ -52,6 +53,7 @@ const Block = ( {
 	cartTotals = {},
 	isEditor = false,
 	shippingRates = [],
+	scrollToTop,
 } ) => {
 	const [ selectedShippingRate, setSelectedShippingRate ] = useState( {} );
 	const [ contactFields, setContactFields ] = useState( {} );
@@ -60,6 +62,19 @@ const Block = ( {
 	const [ useShippingAsBilling, setUseShippingAsBilling ] = useState(
 		attributes.useShippingAsBilling
 	);
+	const {
+		areThereValidationErrors,
+		showAllValidationErrors,
+	} = useValidationContext();
+
+	const validateSubmit = () => {
+		showAllValidationErrors();
+		if ( areThereValidationErrors() ) {
+			scrollToTop( { focusableSelector: 'input:invalid' } );
+			return false;
+		}
+		return true;
+	};
 
 	const renderShippingRatesControlOption = ( option ) => ( {
 		label: decodeEntities( option.name ),
@@ -100,266 +115,262 @@ const Block = ( {
 	} = useShippingRates();
 
 	return (
-		<ValidationContextProvider>
-			<CheckoutProvider isEditor={ isEditor }>
-				<SidebarLayout className="wc-block-checkout">
-					<Main>
-						<ExpressCheckoutFormControl />
-						<CheckoutForm>
+		<CheckoutProvider isEditor={ isEditor }>
+			<SidebarLayout className="wc-block-checkout">
+				<Main>
+					<ExpressCheckoutFormControl />
+					<CheckoutForm>
+						<FormStep
+							id="contact-fields"
+							className="wc-block-checkout__contact-fields"
+							title={ __(
+								'Contact information',
+								'woo-gutenberg-products-block'
+							) }
+							description={ __(
+								"We'll use this email to send you details and updates about your order.",
+								'woo-gutenberg-products-block'
+							) }
+							stepHeadingContent={ () => (
+								<Fragment>
+									{ __(
+										'Already have an account? ',
+										'woo-gutenberg-products-block'
+									) }
+									<a href="/wp-login.php">
+										{ __(
+											'Log in.',
+											'woo-gutenberg-products-block'
+										) }
+									</a>
+								</Fragment>
+							) }
+						>
+							<TextInput
+								type="email"
+								label={ __(
+									'Email address',
+									'woo-gutenberg-products-block'
+								) }
+								value={ contactFields.email }
+								autoComplete="email"
+								onChange={ ( newValue ) => {
+									setContactFields( {
+										...contactFields,
+										email: newValue,
+									} );
+								} }
+								required={ true }
+							/>
+							<CheckboxControl
+								className="wc-block-checkout__keep-updated"
+								label={ __(
+									'Keep me up to date on news and exclusive offers',
+									'woo-gutenberg-products-block'
+								) }
+								checked={ contactFields.keepUpdated }
+								onChange={ () =>
+									setContactFields( {
+										...contactFields,
+										keepUpdated: ! contactFields.keepUpdated,
+									} )
+								}
+							/>
+						</FormStep>
+						{ SHIPPING_ENABLED && (
 							<FormStep
-								id="contact-fields"
-								className="wc-block-checkout__contact-fields"
+								id="shipping-fields"
+								className="wc-block-checkout__shipping-fields"
 								title={ __(
-									'Contact information',
+									'Shipping address',
 									'woo-gutenberg-products-block'
 								) }
 								description={ __(
-									"We'll use this email to send you details and updates about your order.",
+									'Enter the physical address where you want us to deliver your order.',
 									'woo-gutenberg-products-block'
 								) }
-								stepHeadingContent={ () => (
-									<Fragment>
-										{ __(
-											'Already have an account? ',
-											'woo-gutenberg-products-block'
-										) }
-										<a href="/wp-login.php">
-											{ __(
-												'Log in.',
-												'woo-gutenberg-products-block'
-											) }
-										</a>
-									</Fragment>
-								) }
 							>
-								<TextInput
-									type="email"
-									label={ __(
-										'Email address',
-										'woo-gutenberg-products-block'
-									) }
-									value={ contactFields.email }
-									autoComplete="email"
-									onChange={ ( newValue ) =>
-										setContactFields( {
-											...contactFields,
-											email: newValue,
-										} )
-									}
-									required={ true }
+								<AddressForm
+									onChange={ setShippingFields }
+									values={ shippingFields }
+									fields={ Object.keys( addressFields ) }
+									fieldConfig={ addressFields }
 								/>
-								<CheckboxControl
-									className="wc-block-checkout__keep-updated"
-									label={ __(
-										'Keep me up to date on news and exclusive offers',
-										'woo-gutenberg-products-block'
-									) }
-									checked={ contactFields.keepUpdated }
-									onChange={ () =>
-										setContactFields( {
-											...contactFields,
-											keepUpdated: ! contactFields.keepUpdated,
-										} )
-									}
-								/>
-							</FormStep>
-							{ SHIPPING_ENABLED && (
-								<FormStep
-									id="shipping-fields"
-									className="wc-block-checkout__shipping-fields"
-									title={ __(
-										'Shipping address',
-										'woo-gutenberg-products-block'
-									) }
-									description={ __(
-										'Enter the physical address where you want us to deliver your order.',
-										'woo-gutenberg-products-block'
-									) }
-								>
-									<AddressForm
-										onChange={ setShippingFields }
-										values={ shippingFields }
-										fields={ Object.keys( addressFields ) }
-										fieldConfig={ addressFields }
-									/>
-									{ attributes.showPhoneField && (
-										<TextInput
-											type="tel"
-											label={
-												attributes.requirePhoneField
-													? __(
-															'Phone',
-															'woo-gutenberg-products-block'
-													  )
-													: __(
-															'Phone (optional)',
-															'woo-gutenberg-products-block'
-													  )
-											}
-											value={ shippingFields.phone }
-											autoComplete="tel"
-											onChange={ ( newValue ) =>
-												setShippingFields( {
-													...shippingFields,
-													phone: newValue,
-												} )
-											}
-											required={
-												attributes.requirePhoneField
-											}
-										/>
-									) }
-									<CheckboxControl
-										className="wc-block-checkout__use-address-for-billing"
-										label={ __(
-											'Use same address for billing',
-											'woo-gutenberg-products-block'
-										) }
-										checked={ useShippingAddressAsBilling }
-										onChange={ ( isChecked ) =>
-											setUseShippingAsBilling( isChecked )
+								{ attributes.showPhoneField && (
+									<TextInput
+										type="tel"
+										label={
+											attributes.requirePhoneField
+												? __(
+														'Phone',
+														'woo-gutenberg-products-block'
+												  )
+												: __(
+														'Phone (optional)',
+														'woo-gutenberg-products-block'
+												  )
 										}
-									/>
-								</FormStep>
-							) }
-							{ showBillingFields && (
-								<FormStep
-									id="billing-fields"
-									className="wc-block-checkout__billing-fields"
-									title={ __(
-										'Billing address',
-										'woo-gutenberg-products-block'
-									) }
-									description={ __(
-										'Enter the address that matches your card or payment method.',
-										'woo-gutenberg-products-block'
-									) }
-								>
-									<AddressForm
-										onChange={ setBillingFields }
-										type="billing"
-										values={ billingFields }
-										fields={ Object.keys( addressFields ) }
-										fieldConfig={ addressFields }
-									/>
-								</FormStep>
-							) }
-							{ SHIPPING_ENABLED && (
-								<FormStep
-									id="shipping-option"
-									className="wc-block-checkout__shipping-option"
-									title={ __(
-										'Shipping options',
-										'woo-gutenberg-products-block'
-									) }
-									description={ __(
-										'Select a shipping method below.',
-										'woo-gutenberg-products-block'
-									) }
-								>
-									{ shippingRates.length === 0 && isEditor ? (
-										<NoShipping />
-									) : (
-										<ShippingRatesControl
-											address={
-												shippingFields.country
-													? {
-															address_1:
-																shippingFields.address_1,
-															address_2:
-																shippingFields.apartment,
-															city:
-																shippingFields.city,
-															state:
-																shippingFields.state,
-															postcode:
-																shippingFields.postcode,
-															country:
-																shippingFields.country,
-													  }
-													: null
-											}
-											noResultsMessage={ __(
-												'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.',
-												'woo-gutenberg-products-block'
-											) }
-											renderOption={
-												renderShippingRatesControlOption
-											}
-											shippingRates={ shippingRates }
-											shippingRatesLoading={
-												shippingRatesLoading
-											}
-										/>
-									) }
-									<CheckboxControl
-										className="wc-block-checkout__add-note"
-										label="Add order notes?"
-										checked={
-											selectedShippingRate.orderNote
-										}
-										onChange={ () =>
-											setSelectedShippingRate( {
-												...selectedShippingRate,
-												orderNote: ! selectedShippingRate.orderNote,
+										value={ shippingFields.phone }
+										autoComplete="tel"
+										onChange={ ( newValue ) =>
+											setShippingFields( {
+												...shippingFields,
+												phone: newValue,
 											} )
 										}
+										required={
+											attributes.requirePhoneField
+										}
 									/>
-								</FormStep>
-							) }
-							<FormStep
-								id="payment-method"
-								className="wc-block-checkout__payment-method"
-								title={ __(
-									'Payment method',
-									'woo-gutenberg-products-block'
 								) }
-								description={ __(
-									'Select a payment method below.',
-									'woo-gutenberg-products-block'
-								) }
-							>
-								<PaymentMethods />
-								{ /*@todo this should be something the payment method controls*/ }
 								<CheckboxControl
-									className="wc-block-checkout__save-card-info"
+									className="wc-block-checkout__use-address-for-billing"
 									label={ __(
-										'Save payment information to my account for future purchases.',
+										'Use same address for billing',
 										'woo-gutenberg-products-block'
 									) }
-									checked={ shouldSavePayment }
-									onChange={ () =>
-										setShouldSavePayment(
-											! shouldSavePayment
-										)
+									checked={ useShippingAddressAsBilling }
+									onChange={ ( isChecked ) =>
+										setUseShippingAsBilling( isChecked )
 									}
 								/>
 							</FormStep>
-							<div className="wc-block-checkout__actions">
-								{ attributes.showReturnToCart && (
-									<ReturnToCartButton
-										link={ getSetting(
-											'page-' + attributes?.cartPageId,
-											false
+						) }
+						{ showBillingFields && (
+							<FormStep
+								id="billing-fields"
+								className="wc-block-checkout__billing-fields"
+								title={ __(
+									'Billing address',
+									'woo-gutenberg-products-block'
+								) }
+								description={ __(
+									'Enter the address that matches your card or payment method.',
+									'woo-gutenberg-products-block'
+								) }
+							>
+								<AddressForm
+									onChange={ setBillingFields }
+									type="billing"
+									values={ billingFields }
+									fields={ Object.keys( addressFields ) }
+									fieldConfig={ addressFields }
+								/>
+							</FormStep>
+						) }
+						{ SHIPPING_ENABLED && (
+							<FormStep
+								id="shipping-option"
+								className="wc-block-checkout__shipping-option"
+								title={ __(
+									'Shipping options',
+									'woo-gutenberg-products-block'
+								) }
+								description={ __(
+									'Select a shipping method below.',
+									'woo-gutenberg-products-block'
+								) }
+							>
+								{ shippingRates.length === 0 && isEditor ? (
+									<NoShipping />
+								) : (
+									<ShippingRatesControl
+										address={
+											shippingFields.country
+												? {
+														address_1:
+															shippingFields.address_1,
+														address_2:
+															shippingFields.apartment,
+														city:
+															shippingFields.city,
+														state:
+															shippingFields.state,
+														postcode:
+															shippingFields.postcode,
+														country:
+															shippingFields.country,
+												  }
+												: null
+										}
+										noResultsMessage={ __(
+											'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.',
+											'woo-gutenberg-products-block'
 										) }
+										renderOption={
+											renderShippingRatesControlOption
+										}
+										shippingRates={ shippingRates }
+										shippingRatesLoading={
+											shippingRatesLoading
+										}
 									/>
 								) }
-								<PlaceOrderButton />
-							</div>
-							{ attributes.showPolicyLinks && <Policies /> }
-						</CheckoutForm>
-					</Main>
-					<Sidebar className="wc-block-checkout__sidebar">
-						<CheckoutSidebar
-							cartCoupons={ cartCoupons }
-							cartItems={ cartItems }
-							cartTotals={ cartTotals }
-						/>
-					</Sidebar>
-				</SidebarLayout>
-			</CheckoutProvider>
-		</ValidationContextProvider>
+								<CheckboxControl
+									className="wc-block-checkout__add-note"
+									label="Add order notes?"
+									checked={ selectedShippingRate.orderNote }
+									onChange={ () =>
+										setSelectedShippingRate( {
+											...selectedShippingRate,
+											orderNote: ! selectedShippingRate.orderNote,
+										} )
+									}
+								/>
+							</FormStep>
+						) }
+						<FormStep
+							id="payment-method"
+							className="wc-block-checkout__payment-method"
+							title={ __(
+								'Payment method',
+								'woo-gutenberg-products-block'
+							) }
+							description={ __(
+								'Select a payment method below.',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							<PaymentMethods />
+							{ /*@todo this should be something the payment method controls*/ }
+							<CheckboxControl
+								className="wc-block-checkout__save-card-info"
+								label={ __(
+									'Save payment information to my account for future purchases.',
+									'woo-gutenberg-products-block'
+								) }
+								checked={ shouldSavePayment }
+								onChange={ () =>
+									setShouldSavePayment( ! shouldSavePayment )
+								}
+							/>
+						</FormStep>
+						<div className="wc-block-checkout__actions">
+							{ attributes.showReturnToCart && (
+								<ReturnToCartButton
+									link={ getSetting(
+										'page-' + attributes?.cartPageId,
+										false
+									) }
+								/>
+							) }
+							<PlaceOrderButton
+								validateSubmit={ validateSubmit }
+							/>
+						</div>
+						{ attributes.showPolicyLinks && <Policies /> }
+					</CheckoutForm>
+				</Main>
+				<Sidebar className="wc-block-checkout__sidebar">
+					<CheckoutSidebar
+						cartCoupons={ cartCoupons }
+						cartItems={ cartItems }
+						cartTotals={ cartTotals }
+					/>
+				</Sidebar>
+			</SidebarLayout>
+		</CheckoutProvider>
 	);
 };
 
-export default Block;
+export default withScrollToTop( Block );

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -154,12 +154,12 @@ const Block = ( {
 								) }
 								value={ contactFields.email }
 								autoComplete="email"
-								onChange={ ( newValue ) => {
+								onChange={ ( newValue ) =>
 									setContactFields( {
 										...contactFields,
 										email: newValue,
-									} );
-								} }
+									} )
+								}
 								required={ true }
 							/>
 							<CheckboxControl

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -68,8 +68,8 @@ const Block = ( {
 	} = useValidationContext();
 
 	const validateSubmit = () => {
-		showAllValidationErrors();
 		if ( areThereValidationErrors() ) {
+			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 			return false;
 		}

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -15,7 +15,7 @@ import {
 	PlaceOrderButton,
 	ReturnToCartButton,
 } from '@woocommerce/base-components/cart-checkout';
-import TextInput from '@woocommerce/base-components/text-input';
+import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
 import ShippingRatesControl from '@woocommerce/base-components/shipping-rates-control';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
@@ -146,7 +146,7 @@ const Block = ( {
 								</Fragment>
 							) }
 						>
-							<TextInput
+							<ValidatedTextInput
 								type="email"
 								label={ __(
 									'Email address',
@@ -197,7 +197,7 @@ const Block = ( {
 									fieldConfig={ addressFields }
 								/>
 								{ attributes.showPhoneField && (
-									<TextInput
+									<ValidatedTextInput
 										type="tel"
 										label={
 											attributes.requirePhoneField

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -63,12 +63,12 @@ const Block = ( {
 		attributes.useShippingAsBilling
 	);
 	const {
-		areThereValidationErrors,
+		hasValidationErrors,
 		showAllValidationErrors,
 	} = useValidationContext();
 
 	const validateSubmit = () => {
-		if ( areThereValidationErrors() ) {
+		if ( hasValidationErrors() ) {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 			return false;

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -7,7 +7,10 @@ import {
 	withStoreCartApiHydration,
 } from '@woocommerce/block-hocs';
 import { useStoreCart } from '@woocommerce/base-hooks';
-import { StoreNoticesProvider } from '@woocommerce/base-context';
+import {
+	StoreNoticesProvider,
+	ValidationContextProvider,
+} from '@woocommerce/base-context';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
@@ -59,13 +62,15 @@ const CheckoutFrontend = ( props ) => {
 					showErrorMessage={ CURRENT_USER_IS_ADMIN }
 				>
 					<StoreNoticesProvider context="wc/checkout">
-						<Block
-							{ ...props }
-							cartCoupons={ cartCoupons }
-							cartItems={ cartItems }
-							cartTotals={ cartTotals }
-							shippingRates={ shippingRates }
-						/>
+						<ValidationContextProvider>
+							<Block
+								{ ...props }
+								cartCoupons={ cartCoupons }
+								cartItems={ cartItems }
+								cartTotals={ cartTotals }
+								shippingRates={ shippingRates }
+							/>
+						</ValidationContextProvider>
 					</StoreNoticesProvider>
 				</BlockErrorBoundary>
 			) }

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -236,7 +236,7 @@
  *                                                               error to false.
  * @property {function()}               showAllValidationErrors  Sets the hidden prop of all
  *                                                               errors to false.
- * @property {function():boolean}       areThereValidationErrors Returns true if there is at least
+ * @property {function():boolean}       hasValidationErrors      Returns true if there is at least
  *                                                               one error.
  */
 

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -218,10 +218,9 @@
 /**
  * @typedef {Object} ValidationContext
  *
- * @property {function(string):string}  getValidationError       Return validation error or empty
- *                                                               string if it doesn't exist for the
+ * @property {function(string):Object}  getValidationError       Return validation error for the
  *                                                               given property.
- * @property {function(Object<string>)} setValidationErrors      Receive an object of properties and
+ * @property {function(Object<Object>)} setValidationErrors      Receive an object of properties and
  *                                                               error messages as strings and adds
  *                                                               to the validation error state.
  * @property {function(string)}         clearValidationError     Clears a validation error for the
@@ -231,6 +230,14 @@
  * @property {function(string)}         getValidationErrorId     Returns the css id for the
  *                                                               validation error using the given
  *                                                               inputId string.
+ * @property {function(string)}         hideValidationError      Sets the hidden prop of a specific
+ *                                                               error to true.
+ * @property {function(string)}         showValidationError      Sets the hidden prop of a specific
+ *                                                               error to false.
+ * @property {function()}               showAllValidationErrors  Sets the hidden prop of all
+ *                                                               errors to false.
+ * @property {function():boolean}       areThereValidationErrors Returns true if there is at least
+ *                                                               one error.
  */
 
 export {};


### PR DESCRIPTION
Part of #1939.
Fixes #1848.
Fixes #1994.

This PR extends the validation context introduced in #1972 with some new methods:

* `hideValidationError` and `showValidationError` allow marking an error as visible or hidden to the user.
* `showAllValidationErrors` does the same but with all errors.
* `areThereValidationErrors` returns true whether there is at least one error.

It also changes the shape of the stored errors to `{ message: 'Test error', hidden: false }`. This allows adding errors in the context but displaying them conditionally. This way we can create validation errors when an input field is mounted, so if the user tries to submit the form without interacting with any field, those errors already exist and we can prevent the submit event and display the errors.

There are two new components that take care of creating validation errors on mount:
* `ValidatedTextInput` and `ValidatedSelect`, those components extend the `TextInput` and `Select` component we were currently using, but add validation on top of them. They also take care of clearing/hiding the errors when values are updated, the input is blurred, etc.

`ValidatedTextInput` relies on the native browser `<input>` validation rules. This has some advantages:
* We get email validation for free for the email input, required fields, etc. If we ever wanted to add new rules (min size for the address field, for example), we could do that with plain HTML.
* When a form fails to submit because there are validation errors, we can directly scroll to and focus the first invalid input.

That doesn't mean we can't build more complex validation rules. The validation check introduced in #1972 that verified a country was set when filling the address form in the shipping calculator, still works (and it works in the _Checkout_ block too).

### Screenshots

![Peek 2020-03-18 17-11](https://user-images.githubusercontent.com/3616980/76982049-9e6aae80-693b-11ea-89f0-78c8d127593f.gif)

### How to test the changes in this Pull Request:

1. Create a page with the _Checkout_ block and try filling the form leaving some fields empty, entering wrong emails in the email field, submitting the form without interacting with any field, etc.
2. Try entering the city, state or postal code before entering the Country and verify an error appears (only in the shipping form, it shouldn't happen in the billing form!).
3. Verify the coupon input field and the shipping calculator of the _Cart_ block still report errors properly like in #1972.