### PR TITLE
Fix currency format in On Sale badge

### DIFF
--- a/assets/js/base/components/cart-checkout/product-sale-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/index.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-import { formatPrice } from '@woocommerce/base-utils';
+import { __experimentalCreateInterpolateElement } from 'wordpress-element';
+import { __ } from '@wordpress/i18n';
+import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import PropTypes from 'prop-types';
 
 /**
@@ -15,7 +16,7 @@ import './style.scss';
  *
  * @param {Object} props            Incoming props.
  * @param {Object} props.currency   Currency object.
- * @param {number} props.saleAmount Currency object.
+ * @param {number} props.saleAmount Discounted amount.
  *
  * @return {*} The component.
  */
@@ -25,10 +26,16 @@ const ProductSaleBadge = ( { currency, saleAmount } ) => {
 	}
 	return (
 		<div className="wc-block-sale-badge">
-			{ sprintf(
-				/* translators: %s discount amount */
-				__( 'Save %s!', 'woo-gutenberg-products-block' ),
-				formatPrice( saleAmount, currency )
+			{ __experimentalCreateInterpolateElement(
+				__( 'Save <price></price>!', 'woo-gutenberg-products-block' ),
+				{
+					price: (
+						<FormattedMonetaryAmount
+							currency={ currency }
+							value={ saleAmount }
+						/>
+					),
+				}
 			) }
 		</div>
 	);

--- a/assets/js/base/components/cart-checkout/product-sale-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/index.js
@@ -27,6 +27,7 @@ const ProductSaleBadge = ( { currency, saleAmount } ) => {
 	return (
 		<div className="wc-block-sale-badge">
 			{ __experimentalCreateInterpolateElement(
+				/* translators: <price></price> will be replaced by the discount amount */
 				__( 'Save <price></price>!', 'woo-gutenberg-products-block' ),
 				{
 					price: (

--- a/assets/js/base/components/cart-checkout/product-sale-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/index.js
@@ -27,8 +27,8 @@ const ProductSaleBadge = ( { currency, saleAmount } ) => {
 	return (
 		<div className="wc-block-sale-badge">
 			{ __experimentalCreateInterpolateElement(
-				/* translators: <price></price> will be replaced by the discount amount */
-				__( 'Save <price></price>!', 'woo-gutenberg-products-block' ),
+				/* translators: <price/> will be replaced by the discount amount */
+				__( 'Save <price/>!', 'woo-gutenberg-products-block' ),
 				{
 					price: (
 						<FormattedMonetaryAmount

--- a/assets/js/base/utils/price.js
+++ b/assets/js/base/utils/price.js
@@ -99,7 +99,7 @@ export const getCurrency = ( currencyData = {} ) => {
  * Format a price, provided using the smallest unit of the currency, as a
  * decimal complete with currency symbols using current store settings.
  *
- * @param {number} price Price in minor unit, e.g. cents.
+ * @param {number|string} price Price in minor unit, e.g. cents.
  * @param {Object} currencyData Currency data object.
  */
 export const formatPrice = ( price, currencyData ) => {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -88,7 +88,8 @@ table.wc-block-cart-items {
 			font-size: 16px;
 			line-height: 19px;
 
-			.wc-block-formatted-money-amount {
+			.wc-block-product-price,
+			.wc-block-product-price--regular {
 				display: block;
 			}
 		}


### PR DESCRIPTION
Fixes #2155.

### How to test the changes in this Pull Request:

1. In your currency settings, set the decimal separator to comma `,`.
2. Go to the _Cart_ block with a product on sale.
2. Verify the `Save 1,23€!` badge shows the value separated with a comma instead of a dot.
