### PR TITLE
Refactor to simplify checkout context error dispatcher.

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/actions.js
+++ b/assets/js/base/context/cart-checkout/checkout/actions.js
@@ -32,12 +32,10 @@ export const actions = {
 	setComplete: () => ( {
 		type: SET_COMPLETE,
 	} ),
-	setHasError: () => ( {
-		type: SET_HAS_ERROR,
-	} ),
-	clearError: () => ( {
-		type: SET_NO_ERROR,
-	} ),
+	setHasError: ( hasError = true ) => {
+		const type = hasError ? SET_HAS_ERROR : SET_NO_ERROR;
+		return { type };
+	},
 	incrementCalculating: () => ( {
 		type: INCREMENT_CALCULATING,
 	} ),

--- a/assets/js/base/context/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/index.js
@@ -50,12 +50,13 @@ const CheckoutContext = createContext( {
 	dispatchActions: {
 		resetCheckout: () => void null,
 		setRedirectUrl: () => void null,
-		setHasError: () => void null,
-		clearError: () => void null,
+		setHasError: ( hasError ) => void hasError,
 		incrementCalculating: () => void null,
 		decrementCalculating: () => void null,
 		setOrderId: () => void null,
 	},
+	isEditor: false,
+	hasOrder: false,
 } );
 
 /**
@@ -96,7 +97,7 @@ export const CheckoutProvider = ( {
 	const [ checkoutState, dispatch ] = useReducer( reducer, DEFAULT_STATE );
 	const [ observers, subscriber ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );
-	// set observers on ref so it's always current
+	// set observers on ref so it's always current.
 	useEffect( () => {
 		currentObservers.current = observers;
 	}, [ observers ] );
@@ -121,8 +122,8 @@ export const CheckoutProvider = ( {
 			resetCheckout: () => void dispatch( actions.setPristine() ),
 			setRedirectUrl: ( url ) =>
 				void dispatch( actions.setRedirectUrl( url ) ),
-			setHasError: () => void dispatch( actions.setHasError() ),
-			clearError: () => void dispatch( actions.clearError() ),
+			setHasError: ( hasError ) =>
+				void dispatch( actions.setHasError( hasError ) ),
 			incrementCalculating: () =>
 				void dispatch( actions.incrementCalculating() ),
 			decrementCalculating: () =>
@@ -133,7 +134,7 @@ export const CheckoutProvider = ( {
 		[]
 	);
 
-	// emit events
+	// emit events.
 	useEffect( () => {
 		const status = checkoutState.status;
 		if ( status === STATUS.PROCESSING ) {
@@ -144,7 +145,7 @@ export const CheckoutProvider = ( {
 			).then( ( response ) => {
 				if ( response !== true ) {
 					// @todo handle any validation error property values in the
-					// response
+					// response.
 					dispatchActions.setHasError();
 				}
 				dispatch( actions.setComplete() );
@@ -164,7 +165,7 @@ export const CheckoutProvider = ( {
 					{}
 				).then( () => {
 					// all observers have done their thing so let's redirect
-					// (if no error)
+					// (if no error).
 					if ( ! checkoutState.hasError ) {
 						window.location = checkoutState.redirectUrl;
 					}

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -165,16 +165,8 @@ export const ShippingDataProvider = ( { children } ) => {
 
 	// dispatch checkout error if there's a shipping error.
 	useEffect( () => {
-		if ( currentErrorStatus.hasError ) {
-			dispatchActions.setHasError();
-		} else {
-			dispatchActions.clearError();
-		}
-	}, [
-		currentErrorStatus,
-		dispatchActions.setHasError,
-		dispatchActions.clearError,
-	] );
+		dispatchActions.setHasError( currentErrorStatus.hasError );
+	}, [ currentErrorStatus, dispatchActions.setHasError ] );
 
 	/**
 	 * @type {ShippingDataContext}

--- a/assets/js/type-defs/checkout.js
+++ b/assets/js/type-defs/checkout.js
@@ -1,20 +1,18 @@
 /**
  * @typedef {Object} CheckoutDispatchActions
  *
- * @property {function()}                 resetCheckout        Dispatches an action that resets
- *                                                             the checkout to a pristine state.
- * @property {function( string )}         setRedirectUrl       Dispatches an action that sets the
- *                                                             redirectUrl to the given value.
- * @property {function()}                 setHasError          Dispatches an action that sets the
- *                                                             checkout status to having an error.
- * @property {function()}                 clearError           Dispatches an action that clears the
- *                                                             hasError status for the checkout.
- * @property {function()}                 incrementCalculating Dispatches an action that increments
- *                                                             the calculating state for checkout by one.
- * @property {function()}                 decrementCalculating Dispatches an action that decrements
- *                                                             the calculating state for checkout by one.
- * @property {function( number, string )} setOrderId           Dispatches an action that stores the draft
- *                                                             order ID and key to state.
+ * @property {function()}               resetCheckout        Dispatches an action that resets
+ *                                                           the checkout to a pristine state.
+ * @property {function(string)}         setRedirectUrl       Dispatches an action that sets the
+ *                                                           redirectUrl to the given value.
+ * @property {function(boolean=)}      setHasError          Dispatches an action that sets the
+ *                                                           checkout status to having an error.
+ * @property {function()}               incrementCalculating Dispatches an action that increments
+ *                                                           the calculating state for checkout by one.
+ * @property {function()}               decrementCalculating Dispatches an action that decrements
+ *                                                           the calculating state for checkout by one.
+ * @property {function(number, string)} setOrderId           Dispatches an action that stores the draft
+ *                                                           order ID and key to state.
  */
 
 /**


### PR DESCRIPTION
Fixes: #2081

See the description in the related issue. In this pull:

- `setHasError` now receives a boolean that determines what state to set.
- removed `clearError` dispatcher from checkout context.
- fix related type-defs in checkout context.

## To Test

Just need to ensure the checkout block loads in the editor and frontend context without issues.
