### PR TITLE
Fix build issues for production builds

### DIFF
--- a/assets/js/base/components/payment-methods/express-checkout.js
+++ b/assets/js/base/components/payment-methods/express-checkout.js
@@ -8,6 +8,7 @@ import { useExpressPaymentMethods } from '@woocommerce/base-hooks';
  * Internal dependencies
  */
 import ExpressPaymentMethods from './express-payment-methods';
+import './style.scss';
 
 const ExpressCheckoutContainer = ( { children } ) => {
 	return (

--- a/assets/js/base/components/payment-methods/index.js
+++ b/assets/js/base/components/payment-methods/index.js
@@ -1,8 +1,3 @@
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 export { default as PaymentMethods } from './payment-methods';
 export { default as ExpressPaymentMethods } from './express-payment-methods';
 export { default as ExpressCheckoutFormControl } from './express-checkout';

--- a/assets/js/base/components/sidebar-layout/index.js
+++ b/assets/js/base/components/sidebar-layout/index.js
@@ -1,8 +1,3 @@
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 export { default as Sidebar } from './sidebar';
 export { default as Main } from './main';
 export { default as SidebarLayout } from './sidebar-layout';

--- a/assets/js/base/components/sidebar-layout/sidebar-layout.js
+++ b/assets/js/base/components/sidebar-layout/sidebar-layout.js
@@ -4,6 +4,11 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 const SidebarLayout = ( { children, className } ) => {
 	return (
 		<div className={ classNames( 'wc-block-sidebar-layout', className ) }>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -152,10 +152,10 @@ table.wc-block-cart-items {
 		min-height: 460px;
 	}
 }
-.wc-block-cart--skeleton {
+.wc-block-sidebar-layout.wc-block-cart--skeleton {
 	display: none;
 }
-.is-loading + .wc-block-cart--skeleton {
+.is-loading + .wc-block-sidebar-layout.wc-block-cart--skeleton {
 	display: flex;
 }
 

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -154,10 +154,10 @@
 		min-height: 460px;
 	}
 }
-.wc-block-checkout--skeleton {
+.wc-block-sidebar-layout.wc-block-checkout--skeleton {
 	display: none;
 }
-.is-loading + .wc-block-checkout--skeleton {
+.is-loading + .wc-block-sidebar-layout.wc-block-checkout--skeleton {
 	display: flex;
 }
 

--- a/assets/js/settings/blocks/index.js
+++ b/assets/js/settings/blocks/index.js
@@ -1,3 +1,7 @@
-export * from './store-api-nonce';
+/**
+ * Internal dependencies
+ */
+import './store-api-nonce';
+
 export * from './constants';
 export { ENDPOINTS } from './endpoints';

--- a/assets/js/settings/blocks/store-api-nonce.js
+++ b/assets/js/settings/blocks/store-api-nonce.js
@@ -46,7 +46,7 @@ const setNonce = ( headers ) => {
  *
  * @return {*} The evaluated result of the remaining middleware chain.
  */
-export const storeNonceMiddleware = ( options, next ) => {
+const storeNonceMiddleware = ( options, next ) => {
 	if ( isStoreApiGetRequest( options ) ) {
 		const existingHeaders = options.headers || {};
 		options.headers = {

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -27,6 +27,12 @@ const requestToExternal = ( request ) => {
 		'@woocommerce/settings': [ 'wc', 'wcSettings' ],
 		'@woocommerce/block-data': [ 'wc', 'wcBlocksData' ],
 	};
+	// returning null for these packages ensures that the package installed
+	// in node_modules is used instead of the default external defined in the
+	// DependencyExtractionWebpackPlugin
+	if ( [ '@wordpress/primitives', '@wordpress/icons' ].includes( request ) ) {
+		return null;
+	}
 	if ( wcDepMap[ request ] ) {
 		return wcDepMap[ request ];
 	}
@@ -38,6 +44,8 @@ const requestToHandle = ( request ) => {
 		'@woocommerce/settings': 'wc-settings',
 		'@woocommerce/block-settings': 'wc-settings',
 		'@woocommerce/block-data': 'wc-blocks-data-store',
+		'@wordpress/primitives': '',
+		'@wordpress/icons': '',
 	};
 	if ( wcHandleMap[ request ] ) {
 		return wcHandleMap[ request ];

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -30,7 +30,13 @@ const requestToExternal = ( request ) => {
 	// returning null for these packages ensures that the package installed
 	// in node_modules is used instead of the default external defined in the
 	// DependencyExtractionWebpackPlugin
-	if ( [ '@wordpress/primitives', '@wordpress/icons' ].includes( request ) ) {
+	if (
+		[
+			'@wordpress/primitives',
+			'@wordpress/icons',
+			'@wordpress/warning',
+		].includes( request )
+	) {
 		return null;
 	}
 	if ( wcDepMap[ request ] ) {

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -38,8 +38,6 @@ const requestToHandle = ( request ) => {
 		'@woocommerce/settings': 'wc-settings',
 		'@woocommerce/block-settings': 'wc-settings',
 		'@woocommerce/block-data': 'wc-blocks-data-store',
-		'@wordpress/primitives': '',
-		'@wordpress/icons': '',
 	};
 	if ( wcHandleMap[ request ] ) {
 		return wcHandleMap[ request ];

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -27,18 +27,6 @@ const requestToExternal = ( request ) => {
 		'@woocommerce/settings': [ 'wc', 'wcSettings' ],
 		'@woocommerce/block-data': [ 'wc', 'wcBlocksData' ],
 	};
-	// returning null for these packages ensures that the package installed
-	// in node_modules is used instead of the default external defined in the
-	// DependencyExtractionWebpackPlugin
-	if (
-		[
-			'@wordpress/primitives',
-			'@wordpress/icons',
-			'@wordpress/warning',
-		].includes( request )
-	) {
-		return null;
-	}
 	if ( wcDepMap[ request ] ) {
 		return wcDepMap[ request ];
 	}

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -113,15 +113,15 @@ const stableMainEntry = {
 	blocks: './assets/js/index.js',
 
 	// @wordpress/components styles
-	'panel-style': './node_modules/@wordpress/components/src/panel/style.scss',
+	'panel-style': './node_modules/wordpress-components/src/panel/style.scss',
 	'custom-select-control-style':
-		'./node_modules/@wordpress/components/src/custom-select-control/style.scss',
+		'./node_modules/wordpress-components/src/custom-select-control/style.scss',
 	'checkbox-control-style':
-		'./node_modules/@wordpress/components/src/checkbox-control/style.scss',
+		'./node_modules/wordpress-components/src/checkbox-control/style.scss',
 	'spinner-style':
-		'./node_modules/@wordpress/components/src/spinner/style.scss',
+		'./node_modules/wordpress-components/src/spinner/style.scss',
 	'snackbar-notice-style':
-		'./node_modules/@wordpress/components/src/snackbar/style.scss',
+		'./node_modules/wordpress-components/src/snackbar/style.scss',
 
 	// Blocks
 	'handpicked-products': './assets/js/blocks/handpicked-products/index.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1291,6 +1291,7 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
       "integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
+      "dev": true,
       "requires": {
         "@emotion/primitives-core": "10.0.27"
       }
@@ -1299,6 +1300,7 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
       "integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
+      "dev": true,
       "requires": {
         "css-to-react-native": "^2.2.1"
       }
@@ -5291,7 +5293,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.10.0.tgz",
       "integrity": "sha512-CedhhFfcubM/lsluY7JPC49VG0/Ee0chOBJ1vyDEvIJmQk0bM3sLfgt5qVK773yivVOqD9blQMO+JihnaMXF8w==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@wordpress/escape-html": "^1.6.0",
@@ -5364,7 +5365,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
       "integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
         "gettext-parser": "^1.3.1",
@@ -5378,6 +5378,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.1.0.tgz",
       "integrity": "sha512-JPSWz1qOj7pWhAd3pQaHIRrgVDaePv7w6nPX5Uy3LFny+RfBXMNDh+tBGEQvC5iAAhBhDvJyekiDc63tbdnO4g==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.3",
         "@wordpress/element": "^2.11.0",
@@ -5388,6 +5389,7 @@
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
           "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.3",
             "@wordpress/escape-html": "^1.7.0",
@@ -5402,7 +5404,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.7.0.tgz",
       "integrity": "sha512-fRHTAivQlWOQVn8wu8NHM8D5sacSvY6upJ+MgWSu1Q7pqy51zaCPE2T9lhym3GC1QzABus6VjDctR8jwfNfd/g==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4"
       }
@@ -5650,6 +5651,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.1.0.tgz",
       "integrity": "sha512-qENxMXnGASutHqbQzbGOj/66B1LQwSBBLGtL9/Tjze+X9e04tUfdJCGroAgaEKmpDFJO39sL26UhW/f8rKz7cw==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.3",
         "@wordpress/element": "^2.11.0",
@@ -5660,6 +5662,7 @@
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
           "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.3",
             "@wordpress/escape-html": "^1.7.0",
@@ -6655,7 +6658,8 @@
     "@wordpress/warning": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.0.0.tgz",
-      "integrity": "sha512-/xa3e4GuXdMhxKtGYbwkCvOJLRkFgRexhsJpq5xFHz/7jSFdBdIY/eiOIVk1jhnjQpS+w3jL9VSAsE1R2AlV7A=="
+      "integrity": "sha512-/xa3e4GuXdMhxKtGYbwkCvOJLRkFgRexhsJpq5xFHz/7jSFdBdIY/eiOIVk1jhnjQpS+w3jL9VSAsE1R2AlV7A==",
+      "dev": true
     },
     "@wordpress/wordcount": {
       "version": "2.7.0",
@@ -8699,7 +8703,8 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+      "dev": true
     },
     "can-use-dom": {
       "version": "0.1.0",
@@ -9807,7 +9812,8 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "dev": true
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -9885,6 +9891,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
       "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -9894,7 +9901,8 @@
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
         }
       }
     },
@@ -22989,7 +22997,8 @@
     "react-resize-aware": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.0.tgz",
-      "integrity": "sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q=="
+      "integrity": "sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q==",
+      "dev": true
     },
     "react-router": {
       "version": "5.1.2",
@@ -29430,39 +29439,34 @@
       "dev": true
     },
     "wordpress-components": {
-      "version": "npm:@wordpress/components@9.2.4",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.4.tgz",
-      "integrity": "sha512-em+X7wKVMKNoqwYD6gCv1J3YyKFGoMkqLobfhcjFWCdzOIb3o7CnQD/QuBKebB73VlInjcxAlZ1wv5379OuVXw==",
+      "version": "npm:@wordpress/components@8.5.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.5.0.tgz",
+      "integrity": "sha512-2wBpL7a9udh2yvzIA242Fhu2+srNv4WXFa0jjXJrf99smlVm2BxLMQtlNgfaV4LkYFAAnc0Bkud90NdrOoZ/ig==",
       "requires": {
-        "@babel/runtime": "^7.8.3",
-        "@emotion/core": "^10.0.22",
-        "@emotion/css": "^10.0.22",
-        "@emotion/native": "^10.0.22",
-        "@emotion/styled": "^10.0.23",
-        "@wordpress/a11y": "^2.7.0",
-        "@wordpress/compose": "^3.11.0",
-        "@wordpress/deprecated": "^2.7.0",
-        "@wordpress/dom": "^2.8.0",
-        "@wordpress/element": "^2.11.0",
-        "@wordpress/hooks": "^2.7.0",
-        "@wordpress/i18n": "^3.9.0",
-        "@wordpress/icons": "^1.1.0",
-        "@wordpress/is-shallow-equal": "^1.8.0",
-        "@wordpress/keycodes": "^2.9.0",
-        "@wordpress/primitives": "^1.1.0",
-        "@wordpress/rich-text": "^3.12.1",
-        "@wordpress/warning": "^1.0.0",
+        "@babel/runtime": "^7.4.4",
+        "@emotion/core": "10.0.22",
+        "@emotion/styled": "10.0.23",
+        "@wordpress/a11y": "^2.5.1",
+        "@wordpress/compose": "^3.9.0",
+        "@wordpress/deprecated": "^2.6.1",
+        "@wordpress/dom": "^2.6.0",
+        "@wordpress/element": "^2.10.0",
+        "@wordpress/hooks": "^2.6.0",
+        "@wordpress/i18n": "^3.7.0",
+        "@wordpress/is-shallow-equal": "^1.6.1",
+        "@wordpress/keycodes": "^2.7.0",
+        "@wordpress/rich-text": "^3.9.0",
         "classnames": "^2.2.5",
         "clipboard": "^2.0.1",
         "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^4.0.5",
+        "downshift": "^3.3.4",
         "gradient-parser": "^0.1.5",
         "lodash": "^4.17.15",
         "memize": "^1.0.5",
         "moment": "^2.22.1",
+        "mousetrap": "^1.6.2",
         "re-resizable": "^6.0.0",
         "react-dates": "^17.1.1",
-        "react-resize-aware": "^3.0.0",
         "react-spring": "^8.0.20",
         "reakit": "^1.0.0-beta.12",
         "rememo": "^3.0.0",
@@ -29480,39 +29484,28 @@
             "@wordpress/is-shallow-equal": "^1.8.0",
             "lodash": "^4.17.15",
             "mousetrap": "^1.6.2"
-          }
-        },
-        "@wordpress/element": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
-          "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-          "requires": {
-            "@babel/runtime": "^7.8.3",
-            "@wordpress/escape-html": "^1.7.0",
-            "lodash": "^4.17.15",
-            "react": "^16.9.0",
-            "react-dom": "^16.9.0"
-          }
-        },
-        "@wordpress/i18n": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-          "integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
-          "requires": {
-            "@babel/runtime": "^7.8.3",
-            "gettext-parser": "^1.3.1",
-            "lodash": "^4.17.15",
-            "memize": "^1.0.5",
-            "sprintf-js": "^1.1.1",
-            "tannin": "^1.1.0"
-          }
-        },
-        "@wordpress/is-shallow-equal": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-          "integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-          "requires": {
-            "@babel/runtime": "^7.8.3"
+          },
+          "dependencies": {
+            "@wordpress/element": {
+              "version": "2.11.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
+              "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
+              "requires": {
+                "@babel/runtime": "^7.8.3",
+                "@wordpress/escape-html": "^1.7.0",
+                "lodash": "^4.17.15",
+                "react": "^16.9.0",
+                "react-dom": "^16.9.0"
+              }
+            },
+            "@wordpress/is-shallow-equal": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
+              "integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
+              "requires": {
+                "@babel/runtime": "^7.8.3"
+              }
+            }
           }
         },
         "@wordpress/keycodes": {
@@ -29523,6 +29516,32 @@
             "@babel/runtime": "^7.8.3",
             "@wordpress/i18n": "^3.9.0",
             "lodash": "^4.17.15"
+          },
+          "dependencies": {
+            "@wordpress/i18n": {
+              "version": "3.9.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
+              "integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
+              "requires": {
+                "@babel/runtime": "^7.8.3",
+                "gettext-parser": "^1.3.1",
+                "lodash": "^4.17.15",
+                "memize": "^1.0.5",
+                "sprintf-js": "^1.1.1",
+                "tannin": "^1.1.0"
+              }
+            }
+          }
+        },
+        "downshift": {
+          "version": "3.4.8",
+          "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.4.8.tgz",
+          "integrity": "sha512-dZL3iNL/LbpHNzUQAaVq/eTD1ocnGKKjbAl/848Q0KEp6t81LJbS37w3f93oD6gqqAnjdgM7Use36qZSipHXBw==",
+          "requires": {
+            "@babel/runtime": "^7.4.5",
+            "compute-scroll-into-view": "^1.0.9",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.9.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1291,7 +1291,6 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
       "integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
-      "dev": true,
       "requires": {
         "@emotion/primitives-core": "10.0.27"
       }
@@ -1300,7 +1299,6 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
       "integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
-      "dev": true,
       "requires": {
         "css-to-react-native": "^2.2.1"
       }
@@ -5380,7 +5378,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.1.0.tgz",
       "integrity": "sha512-JPSWz1qOj7pWhAd3pQaHIRrgVDaePv7w6nPX5Uy3LFny+RfBXMNDh+tBGEQvC5iAAhBhDvJyekiDc63tbdnO4g==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.3",
         "@wordpress/element": "^2.11.0",
@@ -5391,7 +5388,6 @@
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
           "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.3",
             "@wordpress/escape-html": "^1.7.0",
@@ -5654,7 +5650,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.1.0.tgz",
       "integrity": "sha512-qENxMXnGASutHqbQzbGOj/66B1LQwSBBLGtL9/Tjze+X9e04tUfdJCGroAgaEKmpDFJO39sL26UhW/f8rKz7cw==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.3",
         "@wordpress/element": "^2.11.0",
@@ -5665,7 +5660,6 @@
           "version": "2.11.0",
           "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.11.0.tgz",
           "integrity": "sha512-56ZO8a+E7QEsYwiqS+3BQPSHrCPsOAIEz5smXzntb2f6BjvOKeA64pup40mdn1pNGexe06LBA8cjoZVdLBHB1w==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.3",
             "@wordpress/escape-html": "^1.7.0",
@@ -6661,8 +6655,7 @@
     "@wordpress/warning": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.0.0.tgz",
-      "integrity": "sha512-/xa3e4GuXdMhxKtGYbwkCvOJLRkFgRexhsJpq5xFHz/7jSFdBdIY/eiOIVk1jhnjQpS+w3jL9VSAsE1R2AlV7A==",
-      "dev": true
+      "integrity": "sha512-/xa3e4GuXdMhxKtGYbwkCvOJLRkFgRexhsJpq5xFHz/7jSFdBdIY/eiOIVk1jhnjQpS+w3jL9VSAsE1R2AlV7A=="
     },
     "@wordpress/wordcount": {
       "version": "2.7.0",
@@ -8706,8 +8699,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
-      "dev": true
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "can-use-dom": {
       "version": "0.1.0",
@@ -9815,8 +9807,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-      "dev": true
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -9894,7 +9885,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
       "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
-      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -9904,8 +9894,7 @@
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
         }
       }
     },
@@ -23000,8 +22989,7 @@
     "react-resize-aware": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.0.tgz",
-      "integrity": "sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q==",
-      "dev": true
+      "integrity": "sha512-UyLk1KNbFHDye9AFLyr7HBGmzkRDGz2mYp6LDS+LCxM6DXGpviwS5Q4JRzXWdw0tk+n46UE/Kotku/cb8HCh0Q=="
     },
     "react-router": {
       "version": "5.1.2",
@@ -29442,34 +29430,39 @@
       "dev": true
     },
     "wordpress-components": {
-      "version": "npm:@wordpress/components@8.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.5.0.tgz",
-      "integrity": "sha512-2wBpL7a9udh2yvzIA242Fhu2+srNv4WXFa0jjXJrf99smlVm2BxLMQtlNgfaV4LkYFAAnc0Bkud90NdrOoZ/ig==",
+      "version": "npm:@wordpress/components@9.2.4",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.2.4.tgz",
+      "integrity": "sha512-em+X7wKVMKNoqwYD6gCv1J3YyKFGoMkqLobfhcjFWCdzOIb3o7CnQD/QuBKebB73VlInjcxAlZ1wv5379OuVXw==",
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@emotion/core": "10.0.22",
-        "@emotion/styled": "10.0.23",
-        "@wordpress/a11y": "^2.5.1",
-        "@wordpress/compose": "^3.9.0",
-        "@wordpress/deprecated": "^2.6.1",
-        "@wordpress/dom": "^2.6.0",
-        "@wordpress/element": "^2.10.0",
-        "@wordpress/hooks": "^2.6.0",
-        "@wordpress/i18n": "^3.7.0",
-        "@wordpress/is-shallow-equal": "^1.6.1",
-        "@wordpress/keycodes": "^2.7.0",
-        "@wordpress/rich-text": "^3.9.0",
+        "@babel/runtime": "^7.8.3",
+        "@emotion/core": "^10.0.22",
+        "@emotion/css": "^10.0.22",
+        "@emotion/native": "^10.0.22",
+        "@emotion/styled": "^10.0.23",
+        "@wordpress/a11y": "^2.7.0",
+        "@wordpress/compose": "^3.11.0",
+        "@wordpress/deprecated": "^2.7.0",
+        "@wordpress/dom": "^2.8.0",
+        "@wordpress/element": "^2.11.0",
+        "@wordpress/hooks": "^2.7.0",
+        "@wordpress/i18n": "^3.9.0",
+        "@wordpress/icons": "^1.1.0",
+        "@wordpress/is-shallow-equal": "^1.8.0",
+        "@wordpress/keycodes": "^2.9.0",
+        "@wordpress/primitives": "^1.1.0",
+        "@wordpress/rich-text": "^3.12.1",
+        "@wordpress/warning": "^1.0.0",
         "classnames": "^2.2.5",
         "clipboard": "^2.0.1",
         "dom-scroll-into-view": "^1.2.1",
-        "downshift": "^3.3.4",
+        "downshift": "^4.0.5",
         "gradient-parser": "^0.1.5",
         "lodash": "^4.17.15",
         "memize": "^1.0.5",
         "moment": "^2.22.1",
-        "mousetrap": "^1.6.2",
         "re-resizable": "^6.0.0",
         "react-dates": "^17.1.1",
+        "react-resize-aware": "^3.0.0",
         "react-spring": "^8.0.20",
         "reakit": "^1.0.0-beta.12",
         "rememo": "^3.0.0",
@@ -29530,17 +29523,6 @@
             "@babel/runtime": "^7.8.3",
             "@wordpress/i18n": "^3.9.0",
             "lodash": "^4.17.15"
-          }
-        },
-        "downshift": {
-          "version": "3.4.8",
-          "resolved": "https://registry.npmjs.org/downshift/-/downshift-3.4.8.tgz",
-          "integrity": "sha512-dZL3iNL/LbpHNzUQAaVq/eTD1ocnGKKjbAl/848Q0KEp6t81LJbS37w3f93oD6gqqAnjdgM7Use36qZSipHXBw==",
-          "requires": {
-            "@babel/runtime": "^7.4.5",
-            "compute-scroll-into-view": "^1.0.9",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.9.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"./assets/js/atomic/blocks/product/**",
 		"./assets/js/filters/**",
 		"./assets/js/payment-methods-demo/**",
-		"./assets/js/settings/blocks/store-api-nonce"
+		"./assets/js/settings/blocks/**"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"./assets/js/atomic/blocks/product/**",
 		"./assets/js/filters/**",
 		"./assets/js/payment-methods-demo/**",
-		"./aseets/js/settings/blocks/store-api-nonce"
+		"./assets/js/settings/blocks/store-api-nonce"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"*.css",
 		"*.scss",
 		"./assets/js/atomic/blocks/product/**",
-		"./assets/js/filters/**"
+		"./assets/js/filters/**",
+		"./assets/js/payment-methods-demo/**"
 	],
 	"repository": {
 		"type": "git",
@@ -144,7 +145,9 @@
 	},
 	"dependencies": {
 		"@woocommerce/components": "4.0.0",
+		"@wordpress/icons": "^1.1.0",
 		"@wordpress/notices": "2.0.0",
+		"@wordpress/primitives": "^1.1.0",
 		"classnames": "2.2.6",
 		"compare-versions": "3.6.0",
 		"config": "3.3.0",
@@ -153,7 +156,7 @@
 		"react-number-format": "4.4.1",
 		"trim-html": "0.1.9",
 		"use-debounce": "3.4.0",
-		"wordpress-components": "npm:@wordpress/components@8.5.0",
+		"wordpress-components": "npm:@wordpress/components@9.2.4",
 		"wordpress-compose": "npm:@wordpress/compose@3.11.0",
 		"wordpress-element": "npm:@wordpress/element@2.11.0"
 	},

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
 		"*.scss",
 		"./assets/js/atomic/blocks/product/**",
 		"./assets/js/filters/**",
-		"./assets/js/payment-methods-demo/**"
+		"./assets/js/payment-methods-demo/**",
+		"./aseets/js/settings/blocks/store-api-nonce"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -146,10 +146,7 @@
 	},
 	"dependencies": {
 		"@woocommerce/components": "4.0.0",
-		"@wordpress/icons": "^1.1.0",
 		"@wordpress/notices": "2.0.0",
-		"@wordpress/primitives": "^1.1.0",
-		"@wordpress/warning": "^1.0.0",
 		"classnames": "2.2.6",
 		"compare-versions": "3.6.0",
 		"config": "3.3.0",
@@ -158,7 +155,7 @@
 		"react-number-format": "4.4.1",
 		"trim-html": "0.1.9",
 		"use-debounce": "3.4.0",
-		"wordpress-components": "npm:@wordpress/components@9.2.4",
+		"wordpress-components": "npm:@wordpress/components@8.5.0",
 		"wordpress-compose": "npm:@wordpress/compose@3.11.0",
 		"wordpress-element": "npm:@wordpress/element@2.11.0"
 	},

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
 		"@wordpress/icons": "^1.1.0",
 		"@wordpress/notices": "2.0.0",
 		"@wordpress/primitives": "^1.1.0",
+		"@wordpress/warning": "^1.0.0",
 		"classnames": "2.2.6",
 		"compare-versions": "3.6.0",
 		"config": "3.3.0",


### PR DESCRIPTION
Just noticed today that we're getting build issues for production builds with the current master checkout and cart blocks.

The issues are when you do a **production** build of the blocks. On a default WordPress install (latest version of WP, no GB plugin active):

1. payment methods don't load
2.  the style of the checkout block and cart block is single column (and there are other styles not loading).

The fix for both issues is to account for more `sideEffect` exclusions.  As a result, bundlesizes do jump, this is because the payment-methods demo files weren't being included in production builds, so now that they are included the size jumps.

This will be handled in a followup where payment method integrations will be built to their own bundle (which is what will happen anyways when they are implemented in payment extensions).