### PR TITLE
Refactor: split up payment-method.js for stripe extension into smaller files.

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/stripe/elements.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/elements.js
@@ -1,0 +1,144 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	CardElement,
+	CardNumberElement,
+	CardExpiryElement,
+	CardCvcElement,
+} from '@stripe/react-stripe-js';
+
+/**
+ * Internal dependencies
+ */
+import { useElementOptions } from './use-element-options';
+
+const baseTextInputStyles = 'wc-block-gateway-input';
+
+/**
+ * InlineCard component
+ */
+export const InlineCard = ( {
+	inputErrorComponent: ValidationInputError,
+	onChange,
+} ) => {
+	const [ isEmpty, setIsEmpty ] = useState( true );
+	const { options, onActive, error, setError } = useElementOptions( {
+		hidePostalCode: true,
+	} );
+	const errorCallback = ( event ) => {
+		if ( event.error ) {
+			setError( event.error.message );
+		} else {
+			setError( '' );
+		}
+		setIsEmpty( event.empty );
+		onChange( event );
+	};
+	return (
+		<>
+			<div className="wc-block-gateway-container wc-inline-card-element">
+				<CardElement
+					id="wc-stripe-inline-card-element"
+					className={ baseTextInputStyles }
+					options={ options }
+					onBlur={ () => onActive( isEmpty ) }
+					onFocus={ () => onActive( isEmpty ) }
+					onChange={ errorCallback }
+				/>
+				<label htmlFor="wc-stripe-inline-card-element">
+					{ __(
+						'Credit Card Information',
+						'woo-gutenberg-products-block'
+					) }
+				</label>
+			</div>
+			<ValidationInputError errorMessage={ error } />
+		</>
+	);
+};
+
+/**
+ * CardElements component.
+ */
+export const CardElements = ( {
+	onChange,
+	inputErrorComponent: ValidationInputError,
+} ) => {
+	const [ isEmpty, setIsEmpty ] = useState( true );
+	const {
+		options: cardNumOptions,
+		onActive: cardNumOnActive,
+		error: cardNumError,
+		setError: cardNumSetError,
+	} = useElementOptions( { showIcon: false } );
+	const {
+		options: cardExpiryOptions,
+		onActive: cardExpiryOnActive,
+		error: cardExpiryError,
+		setError: cardExpirySetError,
+	} = useElementOptions();
+	const {
+		options: cardCvcOptions,
+		onActive: cardCvcOnActive,
+		error: cardCvcError,
+		setError: cardCvcSetError,
+	} = useElementOptions();
+	const errorCallback = ( errorSetter ) => ( event ) => {
+		if ( event.error ) {
+			errorSetter( event.error.message );
+		} else {
+			errorSetter( '' );
+		}
+		setIsEmpty( event.empty );
+		onChange( event );
+	};
+	return (
+		<div className="wc-block-card-elements">
+			<div className="wc-block-gateway-container wc-card-number-element">
+				<CardNumberElement
+					onChange={ errorCallback( cardNumSetError ) }
+					options={ cardNumOptions }
+					className={ baseTextInputStyles }
+					id="wc-stripe-card-number-element"
+					onFocus={ () => cardNumOnActive( isEmpty ) }
+					onBlur={ () => cardNumOnActive( isEmpty ) }
+				/>
+				<label htmlFor="wc-stripe-card-number-element">
+					{ __( 'Card Number', 'woo-gutenberg-product-blocks' ) }
+				</label>
+				<ValidationInputError errorMessage={ cardNumError } />
+			</div>
+			<div className="wc-block-gateway-container wc-card-expiry-element">
+				<CardExpiryElement
+					onChange={ errorCallback( cardExpirySetError ) }
+					options={ cardExpiryOptions }
+					className={ baseTextInputStyles }
+					onFocus={ () => cardExpiryOnActive( isEmpty ) }
+					onBlur={ () => cardExpiryOnActive( isEmpty ) }
+					id="wc-stripe-card-expiry-element"
+				/>
+				<label htmlFor="wc-stripe-card-expiry-element">
+					{ __( 'Expiry Date', 'woo-gutenberg-product-blocks' ) }
+				</label>
+				<ValidationInputError errorMessage={ cardExpiryError } />
+			</div>
+			<div className="wc-block-gateway-container wc-card-cvc-element">
+				<CardCvcElement
+					onChange={ errorCallback( cardCvcSetError ) }
+					options={ cardCvcOptions }
+					className={ baseTextInputStyles }
+					onFocus={ () => cardCvcOnActive( isEmpty ) }
+					onBlur={ () => cardCvcOnActive( isEmpty ) }
+					id="wc-stripe-card-code-element"
+				/>
+				<label htmlFor="wc-stripe-card-code-element">
+					{ __( 'CVV/CVC', 'woo-gutenberg-product-blocks' ) }
+				</label>
+				<ValidationInputError errorMessage={ cardCvcError } />
+			</div>
+		</div>
+	);
+};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-method.js
@@ -2,26 +2,16 @@
  * Internal dependencies
  */
 import { PAYMENT_METHOD_NAME } from './constants';
