### PR TITLE
Add bundle size github workflow

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,17 @@
+name: Bundle Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2-beta
+      with:
+        fetch-depth: 1
+    - uses: preactjs/compressed-size-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        pattern: "{build/**/*.js,build/**/*.css}"

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -3,15 +3,14 @@ name: Bundle Size
 on: [pull_request]
 
 jobs:
-  build:
+    build-and-size:
+        runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2-beta
-      with:
-        fetch-depth: 1
-    - uses: preactjs/compressed-size-action@v1
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        pattern: "{build/**/*.js,build/**/*.css}"
+        steps:
+            - uses: actions/checkout@v2-beta
+              with:
+                  fetch-depth: 1
+            - uses: preactjs/compressed-size-action@v1
+              with:
+                  repo-token: '${{ secrets.GITHUB_TOKEN }}'
+                  pattern: '{build/**/*.js,build/**/*.css}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,10 @@ jobs:
               - npm run test
           env:
               - WOOCOMMERCE_BLOCKS_PHASE=experimental
-        - name: Javascript/CSS Lint and Bundle Size Check
+        - name: Javascript/CSS Lint check
           script:
               - npm install
-              - npm run build:ci
+              - npm run lint:ci
           env:
               - WOOCOMMERCE_BLOCKS_PHASE=experimental
         - name: E2E Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -7332,15 +7332,6 @@
 			"integrity": "sha512-9wBDgdzbn06on6Xt+ay7EM4HV+NBOkeXhjK9DMezD8/qvJKeUTzheGHhM+U1uNaX4OvuIR4BePDStRLF7vyOfg==",
 			"dev": true
 		},
-		"axios": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-			"dev": true,
-			"requires": {
-				"follow-redirects": "1.5.10"
-			}
-		},
 		"axobject-query": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
@@ -8541,113 +8532,6 @@
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true
-		},
-		"bundlewatch": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/bundlewatch/-/bundlewatch-0.2.6.tgz",
-			"integrity": "sha512-J/j1f8Wqro1AdY4oFvFvIsQTM+fEkV0p7RPv9l0xgevUxETnjF7sFSW32mIEeF245RvdczETUu7bInDsO5uaLg==",
-			"dev": true,
-			"requires": {
-				"axios": "^0.19.0",
-				"bytes": "^3.0.0",
-				"chalk": "^2.4.0",
-				"commander": "^2.15.1",
-				"glob": "^7.1.2",
-				"gzip-size": "^5.1.1",
-				"jsonpack": "^1.1.5",
-				"lodash.merge": "^4.6.1",
-				"read-pkg-up": "^6.0.0"
-			},
-			"dependencies": {
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^4.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.2.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"read-pkg": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-					"dev": true,
-					"requires": {
-						"@types/normalize-package-data": "^2.4.0",
-						"normalize-package-data": "^2.5.0",
-						"parse-json": "^5.0.0",
-						"type-fest": "^0.6.0"
-					},
-					"dependencies": {
-						"type-fest": {
-							"version": "0.6.0",
-							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-							"dev": true
-						}
-					}
-				},
-				"read-pkg-up": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-6.0.0.tgz",
-					"integrity": "sha512-odtTvLl+EXo1eTsMnoUHRmg/XmXdTkwXVxy4VFE9Kp6cCq7b3l7QMdBndND3eAFzrbSAXC/WCUOQQ9rLjifKZw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^4.0.0",
-						"read-pkg": "^5.1.1",
-						"type-fest": "^0.5.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-					"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==",
-					"dev": true
-				}
-			}
 		},
 		"bytes": {
 			"version": "3.1.0",
@@ -12421,26 +12305,6 @@
 			"integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==",
 			"dev": true
 		},
