### PR TITLE
Prevent data hydration on REST requests

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -104,7 +104,7 @@ class Cart extends AbstractBlock {
 		}
 
 		// Hydrate the following data depending on admin or frontend context.
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
 			$this->hydrate_from_api( $data_registry );
 		}
 

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -109,7 +109,9 @@ class Checkout extends AbstractBlock {
 				$methods_exist = wc_get_shipping_method_count() > 0;
 				$data_registry->add( 'shippingMethodsExist', $methods_exist );
 			}
-		} else {
+		}
+
+		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
 			$this->hydrate_from_api( $data_registry );
 			$this->hydrate_customer_payment_methods( $data_registry );
 		}


### PR DESCRIPTION
Autosaves were causing errors in the logs due to data hydratio. Autosave/rest requests are not admin requests, so the checks needed some modification.

Fixes #2174

### How to test the changes in this Pull Request:

1. Insert checkout block into page
2. Wait a few moments for autosave
3. Check logs are clean