### PR TITLE
Update checkout API endpoint to process orders

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -9,6 +9,9 @@ namespace Automattic\WooCommerce\Blocks;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
+use Automattic\WooCommerce\Blocks\Payments\PaymentContext;
+
 /**
  * Library class.
  */
@@ -26,6 +29,7 @@ class Library {
 		add_filter( 'woocommerce_register_shop_order_post_statuses', array( __CLASS__, 'register_draft_order_post_status' ) );
 		add_filter( 'woocommerce_valid_order_statuses_for_payment', array( __CLASS__, 'append_draft_order_post_status' ) );
 		add_action( 'woocommerce_cleanup_draft_orders', array( __CLASS__, 'delete_expired_draft_orders' ) );
+		add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( __CLASS__, 'process_legacy_payment' ), 10, 2 );
 	}
 
 	/**
@@ -193,6 +197,49 @@ class Library {
 			WHERE posts.post_status = 'wc-checkout-draft'
 			AND posts.post_modified <= ( NOW() - INTERVAL 1 DAY )
 			"
+		);
+	}
+
+	/**
+	 * Attempt to process a payment for the checkout API if no payment methods support the
+	 * woocommerce_rest_checkout_process_payment_with_context action.
+	 *
+	 * @param PaymentContext $context Holds context for the payment.
+	 * @param PaymentResult  $result  Result of the payment.
+	 */
+	public static function process_legacy_payment( PaymentContext $context, PaymentResult &$result ) {
+		if ( $result->status ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$post_data = $_POST;
+
+		// Set constants.
+		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+
+		// Add the payment data from the API to the POST global.
+		$_POST = $context->payment_data;
+
+		// Call the process payment method of the chosen gatway.
+		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+
+		if ( ! isset( $available_gateways[ $context->payment_method ] ) ) {
+			return;
+		}
+
+		// Process Payment.
+		$gateway_result = $available_gateways[ $context->payment_method ]->process_payment( $context->order->get_id() );
+
+		// Restore $_POST data.
+		$_POST = $post_data;
+
+		// Handle result.
+		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );
+		$result->set_payment_details(
+			[
+				'redirect' => $gateway_result['redirect'],
+			]
 		);
 	}
 }

--- a/src/Library.php
+++ b/src/Library.php
@@ -24,6 +24,7 @@ class Library {
 		add_action( 'init', array( __CLASS__, 'maybe_create_cronjobs' ) );
 		add_filter( 'wc_order_statuses', array( __CLASS__, 'register_draft_order_status' ) );
 		add_filter( 'woocommerce_register_shop_order_post_statuses', array( __CLASS__, 'register_draft_order_post_status' ) );
+		add_filter( 'woocommerce_valid_order_statuses_for_payment', array( __CLASS__, 'append_draft_order_post_status' ) );
 		add_action( 'woocommerce_cleanup_draft_orders', array( __CLASS__, 'delete_expired_draft_orders' ) );
 	}
 
@@ -161,6 +162,17 @@ class Library {
 			/* translators: %s: number of orders */
 			'label_count'               => _n_noop( 'Drafts <span class="count">(%s)</span>', 'Drafts <span class="count">(%s)</span>', 'woo-gutenberg-products-block' ),
 		];
+		return $statuses;
+	}
+
+	/**
+	 * Append draft status to a list of statuses.
+	 *
+	 * @param array $statuses Array of statuses.
+	 * @return array
+	 */
+	public static function append_draft_order_post_status( $statuses ) {
+		$statuses[] = 'checkout-draft';
 		return $statuses;
 	}
 

--- a/src/Library.php
+++ b/src/Library.php
@@ -228,8 +228,15 @@ class Library {
 			return;
 		}
 
+		$payment_method_object = $available_gateways[ $context->payment_method ];
+		$payment_method_object->validate_fields();
+
+		if ( 0 !== wc_notice_count( 'error' ) ) {
+			return;
+		}
+
 		// Process Payment.
-		$gateway_result = $available_gateways[ $context->payment_method ]->process_payment( $context->order->get_id() );
+		$gateway_result = $payment_method_object->process_payment( $context->order->get_id() );
 
 		// Restore $_POST data.
 		$_POST = $post_data;

