### PR TITLE
Hook up checkout validation with context

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -14,6 +14,7 @@ import {
 import { useValidationContext } from '@woocommerce/base-context';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 
 /**
  * Internal dependencies
@@ -53,11 +54,13 @@ const validateShippingCountry = (
  * Checkout address form.
  */
 const AddressForm = ( {
+	id,
 	fields = Object.keys( defaultAddressFields ),
 	fieldConfig = {},
 	onChange,
 	type = 'shipping',
 	values,
+	instanceId,
 } ) => {
 	const {
 		getValidationError,
@@ -92,8 +95,11 @@ const AddressForm = ( {
 		setValidationErrors,
 		clearValidationError,
 	] );
+
+	id = id || instanceId;
+
 	return (
-		<div className="wc-block-address-form">
+		<div id={ id } className="wc-block-address-form">
 			{ sortedAddressFields.map( ( field ) => {
 				if ( field.hidden ) {
 					return null;
@@ -107,6 +113,7 @@ const AddressForm = ( {
 					return (
 						<Tag
 							key={ field.key }
+							id={ `${ id }-${ field.key }` }
 							label={
 								field.required
 									? field.label
@@ -142,6 +149,7 @@ const AddressForm = ( {
 					return (
 						<Tag
 							key={ field.key }
+							id={ `${ id }-${ field.key }` }
 							country={ values.country }
 							label={
 								field.required
@@ -165,6 +173,7 @@ const AddressForm = ( {
 				return (
 					<ValidatedTextInput
 						key={ field.key }
+						id={ `${ id }-${ field.key }` }
 						className={ `wc-block-address-form__${ field.key }` }
 						label={
 							field.required ? field.label : field.optionalLabel
@@ -196,4 +205,4 @@ AddressForm.propTypes = {
 	type: PropTypes.oneOf( [ 'billing', 'shipping' ] ),
 };
 
-export default AddressForm;
+export default withInstanceId( AddressForm );

--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -57,10 +57,10 @@ const AddressForm = ( {
 	id,
 	fields = Object.keys( defaultAddressFields ),
 	fieldConfig = {},
+	instanceId,
 	onChange,
 	type = 'shipping',
 	values,
-	instanceId,
 } ) => {
 	const {
 		getValidationError,

--- a/assets/js/base/components/cart-checkout/place-order-button/index.js
+++ b/assets/js/base/components/cart-checkout/place-order-button/index.js
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import { useCheckoutContext } from '@woocommerce/base-context';
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import Button from '../button';
 
-const PlaceOrderButton = ( { validateSubmit } ) => {
+const PlaceOrderButton = () => {
 	const {
 		submitLabel,
 		onSubmit,
@@ -20,21 +19,12 @@ const PlaceOrderButton = ( { validateSubmit } ) => {
 	return (
 		<Button
 			className="wc-block-components-checkout-place-order-button"
-			onClick={ () => {
-				const isValid = validateSubmit();
-				if ( isValid ) {
-					onSubmit();
-				}
-			} }
+			onClick={ onSubmit }
 			disabled={ hasError || isCalculating }
 		>
 			{ submitLabel }
 		</Button>
 	);
-};
-
-PlaceOrderButton.propTypes = {
-	validateSubmit: PropTypes.func.isRequired,
 };
 
 export default PlaceOrderButton;

--- a/assets/js/base/components/cart-checkout/place-order-button/index.js
+++ b/assets/js/base/components/cart-checkout/place-order-button/index.js
@@ -9,18 +9,13 @@ import { useCheckoutContext } from '@woocommerce/base-context';
 import Button from '../button';
 
 const PlaceOrderButton = () => {
-	const {
-		submitLabel,
-		onSubmit,
-		hasError,
-		isCalculating,
-	} = useCheckoutContext();
+	const { submitLabel, onSubmit, isCalculating } = useCheckoutContext();
 
 	return (
 		<Button
 			className="wc-block-components-checkout-place-order-button"
 			onClick={ onSubmit }
-			disabled={ hasError || isCalculating }
+			disabled={ isCalculating }
 		>
 			{ submitLabel }
 		</Button>

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -14,6 +14,7 @@ import { ValidatedSelect } from '../select';
 const CountryInput = ( {
 	className,
 	countries,
+	id,
 	label,
 	onChange,
 	value = '',
@@ -33,6 +34,7 @@ const CountryInput = ( {
 	return (
 		<div className={ classnames( className, 'wc-block-country-input' ) }>
 			<ValidatedSelect
+				id={ id }
 				label={ label }
 				onChange={ onChange }
 				options={ options }
@@ -72,6 +74,7 @@ CountryInput.propTypes = {
 	countries: PropTypes.objectOf( PropTypes.string ).isRequired,
 	onChange: PropTypes.func.isRequired,
 	className: PropTypes.string,
+	id: PropTypes.string,
 	label: PropTypes.string,
 	value: PropTypes.string,
 	autoComplete: PropTypes.string,

--- a/assets/js/base/components/select/validated.js
+++ b/assets/js/base/components/select/validated.js
@@ -52,6 +52,13 @@ const ValidatedSelect = ( {
 		validateSelect();
 	}, [ value ] );
 
+	// Remove validation errors when unmounted.
+	useEffect( () => {
+		return () => {
+			clearValidationError( errorId );
+		};
+	}, [] );
+
 	const error = getValidationError( errorId ) || {};
 
 	return (

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -65,6 +65,7 @@ const StateInput = ( {
 			<>
 				<ValidatedSelect
 					className={ className }
+					id={ id }
 					label={ label }
 					onChange={ onChangeState }
 					options={ options }
@@ -99,8 +100,8 @@ const StateInput = ( {
 	}
 	return (
 		<ValidatedTextInput
-			id={ id }
 			className={ className }
+			id={ id }
 			label={ label }
 			onChange={ onChangeState }
 			autoComplete={ autoComplete }

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -14,6 +14,7 @@ import { ValidatedSelect } from '../select';
 
 const StateInput = ( {
 	className,
+	id,
 	states,
 	country,
 	label,
@@ -98,6 +99,7 @@ const StateInput = ( {
 	}
 	return (
 		<ValidatedTextInput
+			id={ id }
 			className={ className }
 			label={ label }
 			onChange={ onChangeState }
@@ -117,6 +119,7 @@ StateInput.propTypes = {
 	).isRequired,
 	onChange: PropTypes.func.isRequired,
 	autoComplete: PropTypes.string,
+	id: PropTypes.string,
 	className: PropTypes.string,
 	country: PropTypes.string,
 	label: PropTypes.string,

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -58,6 +58,13 @@ const ValidatedTextInput = ( {
 		}
 	}, [ validateOnMount ] );
 
+	// Remove validation errors when unmounted.
+	useEffect( () => {
+		return () => {
+			clearValidationError( errorId );
+		};
+	}, [] );
+
 	const errorMessage = getValidationError( errorId ) || {};
 	const hasError = errorMessage.message && ! errorMessage.hidden;
 	const describedBy =

--- a/assets/js/base/context/cart-checkout/billing/constants.js
+++ b/assets/js/base/context/cart-checkout/billing/constants.js
@@ -25,6 +25,7 @@ export const DEFAULT_BILLING_DATA = {
 	country: '',
 	email: '',
 	phone: '',
+	shippingAsBilling: true,
 };
 
 /**

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -143,7 +143,7 @@ export const CheckoutStateProvider = ( {
 				dispatch( actions.setComplete() );
 			} );
 		}
-		if ( checkoutState.isComplete ) {
+		if ( status === STATUS.COMPLETE ) {
 			if ( checkoutState.hasError ) {
 				emitEvent(
 					currentObservers.current,

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -24,6 +24,7 @@ import {
 	emitEventWithAbort,
 	reducer as emitReducer,
 } from './event-emit';
+import { useValidationContext } from '../validation';
 
 /**
  * @typedef {import('@woocommerce/type-defs/checkout').CheckoutDispatchActions} CheckoutDispatchActions
@@ -89,6 +90,7 @@ export const CheckoutStateProvider = ( {
 	const [ checkoutState, dispatch ] = useReducer( reducer, DEFAULT_STATE );
 	const [ observers, subscriber ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );
+	const { setValidationErrors } = useValidationContext();
 	// set observers on ref so it's always current.
 	useEffect( () => {
 		currentObservers.current = observers;
@@ -136,8 +138,7 @@ export const CheckoutStateProvider = ( {
 				{}
 			).then( ( response ) => {
 				if ( response !== true ) {
-					// @todo handle any validation error property values in the
-					// response.
+					setValidationErrors( response );
 					dispatchActions.setHasError();
 				}
 				dispatch( actions.setComplete() );

--- a/assets/js/base/context/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/index.js
@@ -45,8 +45,8 @@ export const CheckoutProvider = ( {
 					activePaymentMethod={ initialActivePaymentMethod }
 				>
 					<ShippingDataProvider>
-						{ children }
 						<CheckoutProcessor />
+						{ children }
 					</ShippingDataProvider>
 				</PaymentMethodDataProvider>
 			</BillingDataProvider>

--- a/assets/js/base/context/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/index.js
@@ -45,8 +45,8 @@ export const CheckoutProvider = ( {
 					activePaymentMethod={ initialActivePaymentMethod }
 				>
 					<ShippingDataProvider>
-						<CheckoutProcessor />
 						{ children }
+						<CheckoutProcessor />
 					</ShippingDataProvider>
 				</PaymentMethodDataProvider>
 			</BillingDataProvider>

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -49,10 +49,6 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 	 * @return {boolean} True if everything was successful.
 	 */
 	const processCheckout = useCallback( async () => {
-		if ( withErrors ) {
-			return false;
-		}
-
 		await triggerFetch( {
 			path: '/wc/store/checkout',
 			method: 'POST',
@@ -95,8 +91,6 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 					dispatchActions.setRedirectUrl(
 						response.payment_result.redirect_url
 					);
-
-					// @todo do we need to trigger more handling here?
 				} );
 			} )
 			.catch( ( error ) => {
@@ -114,6 +108,10 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 		withErrors,
 	] );
 
+	const checkValidation = useCallback( () => {
+		return ! withErrors;
+	}, [ withErrors ] );
+
 	/**
 	 * When the checkout is processing, process the order.
 	 */
@@ -123,6 +121,15 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 			unsubscribeProcessing();
 		};
 	}, [ onCheckoutProcessing, processCheckout ] );
+
+	useEffect( () => {
+		const unsubscribeCompleteSuccess = onCheckoutProcessing(
+			checkValidation
+		);
+		return () => {
+			unsubscribeCompleteSuccess();
+		};
+	}, [ onCheckoutProcessing, checkValidation ] );
 
 	useEffect( () => {
 		const unsubscribeCompleteError = onCheckoutCompleteError( () => {

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -31,7 +31,7 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 	} = useValidationContext();
 	const { shippingAddress } = useShippingDataContext();
 	const { billingData } = useBillingDataContext();
-	const { activePaymentMethod } = usePaymentMethodDataContext();
+	const { activePaymentMethod, errorMessage } = usePaymentMethodDataContext();
 	const { addErrorNotice } = useStoreNotices();
 	const currentBillingData = useRef( billingData );
 	const currentShippingAddress = useRef( shippingAddress );
@@ -42,6 +42,12 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 		currentBillingData.current = billingData;
 		currentShippingAddress.current = shippingAddress;
 	}, [ billingData, shippingAddress ] );
+
+	useEffect( () => {
+		if ( errorMessage ) {
+			addErrorNotice( errorMessage );
+		}
+	}, [ errorMessage ] );
 
 	/**
 	 * Process an order via the /wc/store/checkout endpoint.

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -32,7 +32,7 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 	const { shippingAddress } = useShippingDataContext();
 	const { billingData } = useBillingDataContext();
 	const { activePaymentMethod, errorMessage } = usePaymentMethodDataContext();
-	const { addErrorNotice } = useStoreNotices();
+	const { addErrorNotice, removeNotice } = useStoreNotices();
 	const currentBillingData = useRef( billingData );
 	const currentShippingAddress = useRef( shippingAddress );
 
@@ -45,7 +45,11 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 
 	useEffect( () => {
 		if ( errorMessage ) {
-			addErrorNotice( errorMessage );
+			addErrorNotice( errorMessage, {
+				id: 'payment-method-error',
+			} );
+		} else {
+			removeNotice( 'payment-method-error' );
 		}
 	}, [ errorMessage ] );
 

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -12,24 +12,19 @@ import {
 } from '@woocommerce/base-context';
 import { useEffect, useRef, useCallback } from '@wordpress/element';
 import { useStoreNotices } from '@woocommerce/base-hooks';
-import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 
 /**
  * CheckoutProcessor component. @todo Needs to consume all contexts.
  *
  * Subscribes to checkout context and triggers processing via the API.
  */
-const CheckoutProcessor = ( { scrollToTop } ) => {
+const CheckoutProcessor = () => {
 	const {
 		hasError,
 		onCheckoutProcessing,
-		onCheckoutCompleteError,
 		dispatchActions,
 	} = useCheckoutContext();
-	const {
-		hasValidationErrors,
-		showAllValidationErrors,
-	} = useValidationContext();
+	const { hasValidationErrors } = useValidationContext();
 	const { shippingAddress } = useShippingDataContext();
 	const { billingData } = useBillingDataContext();
 	const {
@@ -138,17 +133,7 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 		};
 	}, [ onCheckoutProcessing, checkValidation ] );
 
-	useEffect( () => {
-		const unsubscribeCompleteError = onCheckoutCompleteError( () => {
-			showAllValidationErrors();
-			scrollToTop( { focusableSelector: 'input:invalid' } );
-		} );
-		return () => {
-			unsubscribeCompleteError();
-		};
-	}, [ onCheckoutCompleteError ] );
-
 	return null;
 };
 
-export default withScrollToTop( CheckoutProcessor );
+export default CheckoutProcessor;

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -132,11 +132,9 @@ const CheckoutProcessor = ( { scrollToTop } ) => {
 	] );
 
 	useEffect( () => {
-		const unsubscribeCompleteSuccess = onCheckoutProcessing(
-			checkValidation
-		);
+		const unsubscribeProcessing = onCheckoutProcessing( checkValidation );
 		return () => {
-			unsubscribeCompleteSuccess();
+			unsubscribeProcessing();
 		};
 	}, [ onCheckoutProcessing, checkValidation ] );
 

--- a/assets/js/base/context/cart-checkout/event-emit/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/emitters.js
@@ -16,11 +16,11 @@
  */
 export const emitEvent = async ( observers, eventType, data ) => {
 	const observersByType = observers[ eventType ]
-		? Object.values( observers[ eventType ] )
+		? observers[ eventType ].values()
 		: [];
-	for ( let i = 0; i < observersByType.length; i++ ) {
+	for ( const observer of observersByType ) {
 		try {
-			await Promise.resolve( observersByType[ i ]( data ) );
+			await Promise.resolve( observer( data ) );
 		} catch ( e ) {
 			// we don't care about errors blocking execution, but will
 			// console.error for troubleshooting.
@@ -46,13 +46,11 @@ export const emitEvent = async ( observers, eventType, data ) => {
  */
 export const emitEventWithAbort = async ( observers, eventType, data ) => {
 	const observersByType = observers[ eventType ]
-		? Object.values( observers[ eventType ] )
+		? observers[ eventType ].values()
 		: [];
-	for ( let i = 0; i < observersByType.length; i++ ) {
+	for ( const observer of observersByType ) {
 		try {
-			const response = await Promise.resolve(
-				observersByType[ i ]( data )
-			);
+			const response = await Promise.resolve( observer( data ) );
 			if ( response !== true ) {
 				return response;
 			}

--- a/assets/js/base/context/cart-checkout/event-emit/reducer.js
+++ b/assets/js/base/context/cart-checkout/event-emit/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, uniqueId } from 'lodash';
+import { uniqueId } from 'lodash';
 
 export const TYPES = {
 	ADD_EVENT_CALLBACK: 'add_event_callback',
@@ -33,19 +33,19 @@ export const actions = {
  * @param {Object} action Incoming action object
  */
 export const reducer = ( state = {}, { type, eventType, id, callback } ) => {
+	const newEvents = new Map( state[ eventType ] );
 	switch ( type ) {
 		case TYPES.ADD_EVENT_CALLBACK:
+			newEvents.set( id, callback );
 			return {
 				...state,
-				[ eventType ]: {
-					...state[ eventType ],
-					[ id ]: callback,
-				},
+				[ eventType ]: newEvents,
 			};
 		case TYPES.REMOVE_EVENT_CALLBACK:
+			newEvents.delete( id );
 			return {
 				...state,
-				[ eventType ]: omit( state[ eventType ], [ id ] ),
+				[ eventType ]: newEvents,
 			};
 	}
 	return state;

--- a/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
@@ -5,24 +5,34 @@ import { emitEvent, emitEventWithAbort } from '../emitters';
 
 describe( 'Testing emitters', () => {
 	let observerMocks = {};
+	let observerA;
+	let observerB;
+	let observerPromiseWithResolvedValue;
 	beforeEach( () => {
-		observerMocks = {
-			observerA: jest.fn().mockReturnValue( true ),
-			observerB: jest.fn().mockReturnValue( true ),
-			observerReturnValue: jest.fn().mockReturnValue( 10 ),
-			observerPromiseWithReject: jest
-				.fn()
-				.mockRejectedValue( 'an error' ),
-			observerPromiseWithResolvedValue: jest.fn().mockResolvedValue( 10 ),
-		};
+		observerA = jest.fn().mockReturnValue( true );
+		observerB = jest.fn().mockReturnValue( true );
+		observerPromiseWithResolvedValue = jest.fn().mockResolvedValue( 10 );
+		observerMocks = new Map( [
+			[ 'observerA', observerA ],
+			[ 'observerB', observerB ],
+			[ 'observerReturnValue', jest.fn().mockReturnValue( 10 ) ],
+			[
+				'observerPromiseWithReject',
+				jest.fn().mockRejectedValue( 'an error' ),
+			],
+			[
+				'observerPromiseWithResolvedValue',
+				observerPromiseWithResolvedValue,
+			],
+		] );
 	} );
 	describe( 'Testing emitEvent()', () => {
 		it( 'invokes all observers', async () => {
 			const observers = { test: observerMocks };
 			const response = await emitEvent( observers, 'test', 'foo' );
 			expect( console ).toHaveErroredWith( 'an error' );
-			expect( observerMocks.observerA ).toHaveBeenCalledTimes( 1 );
-			expect( observerMocks.observerB ).toHaveBeenCalledWith( 'foo' );
+			expect( observerA ).toHaveBeenCalledTimes( 1 );
+			expect( observerB ).toHaveBeenCalledWith( 'foo' );
 			expect( response ).toBe( true );
 		} );
 	} );
@@ -38,9 +48,9 @@ describe( 'Testing emitters', () => {
 					'foo'
 				);
 				expect( console ).not.toHaveErrored();
-				expect( observerMocks.observerB ).toHaveBeenCalledTimes( 1 );
+				expect( observerB ).toHaveBeenCalledTimes( 1 );
 				expect(
-					observerMocks.observerPromiseWithResolvedValue
+					observerPromiseWithResolvedValue
 				).not.toHaveBeenCalled();
 				expect( response ).toBe( 10 );
 			}

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -53,6 +53,7 @@ const reducer = (
 			return {
 				...state,
 				currentStatus: PROCESSING,
+				errorMessage: '',
 			};
 		case COMPLETE:
 			return {

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -165,9 +165,7 @@ export const ShippingDataProvider = ( { children } ) => {
 
 	// dispatch checkout error if there's a shipping error.
 	useEffect( () => {
-		if ( currentErrorStatus.hasError ) {
-			dispatchActions.setHasError( true );
-		}
+		dispatchActions.setHasError( currentErrorStatus.hasError );
 	}, [ currentErrorStatus.hasError, dispatchActions.setHasError ] );
 
 	/**

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -165,8 +165,10 @@ export const ShippingDataProvider = ( { children } ) => {
 
 	// dispatch checkout error if there's a shipping error.
 	useEffect( () => {
-		dispatchActions.setHasError( currentErrorStatus.hasError );
-	}, [ currentErrorStatus, dispatchActions.setHasError ] );
+		if ( currentErrorStatus.hasError ) {
+			dispatchActions.setHasError( true );
+		}
+	}, [ currentErrorStatus.hasError, dispatchActions.setHasError ] );
 
 	/**
 	 * @type {ShippingDataContext}

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -13,7 +13,11 @@ const ValidationContext = createContext( {
 	setValidationErrors: ( errors ) => void errors,
 	clearValidationError: ( property ) => void property,
 	clearAllValidationErrors: () => void null,
-	getValidationErrorId: ( inputId ) => inputId,
+	hideValidationError: () => void null,
+	showValidationError: () => void null,
+	showAllValidationErrors: () => void null,
+	hasValidationErrors: () => false,
+	getValidationErrorId: ( errorId ) => errorId,
 } );
 
 /**
@@ -168,11 +172,11 @@ export const ValidationContextProvider = ( { children } ) => {
 		setValidationErrors,
 		clearValidationError,
 		clearAllValidationErrors,
-		getValidationErrorId,
 		hideValidationError,
 		showValidationError,
 		showAllValidationErrors,
 		hasValidationErrors,
+		getValidationErrorId,
 	};
 	return (
 		<ValidationContext.Provider value={ context }>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -80,15 +80,21 @@ const Checkout = ( {
 
 	const [ contactFields, setContactFields ] = useState( {} );
 	const [ shippingAsBilling, setShippingAsBilling ] = useState( true );
+	const withErrors = hasValidationErrors();
 
 	useEffect( () => {
-		// @todo hasValidationErrors() doesn't return the updated value
-		onCheckoutProcessing( () => ! hasValidationErrors() );
-		onCheckoutCompleteError( () => {
+		const unsubscribeProcessing = onCheckoutProcessing(
+			() => ! withErrors
+		);
+		const unsubscribeCompleteError = onCheckoutCompleteError( () => {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 		} );
-	}, [] );
+		return () => {
+			unsubscribeProcessing();
+			unsubscribeCompleteError();
+		};
+	}, [ onCheckoutProcessing, onCheckoutCompleteError, withErrors ] );
 
 	const renderShippingRatesControlOption = ( option ) => ( {
 		label: decodeEntities( option.name ),

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -62,7 +62,11 @@ const Checkout = ( {
 	scrollToTop,
 } ) => {
 	const { isEditor } = useEditorContext();
-	const { hasOrder } = useCheckoutContext();
+	const {
+		hasOrder,
+		onCheckoutProcessing,
+		onCheckoutCompleteError,
+	} = useCheckoutContext();
 	const {
 		shippingRatesLoading,
 		shippingAddress,
@@ -77,14 +81,14 @@ const Checkout = ( {
 	const [ contactFields, setContactFields ] = useState( {} );
 	const [ shippingAsBilling, setShippingAsBilling ] = useState( true );
 
-	const validateSubmit = () => {
-		if ( hasValidationErrors() ) {
+	useEffect( () => {
+		// @todo hasValidationErrors() doesn't return the updated value
+		onCheckoutProcessing( () => ! hasValidationErrors() );
+		onCheckoutCompleteError( () => {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
-			return false;
-		}
-		return true;
-	};
+		} );
+	}, [] );
 
 	const renderShippingRatesControlOption = ( option ) => ( {
 		label: decodeEntities( option.name ),
@@ -365,7 +369,7 @@ const Checkout = ( {
 								) }
 							/>
 						) }
-						<PlaceOrderButton validateSubmit={ validateSubmit } />
+						<PlaceOrderButton />
 					</div>
 					{ attributes.showPolicyLinks && <Policies /> }
 				</Main>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -20,7 +20,6 @@ import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import {
 	CheckoutProvider,
-	useValidationContext,
 	useCheckoutContext,
 	useEditorContext,
 	useShippingDataContext,
@@ -38,7 +37,6 @@ import {
 	Main,
 } from '@woocommerce/base-components/sidebar-layout';
 import { getSetting } from '@woocommerce/settings';
-import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 
 /**
  * Internal dependencies
@@ -59,42 +57,18 @@ const Checkout = ( {
 	cartItems = [],
 	cartTotals = {},
 	shippingRates = [],
-	scrollToTop,
 } ) => {
 	const { isEditor } = useEditorContext();
-	const {
-		hasOrder,
-		onCheckoutProcessing,
-		onCheckoutCompleteError,
-	} = useCheckoutContext();
+	const { hasOrder } = useCheckoutContext();
 	const {
 		shippingRatesLoading,
 		shippingAddress,
 		setShippingAddress,
 	} = useShippingDataContext();
 	const { billingData, setBillingData } = useBillingDataContext();
-	const {
-		hasValidationErrors,
-		showAllValidationErrors,
-	} = useValidationContext();
 
 	const [ contactFields, setContactFields ] = useState( {} );
 	const [ shippingAsBilling, setShippingAsBilling ] = useState( true );
-	const withErrors = hasValidationErrors();
-
-	useEffect( () => {
-		const unsubscribeProcessing = onCheckoutProcessing(
-			() => ! withErrors
-		);
-		const unsubscribeCompleteError = onCheckoutCompleteError( () => {
-			showAllValidationErrors();
-			scrollToTop( { focusableSelector: 'input:invalid' } );
-		} );
-		return () => {
-			unsubscribeProcessing();
-			unsubscribeCompleteError();
-		};
-	}, [ onCheckoutProcessing, onCheckoutCompleteError, withErrors ] );
 
 	const renderShippingRatesControlOption = ( option ) => ( {
 		label: decodeEntities( option.name ),
@@ -384,4 +358,4 @@ const Checkout = ( {
 	);
 };
 
-export default withScrollToTop( Block );
+export default Block;

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -151,6 +151,7 @@ const Checkout = ( {
 							) }
 						>
 							<ValidatedTextInput
+								id="email"
 								type="email"
 								label={ __(
 									'Email address',
@@ -192,6 +193,7 @@ const Checkout = ( {
 								) }
 							>
 								<AddressForm
+									id="shipping"
 									onChange={ setShippingFields }
 									values={ shippingAddress }
 									fields={ Object.keys( addressFields ) }
@@ -199,6 +201,7 @@ const Checkout = ( {
 								/>
 								{ attributes.showPhoneField && (
 									<ValidatedTextInput
+										id="phone"
 										type="tel"
 										label={
 											attributes.requirePhoneField
@@ -251,6 +254,7 @@ const Checkout = ( {
 								) }
 							>
 								<AddressForm
+									id="billing"
 									onChange={ setBillingData }
 									type="billing"
 									values={ billingData }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -24,6 +24,7 @@ import {
 	useEditorContext,
 	useShippingDataContext,
 	useBillingDataContext,
+	useValidationContext,
 } from '@woocommerce/base-context';
 import {
 	ExpressCheckoutFormControl,
@@ -37,6 +38,7 @@ import {
 	Main,
 } from '@woocommerce/base-components/sidebar-layout';
 import { getSetting } from '@woocommerce/settings';
+import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 
 /**
  * Internal dependencies
@@ -56,10 +58,12 @@ const Checkout = ( {
 	cartCoupons = [],
 	cartItems = [],
 	cartTotals = {},
+	scrollToTop,
 	shippingRates = [],
 } ) => {
 	const { isEditor } = useEditorContext();
-	const { hasOrder } = useCheckoutContext();
+	const { hasOrder, onCheckoutCompleteError } = useCheckoutContext();
+	const { showAllValidationErrors } = useValidationContext();
 	const {
 		shippingRatesLoading,
 		shippingAddress,
@@ -115,6 +119,16 @@ const Checkout = ( {
 			setBillingData( { shippingAsBilling } );
 		}
 	}, [ shippingAsBilling, setBillingData ] );
+
+	useEffect( () => {
+		const unsubscribeCompleteError = onCheckoutCompleteError( () => {
+			showAllValidationErrors();
+			scrollToTop( { focusableSelector: 'input:invalid' } );
+		} );
+		return () => {
+			unsubscribeCompleteError();
+		};
+	}, [ onCheckoutCompleteError ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;
@@ -364,4 +378,4 @@ const Checkout = ( {
 	);
 };
 
-export default Block;
+export default withScrollToTop( Block );

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -110,7 +110,9 @@ const Checkout = ( {
 	);
 	useEffect( () => {
 		if ( shippingAsBilling ) {
-			setBillingData( shippingAddress );
+			setBillingData( { ...shippingAddress, shippingAsBilling } );
+		} else {
+			setBillingData( { shippingAsBilling } );
 		}
 	}, [ shippingAsBilling, setBillingData ] );
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/use-checkout-subscriptions.js
@@ -122,6 +122,7 @@ export const useCheckoutSubscriptions = (
 				setSourceId( response.source.id );
 				return true;
 			} catch ( e ) {
+				paymentStatus.setPaymentStatus().error( e );
 				return e;
 			}
 		};


### PR DESCRIPTION
Closes #1939.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/78149303-2077ce80-7436-11ea-8212-a3b1343c3a78.png)
_(:point_up_2: errors added by the payment method)_

### How to test the changes in this Pull Request:

In order to test it, let's force the payment method to return an error in certain circumstances. In `payment-method-extensions/payment-methods/stripe/payment-method.js` L289, paste something like this:
```JS
if ( billingData.postcode !== 'ABCD' ) {
	paymentStatus
		.setPaymentStatus()
		.error( 'Stripe found an error with your postcode.' );
	const key = billingData.shippingAsBilling
		? 'shipping-postcode'
		: 'billing-postcode';
	return {
		[ key ]: {
			message: 'Postcode must be ABCD.',
		},
	};
}
```
That will make Stripe to return an error if the billing postcode is different from `ABCD`.
1. Go to the _Checkout_ block and enter some data.
2. Feel free to leave some required fields empty or introduce an invalid email. We are testing validation!
3. Click on `Place Order` and verify errors are displayed properly.

### Notes
Currently, not all errors will appear at once: first Checkout validation errors and then, errors created by the payment method. I think this can be worked on in a follow-up and doesn't have to block this PR.