### PR TITLE
Improvements to REST API performance (2nd attempt)

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -12,13 +12,12 @@ use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\BackCompatAssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\PaymentMethodAssets;
-use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Library;
-use Automattic\WooCommerce\Blocks\Registry\Container;
-use Automattic\WooCommerce\Blocks\RestApi;
+use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Stripe;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Cheque;
-
+use Automattic\WooCommerce\Blocks\Registry\Container;
+use Automattic\WooCommerce\Blocks\RestApi;
 
 /**
  * Takes care of bootstrapping the plugin.
@@ -65,14 +64,40 @@ class Bootstrap {
 		}
 
 		$this->remove_core_blocks();
-
-		if ( ! $this->is_built() ) {
-			$this->add_build_notice();
-		}
-
+		$this->add_build_notice();
 		$this->define_feature_flag();
+		$this->define_tables();
 
-		// register core dependencies with the container.
+		Library::init();
+		RestApi::init();
+
+		if ( ! wc()->is_rest_api_request() ) {
+			$this->init_block_assets();
+			$this->init_payment_method_assets();
+			OldAssets::init();
+		}
+	}
+	/**
+	 * Define tables in $wpdb;
+	 */
+	protected function define_tables() {
+		global $wpdb;
+
+		// List of tables without prefixes.
+		$tables = array(
+			'wc_reserved_stock' => 'wc_reserved_stock',
+		);
+
+		foreach ( $tables as $name => $table ) {
+			$wpdb->$name    = $wpdb->prefix . $table;
+			$wpdb->tables[] = $table;
+		}
+	}
+
+	/**
+	 * Add asset classes to the container during init.
+	 */
+	protected function init_block_assets() {
 		$this->container->register(
 			AssetApi::class,
 			function ( Container $container ) {
@@ -90,6 +115,14 @@ class Bootstrap {
 					: new AssetDataRegistry( $asset_api );
 			}
 		);
+		// load AssetDataRegistry.
+		$this->container->get( AssetDataRegistry::class );
+	}
+
+	/**
+	 * Add payment method classes to the container during init.
+	 */
+	protected function init_payment_method_assets() {
 		$this->container->register(
 			PaymentMethodRegistry::class,
 			function( Container $container ) {
@@ -104,18 +137,10 @@ class Bootstrap {
 				return new PaymentMethodAssets( $payment_method_registry, $asset_data_registry );
 			}
 		);
-
-		// load AssetDataRegistry.
-		$this->container->get( AssetDataRegistry::class );
-
 		// load PaymentMethodAssets.
 		$this->container->get( PaymentMethodAssets::class );
 
 		$this->load_payment_method_integrations();
-
-		Library::init();
-		OldAssets::init();
-		RestApi::init();
 	}
 
 	/**
@@ -142,6 +167,9 @@ class Bootstrap {
 	 * Add a notice stating that the build has not been done yet.
 	 */
 	protected function add_build_notice() {
+		if ( $this->is_built() ) {
+			return;
+		}
 		add_action(
 			'admin_notices',
 			function() {
@@ -228,5 +256,6 @@ class Bootstrap {
 				);
 			}
 		);
+		add_action( 'init', [ $this->container->get( PaymentMethodRegistry::class ), 'initialize' ] );
 	}
 }

--- a/src/Library.php
+++ b/src/Library.php
@@ -9,11 +9,6 @@ namespace Automattic\WooCommerce\Blocks;
 
 defined( 'ABSPATH' ) || exit;
 
-use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
-use Automattic\WooCommerce\Blocks\Payments\PaymentContext;
-use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
-use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\NoticeHandler;
-
 /**
  * Library class.
  */
@@ -24,32 +19,12 @@ class Library {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
-		add_action( 'init', array( __CLASS__, 'register_payment_methods' ) );
-		add_action( 'init', array( __CLASS__, 'define_tables' ) );
 		add_action( 'init', array( __CLASS__, 'maybe_create_tables' ) );
 		add_action( 'init', array( __CLASS__, 'maybe_create_cronjobs' ) );
 		add_filter( 'wc_order_statuses', array( __CLASS__, 'register_draft_order_status' ) );
 		add_filter( 'woocommerce_register_shop_order_post_statuses', array( __CLASS__, 'register_draft_order_post_status' ) );
 		add_filter( 'woocommerce_valid_order_statuses_for_payment', array( __CLASS__, 'append_draft_order_post_status' ) );
 		add_action( 'woocommerce_cleanup_draft_orders', array( __CLASS__, 'delete_expired_draft_orders' ) );
-		add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( __CLASS__, 'process_legacy_payment' ), 999, 2 );
-	}
-
-	/**
-	 * Register custom tables within $wpdb object.
-	 */
-	public static function define_tables() {
-		global $wpdb;
-
-		// List of tables without prefixes.
-		$tables = array(
-			'wc_reserved_stock' => 'wc_reserved_stock',
-		);
-
-		foreach ( $tables as $name => $table ) {
-			$wpdb->$name    = $wpdb->prefix . $table;
-			$wpdb->tables[] = $table;
-		}
 	}
 
 	/**
@@ -138,13 +113,6 @@ class Library {
 	}
 
 	/**
-	 * Register payment methods.
-	 */
-	public static function register_payment_methods() {
-		Package::container()->get( PaymentMethodRegistry::class )->initialize();
-	}
-
-	/**
 	 * Register custom order status for orders created via the API during checkout.
 	 *
 	 * Draft order status is used before payment is attempted, during checkout, when a cart is converted to an order.
@@ -205,56 +173,5 @@ class Library {
 			AND posts.post_modified <= ( NOW() - INTERVAL 1 DAY )
 			"
 		);
-	}
-
-	/**
-	 * Attempt to process a payment for the checkout API if no payment methods support the
-	 * woocommerce_rest_checkout_process_payment_with_context action.
-	 *
-	 * @param PaymentContext $context Holds context for the payment.
-	 * @param PaymentResult  $result  Result of the payment.
-	 */
-	public static function process_legacy_payment( PaymentContext $context, PaymentResult &$result ) {
-		if ( $result->status ) {
-			return;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification
-		$post_data = $_POST;
-
-		// Set constants.
-		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
-
-		// Add the payment data from the API to the POST global.
-		$_POST = $context->payment_data;
-
-		// Call the process payment method of the chosen gatway.
-		$payment_method_object = $context->get_payment_method_instance();
-
-		if ( ! $payment_method_object instanceof \WC_Payment_Gateway ) {
-			return;
-		}
-
-		$payment_method_object->validate_fields();
-
-		// If errors were thrown, we need to abort.
-		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
-
-		// Process Payment.
-		$gateway_result = $payment_method_object->process_payment( $context->order->get_id() );
-
-		// Restore $_POST data.
-		$_POST = $post_data;
-
-		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
-		// and a generic notice will be shown instead if payment failed.
-		wc_clear_notices();
-
-		// Handle result.
-		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );
-
-		// set payment_details from result.
-		$result->set_payment_details( array_merge( $result->payment_details, $gateway_result ) );
-		$result->set_redirect_url( $gateway_result['redirect'] );
 	}
 }

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -11,6 +11,10 @@ defined( 'ABSPATH' ) || exit;
 
 use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\RoutesController;
 use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\SchemaController;
