### PR TITLE
Make phone number option respected in billing field

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
+++ b/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
@@ -17,6 +17,7 @@ import { __ } from '@wordpress/i18n';
  * @property {AddressField} city       City name.
  * @property {AddressField} state      State name or code.
  * @property {AddressField} postcode   Postal code.
+ * @property {AddressField} phone      Phone number.
  */
 const AddressFields = {
 	first_name: {
@@ -114,6 +115,14 @@ const AddressFields = {
 		required: true,
 		hidden: false,
 		index: 9,
+	},
+	phone: {
+		label: __( 'Phone', 'woo-gutenberg-products-block' ),
+		optionalLabel: __( 'Phone (optional)', 'woo-gutenberg-products-block' ),
+		autocomplete: 'phone',
+		required: false,
+		hidden: false,
+		index: 10,
 	},
 };
 

--- a/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
+++ b/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
@@ -119,10 +119,11 @@ const AddressFields = {
 	phone: {
 		label: __( 'Phone', 'woo-gutenberg-products-block' ),
 		optionalLabel: __( 'Phone (optional)', 'woo-gutenberg-products-block' ),
-		autocomplete: 'phone',
+		autocomplete: 'tel',
 		required: false,
 		hidden: false,
 		index: 10,
+		type: 'tel',
 	},
 };
 

--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -164,6 +164,7 @@ const AddressForm = ( {
 
 				return (
 					<ValidatedTextInput
+						type={ field.type || 'text' }
 						key={ field.key }
 						className={ `wc-block-address-form__${ field.key }` }
 						label={

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -108,6 +108,11 @@ const Checkout = ( {
 			...defaultAddressFields.address_2,
 			hidden: ! attributes.showAddress2Field,
 		},
+		phone: {
+			...defaultAddressFields.phone,
+			hidden: ! attributes.showPhoneField,
+			required: attributes.requirePhoneField,
+		},
 	};
 
 	const setShippingFields = useCallback(

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -114,6 +114,9 @@ const Checkout = ( {
 			required: attributes.requirePhoneField,
 		},
 	};
+	// We're removing phone from billing form and disregarding it.
+	// eslint-disable-next-line no-unused-vars
+	const { phone: _, ...billingFields } = addressFields;
 
 	const setShippingFields = useCallback(
 		( address ) => {
@@ -210,32 +213,6 @@ const Checkout = ( {
 									fields={ Object.keys( addressFields ) }
 									fieldConfig={ addressFields }
 								/>
-								{ attributes.showPhoneField && (
-									<ValidatedTextInput
-										type="tel"
-										label={
-											attributes.requirePhoneField
-												? __(
-														'Phone',
-														'woo-gutenberg-products-block'
-												  )
-												: __(
-														'Phone (optional)',
-														'woo-gutenberg-products-block'
-												  )
-										}
-										value={ billingData.phone }
-										autoComplete="tel"
-										onChange={ ( newValue ) =>
-											setBillingData( {
-												phone: newValue,
-											} )
-										}
-										required={
-											attributes.requirePhoneField
-										}
-									/>
-								) }
 								<CheckboxControl
 									className="wc-block-checkout__use-address-for-billing"
 									label={ __(
@@ -267,8 +244,8 @@ const Checkout = ( {
 									onChange={ setBillingData }
 									type="billing"
 									values={ billingData }
-									fields={ Object.keys( addressFields ) }
-									fieldConfig={ addressFields }
+									fields={ Object.keys( billingFields ) }
+									fieldConfig={ billingFields }
 								/>
 							</FormStep>
 						) }

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -213,6 +213,7 @@
 				}
 			}
 
+			.wc-block-address-form__phone,
 			.wc-block-address-form__company,
 			.wc-block-address-form__address_1,
 			.wc-block-address-form__address_2 {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Phone number options only existed in shipping form, this PR move the input to `defaultAddressFields` so both shipping and billing can use it.
<!-- Reference any related issues or PRs here -->
Fixes #2022

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. toggle phone form option.
2. untoggle use shipping as billing
3. see the input in billing as well.
