### PR TITLE
Improvements to REST API performance

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -9,11 +9,6 @@ namespace Automattic\WooCommerce\Blocks;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
-use Automattic\WooCommerce\Blocks\Payments\PaymentContext;
-use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
-use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\NoticeHandler;
-
 /**
  * Library class.
  */
@@ -24,32 +19,12 @@ class Library {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
-		add_action( 'init', array( __CLASS__, 'register_payment_methods' ) );
-		add_action( 'init', array( __CLASS__, 'define_tables' ) );
 		add_action( 'init', array( __CLASS__, 'maybe_create_tables' ) );
 		add_action( 'init', array( __CLASS__, 'maybe_create_cronjobs' ) );
 		add_filter( 'wc_order_statuses', array( __CLASS__, 'register_draft_order_status' ) );
 		add_filter( 'woocommerce_register_shop_order_post_statuses', array( __CLASS__, 'register_draft_order_post_status' ) );
 		add_filter( 'woocommerce_valid_order_statuses_for_payment', array( __CLASS__, 'append_draft_order_post_status' ) );
 		add_action( 'woocommerce_cleanup_draft_orders', array( __CLASS__, 'delete_expired_draft_orders' ) );
-		add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( __CLASS__, 'process_legacy_payment' ), 999, 2 );
-	}
-
-	/**
-	 * Register custom tables within $wpdb object.
-	 */
-	public static function define_tables() {
-		global $wpdb;
-
-		// List of tables without prefixes.
-		$tables = array(
-			'wc_reserved_stock' => 'wc_reserved_stock',
-		);
-
-		foreach ( $tables as $name => $table ) {
-			$wpdb->$name    = $wpdb->prefix . $table;
-			$wpdb->tables[] = $table;
-		}
 	}
 
 	/**
@@ -141,13 +116,6 @@ class Library {
 	}
 
 	/**
-	 * Register payment methods.
-	 */
-	public static function register_payment_methods() {
-		Package::container()->get( PaymentMethodRegistry::class )->initialize();
-	}
-
-	/**
 	 * Register custom order status for orders created via the API during checkout.
 	 *
 	 * Draft order status is used before payment is attempted, during checkout, when a cart is converted to an order.
@@ -208,56 +176,5 @@ class Library {
 			AND posts.post_modified <= ( NOW() - INTERVAL 1 DAY )
 			"
 		);
-	}
-
-	/**
-	 * Attempt to process a payment for the checkout API if no payment methods support the
-	 * woocommerce_rest_checkout_process_payment_with_context action.
-	 *
-	 * @param PaymentContext $context Holds context for the payment.
-	 * @param PaymentResult  $result  Result of the payment.
-	 */
-	public static function process_legacy_payment( PaymentContext $context, PaymentResult &$result ) {
-		if ( $result->status ) {
-			return;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification
-		$post_data = $_POST;
-
-		// Set constants.
-		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
-
-		// Add the payment data from the API to the POST global.
-		$_POST = $context->payment_data;
-
-		// Call the process payment method of the chosen gatway.
-		$payment_method_object = $context->get_payment_method_instance();
-
-		if ( ! $payment_method_object instanceof \WC_Payment_Gateway ) {
-			return;
-		}
-
-		$payment_method_object->validate_fields();
-
-		// If errors were thrown, we need to abort.
-		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
-
-		// Process Payment.
-		$gateway_result = $payment_method_object->process_payment( $context->order->get_id() );
-
-		// Restore $_POST data.
-		$_POST = $post_data;
-
-		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
-		// and a generic notice will be shown instead if payment failed.
-		wc_clear_notices();
-
-		// Handle result.
-		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );
-
-		// set payment_details from result.
-		$result->set_payment_details( array_merge( $result->payment_details, $gateway_result ) );
-		$result->set_redirect_url( $gateway_result['redirect'] );
 	}
 }

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -109,19 +109,18 @@ class RestApi {
 	 * @return mixed
 	 */
 	public static function maybe_init_cart_session( $return ) {
-		$wc_instance = wc();
-		// if WooCommerce instance isn't available or already have an
-		// authentication error, just return.
-		if ( ! method_exists( $wc_instance, 'initialize_session' ) || \is_wp_error( $return ) || ! self::is_request_to_store_api() ) {
+		if ( ! function_exists( 'wc_load_cart' ) || \is_wp_error( $return ) || ! self::is_request_to_store_api() ) {
 			return $return;
 		}
-		$wc_instance->frontend_includes();
-		$wc_instance->initialize_session();
-		$wc_instance->initialize_cart();
+		// @todo Core should ensure these functions load with wc_load_cart() so we don't need to manually include.
+		include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
+		include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
 
-		// Ensure cart is up to date.
-		$wc_instance->cart->calculate_shipping();
-		$wc_instance->cart->calculate_totals();
+		// Initializes the cart and session.
+		wc_load_cart();
+
+		// @todo Core should also do this inside wc_load_cart so the cart is loaded from session.
+		wc()->cart->get_cart();
 
 		return $return;
 	}

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -11,6 +11,10 @@ defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController;
 use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController;
+use \Automattic\WooCommerce\Blocks\Payments\PaymentResult;
+use \Automattic\WooCommerce\Blocks\Payments\PaymentContext;
+use \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\NoticeHandler;
 
 /**
  * RestApi class.
@@ -24,6 +28,7 @@ class RestApi {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ), 10 );
 		add_filter( 'rest_authentication_errors', array( __CLASS__, 'maybe_init_cart_session' ), 1 );
 		add_filter( 'rest_authentication_errors', array( __CLASS__, 'store_api_authentication' ) );
+		add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( __CLASS__, 'process_legacy_payment' ), 999, 2 );
 	}
 
 	/**
@@ -136,5 +141,56 @@ class RestApi {
 			'variations'              => __NAMESPACE__ . '\RestApi\Controllers\Variations',
 			'product-reviews'         => __NAMESPACE__ . '\RestApi\Controllers\ProductReviews',
 		];
+	}
+
+	/**
+	 * Attempt to process a payment for the checkout API if no payment methods support the
+	 * woocommerce_rest_checkout_process_payment_with_context action.
+	 *
+	 * @param PaymentContext $context Holds context for the payment.
+	 * @param PaymentResult  $result  Result of the payment.
+	 */
+	public static function process_legacy_payment( PaymentContext $context, PaymentResult &$result ) {
+		if ( $result->status ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$post_data = $_POST;
+
+		// Set constants.
+		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+
+		// Add the payment data from the API to the POST global.
+		$_POST = $context->payment_data;
+
+		// Call the process payment method of the chosen gatway.
+		$payment_method_object = $context->get_payment_method_instance();
+
+		if ( ! $payment_method_object instanceof \WC_Payment_Gateway ) {
+			return;
+		}
+
+		$payment_method_object->validate_fields();
+
+		// If errors were thrown, we need to abort.
+		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
+
+		// Process Payment.
+		$gateway_result = $payment_method_object->process_payment( $context->order->get_id() );
+
+		// Restore $_POST data.
+		$_POST = $post_data;
+
+		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
+		// and a generic notice will be shown instead if payment failed.
+		wc_clear_notices();
+
+		// Handle result.
+		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );
+
+		// set payment_details from result.
+		$result->set_payment_details( array_merge( $result->payment_details, $gateway_result ) );
+		$result->set_redirect_url( $gateway_result['redirect'] );
 	}
 }

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -112,14 +112,14 @@ class RestApi {
 		if ( ! function_exists( 'wc_load_cart' ) || \is_wp_error( $return ) || ! self::is_request_to_store_api() ) {
 			return $return;
 		}
-		// @todo Core should ensure these functions load with wc_load_cart() so we don't need to manually include.
+		// @todo Core should ensure these functions load with wc_load_cart(). See https://github.com/woocommerce/woocommerce/pull/26219
 		include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
 		include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
 
 		// Initializes the cart and session.
 		wc_load_cart();
 
-		// @todo Core should also do this inside wc_load_cart so the cart is loaded from session.
+		// @todo Core should also do this inside wc_load_cart so the cart is loaded from session. See https://github.com/woocommerce/woocommerce/pull/26219
 		wc()->cart->get_cart();
 
 		return $return;

--- a/src/RestApi/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/RestApi/StoreApi/Routes/CartSelectShippingRate.php
@@ -80,6 +80,8 @@ class CartSelectShippingRate extends AbstractCartRoute {
 				throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
 			}
 		}
+
+		$cart->calculate_shipping();
 		$cart->calculate_totals();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/src/RestApi/StoreApi/Utilities/OrderController.php
+++ b/src/RestApi/StoreApi/Utilities/OrderController.php
@@ -50,6 +50,11 @@ class OrderController {
 	 * @param \WC_Order $order The order object to update.
 	 */
 	public function update_order_from_cart( \WC_Order $order ) {
+		// Ensure cart is current.
+		wc()->cart->calculate_shipping();
+		wc()->cart->calculate_totals();
+
+		// Update the current order to match the current cart.
 		$this->update_line_items_from_cart( $order );
 		$this->update_addresses_from_cart( $order );
 		$order->set_currency( get_woocommerce_currency() );


### PR DESCRIPTION
For me, this cut each request time down from around 4s to 2s.

Implements suggestion from #2043 and also changes when cart gets recalculated.

Needs smoke testing; I did a full add to cart to checkout flow to test, and I made sure I didn't regress https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2144

Closes #2043