### PR TITLE
Implement mechanism for reliably passing through server data in editor context.

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -53,6 +53,17 @@ abstract class AbstractBlock {
 	 * Will enqueue any editor assets a block needs to load
 	 */
 	public function enqueue_editor_assets() {
-		// noop, expected that children will override if needed.
+		$this->enqueue_data();
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		// noop. Child classes should override this if needed.
 	}
 }

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -53,7 +53,18 @@ abstract class AbstractBlock {
 	 * Will enqueue any editor assets a block needs to load
 	 */
 	public function enqueue_editor_assets() {
-		$this->enqueue_data();
+		$this->enqueue_data_once();
+	}
+
+
+	/**
+	 * Ensures the enqueue_data method is only called once in a request.
+	 */
+	public function enqueue_data_once() {
+		static $has_run = false;
+		if ( ! $has_run ) {
+			$this->enqueue_data();
+		}
 	}
 
 	/**

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -53,19 +53,9 @@ abstract class AbstractBlock {
 	 * Will enqueue any editor assets a block needs to load
 	 */
 	public function enqueue_editor_assets() {
-		$this->enqueue_data_once();
+		$this->enqueue_data();
 	}
 
-
-	/**
-	 * Ensures the enqueue_data method is only called once in a request.
-	 */
-	public function enqueue_data_once() {
-		static $has_run = false;
-		if ( ! $has_run ) {
-			$this->enqueue_data();
-		}
-	}
 
 	/**
 	 * Extra data passed through from server to client for block.

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -29,6 +29,13 @@ abstract class AbstractBlock {
 	protected $block_name = '';
 
 	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
+	}
+
+	/**
 	 * Registers the block type with WordPress.
 	 */
 	public function register_block_type() {
@@ -40,5 +47,12 @@ abstract class AbstractBlock {
 				'style'         => 'wc-block-style',
 			)
 		);
+	}
+
+	/**
+	 * Will enqueue any editor assets a block needs to load
+	 */
+	public function enqueue_editor_assets() {
+		// noop, expected that children will override if needed.
 	}
 }

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -47,7 +47,7 @@ class Cart extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
-		$this->enqueue_data();
+		$this->enqueue_data( $attributes );
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
 			$this->block_name . '-frontend',

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -47,6 +47,7 @@ class Cart extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
+		$this->enqueue_data();
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
 		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
 			$this->block_name . '-frontend',

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -38,6 +38,7 @@ class Cart extends AbstractBlock {
 		);
 	}
 
+
 	/**
 	 * Append frontend scripts when rendering the Cart block.
 	 *
@@ -46,6 +47,23 @@ class Cart extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
+		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
+		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
+			$this->block_name . '-frontend',
+			$this->block_name . '-block-frontend'
+		);
+		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
+		return $content . $this->get_skeleton();
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
 		$data_registry = Package::container()->get(
 			\Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry::class
 		);
@@ -74,13 +92,6 @@ class Cart extends AbstractBlock {
 			$max_quantity_limit = apply_filters( 'woocommerce_maximum_quantity_selected_cart', 99 );
 			$data_registry->add( 'quantitySelectLimit', $max_quantity_limit );
 		}
-		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script(
-			$this->block_name . '-frontend',
-			$this->block_name . '-block-frontend'
-		);
-		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
-		return $content . $this->get_skeleton();
 	}
 
 	/**

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -41,12 +41,6 @@ class Checkout extends AbstractBlock {
 		);
 	}
 
-	/**
-	 * Enqueues assets for the block editor context.
-	 */
-	public function enqueue_editor_assets() {
-		$this->enqueue_data();
-	}
 
 	/**
 	 * Append frontend scripts when rendering the block.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -42,6 +42,13 @@ class Checkout extends AbstractBlock {
 	}
 
 	/**
+	 * Enqueues assets for the block editor context.
+	 */
+	public function enqueue_editor_assets() {
+		$this->enqueue_data();
+	}
+
+	/**
 	 * Append frontend scripts when rendering the block.
 	 *
 	 * @param array  $attributes Block attributes. Default empty array.
@@ -49,6 +56,21 @@ class Checkout extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
+		$this->enqueue_data( $attributes );
+		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' );
+		Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
+		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
+		return $content . $this->get_skeleton();
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
 		$data_registry = Package::container()->get(
 			AssetDataRegistry::class
 		);
@@ -84,11 +106,6 @@ class Checkout extends AbstractBlock {
 			$this->hydrate_from_api( $data_registry );
 			$this->hydrate_customer_payment_methods( $data_registry );
 		}
-
-		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' );
-		Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
-		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
-		return $content . $this->get_skeleton();
 	}
 
 	/**


### PR DESCRIPTION
Currently in the editor context if you have a registered block already in the post content, when you load the editor, the blocks `render` method will fire.  The render method is what is currently used to pass through server data for the block to consume. 

However, one flaw with this approach is that when the post content does _not_ have a block yet, the blocks `render` method won't have fired and thus anything in that logic will not get loaded in the editor instance.

The fix is to use the `enqueue_block_editor_assets` action to load the server data related things in the context of the block editor.

## To test

Without the work in this pull, the shipping options won't show in the editor context when adding a _new_ checkout (or cart block). So you can verify this fixes that by creating a new page and adding either the cart of checkout block and making sure shipping options are available.

- Verify adding cart or checkout blocks in new editor instance displays/works as expected. 
- Verify loading an editor instance with _existing_ cart or checkout blocks in the content works as expected.
- Verify loading cart or checkout block in the frontend works as expected.