### PR TITLE
Fix flaw with event emitters and complete checkout flow for the cheque payment method.

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/actions.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/actions.js
@@ -6,6 +6,7 @@ import { TYPES } from './constants';
 const {
 	SET_PRISTINE,
 	SET_PROCESSING,
+	SET_PROCESSING_COMPLETE,
 	SET_REDIRECT_URL,
 	SET_COMPLETE,
 	SET_HAS_ERROR,
@@ -31,6 +32,9 @@ export const actions = {
 	} ),
 	setComplete: () => ( {
 		type: SET_COMPLETE,
+	} ),
+	setProcessingComplete: () => ( {
+		type: SET_PROCESSING_COMPLETE,
 	} ),
 	setHasError: ( hasError = true ) => {
 		const type = hasError ? SET_HAS_ERROR : SET_NO_ERROR;

--- a/assets/js/base/context/cart-checkout/checkout-state/constants.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/constants.js
@@ -12,6 +12,7 @@ export const STATUS = {
 	CALCULATING: 'calculating',
 	PROCESSING: 'processing',
 	COMPLETE: 'complete',
+	PROCESSING_COMPLETE: 'processing_complete',
 };
 
 const checkoutData = getSetting( 'checkoutData', { order_id: 0 } );
@@ -31,6 +32,7 @@ export const TYPES = {
 	SET_PRISTINE: 'set_pristine',
 	SET_REDIRECT_URL: 'set_redirect_url',
 	SET_COMPLETE: 'set_checkout_complete',
+	SET_PROCESSING_COMPLETE: 'set_processing_complete',
 	SET_PROCESSING: 'set_checkout_is_processing',
 	SET_HAS_ERROR: 'set_checkout_has_error',
 	SET_NO_ERROR: 'set_checkout_no_error',

--- a/assets/js/base/context/cart-checkout/checkout-state/event-emit.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/event-emit.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { actions, reducer, emitEvent, emitEventWithAbort } from '../event-emit';
+import {
+	emitterCallback,
+	reducer,
+	emitEvent,
+	emitEventWithAbort,
+} from '../event-emit';
 
 const EMIT_TYPES = {
 	CHECKOUT_COMPLETE_WITH_SUCCESS: 'checkout_complete',
@@ -23,54 +28,18 @@ const EMIT_TYPES = {
  * @return {Object} An object with the `onCheckoutComplete` emmitter registration
  */
 const emitterSubscribers = ( dispatcher ) => ( {
-	onCheckoutCompleteSuccess: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.CHECKOUT_COMPLETE_WITH_SUCCESS,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.CHECKOUT_COMPLETE_WITH_SUCCESS,
-					action.id
-				)
-			);
-		};
-	},
-	onCheckoutCompleteError: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.CHECKOUT_COMPLETE_WITH_ERROR,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.CHECKOUT_COMPLETE_WITH_ERROR,
-					action.id
-				)
-			);
-		};
-	},
-	onCheckoutProcessing: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.CHECKOUT_PROCESSING,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.CHECKOUT_PROCESSING,
-					action.id
-				)
-			);
-		};
-	},
+	onCheckoutCompleteSuccess: emitterCallback(
+		EMIT_TYPES.CHECKOUT_COMPLETE_WITH_SUCCESS,
+		dispatcher
+	),
+	onCheckoutCompleteError: emitterCallback(
+		EMIT_TYPES.CHECKOUT_COMPLETE_WITH_ERROR,
+		dispatcher
+	),
+	onCheckoutProcessing: emitterCallback(
+		EMIT_TYPES.CHECKOUT_PROCESSING,
+		dispatcher
+	),
 } );
 
 export {

--- a/assets/js/base/context/cart-checkout/checkout-state/event-emit.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/event-emit.js
@@ -23,10 +23,11 @@ const EMIT_TYPES = {
  * @return {Object} An object with the `onCheckoutComplete` emmitter registration
  */
 const emitterSubscribers = ( dispatcher ) => ( {
-	onCheckoutCompleteSuccess: ( callback ) => {
+	onCheckoutCompleteSuccess: ( callback, priority ) => {
 		const action = actions.addEventCallback(
 			EMIT_TYPES.CHECKOUT_COMPLETE_WITH_SUCCESS,
-			callback
+			callback,
+			priority
 		);
 		dispatcher( action );
 		return () => {
@@ -38,10 +39,11 @@ const emitterSubscribers = ( dispatcher ) => ( {
 			);
 		};
 	},
-	onCheckoutCompleteError: ( callback ) => {
+	onCheckoutCompleteError: ( callback, priority ) => {
 		const action = actions.addEventCallback(
 			EMIT_TYPES.CHECKOUT_COMPLETE_WITH_ERROR,
-			callback
+			callback,
+			priority
 		);
 		dispatcher( action );
 		return () => {
@@ -53,10 +55,11 @@ const emitterSubscribers = ( dispatcher ) => ( {
 			);
 		};
 	},
-	onCheckoutProcessing: ( callback ) => {
+	onCheckoutProcessing: ( callback, priority ) => {
 		const action = actions.addEventCallback(
 			EMIT_TYPES.CHECKOUT_PROCESSING,
-			callback
+			callback,
+			priority
 		);
 		dispatcher( action );
 		return () => {

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -146,7 +146,7 @@ export const CheckoutStateProvider = ( {
 					setValidationErrors( response );
 					dispatchActions.setHasError();
 				}
-				dispatch( actions.setComplete() );
+				dispatch( actions.setProcessingComplete() );
 			} );
 		}
 		if ( status === STATUS.COMPLETE ) {
@@ -161,13 +161,7 @@ export const CheckoutStateProvider = ( {
 					currentObservers.current,
 					EMIT_TYPES.CHECKOUT_COMPLETE_WITH_SUCCESS,
 					{}
-				).then( () => {
-					// all observers have done their thing so let's redirect
-					// (if no error).
-					if ( ! checkoutState.hasError ) {
-						window.location = checkoutState.redirectUrl;
-					}
-				} );
+				);
 			}
 		}
 	}, [
@@ -175,6 +169,7 @@ export const CheckoutStateProvider = ( {
 		checkoutState.hasError,
 		checkoutState.isComplete,
 		checkoutState.redirectUrl,
+		setValidationErrors,
 	] );
 
 	const onSubmit = () => {

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -38,6 +38,7 @@ const CheckoutContext = createContext( {
 	isIdle: false,
 	isCalculating: false,
 	isProcessing: false,
+	isProcessingComplete: false,
 	hasError: false,
 	redirectUrl: '',
 	orderId: 0,
@@ -48,6 +49,7 @@ const CheckoutContext = createContext( {
 		resetCheckout: () => void null,
 		setRedirectUrl: ( url ) => void url,
 		setHasError: ( hasError ) => void hasError,
+		setComplete: () => void null,
 		incrementCalculating: () => void null,
 		decrementCalculating: () => void null,
 		setOrderId: ( id ) => void id,
@@ -124,6 +126,9 @@ export const CheckoutStateProvider = ( {
 				void dispatch( actions.decrementCalculating() ),
 			setOrderId: ( orderId ) =>
 				void dispatch( actions.setOrderId( orderId ) ),
+			setComplete: () => {
+				void dispatch( actions.setComplete() );
+			},
 		} ),
 		[]
 	);
@@ -186,6 +191,8 @@ export const CheckoutStateProvider = ( {
 		isIdle: checkoutState.status === STATUS.IDLE,
 		isCalculating: checkoutState.status === STATUS.CALCULATING,
 		isProcessing: checkoutState.status === STATUS.PROCESSING,
+		isProcessingComplete:
+			checkoutState.status === STATUS.PROCESSING_COMPLETE,
 		hasError: checkoutState.hasError,
 		redirectUrl: checkoutState.redirectUrl,
 		onCheckoutCompleteSuccess,

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -6,6 +6,7 @@ import { TYPES, DEFAULT_STATE, STATUS } from './constants';
 const {
 	SET_PRISTINE,
 	SET_PROCESSING,
+	SET_PROCESSING_COMPLETE,
 	SET_REDIRECT_URL,
 	SET_COMPLETE,
 	SET_HAS_ERROR,
@@ -15,7 +16,14 @@ const {
 	SET_ORDER_ID,
 } = TYPES;
 
-const { PRISTINE, IDLE, CALCULATING, PROCESSING, COMPLETE } = STATUS;
+const {
+	PRISTINE,
+	IDLE,
+	CALCULATING,
+	PROCESSING,
+	PROCESSING_COMPLETE,
+	COMPLETE,
+} = STATUS;
 
 /**
  * Reducer for the checkout state
@@ -76,6 +84,23 @@ export const reducer = ( state = DEFAULT_STATE, { url, type, orderId } ) => {
 					? newState
 					: { ...newState, hasError: false };
 			break;
+		case SET_PROCESSING_COMPLETE:
+			status = PROCESSING_COMPLETE;
+			nextStatus = state.status;
+			if ( state.status === CALCULATING ) {
+				status = CALCULATING;
+				nextStatus = PROCESSING_COMPLETE;
+			}
+			newState =
+				status !== state.status
+					? {
+							...state,
+							status,
+							nextStatus,
+							hasError: false,
+					  }
+					: state;
+			break;
 		case SET_HAS_ERROR:
 			newState = state.hasError
 				? state
@@ -84,7 +109,8 @@ export const reducer = ( state = DEFAULT_STATE, { url, type, orderId } ) => {
 						hasError: true,
 				  };
 			newState =
-				state.status === PROCESSING
+				state.status === PROCESSING ||
+				state.status === PROCESSING_COMPLETE
 					? {
 							...newState,
 							status: IDLE,

--- a/assets/js/base/context/cart-checkout/event-emit/emitter-callback.js
+++ b/assets/js/base/context/cart-checkout/event-emit/emitter-callback.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import { actions } from './reducer';
+
+export const emitterCallback = ( type, dispatcher ) => (
+	callback,
+	priority
+) => {
+	const action = actions.addEventCallback( type, callback, priority );
+	dispatcher( action );
+	return () => {
+		dispatcher( actions.removeEventCallback( type, action.id ) );
+	};
+};

--- a/assets/js/base/context/cart-checkout/event-emit/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/emitters.js
@@ -1,7 +1,7 @@
 const getObserversByPriority = ( observers, eventType ) => {
 	return observers[ eventType ]
 		? Array.from( observers[ eventType ].values() ).sort( ( a, b ) => {
-				return a.priority > b.priority ? -1 : 1;
+				return b.priority - a.priority;
 		  } )
 		: [];
 };

--- a/assets/js/base/context/cart-checkout/event-emit/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/emitters.js
@@ -1,8 +1,8 @@
 const getObserversByPriority = ( observers, eventType ) => {
 	return observers[ eventType ]
-		? Array.from( observers[ eventType ].values() ).sort( ( a, b ) =>
-				a[ 1 ].priority > b[ 1 ].priority ? -1 : 1
-		  )
+		? Array.from( observers[ eventType ].values() ).sort( ( a, b ) => {
+				return a.priority > b.priority ? -1 : 1;
+		  } )
 		: [];
 };
 

--- a/assets/js/base/context/cart-checkout/event-emit/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/emitters.js
@@ -1,3 +1,11 @@
+const getObserversByPriority = ( observers, eventType ) => {
+	return observers[ eventType ]
+		? Array.from( observers[ eventType ].values() ).sort( ( a, b ) =>
+				a[ 1 ].priority > b[ 1 ].priority ? -1 : 1
+		  )
+		: [];
+};
+
 /**
  * Emits events on registered observers for the provided type and passes along
  * the provided data.
@@ -15,12 +23,10 @@
  *                   executed.
  */
 export const emitEvent = async ( observers, eventType, data ) => {
-	const observersByType = observers[ eventType ]
-		? observers[ eventType ].values()
-		: [];
+	const observersByType = getObserversByPriority( observers, eventType );
 	for ( const observer of observersByType ) {
 		try {
-			await Promise.resolve( observer( data ) );
+			await Promise.resolve( observer.callback( data ) );
 		} catch ( e ) {
 			// we don't care about errors blocking execution, but will
 			// console.error for troubleshooting.
@@ -45,12 +51,10 @@ export const emitEvent = async ( observers, eventType, data ) => {
  *                   return value of the aborted observer.
  */
 export const emitEventWithAbort = async ( observers, eventType, data ) => {
-	const observersByType = observers[ eventType ]
-		? observers[ eventType ].values()
-		: [];
+	const observersByType = getObserversByPriority( observers, eventType );
 	for ( const observer of observersByType ) {
 		try {
-			const response = await Promise.resolve( observer( data ) );
+			const response = await Promise.resolve( observer.callback( data ) );
 			if ( response !== true ) {
 				return response;
 			}

--- a/assets/js/base/context/cart-checkout/event-emit/index.js
+++ b/assets/js/base/context/cart-checkout/event-emit/index.js
@@ -1,2 +1,3 @@
 export * from './reducer';
 export * from './emitters';
+export * from './emitter-callback';

--- a/assets/js/base/context/cart-checkout/event-emit/reducer.js
+++ b/assets/js/base/context/cart-checkout/event-emit/reducer.js
@@ -9,12 +9,13 @@ export const TYPES = {
 };
 
 export const actions = {
-	addEventCallback: ( eventType, callback ) => {
+	addEventCallback: ( eventType, callback, priority = 10 ) => {
 		return {
 			id: uniqueId(),
 			type: TYPES.ADD_EVENT_CALLBACK,
 			eventType,
 			callback,
+			priority,
 		};
 	},
 	removeEventCallback: ( eventType, id ) => {
@@ -32,11 +33,14 @@ export const actions = {
  * @param {Object} state  Current state.
  * @param {Object} action Incoming action object
  */
-export const reducer = ( state = {}, { type, eventType, id, callback } ) => {
+export const reducer = (
+	state = {},
+	{ type, eventType, id, callback, priority }
+) => {
 	const newEvents = new Map( state[ eventType ] );
 	switch ( type ) {
 		case TYPES.ADD_EVENT_CALLBACK:
-			newEvents.set( id, callback );
+			newEvents.set( id, { priority, callback } );
 			return {
 				...state,
 				[ eventType ]: newEvents,

--- a/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
@@ -63,7 +63,7 @@ describe( 'Testing emitters', () => {
 		);
 	} );
 	describe( 'Test Priority', () => {
-		it( 'Executes observers in expected order by priority', async () => {
+		it( 'executes observers in expected order by priority', async () => {
 			const a = jest.fn();
 			const b = jest.fn().mockReturnValue( false );
 			const observers = {

--- a/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
+++ b/assets/js/base/context/cart-checkout/event-emit/test/emitters.js
@@ -13,16 +13,22 @@ describe( 'Testing emitters', () => {
 		observerB = jest.fn().mockReturnValue( true );
 		observerPromiseWithResolvedValue = jest.fn().mockResolvedValue( 10 );
 		observerMocks = new Map( [
-			[ 'observerA', observerA ],
-			[ 'observerB', observerB ],
-			[ 'observerReturnValue', jest.fn().mockReturnValue( 10 ) ],
+			[ 'observerA', { priority: 10, callback: observerA } ],
+			[ 'observerB', { priority: 10, callback: observerB } ],
+			[
+				'observerReturnValue',
+				{ priority: 10, callback: jest.fn().mockReturnValue( 10 ) },
+			],
 			[
 				'observerPromiseWithReject',
-				jest.fn().mockRejectedValue( 'an error' ),
+				{
+					priority: 10,
+					callback: jest.fn().mockRejectedValue( 'an error' ),
+				},
 			],
 			[
 				'observerPromiseWithResolvedValue',
-				observerPromiseWithResolvedValue,
+				{ priority: 10, callback: observerPromiseWithResolvedValue },
 			],
 		] );
 	} );
@@ -55,5 +61,21 @@ describe( 'Testing emitters', () => {
 				expect( response ).toBe( 10 );
 			}
 		);
+	} );
+	describe( 'Test Priority', () => {
+		it( 'Executes observers in expected order by priority', async () => {
+			const a = jest.fn();
+			const b = jest.fn().mockReturnValue( false );
+			const observers = {
+				test: new Map( [
+					[ 'observerA', { priority: 200, callback: a } ],
+					[ 'observerB', { priority: 10, callback: b } ],
+				] ),
+			};
+			await emitEventWithAbort( observers, 'test', 'foo' );
+			expect( console ).not.toHaveErrored();
+			expect( a ).toHaveBeenCalledTimes( 1 );
+			expect( b ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/assets/js/base/context/cart-checkout/payment-methods/constants.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/constants.js
@@ -40,7 +40,16 @@ export const DEFAULT_PAYMENT_DATA = {
  * @type {PaymentMethodDataContext}
  */
 export const DEFAULT_PAYMENT_METHOD_DATA = {
-	setPaymentStatus: () => void null,
+	setPaymentStatus: () => ( {
+		started: () => void null,
+		processing: () => void null,
+		completed: () => void null,
+		error: ( errorMessage ) => void errorMessage,
+		failed: ( errorMessage, paymentMethodData ) =>
+			void [ errorMessage, paymentMethodData ],
+		success: ( paymentMethodData, billingData ) =>
+			void [ paymentMethodData, billingData ],
+	} ),
 	currentStatus: {
 		isPristine: true,
 		isStarted: false,
@@ -60,4 +69,7 @@ export const DEFAULT_PAYMENT_METHOD_DATA = {
 	expressPaymentMethods: {},
 	paymentMethodsInitialized: false,
 	expressPaymentMethodsInitialized: false,
+	onPaymentProcessing: () => void null,
+	onPaymentSuccess: () => void null,
+	onPaymentFail: () => void null,
 };

--- a/assets/js/base/context/cart-checkout/payment-methods/event-emit.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/event-emit.js
@@ -1,0 +1,99 @@
+/**
+ * Internal dependencies
+ */
+import { actions, reducer, emitEvent, emitEventWithAbort } from '../event-emit';
+
+const EMIT_TYPES = {
+	PAYMENT_PROCESSING: 'payment_processing',
+	PAYMENT_SUCCESS: 'payment_success',
+	PAYMENT_FAIL: 'payment_fail',
+	PAYMENT_HAS_ERROR: 'payment_has_error',
+};
+
+/**
+ * Receives a reducer dispatcher and returns an object with the
+ * various event emitters for the payment processing events.
+ *
+ * Calling the event registration function with the callback will register it
+ * for the event emitter and will return a dispatcher for removing the
+ * registered callback (useful for implementation in `useEffect`).
+ *
+ * @param {Function} dispatcher The emitter reducer dispatcher.
+ *
+ * @return {Object} An object with the various payment event emitter
+ *                  registration functions
+ */
+const emitterSubscribers = ( dispatcher ) => ( {
+	onPaymentProcessing: ( callback, priority ) => {
+		const action = actions.addEventCallback(
+			EMIT_TYPES.PAYMENT_PROCESSING,
+			callback,
+			priority
+		);
+		dispatcher( action );
+		return () => {
+			dispatcher(
+				actions.removeEventCallback(
+					EMIT_TYPES.PAYMENT_PROCESSING,
+					action.id
+				)
+			);
+		};
+	},
+	onPaymentSuccess: ( callback, priority ) => {
+		const action = actions.addEventCallback(
+			EMIT_TYPES.PAYMENT_SUCCESS,
+			callback,
+			priority
+		);
+		dispatcher( action );
+		return () => {
+			dispatcher(
+				actions.removeEventCallback(
+					EMIT_TYPES.PAYMENT_SUCCESS,
+					action.id
+				)
+			);
+		};
+	},
+	onPaymentFail: ( callback, priority ) => {
+		const action = actions.addEventCallback(
+			EMIT_TYPES.PAYMENT_FAIL,
+			callback,
+			priority
+		);
+		dispatcher( action );
+		return () => {
+			dispatcher(
+				actions.removeEventCallback(
+					EMIT_TYPES.PAYMENT_FAIL,
+					action.id
+				)
+			);
+		};
+	},
+	onPaymentError: ( callback, priority ) => {
+		const action = actions.addEventCallback(
+			EMIT_TYPES.PAYMENT_HAS_ERROR,
+			callback,
+			priority
+		);
+		dispatcher( action );
+		return () => {
+			dispatcher(
+				actions.removeEventCallback(
+					EMIT_TYPES.PAYMENT_HAS_ERROR,
+					action.id
+				)
+			);
+		};
+	},
+} );
+
+export {
+	EMIT_TYPES,
+	emitterSubscribers,
+	reducer,
+	emitEvent,
+	emitEventWithAbort,
+};

--- a/assets/js/base/context/cart-checkout/payment-methods/event-emit.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/event-emit.js
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import { actions, reducer, emitEvent, emitEventWithAbort } from '../event-emit';
+import {
+	reducer,
+	emitEvent,
+	emitEventWithAbort,
+	emitterCallback,
+} from '../event-emit';
 
 const EMIT_TYPES = {
 	PAYMENT_PROCESSING: 'payment_processing',
@@ -24,70 +29,13 @@ const EMIT_TYPES = {
  *                  registration functions
  */
 const emitterSubscribers = ( dispatcher ) => ( {
-	onPaymentProcessing: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.PAYMENT_PROCESSING,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.PAYMENT_PROCESSING,
-					action.id
-				)
-			);
-		};
-	},
-	onPaymentSuccess: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.PAYMENT_SUCCESS,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.PAYMENT_SUCCESS,
-					action.id
-				)
-			);
-		};
-	},
-	onPaymentFail: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.PAYMENT_FAIL,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.PAYMENT_FAIL,
-					action.id
-				)
-			);
-		};
-	},
-	onPaymentError: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.PAYMENT_HAS_ERROR,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.PAYMENT_HAS_ERROR,
-					action.id
-				)
-			);
-		};
-	},
+	onPaymentProcessing: emitterCallback(
+		EMIT_TYPES.PAYMENT_PROCESSING,
+		dispatcher
+	),
+	onPaymentSuccess: emitterCallback( EMIT_TYPES.PAYMENT_SUCCESS, dispatcher ),
+	onPaymentFail: emitterCallback( EMIT_TYPES.PAYMENT_FAIL, dispatcher ),
+	onPaymentError: emitterCallback( EMIT_TYPES.PAYMENT_ERROR, dispatcher ),
 } );
 
 export {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -251,12 +251,11 @@ export const PaymentMethodDataProvider = ( {
 
 	// emit events.
 	useEffect( () => {
-		// @todo emitEventWithAbort can't be used for payment process events
-		// that are successful unless we somehow look at merging data.
-		// Probably what we need is a singleEventEmit (since there should only
-		// ever be one payment to process) event? However, do we need to account
-		// for scenarios where multiple payment methods might be used to pay
-		// the same transaction?
+		// Note: the nature of this event emitter is that it will bail on a
+		// successful payment (that is an observer hooked in that returns an
+		// object in the shape of a successful payment). However, this still
+		// allows for other observers that return true for continuing through
+		// to the next observer (or bailing if there's a problem).
 		if ( currentStatus.isProcessing ) {
 			emitEventWithAbort(
 				currentObservers.current,

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -87,7 +87,7 @@ const isFailResponse = ( response ) => {
 };
 
 const isErrorResponse = ( response ) => {
-	return response && typeof response.error !== 'undefined';
+	return response && typeof response.errorMessage !== 'undefined';
 };
 
 /**
@@ -273,8 +273,8 @@ export const PaymentMethodDataProvider = ( {
 						response.fail.paymentMethodData
 					);
 				} else if ( isErrorResponse( response ) ) {
-					setPaymentStatus().error( response.error );
-					setValidationErrors( response );
+					setPaymentStatus().error( response.errorMessage );
+					setValidationErrors( response.validationErrors );
 				}
 			} );
 		}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -251,6 +251,12 @@ export const PaymentMethodDataProvider = ( {
 
 	// emit events.
 	useEffect( () => {
+		// @todo emitEventWithAbort can't be used for payment process events
+		// that are successful unless we somehow look at merging data.
+		// Probably what we need is a singleEventEmit (since there should only
+		// ever be one payment to process) event? However, do we need to account
+		// for scenarios where multiple payment methods might be used to pay
+		// the same transaction?
 		if ( currentStatus.isProcessing ) {
 			emitEventWithAbort(
 				currentObservers.current,

--- a/assets/js/base/context/cart-checkout/shipping/event-emit.js
+++ b/assets/js/base/context/cart-checkout/shipping/event-emit.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { actions, reducer, emitEvent } from '../event-emit';
+import { emitterCallback, reducer, emitEvent } from '../event-emit';
 
 const EMIT_TYPES = {
 	SHIPPING_RATES_SUCCESS: 'shipping_rates_success',
@@ -22,65 +22,16 @@ const EMIT_TYPES = {
  * @return {Object} An object with `onSuccess` and `onFail` emitter registration.
  */
 const emitterSubscribers = ( dispatcher ) => ( {
-	onSuccess: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.SHIPPING_RATES_SUCCESS,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.SHIPPING_RATES_SUCCESS,
-					action.id
-				)
-			);
-		};
-	},
-	onFail: ( callback, priority ) => {
-		const action = actions.removeEventCallback(
-			EMIT_TYPES.SHIPPING_RATES_FAIL,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher( EMIT_TYPES.SHIPPING_RATES_FAIL, action.id );
-		};
-	},
-	onSelectSuccess: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.SHIPPING_RATE_SELECT_SUCCESS,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.SHIPPING_RATE_SELECT_SUCCESS,
-					action.id
-				)
-			);
-		};
-	},
-	onSelectFail: ( callback, priority ) => {
-		const action = actions.addEventCallback(
-			EMIT_TYPES.SHIPPING_RATE_SELECT_FAIL,
-			callback,
-			priority
-		);
-		dispatcher( action );
-		return () => {
-			dispatcher(
-				actions.removeEventCallback(
-					EMIT_TYPES.SHIPPING_RATE_SELECT_FAIL,
-					action.id
-				)
-			);
-		};
-	},
+	onSuccess: emitterCallback( EMIT_TYPES.SHIPPING_RATES_SUCCESS, dispatcher ),
+	onFail: emitterCallback( EMIT_TYPES.SHIPPING_RATES_FAIL, dispatcher ),
+	onSelectSuccess: emitterCallback(
+		EMIT_TYPES.SHIPPING_RATES_SELECT_SUCCESS,
+		dispatcher
+	),
+	onSelectFail: emitterCallback(
+		EMIT_TYPES.SHIPPING_RATES_SELECT_FAIL,
+		dispatcher
+	),
 } );
 
 export { EMIT_TYPES, emitterSubscribers, reducer, emitEvent };

--- a/assets/js/base/context/cart-checkout/shipping/event-emit.js
+++ b/assets/js/base/context/cart-checkout/shipping/event-emit.js
@@ -22,10 +22,11 @@ const EMIT_TYPES = {
  * @return {Object} An object with `onSuccess` and `onFail` emitter registration.
  */
 const emitterSubscribers = ( dispatcher ) => ( {
-	onSuccess: ( callback ) => {
+	onSuccess: ( callback, priority ) => {
 		const action = actions.addEventCallback(
 			EMIT_TYPES.SHIPPING_RATES_SUCCESS,
-			callback
+			callback,
+			priority
 		);
 		dispatcher( action );
 		return () => {
@@ -37,20 +38,22 @@ const emitterSubscribers = ( dispatcher ) => ( {
 			);
 		};
 	},
-	onFail: ( callback ) => {
+	onFail: ( callback, priority ) => {
 		const action = actions.removeEventCallback(
 			EMIT_TYPES.SHIPPING_RATES_FAIL,
-			callback
+			callback,
+			priority
 		);
 		dispatcher( action );
 		return () => {
 			dispatcher( EMIT_TYPES.SHIPPING_RATES_FAIL, action.id );
 		};
 	},
-	onSelectSuccess: ( callback ) => {
+	onSelectSuccess: ( callback, priority ) => {
 		const action = actions.addEventCallback(
 			EMIT_TYPES.SHIPPING_RATE_SELECT_SUCCESS,
-			callback
+			callback,
+			priority
 		);
 		dispatcher( action );
 		return () => {
@@ -62,10 +65,11 @@ const emitterSubscribers = ( dispatcher ) => ( {
 			);
 		};
 	},
-	onSelectFail: ( callback ) => {
+	onSelectFail: ( callback, priority ) => {
 		const action = actions.addEventCallback(
 			EMIT_TYPES.SHIPPING_RATE_SELECT_FAIL,
-			callback
+			callback,
+			priority
 		);
 		dispatcher( action );
 		return () => {

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -72,6 +72,9 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *                           validation error message displayed to the user.
 	 */
 	const setValidationErrors = ( newErrors ) => {
+		if ( ! newErrors ) {
+			return;
+		}
 		// all values must be a string.
 		newErrors = pickBy(
 			newErrors,

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -97,6 +97,10 @@ export const usePaymentMethodInterface = () => {
 		currentStatus,
 		activePaymentMethod,
 		setActivePaymentMethod,
+		onPaymentProcessing,
+		onPaymentSuccess,
+		onPaymentFail,
+		onPaymentError,
 	} = usePaymentMethodDataContext();
 	const {
 		shippingErrorStatus,
@@ -179,6 +183,10 @@ export const usePaymentMethodInterface = () => {
 			onShippingRateFail,
 			onShippingRateSelectSuccess,
 			onShippingRateSelectFail,
+			onPaymentProcessing,
+			onPaymentSuccess,
+			onPaymentFail,
+			onPaymentError,
 		},
 		components: {
 			ValidationInputError,

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -5,6 +5,7 @@ import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,9 +17,25 @@ const settings = getSetting( 'cheque_data', {} );
 
 const EditPlaceHolder = () => <div>TODO: Edit preview soon...</div>;
 
-const Content = ( props ) => {
-	const { activePaymentMethod } = props;
+/**
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
+ */
 
+/**
+ * Cheque content component
+ *
+ * @param {RegisteredPaymentMethodProps|Object} props Incoming props
+ */
+const Content = ( { activePaymentMethod, eventRegistration } ) => {
+	// hook into payment processing event.
+	useEffect( () => {
+		const unsubscribeProcessing = eventRegistration.onPaymentProcessing(
+			() => true
+		);
+		return () => {
+			unsubscribeProcessing();
+		};
+	}, [ eventRegistration.onPaymentProcessing ] );
 	return activePaymentMethod === PAYMENT_METHOD_NAME ? (
 		<div>{ decodeEntities( settings.description || '' ) }</div>
 	) : null;

--- a/assets/js/type-defs/checkout.js
+++ b/assets/js/type-defs/checkout.js
@@ -5,30 +5,37 @@
  *                                                           the checkout to a pristine state.
  * @property {function(string)}         setRedirectUrl       Dispatches an action that sets the
  *                                                           redirectUrl to the given value.
- * @property {function(boolean=)}      setHasError          Dispatches an action that sets the
+ * @property {function(boolean=)}       setHasError          Dispatches an action that sets the
  *                                                           checkout status to having an error.
+ * @property {function()}               setComplete          Dispatches an action that sets the
+ *                                                           checkout status to complete.
  * @property {function()}               incrementCalculating Dispatches an action that increments
  *                                                           the calculating state for checkout by one.
  * @property {function()}               decrementCalculating Dispatches an action that decrements
  *                                                           the calculating state for checkout by one.
- * @property {function(number|string)} setOrderId            Dispatches an action that stores the draft
+ * @property {function(number|string)}  setOrderId           Dispatches an action that stores the draft
  *                                                           order ID and key to state.
  */
 
 /**
  * @typedef {Object} CheckoutStatusConstants
  *
- * @property {string} PRISTINE    Checkout is in it's initialized state.
- * @property {string} IDLE        When checkout state has changed but there is
- *                                no activity happening.
- * @property {string} CALCULATING When something in the checkout results in the
- *                                totals being recalculated, this will be the
- *                                state while calculating is happening.
- * @property {string} PROCESSING  This is the state when the checkout button has
- *                                been pressed and the checkout data has been
- *                                sent to the server for processing.
- * @property {string} COMPLETE    This is the status when the server has
- *                                completed processing the data successfully.
+ * @property {string} PRISTINE            Checkout is in it's initialized state.
+ * @property {string} IDLE                When checkout state has changed but
+ *                                        there is no activity happening.
+ * @property {string} CALCULATING         When something in the checkout results
+ *                                        in the totals being recalculated,
+ *                                        this will be the state while
+ *                                        calculating is happening.
+ * @property {string} PROCESSING          This is the state when the checkout
+ *                                        button has been pressed and the
+ *                                        checkout data has been sent to the
+ *                                        server for processing.
+ * @property {string} PROCESSING_COMPLETE This is the state when the checkout
+ *                                        processing has been completed.
+ * @property {string} COMPLETE            This is the status when the server has
+ *                                        completed processing the data
+ *                                        successfully.
  */
 
 export {};

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -131,8 +131,8 @@
  * @property {function()}               processing
  * @property {function()}               completed
  * @property {function(string)}         error
- * @property {function(string, Object)} failed
- * @property {function(Object,Object)}  success
+ * @property {function(string, Object, Object=)} failed
+ * @property {function(Object=,Object=)}  success
  */
 
 /**
@@ -175,6 +175,24 @@
  * @property {boolean}                     expressPaymentMethodsInitialized True when all registered
  *                                                                          express payment methods
  *                                                                          have been initialized.
+ * @property {function(function())}        onPaymentProcessing              Event registration
+ *                                                                          callback for registering
+ *                                                                          observers for the
+ *                                                                          payment processing
+ *                                                                          event.
+ * @property {function(function())}        onPaymentSuccess                 Event registration
+ *                                                                          callback for registering
+ *                                                                          observers for the
+ *                                                                          successful payment
+ *                                                                          event.
+ * @property {function(function())}        onPaymentFail                    Event registration
+ *                                                                          callback for registering
+ *                                                                          observers for the
+ *                                                                          failed payment event.
+ * @property {function(function())}        onPaymentError                   Event registration
+ *                                                                          callback for registering
+ *                                                                          observers for the
+ *                                                                          payment error event.
  */
 
 /**
@@ -255,7 +273,7 @@
  *
  * @property {function(string):Object}  getValidationError       Return validation error for the
  *                                                               given property.
- * @property {function(Object<Object>)} setValidationErrors      Receive an object of properties and
+ * @property {function(Object)}         setValidationErrors      Receive an object of properties and
  *                                                               error messages as strings and adds
  *                                                               to the validation error state.
  * @property {function(string)}         clearValidationError     Clears a validation error for the

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -198,65 +198,54 @@
 /**
  * @typedef {Object} CheckoutDataContext
  *
- * @property {string}                  submitLabel        The label to use for
- *                                                        the submit checkout
- *                                                        button.
- * @property {function()}              onSubmit           The callback to
- *                                                        register with the
- *                                                        checkout submit
- *                                                        button.
- * @property {boolean}                 isComplete         True when checkout is
- *                                                        complete and ready for
- *                                                        redirect.
- * @property {boolean}                 isIdle             True when the checkout
- *                                                        state has changed and
- *                                                        checkout has no
- *                                                        activity.
- * @property {boolean}                 isProcessing       True when checkout has
- *                                                        been submitted and is
- *                                                        being processed by the
- *                                                        server.
- * @property {boolean}                 isCalculating      True when something in
- *                                                        the checkout is
- *                                                        resulting in totals
- *                                                        being calculated.
- * @property {boolean}                 hasError           True when the checkout
- *                                                        is in an error state.
- *                                                        Whatever caused the
- *                                                        error
- *                                                        (validation/payment
- *                                                        method) will likely
- *                                                        have triggered a
- *                                                        notice.
- * @property {string}                  redirectUrl        This is the url that
- *                                                        checkout will redirect
- *                                                        to when it's ready.
- * @property {function(function())}    onCheckoutCompleteSuccess Used to register a
- *                                                        callback that will
- *                                                        fire when the checkout
- *                                                        is marked complete
- *                                                        successfully.
- * @property {function(function())}    onCheckoutCompleteError Used to register
- *                                                        a callback that will
- *                                                        fire when the checkout
- *                                                        is marked complete and
- *                                                        has an error.
- * @property {function(function())}    onCheckoutProcessing Used to register a
- *                                                        callback that will
- *                                                        fire when the checkout
- *                                                        has been submitted
- *                                                        before being sent off
- *                                                        to the server.
- * @property {CheckoutDispatchActions} dispatchActions    Various actions that
- *                                                        can be dispatched for
- *                                                        the checkout context
- *                                                        data.
- * @property {number}                  orderId            This is the ID for the
- *                                                        draft order if one exists.
- * @property {boolean}                 hasOrder           True when the checkout has
- *                                                        a draft order from the API.
- * @property {boolean}                 isCart             When true, means the provider is providing
- *                                                        data for the cart.
+ * @property {string}                       submitLabel               The label to use for the
+ *                                                                    submit checkout button.
+ * @property {function()}                   onSubmit                  The callback to register with
+ *                                                                    the checkout submit button.
+ * @property {boolean}                      isComplete                True when checkout is complete
+ *                                                                    and ready for redirect.
+ * @property {boolean}                      isProcessingComplete      True when checkout processing
+ *                                                                    is complete.
+ * @property {boolean}                      isIdle                    True when the checkout state
+ *                                                                    has changed and checkout has
+ *                                                                    no activity.
+ * @property {boolean}                      isProcessing              True when checkout has been
+ *                                                                    submitted and is being
+ *                                                                    processed by the server.
+ * @property {boolean}                      isCalculating             True when something in the
+ *                                                                    checkout is resulting in
+ *                                                                    totals being calculated.
+ * @property {boolean}                      hasError                  True when the checkout is in
+ *                                                                    an error state. Whatever
+ *                                                                    caused the error
+ *                                                                    (validation/payment method)
+ *                                                                    will likely have triggered a
+ *                                                                    notice.
+ * @property {string}                       redirectUrl               This is the url that checkout
+ *                                                                    will redirect to when it's
+ *                                                                    ready.
+ * @property {function(function(),number=)} onCheckoutCompleteSuccess Used to register a callback
+ *                                                                    that will fire when the
+ *                                                                    checkout is marked complete
+ *                                                                    successfully.
+ * @property {function(function(),number=)} onCheckoutCompleteError   Used to register a callback
+ *                                                                    that will fire when the
+ *                                                                    checkout is marked complete
+ *                                                                    and has an error.
+ * @property {function(function(),number=)} onCheckoutProcessing      Used to register a callback
+ *                                                                    that will fire when the
+ *                                                                    checkout has been submitted
+ *                                                                    before being sent off to the
+ *                                                                    server.
+ * @property {CheckoutDispatchActions}      dispatchActions           Various actions that can be
+ *                                                                    dispatched for the checkout
+ *                                                                    context data.
+ * @property {number}                       orderId                   This is the ID for the draft
+ *                                                                    order if one exists.
+ * @property {boolean}                      hasOrder                  True when the checkout has a
+ *                                                                    draft order from the API.
+ * @property {boolean}                      isCart                    When true, means the provider
+ *                                                                    is providing data for the cart.
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -117,27 +117,27 @@
  */
 
 /**
+ * @typedef PreparedCartTotalItem
+ *
+ * @property {string} label  The label for the total item.
+ * @property {number} value  The value for the total item.
+ */
+
+/**
  * @typedef BillingDataProps
  *
- * @property {BillingData}     billingData               The address used for
- *                                                       billing.
- * @property {Function}        setBillingData            Used to set the cart
- *                                                       billing address.
- * @property {Object}          order                     The order object for
- *                                                       the purchase.
- * @property {boolean}         orderLoading              True if the order is
- *                                                       being loaded.
- * @property {CartTotalItem}   cartTotal                 The total item for
- *                                                       the cart.
- * @property {SiteCurrency}    currency                  Currency object.
- * @property {CartTotalItem[]} cartTotalItems            The various subtotal
- *                                                       amounts.
- * @property {boolean}         displayPricesIncludingTax True means that the
- *                                                       site is configured
- *                                                       to display prices
- *                                                       including tax.
- * @property {string[]}        appliedCoupons            All the coupons that
- *                                                       were applied.
+ * @property {BillingData}             billingData               The address used for billing.
+ * @property {Function}                setBillingData            Used to set the cart billing
+ *                                                               address.
+ * @property {Object}                  order                     The order object for the purchase.
+ * @property {boolean}                 orderLoading              True if the order is being loaded.
+ * @property {PreparedCartTotalItem}   cartTotal                 The total item for the cart.
+ * @property {SiteCurrency}            currency                  Currency object.
+ * @property {PreparedCartTotalItem[]} cartTotalItems            The various subtotal amounts.
+ * @property {boolean}                 displayPricesIncludingTax True means that the site is
+ *                                                               configured to display prices
+ *                                                               including tax.
+ * @property {string[]}                appliedCoupons            All the coupons that were applied.
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -166,6 +166,18 @@
  * @property {function()}           onShippingRateSelectFail    Used to subscribe callbacks that
  *                                                              will fire after selecting a shipping
  *                                                              rate unsuccessfully.
+ * @property {function(function())} onPaymentProcessing         Event registration callback for
+ *                                                              registering observers for the
+ *                                                              payment processing event.
+ * @property {function(function())} onPaymentSuccess            Event registration callback for
+ *                                                              registering observers for the
+ *                                                              successful payment event.
+ * @property {function(function())} onPaymentFail               Event registration callback for
+ *                                                              registering observers for the
+ *                                                              failed payment event.
+ * @property {function(function())} onPaymentError              Event registration callback for
+ *                                                              registering observers for the
+ *                                                              payment error event.
  */
 
 /**


### PR DESCRIPTION
With master having the necessary pieces in place to theoretically complete a payment using the cheque payment method and fulfill the checkout flow (including a redirect to order receipt page), I took some time to test things out and fix bugs that popped up.

In the process I discovered a _serious_ flaw with the event emitters that I overlooked when designing the system. The flaw is that all the registered observers on the event emitters _cannot react to any state changes_ because they are all invoked in one render process.  This also means that any state changes in observers can be problematic because subsequent observers would not know of those state changes.

The solution involves recognizing that we are using the event emitters for tracking flow through the checkout and to limit _status_ and _state_ changes to after the event has emitted.  By adding event emitters to the PaymentMethodData context, and adding another Checkout status it actually ended up simplifying the flow logic because now there is a stable point for payment methods to hook in their behaviour and for the `CheckoutProcessor` component to hook in it's logic. 

> Sidenote: I realize "simplifying" seems to be an oxymoron here because it's still relatively complex. But the complexity is absorbed by the providers instead of passed on to extension components to manage (which can increase complexity exponentially if extensions have to check constantly for status changes among all the elements in the checkout flow).

With the changes in this pull:

- Payment method extensions will not be responsible for updating the payment status. The payment method provider context handles that. Payment method components will register observers on the events they need to react to and return appropriate values for communicating with checkout.
- Convention (not enforced) will be that observers _must_ not set any state in checkout (they can set their own local state if they want). Provider state (payment, checkout, shipping) is handled by provider's emitters after all observers for an event have fired.

Here's a _rough_ diagram of the flow (not including shipping events):

![CheckoutFlow@2x](https://user-images.githubusercontent.com/1429108/78320562-bba49d00-7537-11ea-8487-c476454f1938.png)

In this pull:

- new payment method event emitters are added,
- new actions/status to checkout state context added (checkoutProcessingComplete)
- refactor checkout state provider.
- refactor checkout processor.
- wire up cheque payment method so it's hooked into the `onPaymentProcessing` event emitter.

## To Test

It is expected that Cart/Checkout behaviour up to the point of clicking the related submit button should continue to work as expected outside what was done in this branch.

You should be able to finish a complete checkout flow using the cheque payment method without errors.

There should be no errors in the console while testing.

Stripe is _not_ expected to work.

Validation errors after submit button is clicked _may_ have regressed. Please do test, but we can fix in follow-ups unless the cause is clear.


## Followups:

- since payment status is now controlled by checkout, I'm going to remove the payment status setter from being exposed on the `usePaymentMethodInterface` hook. That forces payment methods to use the appropriate api for hooking into the checkout flow (events).
- stripe client side will need modified to work with the new payment event emitters.
- I _may_ have broken some validation behaviour. If so, let's fix in follow-ups to avoid this pull becoming stale.