### PR TITLE
Add tests to some cart and checkout hooks

### DIFF
--- a/assets/js/base/hooks/cart/test/use-store-cart-item-quantity.js
+++ b/assets/js/base/hooks/cart/test/use-store-cart-item-quantity.js
@@ -1,0 +1,201 @@
+/**
+ * External dependencies
+ */
+import TestRenderer, { act } from 'react-test-renderer';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+
+/**
+ * Internal dependencies
+ */
+import * as mockUseStoreCart from '../use-store-cart';
+import { useStoreCartItemQuantity } from '../use-store-cart-item-quantity';
+
+jest.mock( '../use-store-cart', () => ( {
+	useStoreCart: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/block-data', () => ( {
+	__esModule: true,
+	CART_STORE_KEY: 'test/store',
+} ) );
+
+// Make debounce instantaneous.
+jest.mock( 'use-debounce', () => ( {
+	useDebounce: ( a ) => [ a ],
+} ) );
+
+describe( 'useStoreCartItemQuantity', () => {
+	let registry, renderer;
+
+	const getWrappedComponents = ( Component ) => (
+		<RegistryProvider value={ registry }>
+			<Component />
+		</RegistryProvider>
+	);
+
+	const getTestComponent = ( options ) => () => {
+		const props = useStoreCartItemQuantity( options );
+		return <div { ...props } />;
+	};
+
+	let mockRemoveItemFromCart;
+	let mockChangeCartItemQuantity;
+	const setupMocks = ( { isPending } ) => {
+		mockRemoveItemFromCart = jest
+			.fn()
+			.mockReturnValue( { type: 'removeItemFromCartAction' } );
+		mockChangeCartItemQuantity = jest
+			.fn()
+			.mockReturnValue( { type: 'changeCartItemQuantityAction' } );
+		registry.registerStore( storeKey, {
+			reducer: () => ( {} ),
+			actions: {
+				removeItemFromCart: mockRemoveItemFromCart,
+				changeCartItemQuantity: mockChangeCartItemQuantity,
+			},
+			selectors: {
+				isItemQuantityPending: jest.fn().mockReturnValue( isPending ),
+			},
+		} );
+	};
+
+	beforeEach( () => {
+		registry = createRegistry();
+		renderer = null;
+	} );
+
+	afterEach( () => {
+		mockRemoveItemFromCart.mockReset();
+		mockChangeCartItemQuantity.mockReset();
+	} );
+
+	describe( 'with no errors and not pending', () => {
+		beforeEach( () => {
+			setupMocks( { isPending: false } );
+			mockUseStoreCart.useStoreCart.mockReturnValue( {
+				cartErrors: {},
+			} );
+		} );
+
+		it( 'update quantity value should happen instantly', () => {
+			const TestComponent = getTestComponent( {
+				key: '123',
+				quantity: 1,
+			} );
+
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent )
+				);
+			} );
+
+			const { changeQuantity, quantity } = renderer.root.findByType(
+				'div'
+			).props;
+
+			expect( quantity ).toBe( 1 );
+
+			act( () => {
+				changeQuantity( 2 );
+			} );
+
+			const { quantity: newQuantity } = renderer.root.findByType(
+				'div'
+			).props;
+
+			expect( newQuantity ).toBe( 2 );
+		} );
+
+		it( 'removeItem should call the dispatch action', () => {
+			const TestComponent = getTestComponent( {
+				key: '123',
+				quantity: 1,
+			} );
+
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent )
+				);
+			} );
+
+			const { removeItem } = renderer.root.findByType( 'div' ).props;
+
+			act( () => {
+				removeItem();
+			} );
+
+			expect( mockRemoveItemFromCart ).toHaveBeenCalledWith( '123' );
+		} );
+
+		it( 'changeQuantity should call the dispatch action', () => {
+			const TestComponent = getTestComponent( {
+				key: '123',
+				quantity: 1,
+			} );
+
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent )
+				);
+			} );
+
+			const { changeQuantity } = renderer.root.findByType( 'div' ).props;
+
+			act( () => {
+				changeQuantity( 2 );
+			} );
+
+			expect( mockChangeCartItemQuantity.mock.calls ).toEqual( [
+				[ '123', 2 ],
+			] );
+		} );
+	} );
+
+	it( 'should expose store errors', () => {
+		const mockCartErrors = [ { message: 'Test error' } ];
+		setupMocks( { isPending: false } );
+		mockUseStoreCart.useStoreCart.mockReturnValue( {
+			cartErrors: mockCartErrors,
+		} );
+
+		const TestComponent = getTestComponent( {
+			key: '123',
+			quantity: 1,
+		} );
+
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent )
+			);
+		} );
+
+		const { cartItemQuantityErrors } = renderer.root.findByType(
+			'div'
+		).props;
+
+		expect( cartItemQuantityErrors ).toEqual( mockCartErrors );
+	} );
+
+	it( 'isPending should depend on the value provided by the store', () => {
+		setupMocks( { isPending: true } );
+		mockUseStoreCart.useStoreCart.mockReturnValue( {
+			cartErrors: {},
+		} );
+
+		const TestComponent = getTestComponent( {
+			key: '123',
+			quantity: 1,
+		} );
+
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent )
+			);
+		} );
+
+		const { isPending } = renderer.root.findByType( 'div' ).props;
+
+		expect( isPending ).toBe( true );
+	} );
+} );

