### PR TITLE
Prevent All Products block from crashing when error has no json method

### DIFF
--- a/assets/js/data/shared-controls.js
+++ b/assets/js/data/shared-controls.js
@@ -35,10 +35,14 @@ export const controls = {
 					} );
 				} )
 				.catch( ( errorResponse ) => {
-					// Parse error response before rejecting it.
-					errorResponse.json().then( ( error ) => {
-						reject( error );
-					} );
+					if ( typeof errorResponse.json === 'function' ) {
+						// Parse error response before rejecting it.
+						errorResponse.json().then( ( error ) => {
+							reject( error );
+						} );
+					} else {
+						reject( errorResponse.message );
+					}
 				} );
 		} );
 	},


### PR DESCRIPTION
In some cases, the errors will not have the `json()` method so we should guard against that.

### How to test the changes in this Pull Request:

1. With your browser devtools, block requests that contain `/wc/store/products`.
2. Open a block with the _All Products_ block.
3. Verify the error boundary is shown (instead of the block silently failing and staying in a loading state).