### PR TITLE
Update cart after conflicts

### DIFF
--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -167,8 +167,14 @@ export function* applyCoupon( couponCode ) {
 		yield receiveCart( response );
 		yield receiveApplyingCoupon( '' );
 	} catch ( error ) {
-		// Store the error message in state.
 		yield receiveError( error );
+		yield receiveApplyingCoupon( '' );
+
+		// If updated cart state was returned, also update that.
+		if ( error.data?.cart ) {
+			yield receiveCart( error.data.cart );
+		}
+
 		// Re-throw the error.
 		throw error;
 	}
@@ -199,10 +205,14 @@ export function* removeCoupon( couponCode ) {
 		yield receiveCart( response );
 		yield receiveRemovingCoupon( '' );
 	} catch ( error ) {
-		// Store the error message in state.
 		yield receiveError( error );
-		// Finished handling the coupon.
 		yield receiveRemovingCoupon( '' );
+
+		// If updated cart state was returned, also update that.
+		if ( error.data?.cart ) {
+			yield receiveCart( error.data.cart );
+		}
+
 		// Re-throw the error.
 		throw error;
 	}
@@ -234,6 +244,11 @@ export function* addItemToCart( productId, quantity = 1 ) {
 		yield receiveCart( response );
 	} catch ( error ) {
 		yield receiveError( error );
+
+		// If updated cart state was returned, also update that.
+		if ( error.data?.cart ) {
+			yield receiveCart( error.data.cart );
+		}
 	}
 }
 
@@ -259,6 +274,11 @@ export function* removeItemFromCart( cartItemKey ) {
 		yield receiveCart( response );
 	} catch ( error ) {
 		yield receiveError( error );
+
+		// If updated cart state was returned, also update that.
+		if ( error.data?.cart ) {
+			yield receiveCart( error.data.cart );
+		}
 	}
 	yield itemIsPendingDelete( cartItemKey, false );
 }
@@ -293,6 +313,11 @@ export function* changeCartItemQuantity( cartItemKey, quantity ) {
 		yield receiveCart( response );
 	} catch ( error ) {
 		yield receiveError( error );
+
+		// If updated cart state was returned, also update that.
+		if ( error.data?.cart ) {
+			yield receiveCart( error.data.cart );
+		}
 	}
 	yield itemIsPendingQuantity( cartItemKey, false );
 }
@@ -319,6 +344,12 @@ export function* selectShippingRate( rateId, packageId = 0 ) {
 	} catch ( error ) {
 		yield receiveError( error );
 		yield shippingRatesBeingSelected( false );
+
+		// If updated cart state was returned, also update that.
+		if ( error.data?.cart ) {
+			yield receiveCart( error.data.cart );
+		}
+
 		// Re-throw the error.
 		throw error;
 	}
@@ -346,6 +377,12 @@ export function* updateShippingAddress( address ) {
 	} catch ( error ) {
 		yield receiveError( error );
 		yield shippingRatesAreResolving( false );
+
+		// If updated cart state was returned, also update that.
+		if ( error.data?.cart ) {
+			yield receiveCart( error.data.cart );
+		}
+
 		// rethrow error.
 		throw error;
 	}

--- a/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Abstract Cart route.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
+
+/**
+ * Cart class.
+ */
+abstract class AbstractCartRoute extends AbstractRoute {
+	/**
+	 * Get the namespace for this route.
+	 *
+	 * @return string
+	 */
+	public function get_namespace() {
+		return 'wc/store';
+	}
+
+	/**
+	 * Get route response when something went wrong.
+	 *
+	 * @param string $error_code String based error code.
+	 * @param string $error_message User facing error message.
+	 * @param int    $http_status_code HTTP status. Defaults to 500.
+	 * @return \WP_Error WP Error object.
+	 */
+	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500 ) {
+		switch ( $http_status_code ) {
+			case 409:
+				// If there was a conflict, return the cart so the client can resolve it.
+				$controller = new CartController();
+				$cart       = $controller->get_cart_instance();
+
+				return new \WP_Error(
+					$error_code,
+					$error_message,
+					[
+						'status' => $http_status_code,
+						'cart'   => $this->schema->get_item_response( $cart ),
+					]
+				);
+		}
+		return new \WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );
+	}
+}