--- a/assets/js/base/hooks/cart/test/use-store-cart.js
+++ b/assets/js/base/hooks/cart/test/use-store-cart.js
@@ -1,0 +1,171 @@
+/**
+ * External dependencies
+ */
+import TestRenderer, { act } from 'react-test-renderer';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+import * as mockBaseContext from '@woocommerce/base-context';
+import { previewCart } from '@woocommerce/resource-previews';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+
+/**
+ * Internal dependencies
+ */
+import { defaultCartData, useStoreCart } from '../use-store-cart';
+
+jest.mock( '@woocommerce/base-context', () => ( {
+	useEditorContext: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/block-data', () => ( {
+	__esModule: true,
+	CART_STORE_KEY: 'test/store',
+} ) );
+
+describe( 'useStoreCart', () => {
+	let registry, renderer;
+
+	const previewCartData = {
+		cartCoupons: previewCart.coupons,
+		cartItems: previewCart.items,
+		cartItemsCount: previewCart.items_count,
+		cartItemsWeight: previewCart.items_weight,
+		cartNeedsShipping: previewCart.needs_shipping,
+		cartTotals: previewCart.totals,
+		cartIsLoading: false,
+		cartErrors: [],
+		shippingRates: previewCart.shipping_rates,
+		shippingAddress: {
+			country: '',
+			state: '',
+			city: '',
+			postcode: '',
+		},
+	};
+
+	const mockCartItems = [ { key: '1', id: 1, name: 'Lorem Ipsum' } ];
+	const mockShippingAddress = {
+		city: 'New York',
+	};
+	const mockCartData = {
+		coupons: [],
+		items: mockCartItems,
+		itemsCount: 1,
+		itemsWeight: 10,
+		needsShipping: true,
+		shippingAddress: mockShippingAddress,
+		shippingRates: [],
+	};
+	const mockCartTotals = {
+		currency_code: 'USD',
+	};
+	const mockCartIsLoading = false;
+	const mockCartErrors = [];
+	const mockStoreCartData = {
+		cartCoupons: [],
+		cartItems: mockCartItems,
+		cartItemsCount: 1,
+		cartItemsWeight: 10,
+		cartNeedsShipping: true,
+		shippingAddress: mockShippingAddress,
+		shippingRates: [],
+		cartTotals: mockCartTotals,
+		cartIsLoading: mockCartIsLoading,
+		cartErrors: mockCartErrors,
+	};
+
+	const getWrappedComponents = ( Component ) => (
+		<RegistryProvider value={ registry }>
+			<Component />
+		</RegistryProvider>
+	);
+
+	const getTestComponent = ( options ) => () => {
+		const results = useStoreCart( options );
+		return <div results={ results } />;
+	};
+
+	const setUpMocks = () => {
+		const mocks = {
+			selectors: {
+				getCartData: jest.fn().mockReturnValue( mockCartData ),
+				getCartErrors: jest.fn().mockReturnValue( mockCartErrors ),
+				getCartTotals: jest.fn().mockReturnValue( mockCartTotals ),
+				hasFinishedResolution: jest
+					.fn()
+					.mockReturnValue( ! mockCartIsLoading ),
+			},
+		};
+		registry.registerStore( storeKey, {
+			reducer: () => ( {} ),
+			selectors: mocks.selectors,
+		} );
+	};
+
+	beforeEach( () => {
+		registry = createRegistry();
+		renderer = null;
+		setUpMocks();
+	} );
+
+	afterEach( () => {
+		mockBaseContext.useEditorContext.mockReset();
+	} );
+
+	describe( 'in frontend', () => {
+		beforeEach( () => {
+			mockBaseContext.useEditorContext.mockReturnValue( {
+				isEditor: false,
+			} );
+		} );
+
+		it( 'return default data when shouldSelect is false', () => {
+			const TestComponent = getTestComponent( { shouldSelect: false } );
+
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent )
+				);
+			} );
+
+			const { results } = renderer.root.findByType( 'div' ).props;
+
+			expect( results ).toEqual( defaultCartData );
+		} );
+
+		it( 'return store data when shouldSelect is true', () => {
+			const TestComponent = getTestComponent( { shouldSelect: true } );
+
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent )
+				);
+			} );
+
+			const { results } = renderer.root.findByType( 'div' ).props;
+
+			expect( results ).toEqual( mockStoreCartData );
+		} );
+	} );
+
+	describe( 'in editor', () => {
+		beforeEach( () => {
+			mockBaseContext.useEditorContext.mockReturnValue( {
+				isEditor: true,
+			} );
+		} );
+
+		it( 'return preview data in editor', () => {
+			const TestComponent = getTestComponent();
+
+			act( () => {
+				renderer = TestRenderer.create(
+					getWrappedComponents( TestComponent )
+				);
+			} );
+
+			const { results } = renderer.root.findByType( 'div' ).props;
+
+			expect( results ).toEqual( previewCartData );
+		} );
+	} );
+} );

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -12,7 +12,7 @@ import { previewCart } from '@woocommerce/resource-previews';
  * @constant
  * @type  {StoreCart} Object containing cart data.
  */
