### PR TITLE
Show "save payment information" checkbox only if customer ID > 0

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/constants.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/constants.js
@@ -15,7 +15,10 @@ export const STATUS = {
 	PROCESSING_COMPLETE: 'processing_complete',
 };
 
-const checkoutData = getSetting( 'checkoutData', { order_id: 0 } );
+const checkoutData = getSetting( 'checkoutData', {
+	order_id: 0,
+	customer_id: 0,
+} );
 
 export const DEFAULT_STATE = {
 	redirectUrl: '',
@@ -26,6 +29,7 @@ export const DEFAULT_STATE = {
 	hasError: false,
 	calculatingCount: 0,
 	orderId: checkoutData.order_id,
+	customerId: checkoutData.customer_id,
 };
 
 export const TYPES = {

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -202,6 +202,7 @@ export const CheckoutStateProvider = ( {
 		isCart,
 		orderId: checkoutState.orderId,
 		hasOrder: !! checkoutState.orderId,
+		customerId: checkoutState.customerId,
 	};
 	return (
 		<CheckoutContext.Provider value={ checkoutData }>

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -91,7 +91,7 @@ export const usePaymentMethodInterface = () => {
 		onCheckoutCompleteError,
 		onCheckoutProcessing,
 		onSubmit,
-		customerId
+		customerId,
 	} = useCheckoutContext();
 	const {
 		currentStatus,
@@ -172,7 +172,7 @@ export const usePaymentMethodInterface = () => {
 			cartTotalItems: currentCartTotals.current,
 			displayPricesIncludingTax: DISPLAY_CART_PRICES_INCLUDING_TAX,
 			appliedCoupons,
-			customerId
+			customerId,
 		},
 		eventRegistration: {
 			onCheckoutCompleteSuccess,

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -91,6 +91,7 @@ export const usePaymentMethodInterface = () => {
 		onCheckoutCompleteError,
 		onCheckoutProcessing,
 		onSubmit,
+		customerId
 	} = useCheckoutContext();
 	const {
 		currentStatus,
@@ -171,6 +172,7 @@ export const usePaymentMethodInterface = () => {
 			cartTotalItems: currentCartTotals.current,
 			displayPricesIncludingTax: DISPLAY_CART_PRICES_INCLUDING_TAX,
 			appliedCoupons,
+			customerId
 		},
 		eventRegistration: {
 			onCheckoutCompleteSuccess,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -13,6 +13,7 @@ import { InlineCard, CardElements } from './elements';
 import { Elements, useElements, useStripe } from '@stripe/react-stripe-js';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useCheckoutContext } from '@woocommerce/base-context';
 
 /**
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe
@@ -27,9 +28,12 @@ import { __ } from '@wordpress/i18n';
  */
 const CreditCardComponent = ( { billing, eventRegistration, components } ) => {
 	const { ValidationInputError, CheckboxControl } = components;
+	const { customerId } = useCheckoutContext();
 	const [ sourceId, setSourceId ] = useState( 0 );
 	const stripe = useStripe();
-	const [ shouldSavePayment, setShouldSavePayment ] = useState( true );
+	const [ shouldSavePayment, setShouldSavePayment ] = useState(
+		customerId ? true : false
+	);
 	const elements = useElements();
 	const onStripeError = useCheckoutSubscriptions(
 		eventRegistration,
@@ -60,15 +64,19 @@ const CreditCardComponent = ( { billing, eventRegistration, components } ) => {
 	return (
 		<>
 			{ renderedCardElement }
-			<CheckboxControl
-				className="wc-block-checkout__save-card-info"
-				label={ __(
-					'Save payment information to my account for future purchases.',
-					'woo-gutenberg-products-block'
-				) }
-				checked={ shouldSavePayment }
-				onChange={ () => setShouldSavePayment( ! shouldSavePayment ) }
-			/>
+			{ customerId > 0 && (
+				<CheckboxControl
+					className="wc-block-checkout__save-card-info"
+					label={ __(
+						'Save payment information to my account for future purchases.',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ shouldSavePayment }
+					onChange={ () =>
+						setShouldSavePayment( ! shouldSavePayment )
+					}
+				/>
+			) }
 			<img
 				src={ ccSvg }
 				alt={ __(

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -13,7 +13,6 @@ import { InlineCard, CardElements } from './elements';
 import { Elements, useElements, useStripe } from '@stripe/react-stripe-js';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useCheckoutContext } from '@woocommerce/base-context';
 
 /**
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe
@@ -28,7 +27,7 @@ import { useCheckoutContext } from '@woocommerce/base-context';
  */
 const CreditCardComponent = ( { billing, eventRegistration, components } ) => {
 	const { ValidationInputError, CheckboxControl } = components;
-	const { customerId } = useCheckoutContext();
+	const { customerId } = billing;
 	const [ sourceId, setSourceId ] = useState( 0 );
 	const stripe = useStripe();
 	const [ shouldSavePayment, setShouldSavePayment ] = useState(

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -262,6 +262,8 @@
  *                                                                    draft order from the API.
  * @property {boolean}                      isCart                    When true, means the provider
  *                                                                    is providing data for the cart.
+ * @property {number}                       customerId                This is the ID of the customer
+ *                                                                    the draft order belongs to.
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -126,6 +126,7 @@
  *                                                               configured to display prices
  *                                                               including tax.
  * @property {string[]}                appliedCoupons            All the coupons that were applied.
+ * @property {number}                  customerId                The customer Id the order belongs to.
  */
 
 /**

--- a/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CheckoutSchema.php
@@ -77,6 +77,12 @@ class CheckoutSchema extends AbstractSchema {
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 			],
+			'customer_id'      => [
+				'description' => __( 'Customer ID if registered. Will return 0 for guests.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
 			'billing_address'  => [
 				'description' => __( 'Billing address.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
@@ -154,6 +160,7 @@ class CheckoutSchema extends AbstractSchema {
 			'status'           => $order->get_status(),
 			'order_key'        => $order->get_order_key(),
 			'customer_note'    => $order->get_customer_note(),
+			'customer_id'      => $order->get_customer_id(),
 			'billing_address'  => $this->billing_address_schema->get_item_response( $order ),
 			'shipping_address' => $this->shipping_address_schema->get_item_response( $order ),
 			'payment_method'   => $order->get_payment_method(),

--- a/src/RestApi/StoreApi/Schemas/OrderSchema.php
+++ b/src/RestApi/StoreApi/Schemas/OrderSchema.php
@@ -176,7 +176,7 @@ class OrderSchema extends AbstractSchema {
 				'readonly'    => true,
 				'properties'  => [
 					'customer_id'         => [
-						'description' => __( 'Customer ID if registered. Will return 0 for guest orders.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Customer ID if registered. Will return 0 for guests.', 'woo-gutenberg-products-block' ),
 						'type'        => 'integer',
 						'context'     => [ 'view', 'edit' ],
 						'readonly'    => true,


### PR DESCRIPTION
Adds customerId to the checkout API response and checkout context so that the Stripe gateway can show the "save payment information" checkbox conditionally.

Fixes #2118

### How to test the changes in this Pull Request:

1. With stripe enabled, view the checkout whilst logged in. "save payment information" checkbox is visible.
2. repeat whilst logged out. "save payment information" is not shown.