### PR TITLE
Prevent auto-scroll to invalid fields

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -71,7 +71,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		hasOrder,
 		hasError: checkoutHasError,
 		isComplete: checkoutIsComplete,
-		isCalculating: checkoutIsCalculating,
 	} = useCheckoutContext();
 	const { showAllValidationErrors } = useValidationContext();
 	const {
@@ -135,15 +134,11 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	}, [ shippingAsBilling, setBillingData ] );
 
 	useEffect( () => {
-		if (
-			checkoutIsComplete &&
-			checkoutHasError &&
-			! checkoutIsCalculating
-		) {
+		if ( checkoutIsComplete && checkoutHasError ) {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 		}
-	}, [ checkoutIsComplete, checkoutHasError, checkoutIsCalculating ] );
+	}, [ checkoutIsComplete, checkoutHasError ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;


### PR DESCRIPTION
Fixes #2173.

I don't think we need that `useEffect()` to run when `checkoutIsCalculating` changes. 

### How to test the changes in this Pull Request:

Copied from #2173:
> 1. Set up a checkout with block and some products in cart.
> 2. Clear out all the address fields.
> 3. Try to submit the order - see error and field validation.
> 4. Type in the "last" field (furthest down the page).
5. Verify you are not scrolled to the top and the focus doesn't move to the first invalid field.


