### PR TITLE
Improve  "sold individually" validation

### DIFF
--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -35,26 +35,26 @@ const getQuantityFromCartItems = ( cartItems, productId ) => {
  *                                  to add to cart functionality.
  */
 export const useStoreAddToCart = ( productId ) => {
-	const [ addingToCart, setAddingToCart ] = useState( false );
+	const { addItemToCart } = useDispatch( storeKey );
 	const { cartItems, cartIsLoading } = useStoreCart();
+
+	const [ addingToCart, setAddingToCart ] = useState( false );
 	const currentCartItemQuantity = useRef(
 		getQuantityFromCartItems( cartItems, productId )
 	);
-	const { addItemToCart } = useDispatch( storeKey );
 
 	const addToCart = () => {
 		setAddingToCart( true );
-		addItemToCart( productId );
+		addItemToCart( productId ).finally( () => {
+			setAddingToCart( false );
+		} );
 	};
 
 	useEffect( () => {
-		if ( addingToCart ) {
-			const quantity = getQuantityFromCartItems( cartItems, productId );
+		const quantity = getQuantityFromCartItems( cartItems, productId );
 
-			if ( quantity !== currentCartItemQuantity.current ) {
-				currentCartItemQuantity.current = quantity;
-				setAddingToCart( false );
-			}
+		if ( quantity !== currentCartItemQuantity.current ) {
+			currentCartItemQuantity.current = quantity;
 		}
 	}, [ cartItems, productId ] );
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -28,11 +28,21 @@ import Dinero from 'dinero.js';
  * @param {boolean}     backOrdersAllowed Whether to allow backorders or not.
  * @param {number|null} lowStockAmount    If present the number of stock
  *                                        remaining.
+ * @param {boolean}     soldIndividually  Whether an item is sold individually or not.
  *
  * @return {number} The maximum number value for the quantity input.
  */
-const getMaximumQuantity = ( backOrdersAllowed, lowStockAmount ) => {
+const getMaximumQuantity = (
+	backOrdersAllowed,
+	lowStockAmount,
+	soldIndividually
+) => {
+	if ( soldIndividually ) {
+		return 1;
+	}
+
 	const maxQuantityLimit = getSetting( 'quantitySelectLimit', 99 );
+
 	if ( backOrdersAllowed || ! lowStockAmount ) {
 		return maxQuantityLimit;
 	}
@@ -59,6 +69,7 @@ const CartLineItemRow = ( { lineItem } ) => {
 		summary = '',
 		low_stock_remaining: lowStockRemaining = null,
 		backorders_allowed: backOrdersAllowed = false,
+		sold_individually: soldIndividually = false,
 		permalink = '',
 		images = [],
 		variation = [],
@@ -133,7 +144,8 @@ const CartLineItemRow = ( { lineItem } ) => {
 					quantity={ quantity }
 					maximum={ getMaximumQuantity(
 						backOrdersAllowed,
-						lowStockRemaining
+						lowStockRemaining,
+						soldIndividually
 					) }
 					onChange={ changeQuantity }
 					itemName={ name }

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-error/constants.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-error/constants.js
@@ -3,3 +3,5 @@ export const PRODUCT_NOT_PURCHASABLE =
 	'woocommerce_rest_cart_product_is_not_purchasable';
 export const PRODUCT_NOT_ENOUGH_STOCK =
 	'woocommerce_rest_cart_product_no_stock';
+export const PRODUCT_SOLD_INDIVIDUALLY =
+	'woocommerce_rest_cart_product_sold_individually';

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
@@ -14,6 +14,7 @@ import {
 	PRODUCT_OUT_OF_STOCK,
 	PRODUCT_NOT_PURCHASABLE,
 	PRODUCT_NOT_ENOUGH_STOCK,
+	PRODUCT_SOLD_INDIVIDUALLY,
 } from './constants';
 
 /**
@@ -61,7 +62,8 @@ const ErrorTitle = ( { errorData } ) => {
 	if (
 		errorData.code === PRODUCT_NOT_ENOUGH_STOCK ||
 		errorData.code === PRODUCT_NOT_PURCHASABLE ||
-		errorData.code === PRODUCT_OUT_OF_STOCK
+		errorData.code === PRODUCT_OUT_OF_STOCK ||
+		errorData.code === PRODUCT_SOLD_INDIVIDUALLY
 	) {
 		heading = __(
 			'There is a problem with your cart',
@@ -85,7 +87,8 @@ const ErrorMessage = ( { errorData } ) => {
 	if (
 		errorData.code === PRODUCT_NOT_ENOUGH_STOCK ||
 		errorData.code === PRODUCT_NOT_PURCHASABLE ||
-		errorData.code === PRODUCT_OUT_OF_STOCK
+		errorData.code === PRODUCT_OUT_OF_STOCK ||
+		errorData.code === PRODUCT_SOLD_INDIVIDUALLY
 	) {
 		message =
 			message +
@@ -111,7 +114,8 @@ const ErrorButton = ( { errorData } ) => {
 	if (
 		errorData.code === PRODUCT_NOT_ENOUGH_STOCK ||
 		errorData.code === PRODUCT_NOT_PURCHASABLE ||
-		errorData.code === PRODUCT_OUT_OF_STOCK
+		errorData.code === PRODUCT_OUT_OF_STOCK ||
+		errorData.code === PRODUCT_SOLD_INDIVIDUALLY
 	) {
 		buttonText = __( 'Edit your cart', 'woo-gutenberg-products-block' );
 		buttonUrl = CART_URL;

--- a/src/RestApi/StoreApi/Routes/CartItemsByKey.php
+++ b/src/RestApi/StoreApi/Routes/CartItemsByKey.php
@@ -98,14 +98,9 @@ class CartItemsByKey extends AbstractRoute {
 	protected function get_route_update_response( \WP_REST_Request $request ) {
 		$controller = new CartController();
 		$cart       = $controller->get_cart_instance();
-		$cart_item  = $controller->get_cart_item( $request['key'] );
-
-		if ( ! $cart_item ) {
-			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );
-		}
 
 		if ( isset( $request['quantity'] ) ) {
-			$cart->set_quantity( $request['key'], $request['quantity'] );
+			$controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 		}
 
 		return rest_ensure_response( $this->prepare_item_for_response( $controller->get_cart_item( $request['key'] ), $request ) );

--- a/src/RestApi/StoreApi/Routes/CartUpdateItem.php
+++ b/src/RestApi/StoreApi/Routes/CartUpdateItem.php
@@ -59,14 +59,9 @@ class CartUpdateItem extends AbstractCartRoute {
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		$controller = new CartController();
 		$cart       = $controller->get_cart_instance();
-		$cart_item  = $controller->get_cart_item( $request['key'] );
-
-		if ( ! $cart_item ) {
-			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item no longer exists or is invalid.', 'woo-gutenberg-products-block' ), 409 );
-		}
 
 		if ( isset( $request['quantity'] ) ) {
-			$cart->set_quantity( $request['key'], $request['quantity'] );
+			$controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -172,7 +172,7 @@ class CartController {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_product', __( 'Cart item is invalid.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
-		if ( $product->is_sold_individually() ) {
+		if ( $product->is_sold_individually() && $quantity > 1 ) {
 			throw new RouteException(
 				'woocommerce_rest_cart_product_sold_individually',
 				sprintf(
@@ -251,7 +251,7 @@ class CartController {
 				'woocommerce_rest_cart_product_sold_individually',
 				sprintf(
 					/* translators: %s: product name */
-					__( 'Only one of "%s" is allowed per order.', 'woo-gutenberg-products-block' ),
+					__( 'There are too many &quot;%s&quot; in the cart. Only 1 can be purchased.', 'woo-gutenberg-products-block' ),
 					$product->get_name()
 				),
 				403

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -152,7 +152,7 @@ class CartController {
 	}
 
 	/**
-	 * Based on core `set_quantity` method, but validates if an item is solve individually first.
+	 * Based on core `set_quantity` method, but validates if an item is sold individually first.
 	 *
 	 * @throws RouteException Exception if invalid data is detected.
 	 *
@@ -196,13 +196,7 @@ class CartController {
 		$cart_items = $this->get_cart_items();
 
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
-			$product = $cart_item['data'];
-
-			if ( ! $product instanceof \WC_Product ) {
-				continue;
-			}
-
-			$this->validate_cart_item( $product );
+			$this->validate_cart_item( $cart_item );
 		}
 	}
 
@@ -216,14 +210,8 @@ class CartController {
 		$cart_items = $this->get_cart_items();
 
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
-			$product = $cart_item['data'];
-
-			if ( ! $product instanceof \WC_Product ) {
-				continue;
-			}
-
 			try {
-				$this->validate_cart_item( $product );
+				$this->validate_cart_item( $cart_item );
 			} catch ( RouteException $error ) {
 				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
 			}
@@ -237,15 +225,33 @@ class CartController {
 	 *
 	 * @throws RouteException Exception if invalid data is detected.
 	 *
-	 * @param \WC_Product $product Product object associated with the cart item.
+	 * @param array $cart_item Cart item data.
 	 */
-	public function validate_cart_item( \WC_Product $product ) {
+	protected function validate_cart_item( $cart_item ) {
+		$product = $cart_item['data'];
+
+		if ( ! $product instanceof \WC_Product ) {
+			return;
+		}
+
 		if ( ! $product->is_purchasable() ) {
 			throw new RouteException(
 				'woocommerce_rest_cart_product_is_not_purchasable',
 				sprintf(
 					/* translators: %s: product name */
 					__( '&quot;%s&quot; is not available for purchase.', 'woo-gutenberg-products-block' ),
+					$product->get_name()
+				),
+				403
+			);
+		}
+
+		if ( $product->is_sold_individually() && $cart_item['quantity'] > 1 ) {
+			throw new RouteException(
+				'woocommerce_rest_cart_product_sold_individually',
+				sprintf(
+					/* translators: %s: product name */
+					__( 'Only one of "%s" is allowed per order.', 'woo-gutenberg-products-block' ),
 					$product->get_name()
 				),
 				403


### PR DESCRIPTION
- Adds checks for "sold individually" to the cart update endpoint.
- Adds checks for "sold individually" to the cart validation function (for checkout).
- Enforces a maximum of 1 if sold individually on the client side.
- Ensures add to cart events, if fired, are not never-ending by using the promise.

Fixes #2215

### How to test the changes in this Pull Request:

1. Edit an item and make it "sold individually"
2. Ensure only 1 can be added from store product pages.
3. Ensure maximum of 1 is allowed on cart page.
4. Add an item to cart which is not "sold individually". Set qty to 10. Edit and make "sold individually" true. Now view cart page and see errors.