--- a/src/RestApi/StoreApi/Routes/AbstractRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractRoute.php
@@ -72,9 +72,9 @@ abstract class AbstractRoute implements RouteInterface {
 				$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
 			}
 		} catch ( RouteException $error ) {
-			$response = new \WP_Error( $error->getErrorCode(), $error->getMessage(), [ 'status' => $error->getCode() ] );
+			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode() );
 		} catch ( \Exception $error ) {
-			$response = new \WP_Error( 'unknown_server_error', $error->getMessage(), [ 'status' => '500' ] );
+			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
 		}
 		return $response;
 	}
@@ -153,6 +153,18 @@ abstract class AbstractRoute implements RouteInterface {
 	 */
 	protected function get_route_delete_response( \WP_REST_Request $request ) {
 		throw new RouteException( 'woocommerce_rest_invalid_endpoint', __( 'Method not implemented', 'woo-gutenberg-products-block' ), 404 );
+	}
+
+	/**
+	 * Get route response when something went wrong.
+	 *
+	 * @param string $error_code String based error code.
+	 * @param string $error_message User facing error message.
+	 * @param int    $http_status_code HTTP status. Defaults to 500.
+	 * @return \WP_Error WP Error object.
+	 */
+	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500 ) {
+		return new \WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Routes/Cart.php
+++ b/src/RestApi/StoreApi/Routes/Cart.php
@@ -14,16 +14,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 /**
  * Cart class.
  */
-class Cart extends AbstractRoute {
-	/**
-	 * Get the namespace for this route.
-	 *
-	 * @return string
-	 */
-	public function get_namespace() {
-		return 'wc/store';
-	}
-
+class Cart extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/RestApi/StoreApi/Routes/CartAddItem.php
+++ b/src/RestApi/StoreApi/Routes/CartAddItem.php
@@ -14,16 +14,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 /**
  * CartAddItem class.
  */
-class CartAddItem extends AbstractRoute {
-	/**
-	 * Get the namespace for this route.
-	 *
-	 * @return string
-	 */
-	public function get_namespace() {
-		return 'wc/store';
-	}
-
+class CartAddItem extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/RestApi/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/RestApi/StoreApi/Routes/CartApplyCoupon.php
@@ -14,16 +14,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 /**
  * CartApplyCoupon class.
  */
-class CartApplyCoupon extends AbstractRoute {
-	/**
-	 * Get the namespace for this route.
-	 *
-	 * @return string
-	 */
-	public function get_namespace() {
-		return 'wc/store';
-	}
-
+class CartApplyCoupon extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/RestApi/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/RestApi/StoreApi/Routes/CartRemoveCoupon.php
@@ -60,9 +60,14 @@ class CartRemoveCoupon extends AbstractCartRoute {
 		$controller  = new CartController();
 		$cart        = $controller->get_cart_instance();
 		$coupon_code = wc_format_coupon_code( $request['code'] );
+		$coupon      = new \WC_Coupon( $coupon_code );
+
+		if ( $coupon->get_code() !== $coupon_code || ! $coupon->is_valid() ) {
+			throw new RouteException( 'woocommerce_rest_cart_coupon_error', __( 'Invalid coupon code.', 'woo-gutenberg-products-block' ), 403 );
+		}
 
 		if ( ! $controller->has_coupon( $coupon_code ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon no longer exists or is invalid.', 'woo-gutenberg-products-block' ), 409 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon is not applied to the cart.', 'woo-gutenberg-products-block' ), 409 );
 		}
 
 		$cart = $controller->get_cart_instance();

--- a/src/RestApi/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/RestApi/StoreApi/Routes/CartRemoveCoupon.php
@@ -67,7 +67,7 @@ class CartRemoveCoupon extends AbstractCartRoute {
 		}
 
 		if ( ! $controller->has_coupon( $coupon_code ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon is not applied to the cart.', 'woo-gutenberg-products-block' ), 409 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon cannot be removed because it is not already applied to the cart.', 'woo-gutenberg-products-block' ), 409 );
 		}
 
 		$cart = $controller->get_cart_instance();

--- a/src/RestApi/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/RestApi/StoreApi/Routes/CartRemoveCoupon.php
@@ -14,16 +14,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 /**
  * CartRemoveCoupon class.
  */
-class CartRemoveCoupon extends AbstractRoute {
-	/**
-	 * Get the namespace for this route.
-	 *
-	 * @return string
-	 */
-	public function get_namespace() {
-		return 'wc/store';
-	}
-
+class CartRemoveCoupon extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *
@@ -71,7 +62,7 @@ class CartRemoveCoupon extends AbstractRoute {
 		$coupon_code = wc_format_coupon_code( $request['code'] );
 
 		if ( ! $controller->has_coupon( $coupon_code ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woo-gutenberg-products-block' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon no longer exists or is invalid.', 'woo-gutenberg-products-block' ), 409 );
 		}
 
 		$cart = $controller->get_cart_instance();

--- a/src/RestApi/StoreApi/Routes/CartRemoveItem.php
+++ b/src/RestApi/StoreApi/Routes/CartRemoveItem.php
@@ -14,16 +14,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 /**
  * CartRemoveItem class.
  */
-class CartRemoveItem extends AbstractRoute {
-	/**
-	 * Get the namespace for this route.
-	 *
-	 * @return string
-	 */
-	public function get_namespace() {
-		return 'wc/store';
-	}
-
+class CartRemoveItem extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *
@@ -67,7 +58,7 @@ class CartRemoveItem extends AbstractRoute {
 		$cart_item  = $controller->get_cart_item( $request['key'] );
 
 		if ( ! $cart_item ) {
-			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item no longer exists or is invalid.', 'woo-gutenberg-products-block' ), 409 );
 		}
 
 		$cart->remove_cart_item( $request['key'] );

--- a/src/RestApi/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/RestApi/StoreApi/Routes/CartSelectShippingRate.php
@@ -14,16 +14,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 /**
  * CartSelectShippingRate class.
  */
-class CartSelectShippingRate extends AbstractRoute {
-	/**
-	 * Get the namespace for this route.
-	 *
-	 * @return string
-	 */
-	public function get_namespace() {
-		return 'wc/store';
-	}
-
+class CartSelectShippingRate extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/RestApi/StoreApi/Routes/CartUpdateItem.php
+++ b/src/RestApi/StoreApi/Routes/CartUpdateItem.php
@@ -14,16 +14,7 @@ use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
 /**
  * CartUpdateItem class.
  */
-class CartUpdateItem extends AbstractRoute {
-	/**
-	 * Get the namespace for this route.
-	 *
-	 * @return string
-	 */
-	public function get_namespace() {
-		return 'wc/store';
-	}
-
+class CartUpdateItem extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *
@@ -71,7 +62,7 @@ class CartUpdateItem extends AbstractRoute {
 		$cart_item  = $controller->get_cart_item( $request['key'] );
 
 		if ( ! $cart_item ) {
-			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );
+			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item no longer exists or is invalid.', 'woo-gutenberg-products-block' ), 409 );
 		}
 
 		if ( isset( $request['quantity'] ) ) {

--- a/tests/php/RestApi/StoreApi/Routes/Cart.php
+++ b/tests/php/RestApi/StoreApi/Routes/Cart.php
@@ -107,7 +107,7 @@ class Cart extends TestCase {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 409, $response->get_status() );
 		$this->assertEquals( 'woocommerce_rest_cart_invalid_key', $data['code'] );
 	}
 
@@ -136,7 +136,7 @@ class Cart extends TestCase {
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 409, $response->get_status() );
 		$this->assertEquals( 'woocommerce_rest_cart_invalid_key', $data['code'] );
 	}
 
@@ -331,7 +331,7 @@ class Cart extends TestCase {
 		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( 403, $response->get_status() );
 
 		// Applied coupon.
 		$request = new WP_REST_Request( 'POST', '/wc/store/cart/remove-coupon' );


### PR DESCRIPTION
I realise there is no standard recommending this, however, it seems like an acceptable solution to our problem. If you try to update something in cart which is gone/no longer exists, this can be due to conflicting local state within the client; therefore one could argue a 409 response is suitable:

> The HTTP 409 Conflict response status code indicates a request conflict with current state of the server.

With this 409 response, as part of the error data, I'm appending the _current_ state, which allows the cart to update and reconcile any differences.

Fixes #2131

### How to test the changes in this Pull Request:

1. Open up a full cart in two tabs.
2. Remove an item from one tab.
3. Remove the same item from the other tab.

In both instances the cart should now update and the item be removed. If you test the endpoint directly and try to remove a non-existing item, you'll get a response like this:

```json
{
  "code": "woocommerce_rest_cart_invalid_key",
  "message": "Cart item no longer exists or is invalid.",
  "data": {
    "status": 409,
    "cart": {
      "coupons": [],
      "shipping_rates": []...
```