### PR TITLE
Update Checkout skeleton to match layout introduced in #2041

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -155,13 +155,15 @@ class Checkout extends AbstractBlock {
 						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
 							<span></span>
 						</fieldset>
-						<div class="wc-block-checkout__actions">
-							<button class="components-button button wc-block-button wc-block-components-checkout-place-order-button">&nbsp;</button>
-						</div>
 					</form>
 				</div>
 				<div class="wc-block-sidebar wc-block-checkout__sidebar">
 					<div class="components-card"></div>
+				</div>
+				<div class="wc-block-main">
+					<div class="wc-block-checkout__actions">
+						<button class="components-button button wc-block-button wc-block-components-checkout-place-order-button">&nbsp;</button>
+					</div>
 				</div>
 			</div>
 		';


### PR DESCRIPTION
In #2041 I changed the layout of the _Checkout_ block so the sidebar appeared before the buttons, but I forgot to update the skeleton. This PR takes care of that.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/78233934-b8c59000-74d6-11ea-9220-bf6bf4a56edc.png)
_(the last step shouldn't have a vertical line on the left)_

### How to test the changes in this Pull Request:

1. Load a page or post with the _Checkout_ block.
2. Verify the last step doesn't have a vertical line on the left (on desktop, that's the only visual change you should see different from master).
