### PR TITLE
Decode billing address data from the server

### DIFF
--- a/assets/js/base/context/cart-checkout/billing/constants.js
+++ b/assets/js/base/context/cart-checkout/billing/constants.js
@@ -7,6 +7,8 @@
  * External dependencies
  */
 import { getSetting } from '@woocommerce/settings';
+import { mapValues } from 'lodash';
+import { decodeEntities } from '@wordpress/html-entities';
 
 const checkoutData = getSetting( 'checkoutData', {} );
 
@@ -28,12 +30,16 @@ export const DEFAULT_BILLING_DATA = {
 	shippingAsBilling: true,
 };
 
+const billingAddress = mapValues( checkoutData.billing_address, ( value ) =>
+	decodeEntities( value )
+);
+
 /**
  * @type {BillingData}
  */
 export const DEFAULT_STATE = {
 	...DEFAULT_BILLING_DATA,
-	...checkoutData.billing_address,
+	...billingAddress,
 };
 
 /**

--- a/assets/js/type-defs/billing.js
+++ b/assets/js/type-defs/billing.js
@@ -1,19 +1,19 @@
 /**
  * @typedef {Object} BillingData
  *
- * @property {string} email             The email for the billing address
- * @property {string} first_name        First name of billing customer
- * @property {string} last_name         Last name of billing customer
- * @property {string} company           Company name for the billing address
- * @property {string} address_1         First line of the billing address
- * @property {string} address_2         Second line of the billing address
- * @property {string} city              The city of the billing address
- * @property {string} state             The state of the billing address (ISO or name)
- * @property {string} postcode          The postal or zip code for the billing address
- * @property {string} country           The country for the billing address (ISO)
- * @property {string} phone             The phone number for the billing address
- * @property {string} shippingAsBilling Whether the shipping and billing
- *                                      address are the same.
+ * @property {string} email              The email for the billing address
+ * @property {string} first_name         First name of billing customer
+ * @property {string} last_name          Last name of billing customer
+ * @property {string} company            Company name for the billing address
+ * @property {string} address_1          First line of the billing address
+ * @property {string} address_2          Second line of the billing address
+ * @property {string} city               The city of the billing address
+ * @property {string} state              The state of the billing address (ISO or name)
+ * @property {string} postcode           The postal or zip code for the billing address
+ * @property {string} country            The country for the billing address (ISO)
+ * @property {string} phone              The phone number for the billing address
+ * @property {boolean} shippingAsBilling Whether the shipping and billing
+ *                                       address are the same.
  */
 
 export {};


### PR DESCRIPTION
Decodes billing address data loaded from the server.

Fixes #2263

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

See instructions in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2263