+use \Automattic\WooCommerce\Blocks\Payments\PaymentResult;
+use \Automattic\WooCommerce\Blocks\Payments\PaymentContext;
+use \Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use \Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\NoticeHandler;
 
 /**
  * RestApi class.
@@ -24,6 +28,7 @@ class RestApi {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_routes' ), 10 );
 		add_filter( 'rest_authentication_errors', array( __CLASS__, 'maybe_init_cart_session' ), 1 );
 		add_filter( 'rest_authentication_errors', array( __CLASS__, 'store_api_authentication' ) );
+		add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( __CLASS__, 'process_legacy_payment' ), 999, 2 );
 	}
 
 	/**
@@ -128,5 +133,56 @@ class RestApi {
 			'variations'              => __NAMESPACE__ . '\RestApi\Controllers\Variations',
 			'product-reviews'         => __NAMESPACE__ . '\RestApi\Controllers\ProductReviews',
 		];
+	}
+
+	/**
+	 * Attempt to process a payment for the checkout API if no payment methods support the
+	 * woocommerce_rest_checkout_process_payment_with_context action.
+	 *
+	 * @param PaymentContext $context Holds context for the payment.
+	 * @param PaymentResult  $result  Result of the payment.
+	 */
+	public static function process_legacy_payment( PaymentContext $context, PaymentResult &$result ) {
+		if ( $result->status ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$post_data = $_POST;
+
+		// Set constants.
+		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
+
+		// Add the payment data from the API to the POST global.
+		$_POST = $context->payment_data;
+
+		// Call the process payment method of the chosen gatway.
+		$payment_method_object = $context->get_payment_method_instance();
+
+		if ( ! $payment_method_object instanceof \WC_Payment_Gateway ) {
+			return;
+		}
+
+		$payment_method_object->validate_fields();
+
+		// If errors were thrown, we need to abort.
+		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
+
+		// Process Payment.
+		$gateway_result = $payment_method_object->process_payment( $context->order->get_id() );
+
+		// Restore $_POST data.
+		$_POST = $post_data;
+
+		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
+		// and a generic notice will be shown instead if payment failed.
+		wc_clear_notices();
+
+		// Handle result.
+		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );
+
+		// set payment_details from result.
+		$result->set_payment_details( array_merge( $result->payment_details, $gateway_result ) );
+		$result->set_redirect_url( $gateway_result['redirect'] );
 	}
 }


### PR DESCRIPTION
From https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2248

This had to be reverted because there were errors on publishing posts with blocks - it seems Gutenberg does make use of Rest APIs and some assets are needed there. This needs some additonal refactoring to be viable.