### PR TITLE
Implement editor previews for stripe cc and check payment methods

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -14,8 +14,6 @@ import { PAYMENT_METHOD_NAME } from './constants';
 
 const settings = getSetting( 'cheque_data', {} );
 
-const EditPlaceHolder = () => <div>TODO: Edit preview soon...</div>;
-
 /**
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
  */
@@ -40,6 +38,10 @@ const Content = ( { activePaymentMethod, eventRegistration } ) => {
 	) : null;
 };
 
+const Edit = ( props ) => {
+	return <Content { ...props } />;
+};
+
 const offlineChequePaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
 	label: (
@@ -51,7 +53,7 @@ const offlineChequePaymentMethod = {
 		</strong>
 	),
 	content: <Content />,
-	edit: <EditPlaceHolder />,
+	edit: <Edit />,
 	canMakePayment: () => true,
 	ariaLabel: decodeEntities(
 		settings.title || __( 'Check Payment', 'woo-gutenberg-products-block' )

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -10,9 +10,11 @@ import { loadStripe } from '../stripe-utils';
 import { StripeCreditCard } from './payment-method';
 import { PAYMENT_METHOD_NAME } from './constants';
 
-const EditPlaceHolder = () => <div>TODO: Card edit preview soon...</div>;
-
 const stripePromise = loadStripe();
+
+const Edit = ( props ) => {
+	return <StripeCreditCard stripe={ stripePromise } { ...props } />;
+};
 
 const stripeCcPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
@@ -22,7 +24,7 @@ const stripeCcPaymentMethod = {
 		</strong>
 	),
 	content: <StripeCreditCard stripe={ stripePromise } />,
-	edit: <EditPlaceHolder />,
+	edit: <Edit />,
 	canMakePayment: () => stripePromise,
 	ariaLabel: __(
 		'Stripe Credit Card payment method',


### PR DESCRIPTION
Fixes: #2056 

This implements the editor previews for Stripe CC and Check payment methods.

Stripe Preview:

<img width="1640" alt="Image 2020-04-09 at 4 42 02 PM" src="https://user-images.githubusercontent.com/1429108/78938909-17fc4500-7a81-11ea-97c4-c732109fc5da.png">

Check Preview:

<img width="1650" alt="Image 2020-04-09 at 4 42 15 PM" src="https://user-images.githubusercontent.com/1429108/78938920-1e8abc80-7a81-11ea-863a-3ae0d5a4d141.png">


"Preview" could be considered a misnomer here because essentially we're showing the same thing as the frontend but using any preview data provided by the block.  

## To Test

This doesn't impact frontend.  You just need to verify the previews show in the editor context and there are no console errors.

Note, while the cc number field can be interacted with, the expiry and ccv fields cannot. I don't think that's an issue (and ideally _all_ fields would not be interactable). I don't think this should block merge but open to pushback on that.