### PR TITLE
Fix cached shipping fees on consecutive orders

### DIFF
--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -100,7 +100,6 @@ class RestApi {
 	 *
 	 * Note: We load the session here early so guest nonces are in place.
 	 *
-	 * @todo check compat < WC 3.6. Make specific to cart endpoint.
 	 * @param mixed $return Value being filtered.
 	 * @return mixed
 	 */
@@ -108,13 +107,16 @@ class RestApi {
 		$wc_instance = wc();
 		// if WooCommerce instance isn't available or already have an
 		// authentication error, just return.
-		if ( ! method_exists( $wc_instance, 'initialize_session' ) || \is_wp_error( $return ) ) {
+		if ( ! method_exists( $wc_instance, 'initialize_session' ) || \is_wp_error( $return ) || ! self::is_request_to_store_api() ) {
 			return $return;
 		}
 		$wc_instance->frontend_includes();
 		$wc_instance->initialize_session();
 		$wc_instance->initialize_cart();
-		$wc_instance->cart->get_cart();
+
+		// Ensure cart is up to date.
+		$wc_instance->cart->calculate_shipping();
+		$wc_instance->cart->calculate_totals();
 
 		return $return;
 	}

--- a/src/RestApi/Controllers/Cart.php
+++ b/src/RestApi/Controllers/Cart.php
@@ -201,7 +201,6 @@ class Cart extends WP_REST_Controller {
 			return new WP_Error( 'woocommerce_rest_cart_error', __( 'Quantity cannot be empty.', 'woo-gutenberg-products-block' ) );
 		}
 
-		// @todo handle variations
 		$result = $this->add_to_cart( $product_id, $quantity, $variation_id );
 
 		if ( is_wp_error( $result ) ) {

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -377,7 +377,7 @@ class CartItemSchema extends ProductSchema {
 
 		$draft_order = WC()->session->get( 'store_api_draft_order', 0 );
 
-		// @todo Remove once min support for WC reaches 4.0.0.
+		// @todo Remove once min support for WC reaches 4.1.0.
 		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {
 			$reserve_stock = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
 		} else {

--- a/src/RestApi/StoreApi/Schemas/OrderSchema.php
+++ b/src/RestApi/StoreApi/Schemas/OrderSchema.php
@@ -425,18 +425,22 @@ class OrderSchema extends AbstractSchema {
 	/**
 	 * Get the total amount of tax for line items.
 	 *
-	 * Needed because orders do not hold this total like carts.
-	 *
-	 * @todo In the future this could be added to the core WC_Order class to better match the WC_Cart class.
+	 * @todo Remove once https://github.com/woocommerce/woocommerce/pull/26101 is merged and released in core.
 	 *
 	 * @param \WC_Order $order Order class instance.
 	 * @return float
 	 */
 	protected function get_subtotal_tax( \WC_Order $order ) {
+		if ( method_exists( $order, 'get_subtotal_tax' ) ) {
+			return $order->get_subtotal_tax();
+		}
+
 		$total = 0;
+
 		foreach ( $order->get_items() as $item ) {
 			$total += $item->get_subtotal_tax();
 		}
+
 		return $total;
 	}
 	/**
@@ -444,12 +448,16 @@ class OrderSchema extends AbstractSchema {
 	 *
 	 * Needed because orders do not hold this total like carts.
 	 *
-	 * @todo In the future this could be added to the core WC_Order class to better match the WC_Cart class.
+	 * @todo Remove once https://github.com/woocommerce/woocommerce/pull/26101 is merged and released in core.
 	 *
 	 * @param \WC_Order $order Order class instance.
 	 * @return float
 	 */
 	protected function get_fee_total( \WC_Order $order ) {
+		if ( method_exists( $order, 'get_fee_total' ) ) {
+			return $order->get_fee_total();
+		}
+
 		$total = 0;
 		foreach ( $order->get_fees() as $item ) {
 			$total += $item->get_total();
@@ -462,12 +470,16 @@ class OrderSchema extends AbstractSchema {
 	 *
 	 * Needed because orders do not hold this total like carts.
 	 *
-	 * @todo In the future this could be added to the core WC_Order class to better match the WC_Cart class.
+	 * @todo Remove once https://github.com/woocommerce/woocommerce/pull/26101 is merged and released in core.
 	 *
 	 * @param \WC_Order $order Order class instance.
 	 * @return float
 	 */
 	protected function get_fee_tax( \WC_Order $order ) {
+		if ( method_exists( $order, 'get_fee_tax' ) ) {
+			return $order->get_fee_tax();
+		}
+
 		$total = 0;
 		foreach ( $order->get_fees() as $item ) {
 			$total += $item->get_total_tax();

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -272,7 +272,7 @@ class CartController {
 	 * @return int
 	 */
 	protected function get_remaining_stock_for_product( $product ) {
-		// @todo Remove once min support for WC reaches 4.0.0.
+		// @todo Remove once min support for WC reaches 4.1.0.
 		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {
 			$reserve_stock_controller = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
 		} else {
@@ -364,23 +364,25 @@ class CartController {
 	}
 
 	/**
-	 * Get shipping packages from the cart and format as required.
+	 * Get shipping packages from the cart with calculated shipping rates.
 	 *
-	 * @param bool  $calculate_rates Should rates for the packages also be returned.
-	 * @param array $destination Pass an address to override the package destination before calculation.
+	 * @param bool $calculate_rates Should rates for the packages also be returned.
 	 * @return array
 	 */
-	public function get_shipping_packages( $calculate_rates = true, $destination = [] ) {
+	public function get_shipping_packages( $calculate_rates = true ) {
 		$cart     = $this->get_cart_instance();
 		$packages = $cart->get_shipping_packages();
 
 		// Add package ID to array.
 		foreach ( $packages as $key => $package ) {
-			$packages[ $key ]['package_id'] = $key;
-
-			if ( ! empty( $destination ) ) {
-				$packages[ $key ]['destination'] = $destination;
+			if ( ! isset( $packages[ $key ]['package_id'] ) ) {
+				$packages[ $key ]['package_id'] = $key;
 			}
+		}
+
+		// See if we need to calculate anything.
+		if ( ! WC()->cart->needs_shipping() ) {
+			return [];
 		}
 
 		return $calculate_rates ? WC()->shipping()->calculate_shipping( $packages ) : $packages;

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -372,7 +372,13 @@ class CartController {
 	 * @return array
 	 */
 	public function get_shipping_packages( $calculate_rates = true ) {
-		$cart     = $this->get_cart_instance();
+		$cart = $this->get_cart_instance();
+
+		// See if we need to calculate anything.
+		if ( ! $cart->needs_shipping() ) {
+			return [];
+		}
+
 		$packages = $cart->get_shipping_packages();
 
 		// Add package ID to array.
@@ -380,11 +386,6 @@ class CartController {
 			if ( ! isset( $packages[ $key ]['package_id'] ) ) {
 				$packages[ $key ]['package_id'] = $key;
 			}
-		}
-
-		// See if we need to calculate anything.
-		if ( ! WC()->cart->needs_shipping() ) {
-			return [];
 		}
 
 		return $calculate_rates ? WC()->shipping()->calculate_shipping( $packages ) : $packages;

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -366,6 +366,8 @@ class CartController {
 	/**
 	 * Get shipping packages from the cart with calculated shipping rates.
 	 *
+	 * @todo this can be refactored once https://github.com/woocommerce/woocommerce/pull/26101 lands.
+	 *
 	 * @param bool $calculate_rates Should rates for the packages also be returned.
 	 * @return array
 	 */

--- a/src/RestApi/StoreApi/Utilities/OrderController.php
+++ b/src/RestApi/StoreApi/Utilities/OrderController.php
@@ -152,7 +152,28 @@ class OrderController {
 	 * @param \WC_Order $order The order object to update.
 	 */
 	protected function update_addresses_from_cart( \WC_Order $order ) {
-		$order->set_props( WC()->customer->get_billing() );
-		$order->set_props( WC()->customer->get_shipping() );
+		$customer_billing = WC()->customer->get_billing();
+		$customer_billing = array_combine(
+			array_map(
+				function( $key ) {
+					return 'billing_' . $key;
+				},
+				array_keys( $customer_billing )
+			),
+			$customer_billing
+		);
+		$order->set_props( $customer_billing );
+
+		$customer_shipping = WC()->customer->get_shipping();
+		$customer_shipping = array_combine(
+			array_map(
+				function( $key ) {
+					return 'shipping_' . $key;
+				},
+				array_keys( $customer_shipping )
+			),
+			$customer_shipping
+		);
+		$order->set_props( $customer_shipping );
 	}
 }

--- a/src/RestApi/StoreApi/Utilities/ProductQuery.php
+++ b/src/RestApi/StoreApi/Utilities/ProductQuery.php
@@ -408,11 +408,6 @@ class ProductQuery {
 	 * @return boolean
 	 */
 	protected function adjust_price_filters_for_displayed_taxes() {
-		// Requires lookup table data. @todo Update this with the correct version once core patch is accepted.
-		if ( version_compare( get_option( 'woocommerce_db_version', null ), '3.10', '<' ) ) {
-			return false;
-		}
-
 		$display  = get_option( 'woocommerce_tax_display_shop' );
 		$database = wc_prices_include_tax() ? 'incl' : 'excl';
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -9,7 +9,7 @@
  * Text Domain:  woo-gutenberg-products-block
  * Requires at least: 5.0
  * Requires PHP: 5.6
- * WC requires at least: 3.7
+ * WC requires at least: 4.0
  * WC tested up to: 4.0
  *
  * @package WooCommerce\Blocks


### PR DESCRIPTION
Fixes shipping method saving on new orders, due to missing shipping calculation when shipping is not needed.

At the same time, I found a bug where the customer data was also not being saved to the order which is fixed in this PR also.

Fixes #2139

I also took this opportunity to sync some of our code to core - see https://github.com/woocommerce/woocommerce/pull/26101 I've updated todos to match.

### How to test the changes in this Pull Request:

1. Follow instructions on https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2139
2. Checkout and ensure billing/shipping fields have values from your customer when logged in.

