### PR TITLE
Support itemized taxes in cart/checkout

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
-import { TAXES_ENABLED } from '@woocommerce/block-settings';
+import {
+	TAXES_ENABLED,
+	DISPLAY_ITEMIZED_TAXES,
+} from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -11,18 +14,33 @@ import { TAXES_ENABLED } from '@woocommerce/block-settings';
 import TotalsItem from '../totals-item';
 
 const TotalsTaxesItem = ( { currency, values } ) => {
-	const { total_tax: totalTax } = values;
+	const { total_tax: totalTax, tax_lines: taxLines } = values;
 
 	if ( ! TAXES_ENABLED ) {
 		return null;
 	}
 
+	if ( ! DISPLAY_ITEMIZED_TAXES ) {
+		return (
+			<TotalsItem
+				currency={ currency }
+				label={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
+				value={ parseInt( totalTax, 10 ) }
+			/>
+		);
+	}
+
 	return (
-		<TotalsItem
-			currency={ currency }
-			label={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
-			value={ parseInt( totalTax, 10 ) }
-		/>
+		<>
+			{ taxLines.map( ( { name, price }, i ) => (
+				<TotalsItem
+					key={ `tax-line-${ i }` }
+					currency={ currency }
+					label={ name }
+					value={ parseInt( price, 10 ) }
+				/>
+			) ) }{ ' ' }
+		</>
 	);
 };
 

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -27,6 +27,10 @@ export const HOME_URL = getSetting( 'homeUrl', '' );
 export const COUPONS_ENABLED = getSetting( 'couponsEnabled', true );
 export const SHIPPING_ENABLED = getSetting( 'shippingEnabled', true );
 export const TAXES_ENABLED = getSetting( 'taxesEnabled', true );
+export const DISPLAY_ITEMIZED_TAXES = getSetting(
+	'displayItemizedTaxes',
+	false
+);
 export const DISPLAY_SHOP_PRICES_INCLUDING_TAX = getSetting(
 	'displayShopPricesIncludingTax',
 	false

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -130,6 +130,7 @@ class Assets {
 				'taxesEnabled'                  => wc_tax_enabled(),
 				'couponsEnabled'                => wc_coupons_enabled(),
 				'shippingEnabled'               => wc_shipping_enabled(),
+				'displayItemizedTaxes'          => 'itemized' === get_option( 'woocommerce_tax_total_display' ),
 				'displayShopPricesIncludingTax' => 'incl' === get_option( 'woocommerce_tax_display_shop' ),
 				'displayCartPricesIncludingTax' => 'incl' === get_option( 'woocommerce_tax_display_cart' ),
 				'showAvatars'                   => '1' === get_option( 'show_avatars' ),


### PR DESCRIPTION
Adds support for the itemized tax setting in core.

Fixes #2211

### Screenshots

![Screenshot 2020-04-22 at 14 30 26](https://user-images.githubusercontent.com/90977/79988138-34977480-84a6-11ea-9641-122e0b9b3d88.png)

### How to test the changes in this Pull Request:

1. In WC > Settings > Taxes, change the tax totals setting to show itemized taxes instead of a single total. You might want to add some extra taxes so rows would be displayed.
2. View cart page.
3. See tax rows/names.
