### PR TITLE
CheckboxControl: stop using Gutenberg's CheckboxControl

### DIFF
--- a/assets/js/base/components/checkbox-control/index.js
+++ b/assets/js/base/components/checkbox-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { CheckboxControl as WPCheckboxControl } from 'wordpress-components';
+import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -13,17 +13,38 @@ import './style.scss';
 /**
  * Component used to show a checkbox control with styles.
  */
-const CheckboxControl = ( { className, ...props } ) => {
+const CheckboxControl = ( {
+	className,
+	label,
+	id,
+	instanceId,
+	onChange,
+	...rest
+} ) => {
+	const checkboxId = id || `checkbox-control-${ instanceId }`;
+
 	return (
-		<WPCheckboxControl
+		<label
 			className={ classNames( 'wc-block-checkbox', className ) }
-			{ ...props }
-		/>
+			htmlFor={ checkboxId }
+		>
+			<input
+				id={ checkboxId }
+				className="wc-block-checkbox__input"
+				type="checkbox"
+				onChange={ ( event ) => onChange( event.target.checked ) }
+				{ ...rest }
+			/>
+			<span className="wc-block-checkbox__label">{ label }</span>
+		</label>
 	);
 };
 
 CheckboxControl.propTypes = {
 	className: PropTypes.string,
+	label: PropTypes.string,
+	id: PropTypes.string,
+	onChange: PropTypes.func,
 };
 
-export default CheckboxControl;
+export default withInstanceId( CheckboxControl );

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -1,13 +1,38 @@
 .wc-block-checkbox {
-	.components-checkbox-control__input[type="checkbox"]:checked {
+	display: block;
+	position: relative;
+}
+
+.wc-block-checkbox__input[type="checkbox"] {
+	appearance: none;
+	border: 1px solid;
+	height: 16px;
+	left: 0;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 16px;
+
+	&:checked {
 		background: currentColor;
-		border-color: currentColor;
 	}
-	.components-checkbox-control__input[type="checkbox"]:focus {
-		border-color: currentColor;
-		box-shadow: 0 0 2px currentColor;
-	}
-	.components-checkbox-control__label {
-		display: inline;
-	}
+}
+
+.wc-block-checkbox__input[type="checkbox"] + .wc-block-checkbox__label {
+	display: block;
+	padding-left: #{16px + $gap-smaller};
+}
+
+.wc-block-checkbox__input[type="checkbox"]:checked + .wc-block-checkbox__label::before {
+	color: #fff;
+	content: "\2713";
+	display: block;
+	height: 16px;
+	left: 0;
+	line-height: 16px;
+	position: absolute;
+	text-align: center;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 16px;
 }

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -1,38 +1,40 @@
 .wc-block-checkbox {
 	display: block;
 	position: relative;
-}
 
-.wc-block-checkbox__input[type="checkbox"] {
-	appearance: none;
-	border: 1px solid;
-	height: 16px;
-	left: 0;
-	position: absolute;
-	top: 50%;
-	transform: translateY(-50%);
-	width: 16px;
+	.wc-block-checkbox__input[type="checkbox"] {
+		appearance: none;
+		border: 1px solid currentColor;
+		height: 1rem;
+		margin: 0;
+		min-height: 16px;
+		min-width: 16px;
+		overflow: hidden;
+		position: static;
+		vertical-align: middle;
+		width: 1rem;
 
-	&:checked {
-		background: currentColor;
+		&:checked {
+			background: currentColor;
+			border-color: currentColor;
+
+			&::before {
+				color: #fff;
+				content: "\2713";
+				display: block;
+				height: calc(1rem - 2px);
+				min-height: 14px;
+				min-width: 14px;
+				margin: 0;
+				line-height: 100%;
+				text-align: center;
+				width: calc(1rem - 2px);
+			}
+		}
 	}
-}
 
-.wc-block-checkbox__input[type="checkbox"] + .wc-block-checkbox__label {
-	display: block;
-	padding-left: #{16px + $gap-smaller};
-}
-
-.wc-block-checkbox__input[type="checkbox"]:checked + .wc-block-checkbox__label::before {
-	color: #fff;
-	content: "\2713";
-	display: block;
-	height: 16px;
-	left: 0;
-	line-height: 16px;
-	position: absolute;
-	text-align: center;
-	top: 50%;
-	transform: translateY(-50%);
-	width: 16px;
+	.wc-block-checkbox__input[type="checkbox"] + .wc-block-checkbox__label {
+		padding-left: $gap-smaller;
+		vertical-align: middle;
+	}
 }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -240,7 +240,6 @@ const Checkout = ( {
 									onChange={ ( isChecked ) =>
 										setShippingAsBilling( isChecked )
 									}
-									required={ attributes.requirePhoneField }
 								/>
 							</FormStep>
 						) }

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -108,8 +108,6 @@ const stableMainEntry = {
 	'panel-style': './node_modules/wordpress-components/src/panel/style.scss',
 	'custom-select-control-style':
 		'./node_modules/wordpress-components/src/custom-select-control/style.scss',
-	'checkbox-control-style':
-		'./node_modules/wordpress-components/src/checkbox-control/style.scss',
 	'spinner-style':
 		'./node_modules/wordpress-components/src/spinner/style.scss',
 	'snackbar-notice-style':


### PR DESCRIPTION
Fixes #2097.

In that issue, we agreed to stop using Gutenberg's `CheckboxControl` in the _Checkout_ block frontend because it was creating duplicate IDs. This PR refactors our `CheckboxControl` so it doesn't have the Gutenberg's dependency.

### Screenshots
![Peek 2020-04-07 11-53](https://user-images.githubusercontent.com/3616980/78655533-6f09ea80-78c6-11ea-9dfb-a04e5e28de08.gif)

### How to test the changes in this Pull Request:

1. Go to the _Checkout_ block frontend and interact with the checkboxes.
2. Verify they still work as expected and look good.
