### PR TITLE
Ensure woocommerceanalytics checkout event fires for checkout block

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -82,10 +82,17 @@ class Checkout extends AbstractBlock {
 			$data_registry->add( 'shippingMethodsExist', $methods_exist );
 		}
 
+		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
+
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' );
 		Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
-		return $content . $this->get_skeleton();
+		
+		$skeleton = $this->get_skeleton();
+		$checkout = WC()->checkout();
+		do_action( 'woocommerce_after_checkout_form', $checkout );
+
+		return $content . $skeleton;
 	}
 
 	/**

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -87,7 +87,7 @@ class Checkout extends AbstractBlock {
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' );
 		Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
-		
+
 		$skeleton = $this->get_skeleton();
 		$checkout = WC()->checkout();
 		do_action( 'woocommerce_after_checkout_form', $checkout );


### PR DESCRIPTION
Fixes #2031

This fires the existing woocommerce core [`woocommerce_after_checkout_form` hook](https://github.com/woocommerce/woocommerce/blob/master/templates/checkout/form-checkout.php#L66) after the checkout block.

The analytics event is [fired off this hook](https://github.com/Automattic/jetpack/blob/master/modules/woocommerce-analytics/classes/wp-woocommerce-analytics-universal.php#L46), so firing the hook ensures the event is triggered. At face value this seems appropriate – this is after the basic checkout render – but we may need to review other uses of the hook to check that this approach works well and doesn't cause issues with other extensions/themes using this hook.

### Screenshots

<img width="601" alt="Screen Shot 2020-03-27 at 4 39 18 PM" src="https://user-images.githubusercontent.com/4167300/77719680-c13b4800-704a-11ea-9562-ef06ad9a7c7f.png">


### How to test the changes in this Pull Request:

0. Test on incognito window, or logged in as customer - analytics aren't fired for admins.
3. Install & activate Jetpack plugin in your dev site (running this branch of blocks plugin). To do this you may need to set up an ngrok tunnel or similar; see [Jetpack repo for more info](https://github.com/Automattic/jetpack/blob/master/docs/development-environment.md).
2. View network tab in dev tools, search for `pixel`.
1. Add stuff to your cart, view checkout block.
3. Confirm that `woocommerceanalytics_product_checkout` event is logged, and parameters are correct (e.g. product info, quantity).

Also check that this event still fires on shortcode based checkout, and doesn't fire when it shouldn't :)
