### PR TITLE
Switch 'Try reloading the page' from links to buttons

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -90,8 +90,10 @@
 	padding: 0;
 	border: 0;
 
+	color: inherit;
 	font-size: inherit;
 	font-weight: normal;
+	text-decoration: underline;
 
 	background: transparent;
 	&:hover {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,3 +1,3 @@
-.link-button {
+.wc-block-link-button {
 	@include link-button();
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,1 +1,3 @@
-/* Moved */
+.link-button {
+	@include link-button();
+}

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -99,7 +99,10 @@ const getErrorBoundaryProps = () => {
 			),
 			{
 				button: (
-					<button className="link-button" onClick={ reloadPage } />
+					<button
+						className="wp-block-link-button"
+						onClick={ reloadPage }
+					/>
 				),
 			}
 		),

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -24,6 +24,8 @@ import FullCart from './full-cart';
 import blockAttributes from './attributes';
 import renderFrontend from '../../../utils/render-frontend.js';
 
+const reloadPage = () => void window.location.reload( true );
+
 /**
  * Renders the frontend block within the cart provider.
  */
@@ -92,13 +94,12 @@ const getErrorBoundaryProps = () => {
 		header: __( 'Something went wrong…', 'woo-gutenberg-products-block' ),
 		text: __experimentalCreateInterpolateElement(
 			__(
-				'The cart has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+				'The cart has encountered an unexpected error. <button>Try reloading the page</button>. If the error persists, please get in touch with us so we can assist.',
 				'woo-gutenberg-products-block'
 			),
 			{
-				a: (
-					// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
-					<a href="javascript:window.location.reload(true)" />
+				button: (
+					<button className="link-button" onClick={ reloadPage } />
 				),
 			}
 		),

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -70,9 +70,6 @@ table.wc-block-cart-items {
 				margin-top: 0.5em;
 				text-transform: none;
 				white-space: nowrap;
-				// Temporary - this is not yet a link or "link button".
-				// May not be needed when remove is hooked up to API properly.
-				text-decoration: underline;
 			}
 			.wc-block-cart-item__remove-icon {
 				@include link-button;

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -23,6 +23,8 @@ import blockAttributes from './attributes';
 import renderFrontend from '../../../utils/render-frontend.js';
 import EmptyCart from './empty-cart/index.js';
 
+const reloadPage = () => void window.location.reload( true );
+
 /**
  * Wrapper component for the checkout block.
  *
@@ -49,13 +51,15 @@ const CheckoutFrontend = ( props ) => {
 					) }
 					text={ __experimentalCreateInterpolateElement(
 						__(
-							'The checkout has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+							'The checkout has encountered an unexpected error. <button>Try reloading the page</button>. If the error persists, please get in touch with us so we can assist.',
 							'woo-gutenberg-products-block'
 						),
 						{
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-has-content
-								<a href="." />
+							button: (
+								<button
+									className="link-button"
+									onClick={ reloadPage }
+								/>
 							),
 						}
 					) }
@@ -109,13 +113,12 @@ const getErrorBoundaryProps = () => {
 		header: __( 'Something went wrong…', 'woo-gutenberg-products-block' ),
 		text: __experimentalCreateInterpolateElement(
 			__(
-				'The checkout has encountered an unexpected error. <a>Try reloading the page</a>. If the error persists, please get in touch with us so we can assist.',
+				'The checkout has encountered an unexpected error. <button>Try reloading the page</button>. If the error persists, please get in touch with us so we can assist.',
 				'woo-gutenberg-products-block'
 			),
 			{
-				a: (
-					// eslint-disable-next-line jsx-a11y/anchor-has-content, jsx-a11y/anchor-is-valid
-					<a href="javascript:window.location.reload(true)" />
+				button: (
+					<button className="link-button" onClick={ reloadPage } />
 				),
 			}
 		),

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -57,7 +57,7 @@ const CheckoutFrontend = ( props ) => {
 						{
 							button: (
 								<button
-									className="link-button"
+									className="wp-block-link-button"
 									onClick={ reloadPage }
 								/>
 							),
@@ -118,7 +118,10 @@ const getErrorBoundaryProps = () => {
 			),
 			{
 				button: (
-					<button className="link-button" onClick={ reloadPage } />
+					<button
+						className="wp-block-link-button"
+						onClick={ reloadPage }
+					/>
 				),
 			}
 		),


### PR DESCRIPTION
This PR refactors the `Try reloading the page` links from the error boundaries of the _Cart_ and _Checkout_ blocks.

Some problems with the previous approach:
* Links to `.` were not working properly when using plain permalinks (`?p=123`).
* Links to `javascript:...` were showing a console error from React saying they are deprecated and might stop working soon.
* Semantically, I think a button is better suited than a link.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/78259845-81b6a500-74fd-11ea-917b-3119d60b55db.png)

### How to test the changes in this Pull Request:

1. In `blocks/cart-checkout/checkout/frontend.js` [line 39](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/blocks/cart-checkout/checkout/frontend.js#L39), add something like `throw new Error( 'test' )` to force the error boundary to appear.
2. Load a page with the _Checkout_ block.
3. Click on `Try reloading the page` and verify the page is reloaded.