### PR TITLE
Checkout: Rename address2 attribute

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -12,7 +12,7 @@ const blockAttributes = {
 		type: 'boolean',
 		default: false,
 	},
-	showAddress2Field: {
+	showApartmentField: {
 		type: 'boolean',
 		default: true,
 	},

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -120,7 +120,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		},
 		address_2: {
 			...defaultAddressFields.address_2,
-			hidden: ! attributes.showAddress2Field,
+			hidden: ! attributes.showApartmentField,
 		},
 	};
 

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -37,7 +37,7 @@ import './editor.scss';
 const BlockSettings = ( { attributes, setAttributes } ) => {
 	const {
 		showCompanyField,
-		showAddress2Field,
+		showApartmentField,
 		showPhoneField,
 		requireCompanyField,
 		requirePhoneField,
@@ -122,10 +122,10 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						'Apartment, suite, etc.',
 						'woo-gutenberg-products-block'
 					) }
-					checked={ showAddress2Field }
+					checked={ showApartmentField }
 					onChange={ () =>
 						setAttributes( {
-							showAddress2Field: ! showAddress2Field,
+							showApartmentField: ! showApartmentField,
 						} )
 					}
 				/>

--- a/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
+++ b/tests/e2e-tests/specs/backend/__snapshots__/checkout.test.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Checkout Block can be created 1`] = `
 "<!-- wp:woocommerce/checkout -->
-<div class=\\"wp-block-woocommerce-checkout is-loading\\" data-show-company-field=\\"false\\" data-require-company-field=\\"false\\" data-show-address-2-field=\\"true\\" data-show-phone-field=\\"true\\" data-require-phone-field=\\"false\\" data-show-policy-links=\\"true\\" data-show-return-to-cart=\\"true\\" data-cart-page-id=\\"0\\"></div>
+<div class=\\"wp-block-woocommerce-checkout is-loading\\" data-show-company-field=\\"false\\" data-require-company-field=\\"false\\" data-show-apartment-field=\\"true\\" data-show-phone-field=\\"true\\" data-require-phone-field=\\"false\\" data-show-policy-links=\\"true\\" data-show-return-to-cart=\\"true\\" data-cart-page-id=\\"0\\"></div>
 <!-- /wp:woocommerce/checkout -->"
 `;


### PR DESCRIPTION
For some odd reason when `data-` attributes are converted to camelCase, numbers are handled differently. `data-show-address-2-field` becomes `showAddress-2Field` rather than the expected showAddress2Field`.

To fix this, renamed the attribute to showApartmentField`. _Note, this does invalidate blocks._

Fixes #2262

### How to test the changes in this Pull Request:

1. Create checkout block.
2. Toggle apartment field off.
3. Ensure it's not shown on the frontend.