### PR TITLE
Update CONTRIBUTING links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 
 Thanks for your interest in contributing to WooCommerce Blocks!
 
-If you wish to contribute code, to get started we recommend first reading our [Getting Started Guide](./docs/contributors/getting-started.md).
+If you wish to contribute code, to get started we recommend first reading our [Getting Started Guide](../docs/contributors/getting-started.md).
 
-All other documentation for contributors can be found [in the docs directory](./docs/readme.md).
+All other documentation for contributors can be found [in the docs directory](../docs/readme.md).
 
 ## Guidelines
 
-Like the WooCommerce project, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](./.github/CODE_OF_CONDUCT.md).
+Like the WooCommerce project, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Reporting Security Issues
 
-Please see [SECURITY.md](./.github/SECURITY.md).
+Please see [SECURITY.md](./SECURITY.md).


### PR DESCRIPTION
The PR updates the links within the CONTRIBUTING.md file to point to the correct locations - they currently 404.

### How to test the changes in this Pull Request:

1. Go to current [CONTRIBUTING.md](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/.github/CONTRIBUTING.md) file - click links and get 404s
2. Display view the file edits in this PR with "Rich Diff" - click links and get directed to correct locations.
