### PR TITLE
Add screen reader text to remove item icon

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -129,6 +129,9 @@ const CartLineItemRow = ( { lineItem } ) => {
 					className="wc-block-cart-item__remove-icon"
 					onClick={ removeItem }
 				>
+					<span className="screen-reader-text">
+						{ __( 'Remove item', 'woo-gutenberg-products-block' ) }
+					</span>
 					<Icon srcElement={ trash } />
 				</button>
 			</td>


### PR DESCRIPTION
Small a11y fix: _Cart_ items remove icon on mobile didn't have a descriptive text.

### How to test the changes in this Pull Request:

1. Open the _Cart_ block in a narrow display simulating mobile.
2. With the Axe extension ([Firefox](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd)) analyze the page and verify there isn't any error related to the button missing text.