### PR TITLE
respect SHIPPING_ENABLED in Cart and Checkout blocks in Editor

### DIFF
--- a/assets/js/previews/cart.js
+++ b/assets/js/previews/cart.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	SHIPPING_METHODS_EXIST,
 	WC_BLOCKS_ASSET_URL,
+	SHIPPING_ENABLED,
 } from '@woocommerce/block-settings';
 
 /**
@@ -164,7 +165,7 @@ export const previewCart = {
 	items_count: 3,
 	items_weight: 0,
 	needs_payment: true,
-	needs_shipping: true,
+	needs_shipping: SHIPPING_ENABLED,
 	totals: {
 		currency_code: 'USD',
 		currency_symbol: '$',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
we use `needsShipping` to decide if we want to show shipping related fields and values in cart and checkout, this value is dynamically decided on the backend, in the preview data we hardcoded it to a static value `true` however if the merchant has explicitly disabled shipping, he should not see shipping related fields in the editor, so this PR respects the `SHIPPING_ENABLED` value in the editor.
<!-- Reference any related issues or PRs here -->
Fixes #2194

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. Disable shipping in the website (from WooCommerce settings -> General -> disable shipping and shipping calculation).
2. See Cart and Checkout blocks in the editor.
3. no shipping fields or related data should be available. 
