### PR TITLE
Fix 'Show Sorting Dropdown' attribute ignored in All Products block

### DIFF
--- a/assets/js/blocks/products/all-products/index.js
+++ b/assets/js/blocks/products/all-products/index.js
@@ -52,11 +52,14 @@ const blockSettings = {
 	 * @param {Object} attributes Attributes to save.
 	 */
 	save( { attributes } ) {
+		const dataAttributes = {};
+		Object.keys( attributes )
+			.sort()
+			.forEach( ( key ) => {
+				dataAttributes[ key ] = attributes[ key ];
+			} );
 		const data = {
-			'data-attributes': JSON.stringify(
-				attributes,
-				Object.keys( attributes ).sort()
-			),
+			'data-attributes': JSON.stringify( dataAttributes ),
 		};
 		return (
 			<div

--- a/tests/e2e-tests/specs/backend/__snapshots__/all-products.test.js.snap
+++ b/tests/e2e-tests/specs/backend/__snapshots__/all-products.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`All Products can be created 1`] = `
 "<!-- wp:woocommerce/all-products {\\"columns\\":3,\\"rows\\":3,\\"alignButtons\\":false,\\"contentVisibility\\":{\\"orderBy\\":true},\\"orderby\\":\\"date\\",\\"layoutConfig\\":[[\\"woocommerce/product-image\\"],[\\"woocommerce/product-title\\"],[\\"woocommerce/product-price\\"],[\\"woocommerce/product-rating\\"],[\\"woocommerce/product-button\\"]]} -->
-<div class=\\"wp-block-woocommerce-all-products wc-block-all-products\\" data-attributes=\\"{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}\\"></div>
+<div class=\\"wp-block-woocommerce-all-products wc-block-all-products\\" data-attributes=\\"{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}\\"></div>
 <!-- /wp:woocommerce/all-products -->"
 `;


### PR DESCRIPTION
Fixes #2018.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/77523681-622cd600-6e86-11ea-8102-b0b39651644a.png)

### How to test the changes in this Pull Request:

**Test the sorting dropdown is shown:**
1. Add an _All Products_ block.
2. Check the '_Show Sorting Dropdown_' toggle.
3. Preview the page in the frontend and verify the sorting dropdown is displayed.

**Test there are no validation errors with blocks added in 2.5.x:**
Create a post with the _All Products_ block in 2.5:
1. `git checkout release/2.5`
2. `composer install && npm install && npm run start`
3. Add an _All Products_ block.
Verify the block keeps working in this branch:
4. `git checkout fix/2018-fix-all-products-sorting-dropdown`
5. `composer install && npm install && npm run start`
6. Reload the page/post where you added the _All Products_ block in step 3.
7. Verify there are no validation errors.