### PR TITLE
Add PayPal Standard

### DIFF
--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -13,6 +13,7 @@
 			outline-offset: -1px;
 			text-align: center;
 			transition: box-shadow 0.1s linear;
+			box-shadow: inset 0 -2px $core-grey-light-600;
 			&.is-active {
 				box-shadow: inset 0 -3px $black;
 				font-weight: 600;
@@ -26,6 +27,12 @@
 			.wc-block-components-tabs__item-content {
 				width: fit-content;
 				display: inline-block;
+
+				img {
+					max-height: 1.2em;
+					position: relative;
+					margin: -0.1em 0;
+				}
 			}
 		}
 	}

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -18,18 +18,10 @@ const settings = getSetting( 'cheque_data', {} );
  */
 
 /**
- * Cheque content component
- *
- * @param {RegisteredPaymentMethodProps|Object} props Incoming props
+ * Content component
  */
-const Content = ( { activePaymentMethod } ) => {
-	return activePaymentMethod === PAYMENT_METHOD_NAME ? (
-		<div>{ decodeEntities( settings.description || '' ) }</div>
-	) : null;
-};
-
-const Edit = ( props ) => {
-	return <Content { ...props } />;
+const Content = () => {
+	return <div>{ decodeEntities( settings.description || '' ) }</div>;
 };
 
 const offlineChequePaymentMethod = {
@@ -43,7 +35,7 @@ const offlineChequePaymentMethod = {
 		</strong>
 	),
 	content: <Content />,
-	edit: <Edit />,
+	edit: <Content />,
 	canMakePayment: () => true,
 	ariaLabel: decodeEntities(
 		settings.title || __( 'Check Payment', 'woo-gutenberg-products-block' )

--- a/assets/js/payment-method-extensions/payment-methods/paypal/constants.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/constants.js
@@ -1,0 +1,1 @@
+export const PAYMENT_METHOD_NAME = 'paypal';

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -3,7 +3,7 @@
  */
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
+import { getSetting, WC_ASSET_URL } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -18,31 +18,27 @@ const settings = getSetting( 'paypal_data', {} );
  */
 
 /**
- * PayPal content component
- *
- * @param {RegisteredPaymentMethodProps|Object} props Incoming props
+ * Content component
  */
-const Content = ( { activePaymentMethod } ) => {
-	return activePaymentMethod === PAYMENT_METHOD_NAME ? (
-		<div>{ decodeEntities( settings.description || '' ) }</div>
-	) : null;
-};
-
-const Edit = ( props ) => {
-	return <Content { ...props } />;
+const Content = () => {
+	return <div>{ decodeEntities( settings.description || '' ) }</div>;
 };
 
 const paypalPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
 	label: (
 		<strong>
-			{ decodeEntities(
-				settings.title || __( 'PayPal', 'woo-gutenberg-products-block' )
-			) }
+			<img
+				src={ `${ WC_ASSET_URL }/images/paypal.png` }
+				alt={ decodeEntities(
+					settings.title ||
+						__( 'PayPal', 'woo-gutenberg-products-block' )
+				) }
+			/>
 		</strong>
 	),
 	content: <Content />,
-	edit: <Edit />,
+	edit: <Content />,
 	canMakePayment: () => true,
 	ariaLabel: decodeEntities(
 		settings.title ||

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { registerPaymentMethod } from '@woocommerce/blocks-registry';
+import { __ } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { PAYMENT_METHOD_NAME } from './constants';
+
+const settings = getSetting( 'paypal_data', {} );
+
+/**
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
+ */
+
+/**
+ * PayPal content component
+ *
+ * @param {RegisteredPaymentMethodProps|Object} props Incoming props
+ */
+const Content = ( { activePaymentMethod } ) => {
+	return activePaymentMethod === PAYMENT_METHOD_NAME ? (
+		<div>{ decodeEntities( settings.description || '' ) }</div>
+	) : null;
+};
+
+const Edit = ( props ) => {
+	return <Content { ...props } />;
+};
+
+const paypalPaymentMethod = {
+	name: PAYMENT_METHOD_NAME,
+	label: (
+		<strong>
+			{ decodeEntities(
+				settings.title || __( 'PayPal', 'woo-gutenberg-products-block' )
+			) }
+		</strong>
+	),
+	content: <Content />,
+	edit: <Edit />,
+	canMakePayment: () => true,
+	ariaLabel: decodeEntities(
+		settings.title ||
+			__( 'Payment via PayPal', 'woo-gutenberg-products-block' )
+	),
+};
+
+registerPaymentMethod( ( Config ) => new Config( paypalPaymentMethod ) );

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -481,6 +481,8 @@ const getPaymentMethodsExtensionConfig = ( options = {} ) => {
 				'./assets/js/payment-method-extensions/payment-methods/stripe/index.js',
 			'wc-payment-method-cheque':
 				'./assets/js/payment-method-extensions/payment-methods/cheque/index.js',
+			'wc-payment-method-paypal':
+				'./assets/js/payment-method-extensions/payment-methods/paypal/index.js',
 		},
 		output: {
 			devtoolNamespace: 'wc',

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\Blocks\Payments\Api as PaymentsApi;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Stripe;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Cheque;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\PayPal;
 
 /**
  * Takes care of bootstrapping the plugin.
@@ -202,6 +203,13 @@ class Bootstrap {
 			function( Container $container ) {
 				$asset_api = $container->get( AssetApi::class );
 				return new Cheque( $asset_api );
+			}
+		);
+		$this->container->register(
+			PayPal::class,
+			function( Container $container ) {
+				$asset_api = $container->get( AssetApi::class );
+				return new PayPal( $asset_api );
 			}
 		);
 	}

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -14,6 +14,7 @@ use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\NoticeHandler;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Stripe;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Cheque;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\PayPal;
 
 /**
  *  The Api class provides an interface to payment method registration.
@@ -99,6 +100,9 @@ class Api {
 		}
 		$payment_method_registry->register(
 			Package::container()->get( Cheque::class )
+		);
+		$payment_method_registry->register(
+			Package::container()->get( PayPal::class )
 		);
 	}
 

--- a/src/Payments/Integrations/PayPay.php
+++ b/src/Payments/Integrations/PayPay.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Cheque (core) gateway implementation.
+ * PayPal Standard (core) gateway implementation.
  *
  * @package WooCommerce/Blocks
  * @since $VID:$
@@ -14,17 +14,17 @@ use WC_Stripe_Helper;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 
 /**
- * Cheque payment method integration
+ * PayPal Standard payment method integration
  *
  * @since $VID:$
  */
-final class Cheque extends AbstractPaymentMethodType {
+final class PayPal extends AbstractPaymentMethodType {
 	/**
 	 * Payment method name defined by payment methods extending this class.
 	 *
 	 * @var string
 	 */
-	protected $name = 'cheque';
+	protected $name = 'paypal';
 
 	/**
 	 * Settings from the WP options table
@@ -53,7 +53,7 @@ final class Cheque extends AbstractPaymentMethodType {
 	 * Initializes the payment method type.
 	 */
 	public function initialize() {
-		$this->settings = get_option( 'woocommerce_cheque_settings', [] );
+		$this->settings = get_option( 'woocommerce_paypal_settings', [] );
 	}
 
 	/**
@@ -72,10 +72,10 @@ final class Cheque extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_script_handles() {
 		$this->asset_api->register_script(
-			'wc-payment-method-cheque',
-			'build/wc-payment-method-cheque.js'
+			'wc-payment-method-paypal',
+			'build/wc-payment-method-paypal.js'
 		);
-		return [ 'wc-payment-method-cheque' ];
+		return [ 'wc-payment-method-paypal' ];
 	}
 
 	/**


### PR DESCRIPTION
This is part of #1473

Adds an integration for PayPal Standard. Only needs to register the gateway since legacy code takes care of processing. Will need an icon when that API is finalised.

### How to test the changes in this Pull Request:

1. Enable PayPal Standard
2. Try placing an order with it
3. :)