### PR TITLE
Pin WooCommerce version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29547,8 +29547,8 @@
       }
     },
     "woocommerce": {
-      "version": "git+https://github.com/woocommerce/woocommerce.git#968f7ddc5b2737ca40b4503701c89e9bc038adb4",
-      "from": "git+https://github.com/woocommerce/woocommerce.git",
+      "version": "git+https://github.com/woocommerce/woocommerce.git#5a746a0775d8407127e314ffde73d5ebb15284bf",
+      "from": "git+https://github.com/woocommerce/woocommerce.git#release/4.1",
       "dev": true
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
 		"webpack": "4.42.0",
 		"webpack-cli": "3.3.11",
 		"webpack-rtl-plugin": "2.0.0",
-		"woocommerce": "git+https://github.com/woocommerce/woocommerce.git",
+		"woocommerce": "git+https://github.com/woocommerce/woocommerce.git#release/4.1",
 		"zenhub-api": "0.2.0"
 	},
 	"engines": {


### PR DESCRIPTION
Pins WooCommere version to a branch release/4.1, this will prevent package-lock each time we run an npm install and will not install Woo again each time.