### PR TITLE
fix broken labels on twentyTwenty

### DIFF
--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -7,6 +7,7 @@
 		position: absolute;
 		transform: translateY(#{$gap-small});
 		left: 0;
+		top: 0;
 		transform-origin: top left;
 		font-size: 16px;
 		line-height: 22px;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2154

Labels didn't align well in TwentyTwenty for some reason, this PR fixes it.

Tested in Safari, Chrome and Firefox, confirmed that it didn't break storefront in all of them as well.

if you have auto-complete fir a form set in safari or firefox, test with it.