### PR TITLE
Storefront compatibility for sticky proceed to checkout button on mobile 

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -233,7 +233,10 @@ table.wc-block-cart-items {
 		padding: $gap;
 		position: fixed;
 		width: 100%;
-		z-index: 1;
+		z-index: 9999;
+	}
+	.wc-block-cart__submit-container-push {
+		height: 100px;
 	}
 }
 .wc-block-cart-coupon-list {

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -52,6 +52,20 @@ class Cart extends AbstractBlock {
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
 		$this->enqueue_assets( $attributes );
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
+
+		// Disable storefront footer bar when using this block.
+		if ( has_action( 'storefront_footer', 'storefront_handheld_footer_bar' ) ) {
+			remove_action( 'storefront_footer', 'storefront_handheld_footer_bar', 999 );
+		}
+
+		// Add placeholder element to footer to push content for the sticky bar on mobile.
+		add_action(
+			'wp_footer',
+			function() {
+				echo '<div class="wc-block-cart__submit-container-push"></div>';
+			}
+		);
+
 		return $content . $this->get_skeleton();
 	}
 

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -53,11 +53,6 @@ class Cart extends AbstractBlock {
 		$this->enqueue_assets( $attributes );
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
 
-		// Disable storefront footer bar when using this block.
-		if ( has_action( 'storefront_footer', 'storefront_handheld_footer_bar' ) ) {
-			remove_action( 'storefront_footer', 'storefront_handheld_footer_bar', 999 );
-		}
-
 		// Add placeholder element to footer to push content for the sticky bar on mobile.
 		add_action(
 			'wp_footer',


### PR DESCRIPTION
Adds compatibility between the sticky checkout button and Strorefront by removing the sticky Storefront bar when rendering the cart and checkout blocks. This uses `remove_action`.

In a similar fashion, this also renders a 'push' div in the footer so that our sticky element does not overlap the footer content on the website.

Fixes #1930

### Screenshots

![Screenshot 2020-03-19 at 15 20 28](https://user-images.githubusercontent.com/90977/77084695-38dbf800-69f7-11ea-8b8d-838219f6594c.png)

### How to test the changes in this Pull Request:

1. View cart/checkout in mobile view whilst running Storefront
2. Check it doesn't overlap the footer, and that the Storefront bar does not render.
