### PR TITLE
fix rates not updating if you change coupon

### DIFF
--- a/assets/js/base/components/shipping-rates-control/index.js
+++ b/assets/js/base/components/shipping-rates-control/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
-import { usePrevious } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -20,13 +19,6 @@ const ShippingRatesControl = ( {
 	noResultsMessage,
 	renderOption,
 } ) => {
-	const previousShippingRates = usePrevious(
-		shippingRates,
-		( newRates ) => newRates.length > 0
-	);
-
-	const shippingRatesToDisplay = previousShippingRates || shippingRates;
-
 	return (
 		<LoadingMask
 			isLoading={ shippingRatesLoading }
@@ -39,11 +31,11 @@ const ShippingRatesControl = ( {
 			<Packages
 				className={ className }
 				collapsible={
-					shippingRatesToDisplay.length > 1 && collapsibleWhenMultiple
+					shippingRates.length > 1 && collapsibleWhenMultiple
 				}
 				noResultsMessage={ noResultsMessage }
 				renderOption={ renderOption }
-				shippingRates={ shippingRatesToDisplay }
+				shippingRates={ shippingRates }
 			/>
 		</LoadingMask>
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This was a bit tricky, but it seems `usePrevious` was not updating well, and was working correctly to begin with (the condition was to use previous if current rates are 0, this could be misleading if the current address has no rates associated with it, we never reached that case but changing address always caused the whole tree to render).

Deleting that code fixed the issue.
<!-- Reference any related issues or PRs here -->
Fixes #2025

### How to test the changes in this Pull Request:
1. setup a free shipping rate + free shipping coupon
2. in checkout, use that coupon to get free shipping
3. scrolling back to shipping rates, that free rate is now visible
4. deleting the coupon will also delete the rate.

You can also test the Cart block to see if nothing changed there.
