### PR TITLE
Use mousedown event so view switches before blur event

### DIFF
--- a/assets/js/components/view-switcher/index.js
+++ b/assets/js/components/view-switcher/index.js
@@ -41,8 +41,15 @@ const ViewSwitcher = ( {
 							isPrimary={ currentView === view.value }
 							isLarge
 							aria-pressed={ currentView === view.value }
+							onMouseDown={ () => {
+								if ( currentView !== view.value ) {
+									setCurrentView( view.value );
+								}
+							} }
 							onClick={ () => {
-								setCurrentView( view.value );
+								if ( currentView !== view.value ) {
+									setCurrentView( view.value );
+								}
 							} }
 						>
 							{ view.name }


### PR DESCRIPTION
When using inner blocks, Gutenberg seems to run some logic on blur which also prevent event propagation.

This PR contains a workaround to switch the view on mousedown - this fires before blur and onClick. Leaving onClick in place for keyboard input.

Fixes #1627

### How to test the changes in this Pull Request:

See #1627
