### PR TITLE
Trigger fragment refresh after editing cart item quantities

### DIFF
--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -45,9 +45,6 @@ const ProductButton = ( { product, className } ) => {
 
 	const firstMount = useRef( true );
 
-	// This is a hack to trigger cart updates till we migrate to block based cart
-	// that relies on the store, see
-	// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
 	useEffect( () => {
 		// Avoid running on first mount when cart quantity is first set.
 		if ( firstMount.current ) {

--- a/assets/js/atomic/components/product/button/index.js
+++ b/assets/js/atomic/components/product/button/index.js
@@ -8,8 +8,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { useStoreAddToCart } from '@woocommerce/base-hooks';
 import { useProductLayoutContext } from '@woocommerce/base-context';
 import { decodeEntities } from '@wordpress/html-entities';
-
-const Event = window.Event || null;
+import { triggerFragmentRefresh } from '@woocommerce/base-utils';
 
 const ProductButton = ( { product, className } ) => {
 	const {
@@ -28,7 +27,6 @@ const ProductButton = ( { product, className } ) => {
 	} = useStoreAddToCart( id );
 	const { layoutStyleClassPrefix } = useProductLayoutContext();
 	const addedToCart = Number.isFinite( cartQuantity ) && cartQuantity > 0;
-	const firstMount = useRef( true );
 	const getButtonText = () => {
 		if ( addedToCart ) {
 			return sprintf(
@@ -45,26 +43,18 @@ const ProductButton = ( { product, className } ) => {
 		return decodeEntities( productCartDetails.text );
 	};
 
+	const firstMount = useRef( true );
+
 	// This is a hack to trigger cart updates till we migrate to block based cart
 	// that relies on the store, see
 	// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
 	useEffect( () => {
+		// Avoid running on first mount when cart quantity is first set.
 		if ( firstMount.current ) {
 			firstMount.current = false;
 			return;
 		}
-		// In IE, Event is an object and can't be instantiated with `new Event()`.
-		if ( typeof Event === 'function' ) {
-			const event = new Event( 'wc_fragment_refresh', {
-				bubbles: true,
-				cancelable: true,
-			} );
-			document.body.dispatchEvent( event );
-		} else {
-			const event = document.createEvent( 'Event' );
-			event.initEvent( 'wc_fragment_refresh', true, true );
-			document.body.dispatchEvent( event );
-		}
+		triggerFragmentRefresh();
 	}, [ cartQuantity ] );
 
 	const wrapperClasses = classnames(

--- a/assets/js/base/hooks/cart/use-store-cart-item-quantity.js
+++ b/assets/js/base/hooks/cart/use-store-cart-item-quantity.js
@@ -69,7 +69,11 @@ export const useStoreCartItemQuantity = ( cartItem ) => {
 	);
 
 	const removeItem = () => {
-		return cartItemKey ? removeItemFromCart( cartItemKey ) : false;
+		return cartItemKey
+			? removeItemFromCart( cartItemKey ).then( () => {
+					triggerFragmentRefresh();
+			  } )
+			: false;
 	};
 
 	// Observe debounced quantity value, fire action to update server on change.

--- a/assets/js/base/hooks/cart/use-store-cart-item-quantity.js
+++ b/assets/js/base/hooks/cart/use-store-cart-item-quantity.js
@@ -81,12 +81,7 @@ export const useStoreCartItemQuantity = ( cartItem ) => {
 		// Don't run it if quantity didn't change but it was set for the first time.
 		if ( cartItemKey && Number.isFinite( previousDebouncedQuantity ) ) {
 			changeCartItemQuantity( cartItemKey, debouncedQuantity ).then(
-				() => {
-					// This is a hack to trigger cart updates till we migrate to block based cart
-					// that relies on the store, see
-					// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
-					triggerFragmentRefresh();
-				}
+				triggerFragmentRefresh
 			);
 		}
 	}, [ debouncedQuantity, cartItemKey ] );

--- a/assets/js/base/utils/index.js
+++ b/assets/js/base/utils/index.js
@@ -2,3 +2,4 @@ export * from './errors';
 export * from './price';
 export * from './address';
 export * from './shipping-rates';
+export * from './legacy-events';

--- a/assets/js/base/utils/legacy-events.js
+++ b/assets/js/base/utils/legacy-events.js
@@ -1,0 +1,16 @@
+const Event = window.Event || null;
+
+export const triggerFragmentRefresh = () => {
+	// In IE, Event is an object and can't be instantiated with `new Event()`.
+	if ( typeof Event === 'function' ) {
+		const event = new Event( 'wc_fragment_refresh', {
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.body.dispatchEvent( event );
+	} else {
+		const event = document.createEvent( 'Event' );
+		event.initEvent( 'wc_fragment_refresh', true, true );
+		document.body.dispatchEvent( event );
+	}
+};

--- a/assets/js/base/utils/legacy-events.js
+++ b/assets/js/base/utils/legacy-events.js
@@ -1,5 +1,8 @@
 const Event = window.Event || null;
 
+// This is a hack to trigger cart updates till we migrate to block based cart
+// that relies on the store, see
+// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
 export const triggerFragmentRefresh = () => {
 	// In IE, Event is an object and can't be instantiated with `new Event()`.
 	if ( typeof Event === 'function' ) {


### PR DESCRIPTION
When a quantity changes, trigger fragment updates.

This borrows the approach from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1258/files but I made a shared util for them both to share.

Fixes #1834

### How to test the changes in this Pull Request:

1. Add cart widget to sidebar.
2. On a page *NOT* set to the core cart page, use a cart block.
3. View page. Update quantity of item in cart. The cart widget should refresh.