### PR TITLE
Lazy load stripe.js and preserve payment method registration order.

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/actions.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/actions.js
@@ -11,8 +11,8 @@ const {
 	ERROR,
 	FAILED,
 	SUCCESS,
-	SET_REGISTERED_PAYMENT_METHOD,
-	SET_REGISTERED_EXPRESS_PAYMENT_METHOD,
+	SET_REGISTERED_PAYMENT_METHODS,
+	SET_REGISTERED_EXPRESS_PAYMENT_METHODS,
 } = ACTION_TYPES;
 
 /**
@@ -81,22 +81,22 @@ export const success = ( { paymentMethodData } ) => ( {
  * Used to dispatch an action for updating a registered payment method in the
  * state.
  *
- * @param {Object} paymentMethod Payment method to register.
+ * @param {Object} paymentMethods Payment methods to register.
  * @return {Object} An action object.
  */
-export const setRegisteredPaymentMethod = ( paymentMethod ) => ( {
-	type: SET_REGISTERED_PAYMENT_METHOD,
-	paymentMethod,
+export const setRegisteredPaymentMethods = ( paymentMethods ) => ( {
+	type: SET_REGISTERED_PAYMENT_METHODS,
+	paymentMethods,
 } );
 
 /**
  * Used to dispatch an action for updating a registered express payment
  * method in the state.
  *
- * @param {Object} paymentMethod Payment method to register.
+ * @param {Object} paymentMethods Payment methods to register.
  * @return {Object} An action object.
  */
-export const setRegisteredExpressPaymentMethod = ( paymentMethod ) => ( {
-	type: SET_REGISTERED_EXPRESS_PAYMENT_METHOD,
-	paymentMethod,
+export const setRegisteredExpressPaymentMethods = ( paymentMethods ) => ( {
+	type: SET_REGISTERED_EXPRESS_PAYMENT_METHODS,
+	paymentMethods,
 } );

--- a/assets/js/base/context/cart-checkout/payment-methods/constants.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/constants.js
@@ -14,9 +14,9 @@ export const STATUS = {
 
 export const ACTION_TYPES = {
 	...STATUS,
-	SET_REGISTERED_PAYMENT_METHOD: 'set_registered_payment_method',
-	SET_REGISTERED_EXPRESS_PAYMENT_METHOD:
-		'set_registered_express_payment_method',
+	SET_REGISTERED_PAYMENT_METHODS: 'set_registered_payment_methods',
+	SET_REGISTERED_EXPRESS_PAYMENT_METHODS:
+		'set_registered_express_payment_methods',
 };
 
 /**

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -12,8 +12,8 @@ import {
 	error,
 	failed,
 	success,
-	setRegisteredPaymentMethod,
-	setRegisteredExpressPaymentMethod,
+	setRegisteredPaymentMethods,
+	setRegisteredExpressPaymentMethods,
 } from './actions';
 import {
 	usePaymentMethods,
@@ -134,12 +134,12 @@ export const PaymentMethodDataProvider = ( {
 		},
 		[ setActive, dispatch ]
 	);
-	const paymentMethodsInitialized = usePaymentMethods( ( paymentMethod ) =>
-		dispatch( setRegisteredPaymentMethod( paymentMethod ) )
+	const paymentMethodsInitialized = usePaymentMethods( ( paymentMethods ) =>
+		dispatch( setRegisteredPaymentMethods( paymentMethods ) )
 	);
 	const expressPaymentMethodsInitialized = useExpressPaymentMethods(
-		( paymentMethod ) => {
-			dispatch( setRegisteredExpressPaymentMethod( paymentMethod ) );
+		( paymentMethods ) => {
+			dispatch( setRegisteredExpressPaymentMethods( paymentMethods ) );
 		}
 	);
 	const { setValidationErrors } = useValidationContext();

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -10,8 +10,8 @@ const {
 	PROCESSING,
 	PRISTINE,
 	COMPLETE,
-	SET_REGISTERED_PAYMENT_METHOD,
-	SET_REGISTERED_EXPRESS_PAYMENT_METHOD,
+	SET_REGISTERED_PAYMENT_METHODS,
+	SET_REGISTERED_EXPRESS_PAYMENT_METHODS,
 } = ACTION_TYPES;
 
 /**
@@ -22,7 +22,7 @@ const {
  */
 const reducer = (
 	state = DEFAULT_PAYMENT_DATA,
-	{ type, paymentMethodData, errorMessage, paymentMethod }
+	{ type, paymentMethodData, errorMessage, paymentMethods }
 ) => {
 	switch ( type ) {
 		case STARTED:
@@ -87,20 +87,20 @@ const reducer = (
 					...state.expressPaymentMethods,
 				},
 			};
-		case SET_REGISTERED_PAYMENT_METHOD:
+		case SET_REGISTERED_PAYMENT_METHODS:
 			return {
 				...state,
 				paymentMethods: {
 					...state.paymentMethods,
-					[ paymentMethod.name ]: paymentMethod,
+					...paymentMethods,
 				},
 			};
-		case SET_REGISTERED_EXPRESS_PAYMENT_METHOD:
+		case SET_REGISTERED_EXPRESS_PAYMENT_METHODS:
 			return {
 				...state,
 				expressPaymentMethods: {
 					...state.expressPaymentMethods,
-					[ paymentMethod.name ]: paymentMethod,
+					...paymentMethods,
 				},
 			};
 	}

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\WooCommerce\Blocks;
 
+use Automattic\WooCommerce\Blocks\Assets\PaymentMethodAssets;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -72,7 +74,8 @@ class Assets {
 		self::register_script( 'wc-active-filters', plugins_url( self::get_block_asset_build_path( 'active-filters' ), __DIR__ ), $block_dependencies );
 
 		if ( WOOCOMMERCE_BLOCKS_PHASE === 'experimental' ) {
-			self::register_script( 'wc-checkout-block', plugins_url( self::get_block_asset_build_path( 'checkout' ), __DIR__ ), $block_dependencies );
+			$payment_method_handles = Package::container()->get( PaymentMethodAssets::class )->get_all_registered_payment_method_script_handles();
+			self::register_script( 'wc-checkout-block', plugins_url( self::get_block_asset_build_path( 'checkout' ), __DIR__ ), array_merge( $block_dependencies, $payment_method_handles ) );
 			self::register_script( 'wc-cart-block', plugins_url( self::get_block_asset_build_path( 'cart' ), __DIR__ ), $block_dependencies );
 		}
 	}

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -76,12 +76,10 @@ final class Stripe extends AbstractPaymentMethodType {
 	 * @return array
 	 */
 	public function get_payment_method_script_handles() {
-		wp_register_script( 'stripe', 'https://js.stripe.com/v3/', '', '3.0', true );
-
 		$this->asset_api->register_script(
 			'wc-payment-method-stripe',
 			'build/wc-payment-method-stripe.js',
-			[ 'stripe' ]
+			[]
 		);
 
 		return [ 'wc-payment-method-stripe' ];


### PR DESCRIPTION
This pull implements the following:

- `stripe.js` can be lazy loaded by the `@stripe/stripe-js` library we are using which means we don't have to enqueue and register `stripe.js` server side.  Advantages with lazy loading is `stripe.js` will be loaded on demand and thus editor instances will not load it if the checkout block is not in the post content.
- Switching the above caused Stripe cc to always appear as the last tab in the payment methods (and same for any express payment buttons). To preserve order, I refactored payment method initialization so the order of payment method registration is preserved. The logic added will eventually make it simpler to support following the same payment method order that is currently set by merchants on the payment settings page (which can be done in a follow-up eventually...I think there's already an issue for it).
- I fixed an issue where adding the checkout block initially to a page will not show registered payment methods because they are only added as a dependency on frontend script. Now they are added as a dependency on the editor script too so that when you add the checkout block to content the first time, registered payment methods are available.

## To test

This affects stripe payment method registration. So verify that:

- stripe payment methods show up on the frontend (and no errors in the console).
- The checkout block already in post content loads in the editor with no errors and with stripe payment method elements loading.
- When inserting the checkout block added to a brand new page, payment methods show up in the block without any errors in the console.

