### PR TITLE
Checkout: fix skeleton and responsive styles

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -8,9 +8,13 @@ $line-offset-from-circle-size: 8px;
 .wc-block-checkout-form fieldset.wc-block-checkout-step {
 	position: relative;
 	border: none;
-	padding: 0 $gap-larger $gap-larger $gap-larger;
+	padding: 0 0 $gap-larger $gap-larger;
 	background: none;
 	margin: 0;
+
+	@include breakpoint( ">782px" ) {
+		padding-right: $gap-larger;
+	}
 }
 
 .wc-block-checkout-step__heading {

--- a/assets/js/base/components/cart-checkout/form/style.scss
+++ b/assets/js/base/components/cart-checkout/form/style.scss
@@ -1,3 +1,4 @@
 .wc-block-checkout-form {
+	margin: 0;
 	max-width: 100%;
 }

--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/style.scss
@@ -1,6 +1,7 @@
 .wc-block-coupon-code__form {
 	display: flex;
 	margin-bottom: 0;
+	width: 100%;
 
 	.wc-block-coupon-code__input {
 		margin-bottom: 0;

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -4,19 +4,16 @@
 	margin: 0 (-$gap) $gap;
 
 	.wc-block-main {
-		flex: 1 0 65%;
 		margin: 0;
 		padding: 0 $gap;
-		min-width: 500px;
-		max-width: 65%;
+		width: 65%;
 	}
 }
 
 .wc-block-sidebar {
-	flex: 1 1 35%;
 	margin: 0;
-	max-width: 35%;
 	padding: 0 $gap;
+	width: 35%;
 
 	// Reset Gutenberg <Panel> styles when used in the sidebar.
 	.components-panel__body {
@@ -60,19 +57,16 @@
 
 @include breakpoint( "<782px" ) {
 	.wc-block-sidebar-layout {
-		display: block;
+		flex-direction: column;
 		margin: 0 0 $gap;
 
 		.wc-block-main {
 			padding: 0;
-			flex: none;
-			max-width: 100%;
-			min-width: 200px;
+			width: 100%;
 		}
 		.wc-block-sidebar {
 			padding: 0;
-			flex: none;
-			max-width: 100%;
+			width: 100%;
 
 			// Reset (remove) totals "card" styling on mobile.
 			.components-card {

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -137,7 +137,7 @@ const Checkout = ( {
 	return (
 		<>
 			<SidebarLayout className="wc-block-checkout">
-				<Main>
+				<Main className="wc-block-checkout__main">
 					<ExpressCheckoutFormControl />
 					<CheckoutForm>
 						<FormStep
@@ -359,7 +359,7 @@ const Checkout = ( {
 						cartTotals={ cartTotals }
 					/>
 				</Sidebar>
-				<Main>
+				<Main className="wc-block-checkout__main-totals">
 					<div className="wc-block-checkout__actions">
 						{ attributes.showReturnToCart && (
 							<ReturnToCartButton

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -12,6 +12,10 @@
 	.wc-block-order-summary {
 		border: none;
 
+		&.is-opened {
+			padding-bottom: 0;
+		}
+
 		> .components-panel__body-title > .components-panel__body-toggle {
 			padding: $gap-small 0;
 		}
@@ -108,8 +112,8 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin: $gap-large 0 $gap-large*2;
-	padding: 0 $gap-larger;
+	margin: 0 0 $gap-large*2;
+	padding: 0 0 0 $gap-larger;
 
 	.wc-block-components-checkout-place-order-button {
 		width: 50%;
@@ -187,6 +191,33 @@
 	}
 }
 
+@include breakpoint( "<480px" ) {
+	.wc-block-checkout__actions {
+		.wc-block-components-checkout-return-to-cart-button {
+			display: none;
+		}
+
+		.wc-block-components-checkout-place-order-button {
+			width: 100%;
+		}
+	}
+}
+
+@include breakpoint( "<782px" ) {
+	.wc-block-checkout__main {
+		order: 1;
+	}
+
+	.wc-block-checkout__sidebar {
+		margin-bottom: $gap-largest;
+		order: 0;
+	}
+
+	.wc-block-checkout__main-totals {
+		order: 2;
+	}
+}
+
 @include breakpoint( ">480px" ) {
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {
@@ -261,5 +292,9 @@
 		.wc-block-order-summary {
 			margin: -20px;
 		}
+	}
+
+	.wc-block-checkout__actions {
+		padding-right: 36px;
 	}
 }

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -154,7 +154,7 @@ class Checkout extends AbstractBlock {
 	protected function get_skeleton() {
 		return '
 			<div class="wc-block-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton" aria-hidden="true">
-				<div class="wc-block-main">
+				<div class="wc-block-main wc-block-checkout__main">
 					<div class="wc-block-component-express-checkout"></div>
 					<div class="wc-block-component-express-checkout-continue-rule"><span></span></div>
 					<form class="wc-block-checkout-form">
@@ -175,7 +175,7 @@ class Checkout extends AbstractBlock {
 				<div class="wc-block-sidebar wc-block-checkout__sidebar">
 					<div class="components-card"></div>
 				</div>
-				<div class="wc-block-main">
+				<div class="wc-block-main wc-block-checkout__main-totals">
 					<div class="wc-block-checkout__actions">
 						<button class="components-button button wc-block-button wc-block-components-checkout-place-order-button">&nbsp;</button>
 					</div>


### PR DESCRIPTION
Fixes #2098 (and probably some issues from #1539 as well).

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/78350950-4e7c2080-75a6-11ea-88a0-7838e75b7b9f.png)

### How to test the changes in this Pull Request:

1. Load a page with the _Checkout_ block with a narrow viewport width and verify mobile styles are displayed (everything should be in one column).
2. Once loaded, verify the Order summary is rendered on top of the form, like in the designs.
3. Verify there aren't regressions.
