### PR TITLE
Make sure payment method assets are loaded in block editor

### DIFF
--- a/src/PaymentMethodIntegrations/Stripe.php
+++ b/src/PaymentMethodIntegrations/Stripe.php
@@ -69,6 +69,7 @@ class Stripe {
 			add_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before', [ $this, 'enqueue_data' ] );
 		}
 		add_action( 'init', [ $this, 'register_scripts_and_styles' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_extension_assets' ] );
 	}
 
 	/**
@@ -93,7 +94,7 @@ class Stripe {
 		if ( ! $this->asset_registry->exists( 'stripe_data' ) ) {
 			$this->asset_registry->add( 'stripe_data', $data );
 		}
-		wp_enqueue_script( 'wc-payment-method-extensions' );
+		$this->enqueue_extension_assets();
 	}
 
 	/**
@@ -106,6 +107,13 @@ class Stripe {
 			'build/wc-payment-method-extensions.js',
 			[ 'stripe' ]
 		);
+	}
+
+	/**
+	 * Enqueues the payment method assets
+	 */
+	public function enqueue_extension_assets() {
+		wp_enqueue_script( 'wc-payment-method-extensions' );
 	}
 
 	/**


### PR DESCRIPTION
As a part of the work in #1983, I split out the payment method extension registration into it's own built bundle to more closely replicate how payment extensions would be hooking into the payment method api. 

I realized today that in the process I broke the payment method integration in the block editor context as the script was not getting enqueued in the editor.

This pull fixes that.

## To Test

- Verify that with stripe configured, you see it show up in the editor and in the frontend for the checkout block.
- Verify that when you add a new checkout block in a new editor instance that the payment method integration shows up.