### PR TITLE
Add cart & checkout block editor tracks events

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import FeedbackPrompt from '@woocommerce/block-components/feedback-prompt';
 import { InspectorControls } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
 import {
 	Disabled,
 	PanelBody,
@@ -171,10 +172,16 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
  * Component to handle edit mode of "Cart Block".
  */
 const CartEditor = ( { className, attributes, setAttributes } ) => {
+	const defaultView = 'full';
+	const [ previousView, setPreviousView ] = useState( defaultView );
+
 	const viewRenderCallback = ( currentView ) => {
-		recordEditorEvent( 'cart_view', {
-			current_view: currentView,
-		} );
+		if ( previousView !== currentView ) {
+			recordEditorEvent( 'cart_view_toggle', {
+				current_view: currentView,
+			} );
+			setPreviousView( currentView );
+		}
 		return (
 			<>
 				{ currentView === 'full' && (
@@ -248,7 +255,7 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 						),
 					},
 				] }
-				defaultView={ 'full' }
+				defaultView={ defaultView }
 				render={ viewRenderCallback }
 			/>
 		</div>

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -171,6 +171,66 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
  * Component to handle edit mode of "Cart Block".
  */
 const CartEditor = ( { className, attributes, setAttributes } ) => {
+	const viewRenderCallback = ( currentView ) => {
+		recordEditorEvent( 'cart_view', {
+			current_view: currentView,
+		} );
+		return (
+			<>
+				{ currentView === 'full' && (
+					<>
+						{ SHIPPING_ENABLED && (
+							<BlockSettings
+								attributes={ attributes }
+								setAttributes={ setAttributes }
+							/>
+						) }
+						<BlockErrorBoundary
+							header={ __(
+								'Cart Block Error',
+								'woo-gutenberg-products-block'
+							) }
+							text={ __(
+								'There was an error whilst rendering the cart block. If this problem continues, try re-creating the block.',
+								'woo-gutenberg-products-block'
+							) }
+							showErrorMessage={ true }
+							errorMessagePrefix={ __(
+								'Error message:',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							<Disabled>
+								<EditorProvider>
+									<CartProvider>
+										<FullCart attributes={ attributes } />
+									</CartProvider>
+								</EditorProvider>
+							</Disabled>
+						</BlockErrorBoundary>
+					</>
+				) }
+				<BlockErrorBoundary
+					header={ __(
+						'Cart Block Error',
+						'woo-gutenberg-products-block'
+					) }
+					text={ __(
+						'There was an error whilst rendering the cart block. If this problem continues, try re-creating the block.',
+						'woo-gutenberg-products-block'
+					) }
+					showErrorMessage={ true }
+					errorMessagePrefix={ __(
+						'Error message:',
+						'woo-gutenberg-products-block'
+					) }
+				>
+					<EmptyCart hidden={ currentView === 'full' } />
+				</BlockErrorBoundary>
+			</>
+		);
+	};
+
 	return (
 		<div className={ className }>
 			<ViewSwitcher
@@ -189,62 +249,7 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 					},
 				] }
 				defaultView={ 'full' }
-				render={ ( currentView ) => (
-					<>
-						{ currentView === 'full' && (
-							<>
-								{ SHIPPING_ENABLED && (
-									<BlockSettings
-										attributes={ attributes }
-										setAttributes={ setAttributes }
-									/>
-								) }
-								<BlockErrorBoundary
-									header={ __(
-										'Cart Block Error',
-										'woo-gutenberg-products-block'
-									) }
-									text={ __(
-										'There was an error whilst rendering the cart block. If this problem continues, try re-creating the block.',
-										'woo-gutenberg-products-block'
-									) }
-									showErrorMessage={ true }
-									errorMessagePrefix={ __(
-										'Error message:',
-										'woo-gutenberg-products-block'
-									) }
-								>
-									<Disabled>
-										<EditorProvider>
-											<CartProvider>
-												<FullCart
-													attributes={ attributes }
-												/>
-											</CartProvider>
-										</EditorProvider>
-									</Disabled>
-								</BlockErrorBoundary>
-							</>
-						) }
-						<BlockErrorBoundary
-							header={ __(
-								'Cart Block Error',
-								'woo-gutenberg-products-block'
-							) }
-							text={ __(
-								'There was an error whilst rendering the cart block. If this problem continues, try re-creating the block.',
-								'woo-gutenberg-products-block'
-							) }
-							showErrorMessage={ true }
-							errorMessagePrefix={ __(
-								'Error message:',
-								'woo-gutenberg-products-block'
-							) }
-						>
-							<EmptyCart hidden={ currentView === 'full' } />
-						</BlockErrorBoundary>
-					</>
-				) }
+				render={ viewRenderCallback }
 			/>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -26,6 +26,7 @@ import { useSelect } from '@wordpress/data';
 import { getAdminLink } from '@woocommerce/settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import { EditorProvider, useEditorContext } from '@woocommerce/base-context';
+import { recordEditorEvent } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -95,11 +96,14 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				<ToggleControl
 					label={ __( 'Company', 'woo-gutenberg-products-block' ) }
 					checked={ showCompanyField }
-					onChange={ () =>
+					onChange={ () => {
+						recordEditorEvent( 'checkout_settings_company_toggle', {
+							enabled: ! showCompanyField,
+						} );
 						setAttributes( {
 							showCompanyField: ! showCompanyField,
-						} )
-					}
+						} );
+					} }
 				/>
 				{ showCompanyField && (
 					<CheckboxControl
@@ -122,20 +126,29 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						'woo-gutenberg-products-block'
 					) }
 					checked={ showAddress2Field }
-					onChange={ () =>
+					onChange={ () => {
+						recordEditorEvent(
+							'checkout_settings_apartment_toggle',
+							{
+								enabled: ! showAddress2Field,
+							}
+						);
 						setAttributes( {
 							showAddress2Field: ! showAddress2Field,
-						} )
-					}
+						} );
+					} }
 				/>
 				<ToggleControl
 					label={ __( 'Phone', 'woo-gutenberg-products-block' ) }
 					checked={ showPhoneField }
