### PR TITLE
Individually used coupons were not replacing other applied coupons

### DIFF
--- a/src/RestApi/StoreApi/Utilities/CartController.php
+++ b/src/RestApi/StoreApi/Utilities/CartController.php
@@ -568,6 +568,8 @@ class CartController {
 			foreach ( $coupons_to_remove as $code ) {
 				$cart->remove_coupon( $code );
 			}
+
+			$applied_coupons = array_diff( $applied_coupons, $coupons_to_remove );
 		}
 
 		$applied_coupons[] = $coupon_code;


### PR DESCRIPTION
When an individual use coupon is applied, it should replace and remove all other coupons currently in the cart. This logic was broken (the coupon was removed, then added again due to failing to update an array).

Fixes #2250

### How to test the changes in this Pull Request:

The testing instructions in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2250 are valid.