### PR TITLE
Implement makeTrashable to cancel inflight requests in `CheckoutProcessor`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27417,6 +27417,11 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"trashable": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/trashable/-/trashable-1.0.7.tgz",
+			"integrity": "sha512-yDEVYO8VPqaWZg2yulq6xoUYB9XPdWeWCXepDSTp4yAfS8++mOcHXhlvzxP4/aG4MMfbIc5FV1k86KquqQuGwg=="
+		},
 		"traverse": {
 			"version": "0.6.6",
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
@@ -28946,9 +28951,12 @@
 			}
 		},
 		"woocommerce": {
-			"version": "git+https://github.com/woocommerce/woocommerce.git#3e322793ec4926f289811aa121a8a209dbf1323c",
+			"version": "git+https://github.com/woocommerce/woocommerce.git#77ff3ecef81ac74ba8c28dba2fe1f5efa723ba2d",
 			"from": "git+https://github.com/woocommerce/woocommerce.git",
 			"dev": true,
+			"requires": {
+				"@jest/test-sequencer": "^25.0.0"
+			},
 			"dependencies": {
 				"@jest/console": {
 					"version": "25.1.0",

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
 		"dinero.js": "1.8.1",
 		"downshift": "4.1.0",
 		"react-number-format": "4.4.1",
+		"trashable": "^1.0.7",
 		"trim-html": "0.1.9",
 		"use-debounce": "3.4.0",
 		"wordpress-components": "npm:@wordpress/components@8.5.0",


### PR DESCRIPTION
This is for https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2100 but needs tests since the unmount case isn't easily replicatable in real world usage. Adding to backlog.

Based on https://github.com/Automattic/jetpack/pull/15228/files
Background https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
Using package https://github.com/hjylewis/trashable

TODO:
Add test coverage to simulate unmount and confirm promise gets cancelled without errors