### PR TITLE
Update empty states

### DIFF
--- a/assets/js/base/components/product-list/no-matching-products.js
+++ b/assets/js/base/components/product-list/no-matching-products.js
@@ -11,7 +11,7 @@ const NoMatchingProducts = ( { resetCallback = () => {} } ) => {
 		<div className={ `${ layoutStyleClassPrefix }__no-products` }>
 			<Icon
 				className={ `${ layoutStyleClassPrefix }__no-products-image` }
-				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+				alt=""
 				srcElement={ search }
 				size={ 100 }
 			/>

--- a/assets/js/base/components/product-list/no-matching-products.js
+++ b/assets/js/base/components/product-list/no-matching-products.js
@@ -2,17 +2,18 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { WC_BLOCKS_ASSET_URL } from '@woocommerce/block-settings';
 import { useProductLayoutContext } from '@woocommerce/base-context';
+import { Icon, search } from '@woocommerce/icons';
 
 const NoMatchingProducts = ( { resetCallback = () => {} } ) => {
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	return (
 		<div className={ `${ layoutStyleClassPrefix }__no-products` }>
-			<img
-				src={ WC_BLOCKS_ASSET_URL + 'img/no-matching-products.svg' }
-				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+			<Icon
 				className={ `${ layoutStyleClassPrefix }__no-products-image` }
+				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+				srcElement={ search }
+				size={ 100 }
 			/>
 			<strong
 				className={ `${ layoutStyleClassPrefix }__no-products-title` }

--- a/assets/js/base/components/product-list/no-products.js
+++ b/assets/js/base/components/product-list/no-products.js
@@ -11,7 +11,7 @@ const NoProducts = () => {
 		<div className={ `${ layoutStyleClassPrefix }__no-products` }>
 			<Icon
 				className={ `${ layoutStyleClassPrefix }__no-products-image` }
-				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+				alt=""
 				srcElement={ notice }
 				size={ 100 }
 			/>

--- a/assets/js/base/components/product-list/no-products.js
+++ b/assets/js/base/components/product-list/no-products.js
@@ -2,17 +2,18 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { WC_BLOCKS_ASSET_URL } from '@woocommerce/block-settings';
 import { useProductLayoutContext } from '@woocommerce/base-context';
+import { Icon, notice } from '@woocommerce/icons';
 
 const NoProducts = () => {
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	return (
 		<div className={ `${ layoutStyleClassPrefix }__no-products` }>
-			<img
-				src={ WC_BLOCKS_ASSET_URL + 'img/no-products.svg' }
-				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+			<Icon
 				className={ `${ layoutStyleClassPrefix }__no-products-image` }
+				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+				srcElement={ notice }
+				size={ 100 }
 			/>
 			<strong
 				className={ `${ layoutStyleClassPrefix }__no-products-title` }

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -20,6 +20,7 @@
 		max-width: 150px;
 		margin: 0 auto 1em;
 		display: block;
+		color: inherit;
 	}
 	.wc-block-grid__no-products-title {
 		display: block;

--- a/assets/js/blocks/cart-checkout/checkout/empty-cart.js
+++ b/assets/js/blocks/cart-checkout/checkout/empty-cart.js
@@ -10,7 +10,7 @@ const EmptyCart = () => {
 		<div className="wc-block-checkout-empty">
 			<Icon
 				className="wc-block-checkout-empty__image"
-				alt={ __( 'Empty cart', 'woo-gutenberg-products-block' ) }
+				alt=""
 				srcElement={ cart }
 				size={ 100 }
 			/>

--- a/assets/js/blocks/cart-checkout/checkout/empty-cart.js
+++ b/assets/js/blocks/cart-checkout/checkout/empty-cart.js
@@ -2,22 +2,23 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { WC_BLOCKS_ASSET_URL, SHOP_URL } from '@woocommerce/block-settings';
+import { SHOP_URL } from '@woocommerce/block-settings';
+import { Icon, cart } from '@woocommerce/icons';
 
 const EmptyCart = () => {
 	return (
 		<div className="wc-block-checkout-empty">
-			<img
-				src={ WC_BLOCKS_ASSET_URL + 'img/no-products.svg' }
-				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+			<Icon
 				className="wc-block-checkout-empty__image"
+				srcElement={ cart }
+				size={ 100 }
 			/>
 			<strong className="wc-block-checkout-empty__title">
 				{ __( 'Your cart is empty!', 'woo-gutenberg-products-block' ) }
 			</strong>
 			<p className="wc-block-checkout-empty__description">
 				{ __(
-					'Checkout is not available whilst your cart is empty. Add some products to your cart and come back later!',
+					"Checkout is not available whilst your cart is empty—please take a look through our store and come back when you're ready to place an order.",
 					'woo-gutenberg-products-block'
 				) }
 			</p>

--- a/assets/js/blocks/cart-checkout/checkout/empty-cart.js
+++ b/assets/js/blocks/cart-checkout/checkout/empty-cart.js
@@ -10,6 +10,7 @@ const EmptyCart = () => {
 		<div className="wc-block-checkout-empty">
 			<Icon
 				className="wc-block-checkout-empty__image"
+				alt={ __( 'Empty cart', 'woo-gutenberg-products-block' ) }
 				srcElement={ cart }
 				size={ 100 }
 			/>

--- a/assets/js/blocks/cart-checkout/checkout/empty-cart.js
+++ b/assets/js/blocks/cart-checkout/checkout/empty-cart.js
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { WC_BLOCKS_ASSET_URL, SHOP_URL } from '@woocommerce/block-settings';
+
+const EmptyCart = () => {
+	return (
+		<div className="wc-block-checkout-empty">
+			<img
+				src={ WC_BLOCKS_ASSET_URL + 'img/no-products.svg' }
+				alt={ __( 'No products', 'woo-gutenberg-products-block' ) }
+				className="wc-block-checkout-empty__image"
+			/>
+			<strong className="wc-block-checkout-empty__title">
+				{ __( 'Your cart is empty!', 'woo-gutenberg-products-block' ) }
+			</strong>
+			<p className="wc-block-checkout-empty__description">
+				{ __(
+					'Checkout is not available whilst your cart is empty. Add some products to your cart and come back later!',
+					'woo-gutenberg-products-block'
+				) }
+			</p>
+			<span className="wp-block-button">
+				<a href={ SHOP_URL } className="wp-block-button__link">
+					{ __( 'Browse store', 'woo-gutenberg-products-block' ) }
+				</a>
+			</span>
+		</div>
+	);
+};
+
+export default EmptyCart;

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -18,6 +18,7 @@ import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import Block from './block.js';
 import blockAttributes from './attributes';
 import renderFrontend from '../../../utils/render-frontend.js';
+import EmptyCart from './empty-cart';
 
 /**
  * Wrapper component for the checkout block.
@@ -30,38 +31,45 @@ const CheckoutFrontend = ( props ) => {
 		cartItems,
 		cartTotals,
 		shippingRates,
+		cartIsLoading,
 	} = useStoreCart();
 
 	return (
-		<BlockErrorBoundary
-			header={ __(
-				'Something went wrong…',
-				'woo-gutenberg-products-block'
+		<>
+			{ ! cartIsLoading && cartItems.length === 0 ? (
+				<EmptyCart />
+			) : (
+				<BlockErrorBoundary
+					header={ __(
+						'Something went wrong…',
+						'woo-gutenberg-products-block'
+					) }
+					text={ __experimentalCreateInterpolateElement(
+						__(
+							'The checkout has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+							'woo-gutenberg-products-block'
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<a href="." />
+							),
+						}
+					) }
+					showErrorMessage={ CURRENT_USER_IS_ADMIN }
+				>
+					<StoreNoticesProvider context="wc/checkout">
+						<Block
+							{ ...props }
+							cartCoupons={ cartCoupons }
+							cartItems={ cartItems }
+							cartTotals={ cartTotals }
+							shippingRates={ shippingRates }
+						/>
+					</StoreNoticesProvider>
+				</BlockErrorBoundary>
 			) }
-			text={ __experimentalCreateInterpolateElement(
-				__(
-					'The checkout has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
-					'woo-gutenberg-products-block'
-				),
-				{
-					a: (
-						// eslint-disable-next-line jsx-a11y/anchor-has-content
-						<a href="." />
-					),
-				}
-			) }
-			showErrorMessage={ CURRENT_USER_IS_ADMIN }
-		>
-			<StoreNoticesProvider context="wc/checkout">
-				<Block
-					{ ...props }
-					cartCoupons={ cartCoupons }
-					cartItems={ cartItems }
-					cartTotals={ cartTotals }
-					shippingRates={ shippingRates }
-				/>
-			</StoreNoticesProvider>
-		</BlockErrorBoundary>
+		</>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -170,6 +170,7 @@
 		max-width: 150px;
 		margin: 0 auto 1em;
 		display: block;
+		color: inherit;
 	}
 	.wc-block-checkout-empty__title {
 		display: block;

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -161,6 +161,27 @@
 	display: flex;
 }
 
+.wc-block-checkout-empty {
+	padding: $gap-largest;
+	text-align: center;
+	width: 100%;
+
+	.wc-block-checkout-empty__image {
+		max-width: 150px;
+		margin: 0 auto 1em;
+		display: block;
+	}
+	.wc-block-checkout-empty__title {
+		display: block;
+		margin: 0;
+		font-weight: bold;
+	}
+	.wc-block-checkout-empty__description {
+		display: block;
+		margin: 0.25em 0 1em 0;
+	}
+}
+
 @include breakpoint( ">480px" ) {
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {


### PR DESCRIPTION
This PR introduces an empty state for the checkout block (when no items are found) and updates the product block empty states based on the feedback in #1178 (no issue was logged for 1178 but I had it on my list to revisit).

Ref #1178
Fixes #1976

https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1995 should be reviewed first becasue I based this PR on the other branch.

### Screenshots

![Screenshot 2020-03-18 at 21 29 03](https://user-images.githubusercontent.com/90977/77009415-cbc95380-695f-11ea-9cb3-0a41c6097e71.png)
![Screenshot 2020-03-18 at 21 24 37](https://user-images.githubusercontent.com/90977/77009419-ccfa8080-695f-11ea-829c-d800d2d82d24.png)
![Screenshot 2020-03-18 at 21 21 37](https://user-images.githubusercontent.com/90977/77009421-ccfa8080-695f-11ea-92b9-23be7c30ac37.png)

### How to test the changes in this Pull Request:

1. Visit checkout page with an empty cart - see state.
2. Search for something on all products which you know returns no products e.g. price filter 89-90, and view icon.
3. Delete products. View all products. See the final icon.