### PR TITLE
Fix event-emitters not accounting for observers as Object type.

### DIFF
--- a/assets/js/base/context/cart-checkout/event-emit/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/emitters.js
@@ -15,7 +15,9 @@
  *                   executed.
  */
 export const emitEvent = async ( observers, eventType, data ) => {
-	const observersByType = observers[ eventType ] || [];
+	const observersByType = observers[ eventType ]
+		? Object.values( observers[ eventType ] )
+		: [];
 	for ( let i = 0; i < observersByType.length; i++ ) {
 		try {
 			await Promise.resolve( observersByType[ i ]( data ) );
@@ -43,7 +45,9 @@ export const emitEvent = async ( observers, eventType, data ) => {
  *                   return value of the aborted observer.
  */
 export const emitEventWithAbort = async ( observers, eventType, data ) => {
-	const observersByType = observers[ eventType ] || [];
+	const observersByType = observers[ eventType ]
+		? Object.values( observers[ eventType ] )
+		: [];
 	for ( let i = 0; i < observersByType.length; i++ ) {
 		try {
 			const response = await Promise.resolve(

--- a/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
@@ -18,7 +18,7 @@ describe( 'Testing emitters', () => {
 	} );
 	describe( 'Testing emitEvent()', () => {
 		it( 'invokes all observers', async () => {
-			const observers = { test: Object.values( observerMocks ) };
+			const observers = { test: observerMocks };
 			const response = await emitEvent( observers, 'test', 'foo' );
 			expect( console ).toHaveErroredWith( 'an error' );
 			expect( observerMocks.observerA ).toHaveBeenCalledTimes( 1 );
@@ -31,7 +31,7 @@ describe( 'Testing emitters', () => {
 			'aborts on non truthy value and does not invoke remaining ' +
 				'observers',
 			async () => {
-				const observers = { test: Object.values( observerMocks ) };
+				const observers = { test: observerMocks };
 				const response = await emitEventWithAbort(
 					observers,
 					'test',


### PR DESCRIPTION
The `emitEvent` and `emitEventWithAbort` functions have logic assuming that the incoming `observers` argument is an array when if fact it is an object. The work in this pull accounts for that before executing the loop invoking the observer callbacks.

This was first spotted while working on #1983 and verified to fix the issue in that pull. The existing jsdoc type didn't catch this because an array is an object in javascript, thus satisfied the type. This is one of the reason I want to implement typedefs more widely because we should move away from `object` as a type.

Also updated js unit tests.

## To Test

The emitters are covered by unit tests (of course with the test mocks being fixed to match expected incoming argument).  