-		"follow-redirects": {
-			"version": "1.5.10",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-			"dev": true,
-			"requires": {
-				"debug": "=3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -12614,28 +12478,28 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"optional": true,
@@ -12646,14 +12510,14 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"optional": true,
@@ -12664,42 +12528,42 @@
 				},
 				"chownr": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"resolved": false,
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"optional": true,
@@ -12709,28 +12573,28 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+					"resolved": false,
 					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 					"dev": true,
 					"optional": true,
@@ -12740,14 +12604,14 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"resolved": false,
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
@@ -12764,7 +12628,7 @@
 				},
 				"glob": {
 					"version": "7.1.6",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"resolved": false,
 					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 					"dev": true,
 					"optional": true,
@@ -12779,14 +12643,14 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"resolved": false,
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"optional": true,
@@ -12796,7 +12660,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 					"dev": true,
 					"optional": true,
@@ -12806,7 +12670,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"resolved": false,
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
@@ -12817,21 +12681,21 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 					"dev": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"optional": true,
@@ -12841,14 +12705,14 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"optional": true,
@@ -12858,14 +12722,14 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"resolved": false,
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 					"dev": true,
 					"optional": true,
@@ -12876,7 +12740,7 @@
 				},
 				"minizlib": {
 					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 					"dev": true,
 					"optional": true,
@@ -12886,7 +12750,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"optional": true,
@@ -12896,14 +12760,14 @@
 				},
 				"ms": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
 					"dev": true,
 					"optional": true,
@@ -12915,7 +12779,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.14.0",
-					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+					"resolved": false,
 					"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 					"dev": true,
 					"optional": true,
@@ -12934,7 +12798,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
@@ -12945,7 +12809,7 @@
 				},
 				"npm-bundled": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 					"dev": true,
 					"optional": true,
@@ -12955,14 +12819,14 @@
 				},
 				"npm-normalize-package-bin": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.7",
-					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+					"resolved": false,
 					"integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
 					"dev": true,
 					"optional": true,
