### PR TITLE
Update add to cart to useStoreCart hook

### DIFF
--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -4,19 +4,17 @@
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { _n, sprintf } from '@wordpress/i18n';
-import {
-	useMemo,
-	useCallback,
-	useState,
-	useEffect,
-	useRef,
-} from '@wordpress/element';
+import { useMemo, useState, useEffect, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { find } from 'lodash';
-import { useCollection } from '@woocommerce/base-hooks';
-import { COLLECTIONS_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { useStoreCart } from '@woocommerce/base-hooks';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useProductLayoutContext } from '@woocommerce/base-context';
 import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * @typedef {import('@woocommerce/type-defs/hooks').StoreCartItemAddToCart} StoreCartItemAddToCart
+ */
 
 /**
  * A custom hook for exposing cart related data for a given product id and an
@@ -28,51 +26,34 @@ import { decodeEntities } from '@wordpress/html-entities';
  * @param {number} productId  The product id for the product connection to the
  *                            cart.
  *
- * @return {Object} Returns an object with the following properties:
- *    @type {number}   cartQuantity  The quantity of the product currently in
- *                                   the cart.
- *    @type {boolean}  addingToCart  Whether the product is currently being
- *                                   added to the cart (true).
- *    @type {boolean}  cartIsLoading Whether the cart is being loaded.
- *    @type {Function} addToCart     An action dispatcher for adding a single
- *                                   quantity of the product to the cart.
- *                                   Receives no arguments, it operates on the
- *                                   current product.
+ * @return {StoreCartItemAddToCart} An object exposing data and actions relating
+ *                                  to add to cart functionality.
  */
 const useAddToCart = ( productId ) => {
-	const { results: cartResults, isLoading: cartIsLoading } = useCollection( {
-		namespace: '/wc/store',
-		resourceName: 'cart/items',
-	} );
-	const currentCartResults = useRef( null );
-	const { __experimentalPersistItemToCollection } = useDispatch( storeKey );
-	const cartQuantity = useMemo( () => {
-		const productItem = find( cartResults, { id: productId } );
-		return productItem ? productItem.quantity : 0;
-	}, [ cartResults, productId ] );
 	const [ addingToCart, setAddingToCart ] = useState( false );
-	const addToCart = useCallback( () => {
+	const { cartItems, cartIsLoading } = useStoreCart();
+	const currentCartResults = useRef( cartItems );
+	const { addItemToCart } = useDispatch( storeKey );
+
+	const addToCart = () => {
 		setAddingToCart( true );
-		// exclude this item from the cartResults for adding to the new
-		// collection (so it's updated correctly!)
-		const collection = cartResults.filter( ( cartItem ) => {
-			return cartItem.id !== productId;
-		} );
-		__experimentalPersistItemToCollection(
-			'/wc/store',
-			'cart/items',
-			collection,
-			{ id: productId, quantity: 1 }
-		);
-	}, [ productId, cartResults ] );
+		addItemToCart( productId );
+	};
+
+	const cartQuantity = useMemo( () => {
+		const productItem = find( cartItems, { id: productId } );
+		return productItem ? productItem.quantity : 0;
+	}, [ cartItems, productId ] );
+
 	useEffect( () => {
-		if ( currentCartResults.current !== cartResults ) {
+		if ( currentCartResults.current !== cartItems ) {
 			if ( addingToCart ) {
 				setAddingToCart( false );
 			}
-			currentCartResults.current = cartResults;
+			currentCartResults.current = cartItems;
 		}
-	}, [ cartResults, addingToCart ] );
+	}, [ cartItems, addingToCart ] );
+
 	return {
 		cartQuantity,
 		addingToCart,

--- a/assets/js/base/hooks/index.js
+++ b/assets/js/base/hooks/index.js
@@ -9,6 +9,7 @@ export * from './use-collection-data';
 export * from './use-previous';
 export * from './use-shallow-equal';
 export * from './use-store-products';
+export * from './use-store-add-to-cart';
 export * from './use-store-notices';
 export * from './use-query-state';
 export * from './use-throw-error';

--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { useMemo, useState, useEffect, useRef } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { find } from 'lodash';
+import { useStoreCart } from '@woocommerce/base-hooks';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+
+/**
+ * @typedef {import('@woocommerce/type-defs/hooks').StoreCartItemAddToCart} StoreCartItemAddToCart
+ */
+
+/**
+ * A custom hook for exposing cart related data for a given product id and an
+ * action for adding a single quantity of the product _to_ the cart.
+ *
+ *
+ * @param {number} productId  The product id to be added to the cart.
+ *
+ * @return {StoreCartItemAddToCart} An object exposing data and actions relating
+ *                                  to add to cart functionality.
+ */
+export const useStoreAddToCart = ( productId ) => {
+	const [ addingToCart, setAddingToCart ] = useState( false );
+	const { cartItems, cartIsLoading } = useStoreCart();
+	const currentCartItems = useRef( cartItems );
+	const { addItemToCart } = useDispatch( storeKey );
+
+	const addToCart = () => {
+		setAddingToCart( true );
+		addItemToCart( productId );
+	};
+
+	const cartQuantity = useMemo( () => {
+		const productItem = find( currentCartItems.current, { id: productId } );
+		return productItem ? productItem.quantity : 0;
+	}, [ currentCartItems.current, productId ] );
+
+	useEffect( () => {
+		if ( currentCartItems.current !== cartItems ) {
+			if ( addingToCart ) {
+				setAddingToCart( false );
+			}
+			currentCartItems.current = cartItems;
+		}
+	}, [ cartItems, addingToCart ] );
+
+	return {
+		cartQuantity,
+		addingToCart,
+		cartIsLoading,
+		addToCart,
+	};
+};

--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -211,7 +211,6 @@ export function* removeCoupon( couponCode ) {
  * - Calls API to add item.
  * - If successful, yields action to add item from store.
  * - If error, yields action to store error.
- * - Sets cart item as pending while API request is in progress.
  *
  * @param {number} productId Product ID to add to cart.
  * @param {number} quantity Number of product ID being added to cart.

--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -207,6 +207,34 @@ export function* removeCoupon( couponCode ) {
 }
 
 /**
+ * Adds an item to the cart:
+ * - Calls API to add item.
+ * - If successful, yields action to add item from store.
+ * - If error, yields action to store error.
+ * - Sets cart item as pending while API request is in progress.
+ *
+ * @param {number} productId Product ID to add to cart.
+ * @param {number} quantity Number of product ID being added to cart.
+ */
+export function* addItemToCart( productId, quantity = 1 ) {
+	try {
+		const { response } = yield apiFetchWithHeaders( {
+			path: `/wc/store/cart/add-item`,
+			method: 'POST',
+			data: {
+				id: productId,
+				quantity,
+			},
+			cache: 'no-store',
+		} );
+
+		yield receiveCart( response );
+	} catch ( error ) {
+		yield receiveError( error );
+	}
+}
+
+/**
  * Removes specified item from the cart:
  * - Calls API to remove item.
  * - If successful, yields action to remove item from store.

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -42,6 +42,17 @@
  */
 
 /**
+ * @typedef {Object} StoreCartItemAddToCart
+ *
+ * @property {number}   cartQuantity           The quantity of the item in the
+ *                                             cart.
+ * @property {boolean}  addingToCart           Whether the cart item is still
+ *                                             being added or not.
+ * @property {boolean}  cartIsLoading          Whether the cart is being loaded.
+ * @property {Function} addToCart              Callback for adding a cart item.
+ */
+
+/**
  * @typedef {Object} StoreCartItemQuantity
  *
  * @property {number}   quantity               The quantity of the item in the

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -9,6 +9,9 @@ namespace Automattic\WooCommerce\Blocks;
 
 defined( 'ABSPATH' ) || exit;
 
+use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController;
+use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController;
+
 /**
  * RestApi class.
  */
@@ -19,7 +22,6 @@ class RestApi {
 	 */
 	public static function init() {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ), 10 );
-		add_action( 'rest_api_init', array( '\Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController', 'register_routes' ), 10 );
 		add_filter( 'rest_authentication_errors', array( __CLASS__, 'maybe_init_cart_session' ), 1 );
 		add_filter( 'rest_authentication_errors', array( __CLASS__, 'store_api_authentication' ) );
 	}
@@ -28,12 +30,18 @@ class RestApi {
 	 * Register REST API routes.
 	 */
 	public static function register_rest_routes() {
+		// Init the REST API.
 		$controllers = self::get_controllers();
 
 		foreach ( $controllers as $name => $class ) {
 			$instance = new $class();
 			$instance->register_routes();
 		}
+
+		// Init the Store API.
+		$schemas = new SchemaController();
+		$routes  = new RoutesController( $schemas );
+		$routes->register_routes();
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Routes/CartAddItem.php
+++ b/src/RestApi/StoreApi/Routes/CartAddItem.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Cart add item route.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
+
+/**
+ * CartAddItem class.
+ */
+class CartAddItem extends AbstractRoute {
+	/**
+	 * Get the namespace for this route.
+	 *
+	 * @return string
+	 */
+	public function get_namespace() {
+		return 'wc/store';
+	}
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return '/cart/add-item';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'  => \WP_REST_Server::CREATABLE,
+				'callback' => [ $this, 'get_response' ],
+				'args'     => [
+					'id'        => [
+						'description' => __( 'The cart item product or variation ID.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+						'context'     => [ 'view', 'edit' ],
+						'arg_options' => [
+							'sanitize_callback' => 'absint',
+						],
+					],
+					'quantity'  => [
+						'description' => __( 'Quantity of this item in the cart.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+						'context'     => [ 'view', 'edit' ],
+						'arg_options' => [
+							'sanitize_callback' => 'wc_stock_amount',
+						],
+					],
+					'variation' => [
+						'description' => __( 'Chosen attributes (for variations).', 'woo-gutenberg-products-block' ),
+						'type'        => 'array',
+						'context'     => [ 'view', 'edit' ],
+						'items'       => [
+							'type'       => 'object',
+							'properties' => [
+								'attribute' => [
+									'description' => __( 'Variation attribute name.', 'woo-gutenberg-products-block' ),
+									'type'        => 'string',
+									'context'     => [ 'view', 'edit' ],
+								],
+								'value'     => [
+									'description' => __( 'Variation attribute value.', 'woo-gutenberg-products-block' ),
+									'type'        => 'string',
+									'context'     => [ 'view', 'edit' ],
+								],
+							],
+						],
+					],
+				],
+			],
+			'schema' => [ $this->schema, 'get_public_item_schema' ],
+		];
+	}
+
+	/**
+	 * Handle the request and return a valid response for this endpoint.
+	 *
+	 * @throws RouteException On error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_post_response( \WP_REST_Request $request ) {
+		// Do not allow key to be specified during creation.
+		if ( ! empty( $request['key'] ) ) {
+			throw new RouteException( 'woocommerce_rest_cart_item_exists', __( 'Cannot create an existing cart item.', 'woo-gutenberg-products-block' ), 400 );
+		}
+
+		$controller = new CartController();
+		$cart       = $controller->get_cart_instance();
+		$result     = $controller->add_to_cart(
+			[
+				'id'        => $request['id'],
+				'quantity'  => $request['quantity'],
+				'variation' => $request['variation'],
+			]
+		);
+
+		$response = rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		$response->set_status( 201 );
+		return $response;
+	}
+}

--- a/src/RestApi/StoreApi/RoutesController.php
+++ b/src/RestApi/StoreApi/RoutesController.php
@@ -42,6 +42,21 @@ class RoutesController {
 	}
 
 	/**
+	 * Get a route class instance.
+	 *
+	 * @throws Exception If the schema does not exist.
+	 *
+	 * @param string $name Name of schema.
+	 * @return AbstractRoute
+	 */
+	public function get( $name ) {
+		if ( ! isset( $this->routes[ $name ] ) ) {
+			throw new Exception( $name . ' route does not exist' );
+		}
+		return $this->routes[ $name ];
+	}
+
+	/**
 	 * Register defined list of routes with WordPress.
 	 */
 	public function register_routes() {
@@ -59,25 +74,25 @@ class RoutesController {
 	 */
 	protected function initialize() {
 		$this->routes = [
-			new Routes\Cart( $this->schemas->get( 'cart' ) ),
-			new Routes\CartAddItem( $this->schemas->get( 'cart' ) ),
-			new Routes\CartApplyCoupon( $this->schemas->get( 'cart' ) ),
-			new Routes\CartCoupons( $this->schemas->get( 'cart-coupon' ) ),
-			new Routes\CartCouponsByCode( $this->schemas->get( 'cart-coupon' ) ),
-			new Routes\CartItems( $this->schemas->get( 'cart-item' ) ),
-			new Routes\CartItemsByKey( $this->schemas->get( 'cart-item' ) ),
-			new Routes\CartRemoveCoupon( $this->schemas->get( 'cart' ) ),
-			new Routes\CartRemoveItem( $this->schemas->get( 'cart' ) ),
-			new Routes\CartSelectShippingRate( $this->schemas->get( 'cart' ) ),
-			new Routes\CartUpdateItem( $this->schemas->get( 'cart' ) ),
-			new Routes\CartUpdateShipping( $this->schemas->get( 'cart' ) ),
-			new Routes\Checkout( $this->schemas->get( 'checkout' ) ),
-			new Routes\ProductAttributes( $this->schemas->get( 'product-attribute' ) ),
-			new Routes\ProductAttributesById( $this->schemas->get( 'product-attribute' ) ),
-			new Routes\ProductAttributeTerms( $this->schemas->get( 'term' ) ),
-			new Routes\ProductCollectionData( $this->schemas->get( 'product-collection-data' ) ),
-			new Routes\Products( $this->schemas->get( 'product' ) ),
-			new Routes\ProductsById( $this->schemas->get( 'product' ) ),
+			'cart'                      => new Routes\Cart( $this->schemas->get( 'cart' ) ),
+			'cart-add-item'             => new Routes\CartAddItem( $this->schemas->get( 'cart' ) ),
+			'cart-apply-coupon'         => new Routes\CartApplyCoupon( $this->schemas->get( 'cart' ) ),
+			'cart-coupons'              => new Routes\CartCoupons( $this->schemas->get( 'cart-coupon' ) ),
+			'cart-coupons-by-code'      => new Routes\CartCouponsByCode( $this->schemas->get( 'cart-coupon' ) ),
+			'cart-items'                => new Routes\CartItems( $this->schemas->get( 'cart-item' ) ),
+			'cart-items-by-key'         => new Routes\CartItemsByKey( $this->schemas->get( 'cart-item' ) ),
+			'cart-remove-coupon'        => new Routes\CartRemoveCoupon( $this->schemas->get( 'cart' ) ),
+			'cart-remove-item'          => new Routes\CartRemoveItem( $this->schemas->get( 'cart' ) ),
+			'cart-select-shipping-rate' => new Routes\CartSelectShippingRate( $this->schemas->get( 'cart' ) ),
+			'cart-update-item'          => new Routes\CartUpdateItem( $this->schemas->get( 'cart' ) ),
+			'cart-update-shipping'      => new Routes\CartUpdateShipping( $this->schemas->get( 'cart' ) ),
+			'checkout'                  => new Routes\Checkout( $this->schemas->get( 'checkout' ) ),
+			'product-attributes'        => new Routes\ProductAttributes( $this->schemas->get( 'product-attribute' ) ),
+			'product-attributes-by-id'  => new Routes\ProductAttributesById( $this->schemas->get( 'product-attribute' ) ),
+			'product-attribute-terms'   => new Routes\ProductAttributeTerms( $this->schemas->get( 'term' ) ),
+			'product-collection-data'   => new Routes\ProductCollectionData( $this->schemas->get( 'product-collection-data' ) ),
+			'products'                  => new Routes\Products( $this->schemas->get( 'product' ) ),
+			'products-by-id'            => new Routes\ProductsById( $this->schemas->get( 'product' ) ),
 		];
 	}
 }

--- a/src/RestApi/StoreApi/RoutesController.php
+++ b/src/RestApi/StoreApi/RoutesController.php
@@ -10,53 +10,74 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi;
 
 defined( 'ABSPATH' ) || exit;
 
+use Routes\AbstractRoute;
+
 /**
  * RoutesController class.
  */
 class RoutesController {
+
+	/**
+	 * Stores schemas.
+	 *
+	 * @var SchemaController
+	 */
+	protected $schemas;
+
+	/**
+	 * Stores routes.
+	 *
+	 * @var AbstractRoute[]
+	 */
+	protected $routes = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SchemaController $schemas Schema controller class passed to each route.
+	 */
+	public function __construct( SchemaController $schemas ) {
+		$this->schemas = $schemas;
+		$this->initialize();
+	}
+
 	/**
 	 * Register defined list of routes with WordPress.
 	 */
-	public static function register_routes() {
-		$schemas = [
-			'cart'                    => new Schemas\CartSchema(),
-			'checkout'                => new Schemas\CheckoutSchema(),
-			'coupon'                  => new Schemas\CartCouponSchema(),
-			'cart-item'               => new Schemas\CartItemSchema(),
-			'order'                   => new Schemas\OrderSchema(),
-			'product'                 => new Schemas\ProductSchema(),
-			'product-attribute'       => new Schemas\ProductAttributeSchema(),
-			'product-collection-data' => new Schemas\ProductCollectionDataSchema(),
-			'term'                    => new Schemas\TermSchema(),
-		];
-
-		$routes = [
-			new Routes\Cart( $schemas['cart'] ),
-			new Routes\CartApplyCoupon( $schemas['cart'] ),
-			new Routes\CartCoupons( $schemas['coupon'] ),
-			new Routes\CartCouponsByCode( $schemas['coupon'] ),
-			new Routes\CartItems( $schemas['cart-item'] ),
-			new Routes\CartItemsByKey( $schemas['cart-item'] ),
-			new Routes\CartRemoveCoupon( $schemas['cart'] ),
-			new Routes\CartRemoveItem( $schemas['cart'] ),
-			new Routes\CartSelectShippingRate( $schemas['cart'] ),
-			new Routes\CartUpdateItem( $schemas['cart'] ),
-			new Routes\CartUpdateShipping( $schemas['cart'] ),
-			new Routes\Checkout( $schemas['checkout'] ),
-			new Routes\ProductAttributes( $schemas['product-attribute'] ),
-			new Routes\ProductAttributesById( $schemas['product-attribute'] ),
-			new Routes\ProductAttributeTerms( $schemas['term'] ),
-			new Routes\ProductCollectionData( $schemas['product-collection-data'] ),
-			new Routes\Products( $schemas['product'] ),
-			new Routes\ProductsById( $schemas['product'] ),
-		];
-
-		foreach ( $routes as $route ) {
+	public function register_routes() {
+		foreach ( $this->routes as $route ) {
 			register_rest_route(
 				$route->get_namespace(),
 				$route->get_path(),
 				$route->get_args()
 			);
 		}
+	}
+
+	/**
+	 * Load route class instances.
+	 */
+	protected function initialize() {
+		$this->routes = [
+			new Routes\Cart( $this->schemas->get( 'cart' ) ),
+			new Routes\CartAddItem( $this->schemas->get( 'cart' ) ),
+			new Routes\CartApplyCoupon( $this->schemas->get( 'cart' ) ),
+			new Routes\CartCoupons( $this->schemas->get( 'cart-coupon' ) ),
+			new Routes\CartCouponsByCode( $this->schemas->get( 'cart-coupon' ) ),
+			new Routes\CartItems( $this->schemas->get( 'cart-item' ) ),
+			new Routes\CartItemsByKey( $this->schemas->get( 'cart-item' ) ),
+			new Routes\CartRemoveCoupon( $this->schemas->get( 'cart' ) ),
+			new Routes\CartRemoveItem( $this->schemas->get( 'cart' ) ),
+			new Routes\CartSelectShippingRate( $this->schemas->get( 'cart' ) ),
+			new Routes\CartUpdateItem( $this->schemas->get( 'cart' ) ),
+			new Routes\CartUpdateShipping( $this->schemas->get( 'cart' ) ),
+			new Routes\Checkout( $this->schemas->get( 'checkout' ) ),
+			new Routes\ProductAttributes( $this->schemas->get( 'product-attribute' ) ),
+			new Routes\ProductAttributesById( $this->schemas->get( 'product-attribute' ) ),
+			new Routes\ProductAttributeTerms( $this->schemas->get( 'term' ) ),
+			new Routes\ProductCollectionData( $this->schemas->get( 'product-collection-data' ) ),
+			new Routes\Products( $this->schemas->get( 'product' ) ),
+			new Routes\ProductsById( $this->schemas->get( 'product' ) ),
+		];
 	}
 }

--- a/src/RestApi/StoreApi/SchemaController.php
+++ b/src/RestApi/StoreApi/SchemaController.php
@@ -41,7 +41,7 @@ class SchemaController {
 	 * @return AbstractSchema
 	 */
 	public function get( $name ) {
-		if ( ! isset( $this->schemas ) ) {
+		if ( ! isset( $this->schemas[ $name ] ) ) {
 			throw new Exception( $name . ' schema does not exist' );
 		}
 		return $this->schemas[ $name ];

--- a/src/RestApi/StoreApi/SchemaController.php
+++ b/src/RestApi/StoreApi/SchemaController.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Register Schemas.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi;
+
+defined( 'ABSPATH' ) || exit;
+
+use Exception;
+use Schemas\AbstractSchema;
+
+/**
+ * SchemaController class.
+ */
+class SchemaController {
+
+	/**
+	 * Stores schema class instances.
+	 *
+	 * @var AbstractSchema[]
+	 */
+	protected $schemas = [];
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->initialize();
+	}
+
+	/**
+	 * Get a schema class instance.
+	 *
+	 * @throws Exception If the schema does not exist.
+	 *
+	 * @param string $name Name of schema.
+	 * @return AbstractSchema
+	 */
+	public function get( $name ) {
+		if ( ! isset( $this->schemas ) ) {
+			throw new Exception( $name . ' schema does not exist' );
+		}
+		return $this->schemas[ $name ];
+	}
+
+	/**
+	 * Load schema class instances.
+	 */
+	protected function initialize() {
+		$this->schemas = [
+			'cart'                    => new Schemas\CartSchema(
+				new Schemas\CartItemSchema(),
+				new Schemas\CartCouponSchema(),
+				new Schemas\CartShippingRateSchema(),
+				new Schemas\ShippingAddressSchema(),
+				new Schemas\ErrorSchema()
+			),
+			'cart-coupon'             => new Schemas\CartCouponSchema(),
+			'cart-item'               => new Schemas\CartItemSchema(),
+			'checkout'                => new Schemas\CheckoutSchema(
+				new Schemas\BillingAddressSchema(),
+				new Schemas\ShippingAddressSchema()
+			),
+			'product'                 => new Schemas\ProductSchema(),
+			'product-attribute'       => new Schemas\ProductAttributeSchema(),
+			'product-collection-data' => new Schemas\ProductCollectionDataSchema(),
+			'term'                    => new Schemas\TermSchema(),
+		];
+	}
+}

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -26,20 +26,6 @@ class CartItemSchema extends AbstractSchema {
 	protected $title = 'cart_item';
 
 	/**
-	 * We use product schema for line item price info.
-	 *
-	 * @var ProductSchema
-	 */
-	protected $product_schema;
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->product_schema = new ProductSchema();
-	}
-
-	/**
 	 * Cart schema properties.
 	 *
 	 * @return array
@@ -56,18 +42,13 @@ class CartItemSchema extends AbstractSchema {
 				'description' => __( 'The cart item product or variation ID.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
-				'arg_options' => [
-					'sanitize_callback' => 'absint',
-					'validate_callback' => [ $this, 'product_id_exists' ],
-				],
+				'readonly'    => true,
 			],
 			'quantity'            => [
 				'description' => __( 'Quantity of this item in the cart.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
-				'arg_options' => [
-					'sanitize_callback' => 'wc_stock_amount',
-				],
+				'readonly'    => true,
 			],
 			'name'                => [
 				'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
@@ -79,16 +60,19 @@ class CartItemSchema extends AbstractSchema {
 				'description' => __( 'A short summary (or excerpt from the full description) for the product in HTML format.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
 			],
 			'short_description'   => [
 				'description' => __( 'Product short description in HTML format.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
 			],
 			'description'         => [
 				'description' => __( 'Product full description in HTML format.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
 			],
 			'sku'                 => [
 				'description' => __( 'Stock keeping unit, if applicable.', 'woo-gutenberg-products-block' ),
@@ -133,38 +117,45 @@ class CartItemSchema extends AbstractSchema {
 							'description' => __( 'Image ID.', 'woo-gutenberg-products-block' ),
 							'type'        => 'integer',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 						'src'       => [
 							'description' => __( 'Full size image URL.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'format'      => 'uri',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 						'thumbnail' => [
 							'description' => __( 'Thumbnail URL.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'format'      => 'uri',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 						'srcset'    => [
 							'description' => __( 'Thumbnail srcset for responsive images.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 						'sizes'     => [
 							'description' => __( 'Thumbnail sizes for responsive images.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 						'name'      => [
 							'description' => __( 'Image name.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 						'alt'       => [
 							'description' => __( 'Image alternative text.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 					],
 				],
@@ -173,6 +164,7 @@ class CartItemSchema extends AbstractSchema {
 				'description' => __( 'Chosen attributes (for variations).', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
 				'items'       => [
 					'type'       => 'object',
 					'properties' => [
@@ -180,11 +172,13 @@ class CartItemSchema extends AbstractSchema {
 							'description' => __( 'Variation attribute name.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 						'value'     => [
 							'description' => __( 'Variation attribute value.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
 						],
 					],
 				],
@@ -309,17 +303,6 @@ class CartItemSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Check given ID exists,
-	 *
-	 * @param integer $product_id Product ID.
-	 * @return bool
-	 */
-	public function product_id_exists( $product_id ) {
-		$post = get_post( (int) $product_id );
-		return $post && in_array( $post->post_type, [ 'product', 'product_variation' ], true );
-	}
-
-	/**
 	 * Convert a WooCommerce cart item to an object suitable for the response.
 	 *
 	 * @param array $cart_item Cart item array.
@@ -369,8 +352,11 @@ class CartItemSchema extends AbstractSchema {
 		$tax_display_mode = in_array( $tax_display_mode, [ 'incl', 'excl' ], true ) ? $tax_display_mode : get_option( 'woocommerce_tax_display_shop' );
 		$price_function   = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
 
-		// Get individual product prices from product schema.
-		$prices = $this->product_schema->get_prices( $product, $tax_display_mode );
+		// Get individual product prices.
+		$prices['price']         = $this->prepare_money_response( $price_function( $product ), wc_get_price_decimals() );
+		$prices['regular_price'] = $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_regular_price() ] ), wc_get_price_decimals() );
+		$prices['sale_price']    = $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_sale_price() ] ), wc_get_price_decimals() );
+		$prices['price_range']   = $this->get_price_range( $product );
 
 		// Add raw prices (prices with greater precision).
 		$prices['raw_prices'] = [
@@ -381,6 +367,47 @@ class CartItemSchema extends AbstractSchema {
 		];
 
 		return $prices;
+	}
+
+	/**
+	 * Get price range from certain product types.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @return object|null
+	 */
+	protected function get_price_range( \WC_Product $product ) {
+		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
+
+		if ( $product->is_type( 'variable' ) ) {
+			$prices = $product->get_variation_prices( true );
+
+			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
+				return (object) [
+					'min_amount' => $this->prepare_money_response( min( $prices['price'] ), wc_get_price_decimals() ),
+					'max_amount' => $this->prepare_money_response( max( $prices['price'] ), wc_get_price_decimals() ),
+				];
+			}
+		}
+
+		if ( $product->is_type( 'grouped' ) ) {
+			$children       = array_filter( array_map( 'wc_get_product', $product->get_children() ), 'wc_products_array_filter_visible_grouped' );
+			$price_function = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
+
+			foreach ( $children as $child ) {
+				if ( '' !== $child->get_price() ) {
+					$child_prices[] = $price_function( $child );
+				}
+			}
+
+			if ( ! empty( $child_prices ) ) {
+				return (object) [
+					'min_amount' => $this->prepare_money_response( min( $child_prices ), wc_get_price_decimals() ),
+					'max_amount' => $this->prepare_money_response( max( $child_prices ), wc_get_price_decimals() ),
+				];
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
@@ -23,6 +23,31 @@ class CheckoutSchema extends AbstractSchema {
 	protected $title = 'checkout';
 
 	/**
+	 * Billing address schema instance.
+	 *
+	 * @var BillingAddressSchema
+	 */
+	protected $billing_address_schema;
+
+	/**
+	 * Shipping address schema instance.
+	 *
+	 * @var ShippingAddressSchema
+	 */
+	protected $shipping_address_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param BillingAddressSchema  $billing_address_schema Billing address schema instance.
+	 * @param ShippingAddressSchema $shipping_address_schema Shipping address schema instance.
+	 */
+	public function __construct( BillingAddressSchema $billing_address_schema, ShippingAddressSchema $shipping_address_schema ) {
+		$this->billing_address_schema  = $billing_address_schema;
+		$this->shipping_address_schema = $shipping_address_schema;
+	}
+
+	/**
 	 * Checkout schema properties.
 	 *
 	 * @return array
@@ -56,13 +81,13 @@ class CheckoutSchema extends AbstractSchema {
 				'description' => __( 'Billing address.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
-				'properties'  => ( new BillingAddressSchema() )->get_properties(),
+				'properties'  => $this->billing_address_schema->get_properties(),
 			],
 			'shipping_address' => [
 				'description' => __( 'Shipping address.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
-				'properties'  => ( new ShippingAddressSchema() )->get_properties(),
+				'properties'  => $this->shipping_address_schema->get_properties(),
 			],
 			'payment_method'   => [
 				'description' => __( 'The ID of the payment method being used to process the payment.', 'woo-gutenberg-products-block' ),
@@ -129,8 +154,8 @@ class CheckoutSchema extends AbstractSchema {
 			'status'           => $order->get_status(),
 			'order_key'        => $order->get_order_key(),
 			'customer_note'    => $order->get_customer_note(),
-			'billing_address'  => ( new BillingAddressSchema() )->get_item_response( $order ),
-			'shipping_address' => ( new ShippingAddressSchema() )->get_item_response( $order ),
+			'billing_address'  => $this->billing_address_schema->get_item_response( $order ),
+			'shipping_address' => $this->shipping_address_schema->get_item_response( $order ),
 			'payment_method'   => $order->get_payment_method(),
 			'payment_result'   => [
 				'payment_status'  => $payment_result->status,

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -292,7 +292,7 @@ class ProductSchema extends AbstractSchema {
 	protected function get_low_stock_remaining( \WC_Product $product ) {
 		$remaining_stock = $this->get_remaining_stock( $product );
 
-		if ( ! is_null( $$remaining_stock ) && $remaining_stock <= wc_get_low_stock_amount( $product ) ) {
+		if ( ! is_null( $remaining_stock ) && $remaining_stock <= wc_get_low_stock_amount( $product ) ) {
 			return $remaining_stock;
 		}
 

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -253,7 +253,7 @@ class ProductSchema extends AbstractSchema {
 			'short_description'   => $this->prepare_html_response( wc_format_content( $product->get_short_description() ) ),
 			'description'         => $this->prepare_html_response( wc_format_content( $product->get_description() ) ),
 			'on_sale'             => $product->is_on_sale(),
-			'prices'              => (object) $this->get_prices( $product ),
+			'prices'              => (object) $this->prepare_product_price_response( $product ),
 			'average_rating'      => $product->get_average_rating(),
 			'review_count'        => $product->get_review_count(),
 			'images'              => ( new ProductImages() )->images_to_array( $product ),
@@ -271,15 +271,31 @@ class ProductSchema extends AbstractSchema {
 	}
 
 	/**
+	 * Gets remaining stock amount for a product.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @return integer|null
+	 */
+	protected function get_remaining_stock( \WC_Product $product ) {
+		if ( is_null( $product->get_stock_quantity() ) ) {
+			return null;
+		}
+		return $product->get_stock_quantity();
+	}
+
+	/**
 	 * If a product has low stock, return the remaining stock amount for display.
 	 *
 	 * @param \WC_Product $product Product instance.
 	 * @return integer|null
 	 */
 	protected function get_low_stock_remaining( \WC_Product $product ) {
-		if ( ! is_null( $product->get_stock_quantity() ) && $product->get_stock_quantity() <= wc_get_low_stock_amount( $product ) ) {
-			return $product->get_stock_quantity();
+		$remaining_stock = $this->get_remaining_stock( $product );
+
+		if ( ! is_null( $$remaining_stock ) && $remaining_stock <= wc_get_low_stock_amount( $product ) ) {
+			return $remaining_stock;
 		}
+
 		return null;
 	}
 
@@ -290,26 +306,48 @@ class ProductSchema extends AbstractSchema {
 	 * @param string      $tax_display_mode If returned prices are incl or excl of tax.
 	 * @return array
 	 */
-	public function get_prices( \WC_Product $product, $tax_display_mode = '' ) {
-		$prices                  = $this->get_store_currency_response();
-		$tax_display_mode        = in_array( $tax_display_mode, [ 'incl', 'excl' ], true ) ? $tax_display_mode : get_option( 'woocommerce_tax_display_shop' );
-		$price_function          = 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
+	protected function prepare_product_price_response( \WC_Product $product, $tax_display_mode = '' ) {
+		$prices           = $this->get_store_currency_response();
+		$tax_display_mode = $this->get_tax_display_mode( $tax_display_mode );
+		$price_function   = $this->get_price_function_from_tax_display_mode( $tax_display_mode );
+
 		$prices['price']         = $this->prepare_money_response( $price_function( $product ), wc_get_price_decimals() );
 		$prices['regular_price'] = $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_regular_price() ] ), wc_get_price_decimals() );
 		$prices['sale_price']    = $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_sale_price() ] ), wc_get_price_decimals() );
-		$prices['price_range']   = $this->get_price_range( $product );
+		$prices['price_range']   = $this->get_price_range( $product, $tax_display_mode );
 
 		return $prices;
+	}
+
+	/**
+	 * WooCommerce can return prices including or excluding tax; choose the correct method based on tax display mode.
+	 *
+	 * @param string $tax_display_mode Provided tax display mode.
+	 * @return string Valid tax display mode.
+	 */
+	protected function get_tax_display_mode( $tax_display_mode = '' ) {
+		return in_array( $tax_display_mode, [ 'incl', 'excl' ], true ) ? $tax_display_mode : get_option( 'woocommerce_tax_display_shop' );
+	}
+
+	/**
+	 * WooCommerce can return prices including or excluding tax; choose the correct method based on tax display mode.
+	 *
+	 * @param string $tax_display_mode If returned prices are incl or excl of tax.
+	 * @return string Function name.
+	 */
+	protected function get_price_function_from_tax_display_mode( $tax_display_mode ) {
+		return 'incl' === $tax_display_mode ? 'wc_get_price_including_tax' : 'wc_get_price_excluding_tax';
 	}
 
 	/**
 	 * Get price range from certain product types.
 	 *
 	 * @param \WC_Product $product Product instance.
+	 * @param string      $tax_display_mode If returned prices are incl or excl of tax.
 	 * @return object|null
 	 */
-	protected function get_price_range( \WC_Product $product ) {
-		$tax_display_mode = get_option( 'woocommerce_tax_display_shop' );
+	protected function get_price_range( \WC_Product $product, $tax_display_mode = '' ) {
+		$tax_display_mode = $this->get_tax_display_mode( $tax_display_mode );
 
 		if ( $product->is_type( 'variable' ) ) {
 			$prices = $product->get_variation_prices( true );

--- a/src/RestApi/StoreApi/Schemas/ProductSchema.php
+++ b/src/RestApi/StoreApi/Schemas/ProductSchema.php
@@ -242,7 +242,7 @@ class ProductSchema extends AbstractSchema {
 	 * @param \WC_Product $product Product instance.
 	 * @return array
 	 */
-	public function get_item_response( \WC_Product $product ) {
+	public function get_item_response( $product ) {
 		return [
 			'id'                  => $product->get_id(),
 			'name'                => $this->prepare_html_response( $product->get_title() ),

--- a/tests/php/RestApi/StoreApi/Routes/Cart.php
+++ b/tests/php/RestApi/StoreApi/Routes/Cart.php
@@ -351,9 +351,7 @@ class Cart extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'cart' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'cart' );
 		$cart       = wc()->cart;
 		$response   = $controller->prepare_item_for_response( $cart, new \WP_REST_Request() );
@@ -372,10 +370,9 @@ class Cart extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'cart' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'cart' );
+		$schema     = $controller->get_item_schema();
 		$cart       = wc()->cart;
 		$response   = $controller->prepare_item_for_response( $cart, new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();

--- a/tests/php/RestApi/StoreApi/Routes/Cart.php
+++ b/tests/php/RestApi/StoreApi/Routes/Cart.php
@@ -351,8 +351,10 @@ class Cart extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schema    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\Cart( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'cart' );
+		$controller = $routes->get( 'cart' );
 		$cart       = wc()->cart;
 		$response   = $controller->prepare_item_for_response( $cart, new \WP_REST_Request() );
 		$data       = $response->get_data();
@@ -370,8 +372,10 @@ class Cart extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schema    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\Cart( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'cart' );
+		$controller = $routes->get( 'cart' );
 		$cart       = wc()->cart;
 		$response   = $controller->prepare_item_for_response( $cart, new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();

--- a/tests/php/RestApi/StoreApi/Routes/CartCoupons.php
+++ b/tests/php/RestApi/StoreApi/Routes/CartCoupons.php
@@ -156,9 +156,7 @@ class CartCoupons extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'cart-coupon' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'cart-coupons' );
 
 		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), new \WP_REST_Request() );
@@ -172,10 +170,9 @@ class CartCoupons extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'cart-coupon' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'cart-coupons' );
+		$schema     = $controller->get_item_schema();
 		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();
 		$validate   = new ValidateSchema( $schema );

--- a/tests/php/RestApi/StoreApi/Routes/CartCoupons.php
+++ b/tests/php/RestApi/StoreApi/Routes/CartCoupons.php
@@ -156,8 +156,11 @@ class CartCoupons extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartCouponSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\CartCoupons( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'cart-coupon' );
+		$controller = $routes->get( 'cart-coupons' );
+
 		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), new \WP_REST_Request() );
 		$data       = $response->get_data();
 
@@ -169,8 +172,10 @@ class CartCoupons extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartCouponSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\CartCoupons( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'cart-coupon' );
+		$controller = $routes->get( 'cart-coupons' );
 		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();
 		$validate   = new ValidateSchema( $schema );

--- a/tests/php/RestApi/StoreApi/Routes/CartItems.php
+++ b/tests/php/RestApi/StoreApi/Routes/CartItems.php
@@ -212,9 +212,7 @@ class CartItems extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'cart-item' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'cart-items' );
 		$cart       = wc()->cart->get_cart();
 		$response   = $controller->prepare_item_for_response( current( $cart ), new \WP_REST_Request() );
@@ -240,11 +238,10 @@ class CartItems extends TestCase {
 	 * Tests schema of both products in cart to cover as much schema as possible.
 	 */
 	public function test_schema_matches_response() {
-		$cart       = wc()->cart->get_cart();
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'cart-item' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'cart-items' );
+		$schema     = $controller->get_item_schema();
+		$cart       = wc()->cart->get_cart();
 		$validate   = new ValidateSchema( $schema );
 
 		// Simple product.

--- a/tests/php/RestApi/StoreApi/Routes/CartItems.php
+++ b/tests/php/RestApi/StoreApi/Routes/CartItems.php
@@ -212,8 +212,10 @@ class CartItems extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartItemSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\CartItems( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'cart-item' );
+		$controller = $routes->get( 'cart-items' );
 		$cart       = wc()->cart->get_cart();
 		$response   = $controller->prepare_item_for_response( current( $cart ), new \WP_REST_Request() );
 		$data       = $response->get_data();
@@ -239,9 +241,10 @@ class CartItems extends TestCase {
 	 */
 	public function test_schema_matches_response() {
 		$cart       = wc()->cart->get_cart();
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\CartItemSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\CartItems( $schema );
-		$schema     = $controller->get_item_schema();
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'cart-item' );
+		$controller = $routes->get( 'cart-items' );
 		$validate   = new ValidateSchema( $schema );
 
 		// Simple product.

--- a/tests/php/RestApi/StoreApi/Routes/ProductAttributeTerms.php
+++ b/tests/php/RestApi/StoreApi/Routes/ProductAttributeTerms.php
@@ -84,9 +84,7 @@ class ProductAttributeTerms extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'term' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'product-attribute-terms' );
 		$params     = $controller->get_collection_params();
 
@@ -99,12 +97,10 @@ class ProductAttributeTerms extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'term' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'product-attribute-terms' );
-		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'test', 'pa_size' ), new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();
+		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'test', 'pa_size' ), new \WP_REST_Request() );
 		$validate   = new ValidateSchema( $schema );
 
 		$diff = $validate->get_diff_from_object( $response->get_data() );

--- a/tests/php/RestApi/StoreApi/Routes/ProductAttributeTerms.php
+++ b/tests/php/RestApi/StoreApi/Routes/ProductAttributeTerms.php
@@ -84,8 +84,10 @@ class ProductAttributeTerms extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\TermSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\ProductAttributeTerms( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'term' );
+		$controller = $routes->get( 'product-attribute-terms' );
 		$params     = $controller->get_collection_params();
 
 		$this->assertArrayHasKey( 'order', $params );
@@ -97,8 +99,10 @@ class ProductAttributeTerms extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\TermSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\ProductAttributeTerms( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'term' );
+		$controller = $routes->get( 'product-attribute-terms' );
 		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'test', 'pa_size' ), new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();
 		$validate   = new ValidateSchema( $schema );

--- a/tests/php/RestApi/StoreApi/Routes/ProductAttributes.php
+++ b/tests/php/RestApi/StoreApi/Routes/ProductAttributes.php
@@ -78,8 +78,10 @@ class ProductAttributes extends TestCase {
 	 * Test conversion of product to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductAttributeSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\ProductAttributes( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'product-attribute' );
+		$controller = $routes->get( 'product-attributes' );
 		$response   = $controller->prepare_item_for_response( $this->attributes[0], new \WP_REST_Request() );
 		$data       = $response->get_data();
 
@@ -95,8 +97,10 @@ class ProductAttributes extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductAttributeSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\ProductAttributes( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'product-attribute' );
+		$controller = $routes->get( 'product-attributes' );
 		$response   = $controller->prepare_item_for_response( $this->attributes[0], new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();
 		$validate   = new ValidateSchema( $schema );

--- a/tests/php/RestApi/StoreApi/Routes/ProductAttributes.php
+++ b/tests/php/RestApi/StoreApi/Routes/ProductAttributes.php
@@ -78,9 +78,7 @@ class ProductAttributes extends TestCase {
 	 * Test conversion of product to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'product-attribute' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'product-attributes' );
 		$response   = $controller->prepare_item_for_response( $this->attributes[0], new \WP_REST_Request() );
 		$data       = $response->get_data();
@@ -97,10 +95,9 @@ class ProductAttributes extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'product-attribute' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'product-attributes' );
+		$schema     = $controller->get_item_schema();
 		$response   = $controller->prepare_item_for_response( $this->attributes[0], new \WP_REST_Request() );
 		$schema     = $controller->get_item_schema();
 		$validate   = new ValidateSchema( $schema );

--- a/tests/php/RestApi/StoreApi/Routes/ProductCollectionData.php
+++ b/tests/php/RestApi/StoreApi/Routes/ProductCollectionData.php
@@ -163,8 +163,8 @@ class ProductCollectionData extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductCollectionDataSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\ProductCollectionData( $schema );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
+		$controller = $routes->get( 'product-collection-data' );
 		$params     = $controller->get_collection_params();
 
 		$this->assertArrayHasKey( 'calculate_price_range', $params );
@@ -177,8 +177,11 @@ class ProductCollectionData extends TestCase {
 	 */
 	public function test_schema_matches_response() {
 		ProductHelper::create_variation_product();
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductCollectionDataSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\ProductCollectionData( $schema );
+
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
+		$controller = $routes->get( 'product-collection-data' );
+		$schema     = $controller->get_item_schema();
+
 		$request    = new WP_REST_Request( 'GET', '/wc/store/products/collection-data' );
 		$request->set_param( 'calculate_price_range', true );
 		$request->set_param(
@@ -192,7 +195,6 @@ class ProductCollectionData extends TestCase {
 		);
 		$request->set_param( 'calculate_rating_counts', true );
 		$response = $this->server->dispatch( $request );
-		$schema   = $controller->get_item_schema();
 		$validate = new ValidateSchema( $schema );
 
 		$diff = $validate->get_diff_from_object( $response->get_data() );

--- a/tests/php/RestApi/StoreApi/Routes/Products.php
+++ b/tests/php/RestApi/StoreApi/Routes/Products.php
@@ -131,9 +131,7 @@ class Products extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
-		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
-		$schema     = $schemas->get( 'product' );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
 		$controller = $routes->get( 'products' );
 		$params     = $controller->get_collection_params();
 
@@ -171,10 +169,10 @@ class Products extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\Products( $schema );
-		$response   = $controller->prepare_item_for_response( $this->products[0], new \WP_REST_Request() );
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController() );
+		$controller = $routes->get( 'products' );
 		$schema     = $controller->get_item_schema();
+		$response   = $controller->prepare_item_for_response( $this->products[0], new \WP_REST_Request() );
 		$validate   = new ValidateSchema( $schema );
 
 		$diff = $validate->get_diff_from_object( $response->get_data() );

--- a/tests/php/RestApi/StoreApi/Routes/Products.php
+++ b/tests/php/RestApi/StoreApi/Routes/Products.php
@@ -103,8 +103,10 @@ class Products extends TestCase {
 	 * Test conversion of prdouct to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\Products( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'product' );
+		$controller = $routes->get( 'products' );
 		$response   = $controller->prepare_item_for_response( $this->products[0], new \WP_REST_Request() );
 		$data       = $response->get_data();
 
@@ -129,8 +131,10 @@ class Products extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$schema     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\ProductSchema();
-		$controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\Products( $schema );
+		$schemas    = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController();
+		$routes     = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController( $schemas );
+		$schema     = $schemas->get( 'product' );
+		$controller = $routes->get( 'products' );
 		$params     = $controller->get_collection_params();
 
 		$this->assertArrayHasKey( 'page', $params );


### PR DESCRIPTION
Reworked #1984 and I think this also covers the fix in #2093 due to using the apiFetchWithHeaders action.

Fixes #2092

Converts the add to cart functionality which was previously using `__experimentalPersistItemToCollection` to instead use the `useStoreCart` hook.

To support this, a new `cart/add-to-cart` endpoint has been added to the store API. I've reworked some of the routes/schemas to support this and ensure each route returns the correct schema.

**How to test the changes in this Pull Request:**
Copied from #2093:

- Set up a page with All Products block (if needed).
- View the page in an incognto window.
- Add multiple products to cart - should work correctly.
- Optional: also test adding to cart when logged in as a regular customer, and other add to cart flows.

@Aljullu do you get the same issue with this branch?