-					onChange={ () =>
+					onChange={ () => {
+						recordEditorEvent( 'checkout_settings_phone_toggle', {
+							enabled: ! showPhoneField,
+						} );
 						setAttributes( {
 							showPhoneField: ! showPhoneField,
-						} )
-					}
+						} );
+					} }
 				/>
 				{ showPhoneField && (
 					<CheckboxControl
@@ -172,11 +185,17 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						'woo-gutenberg-products-block'
 					) }
 					checked={ showPolicyLinks }
-					onChange={ () =>
+					onChange={ () => {
+						recordEditorEvent(
+							'checkout_settings_policy_links_toggle',
+							{
+								enabled: ! showPolicyLinks,
+							}
+						);
 						setAttributes( {
 							showPolicyLinks: ! showPolicyLinks,
-						} )
-					}
+						} );
+					} }
 				/>
 				{ showPolicyLinks && ( ! PRIVACY_URL || ! TERMS_URL ) && (
 					<Notice
@@ -219,11 +238,18 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						'woo-gutenberg-products-block'
 					) }
 					checked={ showReturnToCart }
-					onChange={ () =>
+					onChange={ () => {
+						recordEditorEvent(
+							'checkout_settings_return_to_cart_toggle',
+							{
+								enabled: ! showReturnToCart,
+							}
+						);
+
 						setAttributes( {
 							showReturnToCart: ! showReturnToCart,
-						} )
-					}
+						} );
+					} }
 				/>
 				{ showReturnToCart &&
 					( currentPostId !== CHECKOUT_PAGE_ID || !! cartPageId ) &&


### PR DESCRIPTION
Fixes #2048 
Fixes #2049

This PR adds usage tracks events for various editor settings for the cart & checkout blocks.

Most `_toggle` events (unless otherwise specified) have a boolean `enabled` prop. 

##### Cart block
- `wcadmin_blocks_cart_settings_shipping_calculator_toggle`
- `wcadmin_blocks_cart_view_toggle { view: 'full' | 'empty' }` when merchant toggles between cart edit modes (empty cart vs full cart)

##### Checkout block
- `wcadmin_blocks_checkout_settings_company_toggle`
- `wcadmin_blocks_checkout_settings_apartment_toggle`
- `wcadmin_blocks_checkout_settings_phone_toggle`
- `wcadmin_blocks_checkout_settings_policy_links_toggle`
- `wcadmin_blocks_checkout_settings_return_to_cart_toggle`

### Screenshots

<img width="1563" alt="Screen Shot 2020-04-02 at 4 24 11 PM" src="https://user-images.githubusercontent.com/4167300/78207514-65ffce80-74fe-11ea-8bee-42cda54a7a9f.png">

### How to test the changes in this Pull Request:

1. Edit a page. Add cart or checkout block.
99. Open dev tools and search for `pixel` to filter tracks related requests.
2. Change the settings for the block, or toggle view for cart block.
3. See tracks requests with appropriate props firing.
4. Test editing various aspects of the blocks and ensure events only fire when appropriate, with correct data.
5. Use blocks on front end and confirm that none of the above events are fired (no `wcadmin_` events should fire).

pb0Spc-ou-p2#comment-658