### PR TITLE
Ensure `AbstractBlock::enqueue_data` is only run once in the editor request.

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -29,6 +29,13 @@ abstract class AbstractBlock {
 	protected $block_name = '';
 
 	/**
+	 * Tracks if assets have been enqueued.
+	 *
+	 * @var boolean
+	 */
+	protected $enqueued_assets = false;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -50,23 +57,41 @@ abstract class AbstractBlock {
 	}
 
 	/**
-	 * Will enqueue any editor assets a block needs to load
-	 */
-	public function enqueue_editor_assets() {
-		$this->enqueue_data();
-	}
-
-	/**
 	 * Append frontend scripts when rendering the block.
 	 *
 	 * @param array  $attributes Block attributes. Default empty array.
 	 * @param string $content    Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
+	public function render( $attributes = [], $content = '' ) {
+		$this->enqueue_assets( $attributes );
+		return $content;
+	}
+
+	/**
+	 * Enqueue assets used for rendering the block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	public function enqueue_assets( array $attributes = [] ) {
+		if ( $this->enqueued_assets ) {
+			return;
+		}
 		$this->enqueue_data( $attributes );
 		$this->enqueue_scripts( $attributes );
-		return $content;
+		$this->enqueued_assets = true;
+	}
+
+	/**
+	 * Enqueue assets used for rendering the block in editor context.
+	 *
+	 * This is needed if a block is not yet within the post content--`render` and `enqueue_assets` may not have ran.
+	 */
+	public function enqueue_editor_assets() {
+		if ( $this->enqueued_assets ) {
+			return;
+		}
+		$this->enqueue_data();
 	}
 
 	/**

--- a/src/BlockTypes/ActiveFilters.php
+++ b/src/BlockTypes/ActiveFilters.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Assets;
+
 /**
  * ActiveFilters class.
  */
@@ -38,14 +40,11 @@ class ActiveFilters extends AbstractBlock {
 	}
 
 	/**
-	 * Append frontend scripts when rendering the block.
+	 * Register/enqueue scripts used for this block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
+	 * @param array $attributes  Any attributes that currently are available from the block.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend' );
-		return $content;
+	protected function enqueue_scripts( array $attributes = [] ) {
+		Assets::register_block_script( $this->block_name . '-frontend' );
 	}
 }

--- a/src/BlockTypes/AllReviews.php
+++ b/src/BlockTypes/AllReviews.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Assets;
+
 /**
  * AllReviews class.
  */
@@ -37,15 +39,11 @@ class AllReviews extends AbstractBlock {
 	}
 
 	/**
-	 * Append frontend scripts when rendering the Product Categories List block.
+	 * Register/enqueue scripts used for this block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
+	 * @param array $attributes  Any attributes that currently are available from the block.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( 'reviews-frontend' );
-
-		return $content;
+	protected function enqueue_scripts( array $attributes = [] ) {
+		Assets::register_block_script( 'reviews-frontend' );
 	}
 }

--- a/src/BlockTypes/AttributeFilter.php
+++ b/src/BlockTypes/AttributeFilter.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Assets;
+
 /**
  * AttributeFilter class.
  */
@@ -38,14 +40,11 @@ class AttributeFilter extends AbstractBlock {
 	}
 
 	/**
-	 * Append frontend scripts when rendering the block.
+	 * Register/enqueue scripts used for this block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
+	 * @param array $attributes  Any attributes that currently are available from the block.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend' );
-		return $content;
+	protected function enqueue_scripts( array $attributes = [] ) {
+		Assets::register_block_script( $this->block_name . '-frontend' );
 	}
 }

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -50,8 +50,7 @@ class Cart extends AbstractBlock {
 	 */
 	public function render( $attributes = array(), $content = '' ) {
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
-		$this->enqueue_data( $attributes );
-		$this->enqueue_scripts( $attributes );
+		$this->enqueue_assets( $attributes );
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
 		return $content . $this->get_skeleton();
 	}
@@ -64,10 +63,6 @@ class Cart extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
-		if ( did_action( 'woocommerce_blocks_cart_enqueue_data' ) ) {
-			return;
-		}
-
 		$data_registry = Package::container()->get(
 			AssetDataRegistry::class
 		);

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -51,8 +51,7 @@ class Checkout extends AbstractBlock {
 	 */
 	public function render( $attributes = array(), $content = '' ) {
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' );
-		$this->enqueue_data( $attributes );
-		$this->enqueue_scripts( $attributes );
+		$this->enqueue_assets( $attributes );
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
 		return $content . $this->get_skeleton();
 	}

--- a/src/BlockTypes/PriceFilter.php
+++ b/src/BlockTypes/PriceFilter.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Assets;
+
 /**
  * PriceFilter class.
  */
@@ -38,14 +40,11 @@ class PriceFilter extends AbstractBlock {
 	}
 
 	/**
-	 * Append frontend scripts when rendering the Product Categories List block.
+	 * Register/enqueue scripts used for this block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
+	 * @param array $attributes  Any attributes that currently are available from the block.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend' );
-		return $content;
+	protected function enqueue_scripts( array $attributes = [] ) {
+		Assets::register_block_script( $this->block_name . '-frontend' );
 	}
 }

--- a/src/BlockTypes/ReviewsByCategory.php
+++ b/src/BlockTypes/ReviewsByCategory.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Assets;
+
 /**
  * ReviewsByCategory class.
  */
@@ -37,15 +39,11 @@ class ReviewsByCategory extends AbstractBlock {
 	}
 
 	/**
-	 * Append frontend scripts when rendering the Product Categories List block.
+	 * Register/enqueue scripts used for this block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
+	 * @param array $attributes  Any attributes that currently are available from the block.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( 'reviews-frontend' );
-
-		return $content;
+	protected function enqueue_scripts( array $attributes = [] ) {
+		Assets::register_block_script( 'reviews-frontend' );
 	}
 }

--- a/src/BlockTypes/ReviewsByProduct.php
+++ b/src/BlockTypes/ReviewsByProduct.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Blocks\Assets;
+
 /**
  * ReviewsByProduct class.
  */
@@ -37,15 +39,11 @@ class ReviewsByProduct extends AbstractBlock {
 	}
 
 	/**
-	 * Append frontend scripts when rendering the Product Categories List block.
+	 * Register/enqueue scripts used for this block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
+	 * @param array $attributes  Any attributes that currently are available from the block.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( 'reviews-frontend' );
-
-		return $content;
+	protected function enqueue_scripts( array $attributes = [] ) {
+		Assets::register_block_script( 'reviews-frontend' );
 	}
 }


### PR DESCRIPTION
Ensures `enqueue_data` only runs once by tracking internally with protected variable.

All classes extending `AbstractBlock` have been updated with the new handling.

Fixes #2077

### How to test the changes in this Pull Request:

I tested this by adding a var_dump within enqueue_data and ensuring it only ran once per block. Before, render would have ran it, then the `enqueue_block_editor_assets` action would have ran it again.

Confirm block functions on frontend and in editor context, including blocks not yet in post content. Test cart and checkout blocks specifically. 