-const defaultCartData = {
+export const defaultCartData = {
 	cartCoupons: [],
 	cartItems: [],
 	cartItemsCount: 0,

--- a/assets/js/base/hooks/checkout/test/use-checkout-redirect-url.js
+++ b/assets/js/base/hooks/checkout/test/use-checkout-redirect-url.js
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import TestRenderer, { act } from 'react-test-renderer';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useCheckoutRedirectUrl } from '../use-checkout-redirect-url';
+
+const mockRedirectUrl = 'https://www.example.com/mock-check-out';
+const mockUseCheckoutContext = {
+	redirectUrl: mockRedirectUrl,
+	dispatchActions: {
+		setRedirectUrl: jest.fn(),
+	},
+};
+jest.mock( '@woocommerce/base-context', () => ( {
+	useCheckoutContext: () => mockUseCheckoutContext,
+} ) );
+
+describe( 'useCheckoutRedirectUrl', () => {
+	let registry, renderer;
+
+	const getWrappedComponents = ( Component ) => (
+		<RegistryProvider value={ registry }>
+			<Component />
+		</RegistryProvider>
+	);
+
+	const getTestComponent = () => () => {
+		const data = useCheckoutRedirectUrl();
+		return <div { ...data } />;
+	};
+
+	beforeEach( () => {
+		registry = createRegistry();
+		renderer = null;
+	} );
+
+	it( 'redirectUrl matches the value provided by the checkout context', () => {
+		const TestComponent = getTestComponent();
+
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent )
+			);
+		} );
+
+		const { redirectUrl } = renderer.root.findByType( 'div' ).props;
+
+		expect( redirectUrl ).toBe( mockRedirectUrl );
+	} );
+
+	it( 'setRedirectUrl calls the correct action in the checkout context', () => {
+		const checkoutUrl = 'https://www.example.com/check-out';
+		const TestComponent = getTestComponent();
+
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent )
+			);
+		} );
+
+		const { setRedirectUrl } = renderer.root.findByType( 'div' ).props;
+
+		setRedirectUrl( checkoutUrl );
+
+		expect(
+			mockUseCheckoutContext.dispatchActions.setRedirectUrl
+		).toHaveBeenCalledWith( checkoutUrl );
+	} );
+} );

