### PR TITLE
Fix blocks not being added in WP <= 5.2

### DIFF
--- a/assets/js/base/components/product-list-item/index.js
+++ b/assets/js/base/components/product-list-item/index.js
@@ -7,7 +7,7 @@ import {
 	useInnerBlockConfigurationContext,
 	useProductLayoutContext,
 } from '@woocommerce/base-context';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 
 /**
  * Internal dependencies

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 
 /**
  * Internal dependencies

--- a/assets/js/base/components/select/validated.js
+++ b/assets/js/base/components/select/validated.js
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 import { useValidationContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 
 /**
  * Internal dependencies

--- a/assets/js/base/components/sort-select/index.js
+++ b/assets/js/base/components/sort-select/index.js
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Label from '@woocommerce/base-components/label';
-import { withInstanceId } from '@wordpress/compose';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 
 /**
  * Internal dependencies

--- a/assets/js/base/components/sort-select/index.js
+++ b/assets/js/base/components/sort-select/index.js
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Label from '@woocommerce/base-components/label';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies

--- a/assets/js/base/components/tabs/index.js
+++ b/assets/js/base/components/tabs/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useState } from '@wordpress/element';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useValidationContext } from '@woocommerce/base-context';
 import { ValidationInputError } from '@woocommerce/base-components/validation';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 
 /**
  * Internal dependencies

--- a/assets/js/base/components/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/totals/totals-coupon-code-input/index.js
@@ -9,7 +9,7 @@ import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
 import Label from '@woocommerce/base-components/label';
 import { ValidationInputError } from '@woocommerce/base-components/validation';
 import PropTypes from 'prop-types';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 import { useValidationContext } from '@woocommerce/base-context';
 
 /**

--- a/assets/js/base/hocs/with-instance-id.js
+++ b/assets/js/base/hocs/with-instance-id.js
@@ -1,0 +1,1 @@
+export { withInstanceId } from 'wordpress-compose';

--- a/assets/js/components/view-switcher/index.js
+++ b/assets/js/components/view-switcher/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ButtonGroup, Button } from '@wordpress/components';
 import { useState, Fragment } from '@wordpress/element';
-import { withInstanceId } from 'wordpress-compose';
+import { withInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies

--- a/assets/js/filters/block-list-block.js
+++ b/assets/js/filters/block-list-block.js
@@ -3,6 +3,8 @@
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { compareWithWpVersion } from '@woocommerce/settings';
+
 const { getBlockType } = wp.blocks;
 const { addFilter } = wp.hooks;
 
@@ -87,8 +89,10 @@ const withDefaultAttributes = createHigherOrderComponent(
  * as defining `attributes` during block registration, you must also declare an
  * array called `defaults`. Defaults should be omitted from `attributes`.
  */
-addFilter(
-	'editor.BlockListBlock',
-	'woocommerce-blocks/block-list-block',
-	withDefaultAttributes
-);
+if ( compareWithWpVersion( '5.3', '<=' ) ) {
+	addFilter(
+		'editor.BlockListBlock',
+		'woocommerce-blocks/block-list-block',
+		withDefaultAttributes
+	);
+}

--- a/assets/js/legacy/base/hocs/with-instance-id.js
+++ b/assets/js/legacy/base/hocs/with-instance-id.js
@@ -1,0 +1,1 @@
+export { withInstanceId } from '@wordpress/compose';

--- a/bin/fallback-module-directory-webpack-plugin.js
+++ b/bin/fallback-module-directory-webpack-plugin.js
@@ -48,8 +48,20 @@ module.exports = class FallbackModuleDirectoryWebpackPlugin {
 		return alias;
 	}
 
+	getPathWithExtension( path ) {
+		const pathParts = path.split( '.' );
+		const pathHasExtension =
+			pathParts.length > 1 &&
+			! pathParts[ pathParts.length - 1 ].includes( '/' );
+		return pathHasExtension ? path : path + '.js';
+	}
+
 	applyFallback( path ) {
-		if ( path.includes( this.search ) && ! fs.existsSync( path ) ) {
+		if (
+			path.includes( this.search ) &&
+			! fs.existsSync( path ) &&
+			! fs.existsSync( this.getPathWithExtension( path ) )
+		) {
 			return path.replace( this.search, this.replacement );
 		}
 		return path;
@@ -86,9 +98,7 @@ module.exports = class FallbackModuleDirectoryWebpackPlugin {
 								return resolver.doResolve(
 									target,
 									obj,
-									`aliased with mapping '${
-										item.name
-									}' to '${ newRequestStr }'`,
+									`aliased with mapping '${ item.name }' to '${ newRequestStr }'`,
 									resolveContext,
 									( err, result ) => {
 										if ( err ) return callback( err );

--- a/bin/fallback-module-directory-webpack-plugin.js
+++ b/bin/fallback-module-directory-webpack-plugin.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 const fs = require( 'fs' );
+const path = require( 'path' );
 
 // Note, this has some inspiration from the AliasPlugin and its implementation
 // @see https://github.com/webpack/enhanced-resolve/blob/v4.1.0/lib/AliasPlugin.js
@@ -48,23 +49,22 @@ module.exports = class FallbackModuleDirectoryWebpackPlugin {
 		return alias;
 	}
 
-	getPathWithExtension( path ) {
-		const pathParts = path.split( '.' );
-		const pathHasExtension =
-			pathParts.length > 1 &&
-			! pathParts[ pathParts.length - 1 ].includes( '/' );
-		return pathHasExtension ? path : path + '.js';
+	getPathWithExtension( pathString ) {
+		if ( ! Boolean( path.extname( pathString ) ) ) {
+			return pathString + '.js';
+		}
+		return pathString;
 	}
 
-	applyFallback( path ) {
+	applyFallback( pathString ) {
 		if (
-			path.includes( this.search ) &&
-			! fs.existsSync( path ) &&
-			! fs.existsSync( this.getPathWithExtension( path ) )
+			pathString.includes( this.search ) &&
+			! fs.existsSync( pathString ) &&
+			! fs.existsSync( this.getPathWithExtension( pathString ) )
 		) {
-			return path.replace( this.search, this.replacement );
+			return pathString.replace( this.search, this.replacement );
 		}
-		return path;
+		return pathString;
 	}
 
 	doApply( resolver, source, target, alias ) {


### PR DESCRIPTION
Fixes #1914.

### How to test the changes in this Pull Request:

Notice you might need to build the project with `npm run build` instead of `npm start`. There are some side effects issues with old dependencies, so a production build is needed to have all blocks available.

1. In a WP 5.0, 5.1 or 5.2 environment try to add a block to a post.
2. Verify the block is added without error.
3. Try adding the _All Reviews_ block and verify it doesn't crash.
