### PR TITLE
Coupon and Cart Item Validation Fixes

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -57,7 +57,7 @@ const CheckoutProcessor = () => {
 	const { hasValidationErrors } = useValidationContext();
 	const { shippingAddress, shippingErrorStatus } = useShippingDataContext();
 	const { billingData } = useBillingDataContext();
-	const { cartNeedsPayment } = useStoreCart();
+	const { cartNeedsPayment, receiveCart } = useStoreCart();
 	const {
 		activePaymentMethod,
 		currentStatus: currentPaymentStatus,
@@ -228,6 +228,10 @@ const CheckoutProcessor = () => {
 			} )
 			.catch( ( error ) => {
 				error.json().then( function( response ) {
+					// If updated cart state was returned, also update that.
+					if ( response.data?.cart ) {
+						receiveCart( response.data.cart );
+					}
 					dispatchActions.setHasError();
 					dispatchActions.setAfterProcessing( response );
 					setIsProcessingOrder( false );

--- a/assets/js/base/hooks/cart/test/use-store-cart.js
+++ b/assets/js/base/hooks/cart/test/use-store-cart.js
@@ -44,6 +44,7 @@ describe( 'useStoreCart', () => {
 		shippingRates: previewCart.shipping_rates,
 		shippingRatesLoading: false,
 		hasShippingAddress: false,
+		receiveCart: () => {},
 	};
 
 	const mockCartItems = [ { key: '1', id: 1, name: 'Lorem Ipsum' } ];
@@ -79,6 +80,7 @@ describe( 'useStoreCart', () => {
 		shippingRates: [],
 		shippingRatesLoading: false,
 		hasShippingAddress: false,
+		receiveCart: () => {},
 	};
 
 	const getWrappedComponents = ( Component ) => (
@@ -103,10 +105,14 @@ describe( 'useStoreCart', () => {
 					.mockReturnValue( ! mockCartIsLoading ),
 				areShippingRatesLoading: jest.fn().mockReturnValue( false ),
 			},
+			actions: {
+				receiveCart: () => {},
+			},
 		};
 		registry.registerStore( storeKey, {
 			reducer: () => ( {} ),
 			selectors: mocks.selectors,
+			actions: mocks.actions,
 		} );
 	};
 

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -83,7 +83,10 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 					shippingRates: previewCart.shipping_rates,
 					shippingRatesLoading: false,
 					hasShippingAddress: false,
-					receiveCart: () => {},
+					receiveCart:
+						typeof previewCart?.receiveCart === 'function'
+							? previewCart.receiveCart
+							: () => {},
 				};
 			}
 

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -36,6 +36,7 @@ export const defaultCartData = {
 	shippingRates: [],
 	shippingRatesLoading: false,
 	hasShippingAddress: false,
+	receiveCart: () => {},
 };
 
 /**
@@ -56,7 +57,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 	const { shouldSelect } = options;
 
 	const results = useSelect(
-		( select ) => {
+		( select, { dispatch } ) => {
 			if ( ! shouldSelect ) {
 				return defaultCartData;
 			}
@@ -82,6 +83,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 					shippingRates: previewCart.shipping_rates,
 					shippingRatesLoading: false,
 					hasShippingAddress: false,
+					receiveCart: () => {},
 				};
 			}
 
@@ -93,6 +95,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 				'getCartData'
 			);
 			const shippingRatesLoading = store.areShippingRatesLoading();
+			const { receiveCart } = dispatch( storeKey );
 
 			return {
 				cartCoupons: cartData.coupons,
@@ -109,6 +112,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 				shippingRates: cartData.shippingRates,
 				shippingRatesLoading,
 				hasShippingAddress: !! cartData.shippingAddress.country,
+				receiveCart,
 			};
 		},
 		[ shouldSelect ]

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -67,15 +67,14 @@ const Cart = ( { attributes } ) => {
 		appliedCoupons,
 	} = useStoreCartCoupons();
 
-	const { addErrorNotice, removeNotice } = useStoreNotices();
+	const { addErrorNotice } = useStoreNotices();
 
 	// Ensures any cart errors listed in the API response get shown.
 	useEffect( () => {
-		removeNotice( 'cart-item-error' );
 		cartItemErrors.forEach( ( error ) => {
 			addErrorNotice( decodeEntities( error.message ), {
-				isDismissible: false,
-				id: 'cart-item-error',
+				isDismissible: true,
+				id: error.code,
 			} );
 		} );
 	}, [ cartItemErrors ] );

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-error/constants.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-error/constants.js
@@ -5,3 +5,4 @@ export const PRODUCT_NOT_ENOUGH_STOCK =
 	'woocommerce_rest_cart_product_no_stock';
 export const PRODUCT_SOLD_INDIVIDUALLY =
 	'woocommerce_rest_cart_product_sold_individually';
+export const GENERIC_CART_ITEM_ERROR = 'woocommerce_rest_cart_item_error';

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
@@ -15,7 +15,16 @@ import {
 	PRODUCT_NOT_PURCHASABLE,
 	PRODUCT_NOT_ENOUGH_STOCK,
 	PRODUCT_SOLD_INDIVIDUALLY,
+	GENERIC_CART_ITEM_ERROR,
 } from './constants';
+
+const cartItemErrorCodes = [
+	PRODUCT_OUT_OF_STOCK,
+	PRODUCT_NOT_PURCHASABLE,
+	PRODUCT_NOT_ENOUGH_STOCK,
+	PRODUCT_SOLD_INDIVIDUALLY,
+	GENERIC_CART_ITEM_ERROR,
+];
 
 /**
  * When an order was not created for the checkout, for example, when an item
@@ -59,12 +68,7 @@ const CheckoutError = () => {
 const ErrorTitle = ( { errorData } ) => {
 	let heading = __( 'Checkout error', 'woo-gutenberg-products-block' );
 
-	if (
-		errorData.code === PRODUCT_NOT_ENOUGH_STOCK ||
-		errorData.code === PRODUCT_NOT_PURCHASABLE ||
-		errorData.code === PRODUCT_OUT_OF_STOCK ||
-		errorData.code === PRODUCT_SOLD_INDIVIDUALLY
-	) {
+	if ( cartItemErrorCodes.includes( errorData.code ) ) {
 		heading = __(
 			'There is a problem with your cart',
 			'woo-gutenberg-products-block'
@@ -84,12 +88,7 @@ const ErrorTitle = ( { errorData } ) => {
 const ErrorMessage = ( { errorData } ) => {
 	let message = errorData.message;
 
-	if (
-		errorData.code === PRODUCT_NOT_ENOUGH_STOCK ||
-		errorData.code === PRODUCT_NOT_PURCHASABLE ||
-		errorData.code === PRODUCT_OUT_OF_STOCK ||
-		errorData.code === PRODUCT_SOLD_INDIVIDUALLY
-	) {
+	if ( cartItemErrorCodes.includes( errorData.code ) ) {
 		message =
 			message +
 			' ' +
@@ -111,12 +110,7 @@ const ErrorButton = ( { errorData } ) => {
 	let buttonText = __( 'Retry', 'woo-gutenberg-products-block' );
 	let buttonUrl = 'javascript:window.location.reload(true)';
 
-	if (
-		errorData.code === PRODUCT_NOT_ENOUGH_STOCK ||
-		errorData.code === PRODUCT_NOT_PURCHASABLE ||
-		errorData.code === PRODUCT_OUT_OF_STOCK ||
-		errorData.code === PRODUCT_SOLD_INDIVIDUALLY
-	) {
+	if ( cartItemErrorCodes.includes( errorData.code ) ) {
 		buttonText = __( 'Edit your cart', 'woo-gutenberg-products-block' );
 		buttonUrl = CART_URL;
 	}

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
@@ -158,8 +158,8 @@ export const useCheckoutSubscriptions = (
 					messageContext: emitResponse.noticeContexts.PAYMENTS,
 				};
 			}
-			// leave for checkout to handle.
-			return null;
+			// so we don't break the observers.
+			return true;
 		};
 		const unsubscribeProcessing = eventRegistration.onPaymentProcessing(
 			onSubmit

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -34,6 +34,8 @@
  *                                                      being loaded.
  * @property {boolean}             hasShippingAddress   Whether or not the cart
  *                                                      has a shipping address yet.
+ * @property {function}            receiveCart          Dispatcher to receive
+ *                                                      updated cart.
  */
 
 /**

--- a/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
@@ -30,9 +30,10 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @param string $error_code String based error code.
 	 * @param string $error_message User facing error message.
 	 * @param int    $http_status_code HTTP status. Defaults to 500.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
 	 * @return \WP_Error WP Error object.
 	 */
-	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500 ) {
+	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
 		switch ( $http_status_code ) {
 			case 409:
 				// If there was a conflict, return the cart so the client can resolve it.
@@ -42,10 +43,13 @@ abstract class AbstractCartRoute extends AbstractRoute {
 				return new \WP_Error(
 					$error_code,
 					$error_message,
-					[
-						'status' => $http_status_code,
-						'cart'   => $this->schema->get_item_response( $cart ),
-					]
+					array_merge(
+						$additional_data,
+						[
+							'status' => $http_status_code,
+							'cart'   => $this->schema->get_item_response( $cart ),
+						]
+					)
 				);
 		}
 		return new \WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );

--- a/src/RestApi/StoreApi/Routes/AbstractRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractRoute.php
@@ -72,7 +72,7 @@ abstract class AbstractRoute implements RouteInterface {
 				$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
 			}
 		} catch ( RouteException $error ) {
-			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode() );
+			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
 			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
 		}
@@ -161,10 +161,11 @@ abstract class AbstractRoute implements RouteInterface {
 	 * @param string $error_code String based error code.
 	 * @param string $error_message User facing error message.
 	 * @param int    $http_status_code HTTP status. Defaults to 500.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
 	 * @return \WP_Error WP Error object.
 	 */
-	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500 ) {
-		return new \WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );
+	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
+		return new \WP_Error( $error_code, $error_message, array_merge( $additional_data, [ 'status' => $http_status_code ] ) );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Routes/Checkout.php
+++ b/src/RestApi/StoreApi/Routes/Checkout.php
@@ -200,6 +200,33 @@ class Checkout extends AbstractRoute {
 	}
 
 	/**
+	 * Get route response when something went wrong.
+	 *
+	 * @param string $error_code String based error code.
+	 * @param string $error_message User facing error message.
+	 * @param int    $http_status_code HTTP status. Defaults to 500.
+	 * @return \WP_Error WP Error object.
+	 */
+	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500 ) {
+		switch ( $http_status_code ) {
+			case 409:
+				// If there was a conflict, return the cart so the client can resolve it.
+				$controller = new CartController();
+				$cart       = $controller->get_cart_instance();
+
+				return new \WP_Error(
+					$error_code,
+					$error_message,
+					[
+						'status' => $http_status_code,
+						'cart'   => wc()->api->get_endpoint_data( '/wc/store/cart' ),
+					]
+				);
+		}
+		return new \WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );
+	}
+
+	/**
 	 * Gets draft order data from the customer session.
 	 *
 	 * @return array

--- a/src/RestApi/StoreApi/Routes/RouteException.php
+++ b/src/RestApi/StoreApi/Routes/RouteException.php
@@ -19,15 +19,23 @@ class RouteException extends \Exception {
 	public $error_code;
 
 	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
 	 * Setup exception.
 	 *
 	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
 	 * @param string $message          User-friendly translated error message, e.g. 'Product ID is invalid'.
 	 * @param int    $http_status_code Proper HTTP status code to respond with, e.g. 400.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
 	 */
-	public function __construct( $error_code, $message, $http_status_code = 400 ) {
-		$this->error_code = $error_code;
-
+	public function __construct( $error_code, $message, $http_status_code = 400, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->additional_data = array_filter( (array) $additional_data );
 		parent::__construct( $message, $http_status_code );
 	}
 
@@ -38,5 +46,14 @@ class RouteException extends \Exception {
 	 */
 	public function getErrorCode() {
 		return $this->error_code;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
 	}
 }

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -512,7 +512,7 @@ class CartController {
 		if ( ! $coupon->is_valid() ) {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
-				$coupon->get_error_message(),
+				wp_strip_all_tags( $coupon->get_error_message() ),
 				403
 			);
 		}
@@ -566,7 +566,7 @@ class CartController {
 		if ( ! $coupon->is_valid() ) {
 			wc()->cart->remove_coupon( $coupon->get_code() );
 			wc()->cart->calculate_totals();
-			throw new RouteException( 'woocommerce_rest_cart_coupon_error', $coupon->get_error_message(), 409 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_error', wp_strip_all_tags( $coupon->get_error_message() ), 409 );
 		}
 	}
 

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -51,7 +51,7 @@ class CartController {
 			$request['cart_item_data']
 		);
 
-		$this->validate_add_to_cart( $product, $request['quantity'] );
+		$this->validate_add_to_cart( $product, $request );
 
 		$existing_cart_id = wc()->cart->find_product_in_cart( $cart_id );
 

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\RouteException;
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\NoticeHandler;
 
 /**
  * Woo Cart Controller class.
@@ -43,64 +44,16 @@ class CartController {
 
 		$request = $this->filter_request_data( $this->parse_variation_data( $request ) );
 		$product = $this->get_product_for_cart( $request );
-
-		if ( $product->is_type( 'variation' ) ) {
-			$product_id   = $product->get_parent_id();
-			$variation_id = $product->get_id();
-		} else {
-			$product_id   = $product->get_id();
-			$variation_id = 0;
-		}
-
-		$cart_id          = wc()->cart->generate_cart_id(
-			$product_id,
-			$variation_id,
+		$cart_id = wc()->cart->generate_cart_id(
+			$this->get_product_id( $product ),
+			$this->get_variation_id( $product ),
 			$request['variation'],
 			$request['cart_item_data']
 		);
+
+		$this->validate_add_to_cart( $product, $request['quantity'] );
+
 		$existing_cart_id = wc()->cart->find_product_in_cart( $cart_id );
-
-		if ( ! $product->is_purchasable() ) {
-			throw new RouteException(
-				'woocommerce_rest_cart_product_is_not_purchasable',
-				sprintf(
-					/* translators: %s: product name */
-					__( '&quot;%s&quot; is not available for purchase.', 'woo-gutenberg-products-block' ),
-					$product->get_name()
-				),
-				403
-			);
-		}
-
-		if ( ! $product->is_in_stock() ) {
-			throw new RouteException(
-				'woocommerce_rest_cart_product_no_stock',
-				sprintf(
-					/* translators: %s: product name */
-					__( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'woo-gutenberg-products-block' ),
-					$product->get_name()
-				),
-				403
-			);
-		}
-
-		if ( $product->managing_stock() ) {
-			$qty_remaining = $this->get_remaining_stock_for_product( $product );
-			$qty_in_cart   = $this->get_product_quantity_in_cart( $product );
-
-			if ( $qty_remaining < $qty_in_cart + $request['quantity'] ) {
-				throw new RouteException(
-					'woocommerce_rest_cart_product_no_stock',
-					sprintf(
-						/* translators: 1: product name 2: quantity in stock */
-						__( 'You cannot add that amount of &quot;%1$s&quot; to the cart because there is not enough stock (%2$s remaining).', 'woo-gutenberg-products-block' ),
-						$product->get_name(),
-						wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product )
-					),
-					403
-				);
-			}
-		}
 
 		if ( $existing_cart_id ) {
 			if ( $product->is_sold_individually() ) {
@@ -125,8 +78,8 @@ class CartController {
 				$request['cart_item_data'],
 				array(
 					'key'          => $cart_id,
-					'product_id'   => $product_id,
-					'variation_id' => $variation_id,
+					'product_id'   => $this->get_product_id( $product ),
+					'variation_id' => $this->get_variation_id( $product ),
 					'variation'    => $request['variation'],
 					'quantity'     => $request['quantity'],
 					'data'         => $product,
@@ -141,9 +94,9 @@ class CartController {
 		do_action(
 			'woocommerce_add_to_cart',
 			$cart_id,
-			$product_id,
+			$this->get_product_id( $product ),
 			$request['quantity'],
-			$variation_id,
+			$this->get_variation_id( $product ),
 			$request['variation'],
 			$request['cart_item_data']
 		);
@@ -191,6 +144,83 @@ class CartController {
 	 * Validate all items in the cart and check for errors.
 	 *
 	 * @throws RouteException Exception if invalid data is detected.
+	 *
+	 * @param \WC_Product $product Product object associated with the cart item.
+	 * @param array       $request Add to cart request params.
+	 */
+	public function validate_add_to_cart( \WC_Product $product, $request ) {
+		if ( ! $product->is_purchasable() ) {
+			$this->throw_default_product_exception( $product );
+		}
+
+		if ( ! $product->is_in_stock() ) {
+			throw new RouteException(
+				'woocommerce_rest_cart_product_no_stock',
+				sprintf(
+					/* translators: %s: product name */
+					__( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'woo-gutenberg-products-block' ),
+					$product->get_name()
+				),
+				403
+			);
+		}
+
+		if ( $product->managing_stock() ) {
+			$qty_remaining = $this->get_remaining_stock_for_product( $product );
+			$qty_in_cart   = $this->get_product_quantity_in_cart( $product );
+
+			if ( $qty_remaining < $qty_in_cart + $request['quantity'] ) {
+				throw new RouteException(
+					'woocommerce_rest_cart_product_no_stock',
+					sprintf(
+						/* translators: 1: product name 2: quantity in stock */
+						__( 'You cannot add that amount of &quot;%1$s&quot; to the cart because there is not enough stock (%2$s remaining).', 'woo-gutenberg-products-block' ),
+						$product->get_name(),
+						wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product )
+					),
+					403
+				);
+			}
+		}
+
+		/**
+		 * Hook: woocommerce_add_to_cart_validation (legacy).
+		 *
+		 * Allow 3rd parties to validate if an item can be added to the cart. This is a legacy hook from Woo core.
+		 * This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture
+		 * notices and convert to exceptions instead.
+		 */
+		$passed_validation = apply_filters(
+			'woocommerce_add_to_cart_validation',
+			true,
+			$this->get_product_id( $product ),
+			$request['quantity'],
+			$this->get_variation_id( $product ),
+			$request['variation']
+		);
+
+		if ( ! $passed_validation ) {
+			// Validation did not pass - see if an error notice was thrown.
+			NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_add_to_cart_error' );
+
+			// If no notice was thrown, throw the default notice instead.
+			$this->throw_default_product_exception( $product );
+		}
+
+		/**
+		 * Fire action to validate add to cart. Functions hooking into this should throw an \Exception to prevent
+		 * add to cart from occuring.
+		 *
+		 * @param \WC_Product $product Product object being added to the cart.
+		 * @param array       $request Add to cart request params including id, quantity, and variation attributes.
+		 */
+		do_action( 'wooocommerce_store_api_validate_add_to_cart', $product, $request );
+	}
+
+	/**
+	 * Validate all items in the cart and check for errors.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
 	 */
 	public function validate_cart_items() {
 		$cart_items = $this->get_cart_items();
@@ -198,6 +228,16 @@ class CartController {
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
 			$this->validate_cart_item( $cart_item );
 		}
+
+		/**
+		 * Hook: woocommerce_check_cart_items
+		 *
+		 * Allow 3rd parties to validate cart items. This is a legacy hook from Woo core.
+		 * This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture
+		 * notices and convert to exceptions instead.
+		 */
+		do_action( 'woocommerce_check_cart_items' );
+		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_cart_item_error' );
 	}
 
 	/**
@@ -225,9 +265,9 @@ class CartController {
 	 *
 	 * @throws RouteException Exception if invalid data is detected.
 	 *
-	 * @param array $cart_item Cart item data.
+	 * @param array $cart_item Cart item array.
 	 */
-	protected function validate_cart_item( $cart_item ) {
+	public function validate_cart_item( $cart_item ) {
 		$product = $cart_item['data'];
 
 		if ( ! $product instanceof \WC_Product ) {
@@ -235,15 +275,7 @@ class CartController {
 		}
 
 		if ( ! $product->is_purchasable() ) {
-			throw new RouteException(
-				'woocommerce_rest_cart_product_is_not_purchasable',
-				sprintf(
-					/* translators: %s: product name */
-					__( '&quot;%s&quot; is not available for purchase.', 'woo-gutenberg-products-block' ),
-					$product->get_name()
-				),
-				403
-			);
+			$this->throw_default_product_exception( $product );
 		}
 
 		if ( $product->is_sold_individually() && $cart_item['quantity'] > 1 ) {
@@ -292,6 +324,15 @@ class CartController {
 				);
 			}
 		}
+
+		/**
+		 * Fire action to validate add to cart. Functions hooking into this should throw an \Exception to prevent
+		 * add to cart from occuring.
+		 *
+		 * @param \WC_Product $product Product object being added to the cart.
+		 * @param array       $cart_item Cart item array.
+		 */
+		do_action( 'wooocommerce_store_api_validate_cart_item', $product, $cart_item );
 	}
 
 	/**
@@ -306,54 +347,6 @@ class CartController {
 			$coupon = new \WC_Coupon( $code );
 			$this->validate_cart_coupon( $coupon );
 		}
-	}
-
-	/**
-	 * Validates an existing cart coupon and returns any errors.
-	 *
-	 * @throws RouteException Exception if invalid data is detected.
-	 *
-	 * @param \WC_Coupon $coupon Coupon object applied to the cart.
-	 */
-	protected function validate_cart_coupon( \WC_Coupon $coupon ) {
-		if ( ! $coupon->is_valid() ) {
-			wc()->cart->remove_coupon( $coupon->get_code() );
-			wc()->cart->calculate_totals();
-			throw new RouteException( 'woocommerce_rest_cart_coupon_error', $coupon->get_error_message(), 409 );
-		}
-	}
-
-	/**
-	 * Gets the qty of a product across line items.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return int
-	 */
-	protected function get_product_quantity_in_cart( $product ) {
-		$product_quantities = wc()->cart->get_cart_item_quantities();
-		$product_id         = $product->get_stock_managed_by_id();
-
-		return isset( $product_quantities[ $product_id ] ) ? $product_quantities[ $product_id ] : 0;
-	}
-
-	/**
-	 * Gets remaining stock for a product.
-	 *
-	 * @param \WC_Product $product Product object.
-	 * @return int
-	 */
-	protected function get_remaining_stock_for_product( $product ) {
-		// @todo Remove once min support for WC reaches 4.1.0.
-		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {
-			$reserve_stock_controller = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
-		} else {
-			$reserve_stock_controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ReserveStock();
-		}
-
-		$draft_order  = wc()->session->get( 'store_api_draft_order', 0 );
-		$qty_reserved = $reserve_stock_controller->get_reserved_stock( $product, $draft_order );
-
-		return $product->get_stock_quantity() - $qty_reserved;
 	}
 
 	/**
@@ -563,6 +556,54 @@ class CartController {
 	}
 
 	/**
+	 * Validates an existing cart coupon and returns any errors.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 *
+	 * @param \WC_Coupon $coupon Coupon object applied to the cart.
+	 */
+	protected function validate_cart_coupon( \WC_Coupon $coupon ) {
+		if ( ! $coupon->is_valid() ) {
+			wc()->cart->remove_coupon( $coupon->get_code() );
+			wc()->cart->calculate_totals();
+			throw new RouteException( 'woocommerce_rest_cart_coupon_error', $coupon->get_error_message(), 409 );
+		}
+	}
+
+	/**
+	 * Gets the qty of a product across line items.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return int
+	 */
+	protected function get_product_quantity_in_cart( $product ) {
+		$product_quantities = wc()->cart->get_cart_item_quantities();
+		$product_id         = $product->get_stock_managed_by_id();
+
+		return isset( $product_quantities[ $product_id ] ) ? $product_quantities[ $product_id ] : 0;
+	}
+
+	/**
+	 * Gets remaining stock for a product.
+	 *
+	 * @param \WC_Product $product Product object.
+	 * @return int
+	 */
+	protected function get_remaining_stock_for_product( $product ) {
+		// @todo Remove once min support for WC reaches 4.1.0.
+		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {
+			$reserve_stock_controller = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
+		} else {
+			$reserve_stock_controller = new \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\ReserveStock();
+		}
+
+		$draft_order  = wc()->session->get( 'store_api_draft_order', 0 );
+		$qty_reserved = $reserve_stock_controller->get_reserved_stock( $product, $draft_order );
+
+		return $product->get_stock_quantity() - $qty_reserved;
+	}
+
+	/**
 	 * Get a product object to be added to the cart.
 	 *
 	 * @throws RouteException Exception if invalid data is detected.
@@ -582,6 +623,45 @@ class CartController {
 		}
 
 		return $product;
+	}
+
+	/**
+	 * For a given product, get the product ID.
+	 *
+	 * @param \WC_Product $product Product object associated with the cart item.
+	 * @return int
+	 */
+	protected function get_product_id( \WC_Product $product ) {
+		return $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id();
+	}
+
+	/**
+	 * For a given product, get the variation ID.
+	 *
+	 * @param \WC_Product $product Product object associated with the cart item.
+	 * @return int
+	 */
+	protected function get_variation_id( \WC_Product $product ) {
+		return $product->is_type( 'variation' ) ? $product->get_id() : 0;
+	}
+
+	/**
+	 * Default exception thrown when an item cannot be added to the cart.
+	 *
+	 * @throws RouteException Exception with code woocommerce_rest_cart_product_is_not_purchasable.
+	 *
+	 * @param \WC_Product $product Product object associated with the cart item.
+	 */
+	protected function throw_default_product_exception( \WC_Product $product ) {
+		throw new RouteException(
+			'woocommerce_rest_cart_product_is_not_purchasable',
+			sprintf(
+				/* translators: %s: product name */
+				__( '&quot;%s&quot; is not available for purchase.', 'woo-gutenberg-products-block' ),
+				$product->get_name()
+			),
+			403
+		);
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -318,6 +318,7 @@ class CartController {
 	protected function validate_cart_coupon( \WC_Coupon $coupon ) {
 		if ( ! $coupon->is_valid() ) {
 			wc()->cart->remove_coupon( $coupon->get_code() );
+			wc()->cart->calculate_totals();
 			throw new RouteException( 'woocommerce_rest_cart_coupon_error', $coupon->get_error_message(), 409 );
 		}
 	}

--- a/src/RestApi/StoreApi/Utilities/NoticeHandler.php
+++ b/src/RestApi/StoreApi/Utilities/NoticeHandler.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Helper class to convert notices to exceptions.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities;
+
+defined( 'ABSPATH' ) || exit;
+
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes\RouteException;
+
+/**
+ * NoticeHandler class.
+ */
+class NoticeHandler {
+
+	/**
+	 * Convert queued error notices into an exception.
+	 *
+	 * For example, Payment methods may add error notices during validate_fields call to prevent checkout.
+	 * Since we're not rendering notices at all, we need to convert them to exceptions.
+	 *
+	 * This method will find the first error message and thrown an exception instead. Discards notices once complete.
+	 *
+	 * @throws RouteException If an error notice is detected, Exception is thrown.
+	 *
+	 * @param string $error_code Error code for the thrown exceptions.
+	 */
+	public static function convert_notices_to_exceptions( $error_code = 'unknown_server_error' ) {
+		if ( 0 === wc_notice_count( 'error' ) ) {
+			return;
+		}
+
+		$error_notices = wc_get_notices( 'error' );
+
+		// Prevent notices from being output later on.
+		wc_clear_notices();
+
+		foreach ( $error_notices as $error_notice ) {
+			throw new RouteException( $error_code, $error_notice['notice'], 400 );
+		}
+	}
+}

--- a/src/RestApi/StoreApi/Utilities/OrderController.php
+++ b/src/RestApi/StoreApi/Utilities/OrderController.php
@@ -113,10 +113,8 @@ class OrderController {
 	 */
 	protected function update_line_items_from_cart( \WC_Order $order ) {
 		$cart_controller = new CartController();
-		$cart_controller->validate_cart_items();
-
-		$cart        = $cart_controller->get_cart_instance();
-		$cart_hashes = $cart_controller->get_cart_hashes();
+		$cart            = $cart_controller->get_cart_instance();
+		$cart_hashes     = $cart_controller->get_cart_hashes();
 
 		if ( $order->get_cart_hash() !== $cart_hashes['line_items'] ) {
 			$order->remove_order_items( 'line_item' );

--- a/src/RestApi/StoreApi/Utilities/OrderController.php
+++ b/src/RestApi/StoreApi/Utilities/OrderController.php
@@ -106,21 +106,58 @@ class OrderController {
 	 *
 	 * @param \WC_Order $order Order object.
 	 */
-	public function validate_before_payment( \WC_Order $order ) {
+	public function validate_order_before_payment( \WC_Order $order ) {
 		$coupons = $order->get_coupon_codes();
+
+		$coupon_errors = [];
 
 		foreach ( $coupons as $coupon_code ) {
 			$coupon = new \WC_Coupon( $coupon_code );
 
-			$this->validate_coupon_email_restriction( $coupon, $order );
-			$this->validate_coupon_usage_limit( $coupon, $order );
+			try {
+				$this->validate_coupon_email_restriction( $coupon, $order );
+			} catch ( \Exception $error ) {
+				$coupon_errors[ $coupon_code ] = $error->getMessage();
+			}
+			try {
+				$this->validate_coupon_usage_limit( $coupon, $order );
+			} catch ( \Exception $error ) {
+				$coupon_errors[ $coupon_code ] = $error->getMessage();
+			}
+		}
+
+		if ( $coupon_errors ) {
+			// Remove all coupons that were not valid.
+			foreach ( $coupon_errors as $coupon_code => $message ) {
+				wc()->cart->remove_coupon( $coupon_code );
+			}
+
+			// Recalculate totals.
+			wc()->cart->calculate_totals();
+
+			// Re-sync order with cart.
+			$this->update_order_from_cart( $order );
+
+			// Return exception so customer can review before payment.
+			throw new RouteException(
+				'woocommerce_rest_cart_coupon_errors',
+				sprintf(
+					// Translators: %s Coupon codes.
+					__( 'Invalid coupons were removed from the cart: "%s"', 'woo-gutenberg-products-block' ),
+					implode( '", "', array_keys( $coupon_errors ) )
+				),
+				409,
+				[
+					'removed_coupons' => $coupon_errors,
+				]
+			);
 		}
 	}
 
 	/**
 	 * Check email restrictions of a coupon against the order.
 	 *
-	 * @throws RouteException Exception if invalid data is detected.
+	 * @throws \Exception Exception if invalid data is detected.
 	 *
 	 * @param \WC_Coupon $coupon Coupon object applied to the cart.
 	 * @param \WC_Order  $order Order object.
@@ -128,16 +165,15 @@ class OrderController {
 	protected function validate_coupon_email_restriction( \WC_Coupon $coupon, $order ) {
 		$restrictions = $coupon->get_email_restrictions();
 
-		if ( ! empty( $restrictions ) && ! wc()->cart->is_coupon_emails_allowed( [ $order->get_billing_email() ], $restrictions ) ) {
-			wc()->cart->remove_coupon( $coupon->get_code() );
-			throw new RouteException( 'woocommerce_rest_cart_coupon_error', $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED ), 409 );
+		if ( ! empty( $restrictions ) && $order->get_billing_email() && ! wc()->cart->is_coupon_emails_allowed( [ $order->get_billing_email() ], $restrictions ) ) {
+			throw new \Exception( $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED ) );
 		}
 	}
 
 	/**
 	 * Check usage restrictions of a coupon against the order.
 	 *
-	 * @throws RouteException Exception if invalid data is detected.
+	 * @throws \Exception Exception if invalid data is detected.
 	 *
 	 * @param \WC_Coupon $coupon Coupon object applied to the cart.
 	 * @param \WC_Order  $order Order object.
@@ -150,8 +186,7 @@ class OrderController {
 			$usage_count = $order->get_customer_id() ? $data_store->get_usage_by_user_id( $coupon, $order->get_customer_id() ) : $data_store->get_usage_by_email( $coupon, $order->get_billing_email() );
 
 			if ( $usage_count >= $coupon_usage_limit ) {
-				wc()->cart->remove_coupon( $coupon->get_code() );
-				throw new RouteException( 'woocommerce_rest_cart_coupon_error', $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED ), 409 );
+				throw new \Exception( $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED ) );
 			}
 		}
 	}
@@ -176,32 +211,32 @@ class OrderController {
 		$cart_hashes     = $cart_controller->get_cart_hashes();
 
 		if ( $order->get_cart_hash() !== $cart_hashes['line_items'] ) {
-			$order->remove_order_items( 'line_item' );
 			$order->set_cart_hash( $cart_hashes['line_items'] );
+			$order->remove_order_items( 'line_item' );
 			WC()->checkout->create_order_line_items( $order, $cart );
 		}
 
-		if ( $order->get_meta_data( 'shipping_hash' ) !== $cart_hashes['shipping'] ) {
+		if ( $order->get_meta_data( '_shipping_hash' ) !== $cart_hashes['shipping'] ) {
+			$order->update_meta_data( '_shipping_hash', $cart_hashes['shipping'] );
 			$order->remove_order_items( 'shipping' );
-			$order->update_meta_data( 'shipping_hash', $cart_hashes['shipping'] );
 			WC()->checkout->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping()->get_packages() );
 		}
 
-		if ( $order->get_meta_data( 'coupons_hash' ) !== $cart_hashes['coupons'] ) {
+		if ( $order->get_meta_data( '_coupons_hash' ) !== $cart_hashes['coupons'] ) {
 			$order->remove_order_items( 'coupon' );
-			$order->update_meta_data( 'coupons_hash', $cart_hashes['coupons'] );
+			$order->update_meta_data( '_coupons_hash', $cart_hashes['coupons'] );
 			WC()->checkout->create_order_coupon_lines( $order, $cart );
 		}
 
-		if ( $order->get_meta_data( 'fees_hash' ) !== $cart_hashes['fees'] ) {
+		if ( $order->get_meta_data( '_fees_hash' ) !== $cart_hashes['fees'] ) {
+			$order->update_meta_data( '_fees_hash', $cart_hashes['fees'] );
 			$order->remove_order_items( 'fee' );
-			$order->update_meta_data( 'fees_hash', $cart_hashes['fees'] );
 			WC()->checkout->create_order_fee_lines( $order, $cart );
 		}
 
-		if ( $order->get_meta_data( 'taxes_hash' ) !== $cart_hashes['taxes'] ) {
+		if ( $order->get_meta_data( '_taxes_hash' ) !== $cart_hashes['taxes'] ) {
+			$order->update_meta_data( '_taxes_hash', $cart_hashes['taxes'] );
 			$order->remove_order_items( 'tax' );
-			$order->update_meta_data( 'taxes_hash', $cart_hashes['taxes'] );
 			WC()->checkout->create_order_tax_lines( $order, $cart );
 		}
 	}


### PR DESCRIPTION
This PR has several fixes related to validation on the cart and checkout. It resolves the following bug reports:

_No validation when you created an email restricted coupon #2235_

Fixed by running late validation before payment. Payment is prevented, and restricted coupons are removed. This updates cart totals so the payment can be attempted again.

Fixes #2235

_Ensure our Add to Cart has parity with Core Add to Cart in term of filters #2218_

We were missing 2 general purpose filters from woo core that plugins use to run custom validation:

- `woocommerce_add_to_cart_validation`
- `woocommerce_check_cart_items`

I've added them to the API and included our Notice->Exception logic to avoid notices being added in the background.

Fixes #2218

_Coupons with restrictions are showing raw errors (HTML) when restrictions are not met. #2212_

All we get from core is a message; this is resolved by stripping HTML tags before providing the API response.

Fixes #2212

_Previously applied coupons that no longer meet criteria are still visible in cart (even if they do nothing) #2213_

We have logic in place to gather errors for cart items, so I added similar logic for coupons. The coupon is removed, and a notice is surfaced. To keep notices visible when doing lots of cart updates, I made it dismissable and prevented all notice being cleared after cart updates.

#2213

### How to test the changes in this Pull Request:

**Test case 1:**
1. Create a coupon with a min spend
2. Apply min spend coupon without meeting requirements. Check error message is correctly formatted.
3. Meet requirements by adding products to cart. Add coupon again.
4. Reduce cart qty until requires are not met again. Check notice is shown and the coupon is removed.

**Test case 2:**
1. Create a coupon with a usage restriction of `*@automattic.com`
2. Apply it.
3. Go to place an order without setting the billing email to an automattic address.
4. See error notice and cart removal. Cart totals should be correct.

**Test case 3:**
1. Create a product with a dependency using https://en-gb.wordpress.org/plugins/woocommerce-product-dependencies/
2. Try to add it to cart. Add to cart will fail. There is no notice because of https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2242

