### PR TITLE
Table creation validation for install routine

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\BackCompatAssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Library;
+use Automattic\WooCommerce\Blocks\Installer;
 use Automattic\WooCommerce\Blocks\Registry\Container;
 use Automattic\WooCommerce\Blocks\RestApi;
 use Automattic\WooCommerce\Blocks\Payments\Api as PaymentsApi;
@@ -72,6 +73,7 @@ class Bootstrap {
 			$this->add_build_notice();
 			$this->define_feature_flag();
 			$this->container->get( AssetDataRegistry::class );
+			$this->container->get( Installer::class );
 			BlockAssets::init();
 		}
 
@@ -179,6 +181,12 @@ class Bootstrap {
 			RestApi::class,
 			function ( Container $container ) {
 				return new RestApi();
+			}
+		);
+		$this->container->register(
+			Installer::class,
+			function ( Container $container ) {
+				return new Installer();
 			}
 		);
 	}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Handles installation of Blocks plugin dependencies.
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Installer class.
+ */
+class Installer {
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Installation tasks ran on admin_init callback.
+	 */
+	public function install() {
+		$this->maybe_create_tables();
+		$this->maybe_create_cronjobs();
+	}
+
+	/**
+	 * Initialize class features.
+	 */
+	protected function init() {
+		add_action( 'admin_init', array( $this, 'install' ) );
+	}
+
+	/**
+	 * Set up the database tables which the plugin needs to function.
+	 */
+	protected function maybe_create_tables() {
+		global $wpdb;
+
+		$schema_version    = 260;
+		$db_schema_version = (int) get_option( 'wc_blocks_db_schema_version', 0 );
+
+		if ( $db_schema_version > $schema_version ) {
+			return;
+		}
+
+		$show_errors = $wpdb->hide_errors();
+		$table_name  = $wpdb->prefix . 'wc_reserved_stock';
+		$collate     = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+		$exists      = $this->maybe_create_table(
+			$wpdb->prefix . 'wc_reserved_stock',
+			"
+			CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
+				`order_id` bigint(20) NOT NULL,
+				`product_id` bigint(20) NOT NULL,
+				`stock_quantity` double NOT NULL DEFAULT 0,
+				`timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				`expires` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				PRIMARY KEY  (`order_id`, `product_id`)
+			) $collate;
+			"
+		);
+
+		if ( $show_errors ) {
+			$wpdb->show_errors();
+		}
+
+		if ( ! $exists ) {
+			return $this->add_create_table_notice( $table_name );
+		}
+
+		// Update succeeded. This is only updated when successful and validated.
+		// $schema_version should be incremented when changes to schema are made within this method.
+		update_option( 'wc_blocks_db_schema_version', $schema_version );
+	}
+
+	/**
+	 * Create database table, if it doesn't already exist.
+	 *
+	 * Based on admin/install-helper.php maybe_create_table function.
+	 *
+	 * @param string $table_name Database table name.
+	 * @param string $create_sql Create database table SQL.
+	 * @return bool False on error, true if already exists or success.
+	 */
+	protected function maybe_create_table( $table_name, $create_sql ) {
+		global $wpdb;
+
+		if ( in_array( $table_name, $wpdb->get_col( 'SHOW TABLES', 0 ), true ) ) {
+			return true;
+		}
+
+		$wpdb->query( $create_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		return in_array( $table_name, $wpdb->get_col( 'SHOW TABLES', 0 ), true );
+	}
+
+	/**
+	 * Add a notice if table creation fails.
+	 *
+	 * @param string $table_name Name of the missing table.
+	 */
+	protected function add_create_table_notice( $table_name ) {
+		add_action(
+			'admin_notices',
+			function() use ( $table_name ) {
+				echo '<div class="error"><p>';
+				printf(
+					/* Translators: %1$s table name, %2$s database user, %3$s database name. */
+					esc_html__( 'WooCommerce %1$s table creation failed. Does the %2$s user have CREATE privileges on the %3$s database?', 'woo-gutenberg-products-block' ),
+					'<code>' . esc_html( $table_name ) . '</code>',
+					'<code>' . esc_html( DB_USER ) . '</code>',
+					'<code>' . esc_html( DB_NAME ) . '</code>'
+				);
+				echo '</p></div>';
+			}
+		);
+	}
+
+	/**
+	 * Maybe create cron events.
+	 */
+	protected function maybe_create_cronjobs() {
+		if ( function_exists( 'as_next_scheduled_action' ) && false === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
+			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'woocommerce_cleanup_draft_orders' );
+		}
+	}
+}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -38,7 +38,7 @@ class Installer {
 	/**
 	 * Set up the database tables which the plugin needs to function.
 	 */
-	protected function maybe_create_tables() {
+	public function maybe_create_tables() {
 		global $wpdb;
 
 		$schema_version    = 260;

--- a/src/Library.php
+++ b/src/Library.php
@@ -58,9 +58,10 @@ class Library {
 			return;
 		}
 
-		$table_name = $wpdb->prefix . 'wc_reserved_stock';
-		$collate    = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
-		$exists     = self::maybe_create_table(
+		$show_errors = $wpdb->hide_errors();
+		$table_name  = $wpdb->prefix . 'wc_reserved_stock';
+		$collate     = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+		$exists      = self::maybe_create_table(
 			$wpdb->prefix . 'wc_reserved_stock',
 			"
 			CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
@@ -73,6 +74,10 @@ class Library {
 			) $collate;
 			"
 		);
+
+		if ( $show_errors ) {
+			$wpdb->show_errors();
+		}
 
 		if ( ! $exists ) {
 			return self::add_create_table_notice( $table_name );
@@ -99,7 +104,6 @@ class Library {
 			return true;
 		}
 
-		$wpdb->hide_errors();
 		$wpdb->query( $create_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
 		return in_array( $table_name, $wpdb->get_col( 'SHOW TABLES', 0 ), true );

--- a/src/Library.php
+++ b/src/Library.php
@@ -54,7 +54,7 @@ class Library {
 		$schema_version    = 260;
 		$db_schema_version = (int) get_option( 'wc_blocks_db_schema_version', 0 );
 
-		if ( $db_schema_version < $schema_version ) {
+		if ( $db_schema_version > $schema_version ) {
 			return;
 		}
 

--- a/src/Library.php
+++ b/src/Library.php
@@ -20,8 +20,6 @@ class Library {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_blocks' ) );
 		add_action( 'init', array( __CLASS__, 'define_tables' ) );
-		add_action( 'init', array( __CLASS__, 'maybe_create_tables' ) );
-		add_action( 'init', array( __CLASS__, 'maybe_create_cronjobs' ) );
 		add_filter( 'wc_order_statuses', array( __CLASS__, 'register_draft_order_status' ) );
 		add_filter( 'woocommerce_register_shop_order_post_statuses', array( __CLASS__, 'register_draft_order_post_status' ) );
 		add_filter( 'woocommerce_valid_order_statuses_for_payment', array( __CLASS__, 'append_draft_order_post_status' ) );
@@ -42,101 +40,6 @@ class Library {
 		foreach ( $tables as $name => $table ) {
 			$wpdb->$name    = $wpdb->prefix . $table;
 			$wpdb->tables[] = $table;
-		}
-	}
-
-	/**
-	 * Set up the database tables which the plugin needs to function.
-	 */
-	public static function maybe_create_tables() {
-		global $wpdb;
-
-		$schema_version    = 260;
-		$db_schema_version = (int) get_option( 'wc_blocks_db_schema_version', 0 );
-
-		if ( $db_schema_version > $schema_version ) {
-			return;
-		}
-
-		$show_errors = $wpdb->hide_errors();
-		$table_name  = $wpdb->prefix . 'wc_reserved_stock';
-		$collate     = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
-		$exists      = self::maybe_create_table(
-			$wpdb->prefix . 'wc_reserved_stock',
-			"
-			CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
-				`order_id` bigint(20) NOT NULL,
-				`product_id` bigint(20) NOT NULL,
-				`stock_quantity` double NOT NULL DEFAULT 0,
-				`timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				`expires` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				PRIMARY KEY  (`order_id`, `product_id`)
-			) $collate;
-			"
-		);
-
-		if ( $show_errors ) {
-			$wpdb->show_errors();
-		}
-
-		if ( ! $exists ) {
-			return self::add_create_table_notice( $table_name );
-		}
-
-		// Update succeeded. This is only updated when successful and validated.
-		// $schema_version should be incremented when changes to schema are made within this method.
-		update_option( 'wc_blocks_db_schema_version', $schema_version );
-	}
-
-	/**
-	 * Create database table, if it doesn't already exist.
-	 *
-	 * Based on admin/install-helper.php maybe_create_table function.
-	 *
-	 * @param string $table_name Database table name.
-	 * @param string $create_sql Create database table SQL.
-	 * @return bool False on error, true if already exists or success.
-	 */
-	protected static function maybe_create_table( $table_name, $create_sql ) {
-		global $wpdb;
-
-		if ( in_array( $table_name, $wpdb->get_col( 'SHOW TABLES', 0 ), true ) ) {
-			return true;
-		}
-
-		$wpdb->query( $create_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
-
-		return in_array( $table_name, $wpdb->get_col( 'SHOW TABLES', 0 ), true );
-	}
-
-	/**
-	 * Add a notice if table creation fails.
-	 *
-	 * @param string $table_name Name of the missing table.
-	 */
-	protected static function add_create_table_notice( $table_name ) {
-		add_action(
-			'admin_notices',
-			function() use ( $table_name ) {
-				echo '<div class="error"><p>';
-				printf(
-					/* Translators: %1$s table name, %2$s database user, %3$s database name. */
-					esc_html__( 'WooCommerce %1$s table creation failed. Does the %2$s user have CREATE privileges on the %3$s database?', 'woo-gutenberg-products-block' ),
-					'<code>' . esc_html( $table_name ) . '</code>',
-					'<code>' . esc_html( DB_USER ) . '</code>',
-					'<code>' . esc_html( DB_NAME ) . '</code>'
-				);
-				echo '</p></div>';
-			}
-		);
-	}
-
-	/**
-	 * Maybe create cron events.
-	 */
-	public static function maybe_create_cronjobs() {
-		if ( function_exists( 'as_next_scheduled_action' ) && false === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
-			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'woocommerce_cleanup_draft_orders' );
 		}
 	}
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -84,7 +84,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '2.6.0-dev';
+					$version = '2.6.0-beta.1';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/src/Package.php
+++ b/src/Package.php
@@ -84,7 +84,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '2.6.0-beta.1';
+					$version = '2.6.0-dev';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/src/StoreApi/Utilities/ReserveStock.php
+++ b/src/StoreApi/Utilities/ReserveStock.php
@@ -14,17 +14,26 @@ defined( 'ABSPATH' ) || exit;
  */
 final class ReserveStock {
 	/**
-	 * Current DB version.
+	 * Is stock reservation enabled?
 	 *
-	 * @var integer
+	 * @var boolean
 	 */
-	private $db_version = 0;
+	private $enabled = true;
 
 	/**
 	 * Constructor
 	 */
 	public function __construct() {
-		$this->db_version = get_option( 'wc_blocks_db_schema_version', 0 );
+		$this->enabled = get_option( 'wc_blocks_db_schema_version', 0 ) >= 260;
+	}
+
+	/**
+	 * Is stock reservation enabled?
+	 *
+	 * @return boolean
+	 */
+	protected function is_enabled() {
+		return $this->enabled;
 	}
 
 	/**
@@ -38,7 +47,7 @@ final class ReserveStock {
 	public function get_reserved_stock( \WC_Product $product, $exclude_order_id = 0 ) {
 		global $wpdb;
 
-		if ( $this->db_version < 260 ) {
+		if ( ! $this->is_enabled() ) {
 			return 0;
 		}
 
@@ -57,7 +66,7 @@ final class ReserveStock {
 	public function reserve_stock_for_order( \WC_Order $order, $minutes = 0 ) {
 		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
 
-		if ( ! $minutes || $this->db_version < 260 ) {
+		if ( ! $minutes || ! $this->is_enabled() ) {
 			return;
 		}
 
@@ -113,7 +122,7 @@ final class ReserveStock {
 	public function release_stock_for_order( \WC_Order $order ) {
 		global $wpdb;
 
-		if ( $this->db_version < 260 ) {
+		if ( ! $this->is_enabled() ) {
 			return;
 		}
 

--- a/src/StoreApi/Utilities/ReserveStock.php
+++ b/src/StoreApi/Utilities/ReserveStock.php
@@ -14,6 +14,20 @@ defined( 'ABSPATH' ) || exit;
  */
 final class ReserveStock {
 	/**
+	 * Current DB version.
+	 *
+	 * @var integer
+	 */
+	private $db_version = 0;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->db_version = get_option( 'wc_blocks_db_schema_version', 0 );
+	}
+
+	/**
 	 * Query for any existing holds on stock for this item.
 	 *
 	 * @param \WC_Product $product Product to get reserved stock for.
@@ -23,6 +37,10 @@ final class ReserveStock {
 	 */
 	public function get_reserved_stock( \WC_Product $product, $exclude_order_id = 0 ) {
 		global $wpdb;
+
+		if ( $this->db_version < 260 ) {
+			return 0;
+		}
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
 		return (int) $wpdb->get_var( $this->get_query_for_reserved_stock( $product->get_stock_managed_by_id(), $exclude_order_id ) );
@@ -39,7 +57,7 @@ final class ReserveStock {
 	public function reserve_stock_for_order( \WC_Order $order, $minutes = 0 ) {
 		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
 
-		if ( ! $minutes ) {
+		if ( ! $minutes || $this->db_version < 260 ) {
 			return;
 		}
 
@@ -94,6 +112,10 @@ final class ReserveStock {
 	 */
 	public function release_stock_for_order( \WC_Order $order ) {
 		global $wpdb;
+
+		if ( $this->db_version < 260 ) {
+			return;
+		}
 
 		$wpdb->delete(
 			$wpdb->wc_reserved_stock,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -98,6 +98,7 @@ function wc_install_core() {
 	$GLOBALS['wp_roles'] = null; // WPCS: override ok.
 	wp_roles();
 	echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
+	\Automattic\WooCommerce\Blocks\Library::maybe_create_tables();
 }
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -98,7 +98,7 @@ function wc_install_core() {
 	$GLOBALS['wp_roles'] = null; // WPCS: override ok.
 	wp_roles();
 	echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
-	\Automattic\WooCommerce\Blocks\Library::maybe_create_tables();
+	\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Installer::class )->install();
 }
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -97,8 +97,8 @@ function wc_install_core() {
 	include wc_dir() . '/uninstall.php';
 	$GLOBALS['wp_roles'] = null; // WPCS: override ok.
 	wp_roles();
-	echo esc_html( 'Installing WooCommerce...' . PHP_EOL );
-	\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Installer::class )->install();
+	echo esc_html( 'Installing WooCommerce Blocks...' . PHP_EOL );
+	\Automattic\WooCommerce\Blocks\Package::container()->get( \Automattic\WooCommerce\Blocks\Installer::class )->maybe_create_tables();
 }
 
 /**


### PR DESCRIPTION
Improves the install routine to protect against missing table errors in stock reservation class;

- Includes create table method which returns if the table exists or not
- New db_schema_version to track schema updates
- If table creation fails, an admin notice is added
- If table creation fails, db_schema_version is not incremented
- Reserve stock class only runs logic if db_schema_version is satisfied

Fixes #2279

The admin notice informs the user which table could not be created on which database, by which user:

<img width="1266" alt="Dashboard ‹ Local Testing — WordPress 2020-04-25 08-32-47" src="https://user-images.githubusercontent.com/90977/80274116-fda4a700-86cf-11ea-8e21-5e6a83bc2872.png">

### How to test the changes in this Pull Request:

1. Delete the wc_reserve_stock table prior to running this PR
2. Checkout branch
3. Table will be created, stock functionality continues to work