### PR TITLE
Parse error response before rejecting

### DIFF
--- a/assets/js/base/hooks/cart/use-store-cart-coupons.js
+++ b/assets/js/base/hooks/cart/use-store-cart-coupons.js
@@ -23,7 +23,7 @@ import { useStoreNotices } from '../use-store-notices';
  * store api /cart/coupons endpoint.
  */
 export const useStoreCartCoupons = () => {
-	const { cartCoupons, cartErrors, cartIsLoading } = useStoreCart();
+	const { cartCoupons, cartIsLoading } = useStoreCart();
 	const { addErrorNotice, addSnackbarNotice } = useStoreNotices();
 	const { setValidationErrors } = useValidationContext();
 
@@ -106,7 +106,6 @@ export const useStoreCartCoupons = () => {
 
 	return {
 		appliedCoupons: cartCoupons,
-		cartCouponsErrors: cartErrors,
 		isLoading: cartIsLoading,
 		...results,
 	};

--- a/assets/js/data/shared-controls.js
+++ b/assets/js/data/shared-controls.js
@@ -34,8 +34,11 @@ export const controls = {
 						triggerFetch.setNonce( fetchResponse.headers );
 					} );
 				} )
-				.catch( ( error ) => {
-					reject( error );
+				.catch( ( errorResponse ) => {
+					// Parse error response before rejecting it.
+					errorResponse.json().then( ( error ) => {
+						reject( error );
+					} );
 				} );
 		} );
 	},

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -38,7 +38,6 @@
  * @property {Function} removeCoupon      Callback for removing a coupon by code.
  * @property {boolean}  isApplyingCoupon  True when a coupon is being applied.
  * @property {boolean}  isRemovingCoupon  True when a coupon is being removed.
- * @property {boolean}  cartCouponsErrors An array of errors thrown by the cart.
  */
 
 /**


### PR DESCRIPTION
Fixes coupon validation methods by ensuring error responses are parsed correctly within apiFetchWithHeaders.

Fixes #2039

### How to test the changes in this Pull Request:

1. Apply an invalid coupon
2. Check validation message is displayed
