### PR TITLE
Capture legacy payment notices

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -231,7 +231,7 @@ export const CheckoutStateProvider = ( {
 						// no error handling in place by anything so let's fall
 						// back to default
 						const message =
-							data.processingResponse.message ||
+							data.processingResponse?.message ||
 							__(
 								'Something went wrong. Please contact us to get assistance.',
 								'woo-gutenberg-products-block'

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -141,6 +141,17 @@ export const CheckoutStateProvider = ( {
 			setOrderId: ( orderId ) =>
 				void dispatch( actions.setOrderId( orderId ) ),
 			setAfterProcessing: ( response ) => {
+				// capture general error message if this is an error response.
+				if (
+					! response.payment_result &&
+					response.message &&
+					response?.data?.status !== 200
+				) {
+					response.payment_result = {
+						...response.payment_result,
+						message: response.message,
+					};
+				}
 				if ( response.payment_result ) {
 					if (
 						// eslint-disable-next-line camelcase

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -33,6 +33,8 @@ const {
  *
  * @param {Object}        data                 The value of `payment_result` from the checkout
  *                                             processing endpoint response.
+ * @param {string}        data.message         If there was a general error message it will appear
+ *                                             on this property.
  * @param {string}        data.payment_status  The payment status. One of 'success', 'failure',
  *                                             'pending', 'error'.
  * @param {Array<Object>} data.payment_details An array of Objects with a 'key' property that is a
@@ -44,6 +46,7 @@ const {
  */
 export const prepareResponseData = ( data ) => {
 	const responseData = {
+		message: data?.message || '',
 		paymentStatus: data.payment_status,
 		paymentDetails: {},
 	};

--- a/src/Library.php
+++ b/src/Library.php
@@ -277,6 +277,9 @@ class Library {
 
 		$error_notices = wc_get_notices( 'error' );
 
+		// Prevent notices from being output later on.
+		wc_clear_notices();
+
 		foreach ( $error_notices as $error_notice ) {
 			throw new \Exception( $error_notice['notice'] );
 		}

--- a/src/Library.php
+++ b/src/Library.php
@@ -239,9 +239,8 @@ class Library {
 
 		$payment_method_object->validate_fields();
 
-		if ( 0 !== wc_notice_count( 'error' ) ) {
-			return;
-		}
+		// If errors were thrown, we need to abort.
+		self::convert_notices_to_exceptions();
 
 		// Process Payment.
 		$gateway_result = $payment_method_object->process_payment( $context->order->get_id() );
@@ -249,7 +248,8 @@ class Library {
 		// Restore $_POST data.
 		$_POST = $post_data;
 
-		// Clear notices so they don't show up in the block.
+		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
+		// and a generic notice will be shown instead if payment failed.
 		wc_clear_notices();
 
 		// Handle result.
@@ -258,5 +258,27 @@ class Library {
 		// set payment_details from result.
 		$result->set_payment_details( array_merge( $result->payment_details, $gateway_result ) );
 		$result->set_redirect_url( $gateway_result['redirect'] );
+	}
+
+	/**
+	 * Convert notices to Exceptions.
+	 *
+	 * Payment methods may add error notices during validate_fields call to prevent checkout. Since we're not rendering
+	 * notices at all, we need to convert them to exceptions.
+	 *
+	 * This method will find the first error message and thrown an exception instead.
+	 *
+	 * @throws \Exception If an error notice is detected, Exception is thrown.
+	 */
+	protected static function convert_notices_to_exceptions() {
+		if ( 0 === wc_notice_count( 'error' ) ) {
+			return;
+		}
+
+		$error_notices = wc_get_notices( 'error' );
+
+		foreach ( $error_notices as $error_notice ) {
+			throw new \Exception( $error_notice['notice'] );
+		}
 	}
 }


### PR DESCRIPTION
This PR will capture thrown notices from payment gateways and instead throw an exception that the API can pickup and expose. Notices are cleared during this process.

**To test**

Edit woo core `abstract-wc-payment-gateway.php` and make it always throw a notice:

```php
/**
	 * Validate frontend fields.
	 *
	 * Validate payment fields on the frontend.
	 *
	 * @return bool
	 */
	public function validate_fields() {
		wc_add_notice( 'Test Notice', 'error' );
		return true;
	}
```

Place an order using cheque via block checkout. You will see this notice above the checkout.