### PR TITLE
Respect needs_shipping in Cart and Checkout

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-fees-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-fees-item/index.js
@@ -2,10 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	DISPLAY_CART_PRICES_INCLUDING_TAX,
-	SHIPPING_ENABLED,
-} from '@woocommerce/block-settings';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
+import { useShippingDataContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
 
 /**
@@ -14,7 +12,8 @@ import PropTypes from 'prop-types';
 import TotalsItem from '../totals-item';
 
 const TotalsFeesItem = ( { currency, values } ) => {
-	if ( ! SHIPPING_ENABLED ) {
+	const { needsShipping } = useShippingDataContext();
+	if ( ! needsShipping ) {
 		return null;
 	}
 	const { total_fees: totalFees, total_fees_tax: totalFeesTax } = values;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -16,7 +16,6 @@ import {
 import {
 	COUPONS_ENABLED,
 	DISPLAY_CART_PRICES_INCLUDING_TAX,
-	SHIPPING_ENABLED,
 } from '@woocommerce/block-settings';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import { Card, CardBody } from 'wordpress-components';
@@ -55,6 +54,7 @@ const Cart = ( { attributes } ) => {
 		cartItems,
 		cartTotals,
 		cartIsLoading,
+		needsShipping,
 		cartItemsCount,
 		cartItemErrors,
 	} = useStoreCart();
@@ -119,7 +119,7 @@ const Cart = ( { attributes } ) => {
 							removeCoupon={ removeCoupon }
 							values={ cartTotals }
 						/>
-						{ SHIPPING_ENABLED && (
+						{ needsShipping && (
 							<TotalsShippingItem
 								showCalculator={ isShippingCalculatorEnabled }
 								showRatesWithoutAddress={

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -54,9 +54,9 @@ const Cart = ( { attributes } ) => {
 		cartItems,
 		cartTotals,
 		cartIsLoading,
-		needsShipping,
 		cartItemsCount,
 		cartItemErrors,
+		cartNeedsShipping,
 	} = useStoreCart();
 
 	const {
@@ -119,7 +119,7 @@ const Cart = ( { attributes } ) => {
 							removeCoupon={ removeCoupon }
 							values={ cartTotals }
 						/>
-						{ needsShipping && (
+						{ cartNeedsShipping && (
 							<TotalsShippingItem
 								showCalculator={ isShippingCalculatorEnabled }
 								showRatesWithoutAddress={

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -30,7 +30,6 @@ import {
 	ExpressCheckoutFormControl,
 	PaymentMethods,
 } from '@woocommerce/base-components/payment-methods';
-import { SHIPPING_ENABLED } from '@woocommerce/block-settings';
 import { decodeEntities } from '@wordpress/html-entities';
 import {
 	Sidebar,
@@ -68,6 +67,7 @@ const Checkout = ( {
 		shippingRatesLoading,
 		shippingAddress,
 		setShippingAddress,
+		needsShipping,
 	} = useShippingDataContext();
 	const { billingData, setBillingData } = useBillingDataContext();
 
@@ -87,7 +87,7 @@ const Checkout = ( {
 		secondaryDescription: decodeEntities( option.delivery_time ),
 	} );
 
-	const showBillingFields = ! SHIPPING_ENABLED || ! shippingAsBilling;
+	const showBillingFields = ! needsShipping || ! shippingAsBilling;
 	const addressFields = {
 		...defaultAddressFields,
 		company: {
@@ -195,7 +195,7 @@ const Checkout = ( {
 								}
 							/>
 						</FormStep>
-						{ SHIPPING_ENABLED && (
+						{ needsShipping && (
 							<FormStep
 								id="shipping-fields"
 								className="wc-block-checkout__shipping-fields"
@@ -279,7 +279,7 @@ const Checkout = ( {
 								/>
 							</FormStep>
 						) }
-						{ SHIPPING_ENABLED && (
+						{ needsShipping && (
 							<FormStep
 								id="shipping-option"
 								className="wc-block-checkout__shipping-option"

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -10,6 +10,7 @@ import {
 	TotalsShippingItem,
 	TotalsTaxesItem,
 } from '@woocommerce/base-components/cart-checkout';
+import { useShippingDataContext } from '@woocommerce/base-context';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import {
 	COUPONS_ENABLED,
@@ -33,6 +34,8 @@ const CheckoutSidebar = ( {
 		isApplyingCoupon,
 		isRemovingCoupon,
 	} = useStoreCartCoupons();
+
+	const { needsShipping } = useShippingDataContext();
 	const totalsCurrency = getCurrencyFromPriceResponse( cartTotals );
 
 	return (
@@ -47,13 +50,15 @@ const CheckoutSidebar = ( {
 				removeCoupon={ removeCoupon }
 				values={ cartTotals }
 			/>
-			<TotalsShippingItem
-				currency={ totalsCurrency }
-				noResultsMessage={ null }
-				isCheckout={ true }
-				showCalculator={ false }
-				values={ cartTotals }
-			/>
+			{ needsShipping && (
+				<TotalsShippingItem
+					currency={ totalsCurrency }
+					noResultsMessage={ null }
+					isCheckout={ true }
+					showCalculator={ false }
+					values={ cartTotals }
+				/>
+			) }
 			{ ! DISPLAY_CART_PRICES_INCLUDING_TAX && (
 				<TotalsTaxesItem
 					currency={ totalsCurrency }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR builds on the previously introduced `needs_shipping` and `needsShipping` data, it toggles off some shipping sections from Cart and Checkout when the current cart doesn't need shipping, the value of needs_shipping is based on `WC_Cart::needs_shipping()`.
Some code that was previously checked only against `SHIPPING_ENABLED` is now using 'needsShipping` as it can give false positive (cart only containing digital products) while `SHIPPING_ENABLED` watches the whole site state, in places when we used the constant, `needs_shipping` cover both cases so it became redundant (I left because we still use it in the editor to show certain settings if shipping is enabled).
`needs_shipping` only checks for if shipping zones exists.
### How to test the changes in this Pull Request:

1. Make sure shipping is enabled, add to your cart a digital product
2. shipping should not be present.
3. add a physical product
4. shipping should show up now.
5. if you don't have shipping zones, shipping fees and row won't show up.