-import {
-	getStripeServerData,
-	stripePromise,
-	getErrorMessageForTypeAndCode,
-} from '../../stripe-utils';
+import { getStripeServerData, stripePromise } from '../../stripe-utils';
 import { ccSvg } from './cc';
+import { useCheckoutSubscriptions } from './use-checkout-subscriptions';
+import { InlineCard, CardElements } from './elements';
 
 /**
  * External dependencies
  */
-import {
-	Elements,
-	CardElement,
-	CardNumberElement,
-	CardExpiryElement,
-	CardCvcElement,
-	useElements,
-	useStripe,
-} from '@stripe/react-stripe-js';
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { Elements, useElements, useStripe } from '@stripe/react-stripe-js';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -29,319 +19,6 @@ import { __ } from '@wordpress/i18n';
  * @typedef {import('../../stripe-utils/type-defs').StripePaymentRequest} StripePaymentRequest
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
  */
-
-const elementOptions = {
-	style: {
-		base: {
-			iconColor: '#666EE8',
-			color: '#31325F',
-			fontSize: '15px',
-			'::placeholder': {
-				color: '#fff',
-			},
-		},
-	},
-	classes: {
-		focus: 'focused',
-		empty: 'empty',
-		invalid: 'has-error',
-	},
-};
-
-const useElementOptions = ( overloadedOptions ) => {
-	const [ isActive, setIsActive ] = useState( false );
-	const [ options, setOptions ] = useState( {
-		...elementOptions,
-		...overloadedOptions,
-	} );
-	const [ error, setError ] = useState( '' );
-
-	useEffect( () => {
-		const color = isActive ? '#CFD7E0' : '#fff';
-
-		setOptions( ( prevOptions ) => {
-			const showIcon =
-				typeof prevOptions.showIcon !== 'undefined'
-					? { showIcon: isActive }
-					: {};
-			return {
-				...options,
-				style: {
-					...options.style,
-					base: {
-						...options.style.base,
-						'::placeholder': {
-							color,
-						},
-					},
-				},
-				...showIcon,
-			};
-		} );
-	}, [ isActive ] );
-
-	const onActive = useCallback(
-		( isEmpty ) => {
-			if ( ! isEmpty ) {
-				setIsActive( true );
-			} else {
-				setIsActive( ( prevActive ) => ! prevActive );
-			}
-		},
-		[ setIsActive ]
-	);
-	return { options, onActive, error, setError };
-};
-
-const baseTextInputStyles = 'wc-block-gateway-input';
-
-const InlineCard = ( {
-	inputErrorComponent: ValidationInputError,
-	onChange,
-} ) => {
-	const [ isEmpty, setIsEmpty ] = useState( true );
-	const { options, onActive, error, setError } = useElementOptions( {
-		hidePostalCode: true,
-	} );
-	const errorCallback = ( event ) => {
-		if ( event.error ) {
-			setError( event.error.message );
-		} else {
-			setError( '' );
-		}
-		setIsEmpty( event.empty );
-		onChange( event );
-	};
-	return (
-		<>
-			<div className="wc-block-gateway-container wc-inline-card-element">
-				<CardElement
-					id="wc-stripe-inline-card-element"
-					className={ baseTextInputStyles }
-					options={ options }
-					onBlur={ () => onActive( isEmpty ) }
-					onFocus={ () => onActive( isEmpty ) }
-					onChange={ errorCallback }
-				/>
-				<label htmlFor="wc-stripe-inline-card-element">
-					{ __(
-						'Credit Card Information',
-						'woo-gutenberg-products-block'
-					) }
-				</label>
-			</div>
-			<ValidationInputError errorMessage={ error } />
-		</>
-	);
-};
-
-const CardElements = ( {
-	onChange,
-	inputErrorComponent: ValidationInputError,
-} ) => {
-	const [ isEmpty, setIsEmpty ] = useState( true );
-	const {
-		options: cardNumOptions,
-		onActive: cardNumOnActive,
-		error: cardNumError,
-		setError: cardNumSetError,
-	} = useElementOptions( { showIcon: false } );
-	const {
-		options: cardExpiryOptions,
-		onActive: cardExpiryOnActive,
-		error: cardExpiryError,
-		setError: cardExpirySetError,
-	} = useElementOptions();
-	const {
-		options: cardCvcOptions,
-		onActive: cardCvcOnActive,
-		error: cardCvcError,
-		setError: cardCvcSetError,
-	} = useElementOptions();
-	const errorCallback = ( errorSetter ) => ( event ) => {
-		if ( event.error ) {
-			errorSetter( event.error.message );
-		} else {
-			errorSetter( '' );
-		}
-		setIsEmpty( event.empty );
-		onChange( event );
-	};
-	return (
-		<div className="wc-block-card-elements">
-			<div className="wc-block-gateway-container wc-card-number-element">
-				<CardNumberElement
-					onChange={ errorCallback( cardNumSetError ) }
-					options={ cardNumOptions }
-					className={ baseTextInputStyles }
-					id="wc-stripe-card-number-element"
-					onFocus={ () => cardNumOnActive( isEmpty ) }
-					onBlur={ () => cardNumOnActive( isEmpty ) }
-				/>
-				<label htmlFor="wc-stripe-card-number-element">
-					{ __( 'Card Number', 'woo-gutenberg-product-blocks' ) }
-				</label>
-				<ValidationInputError errorMessage={ cardNumError } />
-			</div>
-			<div className="wc-block-gateway-container wc-card-expiry-element">
-				<CardExpiryElement
-					onChange={ errorCallback( cardExpirySetError ) }
-					options={ cardExpiryOptions }
-					className={ baseTextInputStyles }
-					onFocus={ cardExpiryOnActive }
-					onBlur={ cardExpiryOnActive }
-					id="wc-stripe-card-expiry-element"
-				/>
-				<label htmlFor="wc-stripe-card-expiry-element">
-					{ __( 'Expiry Date', 'woo-gutenberg-product-blocks' ) }
-				</label>
-				<ValidationInputError errorMessage={ cardExpiryError } />
-			</div>
-			<div className="wc-block-gateway-container wc-card-cvc-element">
-				<CardCvcElement
-					onChange={ errorCallback( cardCvcSetError ) }
-					options={ cardCvcOptions }
-					className={ baseTextInputStyles }
-					onFocus={ cardCvcOnActive }
-					onBlur={ cardCvcOnActive }
-					id="wc-stripe-card-code-element"
-				/>
-				<label htmlFor="wc-stripe-card-code-element">
-					{ __( 'CVV/CVC', 'woo-gutenberg-product-blocks' ) }
-				</label>
-				<ValidationInputError errorMessage={ cardCvcError } />
-			</div>
-		</div>
-	);
-};
-
-const useStripeCheckoutSubscriptions = (
-	eventRegistration,
-	paymentStatus,
-	billing,
-	sourceId,
-	setSourceId,
-	shouldSavePayment,
-	stripe,
-	elements
-) => {
-	const onStripeError = useRef( ( event ) => {
-		return event;
-	} );
-	// hook into and register callbacks for events.
-	useEffect( () => {
-		onStripeError.current = ( event ) => {
-			const type = event.error.type;
-			const code = event.error.code || '';
-			let message = getErrorMessageForTypeAndCode( type, code );
-			message = message || event.error.message;
-			paymentStatus.setPaymentStatus().error( message );
-
-			// @todo we'll want to do inline invalidation errors for any element
-			// inputs
-			return {};
-		};
-		const createSource = async ( ownerInfo ) => {
-			const elementToGet = getStripeServerData().inline_cc_form
-				? CardElement
-				: CardNumberElement;
-			return await stripe.createSource(
-				elements.getElement( elementToGet ),
-				{
-					type: 'card',
-					owner: ownerInfo,
-				}
-			);
-		};
-		const onSubmit = async () => {
-			try {
-				paymentStatus.setPaymentStatus().processing();
-				const { billingData } = billing;
-				// use token if it's set.
-				if ( sourceId !== 0 ) {
-					paymentStatus.setPaymentStatus().success( billingData, {
-						paymentMethod: PAYMENT_METHOD_NAME,
-						paymentRequestType: 'cc',
-						sourceId,
-						shouldSavePayment,
-					} );
-					return true;
-				}
-				const ownerInfo = {
-					address: {
-						line1: billingData.address_1,
-						line2: billingData.address_2,
-						city: billingData.city,
-						state: billingData.state,
-						postal_code: billingData.postcode,
-						country: billingData.country,
-					},
-				};
-				if ( billingData.phone ) {
-					ownerInfo.phone = billingData.phone;
-				}
-				if ( billingData.email ) {
-					ownerInfo.email = billingData.email;
-				}
-				if ( billingData.first_name || billingData.last_name ) {
-					ownerInfo.name = `${ billingData.first_name } ${ billingData.last_name }`;
-				}
-
-				const response = await createSource( ownerInfo );
-				if ( response.error ) {
-					return onStripeError.current( response );
-				}
-				paymentStatus.setPaymentStatus().success( billingData, {
-					sourceId: response.source.id,
-					paymentMethod: PAYMENT_METHOD_NAME,
-					paymentRequestType: 'cc',
-					shouldSavePayment,
-				} );
-				setSourceId( response.source.id );
-				return true;
-			} catch ( e ) {
-				return e;
-			}
-		};
-		const onComplete = () => {
-			paymentStatus.setPaymentStatus().completed();
-		};
-		const onError = () => {
-			paymentStatus.setPaymentStatus().started();
-		};
-		// @todo Right now all the registered callbacks will go stale, so we need
-		// either implement useRef or make sure functions being used from these
-		// callbacks don't change so we can add them as dependencies.
-		// validation and stripe processing (get source etc).
-		const unsubscribeProcessing = eventRegistration.onCheckoutProcessing(
-			onSubmit
-		);
-		const unsubscribeCheckoutComplete = eventRegistration.onCheckoutCompleteSuccess(
-			onComplete
-		);
-		const unsubscribeCheckoutCompleteError = eventRegistration.onCheckoutCompleteError(
-			onError
-		);
-		return () => {
-			unsubscribeProcessing();
-			unsubscribeCheckoutComplete();
-			unsubscribeCheckoutCompleteError();
-		};
-	}, [
-		eventRegistration.onCheckoutProcessing,
-		eventRegistration.onCheckoutCompleteSuccess,
-		eventRegistration.onCheckoutCompleteError,
-		paymentStatus.setPaymentStatus,
-		stripe,
-		sourceId,
-		billing.billingData,
-		setSourceId,
-		shouldSavePayment,
-	] );
-	return onStripeError.current;
-};
-
-// @todo add intents?
 
 /**
  * Stripe Credit Card component
@@ -359,7 +36,7 @@ const CreditCardComponent = ( {
 	const stripe = useStripe();
 	const [ shouldSavePayment, setShouldSavePayment ] = useState( true );
 	const elements = useElements();
-	const onStripeError = useStripeCheckoutSubscriptions(
+	const onStripeError = useCheckoutSubscriptions(
 		eventRegistration,
 		paymentStatus,
 		billing,
@@ -386,15 +63,6 @@ const CreditCardComponent = ( {
 			inputErrorComponent={ ValidationInputError }
 		/>
 	);
-
-	// we need to pass along source for customer from server if it's available
-	// and pre-populate for checkout (so it'd need to be returned with the
-	// order endpoint and available on billing details?)
-	// so this will need to be an option for selecting if there's a saved
-	// source attached with the order (see woocommerce/templates/myaccount/payment-methods.php)
-	// so that data will need to be included with the order endpoint (billing data) to choose from.
-
-	//@todo do need to add save payment method checkbox here.
 	return (
 		<>
 			{ renderedCardElement }

--- a/assets/js/payment-method-extensions/payment-methods/stripe/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/use-checkout-subscriptions.js
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { CardElement, CardNumberElement } from '@stripe/react-stripe-js';
+
+/**
+ * Internal dependencies
+ */
+import { PAYMENT_METHOD_NAME } from './constants';
+import {
+	getStripeServerData,
+	getErrorMessageForTypeAndCode,
+} from '../../stripe-utils';
+
+/**
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').EventRegistrationProps} EventRegistrationProps
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').PaymentStatusProps} PaymentStatusProps
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').BillingDataProps} BillingDataProps
+ * @typedef {import('../../stripe-utils/type-defs').Stripe} Stripe
+ */
+
+/**
+ * A custom hook for the Stripe processing and event observer logic.
+ *
+ * @param {EventRegistrationProps}     eventRegistration Event registration
+ *                                                       functions.
+ * @param {PaymentStatusProps}         paymentStatus     Various payment status
+ *                                                       helpers.
+ * @param {BillingDataProps}           billing           Various billing data
+ *                                                       items.
+ * @param {number}                     sourceId          Current set stripe
+ *                                                       source id.
+ * @param {function(number):undefined} setSourceId       Setter for stripe
+ *                                                       source id.
+ * @param {boolean}                    shouldSavePayment Whether to save the
+ *                                                       payment or not.
+ * @param {Stripe}                     stripe            The stripe.js object.
+ * @param {Object}                     elements          Stripe Elements object.
+ *
+ * @return {function(Object):Object} Returns a function for handling stripe error.
+ */
+export const useCheckoutSubscriptions = (
+	eventRegistration,
+	paymentStatus,
+	billing,
+	sourceId,
+	setSourceId,
+	shouldSavePayment,
+	stripe,
+	elements
+) => {
+	const onStripeError = useRef( ( event ) => {
+		return event;
+	} );
+	// hook into and register callbacks for events.
+	useEffect( () => {
+		onStripeError.current = ( event ) => {
+			const type = event.error.type;
+			const code = event.error.code || '';
+			let message = getErrorMessageForTypeAndCode( type, code );
+			message = message || event.error.message;
+			paymentStatus.setPaymentStatus().error( message );
+			return {};
+		};
+		const createSource = async ( ownerInfo ) => {
+			const elementToGet = getStripeServerData().inline_cc_form
+				? CardElement
+				: CardNumberElement;
+			return await stripe.createSource(
+				elements.getElement( elementToGet ),
+				{
+					type: 'card',
+					owner: ownerInfo,
+				}
+			);
+		};
+		const onSubmit = async () => {
+			try {
+				paymentStatus.setPaymentStatus().processing();
+				const { billingData } = billing;
+				// use token if it's set.
+				if ( sourceId !== 0 ) {
+					paymentStatus.setPaymentStatus().success( billingData, {
+						paymentMethod: PAYMENT_METHOD_NAME,
+						paymentRequestType: 'cc',
+						sourceId,
+						shouldSavePayment,
+					} );
+					return true;
+				}
+				const ownerInfo = {
+					address: {
+						line1: billingData.address_1,
+						line2: billingData.address_2,
+						city: billingData.city,
+						state: billingData.state,
+						postal_code: billingData.postcode,
+						country: billingData.country,
+					},
+				};
+				if ( billingData.phone ) {
+					ownerInfo.phone = billingData.phone;
+				}
+				if ( billingData.email ) {
+					ownerInfo.email = billingData.email;
+				}
+				if ( billingData.first_name || billingData.last_name ) {
+					ownerInfo.name = `${ billingData.first_name } ${ billingData.last_name }`;
+				}
+
+				const response = await createSource( ownerInfo );
+				if ( response.error ) {
+					return onStripeError.current( response );
+				}
+				paymentStatus.setPaymentStatus().success( billingData, {
+					sourceId: response.source.id,
+					paymentMethod: PAYMENT_METHOD_NAME,
+					paymentRequestType: 'cc',
+					shouldSavePayment,
+				} );
+				setSourceId( response.source.id );
+				return true;
+			} catch ( e ) {
+				return e;
+			}
+		};
+		const onComplete = () => {
+			paymentStatus.setPaymentStatus().completed();
+		};
+		const onError = () => {
+			paymentStatus.setPaymentStatus().started();
+		};
+		const unsubscribeProcessing = eventRegistration.onCheckoutProcessing(
+			onSubmit
+		);
+		const unsubscribeCheckoutComplete = eventRegistration.onCheckoutCompleteSuccess(
+			onComplete
+		);
+		const unsubscribeCheckoutCompleteError = eventRegistration.onCheckoutCompleteError(
+			onError
+		);
+		return () => {
+			unsubscribeProcessing();
+			unsubscribeCheckoutComplete();
+			unsubscribeCheckoutCompleteError();
+		};
+	}, [
+		eventRegistration.onCheckoutProcessing,
+		eventRegistration.onCheckoutCompleteSuccess,
+		eventRegistration.onCheckoutCompleteError,
+		paymentStatus.setPaymentStatus,
+		stripe,
+		sourceId,
+		billing.billingData,
+		setSourceId,
+		shouldSavePayment,
+	] );
+	return onStripeError.current;
+};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/use-element-options.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/use-element-options.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+/**
+ * @typedef {import('../../stripe-utils/type-defs').StripeElementOptions} StripeElementOptions
+ */
+
+/**
+ * Default options for the stripe elements.
+ */
+const elementOptions = {
+	style: {
+		base: {
+			iconColor: '#666EE8',
+			color: '#31325F',
+			fontSize: '15px',
+			'::placeholder': {
+				color: '#fff',
+			},
+		},
+	},
+	classes: {
+		focus: 'focused',
+		empty: 'empty',
+		invalid: 'has-error',
+	},
+};
+
+/**
+ * A custom hook handling options implemented on the stripe elements.
+ *
+ * @param {Object} [overloadedOptions] An array of extra options to merge with
+ *                                     the options provided for the element.
+ *
+ * @return {StripeElementOptions}  The stripe element options interface
+ */
+export const useElementOptions = ( overloadedOptions ) => {
+	const [ isActive, setIsActive ] = useState( false );
+	const [ options, setOptions ] = useState( {
+		...elementOptions,
+		...overloadedOptions,
+	} );
+	const [ error, setError ] = useState( '' );
+
+	useEffect( () => {
+		const color = isActive ? '#CFD7E0' : '#fff';
+
+		setOptions( ( prevOptions ) => {
+			const showIcon =
+				typeof prevOptions.showIcon !== 'undefined'
+					? { showIcon: isActive }
+					: {};
+			return {
+				...options,
+				style: {
+					...options.style,
+					base: {
+						...options.style.base,
+						'::placeholder': {
+							color,
+						},
+					},
+				},
+				...showIcon,
+			};
+		} );
+	}, [ isActive ] );
+
+	const onActive = useCallback(
+		( isEmpty ) => {
+			if ( ! isEmpty ) {
+				setIsActive( true );
+			} else {
+				setIsActive( ( prevActive ) => ! prevActive );
+			}
+		},
+		[ setIsActive ]
+	);
+	return { options, onActive, error, setError };
+};

