### PR TITLE
Reinitialise useSelectShippingRate when rates change.

### DIFF
--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -2,10 +2,9 @@
  * External dependencies
  */
 import { useDispatch } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
-import { useThrowError, usePrevious } from '@woocommerce/base-hooks';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import { useThrowError } from '@woocommerce/base-hooks';
 
 /**
  * This is a custom hook for loading the selected shipping rate from the cart store and actions for selecting a rate.
@@ -20,31 +19,37 @@ See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tr
  */
 export const useSelectShippingRate = ( shippingRates ) => {
 	const throwError = useThrowError();
-	const derivedSelectedRates = shippingRates
-		.map(
-			// the API responds with those keys.
-			/* eslint-disable camelcase */
-			( p ) => [
-				p.package_id,
-				p.shipping_rates.find( ( rate ) => rate.selected )?.rate_id,
-			]
-			/* eslint-enable */
-		)
-		// A fromEntries ponyfill, creates an object from an array of arrays.
-		.reduce( ( obj, [ key, val ] ) => {
-			obj[ key ] = val;
-			return obj;
-		}, {} );
+	const derivedSelectedRates = useMemo(
+		() =>
+			shippingRates
+				.map(
+					// the API responds with those keys.
+					/* eslint-disable camelcase */
+					( p ) => [
+						p.package_id,
+						p.shipping_rates.find( ( rate ) => rate.selected )
+							?.rate_id,
+					]
+					/* eslint-enable */
+				)
+				// A fromEntries ponyfill, creates an object from an array of arrays.
+				.reduce( ( obj, [ key, val ] ) => {
+					obj[ key ] = val;
+					return obj;
+				}, {} ),
+		[ shippingRates ]
+	);
 
-	const previousDerivedSelectedRates = usePrevious(derivedSelectedRates);
 	const [ selectedShippingRates, setSelectedShipping ] = useState(
 		derivedSelectedRates
-		);
-	useEffect(() => {
-		if (!isShallowEqual(previousDerivedSelectedRates, derivedSelectedRates)) {
-			setSelectedShipping(derivedSelectedRates)
-		}
-	}, [previousDerivedSelectedRates, derivedSelectedRates])
+	);
+
+	// useState initial state is always remembered, so even if that value changes,
+	// useState won't update, we're forcing it to update if the initial value changes,
+	// useMemo helps us not running this function when we don't need to.
+	useEffect( () => {
+		setSelectedShipping( derivedSelectedRates );
+	}, [ derivedSelectedRates ] );
 	const { selectShippingRate } = useDispatch( storeKey );
 	const setRate = ( newShippingRate, packageId ) => {
 		setSelectedShipping( {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes a small issue when selecting shippingRates, currently, we depend on `useState` to maintain the selected shipping rates, and we initialize `useState` with selected rates from the server, the problem is that, if rates changes, useState is not recreated again (and the initial value is not changed), weirdly enough, this issue is not present if you change the country.

so overall, this PR adds a useEffect that watches a memoized initial rates and updates the state if that value changes.

This could also be fixed if `useState` took a dependency array like other hooks (but this won't happen https://github.com/facebook/react/issues/14738), some solutions exists like [`useStateWithDeps`](https://www.npmjs.com/package/use-state-with-deps) but I didn’t want to introduce a new thing.
<!-- Reference any related issues or PRs here -->
Fixes #1970

### How to test the changes in this Pull Request:

1. setup a deletable shipping rate (free shipping with a coupon, or free shipping above a cart amount) 
2. meet the criteria for that rate and select it.
3. remove coupon and reduce amount so the rates gets removed.
4. see that another rate (depends on the server) will be selected and applied.
