### PR TITLE
Don't show "select" labels for shipping or payment method steps if there is only one option

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -39,9 +39,11 @@ const FormStep = ( {
 				title={ title }
 				stepHeadingContent={ stepHeadingContent() }
 			/>
-			<span className="wc-block-checkout-step__description">
-				{ description }
-			</span>
+			{ !! description && (
+				<span className="wc-block-checkout-step__description">
+					{ description }
+				</span>
+			) }
 			<div className="wc-block-checkout-step__content">{ children }</div>
 		</fieldset>
 	);

--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/shipping-rate-selector.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/shipping-rate-selector.js
@@ -33,9 +33,9 @@ const ShippingRateSelector = ( {
 		<fieldset className="wc-block-totals__shipping-options-fieldset">
 			<legend className="screen-reader-text">
 				{ hasRates
-					? __( 'Shipping methods', 'woo-gutenberg-products-block' )
+					? __( 'Shipping options', 'woo-gutenberg-products-block' )
 					: __(
-							'Choose a shipping method',
+							'Choose a shipping option',
 							'woo-gutenberg-products-block'
 					  ) }
 			</legend>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -336,7 +336,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							description={
-								paymentMethods && paymentMethods.length > 1
+								Object.keys( paymentMethods ).length > 1
 									? __(
 											'Select a payment method below.',
 											'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -25,7 +25,7 @@ import {
 	useBillingDataContext,
 	useValidationContext,
 } from '@woocommerce/base-context';
-import { useStoreCart } from '@woocommerce/base-hooks';
+import { useStoreCart, usePaymentMethods } from '@woocommerce/base-hooks';
 import {
 	ExpressCheckoutFormControl,
 	PaymentMethods,
@@ -74,6 +74,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		needsShipping,
 	} = useShippingDataContext();
 	const { billingData, setBillingData } = useBillingDataContext();
+	const { paymentMethods } = usePaymentMethods();
 
 	const [ shippingAsBilling, setShippingAsBilling ] = useState(
 		needsShipping
@@ -274,10 +275,14 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Shipping options',
 									'woo-gutenberg-products-block'
 								) }
-								description={ __(
-									'Select a shipping method below.',
-									'woo-gutenberg-products-block'
-								) }
+								description={
+									shippingRates.length > 1
+										? __(
+												'Select a shipping method below.',
+												'woo-gutenberg-products-block'
+										  )
+										: ''
+								}
 							>
 								{ shippingRates.length === 0 && isEditor ? (
 									<NoShippingPlaceholder />
@@ -330,10 +335,14 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								'Payment method',
 								'woo-gutenberg-products-block'
 							) }
-							description={ __(
-								'Select a payment method below.',
-								'woo-gutenberg-products-block'
-							) }
+							description={
+								paymentMethods && paymentMethods.length > 1
+									? __(
+											'Select a payment method below.',
+											'woo-gutenberg-products-block'
+									  )
+									: ''
+							}
 						>
 							<PaymentMethods />
 						</FormStep>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -46,6 +46,10 @@ import CheckoutSidebar from './sidebar';
 import CheckoutOrderError from './checkout-order-error';
 import NoShippingPlaceholder from './no-shipping-placeholder';
 import './style.scss';
+import {
+	getShippingRatesPackageCount,
+	getShippingRatesRateCount,
+} from './utils';
 
 const Block = ( props ) => (
 	<CheckoutProvider>
@@ -55,12 +59,7 @@ const Block = ( props ) => (
 
 const Checkout = ( { attributes, scrollToTop } ) => {
 	const { isEditor } = useEditorContext();
-	const {
-		cartItems,
-		cartTotals,
-		shippingRates,
-		cartCoupons,
-	} = useStoreCart();
+	const { cartItems, cartTotals, cartCoupons } = useStoreCart();
 	const {
 		hasOrder,
 		hasError: checkoutHasError,
@@ -68,6 +67,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	} = useCheckoutContext();
 	const { showAllValidationErrors } = useValidationContext();
 	const {
+		shippingRates,
 		shippingRatesLoading,
 		shippingAddress,
 		setShippingAddress,
@@ -276,15 +276,18 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'woo-gutenberg-products-block'
 								) }
 								description={
-									shippingRates.length > 1
+									getShippingRatesRateCount( shippingRates ) >
+									1
 										? __(
-												'Select a shipping method below.',
+												'Select shipping options below.',
 												'woo-gutenberg-products-block'
 										  )
 										: ''
 								}
 							>
-								{ shippingRates.length === 0 && isEditor ? (
+								{ getShippingRatesPackageCount(
+									shippingRates
+								) === 0 && isEditor ? (
 									<NoShippingPlaceholder />
 								) : (
 									<ShippingRatesControl

--- a/assets/js/blocks/cart-checkout/checkout/utils.js
+++ b/assets/js/blocks/cart-checkout/checkout/utils.js
@@ -1,0 +1,19 @@
+/**
+ * Get the number of packages in a shippingRates array.
+ *
+ * @param {Array} shippingRates Shipping rates and packages array.
+ */
+export const getShippingRatesPackageCount = ( shippingRates ) => {
+	return Object.keys( shippingRates ).length;
+};
+
+/**
+ * Get the number of rates in a shippingRates array.
+ *
+ * @param {Array} shippingRates Shipping rates and packages array.
+ */
+export const getShippingRatesRateCount = ( shippingRates ) => {
+	return shippingRates.reduce( function( count, shippingPackage ) {
+		return count + shippingPackage.shipping_rates.length;
+	}, 0 );
+};


### PR DESCRIPTION
If there is only 1 shipping method, or payment method, hide the "select a X" text. This PR also hides the containing div if the description that gets passed is empty.

Fixes #2088

### Screenshots

![Screenshot 2020-04-06 at 17 19 01](https://user-images.githubusercontent.com/90977/78581244-88aa2400-782b-11ea-88e6-a00878e479b9.png)
![Screenshot 2020-04-06 at 17 18 52](https://user-images.githubusercontent.com/90977/78581245-8942ba80-782b-11ea-99a9-c8a1f9312384.png)

### How to test the changes in this Pull Request:

1. Only enable 1 shipping method/payment method. View checkout and confirm text is hidden.
2. Enable > 1 shipping and payment method. View checkout and confirm text is displayed.