### PR TITLE
Fix runaway state change loop for showing validation errors in event subscription.

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -61,7 +61,11 @@ const Checkout = ( {
 	shippingRates = [],
 } ) => {
 	const { isEditor } = useEditorContext();
-	const { hasOrder, onCheckoutCompleteError } = useCheckoutContext();
+	const {
+		hasOrder,
+		hasError: checkoutHasError,
+		isComplete: checkoutIsComplete,
+	} = useCheckoutContext();
 	const { showAllValidationErrors } = useValidationContext();
 	const {
 		shippingRatesLoading,
@@ -121,14 +125,11 @@ const Checkout = ( {
 	}, [ shippingAsBilling, setBillingData ] );
 
 	useEffect( () => {
-		const unsubscribeCompleteError = onCheckoutCompleteError( () => {
+		if ( checkoutIsComplete && checkoutHasError ) {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
-		} );
-		return () => {
-			unsubscribeCompleteError();
-		};
-	}, [ onCheckoutCompleteError ] );
+		}
+	}, [ checkoutIsComplete, checkoutHasError ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;


### PR DESCRIPTION
While working on #2054, in testing I noticed that we were getting in infinite set state loop due to the event subscription for validation errors happening in `checkout/block.js`.  As discovered in #2108, event observers _cannot_ set context state (because the observers have no awareness of state changes and thus can be executing on stale contexts - which in turn can create this loop).

As a result, I've reconfigured the logic causing this error to react to checkout status and error state instead.

## To test

I've been testing this the pull I'm doing for #2054 and verified this fixes the loop. I'm not sure how to test this other than that (the pull isn't published yet), so this could just get a code review for now and it will get more testing against payment method error creation as we start polishing that off.