### PR TITLE
Fix global validation error reporting and cheque payment method regressions

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -250,8 +250,7 @@ export const CheckoutStateProvider = ( {
 				).then( ( response ) => {
 					if ( isSuccessResponse( response ) ) {
 						dispatch( actions.setComplete( response ) );
-					}
-					if (
+					} else if (
 						isErrorResponse( response ) ||
 						isFailResponse( response )
 					) {
@@ -269,6 +268,10 @@ export const CheckoutStateProvider = ( {
 							// and then setting checkout to IDLE state.
 							dispatch( actions.setHasError( true ) );
 						}
+					} else {
+						// nothing hooked in had any response type so let's just
+						// consider successful
+						dispatch( actions.setComplete() );
 					}
 				} );
 			}

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -101,7 +101,7 @@ export const reducer = (
 					? {
 							...state,
 							status: COMPLETE,
-							redirectUrl: data.redirectUrl || state.redirectUrl,
+							redirectUrl: data?.redirectUrl || state.redirectUrl,
 					  }
 					: state;
 			break;

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -299,6 +299,10 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 					} );
 					setPaymentStatus().error( response.message );
 					setValidationErrors( response?.validationErrors );
+				} else {
+					// otherwise there are no payment methods doing anything so
+					// just consider success
+					setPaymentStatus().success();
 				}
 			} );
 		}

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -71,7 +71,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	const {
 		hasOrder,
 		hasError: checkoutHasError,
-		isComplete: checkoutIsComplete,
+		isIdle: checkoutIsIdle,
 	} = useCheckoutContext();
 	const { showAllValidationErrors } = useValidationContext();
 	const {
@@ -135,11 +135,11 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	}, [ shippingAsBilling, setBillingData ] );
 
 	useEffect( () => {
-		if ( checkoutIsComplete && checkoutHasError ) {
+		if ( checkoutIsIdle && checkoutHasError ) {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 		}
-	}, [ checkoutIsComplete, checkoutHasError ] );
+	}, [ checkoutIsIdle, checkoutHasError ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -5,7 +5,6 @@ import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,16 +22,7 @@ const settings = getSetting( 'cheque_data', {} );
  *
  * @param {RegisteredPaymentMethodProps|Object} props Incoming props
  */
-const Content = ( { activePaymentMethod, eventRegistration } ) => {
-	// hook into payment processing event.
-	useEffect( () => {
-		const unsubscribeProcessing = eventRegistration.onPaymentProcessing(
-			() => true
-		);
-		return () => {
-			unsubscribeProcessing();
-		};
-	}, [ eventRegistration.onPaymentProcessing ] );
+const Content = ( { activePaymentMethod } ) => {
 	return activePaymentMethod === PAYMENT_METHOD_NAME ? (
 		<div>{ decodeEntities( settings.description || '' ) }</div>
 	) : null;


### PR DESCRIPTION
Fixes #2227 

The refactor in #2189 introduced these regressions. I thought for sure I had tested Check but I must have only tested Stripe because it was pretty clearly borked. 

In this pull I:

- fixed the global validation error reporting on submit
- fixed cheque payment method selection not completing payment (note, this also covers bugs that would have surfaced if there are no observers registered to the event emitters or observers just return true because they have nothing to communicate back to checkout).

## To test

It's best testing this in incognito mode for the browser.

- submit without filling any fields in checkout. You should get validation errors and scroll to first error.
- Reload checkout and try filling out some fields and leaving others blank. You should see inline validation errors immediately but also submit should still surface any remaining along with scrolling to first one.
- After addressing all validation errors and while selecting cheque, the order should process immediately and have the expected details.

Stripe shouldn't need tested because the logic changes shouldn't affect it but would still be good to do as a confidence check.