### PR TITLE
create a notice instead of throwing an errors if there is an error for shipping update

### DIFF
--- a/assets/js/base/hooks/shipping/use-shipping-address.js
+++ b/assets/js/base/hooks/shipping/use-shipping-address.js
@@ -12,7 +12,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  * Internal dependencies
  */
 import { useStoreCart } from '../cart/use-store-cart';
-import { useThrowError } from '../use-throw-error';
+import { useStoreNotices } from '../use-store-notices';
 import { pluckAddress } from '../../utils';
 
 const shouldUpdateStore = ( oldAddress, newAddress ) =>
@@ -23,7 +23,7 @@ export const useShippingAddress = () => {
 	const [ shippingAddress, setShippingAddress ] = useState( initialAddress );
 	const [ debouncedShippingAddress ] = useDebounce( shippingAddress, 400 );
 	const { updateShippingAddress } = useDispatch( storeKey );
-	const throwError = useThrowError();
+	const { addErrorNotice } = useStoreNotices();
 
 	// Note, we're intentionally not using initialAddress as a dependency here
 	// so that the stale (previous) value is being used for comparison.
@@ -34,8 +34,9 @@ export const useShippingAddress = () => {
 		) {
 			updateShippingAddress( debouncedShippingAddress ).catch(
 				( error ) => {
-					// error is non-recoverable so throw
-					throwError( error );
+					addErrorNotice( error.message, {
+						id: 'shipping-form',
+					} );
 				}
 			);
 		}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2199

I'm looking for feedback into this, I'm not sure how should we handle this, would the current implementation be enough, I think we should signal to the express payment method that this failed, I believe this is already done (we just make it recoverable now).

This also needs testing, I tested by hardcoding a country value in the action dispatcher, triggering this from normal UI can't be done, it can only be done in express checkout, so someone should test there:

1. in WooCommerce -> Settings -> General -> Shipping location(s) -> Ship to specific countries, define some countries.
2. In Express payment shipping section, select a country that is not within those countries.
3. The block should only return a notice.
