### PR TITLE
Handle errors in processOrder

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -176,7 +176,7 @@ const CheckoutProcessor = () => {
 						} else {
 							addErrorNotice(
 								__(
-									'Something went wrong. Please check your payment details and try again.',
+									'Something went wrong. Please contact us to get assistance.',
 									'woo-gutenberg-products-block'
 								),
 								{
@@ -199,7 +199,7 @@ const CheckoutProcessor = () => {
 				const message =
 					error.message ||
 					__(
-						'Something went wrong. Please contact the site administrator to get assistance.',
+						'Something went wrong. Please contact us to get assistance.',
 						'woo-gutenberg-products-block'
 					);
 				addErrorNotice( message, {

--- a/assets/js/base/context/store-notices-context.js
+++ b/assets/js/base/context/store-notices-context.js
@@ -13,7 +13,7 @@ const StoreNoticesContext = createContext( {
 	notices: [],
 	createNotice: ( status, text, props ) => void { status, text, props },
 	createSnackBarNotice: () => void null,
-	removeNotice: () => void null,
+	removeNotice: ( id ) => void id,
 	context: 'wc/core',
 } );
 

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -1,3 +1,7 @@
+.wp-block-woocommerce-checkout .with-scroll-to-top__scroll-point {
+	top: -96px;
+}
+
 .wc-block-checkout__add-note,
 .wc-block-checkout__keep-updated {
 	margin-top: $gap;


### PR DESCRIPTION
Fixes #2059.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/78777398-bdd48480-7999-11ea-98b7-e4291641570e.png)

### How to test the changes in this Pull Request:

There are several errors that might occur when processing an order, for each one of them, we need to test that the user is not redirected to the success page and that the appropiate error appears on top of the _Checkout_ block.

**Error 1**
Path not available for some reason. You can trigger it modifying [L149](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/context/cart-checkout/checkout/processor/index.js#L149) from `context/cart-checkout/checkout/processor/index.js`:
```diff
-path: '/wc/store/checkout',
+path: '/wc/store/wrong-path',
```

**Error 2**
There was an error while parsing the JSON returned by the server. You can trigger it adding these lines in [L167](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/context/cart-checkout/checkout/processor/index.js#L167) from `context/cart-checkout/checkout/processor/index.js`:
```JS
fetchResponse = {
	json: Promise.reject(),
};
```

**Error 3**
The response was not ok. You can trigger it adding these lines in [L170](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/base/context/cart-checkout/checkout/processor/index.js#L170) from `context/cart-checkout/checkout/processor/index.js`:
```JS
fetchResponse = {
	ok: false,
};
```

For each of these errors:
1. Add the code that will trigger the error.
2. Make a purchase.
3. Verify the error appears and you were not redirected to the success page.