### PR TITLE
Remove prop types on production to reduce bundle size

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,4 +9,9 @@ module.exports = {
 			},
 		],
 	],
+	env: {
+		production: {
+			plugins: [ 'react-remove-prop-types' ],
+		},
+	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7943,6 +7943,12 @@
 				}
 			}
 		},
+		"babel-plugin-react-remove-prop-types": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-react-remove-prop-types/-/babel-plugin-react-remove-prop-types-3.0.0.tgz",
+			"integrity": "sha1-rauYSv+3O3iJMfJtwVfmLjfxHtU=",
+			"dev": true
+		},
 		"babel-plugin-syntax-async-generators": {
 			"version": "6.13.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
 		"babel-core": "7.0.0-bridge.0",
 		"babel-eslint": "10.1.0",
 		"babel-loader": "8.1.0",
+		"babel-plugin-react-remove-prop-types": "^3.0.0",
 		"babel-plugin-transform-async-generator-functions": "6.24.1",
 		"babel-plugin-transform-object-rest-spread": "6.26.0",
 		"babel-plugin-transform-react-jsx": "6.24.1",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This felt like a very easy win so I tackled it now, it should remove all prop types from production builds, it uses a babel plugin that automatically removes it on production.
<!-- Reference any related issues or PRs here -->
Fixes #1738 however in a less manual way.

This should not break anything, we will if the bundle size changes. if it didn't then this didn't work and should be merged.