### PR TITLE
Implement stripe server-side handling (stripe cc)

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -14,6 +14,26 @@ import { useEffect, useRef, useCallback } from '@wordpress/element';
 import { useStoreNotices } from '@woocommerce/base-hooks';
 
 /**
+ * @typedef {import('@woocommerce/type-defs/payments').PaymentDataResponse} PaymentDataResponse
+ */
+
+/**
+ * Utility function for preparing payment data for the request.
+ *
+ * @param {Object} paymentData Arbitrary payment data provided by the payment
+ *                             method.
+ *
+ * @return {PaymentDataResponse[]} Returns the payment data as an array of
+ *                                 PaymentDataResponse objects.
+ */
+const preparePaymentData = ( paymentData ) => {
+	return Object.keys( paymentData ).map( ( property ) => {
+		const value = paymentData[ property ];
+		return { key: property, value };
+	}, [] );
+};
+
+/**
  * CheckoutProcessor component. @todo Needs to consume all contexts.
  *
  * Subscribes to checkout context and triggers processing via the API.
@@ -34,6 +54,7 @@ const CheckoutProcessor = () => {
 		activePaymentMethod,
 		currentStatus: currentPaymentStatus,
 		errorMessage,
+		paymentMethodData,
 	} = usePaymentMethodDataContext();
 	const { addErrorNotice, removeNotice } = useStoreNotices();
 	const currentBillingData = useRef( billingData );
@@ -71,8 +92,7 @@ const CheckoutProcessor = () => {
 			method: 'POST',
 			data: {
 				payment_method: activePaymentMethod,
-				// @todo Hook this up to payment method data.
-				payment_data: [],
+				payment_data: preparePaymentData( paymentMethodData ),
 				billing_address: currentBillingData.current,
 				shipping_address: currentShippingAddress.current,
 				customer_note: '',
@@ -124,6 +144,7 @@ const CheckoutProcessor = () => {
 		activePaymentMethod,
 		currentBillingData,
 		currentShippingAddress,
+		paymentMethodData,
 	] );
 	// setup checkout processing event observers.
 	useEffect( () => {

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -14,7 +14,7 @@ import { useEffect, useRef, useCallback } from '@wordpress/element';
 import { useStoreNotices } from '@woocommerce/base-hooks';
 
 /**
- * @typedef {import('@woocommerce/type-defs/payments').PaymentDataResponse} PaymentDataResponse
+ * @typedef {import('@woocommerce/type-defs/payments').PaymentDataItem} PaymentDataItem
  */
 
 /**
@@ -23,8 +23,8 @@ import { useStoreNotices } from '@woocommerce/base-hooks';
  * @param {Object} paymentData Arbitrary payment data provided by the payment
  *                             method.
  *
- * @return {PaymentDataResponse[]} Returns the payment data as an array of
- *                                 PaymentDataResponse objects.
+ * @return {PaymentDataItem[]} Returns the payment data as an array of
+ *                                 PaymentDataItem objects.
  */
 const preparePaymentData = ( paymentData ) => {
 	return Object.keys( paymentData ).map( ( property ) => {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
@@ -247,9 +247,8 @@ const ApplePayExpressComponent = ( {
 		) {
 			if ( forSuccess ) {
 				completePayment( handlers.sourceEvent );
-			} else {
-				abortPayment( handlers.sourceEvent );
 			}
+			abortPayment( handlers.sourceEvent );
 		}
 	};
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/apple-pay/apple-pay-express.js
@@ -247,8 +247,9 @@ const ApplePayExpressComponent = ( {
 		) {
 			if ( forSuccess ) {
 				completePayment( handlers.sourceEvent );
+			} else {
+				abortPayment( handlers.sourceEvent );
 			}
-			abortPayment( handlers.sourceEvent );
 		}
 	};
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
@@ -89,7 +89,7 @@ export const useCheckoutSubscriptions = (
 						paymentMethodData: {
 							paymentMethod: PAYMENT_METHOD_NAME,
 							paymentRequestType: 'cc',
-							sourceId,
+							stripe_source: sourceId,
 							shouldSavePayment,
 						},
 						billingData,
@@ -124,7 +124,7 @@ export const useCheckoutSubscriptions = (
 				setSourceId( response.source.id );
 				return {
 					paymentMethodData: {
-						sourceId: response.source.id,
+						stripe_source: response.source.id,
 						paymentMethod: PAYMENT_METHOD_NAME,
 						paymentRequestType: 'cc',
 						shouldSavePayment,

--- a/assets/js/type-defs/payments.js
+++ b/assets/js/type-defs/payments.js
@@ -1,0 +1,8 @@
+/**
+ * @typedef {Object} PaymentDataResponse
+ *
+ * @property {string} key   Property for the payment data item.
+ * @property {string} value Value for the payment data item.
+ */
+
+export {};

--- a/assets/js/type-defs/payments.js
+++ b/assets/js/type-defs/payments.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Object} PaymentDataResponse
+ * @typedef {Object} PaymentDataItem
  *
  * @property {string} key   Property for the payment data item.
  * @property {string} value Value for the payment data item.


### PR DESCRIPTION
Fixes: #2054
Fixes: #2058 

With the work in this pull, one can use stripe CC payment method to complete a checkout purchase!

<img width="818" alt="Image 2020-04-03 at 4 15 16 PM" src="https://user-images.githubusercontent.com/1429108/78402493-ab88ce00-75c8-11ea-8c1e-077b09862147.png">

There was actually no server side code needed to implement this since the checkout endpoint has some nifty logic to enable existing server side gateway extension code to "just work" (ht @mikejolley ). Instead, I just had to finish wiring up the checkout processor to use the payment method provided payment data (while also making sure it's in the shape the endpoint expects) and also make sure the client side payment method component was also providing the data in the expected shape the gateway extension `process_payment` function was expecting.

**Note:** this pull has a dependency on #2119 (which I have the fix included in this pull to make it easier to test) and #2115  (which this pull's branch is based off of). So assuming testing goes well, we'll want to merge the dependent pulls first then rebase into this branch (basing it off master) before merging.

## To test

- Setup the WooCommerce Stripe Extension on your test site and add test credentials.
- Add some products to your cart.
- Fill out test credit card information.
- Click to make payment.
- Win.

## Caveats

This pull does not:

- handle failed/error payment responses from the server.
- handle surfacing validation issues for the payment method.

So conditions for merge (besides good code review) are that existing checkout block behaviour (compared with master) is not broken and that you can complete a _successful_ stripe payment without any console errors or user facing errors. A successful payment is considered one that results in making a purchase from the checkout block using stripe cc and being redirected to the order details page after purchase automatically. 