### PR TITLE
Do not scroll to top when payment methods have an error

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -61,7 +61,6 @@ const CheckoutProcessor = () => {
 	const {
 		activePaymentMethod,
 		currentStatus: currentPaymentStatus,
-		errorMessage,
 		paymentMethodData,
 		expressPaymentMethods,
 		paymentMethods,
@@ -112,16 +111,6 @@ const CheckoutProcessor = () => {
 		currentShippingAddress.current = shippingAddress;
 		currentRedirectUrl.current = redirectUrl;
 	}, [ billingData, shippingAddress, redirectUrl ] );
-
-	useEffect( () => {
-		if ( errorMessage ) {
-			addErrorNotice( errorMessage, {
-				id: 'payment-method-error',
-			} );
-		} else {
-			removeNotice( 'payment-method-error' );
-		}
-	}, [ errorMessage ] );
 
 	const checkValidation = useCallback( () => {
 		if ( hasValidationErrors ) {

--- a/assets/js/base/hooks/use-store-notices.js
+++ b/assets/js/base/hooks/use-store-notices.js
@@ -34,6 +34,9 @@ export const useStoreNotices = () => {
 				void createNotice( 'success', text, {
 					...noticeProps,
 				} ),
+			hasNoticesOfType: ( type ) => {
+				return notices.some( ( notice ) => notice.type === type );
+			},
 			removeNotices: ( status = null ) => {
 				notices.map( ( notice ) => {
 					if ( status === null || notice.status === status ) {

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -30,7 +30,11 @@ import {
 	useValidationContext,
 	StoreNoticesProvider,
 } from '@woocommerce/base-context';
-import { useStoreCart, usePaymentMethods } from '@woocommerce/base-hooks';
+import {
+	useStoreCart,
+	usePaymentMethods,
+	useStoreNotices,
+} from '@woocommerce/base-hooks';
 import {
 	ExpressCheckoutFormControl,
 	PaymentMethods,
@@ -84,6 +88,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	} = useShippingDataContext();
 	const { billingData, setBillingData } = useBillingDataContext();
 	const { paymentMethods } = usePaymentMethods();
+	const { hasNoticesOfType } = useStoreNotices();
 
 	const [ shippingAsBilling, setShippingAsBilling ] = useState(
 		needsShipping
@@ -135,12 +140,15 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		}
 	}, [ shippingAsBilling, setBillingData ] );
 
+	const withNotices = hasNoticesOfType( 'default' );
 	useEffect( () => {
 		if ( checkoutIsIdle && checkoutHasError ) {
 			showAllValidationErrors();
-			scrollToTop( { focusableSelector: 'input:invalid' } );
+			if ( withNotices ) {
+				scrollToTop( { focusableSelector: 'input:invalid' } );
+			}
 		}
-	}, [ checkoutIsIdle, checkoutHasError ] );
+	}, [ checkoutIsIdle, checkoutHasError, withNotices ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -78,7 +78,10 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		isIdle: checkoutIsIdle,
 		isProcessing: checkoutIsProcessing,
 	} = useCheckoutContext();
-	const { showAllValidationErrors } = useValidationContext();
+	const {
+		hasValidationErrors,
+		showAllValidationErrors,
+	} = useValidationContext();
 	const {
 		shippingRates,
 		shippingRatesLoading,
@@ -140,15 +143,16 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		}
 	}, [ shippingAsBilling, setBillingData ] );
 
-	const withNotices = hasNoticesOfType( 'default' );
+	const hasErrorsToDisplay =
+		checkoutIsIdle &&
+		checkoutHasError &&
+		( hasValidationErrors || hasNoticesOfType( 'default' ) );
 	useEffect( () => {
-		if ( checkoutIsIdle && checkoutHasError ) {
+		if ( hasErrorsToDisplay ) {
 			showAllValidationErrors();
-			if ( withNotices ) {
-				scrollToTop( { focusableSelector: 'input:invalid' } );
-			}
+			scrollToTop( { focusableSelector: 'input:invalid' } );
 		}
-	}, [ checkoutIsIdle, checkoutHasError, withNotices ] );
+	}, [ hasErrorsToDisplay ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;


### PR DESCRIPTION
Fixes #2243.

### Screenshots
<img src="https://user-images.githubusercontent.com/3616980/79574064-e5c19780-80bf-11ea-8a2a-07aab64d0f4c.gif" alt="Screencast" width="518" />

### How to test the changes in this Pull Request:

1. Submit the _Checkout_ form without filling any input field and verify the errors appear and the page scrolled to the top.
2. Fill the form but leaving the card data empty and submit again. Verify the payment method errors appear but the page didn't scroll to the top.