### PR TITLE
Move calculating state outside of checkout state

### DIFF
--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -103,7 +103,7 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 	}, [ customerPaymentMethods, selectedToken ] );
 	const updateToken = useCallback(
 		( token ) => {
-			if ( token !== 0 ) {
+			if ( token !== '0' ) {
 				// @todo this will need updated when the signature changes to
 				// allow no billing data included.
 				setPaymentStatus().success( null, {

--- a/assets/js/base/context/cart-checkout/checkout-state/constants.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/constants.js
@@ -9,7 +9,6 @@ import { getSetting } from '@woocommerce/settings';
 export const STATUS = {
 	PRISTINE: 'pristine',
 	IDLE: 'idle',
-	CALCULATING: 'calculating',
 	PROCESSING: 'processing',
 	COMPLETE: 'complete',
 	PROCESSING_COMPLETE: 'processing_complete',
@@ -23,9 +22,6 @@ const checkoutData = getSetting( 'checkoutData', {
 export const DEFAULT_STATE = {
 	redirectUrl: '',
 	status: STATUS.PRISTINE,
-	// this is used by the reducer to set what status the state will
-	// take after calculating is complete.
-	nextStatus: STATUS.IDLE,
 	hasError: false,
 	calculatingCount: 0,
 	orderId: checkoutData.order_id,

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -95,6 +95,8 @@ export const CheckoutStateProvider = ( {
 	const { setValidationErrors } = useValidationContext();
 	const { addErrorNotice, removeNotices } = useStoreNotices();
 
+	const isCalculating = checkoutState.calculatingCount > 0;
+
 	// set observers on ref so it's always current.
 	useEffect( () => {
 		currentObservers.current = observers;
@@ -189,7 +191,7 @@ export const CheckoutStateProvider = ( {
 		onSubmit,
 		isComplete: checkoutState.status === STATUS.COMPLETE,
 		isIdle: checkoutState.status === STATUS.IDLE,
-		isCalculating: checkoutState.status === STATUS.CALCULATING,
+		isCalculating,
 		isProcessing: checkoutState.status === STATUS.PROCESSING,
 		isProcessingComplete:
 			checkoutState.status === STATUS.PROCESSING_COMPLETE,

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -16,14 +16,7 @@ const {
 	SET_ORDER_ID,
 } = TYPES;
 
-const {
-	PRISTINE,
-	IDLE,
-	CALCULATING,
-	PROCESSING,
-	PROCESSING_COMPLETE,
-	COMPLETE,
-} = STATUS;
+const { PRISTINE, IDLE, PROCESSING, PROCESSING_COMPLETE, COMPLETE } = STATUS;
 
 /**
  * Reducer for the checkout state
@@ -32,7 +25,7 @@ const {
  * @param {Object} action Incoming action object.
  */
 export const reducer = ( state = DEFAULT_STATE, { url, type, orderId } ) => {
-	let status, nextStatus, newState;
+	let newState;
 	switch ( type ) {
 		case SET_PRISTINE:
 			newState = DEFAULT_STATE;
@@ -47,34 +40,20 @@ export const reducer = ( state = DEFAULT_STATE, { url, type, orderId } ) => {
 					: state;
 			break;
 		case SET_COMPLETE:
-			status = COMPLETE;
-			nextStatus = state.status;
-			if ( state.status === CALCULATING ) {
-				status = CALCULATING;
-				nextStatus = COMPLETE;
-			}
 			newState =
-				status !== state.status
+				state.status !== COMPLETE
 					? {
 							...state,
-							status,
-							nextStatus,
+							status: COMPLETE,
 					  }
 					: state;
 			break;
 		case SET_PROCESSING:
-			status = PROCESSING;
-			nextStatus = state.status;
-			if ( state.status === CALCULATING ) {
-				status = CALCULATING;
-				nextStatus = PROCESSING;
-			}
 			newState =
-				status !== state.status
+				state.status !== PROCESSING
 					? {
 							...state,
-							status,
-							nextStatus,
+							status: PROCESSING,
 							hasError: false,
 					  }
 					: state;
@@ -85,18 +64,11 @@ export const reducer = ( state = DEFAULT_STATE, { url, type, orderId } ) => {
 					: { ...newState, hasError: false };
 			break;
 		case SET_PROCESSING_COMPLETE:
-			status = PROCESSING_COMPLETE;
-			nextStatus = state.status;
-			if ( state.status === CALCULATING ) {
-				status = CALCULATING;
-				nextStatus = PROCESSING_COMPLETE;
-			}
 			newState =
-				status !== state.status
+				state.status !== SET_PROCESSING_COMPLETE
 					? {
 							...state,
-							status,
-							nextStatus,
+							status: PROCESSING_COMPLETE,
 							hasError: false,
 					  }
 					: state;
@@ -128,22 +100,12 @@ export const reducer = ( state = DEFAULT_STATE, { url, type, orderId } ) => {
 		case INCREMENT_CALCULATING:
 			newState = {
 				...state,
-				status: CALCULATING,
-				nextStatus: state.status,
 				calculatingCount: state.calculatingCount + 1,
 			};
 			break;
 		case DECREMENT_CALCULATING:
-			status = CALCULATING;
-			nextStatus = state.status;
-			if ( state.calculatingCount <= 1 ) {
-				status = state.nextStatus;
-				nextStatus = IDLE;
-			}
 			newState = {
 				...state,
-				status,
-				nextStatus,
 				calculatingCount: Math.max( 0, state.calculatingCount - 1 ),
 			};
 			break;

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -170,6 +170,21 @@ export const PaymentMethodDataProvider = ( {
 		[ subscriber ]
 	);
 
+	const currentStatus = useMemo(
+		() => ( {
+			isPristine: paymentStatus.currentStatus === PRISTINE,
+			isStarted: paymentStatus.currentStatus === STARTED,
+			isProcessing: paymentStatus.currentStatus === PROCESSING,
+			isFinished: [ ERROR, FAILED, SUCCESS ].includes(
+				paymentStatus.currentStatus
+			),
+			hasError: paymentStatus.currentStatus === ERROR,
+			hasFailed: paymentStatus.currentStatus === FAILED,
+			isSuccessful: paymentStatus.currentStatus === SUCCESS,
+		} ),
+		[ paymentStatus.currentStatus ]
+	);
+
 	// flip payment to processing if checkout processing is complete and there
 	// are no errors.
 	useEffect( () => {
@@ -205,21 +220,6 @@ export const PaymentMethodDataProvider = ( {
 		paymentMethodsInitialized,
 		paymentStatus.paymentMethods,
 	] );
-
-	const currentStatus = useMemo(
-		() => ( {
-			isPristine: paymentStatus.currentStatus === PRISTINE,
-			isStarted: paymentStatus.currentStatus === STARTED,
-			isProcessing: paymentStatus.currentStatus === PROCESSING,
-			isFinished: [ ERROR, FAILED, SUCCESS ].includes(
-				paymentStatus.currentStatus
-			),
-			hasError: paymentStatus.currentStatus === ERROR,
-			hasFailed: paymentStatus.currentStatus === FAILED,
-			isSuccessful: paymentStatus.currentStatus === SUCCESS,
-		} ),
-		[ paymentStatus.currentStatus ]
-	);
 
 	/**
 	 * @type {PaymentStatusDispatch}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -112,6 +112,7 @@ export const PaymentMethodDataProvider = ( {
 	const {
 		isComplete: checkoutIsComplete,
 		isProcessingComplete: checkoutIsProcessingComplete,
+		isCalculating: checkoutIsCalculating,
 		hasError: checkoutHasError,
 	} = useCheckoutContext();
 	const [ activePaymentMethod, setActive ] = useState(
@@ -172,10 +173,20 @@ export const PaymentMethodDataProvider = ( {
 	// flip payment to processing if checkout processing is complete and there
 	// are no errors.
 	useEffect( () => {
-		if ( checkoutIsProcessingComplete && ! checkoutHasError ) {
+		if (
+			checkoutIsProcessingComplete &&
+			! checkoutHasError &&
+			! checkoutIsCalculating &&
+			! currentStatus.isFinished
+		) {
 			setPaymentStatus().processing();
 		}
-	}, [ checkoutIsProcessingComplete, checkoutHasError ] );
+	}, [
+		checkoutIsProcessingComplete,
+		checkoutHasError,
+		checkoutIsCalculating,
+		currentStatus.isFinished,
+	] );
 
 	// set initial active payment method if it's undefined.
 	useEffect( () => {

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -26,40 +26,54 @@ const reducer = (
 ) => {
 	switch ( type ) {
 		case STARTED:
-			return {
-				...state,
-				currentStatus: STARTED,
-			};
+			return state.currentStatus !== STARTED
+				? {
+						...state,
+						currentStatus: STARTED,
+				  }
+				: state;
 		case ERROR:
-			return {
-				...state,
-				currentStatus: ERROR,
-				errorMessage: errorMessage || state.errorMessage,
-			};
+			return state.currentStatus !== ERROR
+				? {
+						...state,
+						currentStatus: ERROR,
+						errorMessage: errorMessage || state.errorMessage,
+				  }
+				: state;
 		case FAILED:
-			return {
-				...state,
-				currentStatus: FAILED,
-				paymentMethodData: paymentMethodData || state.paymentMethodData,
-				errorMessage: errorMessage || state.errorMessage,
-			};
+			return state.currentStatus !== FAILED
+				? {
+						...state,
+						currentStatus: FAILED,
+						paymentMethodData:
+							paymentMethodData || state.paymentMethodData,
+						errorMessage: errorMessage || state.errorMessage,
+				  }
+				: state;
 		case SUCCESS:
-			return {
-				...state,
-				currentStatus: SUCCESS,
-				paymentMethodData: paymentMethodData || state.paymentMethodData,
-			};
+			return state.currentStatus !== SUCCESS
+				? {
+						...state,
+						currentStatus: SUCCESS,
+						paymentMethodData:
+							paymentMethodData || state.paymentMethodData,
+				  }
+				: state;
 		case PROCESSING:
-			return {
-				...state,
-				currentStatus: PROCESSING,
-				errorMessage: '',
-			};
+			return state.currentStatus !== PROCESSING
+				? {
+						...state,
+						currentStatus: PROCESSING,
+						errorMessage: '',
+				  }
+				: state;
 		case COMPLETE:
-			return {
-				...state,
-				currentStatus: COMPLETE,
-			};
+			return state.currentStatus !== COMPLETE
+				? {
+						...state,
+						currentStatus: COMPLETE,
+				  }
+				: state;
 
 		case PRISTINE:
 			return {

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -40,10 +40,10 @@ const { NONE, INVALID_ADDRESS, UNKNOWN } = ERROR_TYPES;
  * @param {Object} action The incoming action.
  */
 const errorStatusReducer = ( state, { type } ) => {
-	if ( Object.keys( ERROR_TYPES ).includes( type ) ) {
-		return state;
+	if ( Object.values( ERROR_TYPES ).includes( type ) ) {
+		return type;
 	}
-	return type;
+	return state;
 };
 
 const ShippingDataContext = createContext( DEFAULT_SHIPPING_CONTEXT_DATA );

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -64,6 +64,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		hasOrder,
 		hasError: checkoutHasError,
 		isComplete: checkoutIsComplete,
+		isCalculating: checkoutIsCalculating,
 	} = useCheckoutContext();
 	const { showAllValidationErrors } = useValidationContext();
 	const {
@@ -127,11 +128,15 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	}, [ shippingAsBilling, setBillingData ] );
 
 	useEffect( () => {
-		if ( checkoutIsComplete && checkoutHasError ) {
+		if (
+			checkoutIsComplete &&
+			checkoutHasError &&
+			! checkoutIsCalculating
+		) {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 		}
-	}, [ checkoutIsComplete, checkoutHasError ] );
+	}, [ checkoutIsComplete, checkoutHasError, checkoutIsCalculating ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;

--- a/assets/js/type-defs/checkout.js
+++ b/assets/js/type-defs/checkout.js
@@ -23,10 +23,6 @@
  * @property {string} PRISTINE            Checkout is in it's initialized state.
  * @property {string} IDLE                When checkout state has changed but
  *                                        there is no activity happening.
- * @property {string} CALCULATING         When something in the checkout results
- *                                        in the totals being recalculated,
- *                                        this will be the state while
- *                                        calculating is happening.
  * @property {string} PROCESSING          This is the state when the checkout
  *                                        button has been pressed and the
  *                                        checkout data has been sent to the


### PR DESCRIPTION
While working on #2127 I realized there was a flaw with having "calculating" be a checkout flow status because of how we're relying on status changes to inform flow context (and `useEffect` logic running). This was exposed due to applePay triggering shipping rate requests on successful payment because of the way apple pay shipping address is passed through on various api events. Long story short, because of this extra request, the calculating checkout status would change and then back to `checkoutProcessingComplete` which  would trigger another round of payment events getting fired and create a loop causing errors.

This pull resolves that (and verified in testing on #2127) by moving calculating state outside of checkout flow status.

## To test

This impacts the following:

- Cart "Proceed to Checkout" button responding to any loading state for cart line item quantity changes or shipping rate changes.
- Checkout process order button responding to any loading state changes.
- Validation of fields in checkout.
- Completing a cheque or stripe cc purchase (this should not affect that flow).

Testing should cover all of the above points and there should be no errors in the console.