### PR TITLE
Fix entities in coupon validation error messages

### DIFF
--- a/assets/js/base/components/validation/validation-input-error.js
+++ b/assets/js/base/components/validation/validation-input-error.js
@@ -3,6 +3,7 @@
  */
 import { useValidationContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -26,7 +27,9 @@ export const ValidationInputError = ( {
 
 	return (
 		<div className="wc-block-form-input-validation-error" role="alert">
-			<p id={ getValidationErrorId( elementId ) }>{ errorMessage }</p>
+			<p id={ getValidationErrorId( elementId ) }>
+				{ decodeEntities( errorMessage ) }
+			</p>
 		</div>
 	);
 };

--- a/assets/js/base/components/validation/validation-input-error.js
+++ b/assets/js/base/components/validation/validation-input-error.js
@@ -3,7 +3,6 @@
  */
 import { useValidationContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -27,9 +26,7 @@ export const ValidationInputError = ( {
 
 	return (
 		<div className="wc-block-form-input-validation-error" role="alert">
-			<p id={ getValidationErrorId( elementId ) }>
-				{ decodeEntities( errorMessage ) }
-			</p>
+			<p id={ getValidationErrorId( elementId ) }>{ errorMessage }</p>
 		</div>
 	);
 };

--- a/assets/js/base/hooks/cart/use-store-cart-coupons.js
+++ b/assets/js/base/hooks/cart/use-store-cart-coupons.js
@@ -7,6 +7,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useValidationContext } from '@woocommerce/base-context';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -59,7 +60,10 @@ export const useStoreCartCoupons = () => {
 					} )
 					.catch( ( error ) => {
 						setValidationErrors( {
-							coupon: { message: error.message, hidden: false },
+							coupon: {
+								message: decodeEntities( error.message ),
+								hidden: false,
+							},
 						} );
 						// Finished handling the coupon.
 						receiveApplyingCoupon( '' );

--- a/src/RestApi/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/RestApi/StoreApi/Routes/CartApplyCoupon.php
@@ -68,7 +68,7 @@ class CartApplyCoupon extends AbstractRoute {
 
 		$controller  = new CartController();
 		$cart        = $controller->get_cart_instance();
-		$coupon_code = wc_format_coupon_code( $request['code'] );
+		$coupon_code = wc_format_coupon_code( wp_unslash( $request['code'] ) );
 
 		try {
 			$controller->apply_coupon( $coupon_code );


### PR DESCRIPTION
Fixes the entities in validation error messages.

The coupon issue with ' characters didn't break for me, but it could have been missing unslash. Paging @Aljullu to retest with this branch.

Fixes #2164

### How to test the changes in this Pull Request:

1. Create coupon called `won't apply`
2. Apply it. Should work.
3. Apply `won't apply2`. Error message should be correctly formatted.