--- a/src/Payments/PaymentContext.php
+++ b/src/Payments/PaymentContext.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Payment context.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\Payments;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PaymentContext class.
+ */
+class PaymentContext {
+	/**
+	 * Payment method ID.
+	 *
+	 * @var string
+	 */
+	protected $payment_method = '';
+
+	/**
+	 * Order object for the order being paid.
+	 *
+	 * @var \WC_Order
+	 */
+	protected $order;
+
+	/**
+	 * Holds data to send to the payment gateway to support payment.
+	 *
+	 * @var array Key value pairs.
+	 */
+	protected $payment_data = [];
+
+	/**
+	 * Magic getter for protected properties.
+	 *
+	 * @param string $name Property name.
+	 */
+	public function __get( $name ) {
+		if ( in_array( $name, [ 'payment_method', 'order', 'payment_data' ], true ) ) {
+			return $this->$name;
+		}
+		return null;
+	}
+
+	/**
+	 * Set the chosen payment method ID context.
+	 *
+	 * @param string $payment_method Payment method ID.
+	 */
+	public function set_payment_method( $payment_method ) {
+		$this->payment_method = (string) $payment_method;
+	}
+
+	/**
+	 * Set the order context.
+	 *
+	 * @param \WC_Order $order Order object.
+	 */
+	public function set_order( \WC_Order $order ) {
+		$this->order = $order;
+	}
+
+	/**
+	 * Set payment data context.
+	 *
+	 * @param array $payment_data Array of key value pairs of data.
+	 */
+	public function set_payment_data( $payment_data = [] ) {
+		$this->payment_data = [];
+
+		foreach ( $payment_data as $key => $value ) {
+			$this->payment_data[ (string) $key ] = (string) $value;
+		}
+	}
+}

--- a/src/Payments/PaymentResult.php
+++ b/src/Payments/PaymentResult.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Payment result.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\Payments;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * PaymentResult class.
+ */
+class PaymentResult {
+	/**
+	 * List of valid payment statuses.
+	 *
+	 * @var array
+	 */
+	protected $valid_statuses = [ 'success', 'failure', 'pending', 'error' ];
+
+	/**
+	 * Current payment status.
+	 *
+	 * @var string
+	 */
+	protected $status = '';
+
+	/**
+	 * Array of details about the payment.
+	 *
+	 * @var string
+	 */
+	protected $payment_details = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $status Sets the payment status for the result.
+	 */
+	public function __construct( $status = '' ) {
+		if ( $status ) {
+			$this->set_status( $status );
+		}
+	}
+
+	/**
+	 * Magic getter for protected properties.
+	 *
+	 * @param string $name Property name.
+	 */
+	public function __get( $name ) {
+		if ( in_array( $name, [ 'status', 'payment_details' ], true ) ) {
+			return $this->$name;
+		}
+		return null;
+	}
+
+	/**
+	 * Set payment status.
+	 *
+	 * @throws \Exception When an invalid status is provided.
+	 *
+	 * @param string $payment_status Status to set.
+	 */
+	public function set_status( $payment_status ) {
+		if ( ! in_array( $payment_status, $this->valid_statuses, true ) ) {
+			throw new \Exception( sprintf( 'Invalid payment status %s. Use one of %s', $payment_status, implode( ', ', $this->valid_statuses ) ) );
+		}
+		$this->status = $payment_status;
+	}
+
+	/**
+	 * Set payment details.
+	 *
+	 * @param array $payment_details Array of key value pairs of data.
+	 */
+	public function set_payment_details( $payment_details = [] ) {
+		$this->payment_details = [];
+
+		foreach ( $payment_details as $key => $value ) {
+			$this->payment_details[ (string) $key ] = (string) $value;
+		}
+	}
+}

