### PR TITLE
fix broken e2e-tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5106,22 +5106,22 @@
       }
     },
     "@wordpress/e2e-test-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-4.0.0.tgz",
-      "integrity": "sha512-w9IQo4+nlrwQxKKOOk03JLQ6BF/Op/jH5/RHsDIQChli5KJYGY2TkKy5ilVcx1/tLerwkXSIWUrNDlOszhoSig==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-4.3.1.tgz",
+      "integrity": "sha512-5/JWB68PaXH8eYLwMc1CfmJcAwSIySuBBJA6KyizV+kXRh45KNqkqRO6XluhUsgzDP5WhrBvF8XmATDpmntptw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.4",
-        "@wordpress/keycodes": "^2.7.0",
-        "@wordpress/url": "^2.9.0",
+        "@babel/runtime": "^7.8.3",
+        "@wordpress/keycodes": "^2.9.0",
+        "@wordpress/url": "^2.11.0",
         "lodash": "^4.17.15",
         "node-fetch": "^1.7.3"
       },
       "dependencies": {
         "@wordpress/i18n": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.9.0.tgz",
-          "integrity": "sha512-ACpLPvdzAosAPqSLUaYQSX7fB5yAV5dFy8Y37FWLsZrv4NhUQ+rfDLdrXrCWm19LEZ5nTFfZUT0TIbYKekqIug==",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.10.0.tgz",
+          "integrity": "sha512-f1+ITy2ImcfV6695QTNnlLxs5oHNXslbqVtJuK4Ug9r6nPPt2EwnKkK+rhdDgaRLeWrF9C1vwBxJCOOU2B1aKw==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.3",
@@ -5133,13 +5133,13 @@
           }
         },
         "@wordpress/keycodes": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.9.0.tgz",
-          "integrity": "sha512-m9SO9eYbzuGv5kNZLimL2O7khDddb+uNAkCJC7juD9K/a+l2LiXSLJRm6gAmnBdrGP8UrTudR0oLaPZLcKXYZA==",
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.10.0.tgz",
+          "integrity": "sha512-BjrkO5C9HTDpY0JO8eqiDFsmjOM1CEfeBxtLCAiG8UdWxYVDPJ2YJb3JICZg8FqZYr6LkpTDNHi6mhdXQu9SKA==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.8.3",
-            "@wordpress/i18n": "^3.9.0",
+            "@wordpress/i18n": "^3.10.0",
             "lodash": "^4.17.15"
           }
         }
@@ -28668,7 +28668,7 @@
       }
     },
     "woocommerce": {
-      "version": "git+https://github.com/woocommerce/woocommerce.git#6f2b232fc7fa53417691a742a419147bb0134a5c",
+      "version": "git+https://github.com/woocommerce/woocommerce.git#3e322793ec4926f289811aa121a8a209dbf1323c",
       "from": "git+https://github.com/woocommerce/woocommerce.git",
       "dev": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
 		"@wordpress/components": "8.5.0",
 		"@wordpress/data-controls": "1.6.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "2.1.0",
-		"@wordpress/e2e-test-utils": "4.0.0",
+		"@wordpress/e2e-test-utils": "4.3.1",
 		"@wordpress/editor": "9.10.0",
 		"@wordpress/element": "2.10.0",
 		"@wordpress/eslint-plugin": "3.3.0",


### PR DESCRIPTION
With new version of GB and WP, some classes changed, but our test utils pointed to the all ones, this PR updates it.