### PR TITLE
Fix prices overflowing in some widths in the Order summary panel

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -77,16 +77,17 @@
 		padding-right: $gap-small;
 	}
 
+	.wc-block-order-summary-item__header {
+		display: flex;
+	}
+
 	.wc-block-product-name {
-		display: inline;
+		flex-grow: 1;
+		margin-right: 0.5em;
 	}
 
 	.wc-block-order-summary-item__prices {
 		font-size: 0.875em;
-	}
-
-	.wc-block-order-summary-item__total-price {
-		float: right;
 	}
 }
 


### PR DESCRIPTION
### Screenshots
_Before:_
<img src="https://user-images.githubusercontent.com/3616980/78891278-8b915880-7a67-11ea-9a4c-12b9cdd731d0.png" alt="Screenshot" width="251" />

_After:_
<img src="https://user-images.githubusercontent.com/3616980/78891298-95b35700-7a67-11ea-8b92-c4c3337c7e6c.png" alt="Screenshot" width="246" />

### How to test the changes in this Pull Request:

1. In the _Checkout_ block try resizing the viewport and verify the price is always rendered next to the product name, not below.