--- a/src/RestApi/StoreApi/Routes/AbstractRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractRoute.php
@@ -92,6 +92,10 @@ abstract class AbstractRoute implements RouteInterface {
 	protected function check_nonce( \WP_REST_Request $request ) {
 		$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
 
+		if ( defined( 'WOOCOMMERCE_STORE_API_DISABLE_NONCE_CHECKS' ) && WOOCOMMERCE_STORE_API_DISABLE_NONCE_CHECKS ) {
+			return;
+		}
+
 		if ( null === $nonce ) {
 			throw new RouteException( 'woocommerce_rest_missing_nonce', __( 'Missing the X-WC-Store-API-Nonce header. This endpoint requires a valid nonce.', 'woo-gutenberg-products-block' ), 403 );
 		}

--- a/src/RestApi/StoreApi/Routes/Checkout.php
+++ b/src/RestApi/StoreApi/Routes/Checkout.php
@@ -44,7 +44,20 @@ class Checkout extends AbstractRoute {
 				'methods'  => \WP_REST_Server::CREATABLE,
 				'callback' => [ $this, 'get_response' ],
 				// @todo Determine the args we want to accept here.
-				'args'     => [],
+				'args'     => [
+					'payment_method' => [
+						'description' => __( 'The ID of the payment method being used to process the payment.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+					],
+					'order_id'       => [
+						'description' => __( 'The order ID being processed.', 'woo-gutenberg-products-block' ),
+						'type'        => 'number',
+					],
+					'order_key'      => [
+						'description' => __( 'The order key; used to validate the order is valid.', 'woo-gutenberg-products-block' ),
+						'type'        => 'string',
+					],
+				],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];
@@ -58,13 +71,145 @@ class Checkout extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
+		$order_id = $this->get_order_id(); // Get from session or args?
+
+		if ( ! $order_id ) {
+			throw new RouteException( 'woocommerce_rest_checkout_missing_order_id', __( 'No order was found for this session pending payment. Was an order created via /cart/create-order yet?', 'woo-gutenberg-products-block' ), 404 );
+		}
+
+		$order              = wc_get_order( $order_id );
+		$order_key          = wp_unslash( $request['order_key'] );
+		$order_key_is_valid = $order && hash_equals( $order->get_order_key(), $order_key );
+
+		if ( ! $order_key_is_valid ) {
+			throw new RouteException( 'woocommerce_rest_checkout_invalid_order', __( 'Invalid order. Please provide a valid order ID and key.', 'woo-gutenberg-products-block' ), 400 );
+		}
+
+		if ( ! $order->needs_payment() ) {
+			return $this->process_checkout_without_payment( $order, $request );
+		}
+
 		// @todo Add order and payment gateway processing here.
+		$payment_method_id     = wc_clean( wp_unslash( $request['payment_method'] ) );
+		$available_gateways    = WC()->payment_gateways->get_available_payment_gateways();
+		$payment_method_object = isset( $available_gateways[ $payment_method_id ] ) ? $available_gateways[ $payment_method_id ] : false;
+
+		if ( ! $payment_method_object ) {
+			throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_method', __( 'Invalid payment method provided.', 'woo-gutenberg-products-block' ), 400 );
+		}
+
+		try {
+			/**
+			 * At this stage some logic is called that may not work or be needed in API context. @todo
+			 *  - gateway->validate_fields which won't work in this context
+			 *  - process_customer Creates accounts, updates customer data to match submitted order details such as addresses
+			 *  - order is created but we already have one
+			 *
+			 * Also @todo there are filters ran by core - which should we apply here? e.g:
+			 *  - woocommerce_checkout_no_payment_needed_redirect
+			 *  - woocommerce_payment_successful_result
+			 */
+
+			// Before sending the order to gateways for processing, update the status to pending payment and set the correct gateway.
+			$order->set_status( 'pending' );
+			$order->set_payment_method( $payment_method_object );
+			$order->save();
+
+			$payment_result = $this->get_payment_result( $payment_method_object->process_payment( $order->get_id() ) );
+
+			if ( 'success' === $payment_result['result'] ) {
+				return $this->get_checkout_success_response_for_order( $order, $request, $payment_result );
+			}
+
+			// If we reached this point, payment was not successful.
+			return $this->get_checkout_fail_response_for_order( $order, $request, $payment_result );
+		} catch ( Exception $e ) {
+			throw new RouteException( 'woocommerce_rest_checkout_payment_error', $e->getMessage(), 400 );
+		}
+	}
+
+	/**
+	 * Wrapper for process_payment to give consistent response.
+	 *
+	 * @param array $raw_result Raw result from the gateway process_payment method.
+	 * @return array
+	 */
+	protected function get_payment_result( $raw_result = array() ) {
+		return wp_parse_args(
+			$raw_result,
+			[
+				'result'   => 'unknown',
+				'redirect' => '',
+			]
+		);
+	}
+
+	/**
+	 * For orders which do not require payment, just update status and create a response.
+	 *
+	 * @param \WC_Order        $order Order object.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	protected function process_checkout_without_payment( \WC_Order $order, \WP_REST_Request $request ) {
+		$order->payment_complete();
+
+		return $this->get_checkout_success_response_for_order(
+			$order,
+			$request,
+			[
+				'result'   => 'success',
+				'redirect' => $order->get_checkout_order_received_url(),
+			]
+		);
+	}
+
+	/**
+	 * Get checkout response object.
+	 *
+	 * @param \WC_Order        $order Order object.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param array            $payment_result Result of the payment.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_checkout_response_for_order( \WC_Order $order, \WP_REST_Request $request, $payment_result = array() ) {
 		// @todo we need to determine the fields we want to return after processing e.g. redirect URLs.
-		$checkout_result = [
-			'order' => new \WC_Order(),
-		];
-		$response        = $this->prepare_item_for_response( $checkout_result, $request );
+		return $this->prepare_item_for_response(
+			(object) [
+				'order'        => $order,
+				'redirect_url' => $order->get_checkout_order_received_url(),
+			],
+			$request
+		);
+	}
+
+	/**
+	 * Get checkout response object.
+	 *
+	 * @param \WC_Order        $order Order object.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param array            $payment_result Result of the payment.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_checkout_success_response_for_order( \WC_Order $order, \WP_REST_Request $request, $payment_result = array() ) {
+		// @todo we need to determine the fields we want to return after processing e.g. redirect URLs.
+		$response = $this->get_checkout_response_for_order( $order, $request, $payment_result );
 		$response->set_status( 200 );
+		return $response;
+	}
+
+	/**
+	 * Get checkout response object.
+	 *
+	 * @param \WC_Order        $order Order object.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param array            $payment_result Result of the payment.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_checkout_fail_response_for_order( \WC_Order $order, \WP_REST_Request $request, $payment_result = array() ) {
+		// @todo we need to determine the fields we want to return after processing e.g. redirect URLs.
+		$response = $this->get_checkout_response_for_order( $order, $request, $payment_result );
+		$response->set_status( 400 );
 		return $response;
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
+
 /**
  * CheckoutSchema class.
  */
@@ -27,7 +29,28 @@ class CheckoutSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'order' => [
+			'payment_status'  => [
+				'description' => __( 'Status of the payment returned by the gateway. One of success, pending, failure, error.', 'woo-gutenberg-products-block' ),
+				'readonly'    => true,
+				'type'        => 'string',
+			],
+			'payment_details' => [
+				'description' => __( 'An array of data being returned from the payment gateway.', 'woo-gutenberg-products-block' ),
+				'readonly'    => true,
+				'type'        => 'array',
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'key'   => [
+							'type' => 'string',
+						],
+						'value' => [
+							'type' => 'string',
+						],
+					],
+				],
+			],
+			'order'           => [
 				'description' => __( 'The order that was processed.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -40,18 +63,23 @@ class CheckoutSchema extends AbstractSchema {
 	/**
 	 * Return the response for checkout.
 	 *
-	 * @todo we need to determine the fields we want to return after processing e.g. redirect URLs.
+	 * @throws Exception On invalid response.
 	 *
-	 * @param object $result Result from checkout action.
+	 * @param array $item Results from checkout action.
 	 * @return array
 	 */
-	public function get_item_response( $result ) {
-		$order_schema = new OrderSchema();
+	public function get_item_response( $item ) {
+		$order          = wc_get_order( absint( $item['order_id'] ) );
+		$payment_result = $item['payment_result'] instanceof PaymentResult ? $item['payment_result'] : false;
+
+		if ( ! $order || ! $payment_result ) {
+			throw new Exception( 'Invalid response.' );
+		}
 
 		return [
-			'note'     => 'This is a placeholder',
-			'redirect' => $result->payment_result['redirect'],
-			'order'    => $order_schema->get_item_response( $result->order ),
+			'payment_status'  => $payment_result->status,
+			'payment_details' => $payment_result->payment_details,
+			'order'           => ( new OrderSchema() )->get_item_response( $order ),
 		];
 	}
 }

--- a/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
@@ -42,14 +42,16 @@ class CheckoutSchema extends AbstractSchema {
 	 *
 	 * @todo we need to determine the fields we want to return after processing e.g. redirect URLs.
 	 *
-	 * @param object $checkout_result Result from checkout action.
+	 * @param object $result Result from checkout action.
 	 * @return array
 	 */
-	public function get_item_response( $checkout_result ) {
+	public function get_item_response( $result ) {
 		$order_schema = new OrderSchema();
+
 		return [
-			'note'  => 'This is a placeholder',
-			'order' => $order_schema->get_item_response( $checkout_result['order'] ),
+			'note'     => 'This is a placeholder',
+			'redirect' => $result->payment_result['redirect'],
+			'order'    => $order_schema->get_item_response( $result->order ),
 		];
 	}
 }


### PR DESCRIPTION
This might be more work when we integrate it, but this should be good enough to merge for now to unblock other tasks.

Creates the `wc/store/checkout` endpoint. This endpoint takes an existing order and processes payment using a gateway.

To make this easier to test, add this to wp-config:

```
define( 'WOOCOMMERCE_STORE_API_DISABLE_NONCE_CHECKS', true );
```

This disables nonce verification so you can use basic auth from a REST client to test the endpoints.

After doing this:

1. Enable the bacs gateway
2. Add some things to your cart logged in
3. Using basic auth, POST to `/wc/store/cart/create-order`. Note the order ID and key in the response.
4. Use the order ID and key to POST to `wc/store/checkout`. The request will be something like this:

```json
{
  "order_id": 100,
  "order_key": "xxxxxx",
  "payment_method": "bacs"
}
```

Check the response and confirm it was successful.

Closes #1938