### PR TITLE
show preview "saved payment methods" in editor

### DIFF
--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -3,7 +3,10 @@
  */
 import { useEffect, useState, useRef, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { usePaymentMethodDataContext } from '@woocommerce/base-context';
+import {
+	useEditorContext,
+	usePaymentMethodDataContext,
+} from '@woocommerce/base-context';
 import RadioControl from '@woocommerce/base-components/radio-control';
 
 /** @typedef {import('@woocommerce/type-defs/contexts').CustomerPaymentMethod} CustomerPaymentMethod */
@@ -50,6 +53,7 @@ const getDefaultPaymentMethodOptions = ( { method, tokenId } ) => {
 };
 
 const SavedPaymentMethodOptions = ( { onSelect } ) => {
+	const { isEditor } = useEditorContext();
 	const {
 		setPaymentStatus,
 		customerPaymentMethods,
@@ -124,10 +128,12 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 		}
 	}, [ selectedToken, updateToken ] );
 
+	// In the editor, show `Use a new payment method` option as selected.
+	const selectedOption = isEditor ? 0 : selectedToken;
 	return currentOptions.current.length > 0 ? (
 		<RadioControl
 			id={ 'wc-payment-method-stripe-saved-tokens' }
-			selected={ selectedToken }
+			selected={ selectedOption }
 			onChange={ updateToken }
 			options={ currentOptions.current }
 		/>

--- a/assets/js/base/context/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/index.js
@@ -19,9 +19,6 @@ import CheckoutProcessor from './processor';
  *
  * @param {Object}  props                       Incoming props for the provider.
  * @param {Object}  props.children              The children being wrapped.
- * @param {string}  [props.activePaymentMethod] Can be used to initialize what the
- *                                              initial active payment method will
- *                                              be.
  * @param {string}  [props.redirectUrl]         Initialize what the checkout will
  *                                              redirect to after successful
  *                                              submit.
@@ -30,7 +27,6 @@ import CheckoutProcessor from './processor';
  */
 export const CheckoutProvider = ( {
 	children,
-	activePaymentMethod: initialActivePaymentMethod,
 	redirectUrl,
 	submitLabel = __( 'Place Order', 'woo-gutenberg-products-block' ),
 } ) => {
@@ -42,9 +38,7 @@ export const CheckoutProvider = ( {
 		>
 			<BillingDataProvider>
 				<ShippingDataProvider>
-					<PaymentMethodDataProvider
-						activePaymentMethod={ initialActivePaymentMethod }
-					>
+					<PaymentMethodDataProvider>
 						{ children }
 						<CheckoutProcessor />
 					</PaymentMethodDataProvider>

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -45,7 +45,8 @@ import {
 } from '@wordpress/element';
 import { getSetting } from '@woocommerce/settings';
 import { useStoreNotices, useEmitResponse } from '@woocommerce/base-hooks';
-
+import { useEditorContext } from '@woocommerce/base-context';
+import { previewSavedPaymentMethods } from '@woocommerce/resource-previews';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').PaymentMethodDataContext} PaymentMethodDataContext

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -100,7 +100,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		isErrorResponse,
 		isFailResponse,
 	} = useEmitResponse();
-	const [ activePaymentMethod, setActive ] = useState( {} );
+	const [ activePaymentMethod, setActive ] = useState( '' );
 	const [ observers, subscriber ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );
 

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -46,6 +46,7 @@ import {
 import { getSetting } from '@woocommerce/settings';
 import { useStoreNotices, useEmitResponse } from '@woocommerce/base-hooks';
 
+
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').PaymentMethodDataContext} PaymentMethodDataContext
  * @typedef {import('@woocommerce/type-defs/contexts').PaymentStatusDispatch} PaymentStatusDispatch
@@ -109,7 +110,11 @@ export const PaymentMethodDataProvider = ( {
 	);
 	const [ observers, subscriber ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );
-	const customerPaymentMethods = getSetting( 'customerPaymentMethods', {} );
+
+	const { isEditor } = useEditorContext();
+	const customerPaymentMethods = isEditor
+		? previewSavedPaymentMethods
+		: getSetting( 'customerPaymentMethods', {} );
 	const [ paymentData, dispatch ] = useReducer(
 		reducer,
 		DEFAULT_PAYMENT_DATA

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -86,13 +86,8 @@ export const usePaymentMethodDataContext = () => {
  * @param {Object} props                     Incoming props for provider
  * @param {Object} props.children            The wrapped components in this
  *                                           provider.
- * @param {string} props.activePaymentMethod The initial active payment method
- *                                           to set for the context.
  */
-export const PaymentMethodDataProvider = ( {
-	children,
-	activePaymentMethod: initialActivePaymentMethod,
-} ) => {
+export const PaymentMethodDataProvider = ( { children } ) => {
 	const { setBillingData } = useBillingDataContext();
 	const {
 		isProcessing: checkoutIsProcessing,
@@ -105,9 +100,7 @@ export const PaymentMethodDataProvider = ( {
 		isErrorResponse,
 		isFailResponse,
 	} = useEmitResponse();
-	const [ activePaymentMethod, setActive ] = useState(
-		initialActivePaymentMethod
-	);
+	const [ activePaymentMethod, setActive ] = useState( {} );
 	const [ observers, subscriber ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );
 

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -46,7 +46,6 @@ import {
 import { getSetting } from '@woocommerce/settings';
 import { useStoreNotices, useEmitResponse } from '@woocommerce/base-hooks';
 import { useEditorContext } from '@woocommerce/base-context';
-import { previewSavedPaymentMethods } from '@woocommerce/resource-previews';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').PaymentMethodDataContext} PaymentMethodDataContext
@@ -112,10 +111,11 @@ export const PaymentMethodDataProvider = ( {
 	const [ observers, subscriber ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );
 
-	const { isEditor } = useEditorContext();
-	const customerPaymentMethods = isEditor
-		? previewSavedPaymentMethods
-		: getSetting( 'customerPaymentMethods', {} );
+	const { isEditor, previewData } = useEditorContext();
+	const customerPaymentMethods =
+		isEditor && previewData?.previewSavedPaymentMethods
+			? previewData?.previewSavedPaymentMethods
+			: getSetting( 'customerPaymentMethods', {} );
 	const [ paymentData, dispatch ] = useReducer(
 		reducer,
 		DEFAULT_PAYMENT_DATA

--- a/assets/js/base/context/editor/index.js
+++ b/assets/js/base/context/editor/index.js
@@ -12,7 +12,7 @@ import { useSelect } from '@wordpress/data';
 const EditorContext = createContext( {
 	isEditor: false,
 	currentPostId: 0,
-	previewCart: {},
+	previewData: {},
 } );
 
 /**
@@ -27,13 +27,13 @@ export const useEditorContext = () => {
  *
  * @param {Object}          props                 Incoming props for the provider.
  * @param {*}               props.children        The children being wrapped.
- * @param {CartData|Object} [props.previewCart]   The preview data for editor.
+ * @param {CartData|Object} [props.previewData]   The preview data for editor.
  * @param {number}          [props.currentPostId] The post being edited.
  */
 export const EditorProvider = ( {
 	children,
 	currentPostId = 0,
-	previewCart = {},
+	previewData = {},
 } ) => {
 	/**
 	 * @type {number} editingPostId
@@ -55,7 +55,7 @@ export const EditorProvider = ( {
 	const editorData = {
 		isEditor: true,
 		currentPostId: editingPostId,
-		previewCart,
+		previewData,
 	};
 
 	return (

--- a/assets/js/base/context/editor/index.js
+++ b/assets/js/base/context/editor/index.js
@@ -25,10 +25,10 @@ export const useEditorContext = () => {
 /**
  * Editor provider
  *
- * @param {Object}          props                 Incoming props for the provider.
- * @param {*}               props.children        The children being wrapped.
- * @param {CartData|Object} [props.previewData]   The preview data for editor.
- * @param {number}          [props.currentPostId] The post being edited.
+ * @param {Object} props                 Incoming props for the provider.
+ * @param {*}      props.children        The children being wrapped.
+ * @param {Object} [props.previewData]   The preview data for editor.
+ * @param {number} [props.currentPostId] The post being edited.
  */
 export const EditorProvider = ( {
 	children,

--- a/assets/js/base/hooks/cart/test/use-store-cart.js
+++ b/assets/js/base/hooks/cart/test/use-store-cart.js
@@ -160,7 +160,7 @@ describe( 'useStoreCart', () => {
 		beforeEach( () => {
 			mockBaseContext.useEditorContext.mockReturnValue( {
 				isEditor: true,
-				previewCart,
+				previewData: { previewCart },
 			} );
 		} );
 

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -52,7 +52,7 @@ export const defaultCartData = {
  */
 export const useStoreCart = ( options = { shouldSelect: true } ) => {
 	const { isEditor, previewData } = useEditorContext();
-	const { previewCart } = previewData;
+	const previewCart = previewData?.previewCart || {};
 	const { shouldSelect } = options;
 
 	const results = useSelect(

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -51,7 +51,8 @@ export const defaultCartData = {
  * @return {StoreCart} Object containing cart data.
  */
 export const useStoreCart = ( options = { shouldSelect: true } ) => {
-	const { isEditor, previewCart } = useEditorContext();
+	const { isEditor, previewData } = useEditorContext();
+	const { previewCart } = previewData;
 	const { shouldSelect } = options;
 
 	const results = useSelect(

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -212,7 +212,9 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 									/>
 								) }
 								<Disabled>
-									<EditorProvider previewCart={ previewCart }>
+									<EditorProvider
+										previewData={ { previewCart } }
+									>
 										<CartProvider>
 											<Block attributes={ attributes } />
 										</CartProvider>

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -24,6 +24,7 @@ import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import { EditorProvider, useEditorContext } from '@woocommerce/base-context';
 import {
 	previewCart,
+	previewSavedPaymentMethods,
 	checkoutBlockPreview,
 } from '@woocommerce/resource-previews';
 
@@ -277,7 +278,9 @@ const CheckoutEditor = ( { attributes, setAttributes } ) => {
 	}
 
 	return (
-		<EditorProvider previewCart={ previewCart }>
+		<EditorProvider
+			previewData={ { previewCart, previewSavedPaymentMethods } }
+		>
 			<div className={ className }>
 				<BlockSettings
 					attributes={ attributes }

--- a/assets/js/previews/index.js
+++ b/assets/js/previews/index.js
@@ -3,6 +3,7 @@ export { previewCart } from './cart';
 export { previewReviews } from './reviews';
 export { previewCategories } from './categories';
 export { previewShippingRates } from './shipping-rates';
+export { previewSavedPaymentMethods } from './saved-payment-methods';
 
 export { cartBlockPreview } from './cart-block';
 export { checkoutBlockPreview } from './checkout-block';

--- a/assets/js/previews/saved-payment-methods.js
+++ b/assets/js/previews/saved-payment-methods.js
@@ -7,7 +7,7 @@ export const previewSavedPaymentMethods = {
 				brand: 'Visa',
 			},
 			expires: '12/20',
-			is_default: true,
+			is_default: false,
 			tokenId: 1,
 		},
 	],

--- a/assets/js/previews/saved-payment-methods.js
+++ b/assets/js/previews/saved-payment-methods.js
@@ -1,0 +1,14 @@
+export const previewSavedPaymentMethods = {
+	cc: [
+		{
+			method: {
+				gateway: 'stripe',
+				last4: '5678',
+				brand: 'Visa',
+			},
+			expires: '12/20',
+			is_default: true,
+			tokenId: 1,
+		},
+	],
+};

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -279,7 +279,7 @@
  *                                                        the editor context
  *                                                        (true) or not (false).
  * @property {number}                  currentPostId      The post ID being edited.
- * @property {CartData}                previewCart        Object containing preview
+ * @property {Object}                  previewData        Object containing preview
  *                                                        data for the editor.
  */
 


### PR DESCRIPTION
Fixes #2061

This PR shows a preview of the `Select a payment method` UI in the editor, effectively replacing the payment method placeholder.

To do this, `PaymentMethodDataProvider` detects editor via `useEditorContext`, and if so short-circuits the payment methods init to use new preview data instead of initialising using data in `customerPaymentMethods` setting.

### Screenshots

<img width="1271" alt="Screen Shot 2020-04-08 at 2 20 21 PM" src="https://user-images.githubusercontent.com/4167300/78737636-17da4780-79a4-11ea-8a05-553163881d8c.png">

### How to test the changes in this Pull Request:
1. View the checkout block in the editor – should see preview card as in screenshot above. Confirm that the editor view of the checkout block is correct and not missing any payment-related UI.
2. General test to ensure cart block works correctly on the front end & this hasn't regressed any payment related functionality.
3. Optional - tweak or add new preview saved payment options (e.g. other cards etc) and confirm they are only displayed in editor.

