### PR TITLE
Build storybook to github pages on pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,3 +85,20 @@ jobs:
               - npm run test:e2e
           env:
               - WOOCOMMERCE_BLOCKS_PHASE=experimental
+        - stage: deploy
+          if: (NOT type IN (pull_request)) AND (branch = master)
+          name: Deploy Storybook
+          env:
+              - WOOCOMMERCE_BLOCKS_PHASE=experimental
+          install:
+              - npm ci
+          before_deploy:
+              - npm run storybook:build
+          deploy:
+              provider: pages
+              skip_cleanup: true
+              github_token: $GITHUB_TOKEN
+              keep_history: true
+              local_dir: storybook/dist
+              on:
+                  branch: master

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"test:e2e-dev": "./tests/bin/e2e-test-integration.js --dev",
 		"test:watch": "npm run test -- --watch",
 		"storybook": "start-storybook  -c ./storybook -p 6006 --ci",
-		"build-storybook": "build-storybook  -c ./storybook",
+		"storybook:build": "build-storybook  -c ./storybook -o ./storybook/dist",
 		"changelog": "node ./bin/changelog",
 		"changelog:zenhub": "node ./bin/changelog --changelogSrcType='ZENHUB_RELEASE'"
 	},


### PR DESCRIPTION
This pull adds configuration for deploying a build of storybook to Github pages on any push/merge to master. 

- Builds are output to `storybook/dist` (but only during the deploy)
- Travis is used for deploying.

Using this pull to document and verify travis config isn't borked. Otherwise, it needs to be merged to master to verify the build works as expected.