### PR TITLE
fix nonce issue when logged out user adds to cart from all products

### DIFF
--- a/assets/js/data/collections/actions.js
+++ b/assets/js/data/collections/actions.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { select } from '@wordpress/data-controls';
+
 /**
  * Internal dependencies
  */

--- a/assets/js/data/collections/actions.js
+++ b/assets/js/data/collections/actions.js
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { apiFetch, select } from '@wordpress/data-controls';
-
+import { select } from '@wordpress/data-controls';
 /**
  * Internal dependencies
  */
+import { apiFetchWithHeaders } from '../shared-controls';
 import { ACTION_TYPES as types } from './action-types';
 import { STORE_KEY as SCHEMA_STORE_KEY } from '../schema/constants';
 
@@ -80,15 +80,15 @@ export function* __experimentalPersistItemToCollection(
 	}
 
 	try {
-		const item = yield apiFetch( {
+		const { response } = yield apiFetchWithHeaders( {
 			path: route,
 			method: 'POST',
 			data,
 			cache: 'no-store',
 		} );
 
-		if ( item ) {
-			newCollection.push( item );
+		if ( response ) {
+			newCollection.push( response );
 			yield receiveCollection(
 				namespace,
 				resourceName,


### PR DESCRIPTION
Fixes #2092

This PR switches collections store action `__experimentalPersistItemToCollection` to using `apiFetchWithHeaders` (from shared controls). This supplies and updates the Store API nonce in the store, so subsequent add-to-cart requests have a valid nonce.

### How to test the changes in this Pull Request:

1. Set up a page with All Products block (if needed).
2. View the page in an incognto window.
3. Add multiple products to cart - should work correctly.

Optional: also test adding to cart when logged in as a regular customer, and other add to cart flows. 

This affects the ["atomic" product button component](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/master/assets/js/atomic/components/product/button), so if this can be used in places other than All Products block, test those flows too :)

I've added `skip-changelog` as I don't think bug affects release versions? If this needs changelog reviewers please update :)