### PR TITLE
Abstract Page selector and fix some issues in sidebar.

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -21,6 +21,7 @@ import {
 	CartProvider,
 } from '@woocommerce/base-context';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
+import { useRef } from '@wordpress/element';
 import { getAdminLink } from '@woocommerce/settings';
 import { previewCart, cartBlockPreview } from '@woocommerce/resource-previews';
 
@@ -38,6 +39,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		checkoutPageId,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
+	const { current: savedCheckoutPageId } = useRef( checkoutPageId );
 	return (
 		<InspectorControls>
 			{ currentPostId !== CART_PAGE_ID && (
@@ -107,7 +109,9 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					/>
 				</PanelBody>
 			) }
-			{ ! ( currentPostId === CART_PAGE_ID && checkoutPageId === 0 ) && (
+			{ ! (
+				currentPostId === CART_PAGE_ID && savedCheckoutPageId === 0
+			) && (
 				<PageSelector
 					pageId={ checkoutPageId }
 					setPageId={ ( id ) =>

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -107,21 +107,24 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					/>
 				</PanelBody>
 			) }
-			<PageSelector
-				pageId={ checkoutPageId }
-				setPageId={ ( id ) => setAttributes( { checkoutPageId: id } ) }
-				defaultPageId={ CART_PAGE_ID }
-				labels={ {
-					title: __(
-						'Proceed to Checkout button',
-						'woo-gutenberg-products-block'
-					),
-					default: __(
-						'WooCommerce Checkout Page',
-						'woo-gutenberg-products-block'
-					),
-				} }
-			/>
+			{ ! ( currentPostId === CART_PAGE_ID && checkoutPageId === 0 ) && (
+				<PageSelector
+					pageId={ checkoutPageId }
+					setPageId={ ( id ) =>
+						setAttributes( { checkoutPageId: id } )
+					}
+					labels={ {
+						title: __(
+							'Proceed to Checkout button',
+							'woo-gutenberg-products-block'
+						),
+						default: __(
+							'WooCommerce Checkout Page',
+							'woo-gutenberg-products-block'
+						),
+					} }
+				/>
+			) }
 			<FeedbackPrompt
 				text={ __(
 					'We are currently working on improving our cart and checkout blocks, providing merchants with the tools and customization options they need.',

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -38,7 +38,6 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		checkoutPageId,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
-
 	return (
 		<InspectorControls>
 			{ currentPostId !== CART_PAGE_ID && (
@@ -67,46 +66,50 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 				</Notice>
 			) }
-			<PanelBody
-				title={ __( 'Shipping rates', 'woo-gutenberg-products-block' ) }
-			>
-				<ToggleControl
-					label={ __(
-						'Shipping calculator',
+			{ SHIPPING_ENABLED && (
+				<PanelBody
+					title={ __(
+						'Shipping rates',
 						'woo-gutenberg-products-block'
 					) }
-					help={ __(
-						'Allow customers to estimate shipping by entering their address.',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ isShippingCalculatorEnabled }
-					onChange={ () =>
-						setAttributes( {
-							isShippingCalculatorEnabled: ! isShippingCalculatorEnabled,
-						} )
-					}
-				/>
-				<ToggleControl
-					label={ __(
-						'Hide shipping costs until an address is entered',
-						'woo-gutenberg-products-block'
-					) }
-					help={ __(
-						'If checked, shipping rates will be hidden until the customer uses the shipping calculator or enters their address during checkout.',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ isShippingCostHidden }
-					onChange={ () =>
-						setAttributes( {
-							isShippingCostHidden: ! isShippingCostHidden,
-						} )
-					}
-				/>
-			</PanelBody>
+				>
+					<ToggleControl
+						label={ __(
+							'Shipping calculator',
+							'woo-gutenberg-products-block'
+						) }
+						help={ __(
+							'Allow customers to estimate shipping by entering their address.',
+							'woo-gutenberg-products-block'
+						) }
+						checked={ isShippingCalculatorEnabled }
+						onChange={ () =>
+							setAttributes( {
+								isShippingCalculatorEnabled: ! isShippingCalculatorEnabled,
+							} )
+						}
+					/>
+					<ToggleControl
+						label={ __(
+							'Hide shipping costs until an address is entered',
+							'woo-gutenberg-products-block'
+						) }
+						help={ __(
+							'If checked, shipping rates will be hidden until the customer uses the shipping calculator or enters their address during checkout.',
+							'woo-gutenberg-products-block'
+						) }
+						checked={ isShippingCostHidden }
+						onChange={ () =>
+							setAttributes( {
+								isShippingCostHidden: ! isShippingCostHidden,
+							} )
+						}
+					/>
+				</PanelBody>
+			) }
 			<PageSelector
 				pageId={ checkoutPageId }
 				setPageId={ ( id ) => setAttributes( { checkoutPageId: id } ) }
-				defaultPageId={ CART_PAGE_ID }
 				labels={ {
 					title: __(
 						'Proceed to Checkout button',
@@ -172,21 +175,17 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 					>
 						{ currentView === 'full' && (
 							<>
-								{ SHIPPING_ENABLED && (
+								<EditorProvider previewData={ { previewCart } }>
 									<BlockSettings
 										attributes={ attributes }
 										setAttributes={ setAttributes }
 									/>
-								) }
-								<Disabled>
-									<EditorProvider
-										previewData={ { previewCart } }
-									>
+									<Disabled>
 										<CartProvider>
 											<Block attributes={ attributes } />
 										</CartProvider>
-									</EditorProvider>
-								</Disabled>
+									</Disabled>
+								</EditorProvider>
 							</>
 						) }
 						<EmptyCartEdit hidden={ currentView === 'full' } />

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -8,11 +8,11 @@ import {
 	Disabled,
 	PanelBody,
 	ToggleControl,
-	SelectControl,
 	Notice,
 } from '@wordpress/components';
 import PropTypes from 'prop-types';
 import ViewSwitcher from '@woocommerce/block-components/view-switcher';
+import PageSelector from '@woocommerce/block-components/page-selector';
 import { SHIPPING_ENABLED, CART_PAGE_ID } from '@woocommerce/block-settings';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import {
@@ -20,7 +20,6 @@ import {
 	useEditorContext,
 	CartProvider,
 } from '@woocommerce/base-context';
-import { useSelect } from '@wordpress/data';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import { getAdminLink } from '@woocommerce/settings';
 import { previewCart, cartBlockPreview } from '@woocommerce/resource-previews';
@@ -38,15 +37,6 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		isShippingCostHidden,
 		checkoutPageId,
 	} = attributes;
-	const pages =
-		useSelect( ( select ) => {
-			return select( 'core' ).getEntityRecords( 'postType', 'page', {
-				status: 'publish',
-				orderby: 'title',
-				order: 'asc',
-				per_page: 100,
-			} );
-		}, [] ) || null;
 	const { currentPostId } = useEditorContext();
 
 	return (
@@ -113,44 +103,21 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					}
 				/>
 			</PanelBody>
-			{ ( currentPostId !== CART_PAGE_ID || checkoutPageId ) && pages && (
-				<PanelBody
-					title={ __(
+			<PageSelector
+				pageId={ checkoutPageId }
+				setPageId={ ( id ) => setAttributes( { checkoutPageId: id } ) }
+				defaultPageId={ CART_PAGE_ID }
+				labels={ {
+					title: __(
 						'Proceed to Checkout button',
 						'woo-gutenberg-products-block'
-					) }
-				>
-					<SelectControl
-						label={ __(
-							'Link to',
-							'woo-gutenberg-products-block'
-						) }
-						value={ checkoutPageId }
-						options={ [
-							...[
-								{
-									label: __(
-										'WooCommerce Checkout Page',
-										'woo-gutenberg-products-block'
-									),
-									value: 0,
-								},
-							],
-							...Object.values( pages ).map( ( page ) => {
-								return {
-									label: page.title.raw,
-									value: parseInt( page.id, 10 ),
-								};
-							} ),
-						] }
-						onChange={ ( value ) =>
-							setAttributes( {
-								checkoutPageId: parseInt( value, 10 ),
-							} )
-						}
-					/>
-				</PanelBody>
-			) }
+					),
+					default: __(
+						'WooCommerce Checkout Page',
+						'woo-gutenberg-products-block'
+					),
+				} }
+			/>
 			<FeedbackPrompt
 				text={ __(
 					'We are currently working on improving our cart and checkout blocks, providing merchants with the tools and customization options they need.',

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -110,6 +110,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 			<PageSelector
 				pageId={ checkoutPageId }
 				setPageId={ ( id ) => setAttributes( { checkoutPageId: id } ) }
+				defaultPageId={ CART_PAGE_ID }
 				labels={ {
 					title: __(
 						'Proceed to Checkout button',

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -221,6 +221,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				<PageSelector
 					pageId={ cartPageId }
 					setPageId={ ( id ) => setAttributes( { cartPageId: id } ) }
+					defaultPageId={ CHECKOUT_PAGE_ID }
 					labels={ {
 						title: __(
 							'Return to Cart button',

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -217,23 +217,27 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					}
 				/>
 			</PanelBody>
-			{ showReturnToCart && (
-				<PageSelector
-					pageId={ cartPageId }
-					setPageId={ ( id ) => setAttributes( { cartPageId: id } ) }
-					defaultPageId={ CHECKOUT_PAGE_ID }
-					labels={ {
-						title: __(
-							'Return to Cart button',
-							'woo-gutenberg-products-block'
-						),
-						default: __(
-							'WooCommerce Cart Page',
-							'woo-gutenberg-products-block'
-						),
-					} }
-				/>
-			) }
+			{ showReturnToCart &&
+				! (
+					currentPostId === CHECKOUT_PAGE_ID && cartPageId === 0
+				) && (
+					<PageSelector
+						pageId={ cartPageId }
+						setPageId={ ( id ) =>
+							setAttributes( { cartPageId: id } )
+						}
+						labels={ {
+							title: __(
+								'Return to Cart button',
+								'woo-gutenberg-products-block'
+							),
+							default: __(
+								'WooCommerce Cart Page',
+								'woo-gutenberg-products-block'
+							),
+						} }
+					/>
+				) }
 
 			<FeedbackPrompt
 				text={ __(

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -221,7 +221,6 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				<PageSelector
 					pageId={ cartPageId }
 					setPageId={ ( id ) => setAttributes( { cartPageId: id } ) }
-					defaultPageId={ CHECKOUT_PAGE_ID }
 					labels={ {
 						title: __(
 							'Return to Cart button',

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -8,7 +8,6 @@ import {
 	PanelBody,
 	ToggleControl,
 	CheckboxControl,
-	SelectControl,
 	Notice,
 	Disabled,
 } from '@wordpress/components';
@@ -18,10 +17,10 @@ import {
 	TERMS_URL,
 	CHECKOUT_PAGE_ID,
 } from '@woocommerce/block-settings';
-import { useSelect } from '@wordpress/data';
 import { getAdminLink } from '@woocommerce/settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import { EditorProvider, useEditorContext } from '@woocommerce/base-context';
+import PageSelector from '@woocommerce/block-components/page-selector';
 import {
 	previewCart,
 	previewSavedPaymentMethods,
@@ -46,15 +45,6 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		cartPageId,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
-	const pages =
-		useSelect( ( select ) => {
-			return select( 'core' ).getEntityRecords( 'postType', 'page', {
-				status: 'publish',
-				orderby: 'title',
-				order: 'asc',
-				per_page: 100,
-			} );
-		}, [] ) || null;
 
 	return (
 		<InspectorControls>
@@ -226,40 +216,25 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						} )
 					}
 				/>
-				{ showReturnToCart &&
-					( currentPostId !== CHECKOUT_PAGE_ID || !! cartPageId ) &&
-					pages && (
-						<SelectControl
-							label={ __(
-								'Link to',
-								'woo-gutenberg-products-block'
-							) }
-							value={ cartPageId }
-							options={ [
-								...[
-									{
-										label: __(
-											'WooCommerce Cart Page',
-											'woo-gutenberg-products-block'
-										),
-										value: 0,
-									},
-								],
-								...Object.values( pages ).map( ( page ) => {
-									return {
-										label: page.title.raw,
-										value: parseInt( page.id, 10 ),
-									};
-								} ),
-							] }
-							onChange={ ( value ) =>
-								setAttributes( {
-									cartPageId: parseInt( value, 10 ),
-								} )
-							}
-						/>
-					) }
 			</PanelBody>
+			{ showReturnToCart && (
+				<PageSelector
+					pageId={ cartPageId }
+					setPageId={ ( id ) => setAttributes( { cartPageId: id } ) }
+					defaultPageId={ CHECKOUT_PAGE_ID }
+					labels={ {
+						title: __(
+							'Return to Cart button',
+							'woo-gutenberg-products-block'
+						),
+						default: __(
+							'WooCommerce Cart Page',
+							'woo-gutenberg-products-block'
+						),
+					} }
+				/>
+			) }
+
 			<FeedbackPrompt
 				text={ __(
 					'We are currently working on improving our cart and checkout blocks, providing merchants with the tools and customization options they need.',

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -19,6 +19,7 @@ import {
 } from '@woocommerce/block-settings';
 import { getAdminLink } from '@woocommerce/settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
+import { useRef } from '@wordpress/element';
 import { EditorProvider, useEditorContext } from '@woocommerce/base-context';
 import PageSelector from '@woocommerce/block-components/page-selector';
 import {
@@ -45,7 +46,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		cartPageId,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
-
+	const { current: savedCartPageId } = useRef( cartPageId );
 	return (
 		<InspectorControls>
 			{ currentPostId !== CHECKOUT_PAGE_ID && (
@@ -219,7 +220,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 			</PanelBody>
 			{ showReturnToCart &&
 				! (
-					currentPostId === CHECKOUT_PAGE_ID && cartPageId === 0
+					currentPostId === CHECKOUT_PAGE_ID && savedCartPageId === 0
 				) && (
 					<PageSelector
 						pageId={ cartPageId }

--- a/assets/js/blocks/cart-checkout/checkout/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/editor.scss
@@ -4,22 +4,21 @@
 		line-height: 24px;
 		margin: 0 $gap-small 0 0;
 	}
+}
+.wc-block-checkout__controls-text {
+	color: #999;
+	font-style: italic;
+}
 
-	.wc-block-checkout__controls-text {
-		color: #999;
-		font-style: italic;
-	}
+.components-base-control--nested {
+	padding-left: 52px;
+	margin-top: -12px;
+}
 
-	.components-base-control--nested {
-		padding-left: 52px;
-		margin-top: -12px;
-	}
+.wc-block-checkout__page-notice {
+	margin: 0;
+}
 
-	.wc-block-checkout__page-notice {
-		margin: 0;
-	}
-
-	.components-panel__body-title .components-button {
-		opacity: 1;
-	}
+.components-panel__body-title .components-button {
+	opacity: 1;
 }

--- a/assets/js/components/page-selector/index.js
+++ b/assets/js/components/page-selector/index.js
@@ -19,8 +19,6 @@ const PageSelector = ( { setPageId, pageId, labels } ) => {
 				per_page: 100,
 			} );
 		}, [] ) || null;
-	// We should not render this if this page is the default one page
-	// and the link to option is set to default.
 	if ( pages ) {
 		return (
 			<PanelBody title={ labels.title }>

--- a/assets/js/components/page-selector/index.js
+++ b/assets/js/components/page-selector/index.js
@@ -4,14 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { PanelBody, SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useEditorContext } from '@woocommerce/base-context';
 /**
  * Internal dependencies
  */
 import { formatTitle } from '../utils';
 
-const PageSelector = ( { setPageId, pageId, defaultPageId, labels } ) => {
-	const { currentPostId } = useEditorContext();
+const PageSelector = ( { setPageId, pageId, labels } ) => {
 	const pages =
 		useSelect( ( select ) => {
 			return select( 'core' ).getEntityRecords( 'postType', 'page', {
@@ -23,7 +21,7 @@ const PageSelector = ( { setPageId, pageId, defaultPageId, labels } ) => {
 		}, [] ) || null;
 	// We should not render this if this page is the default one page
 	// and the link to option is set to default.
-	if ( ! ( currentPostId === defaultPageId && pageId === 0 ) && pages ) {
+	if ( pages ) {
 		return (
 			<PanelBody title={ labels.title }>
 				<SelectControl

--- a/assets/js/components/page-selector/index.js
+++ b/assets/js/components/page-selector/index.js
@@ -4,15 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { PanelBody, SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useEditorContext } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
  */
 import { formatTitle } from '../utils';
 
-const PageSelector = ( { setPageId, pageId, defaultPageId, labels } ) => {
-	const { currentPostId } = useEditorContext();
+const PageSelector = ( { setPageId, pageId, labels } ) => {
 	const pages =
 		useSelect( ( select ) => {
 			return select( 'core' ).getEntityRecords( 'postType', 'page', {
@@ -22,7 +20,7 @@ const PageSelector = ( { setPageId, pageId, defaultPageId, labels } ) => {
 				per_page: 100,
 			} );
 		}, [] ) || null;
-	if ( ( currentPostId !== defaultPageId || pageId ) && pages ) {
+	if ( pages ) {
 		return (
 			<PanelBody title={ labels.title }>
 				<SelectControl

--- a/assets/js/components/page-selector/index.js
+++ b/assets/js/components/page-selector/index.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useEditorContext } from '@woocommerce/base-context';
+
+/**
+ * Internal dependencies
+ */
+import { formatTitle } from '../utils';
+
+const PageSelector = ( { setPageId, pageId, defaultPageId, labels } ) => {
+	const { currentPostId } = useEditorContext();
+	const pages =
+		useSelect( ( select ) => {
+			return select( 'core' ).getEntityRecords( 'postType', 'page', {
+				status: 'publish',
+				orderby: 'title',
+				order: 'asc',
+				per_page: 100,
+			} );
+		}, [] ) || null;
+	if ( ( currentPostId !== defaultPageId || pageId ) && pages ) {
+		return (
+			<PanelBody title={ labels.title }>
+				<SelectControl
+					label={ __( 'Link to', 'woo-gutenberg-products-block' ) }
+					value={ pageId }
+					options={ [
+						{
+							label: labels.default,
+							value: 0,
+						},
+						...pages.map( ( page ) => {
+							return {
+								label: formatTitle( page, pages ),
+								value: parseInt( page.id, 10 ),
+							};
+						} ),
+					] }
+					onChange={ ( value ) => setPageId( parseInt( value, 10 ) ) }
+				/>
+			</PanelBody>
+		);
+	}
+	return null;
+};
+
+export default PageSelector;

--- a/assets/js/components/page-selector/index.js
+++ b/assets/js/components/page-selector/index.js
@@ -4,13 +4,14 @@
 import { __ } from '@wordpress/i18n';
 import { PanelBody, SelectControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-
+import { useEditorContext } from '@woocommerce/base-context';
 /**
  * Internal dependencies
  */
 import { formatTitle } from '../utils';
 
-const PageSelector = ( { setPageId, pageId, labels } ) => {
+const PageSelector = ( { setPageId, pageId, defaultPageId, labels } ) => {
+	const { currentPostId } = useEditorContext();
 	const pages =
 		useSelect( ( select ) => {
 			return select( 'core' ).getEntityRecords( 'postType', 'page', {
@@ -20,7 +21,9 @@ const PageSelector = ( { setPageId, pageId, labels } ) => {
 				per_page: 100,
 			} );
 		}, [] ) || null;
-	if ( pages ) {
+	// We should not render this if this page is the default one page
+	// and the link to option is set to default.
+	if ( ! ( currentPostId === defaultPageId && pageId === 0 ) && pages ) {
 		return (
 			<PanelBody title={ labels.title }>
 				<SelectControl

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -192,7 +192,7 @@ export const formatTitle = ( page, pages ) => {
 	if ( ! page.title.raw ) {
 		return page.slug;
 	}
-	const hasSimilar =
-		pages.filter( ( p ) => p.title.raw === page.title.raw ).length > 1;
-	return page.title.raw + ( hasSimilar ? ` - ${ page.slug }` : '' );
+	const isUnique =
+		pages.filter( ( p ) => p.title.raw === page.title.raw ).length === 1;
+	return page.title.raw + ( ! isUnique ? ` - ${ page.slug }` : '' );
 };

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -177,3 +177,22 @@ export const getTerms = ( attribute ) => {
 		),
 	} );
 };
+
+/**
+ * Given a page object and an array of page, format the title.
+ *
+ * @param  {Object} page           Page object.
+ * @param  {Object} page.title     Page title object.
+ * @param  {string} page.title.raw Page title.
+ * @param  {string} page.slug      Page slug.
+ * @param  {Array}  pages          Array of all pages.
+ * @return {string}                Formatted page title to display.
+ */
+export const formatTitle = ( page, pages ) => {
+	if ( ! page.title.raw ) {
+		return page.slug;
+	}
+	const hasSimilar =
+		pages.filter( ( p ) => p.title.raw === page.title.raw ).length > 1;
+	return page.title.raw + ( hasSimilar ? ` - ${ page.slug }` : '' );
+};


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Page selector will now show the page slug if the page title is not set, and will show the page title - page slug if other pages has the same name.

Moves the page selector component in Cart and Checkout blocks to its own component.
Fixes a bug that kept the "set this page as your default" notice even if it was set (context always retuned 0 for current post).
![image](https://user-images.githubusercontent.com/6165348/79889696-589b7d00-83f6-11ea-96c4-bd59102fbc6d.png)
Fixing that unveiled another bug in the page selector condition logic, so it was removed:
The condition would not show the proceed to checkout button (or cart) if:
- The current page is the default Cart page (or checkout) and the select value is 0 (the default value), this was not spotted because the current page ID always retuned 0 because it was being called outside the context.

Some styles didn't apply to the checkout options because they were wrapped in a `.editor-styles-wrapper` which only applies to the editor content, not the sidebar.


<!-- Reference any related issues or PRs here -->
Fixes #2192 
Fixes #2193


### How to test the changes in this Pull Request:

1. Make sure the select page still shows.
2. Make sure they save correctly.
3.
