### PR TITLE
Add checkout skeleton whilst loading

### DIFF
--- a/assets/js/base/components/cart-checkout/button/style.scss
+++ b/assets/js/base/components/cart-checkout/button/style.scss
@@ -3,8 +3,8 @@
 .wc-block-checkout {
 	.button.wc-block-button {
 		align-items: center;
-		background-color: #000 !important;
-		color: #fff !important;
+		background-color: $black;
+		color: $white;
 		display: flex;
 		font-size: inherit;
 		font-weight: bold;
@@ -19,8 +19,8 @@
 		&:hover,
 		&:focus,
 		&:active {
-			background-color: $black !important;
-			color: #fff !important;
+			background-color: $black;
+			color: $white;
 		}
 	}
 }

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -46,23 +46,3 @@
 		}
 	}
 }
-.wc-block-component-express-checkout-continue-rule {
-	display: flex;
-	align-items: center;
-	text-align: center;
-	padding: 0 $gap-larger;
-	margin: $gap-large 0;
-
-	&::before {
-		margin-right: 10px;
-	}
-	&::after {
-		margin-left: 10px;
-	}
-	&::before,
-	&::after {
-		content: " ";
-		flex: 1;
-		border-bottom: 1px solid $core-grey-light-600;
-	}
-}

--- a/assets/js/blocks/cart-checkout/checkout/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/index.js
@@ -49,11 +49,7 @@ const settings = {
 			}
 		} );
 
-		return (
-			<div className={ attributes.className } { ...data }>
-				Checkout block coming soon to store near you
-			</div>
-		);
+		return <div className={ attributes.className } { ...data } />;
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { Icon, card } from '@woocommerce/icons';
 import { kebabCase } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -49,7 +50,12 @@ const settings = {
 			}
 		} );
 
-		return <div className={ attributes.className } { ...data } />;
+		return (
+			<div
+				className={ classnames( 'is-loading', attributes.className ) }
+				{ ...data }
+			/>
+		);
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -155,7 +155,7 @@
 	}
 }
 .wc-block-checkout--skeleton {
-	display: flex;
+	display: none;
 }
 .is-loading + .wc-block-checkout--skeleton {
 	display: flex;

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -83,6 +83,27 @@
 	}
 }
 
+.wc-block-component-express-checkout-continue-rule {
+	display: flex;
+	align-items: center;
+	text-align: center;
+	padding: 0 $gap-larger;
+	margin: $gap-large 0;
+
+	&::before {
+		margin-right: 10px;
+	}
+	&::after {
+		margin-left: 10px;
+	}
+	&::before,
+	&::after {
+		content: " ";
+		flex: 1;
+		border-bottom: 1px solid $core-grey-light-600;
+	}
+}
+
 .wc-block-checkout__actions {
 	display: flex;
 	justify-content: space-between;
@@ -97,6 +118,47 @@
 		height: auto;
 		margin-left: auto;
 	}
+}
+
+
+// Loading placeholder state.
+.wc-block-checkout--is-loading {
+	.wc-block-component-express-checkout,
+	.wc-block-checkout__actions button {
+		@include placeholder();
+		@include force-content();
+	}
+	.wc-block-component-express-checkout {
+		min-height: 150px;
+	}
+	.wc-block-component-express-checkout-continue-rule span {
+		@include placeholder();
+		@include force-content();
+		width: 150px;
+	}
+	.wc-block-checkout-form {
+		fieldset span {
+			@include placeholder();
+			@include force-content();
+			display: block;
+			min-height: 100px;
+		}
+		.wc-block-checkout-step::before,
+		.wc-block-checkout-step::after {
+			@include placeholder();
+		}
+	}
+	.wc-block-checkout__sidebar .components-card {
+		@include placeholder();
+		@include force-content();
+		min-height: 460px;
+	}
+}
+.wc-block-checkout--skeleton {
+	display: flex;
+}
+.is-loading + .wc-block-checkout--skeleton {
+	display: flex;
 }
 
 @include breakpoint( ">480px" ) {

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -79,6 +79,40 @@ class Checkout extends AbstractBlock {
 			}
 		}
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
-		return $content;
+		return $content . $this->get_skeleton();
+	}
+
+	/**
+	 * Render skeleton markup for the checkout block.
+	 */
+	protected function get_skeleton() {
+		return '
+			<div class="wc-block-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton" aria-hidden="true">
+				<div class="wc-block-main">
+					<div class="wc-block-component-express-checkout"></div>
+					<div class="wc-block-component-express-checkout-continue-rule"><span></span></div>
+					<form class="wc-block-checkout-form">
+						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
+							<span></span>
+						</fieldset>
+						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
+							<span></span>
+						</fieldset>
+						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
+							<span></span>
+						</fieldset>
+						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
+							<span></span>
+						</fieldset>
+						<div class="wc-block-checkout__actions">
+							<button class="components-button button wc-block-button wc-block-components-checkout-place-order-button">&nbsp;</button>
+						</div>
+					</form>
+				</div>
+				<div class="wc-block-sidebar wc-block-checkout__sidebar">
+					<div class="components-card"></div>
+				</div>
+			</div>
+		';
 	}
 }

--- a/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
+++ b/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Checkout Block can be created 1`] = `
 "<!-- wp:woocommerce/checkout -->
-<div class=\\"wp-block-woocommerce-checkout\\" data-use-shipping-as-billing=\\"true\\" data-show-company-field=\\"false\\" data-require-company-field=\\"false\\" data-show-address-2-field=\\"true\\" data-show-phone-field=\\"true\\" data-require-phone-field=\\"false\\" data-show-policy-links=\\"true\\" data-show-return-to-cart=\\"true\\" data-cart-page-id=\\"0\\">Checkout block coming soon to store near you</div>
+<div class=\\"wp-block-woocommerce-checkout is-loading\\" data-use-shipping-as-billing=\\"true\\" data-show-company-field=\\"false\\" data-require-company-field=\\"false\\" data-show-address-2-field=\\"true\\" data-show-phone-field=\\"true\\" data-require-phone-field=\\"false\\" data-show-policy-links=\\"true\\" data-show-return-to-cart=\\"true\\" data-cart-page-id=\\"0\\"></div>
 <!-- /wp:woocommerce/checkout -->"
 `;


### PR DESCRIPTION
Following on from the cart skeleton I added (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1866) this adds a loading Skeleton to the checkout and removes the 'coming soon' placeholder text we had in place.

### Screenshots

![Screenshot 2020-03-18 at 16 36 39](https://user-images.githubusercontent.com/90977/77005907-873ab980-6959-11ea-8ca2-6eeba2b3ffa6.png)

### How to test the changes in this Pull Request:

1. Re-save or re-create the checkout block - the markup needs updating/invalidating
2. View the page with throttling
3. See the skeleton until the real checkout loads and replaces it.