### PR TITLE
Load product grid styles in WP <=5.2

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -115,6 +115,10 @@ const stableMainEntry = {
 	'snackbar-notice-style':
 		'./node_modules/@wordpress/components/src/snackbar/style.scss',
 
+	// Styles for grid blocks. WP <=5.2 doesn't have the All Products block,
+	// so this file would not be included if not explicitly declared here.
+	'product-list-style': './assets/js/base/components/product-list/style.scss',
+
 	// Blocks
 	'handpicked-products': './assets/js/blocks/handpicked-products/index.js',
 	'product-best-sellers': './assets/js/blocks/product-best-sellers/index.js',

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -117,6 +117,8 @@ const stableMainEntry = {
 
 	// Styles for grid blocks. WP <=5.2 doesn't have the All Products block,
 	// so this file would not be included if not explicitly declared here.
+	// This file is excluded from the default build so CSS styles are included
+	// in the other the components are imported.
 	'product-list-style': './assets/js/base/components/product-list/style.scss',
 
 	// Blocks

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,7 +107,14 @@ const CoreConfig = {
 
 const GutenbergBlocksConfig = {
 	...baseConfig,
-	...getMainConfig( { alias: getAlias() } ),
+	...getMainConfig( {
+		alias: getAlias(),
+		// This file is already imported by the All Products dependencies,
+		// so we can safely exclude it from the default build. It's still
+		// needed in the legacy build because it doesn't include the
+		// All Products block.
+		exclude: [ 'product-list-style' ],
+	} ),
 };
 
 const BlocksFrontendConfig = {


### PR DESCRIPTION
We moved product grid styles to the `ProductList` component, but that component is not loaded in WP <= 5.2 because  the _All Product_ block is restricted to WP >= 5.3, so product grid styles were not loading in WP <= 5.2.

This PR explicitly declares the `ProductList` styles as an entry file in Webpack config, so it's always loaded no matter if it's the legacy build or the default build.

Notice this issue is affecting the last release of blocks (2.5.x), so I think it might be worth doing a point release for it.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/77162028-4ce13180-6aab-11ea-8630-45204f574726.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/77161948-1c00fc80-6aab-11ea-90eb-755b47b1b88b.png)

### How to test the changes in this Pull Request:

1. In a WP 5.0, 5.1 or 5.2 environment add a _Products by Tag_ block, for example.
2. Preview it in the frontend and verify it's correctly styled.

### Changelog

> Fix broken product grid blocks styles in old versions of WordPress.