### PR TITLE
Handle errors when loading payment methods

### DIFF
--- a/assets/js/base/components/block-error-boundary/index.js
+++ b/assets/js/base/components/block-error-boundary/index.js
@@ -11,7 +11,7 @@ import BlockError from './block-error';
 import './style.scss';
 
 class BlockErrorBoundary extends Component {
-	state = { hasError: false };
+	state = { errorMessage: '', hasError: false };
 
 	static getDerivedStateFromError( error ) {
 		if (

--- a/assets/js/base/components/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/base/components/payment-methods/payment-method-error-boundary.js
@@ -4,18 +4,24 @@
 import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import { Notice } from 'wordpress-components';
+import PropTypes from 'prop-types';
+import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 
 class PaymentMethodErrorBoundary extends Component {
 	state = { errorMessage: '' };
 
 	static getDerivedStateFromError( error ) {
+		const { isEditor } = this.props;
+
+		const errorMessage =
+			error.message && ( isEditor || CURRENT_USER_IS_ADMIN )
+				? error.message
+				: __(
+						'There was an error loading the payment method.',
+						'woo-gutenberg-products-block'
+				  );
 		return {
-			errorMessage:
-				error.message ||
-				__(
-					'There was an error loading the payment method.',
-					'woo-gutenberg-products-block'
-				),
+			errorMessage,
 		};
 	}
 
@@ -33,5 +39,13 @@ class PaymentMethodErrorBoundary extends Component {
 		return this.props.children;
 	}
 }
+
+PaymentMethodErrorBoundary.propTypes = {
+	isEditor: PropTypes.bool,
+};
+
+PaymentMethodErrorBoundary.defaultProps = {
+	isEditor: false,
+};
 
 export default PaymentMethodErrorBoundary;

--- a/assets/js/base/components/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/base/components/payment-methods/payment-method-error-boundary.js
@@ -5,11 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
 import { Notice } from 'wordpress-components';
 
-/**
- * Internal dependencies
- */
-//import './editor.scss';
-
 class PaymentMethodErrorBoundary extends Component {
 	state = { errorMessage: '' };
 

--- a/assets/js/base/components/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/base/components/payment-methods/payment-method-error-boundary.js
@@ -8,30 +8,28 @@ import PropTypes from 'prop-types';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 
 class PaymentMethodErrorBoundary extends Component {
-	state = { errorMessage: '' };
+	state = { errorMessage: '', hasError: false };
 
 	static getDerivedStateFromError( error ) {
-		const { isEditor } = this.props;
-
-		const errorMessage =
-			error.message && ( isEditor || CURRENT_USER_IS_ADMIN )
-				? error.message
-				: __(
-						'There was an error loading the payment method.',
-						'woo-gutenberg-products-block'
-				  );
 		return {
-			errorMessage,
+			errorMessage: error.message,
+			hasError: true,
 		};
 	}
 
 	render() {
-		const { errorMessage } = this.state;
+		const { hasError, errorMessage } = this.state;
+		const { isEditor } = this.props;
 
-		if ( errorMessage ) {
+		if ( hasError ) {
 			return (
 				<Notice isDismissible={ false } status="error">
-					{ errorMessage }
+					{ errorMessage && ( isEditor || CURRENT_USER_IS_ADMIN )
+						? errorMessage
+						: __(
+								'There was an error loading the payment method.',
+								'woo-gutenberg-products-block'
+						  ) }
 				</Notice>
 			);
 		}

--- a/assets/js/base/components/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/base/components/payment-methods/payment-method-error-boundary.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component } from 'react';
+import { Notice } from 'wordpress-components';
+
+/**
+ * Internal dependencies
+ */
+//import './editor.scss';
+
+class PaymentMethodErrorBoundary extends Component {
+	state = { errorMessage: '' };
+
+	static getDerivedStateFromError( error ) {
+		return {
+			errorMessage:
+				error.message ||
+				__(
+					'There was an error loading the payment method.',
+					'woo-gutenberg-products-block'
+				),
+		};
+	}
+
+	render() {
+		const { errorMessage } = this.state;
+
+		if ( errorMessage ) {
+			return (
+				<Notice isDismissible={ false } status="error">
+					{ errorMessage }
+				</Notice>
+			);
+		}
+
+		return this.props.children;
+	}
+}
+
+export default PaymentMethodErrorBoundary;

--- a/assets/js/base/components/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/base/components/payment-methods/payment-method-error-boundary.js
@@ -22,14 +22,23 @@ class PaymentMethodErrorBoundary extends Component {
 		const { isEditor } = this.props;
 
 		if ( hasError ) {
+			let errorText = __(
+				'This site is experiencing difficulties with this payment method. Please contact the owner of the site for assistance.',
+				'woo-gutenberg-products-block'
+			);
+			if ( isEditor || CURRENT_USER_IS_ADMIN ) {
+				if ( errorMessage ) {
+					errorText = errorMessage;
+				} else {
+					errorText = __(
+						"There was an error with this payment method. Please verify it's configured correctly.",
+						'woo-gutenberg-products-block'
+					);
+				}
+			}
 			return (
 				<Notice isDismissible={ false } status="error">
-					{ errorMessage && ( isEditor || CURRENT_USER_IS_ADMIN )
-						? errorMessage
-						: __(
-								'There was an error loading the payment method.',
-								'woo-gutenberg-products-block'
-						  ) }
+					{ errorText }
 				</Notice>
 			);
 		}

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -24,6 +24,7 @@ import {
 import Tabs from '../tabs';
 import NoPaymentMethods from './no-payment-methods';
 import SavedPaymentMethodOptions from './saved-payment-method-options';
+import PaymentMethodErrorBoundary from './payment-method-error-boundary';
 
 /**
  * Returns a payment method for the given context.
@@ -75,12 +76,14 @@ const PaymentMethods = () => {
 				currentPaymentMethods.current,
 				isEditor
 			);
-			return paymentMethod
-				? cloneElement( paymentMethod, {
+			return paymentMethod ? (
+				<PaymentMethodErrorBoundary>
+					{ cloneElement( paymentMethod, {
 						activePaymentMethod,
 						...currentPaymentMethodInterface.current,
-				  } )
-				: null;
+					} ) }
+				</PaymentMethodErrorBoundary>
+			) : null;
 		},
 		[ isEditor, activePaymentMethod ]
 	);

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -77,7 +77,7 @@ const PaymentMethods = () => {
 				isEditor
 			);
 			return paymentMethod ? (
-				<PaymentMethodErrorBoundary>
+				<PaymentMethodErrorBoundary isEditor={ isEditor }>
 					{ cloneElement( paymentMethod, {
 						activePaymentMethod,
 						...currentPaymentMethodInterface.current,

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -88,21 +88,6 @@ const usePaymentMethodRegistration = (
 				setIsInitialized( true );
 			}
 		};
-		const updateInvalidPaymentMethod = ( current, errorMessage = '' ) => {
-			updatePaymentMethod( current, false );
-			if ( CURRENT_USER_IS_ADMIN ) {
-				throw new Error(
-					sprintf(
-						__(
-							// translators: %s is the error method returned by the payment method.
-							'Problem with payment method initialization: %s',
-							'woo-gutenberg-products-block'
-						),
-						errorMessage
-					)
-				);
-			}
-		};
 		// loop through payment methods and see what the state is
 		for ( const paymentMethodName in registeredPaymentMethods ) {
 			const current = registeredPaymentMethods[ paymentMethodName ];
@@ -115,16 +100,25 @@ const usePaymentMethodRegistration = (
 				)
 					.then( ( canPay ) => {
 						if ( canPay.error ) {
-							updateInvalidPaymentMethod(
-								current,
-								canPay.error.message
-							);
+							throw new Error( canPay.error.message );
 						} else {
 							updatePaymentMethod( current, canPay );
 						}
 					} )
 					.catch( ( error ) => {
-						updateInvalidPaymentMethod( current, error.message );
+						updatePaymentMethod( current, false );
+						if ( CURRENT_USER_IS_ADMIN ) {
+							throw new Error(
+								sprintf(
+									__(
+										// translators: %s is the error method returned by the payment method.
+										'Problem with payment method initialization: %s',
+										'woo-gutenberg-products-block'
+									),
+									error.message
+								)
+							);
+						}
 					} );
 			}
 		}

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,7 +14,25 @@ import { PAYMENT_METHOD_NAME } from './constants';
 const stripePromise = loadStripe();
 
 const Edit = ( props ) => {
-	return <StripeCreditCard stripe={ stripePromise } { ...props } />;
+	const [ errorMessage, setErrorMessage ] = useState( '' );
+
+	useEffect( () => {
+		Promise.resolve( stripePromise ).then( ( { error } ) => {
+			setErrorMessage( error.message );
+		} );
+	}, [ stripePromise, setErrorMessage ] );
+
+	return ! errorMessage ? (
+		<StripeCreditCard stripe={ stripePromise } { ...props } />
+	) : (
+		<div className="components-notice is-error">
+			{ errorMessage ||
+				__(
+					'There was an error loading Stripe.',
+					'woo-gutenberg-products-block'
+				) }
+		</div>
+	);
 };
 
 const stripeCcPaymentMethod = {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -13,26 +13,23 @@ import { PAYMENT_METHOD_NAME } from './constants';
 
 const stripePromise = loadStripe();
 
-const Edit = ( props ) => {
+const StripeComponent = ( props ) => {
 	const [ errorMessage, setErrorMessage ] = useState( '' );
-
 	useEffect( () => {
 		Promise.resolve( stripePromise ).then( ( { error } ) => {
-			setErrorMessage( error.message );
+			if ( error ) {
+				setErrorMessage( error.message );
+			}
 		} );
 	}, [ stripePromise, setErrorMessage ] );
 
-	return ! errorMessage ? (
-		<StripeCreditCard stripe={ stripePromise } { ...props } />
-	) : (
-		<div className="components-notice is-error">
-			{ errorMessage ||
-				__(
-					'There was an error loading Stripe.',
-					'woo-gutenberg-products-block'
-				) }
-		</div>
-	);
+	useEffect( () => {
+		if ( errorMessage ) {
+			throw new Error( errorMessage );
+		}
+	}, [ errorMessage ] );
+
+	return <StripeCreditCard stripe={ stripePromise } { ...props } />;
 };
 
 const stripeCcPaymentMethod = {
@@ -42,8 +39,8 @@ const stripeCcPaymentMethod = {
 			{ __( 'Credit/Debit Card', 'woo-gutenberg-products-block' ) }
 		</strong>
 	),
-	content: <StripeCreditCard stripe={ stripePromise } />,
-	edit: <Edit />,
+	content: <StripeComponent />,
+	edit: <StripeComponent />,
 	canMakePayment: () => stripePromise,
 	ariaLabel: __(
 		'Stripe Credit Card payment method',

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/load-stripe.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/load-stripe.js
@@ -10,14 +10,11 @@ import { getApiKey } from './utils';
 
 const stripePromise = () =>
 	new Promise( ( resolve ) => {
-		let stripe = null;
 		try {
-			stripe = loadStripe( getApiKey() );
+			resolve( loadStripe( getApiKey() ) );
 		} catch ( error ) {
-			// eslint-disable-next-line no-console
-			//console.error( error.message );
+			resolve( { error } );
 		}
-		resolve( stripe );
 	} );
 
 export { stripePromise as loadStripe };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/load-stripe.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/load-stripe.js
@@ -13,6 +13,8 @@ const stripePromise = () =>
 		try {
 			resolve( loadStripe( getApiKey() ) );
 		} catch ( error ) {
+			// In order to avoid showing console error publicly to users,
+			// we resolve instead of rejecting when there is an error.
 			resolve( { error } );
 		}
 	} );


### PR DESCRIPTION
Fixes #2065.
Fixes #2220.

### Screenshots
_Frontend:_
![imatge](https://user-images.githubusercontent.com/3616980/79318113-e19e4a00-7f06-11ea-8ff3-3821ee899a6e.png)

_Editor:_
![imatge](https://user-images.githubusercontent.com/3616980/79318188-f11d9300-7f06-11ea-82a4-35b87f57ba7e.png)

### How to test the changes in this Pull Request:

1. To force Stripe to fail you can:
	* Go into the Stripe plugin settings and uncheck `Enable Test Mode` without adding any live key.
	* Follow the steps in #2220.
	* Or replace [L15](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/load-stripe.js#L15) of `load-stripe.js` to force an error.
```diff
-stripe = loadStripe( getApiKey() );
+stripe = undefinedFunctionThatFails( getApiKey() );
```
2.  Verify this is true:
	* Stripe silently fails in the frontend for normal users. Making other payment methods available.
	* For admins, it does the same but it also shows an error in the console.
	* In the editor, it shows a notice.