### PR TITLE
Render the checkout shortcode if viewing an unsupported endpoint

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -50,10 +50,24 @@ class Checkout extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
+		if ( $this->is_checkout_endpoint() ) {
+			// @todo Currently the block only takes care of the main checkout form -- if an endpoint is set, refer to the
+			// legacy shortcode instead and do not render block.
+			return '[woocommerce_checkout]';
+		}
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' );
 		$this->enqueue_assets( $attributes );
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
 		return $content . $this->get_skeleton();
+	}
+
+	/**
+	 * Check if we're viewing a checkout page endpoint, rather than the main checkout page itself.
+	 *
+	 * @return boolean
+	 */
+	protected function is_checkout_endpoint() {
+		return is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'order-received' );
 	}
 
 	/**


### PR DESCRIPTION
We discovered that the checkout shortcode is responsible for rendering the ORDER PAGE and ORDER RECEIVED endpoints. Our block does not yet account for this.

To workaround this, we can render the legacy shortcode on these pages instead. 🎉 

Fixes #2145

### How to test the changes in this Pull Request:

1. Set checkout as default checkout page
2. Place order
3. View confirmation page. Sigh of relief.