--- a/assets/js/base/hooks/checkout/test/use-checkout-submit.js
+++ b/assets/js/base/hooks/checkout/test/use-checkout-submit.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import TestRenderer, { act } from 'react-test-renderer';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useCheckoutSubmit } from '../use-checkout-submit';
+
+const mockSubmitLabel = 'Submit!';
+const mockUseCheckoutContext = {
+	submitLabel: mockSubmitLabel,
+	onSubmit: jest.fn(),
+};
+jest.mock( '@woocommerce/base-context', () => ( {
+	useCheckoutContext: () => mockUseCheckoutContext,
+} ) );
+
+describe( 'useCheckoutSubmit', () => {
+	let registry, renderer;
+
+	const getWrappedComponents = ( Component ) => (
+		<RegistryProvider value={ registry }>
+			<Component />
+		</RegistryProvider>
+	);
+
+	const getTestComponent = () => () => {
+		const data = useCheckoutSubmit();
+		return <div { ...data } />;
+	};
+
+	beforeEach( () => {
+		registry = createRegistry();
+		renderer = null;
+	} );
+
+	it( 'submitLabel matches the value provided by the checkout context', () => {
+		const TestComponent = getTestComponent();
+
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent )
+			);
+		} );
+
+		const { submitLabel } = renderer.root.findByType( 'div' ).props;
+
+		expect( submitLabel ).toBe( mockSubmitLabel );
+	} );
+
+	it( 'onSubmit calls the correct action in the checkout context', () => {
+		const TestComponent = getTestComponent();
+
+		act( () => {
+			renderer = TestRenderer.create(
+				getWrappedComponents( TestComponent )
+			);
+		} );
+
+		const { onSubmit } = renderer.root.findByType( 'div' ).props;
+
+		onSubmit();
+
+		expect( mockUseCheckoutContext.onSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/assets/js/hocs/test/with-attributes.js
+++ b/assets/js/hocs/test/with-attributes.js
@@ -59,12 +59,8 @@ describe( 'withAttributes Component', () => {
 
 		beforeEach( () => {
 			getAttributesPromise = Promise.resolve( mockAttributes );
-			mockUtils.getAttributes.mockImplementation(
-				() => getAttributesPromise
-			);
-			mockUtils.getTerms.mockImplementation( () =>
-				Promise.resolve( [] )
-			);
+			mockUtils.getAttributes.mockReturnValue( getAttributesPromise );
+			mockUtils.getTerms.mockResolvedValue( [] );
 		} );
 
 		it( 'getAttributes is called on mount', () => {
@@ -108,9 +104,7 @@ describe( 'withAttributes Component', () => {
 		let renderer;
 
 		beforeEach( () => {
-			mockUtils.getAttributes.mockImplementation( () =>
-				Promise.resolve( mockAttributes )
-			);
+			mockUtils.getAttributes.mockResolvedValue( mockAttributes );
 			renderer = TestRenderer.create( <TestComponent /> );
 		} );
 
@@ -130,12 +124,8 @@ describe( 'withAttributes Component', () => {
 		let renderer;
 
 		beforeEach( () => {
-			mockUtils.getAttributes.mockImplementation(
-				() => getAttributesPromise
-			);
-			mockBaseUtils.formatError.mockImplementation(
-				() => formattedError
-			);
+			mockUtils.getAttributes.mockReturnValue( getAttributesPromise );
+			mockBaseUtils.formatError.mockReturnValue( formattedError );
 			renderer = TestRenderer.create( <TestComponent /> );
 		} );
 


### PR DESCRIPTION
Part of #1475.

This PR adds tests to `useStoreCart`, `useStoreCartItemQuantity`, `useCheckoutRedirectUrl` and `useCheckoutSubmit` hooks.