### PR TITLE
Refactor payment method interface to remove payment status dispatcher

### DIFF
--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -93,7 +93,6 @@ export const usePaymentMethodInterface = () => {
 		onSubmit,
 	} = useCheckoutContext();
 	const {
-		setPaymentStatus,
 		currentStatus,
 		activePaymentMethod,
 		setActivePaymentMethod,
@@ -147,10 +146,7 @@ export const usePaymentMethodInterface = () => {
 			isIdle,
 			isProcessing,
 		},
-		paymentStatus: {
-			currentStatus,
-			setPaymentStatus,
-		},
+		paymentStatus: currentStatus,
 		shippingStatus: {
 			shippingErrorStatus,
 			shippingErrorTypes,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
@@ -116,10 +116,7 @@ const ApplePayExpressComponent = ( {
 		}
 		// otherwise we just update it (but only if payment processing hasn't
 		// already started).
-		if (
-			! paymentStatus.currentStatus.isPristine &&
-			currentPaymentRequest.current
-		) {
+		if ( ! paymentStatus.isPristine && currentPaymentRequest.current ) {
 			updatePaymentRequest( {
 				// @ts-ignore
 				paymentRequest: currentPaymentRequest.current,
@@ -134,7 +131,7 @@ const ApplePayExpressComponent = ( {
 		shippingData.shippingAddress.country,
 		shippingData.needsShipping,
 		billing.cartTotalItems,
-		paymentStatus.currentStatus.isPristine,
+		paymentStatus.isPristine,
 		stripe,
 	] );
 
@@ -185,7 +182,7 @@ const ApplePayExpressComponent = ( {
 		const handlers = eventHandlers.current;
 		if (
 			typeof handlers.shippingAddressChange === 'function' &&
-			currentPaymentStatus.current.currentStatus.isProcessing
+			currentPaymentStatus.current.isProcessing
 		) {
 			handlers.shippingAddressChange.updateWith( {
 				status: forSuccess ? 'success' : 'fail',
@@ -204,7 +201,7 @@ const ApplePayExpressComponent = ( {
 		const handlers = eventHandlers.current;
 		if (
 			typeof handlers.shippingOptionsChange === 'function' &&
-			currentPaymentStatus.current.currentStatus.isProcessing
+			currentPaymentStatus.current.isProcessing
 		) {
 			const updateObject = forSuccess
 				? {
@@ -227,7 +224,7 @@ const ApplePayExpressComponent = ( {
 		const handlers = eventHandlers.current;
 		if (
 			typeof handlers.sourceEvent === 'function' &&
-			currentPaymentStatus.current.currentStatus.isSuccessful
+			currentPaymentStatus.current.isSuccessful
 		) {
 			if ( forSuccess ) {
 				completePayment( handlers.sourceEvent );

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -74,19 +74,6 @@
  */
 
 /**
- * @typedef PaymentStatusProps
- *
- * @property {PaymentMethodCurrentStatus} currentStatus    Various status state
- *                                                         indicators for the
- *                                                         payment method based
- *                                                         on it's current
- *                                                         status.
- * @property {PaymentStatusDispatch}      setPaymentStatus Used to dispatch
- *                                                         various payment
- *                                                         status updates.
- */
-
-/**
  * @typedef ShippingStatusProps
  *
  * @property {string}             shippingErrorStatus Current error status for
@@ -194,22 +181,22 @@
  *
  * @typedef {Object} RegisteredPaymentMethodProps
  *
- * @property {CheckoutStatusProps}       checkoutStatus            The current checkout status exposed
+ * @property {CheckoutStatusProps}        checkoutStatus           The current checkout status exposed
  *                                                                 as various boolean state.
- * @property {PaymentStatusProps}        paymentStatus             Various payment status helpers.
- * @property {ShippingStatusProps}       shippingStatus            Various shipping status helpers.
- * @property {ShippingDataProps}         shippingData              Various data related to shipping.
- * @property {BillingDataProps}          billing                   Various billing data items.
- * @property {EventRegistrationProps}    eventRegistration         Various event registration helpers
+ * @property {PaymentMethodCurrentStatus} paymentStatus            Various payment status helpers.
+ * @property {ShippingStatusProps}        shippingStatus           Various shipping status helpers.
+ * @property {ShippingDataProps}          shippingData             Various data related to shipping.
+ * @property {BillingDataProps}           billing                  Various billing data items.
+ * @property {EventRegistrationProps}     eventRegistration        Various event registration helpers
  *                                                                 for subscribing callbacks for
  *                                                                 events.
- * @property {Function}                  [onSubmit]                Used to trigger checkout
+ * @property {Function}                   [onSubmit]               Used to trigger checkout
  *                                                                 processing.
- * @property {string}                    [activePaymentMethod]     Indicates what the active payment
+ * @property {string}                     [activePaymentMethod]    Indicates what the active payment
  *                                                                 method is.
- * @property {function( string )}        [setActivePaymentMethod]  Used to set the active payment
+ * @property {function( string )}         [setActivePaymentMethod] Used to set the active payment
  *                                                                 method.
- * @property {ComponentProps}            components                Components exposed to payment
+ * @property {ComponentProps}             components               Components exposed to payment
  *                                                                 methods for use.
  */
 


### PR DESCRIPTION
Fixes: #2110 (see issue for background).

In this pull:

- `usePaymentMethodInterface` no longer exposes the payment status dispatcher to payment methods.
- `paymentStatus` is now mapped to the payment data context's `currentStatus` property (updated type-defs).
- Apple Pay express has been updated to use the new `currentStatus` property

Note dispatcher updates in the payment methods are handled in #2115

## To test

Simply need to verify that the checkout block does not break in frontend or backend, nor should there be any console errors.