@@ -12973,7 +12837,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
@@ -12986,21 +12850,21 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"optional": true,
@@ -13010,21 +12874,21 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+					"resolved": false,
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
@@ -13035,21 +12899,21 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+					"resolved": false,
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"optional": true,
@@ -13062,7 +12926,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"resolved": false,
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
@@ -13071,7 +12935,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"resolved": false,
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
@@ -13087,7 +12951,7 @@
 				},
 				"rimraf": {
 					"version": "2.7.1",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 					"dev": true,
 					"optional": true,
@@ -13097,49 +12961,49 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"resolved": false,
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"resolved": false,
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"resolved": false,
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"optional": true,
@@ -13151,7 +13015,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
@@ -13161,7 +13025,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"optional": true,
@@ -13171,14 +13035,14 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"resolved": false,
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.13",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+					"resolved": false,
 					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 					"dev": true,
 					"optional": true,
@@ -13194,14 +13058,14 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+					"resolved": false,
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"optional": true,
@@ -13211,14 +13075,14 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"resolved": false,
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"resolved": false,
 					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true,
 					"optional": true
@@ -17617,12 +17481,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
-		},
-		"jsonpack": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/jsonpack/-/jsonpack-1.1.5.tgz",
-			"integrity": "sha1-1CsNz9kaxY7zEQ+W0sWZQEw9wnw=",
-			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -28651,7 +28509,7 @@
 			}
 		},
 		"woocommerce": {
-			"version": "git+https://github.com/woocommerce/woocommerce.git#77ff3ecef81ac74ba8c28dba2fe1f5efa723ba2d",
+			"version": "git+https://github.com/woocommerce/woocommerce.git#6f2b232fc7fa53417691a742a419147bb0134a5c",
 			"from": "git+https://github.com/woocommerce/woocommerce.git",
 			"dev": true,
 			"requires": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"deploy": "cross-env WOOCOMMERCE_BLOCKS_PHASE=stable composer install --no-dev && npm run build --loglevel error && sh ./bin/github-deploy.sh",
 		"release": "sh ./bin/wordpress-deploy.sh",
 		"build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
-		"build:ci": "npm run build && npm run size-check && npm run lint:js && npm run lint:css",
+		"build:ci": "npm run build && npm run lint:js && npm run lint:css",
 		"build:e2e-test": "npm run build",
 		"dev": "cross-env BABEL_ENV=default webpack",
 		"docker:up": "docker-compose up -d",
@@ -52,7 +52,6 @@
 		"test:e2e:update": "./tests/bin/e2e-test-integration.js -- --updateSnapshot",
 		"test:e2e-dev": "./tests/bin/e2e-test-integration.js --dev",
 		"test:watch": "npm run test -- --watch",
-		"size-check": "bundlewatch",
 		"storybook": "start-storybook  -c ./storybook -p 6006 --ci",
 		"build-storybook": "build-storybook  -c ./storybook",
 		"changelog": "node ./bin/changelog",
@@ -101,7 +100,6 @@
 		"babel-plugin-transform-react-jsx": "6.24.1",
 		"babel-plugin-transform-react-remove-prop-types": "0.4.24",
 		"babel-plugin-transform-runtime": "6.23.0",
-		"bundlewatch": "0.2.6",
 		"chalk": "3.0.0",
 		"clean-webpack-plugin": "3.0.0",
 		"commander": "4.1.1",
@@ -163,38 +161,6 @@
 		"hooks": {
 			"pre-commit": "lint-staged"
 		}
-	},
-	"bundlewatch": {
-		"files": [
-			{
-				"path": "./build/*.js",
-				"maxSize": "200 kB"
-			},
-			{
-				"path": "./build/*frontend*.js",
-				"maxSize": "60 kB"
-			},
-			{
-				"path": "./build/cart.js",
-				"maxSize": "80 kB"
-			},
-			{
-				"path": "./build/cart-frontend.js",
-				"maxSize": "160 kB"
-			},
-			{
-				"path": "./build/checkout-frontend.js",
-				"maxSize": "160 kB"
-			},
-			{
-				"path": "./build/*.css",
-				"maxSize": "50kB"
-			},
-			{
-				"path": "./build/vendors*.js",
-				"maxSize": "360 kb"
-			}
-		]
 	},
 	"lint-staged": {
 		"*.scss": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"deploy": "cross-env WOOCOMMERCE_BLOCKS_PHASE=stable composer install --no-dev && npm run build --loglevel error && sh ./bin/github-deploy.sh",
 		"release": "sh ./bin/wordpress-deploy.sh",
 		"build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",
-		"build:ci": "npm run build && npm run lint:js && npm run lint:css",
+		"lint:ci": "npm run lint:js && npm run lint:css",
 		"build:e2e-test": "npm run build",
 		"dev": "cross-env BABEL_ENV=default webpack",
 		"docker:up": "docker-compose up -d",


### PR DESCRIPTION
This workflow implements a bundle-size monitoring utility for our repository to give better metrics on increases in bundle-sizes. I basically copied the configuration for the WordPress gutenberg project workflow and it utilizes the [`preactjs/compressed-size-action`](https://github.com/preactjs/compressed-size-action).

This will replace our existing bundlewatch implementation.

### Benefits of the switch:

- We get inline feedback (as a comment) in the pull on any size changes. 
- This compares overall changes against the base branch for the pull (which we weren't getting with bundlewatch).
- A list of all files and their changes is shown in a collapsed list in the posted comment. With bundlewatch, their linking system was broken, so if we wanted that granularity we had to go into the travis-ci job (which only showed us the sizes, not the difference from the base branch).
- Removes the time for the bundlewatch checks from the linting travis job (not a huge difference but helps).

The only real downside to this switch is that we don't block merging pull with this. So there's no _enforced_ size budgets. I'm not sure that's much of a downside though because our current pattern has been mostly to use this for awareness and we've generally bumped bundets to merge pulls (while having an issue for following up on size reviews).

So the big benefit here is getting _actionable_ feedback on significant change (or improvements!!) on bundle sizes in context of the pull making those changes.