### PR TITLE
Add notice errors to add to cart button and All products

### DIFF
--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -61,6 +61,7 @@ export const useStoreAddToCart = ( productId ) => {
 				addErrorNotice( error.message, {
 					context: 'wc/all-products',
 					id: 'add-to-cart',
+					isDismissible: true,
 				} );
 			} )
 			.finally( () => {

--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -42,7 +42,7 @@ const getQuantityFromCartItems = ( cartItems, productId ) => {
 export const useStoreAddToCart = ( productId ) => {
 	const { addItemToCart } = useDispatch( storeKey );
 	const { cartItems, cartIsLoading } = useStoreCart();
-	const { addErrorNotice } = useStoreNotices();
+	const { addErrorNotice, removeNotice } = useStoreNotices();
 
 	const [ addingToCart, setAddingToCart ] = useState( false );
 	const currentCartItemQuantity = useRef(
@@ -52,6 +52,11 @@ export const useStoreAddToCart = ( productId ) => {
 	const addToCart = () => {
 		setAddingToCart( true );
 		addItemToCart( productId )
+			.then( ( result ) => {
+				if ( result === true ) {
+					removeNotice( 'add-to-cart' );
+				}
+			} )
 			.catch( ( error ) => {
 				addErrorNotice( error.message, {
 					context: 'wc/all-products',

--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -6,6 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { find } from 'lodash';
 import { useStoreCart } from '@woocommerce/base-hooks';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -58,7 +59,7 @@ export const useStoreAddToCart = ( productId ) => {
 				}
 			} )
 			.catch( ( error ) => {
-				addErrorNotice( error.message, {
+				addErrorNotice( decodeEntities( error.message ), {
 					context: 'wc/all-products',
 					id: 'add-to-cart',
 					isDismissible: true,

--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -8,6 +8,11 @@ import { useStoreCart } from '@woocommerce/base-hooks';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 
 /**
+ * Internal dependencies
+ */
+import { useStoreNotices } from './use-store-notices';
+
+/**
  * @typedef {import('@woocommerce/type-defs/hooks').StoreCartItemAddToCart} StoreCartItemAddToCart
  */
 
@@ -37,6 +42,7 @@ const getQuantityFromCartItems = ( cartItems, productId ) => {
 export const useStoreAddToCart = ( productId ) => {
 	const { addItemToCart } = useDispatch( storeKey );
 	const { cartItems, cartIsLoading } = useStoreCart();
+	const { addErrorNotice } = useStoreNotices();
 
 	const [ addingToCart, setAddingToCart ] = useState( false );
 	const currentCartItemQuantity = useRef(
@@ -45,9 +51,16 @@ export const useStoreAddToCart = ( productId ) => {
 
 	const addToCart = () => {
 		setAddingToCart( true );
-		addItemToCart( productId ).finally( () => {
-			setAddingToCart( false );
-		} );
+		addItemToCart( productId )
+			.catch( ( error ) => {
+				addErrorNotice( error.message, {
+					context: 'wc/all-products',
+					id: 'add-to-cart',
+				} );
+			} )
+			.finally( () => {
+				setAddingToCart( false );
+			} );
 	};
 
 	useEffect( () => {

--- a/assets/js/blocks/products/all-products/frontend.js
+++ b/assets/js/blocks/products/all-products/frontend.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { withRestApiHydration } from '@woocommerce/block-hocs';
+import { StoreNoticesProvider } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -9,12 +10,25 @@ import { withRestApiHydration } from '@woocommerce/block-hocs';
 import Block from './block';
 import renderFrontend from '../../../utils/render-frontend.js';
 
+/**
+ * Wrapper component to supply the notice provider.
+ *
+ * @param {*} props
+ */
+const AllProductsFrontend = ( props ) => {
+	return (
+		<StoreNoticesProvider context="wc/all-products">
+			<Block { ...props } />
+		</StoreNoticesProvider>
+	);
+};
+
 const getProps = ( el ) => ( {
 	attributes: JSON.parse( el.dataset.attributes ),
 } );
 
 renderFrontend(
 	'.wp-block-woocommerce-all-products',
-	withRestApiHydration( Block ),
+	withRestApiHydration( AllProductsFrontend ),
 	getProps
 );

--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -254,6 +254,8 @@ export function* addItemToCart( productId, quantity = 1 ) {
 		// Re-throw the error.
 		throw error;
 	}
+
+	return true;
 }
 
 /**

--- a/assets/js/data/cart/actions.js
+++ b/assets/js/data/cart/actions.js
@@ -226,6 +226,7 @@ export function* removeCoupon( couponCode ) {
  * - If successful, yields action to add item from store.
  * - If error, yields action to store error.
  *
+ * @throws Will throw an error if there is an API problem.
  * @param {number} productId Product ID to add to cart.
  * @param {number} quantity Number of product ID being added to cart.
  */
@@ -249,6 +250,9 @@ export function* addItemToCart( productId, quantity = 1 ) {
 		if ( error.data?.cart ) {
 			yield receiveCart( error.data.cart );
 		}
+
+		// Re-throw the error.
+		throw error;
 	}
 }
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Adds notices to All products, shows an error if `addToCart` returns an error, rethrows the error from `*addToCart` action, clears previous notices if adding was successful (At first I cleared notices before adding, this caused a jump if this add also has an error).
<!-- Reference any related issues or PRs here -->
Fixes #2242

### Screenshots
Note: I still have this issue https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2206 present, not sure how to get it fixed (installing Woo assets didn't fix it).
![image](https://user-images.githubusercontent.com/6165348/80087777-7a5e4680-8553-11ea-9b6c-8195a4d76876.png)


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Have a product that is sold individually or is limited in quantity.
2. try adding above the allowed amount in All Products.
3. you should see a notice.
4. try adding a normal product, notice should be gone and the error will be added.

<!-- If you can, add the appropriate labels -->

### Changelog

> An error notice will be shown in All Product if the customer is trying to add a product above stock or sold individually. 
