### PR TITLE
Add storybook info to dev docs

### DIFF
--- a/docs/contributors/storybook.md
+++ b/docs/contributors/storybook.md
@@ -1,0 +1,20 @@
+# Storybook
+
+This repo includes [Storybook](https://storybook.js.org) tooling so we can test and develop components in isolation.
+
+The storybook is automatically built and published to [GitHub pages](https://woocommerce.github.io/woocommerce-gutenberg-products-block/) on every push to master. See [travis.yml](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/.travis.yml) for details.
+
+https://woocommerce.github.io/woocommerce-gutenberg-products-block/
+
+## How to run Storybook locally and test components
+
+- `npm run storybook`
+- Point your browser at port 6006, e.g. http://localhost:6006
+- Play with components 🎛!
+
+## How to add a story for a component
+
+- Add a `stories` folder alongside the component.
+- Add stories in `.js` files in this folder. 
+
+If you're stuck, copy source of an existing story to get started.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -10,6 +10,7 @@ The WooCommerce Blocks Handbook provides documentation for designers and develop
 -   [Coding Guidelines](contributors/coding-guidelines.md)
 -   [Smoke Testing](contributors/smoke-testing.md)
 -   [JavaScript Testing](contributors/javascript-testing.md)
+-   [Component Testing & Development (with Storybook)](contributors/storybook.md)
 
 **Releases**
 


### PR DESCRIPTION
Adding some basic info about how we use storybook to our docs – in particular I wanted to make sure we had a link to the published stories on GitHub Pages :)
