### PR TITLE
Update stripe payment methods to work with new event emitters

### DIFF
--- a/assets/js/base/components/payment-methods/express-checkout.js
+++ b/assets/js/base/components/payment-methods/express-checkout.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useExpressPaymentMethods } from '@woocommerce/base-hooks';
+import { StoreNoticesProvider } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -18,7 +19,9 @@ const ExpressCheckoutContainer = ( { children } ) => {
 					{ __( 'Express checkout', 'woo-gutenberg-products-block' ) }
 				</div>
 				<div className="wc-block-component-express-checkout__content">
-					{ children }
+					<StoreNoticesProvider context="wc/express-payment-area">
+						{ children }
+					</StoreNoticesProvider>
 				</div>
 			</div>
 			<div className="wc-block-component-express-checkout-continue-rule">

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -137,13 +137,16 @@ export const PaymentMethodDataProvider = ( {
 		}
 	);
 	const { setValidationErrors } = useValidationContext();
-	const { addErrorNotice } = useStoreNotices();
+	const { addErrorNotice, removeNotice } = useStoreNotices();
 
 	const setExpressPaymentError = ( message ) => {
 		addErrorNotice( message, {
 			context: 'wc/express-payment-area',
 			id: 'wc-express-payment-error',
 		} );
+		if ( ! message ) {
+			removeNotice( 'wc-express-payment-error' );
+		}
 	};
 	// ensure observers are always current.
 	useEffect( () => {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -44,6 +44,7 @@ import {
 	useMemo,
 } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings';
+import { useStoreNotices } from '@woocommerce/base-hooks';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').PaymentMethodDataContext} PaymentMethodDataContext
@@ -136,7 +137,14 @@ export const PaymentMethodDataProvider = ( {
 		}
 	);
 	const { setValidationErrors } = useValidationContext();
+	const { addErrorNotice } = useStoreNotices();
 
+	const setExpressPaymentError = ( message ) => {
+		addErrorNotice( message, {
+			context: 'wc/express-payment-area',
+			id: 'wc-express-payment-error',
+		} );
+	};
 	// ensure observers are always current.
 	useEffect( () => {
 		currentObservers.current = observers;
@@ -270,7 +278,8 @@ export const PaymentMethodDataProvider = ( {
 				} else if ( isFailResponse( response ) ) {
 					setPaymentStatus().failed(
 						response.fail.errorMessage,
-						response.fail.paymentMethodData
+						response.fail.paymentMethodData,
+						response.fail.billingData
 					);
 				} else if ( isErrorResponse( response ) ) {
 					setPaymentStatus().error( response.errorMessage );
@@ -325,6 +334,7 @@ export const PaymentMethodDataProvider = ( {
 		expressPaymentMethods: paymentStatus.expressPaymentMethods,
 		paymentMethodsInitialized,
 		expressPaymentMethodsInitialized,
+		setExpressPaymentError,
 	};
 	return (
 		<PaymentMethodDataContext.Provider value={ paymentData }>

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -100,6 +100,7 @@ export const usePaymentMethodInterface = () => {
 		onPaymentSuccess,
 		onPaymentFail,
 		onPaymentError,
+		setExpressPaymentError,
 	} = usePaymentMethodDataContext();
 	const {
 		shippingErrorStatus,
@@ -191,5 +192,6 @@ export const usePaymentMethodInterface = () => {
 		onSubmit,
 		activePaymentMethod,
 		setActivePaymentMethod,
+		setExpressPaymentError,
 	};
 };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
@@ -155,6 +155,7 @@ const ApplePayExpressComponent = ( {
 	// kick off payment processing.
 	const onButtonClick = () => {
 		setActivePaymentMethod( PAYMENT_METHOD_NAME );
+		setExpressPaymentError( '' );
 		setApplePayProcessing( true );
 	};
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
@@ -68,6 +68,7 @@ const ApplePayExpressComponent = ( {
 	onSubmit,
 	activePaymentMethod,
 	setActivePaymentMethod,
+	setExpressPaymentError,
 } ) => {
 	/**
 	 * @type {[ StripePaymentRequest|null, function( StripePaymentRequest ):StripePaymentRequest|null]}
@@ -76,6 +77,7 @@ const ApplePayExpressComponent = ( {
 	const [ paymentRequest, setPaymentRequest ] = useState( null );
 	const stripe = useStripe();
 	const [ canMakePayment, setCanMakePayment ] = useState( false );
+	const [ applePayProcessing, setApplePayProcessing ] = useState( false );
 	const eventHandlers = useRef( DEFAULT_STRIPE_EVENT_HANDLERS );
 	const currentBilling = useRef( billing );
 	const currentShipping = useRef( shippingData );
@@ -116,7 +118,11 @@ const ApplePayExpressComponent = ( {
 		}
 		// otherwise we just update it (but only if payment processing hasn't
 		// already started).
-		if ( ! paymentStatus.isPristine && currentPaymentRequest.current ) {
+		if (
+			! paymentStatus.isPristine &&
+			! applePayProcessing &&
+			currentPaymentRequest.current
+		 ) {
 			updatePaymentRequest( {
 				// @ts-ignore
 				paymentRequest: currentPaymentRequest.current,
@@ -133,6 +139,7 @@ const ApplePayExpressComponent = ( {
 		billing.cartTotalItems,
 		paymentStatus.isPristine,
 		stripe,
+		applePayProcessing,
 	] );
 
 	// whenever paymentRequest changes, then we need to update whether
@@ -148,33 +155,26 @@ const ApplePayExpressComponent = ( {
 	// kick off payment processing.
 	const onButtonClick = () => {
 		setActivePaymentMethod( PAYMENT_METHOD_NAME );
-		currentPaymentStatus.current.setPaymentStatus().processing();
+		setApplePayProcessing( true );
 	};
 
 	const abortPayment = ( paymentMethod, message ) => {
 		paymentMethod.complete( 'fail' );
-		currentPaymentStatus.current
-			.setPaymentStatus()
-			.failed(
+		setApplePayProcessing( false );
+		return {
+			fail: {
 				message,
-				getBillingData( paymentMethod ),
-				getPaymentMethodData( paymentMethod, PAYMENT_METHOD_NAME )
-			);
+				billingData: getBillingData( paymentMethod ),
+				paymentMethodData: getPaymentMethodData(
+					paymentMethod,
+					PAYMENT_METHOD_NAME
+				),
+			},
+		};
 	};
 
 	const completePayment = ( paymentMethod ) => {
 		paymentMethod.complete( 'success' );
-		currentPaymentStatus.current.setPaymentStatus().completed();
-	};
-
-	const processPayment = ( paymentMethod ) => {
-		currentPaymentStatus.current
-			.setPaymentStatus()
-			.success(
-				getBillingData( paymentMethod ),
-				getPaymentMethodData( paymentMethod, PAYMENT_METHOD_NAME )
-			);
-		onSubmit();
 	};
 
 	// event callbacks.
@@ -182,7 +182,7 @@ const ApplePayExpressComponent = ( {
 		const handlers = eventHandlers.current;
 		if (
 			typeof handlers.shippingAddressChange === 'function' &&
-			currentPaymentStatus.current.isProcessing
+			applePayProcessing
 		) {
 			handlers.shippingAddressChange.updateWith( {
 				status: forSuccess ? 'success' : 'fail',
@@ -201,7 +201,7 @@ const ApplePayExpressComponent = ( {
 		const handlers = eventHandlers.current;
 		if (
 			typeof handlers.shippingOptionsChange === 'function' &&
-			currentPaymentStatus.current.isProcessing
+			applePayProcessing
 		) {
 			const updateObject = forSuccess
 				? {
@@ -220,17 +220,33 @@ const ApplePayExpressComponent = ( {
 		}
 	};
 
+	const onPaymentProcessing = () => {
+		const handlers = eventHandlers.current;
+		if (
+			typeof handlers.sourceEvent === 'function' &&
+			applePayProcessing
+		) {
+			return {
+				billingData: getBillingData( handlers.sourceEvent ),
+				paymentMethodData: getPaymentMethodData(
+					handlers.sourceEvent,
+					PAYMENT_METHOD_NAME
+				),
+			};
+		}
+		return true;
+	};
+
 	const onCheckoutComplete = ( forSuccess = true ) => () => {
 		const handlers = eventHandlers.current;
 		if (
 			typeof handlers.sourceEvent === 'function' &&
-			currentPaymentStatus.current.isSuccessful
+			applePayProcessing
 		) {
 			if ( forSuccess ) {
 				completePayment( handlers.sourceEvent );
-			} else {
-				abortPayment( handlers.sourceEvent );
 			}
+			abortPayment( handlers.sourceEvent );
 		}
 	};
 
@@ -256,11 +272,7 @@ const ApplePayExpressComponent = ( {
 					! getStripeServerData().allowPrepaidCard &&
 					paymentMethod.source.card.funding
 				) {
-					// @todo this error message can be converted to use wp.i18n
-					// and be inline.
-					abortPayment(
-						paymentMethod,
-						// eslint-disable-next-line no-undef
+					setExpressPaymentError(
 						__(
 							"Sorry, we're not accepting prepaid cards at this time.",
 							'woocommerce-gateway-stripe'
@@ -269,7 +281,7 @@ const ApplePayExpressComponent = ( {
 					return;
 				}
 				eventHandlers.current.sourceEvent = paymentMethod;
-				processPayment( paymentMethod );
+				onSubmit();
 			} );
 		}
 	}, [ paymentRequest, canMakePayment ] );
@@ -290,6 +302,9 @@ const ApplePayExpressComponent = ( {
 			const unsubscribeShippingRateSelectFail = subscriber.onShippingRateSelectFail(
 				onShippingRatesEvent( false )
 			);
+			const unsubscribePaymentProcessing = subscriber.onPaymentProcessing(
+				onPaymentProcessing
+			);
 			const unsubscribeCheckoutCompleteSuccess = subscriber.onCheckoutCompleteSuccess(
 				onCheckoutComplete()
 			);
@@ -299,6 +314,7 @@ const ApplePayExpressComponent = ( {
 			return () => {
 				unsubscribeCheckoutCompleteFail();
 				unsubscribeCheckoutCompleteSuccess();
+				unsubscribePaymentProcessing();
 				unsubscribeShippingRateFail();
 				unsubscribeShippingRateSuccess();
 				unsubscribeShippingRateSelectSuccess();

--- a/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
@@ -122,7 +122,7 @@ const ApplePayExpressComponent = ( {
 			! paymentStatus.isPristine &&
 			! applePayProcessing &&
 			currentPaymentRequest.current
-		 ) {
+		) {
 			updatePaymentRequest( {
 				// @ts-ignore
 				paymentRequest: currentPaymentRequest.current,
@@ -176,6 +176,7 @@ const ApplePayExpressComponent = ( {
 
 	const completePayment = ( paymentMethod ) => {
 		paymentMethod.complete( 'success' );
+		setApplePayProcessing( false );
 	};
 
 	// event callbacks.
@@ -246,8 +247,9 @@ const ApplePayExpressComponent = ( {
 		) {
 			if ( forSuccess ) {
 				completePayment( handlers.sourceEvent );
+			} else {
+				abortPayment( handlers.sourceEvent );
 			}
-			abortPayment( handlers.sourceEvent );
 		}
 	};
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/normalize.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/normalize.js
@@ -3,7 +3,7 @@
  * @typedef {import('../stripe-utils/type-defs').StripeShippingOption} StripeShippingOption
  * @typedef {import('../stripe-utils/type-defs').StripeShippingAddress} StripeShippingAddress
  * @typedef {import('../stripe-utils/type-defs').StripePaymentResponse} StripePaymentResponse
- * @typedef {import('@woocommerce/type-defs/cart').CartTotalItem} CartTotalItem
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').PreparedCartTotalItem} CartTotalItem
  * @typedef {import('@woocommerce/type-defs/cart').CartShippingOption} CartShippingOption
  * @typedef {import('@woocommerce/type-defs/cart').CartShippingAddress} CartShippingAddress
  * @typedef {import('@woocommerce/type-defs/cart').CartBillingAddress} CartBillingAddress

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -25,12 +25,7 @@ import { __ } from '@wordpress/i18n';
  *
  * @param {RegisteredPaymentMethodProps} props Incoming props
  */
-const CreditCardComponent = ( {
-	paymentStatus,
-	billing,
-	eventRegistration,
-	components,
-} ) => {
+const CreditCardComponent = ( { billing, eventRegistration, components } ) => {
 	const { ValidationInputError, CheckboxControl } = components;
 	const [ sourceId, setSourceId ] = useState( 0 );
 	const stripe = useStripe();
@@ -38,7 +33,6 @@ const CreditCardComponent = ( {
 	const elements = useElements();
 	const onStripeError = useCheckoutSubscriptions(
 		eventRegistration,
-		paymentStatus,
 		billing,
 		sourceId,
 		setSourceId,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { CardElement, CardNumberElement } from '@stripe/react-stripe-js';
 
 /**
@@ -18,6 +18,7 @@ import {
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').PaymentStatusProps} PaymentStatusProps
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').BillingDataProps} BillingDataProps
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe
+ * @typedef {import('react').Dispatch<number>} SourceIdDispatch
  */
 
 /**
@@ -25,13 +26,11 @@ import {
  *
  * @param {EventRegistrationProps}     eventRegistration Event registration
  *                                                       functions.
- * @param {PaymentStatusProps}         paymentStatus     Various payment status
- *                                                       helpers.
  * @param {BillingDataProps}           billing           Various billing data
  *                                                       items.
  * @param {number}                     sourceId          Current set stripe
  *                                                       source id.
- * @param {function(number):undefined} setSourceId       Setter for stripe
+ * @param {SourceIdDispatch}           setSourceId       Setter for stripe
  *                                                       source id.
  * @param {boolean}                    shouldSavePayment Whether to save the
  *                                                       payment or not.
@@ -42,7 +41,6 @@ import {
  */
 export const useCheckoutSubscriptions = (
 	eventRegistration,
-	paymentStatus,
 	billing,
 	sourceId,
 	setSourceId,
@@ -50,6 +48,7 @@ export const useCheckoutSubscriptions = (
 	stripe,
 	elements
 ) => {
+	const [ error, setError ] = useState( '' );
 	const onStripeError = useRef( ( event ) => {
 		return event;
 	} );
@@ -60,8 +59,8 @@ export const useCheckoutSubscriptions = (
 			const code = event.error.code || '';
 			let message = getErrorMessageForTypeAndCode( type, code );
 			message = message || event.error.message;
-			paymentStatus.setPaymentStatus().error( message );
-			return {};
+			setError( error );
+			return message;
 		};
 		const createSource = async ( ownerInfo ) => {
 			const elementToGet = getStripeServerData().inline_cc_form
@@ -77,17 +76,24 @@ export const useCheckoutSubscriptions = (
 		};
 		const onSubmit = async () => {
 			try {
-				paymentStatus.setPaymentStatus().processing();
 				const { billingData } = billing;
+				// if there's an error return that.
+				if ( error ) {
+					return {
+						errorMessage: error,
+					};
+				}
 				// use token if it's set.
 				if ( sourceId !== 0 ) {
-					paymentStatus.setPaymentStatus().success( billingData, {
-						paymentMethod: PAYMENT_METHOD_NAME,
-						paymentRequestType: 'cc',
-						sourceId,
-						shouldSavePayment,
-					} );
-					return true;
+					return {
+						paymentMethodData: {
+							paymentMethod: PAYMENT_METHOD_NAME,
+							paymentRequestType: 'cc',
+							sourceId,
+							shouldSavePayment,
+						},
+						billingData,
+					};
 				}
 				const ownerInfo = {
 					address: {
@@ -111,51 +117,42 @@ export const useCheckoutSubscriptions = (
 
 				const response = await createSource( ownerInfo );
 				if ( response.error ) {
-					return onStripeError.current( response );
+					return {
+						errorMessage: onStripeError.current( response ),
+					};
 				}
-				paymentStatus.setPaymentStatus().success( billingData, {
-					sourceId: response.source.id,
-					paymentMethod: PAYMENT_METHOD_NAME,
-					paymentRequestType: 'cc',
-					shouldSavePayment,
-				} );
 				setSourceId( response.source.id );
-				return true;
+				return {
+					paymentMethodData: {
+						sourceId: response.source.id,
+						paymentMethod: PAYMENT_METHOD_NAME,
+						paymentRequestType: 'cc',
+						shouldSavePayment,
+					},
+					billingData,
+				};
 			} catch ( e ) {
-				paymentStatus.setPaymentStatus().error( e );
-				return e;
+				return {
+					errorMessage: e,
+				};
 			}
 		};
-		const onComplete = () => {
-			paymentStatus.setPaymentStatus().completed();
-		};
-		const onError = () => {
-			paymentStatus.setPaymentStatus().started();
-		};
-		const unsubscribeProcessing = eventRegistration.onCheckoutProcessing(
+		const unsubscribeProcessing = eventRegistration.onPaymentProcessing(
 			onSubmit
-		);
-		const unsubscribeCheckoutComplete = eventRegistration.onCheckoutCompleteSuccess(
-			onComplete
-		);
-		const unsubscribeCheckoutCompleteError = eventRegistration.onCheckoutCompleteError(
-			onError
 		);
 		return () => {
 			unsubscribeProcessing();
-			unsubscribeCheckoutComplete();
-			unsubscribeCheckoutCompleteError();
 		};
 	}, [
 		eventRegistration.onCheckoutProcessing,
 		eventRegistration.onCheckoutCompleteSuccess,
 		eventRegistration.onCheckoutCompleteError,
-		paymentStatus.setPaymentStatus,
 		stripe,
 		sourceId,
 		billing.billingData,
 		setSourceId,
 		shouldSavePayment,
+		error,
 	] );
 	return onStripeError.current;
 };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  * @typedef {import('./type-defs').StripeServerData} StripeServerData
  * @typedef {import('./type-defs').StripePaymentItem} StripePaymentItem
  * @typedef {import('./type-defs').StripePaymentRequest} StripePaymentRequest
- * @typedef {import('@woocommerce/type-defs/cart').CartTotalItem} CartTotalItem
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').PreparedCartTotalItem} CartTotalItem
  */
 
 // @todo this can't be in the file because the block might not show up unless it's

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -193,6 +193,13 @@
  *                                                                          callback for registering
  *                                                                          observers for the
  *                                                                          payment error event.
+ * @property {function(string)}            setExpressPaymentError           A function used by
+ *                                                                          express payment methods
+ *                                                                          to indicate an error
+ *                                                                          for checkout to handle.
+ *                                                                          It receives an error
+ *                                                                          message string. Does not
+ *                                                                          change payment status.
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -198,6 +198,10 @@
  *                                                                 method.
  * @property {ComponentProps}             components               Components exposed to payment
  *                                                                 methods for use.
+ * @property {function(string)}          [setExpressPaymentError]  For setting an error (error
+ *                                                                 message string) for express
+ *                                                                 payment methods. Does not change
+ *                                                                 payment status.
  */
 
 export {};


### PR DESCRIPTION
Fixes: #2111 (see issue for description).

In this pull I added a new interface for setting an express payment error (because there are a class of errors that will need displayed in the editor if the express payment method has an issue).  Here's a screenshot of how the error is displayed:

<img width="746" alt="Image 2020-04-03 at 11 23 08 AM" src="https://user-images.githubusercontent.com/1429108/78377663-e3c6e700-759d-11ea-890d-904e283b91fa.png">

The `setExpressPaymentError` function does not change payment status as effectively the only way to handle the error is to restart the payment process.  This function will clear the existing notice if invoked with a falsey value as the argument.

Also in this pull:

- refactored stripe cc payment method to remove all usages of payment status dispatcher.
- refactored stripe apple pay method to remove all usages of payment status dispatcher.

## To test

You can test the new notice function by replacing the existing `payment-extensions/payment-methods/stripe/index.js` file with the following temporary code:

```jsx
/**
 * External dependencies
 */
import {
	registerPaymentMethod,
	registerExpressPaymentMethod,
} from '@woocommerce/blocks-registry';

/**
 * Internal dependencies
 */
import stripeCcPaymentMethod from './credit-card';
import ApplePayPaymentMethod from './apple-pay';
import { applePayImage } from './apple-pay/apple-pay-preview';

registerPaymentMethod( ( Config ) => new Config( stripeCcPaymentMethod ) );
registerExpressPaymentMethod(
	( Config ) => new Config( ApplePayPaymentMethod )
);

const DummyApplePay = ( { setExpressPaymentError } ) => {
	return (
		<a onClick={ () => setExpressPaymentError( 'Testing Error' ) }>
			<img
				src={ applePayImage }
				onClick={ () => setExpressPaymentError( 'Testing Error' ) }
				alt="apple pay dummy"
			/>
		</a>
	);
};

registerExpressPaymentMethod(
	( Config ) =>
		new Config( {
			id: 'dummy-apple-pay',
			content: <DummyApplePay />,
			edit: <DummyApplePay />,
			canMakePayment: Promise.resolve( true ),
		} )
);
```

That will add a dummy apple pay button to test on the frontend and it basically just triggers the notice when the button is clicked.

- Verify checkout and cart blocks load in the editor and frontend with no console errors.