--- a/assets/js/payment-method-extensions/stripe-utils/type-defs.js
+++ b/assets/js/payment-method-extensions/stripe-utils/type-defs.js
@@ -283,4 +283,18 @@
  *                                      form or separate inputs.
  */
 
+/**
+ * @typedef {Object} StripeElementOptions
+ *
+ * @property {Object}            options  The configuration object for stripe
+ *                                        elements.
+ * @property {function(boolean)} onActive A callback for setting whether an
+ *                                        element is active or not. "Active"
+ *                                        means it's not empty.
+ * @property {string}            error    Any error message from the stripe
+ *                                        element.
+ * @property {function(string)}  setError A callback for setting an error
+ *                                        message.
+ */
+
 export {};

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -127,12 +127,12 @@
 /**
  * @typedef {Object} PaymentStatusDispatchers
  *
- * @property {function()} started
- * @property {function()} processing
- * @property {function()} completed
- * @property {function(string)} error
+ * @property {function()}               started
+ * @property {function()}               processing
+ * @property {function()}               completed
+ * @property {function(string)}         error
  * @property {function(string, Object)} failed
- * @property {function(Object)} success
+ * @property {function(Object,Object)}  success
  */
 
 /**


### PR DESCRIPTION
Fixes: #2063 

In this pull, the stripe client extension has been reorganized into smaller files.  This helps with:

- reviewing code (less lines to look over)
- establishing what are dependencies.
- easier maintenance.

As a part of this work I also added more internal documentation to describe the various components and custom hooks used by the stripe client and I fixed some bugs noticed in the `CardElements` component.

## To Test

This impacts the stripe payment method extension. You'll need the Stripe Gateway plugin installed, active, and configured in order to test.

- Verify the stripe payment option shows on the frontend and you can interact with the fields and validation errors work as expected for the fields (i.e. leave a field only partially filled).
- Verify the stripe payment option shows in the editor as expected (currently just placeholder text).

There should be no console errors when testing the above.