### PR TITLE
Fixes to totals recalculation and taxes

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import { TAXES_ENABLED } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -11,6 +12,10 @@ import TotalsItem from '../totals-item';
 
 const TotalsTaxesItem = ( { currency, values } ) => {
 	const { total_tax: totalTax } = values;
+
+	if ( ! TAXES_ENABLED ) {
+		return null;
+	}
 
 	return (
 		<TotalsItem

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -26,6 +26,7 @@ export const HAS_TAGS = getSetting( 'hasTags', true );
 export const HOME_URL = getSetting( 'homeUrl', '' );
 export const COUPONS_ENABLED = getSetting( 'couponsEnabled', true );
 export const SHIPPING_ENABLED = getSetting( 'shippingEnabled', true );
+export const TAXES_ENABLED = getSetting( 'taxesEnabled', true );
 export const DISPLAY_SHOP_PRICES_INCLUDING_TAX = getSetting(
 	'displayShopPricesIncludingTax',
 	false

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -127,6 +127,7 @@ class Assets {
 				'isLargeCatalog'                => $product_counts->publish > 100,
 				'limitTags'                     => $tag_count > 100,
 				'hasTags'                       => $tag_count > 0,
+				'taxesEnabled'                  => wc_tax_enabled(),
 				'couponsEnabled'                => wc_coupons_enabled(),
 				'shippingEnabled'               => wc_shipping_enabled(),
 				'displayShopPricesIncludingTax' => 'incl' === get_option( 'woocommerce_tax_display_shop' ),

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -104,20 +104,12 @@ class RestApi {
 	 * @return mixed
 	 */
 	public static function maybe_init_cart_session( $return ) {
-		$wc_instance = wc();
-		// if WooCommerce instance isn't available or already have an
-		// authentication error, just return.
-		if ( ! method_exists( $wc_instance, 'initialize_session' ) || \is_wp_error( $return ) || ! self::is_request_to_store_api() ) {
-			return $return;
+		if ( function_exists( 'wc_load_cart' ) && ! \is_wp_error( $return ) && self::is_request_to_store_api() ) {
+			// @todo Load Dependencies for wc_load_cart(). See https://github.com/woocommerce/woocommerce/pull/26219
+			include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
+			include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
+			wc_load_cart();
 		}
-		$wc_instance->frontend_includes();
-		$wc_instance->initialize_session();
-		$wc_instance->initialize_cart();
-
-		// Ensure cart is up to date.
-		$wc_instance->cart->calculate_shipping();
-		$wc_instance->cart->calculate_totals();
-
 		return $return;
 	}
 

--- a/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
@@ -10,6 +10,7 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\AbstractSchema;
 
 /**
  * Cart class.
@@ -22,6 +23,39 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 */
 	public function get_namespace() {
 		return 'wc/store';
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AbstractSchema $schema Schema class for this route.
+	 */
+	public function __construct( AbstractSchema $schema ) {
+		$this->schema = $schema;
+		$this->maybe_recalculate_totals();
+	}
+
+	/**
+	 * If shipping/tax data has changed on the server since last calculation, trigger a recalculation now.
+	 *
+	 * @return void
+	 */
+	protected function maybe_recalculate_totals() {
+		$current_hash = wc()->session->get( 'store_api_calculation_hash', '' );
+		$new_hash     = md5(
+			wp_json_encode(
+				[
+					\WC_Cache_Helper::get_transient_version( 'shipping' ),
+					wc()->cart->get_cart_hash(),
+				]
+			)
+		);
+		if ( ! hash_equals( $current_hash, $new_hash ) ) {
+			wc()->session->set( 'store_api_calculation_hash', $new_hash );
+			wc()->cart->get_cart();
+			wc()->cart->calculate_shipping();
+			wc()->cart->calculate_totals();
+		}
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
@@ -10,7 +10,6 @@ namespace Automattic\WooCommerce\Blocks\RestApi\StoreApi\Routes;
 defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Utilities\CartController;
-use Automattic\WooCommerce\Blocks\RestApi\StoreApi\Schemas\AbstractSchema;
 
 /**
  * Cart class.

--- a/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/RestApi/StoreApi/Routes/AbstractCartRoute.php
@@ -26,13 +26,14 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	}
 
 	/**
-	 * Constructor.
+	 * Get the route response based on the type of request.
 	 *
-	 * @param AbstractSchema $schema Schema class for this route.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_Error|\WP_REST_Response
 	 */
-	public function __construct( AbstractSchema $schema ) {
-		$this->schema = $schema;
+	public function get_response( \WP_REST_Request $request ) {
 		$this->maybe_recalculate_totals();
+		return parent::get_response( $request );
 	}
 
 	/**

--- a/src/RestApi/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/RestApi/StoreApi/Routes/CartSelectShippingRate.php
@@ -80,6 +80,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 				throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
 			}
 		}
+		$cart->calculate_shipping();
 		$cart->calculate_totals();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/src/RestApi/StoreApi/Routes/CartUpdateShipping.php
+++ b/src/RestApi/StoreApi/Routes/CartUpdateShipping.php
@@ -125,7 +125,7 @@ class CartUpdateShipping extends AbstractRoute {
 		$request    = $this->validate_shipping_address( $request );
 
 		// Update customer session.
-		WC()->customer->set_props(
+		wc()->customer->set_props(
 			array(
 				'shipping_first_name' => isset( $request['first_name'] ) ? $request['first_name'] : null,
 				'shipping_last_name'  => isset( $request['last_name'] ) ? $request['last_name'] : null,
@@ -137,7 +137,7 @@ class CartUpdateShipping extends AbstractRoute {
 				'shipping_address_2'  => isset( $request['address_2'] ) ? $request['address_2'] : null,
 			)
 		);
-		WC()->customer->save();
+		wc()->customer->save();
 
 		$cart->calculate_shipping();
 		$cart->calculate_totals();
@@ -153,7 +153,7 @@ class CartUpdateShipping extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	public function validate_shipping_address( $request ) {
-		$valid_countries = WC()->countries->get_shipping_countries();
+		$valid_countries = wc()->countries->get_shipping_countries();
 
 		if ( empty( $request['country'] ) ) {
 			throw new RouteException(
@@ -188,7 +188,7 @@ class CartUpdateShipping extends AbstractRoute {
 		$request['postcode'] = $request['postcode'] ? wc_format_postcode( $request['postcode'], $request['country'] ) : null;
 
 		if ( ! empty( $request['state'] ) ) {
-			$valid_states = WC()->countries->get_states( $request['country'] );
+			$valid_states = wc()->countries->get_states( $request['country'] );
 
 			if ( is_array( $valid_states ) && count( $valid_states ) > 0 ) {
 				$valid_state_values = array_map( 'wc_strtoupper', array_flip( array_map( 'wc_strtoupper', $valid_states ) ) );

--- a/src/RestApi/StoreApi/Routes/Checkout.php
+++ b/src/RestApi/StoreApi/Routes/Checkout.php
@@ -244,7 +244,7 @@ class Checkout extends AbstractRoute {
 	 * @return array
 	 */
 	protected function get_draft_order_id() {
-		return WC()->session->get( 'store_api_draft_order', 0 );
+		return wc()->session->get( 'store_api_draft_order', 0 );
 	}
 
 	/**
@@ -253,7 +253,7 @@ class Checkout extends AbstractRoute {
 	 * @param integer $order_id Draft order ID.
 	 */
 	protected function set_draft_order_id( $order_id ) {
-		WC()->session->set( 'store_api_draft_order', $order_id );
+		wc()->session->set( 'store_api_draft_order', $order_id );
 	}
 
 	/**
@@ -275,7 +275,7 @@ class Checkout extends AbstractRoute {
 		}
 
 		// Pending and failed orders can be retried if the cart hasn't changed.
-		if ( $draft_order_object->needs_payment() && $draft_order_object->has_cart_hash( WC()->cart->get_cart_hash() ) ) {
+		if ( $draft_order_object->needs_payment() && $draft_order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
 			return $draft_order_object;
 		}
 
@@ -427,7 +427,7 @@ class Checkout extends AbstractRoute {
 		$payment_method = isset( $request['payment_method'] )
 			? wc_clean( wp_unslash( $request['payment_method'] ) )
 			: '';
-		$valid_methods  = WC()->payment_gateways->get_payment_gateway_ids();
+		$valid_methods  = wc()->payment_gateways->get_payment_gateway_ids();
 
 		if ( empty( $payment_method ) ) {
 			throw new RouteException(
@@ -461,7 +461,7 @@ class Checkout extends AbstractRoute {
 	 */
 	protected function get_request_payment_method( \WP_REST_Request $request ) {
 		$payment_method        = $this->get_request_payment_method_id( $request );
-		$gateways              = WC()->payment_gateways->payment_gateways();
+		$gateways              = wc()->payment_gateways->payment_gateways();
 		$payment_method_object = isset( $gateways[ $payment_method ] ) ? $gateways[ $payment_method ] : false;
 
 		// The abstract gateway is available method uses the cart global, so instead, check enabled directly.

--- a/src/RestApi/StoreApi/Schemas/CartItemSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartItemSchema.php
@@ -400,7 +400,7 @@ class CartItemSchema extends ProductSchema {
 			return null;
 		}
 
-		$draft_order = WC()->session->get( 'store_api_draft_order', 0 );
+		$draft_order = wc()->session->get( 'store_api_draft_order', 0 );
 
 		// @todo Remove once min support for WC reaches 4.1.0.
 		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {

--- a/src/RestApi/StoreApi/Schemas/CartSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartSchema.php
@@ -275,7 +275,7 @@ class CartSchema extends AbstractSchema {
 		return [
 			'coupons'          => array_values( array_map( [ $this->coupon_schema, 'get_item_response' ], array_filter( $cart->get_applied_coupons() ) ) ),
 			'shipping_rates'   => array_values( array_map( [ $this->shipping_rate_schema, 'get_item_response' ], $controller->get_shipping_packages() ) ),
-			'shipping_address' => $this->shipping_address_schema->get_item_response( WC()->customer ),
+			'shipping_address' => $this->shipping_address_schema->get_item_response( wc()->customer ),
 			'items'            => array_values( array_map( [ $this->item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
 			'items_count'      => $cart->get_cart_contents_count(),
 			'items_weight'     => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),

--- a/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/RestApi/StoreApi/Schemas/CartShippingRateSchema.php
@@ -268,7 +268,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	protected function prepare_rates_response( $package ) {
 		$rates          = $package['rates'];
-		$selected_rates = WC()->session->get( 'chosen_shipping_methods', array() );
+		$selected_rates = wc()->session->get( 'chosen_shipping_methods', array() );
 		$selected_rate  = isset( $chosen_shipping_methods[ $package['package_id'] ] ) ? $chosen_shipping_methods[ $package['package_id'] ] : '';
 
 		if ( empty( $selected_rate ) && ! empty( $package['rates'] ) ) {

--- a/src/RestApi/StoreApi/Utilities/ProductQuery.php
+++ b/src/RestApi/StoreApi/Utilities/ProductQuery.php
@@ -205,7 +205,7 @@ class ProductQuery {
 		$orderby = $request->get_param( 'orderby' );
 		$order   = $request->get_param( 'order' );
 
-		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
+		$ordering_args   = wc()->query->get_catalog_ordering_args( $orderby, $order );
 		$args['orderby'] = $ordering_args['orderby'];
 		$args['order']   = $ordering_args['order'];
 


### PR DESCRIPTION
Calls to the cart API were not recalculating totals in a consistent manner. The hydration of cart didn't recalc at all, because the Store API initialization code doesn't run there.

This PR triggers cart totals recalculation when either the shipping transient changes (core changes this when updating tax and shipping rates in settings), or if the cart contents change.

Also fixes a bug where taxes were showing if disabled.

Renamed all instances of `WC()` to `wc()` since there were a mixture across codebase.

Fixes #2210

### How to test the changes in this Pull Request:

See instructions in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2210
