### PR TITLE
Check for instance of WP_Block in render_callback

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -59,12 +59,12 @@ abstract class AbstractBlock {
 	/**
 	 * Append frontend scripts when rendering the block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
+	 * @param array|\WP_Block $attributes Block attributes, or an instance of a WP_Block. Defaults to an empty array.
+	 * @param string          $content    Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = [], $content = '' ) {
-		$this->enqueue_assets( $attributes );
+		$this->enqueue_assets( is_a( $attributes, '\WP_Block' ) ? $attributes->attributes : $attributes );
 		return $content;
 	}
 

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -44,13 +44,13 @@ class Cart extends AbstractBlock {
 	/**
 	 * Append frontend scripts when rendering the Cart block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
+	 * @param array|\WP_Block $attributes Block attributes, or an instance of a WP_Block. Defaults to an empty array.
+	 * @param string          $content    Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
-		$this->enqueue_assets( $attributes );
+		$this->enqueue_assets( is_a( $attributes, '\WP_Block' ) ? $attributes->attributes : $attributes );
 		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
 
 		// Add placeholder element to footer to push content for the sticky bar on mobile.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -45,8 +45,8 @@ class Checkout extends AbstractBlock {
 	/**
 	 * Append frontend scripts when rendering the block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
+	 * @param array|\WP_Block $attributes Block attributes, or an instance of a WP_Block. Defaults to an empty array.
+	 * @param string          $content    Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
 	public function render( $attributes = array(), $content = '' ) {
@@ -56,7 +56,7 @@ class Checkout extends AbstractBlock {
 			return '[woocommerce_checkout]';
 		}
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' );
-		$this->enqueue_assets( $attributes );
+		$this->enqueue_assets( is_a( $attributes, '\WP_Block' ) ? $attributes->attributes : $attributes );
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
 		return $content . $this->get_skeleton();
 	}


### PR DESCRIPTION
A recent change to https://github.com/WordPress/gutenberg/pull/21467 saw render_callback being passed a WP_Block instance instead of an array of attributes.

Since array_access could lead to conflicts if an attribute is named the same as a class variable within WP_Block, I think we can just see what we've been passed and handled accordingly.

Fixes #2257
