### PR TITLE
Fix snackbar being too high and covering coupon section

### DIFF
--- a/assets/js/base/components/store-notices-container/style.scss
+++ b/assets/js/base/components/store-notices-container/style.scss
@@ -27,8 +27,9 @@
 
 .components-snackbar-list {
 	position: fixed;
-	bottom: 100px;
-	left: 100px;
+	bottom: 40px;
+	left: 16px;
+	width: auto;
 
 	@include breakpoint( "<600px" ) {
 		position: fixed;

--- a/assets/js/base/components/store-notices-container/style.scss
+++ b/assets/js/base/components/store-notices-container/style.scss
@@ -27,20 +27,19 @@
 
 .components-snackbar-list {
 	position: fixed;
-	bottom: 40px;
+	bottom: 20px;
 	left: 16px;
 	width: auto;
 
-	@include breakpoint( "<600px" ) {
+	@include breakpoint( "<782px" ) {
 		position: fixed;
 		top: 10px;
 		left: 0;
 		bottom: auto;
-		width: fit-content;
 	}
 
 	.components-snackbar-list__notice-container {
-		@include breakpoint( "<600px" ) {
+		@include breakpoint( "<782px" ) {
 			margin-left: 10px;
 			margin-right: 10px;
 		}


### PR DESCRIPTION

<!-- Reference any related issues or PRs here -->
Fixes #2204

I reverted those values to same values Gutenberg set for notices, also, it applied 100% width, I removed that so it doesn't cover the coupon or button section.
![image](https://user-images.githubusercontent.com/6165348/79745116-7f2abc80-82ff-11ea-876f-96ebfd5442f2.png)

### How to test the changes in this Pull Request:

1. Make sure the snackbar looks good on mobile and desktop.
2. Make sure it doesn't cover the inputs to the right.
3. Make sure no regressions are created.
