### PR TITLE
Make all font sizes accessible + add docs about font-size() mixin

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -118,3 +118,7 @@
 	// IE11 doesn't support overflow-wrap neither word-break: break-word, so we fallback to -ms-work-break: break-all.
 	-ms-word-break: break-all;
 }
+
+@function rem($size, $base: 16px ) {
+	@return $size / $base * 1rem;
+}

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,4 +1,4 @@
-// Rem output with px fallback
+// Converts a font-size in px to rem and optionally sets a relative line-height.
 @mixin font-size($sizeValue: 16, $lineHeight: false ) {
 	font-size: $sizeValue + px;
 	font-size: ($sizeValue / 16) + rem;

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -3,7 +3,7 @@
 	font-size: $sizeValue + px;
 	font-size: ($sizeValue / 16) + rem;
 	@if ($lineHeight) {
-		line-height: $lineHeight;
+		line-height: $lineHeight / $sizeValue;
 	}
 }
 

--- a/assets/js/base/components/payment-methods/no-payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/no-payment-methods/style.scss
@@ -14,9 +14,9 @@
 		}
 
 		.wc-block-checkout__no-payment-methods-placeholder-description {
+			@include font-size(13);
 			display: block;
 			margin: 0.25em 0 1em 0;
-			font-size: 13px;
 		}
 	}
 }

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -130,7 +130,7 @@
 
 	.wc-block-gateway-input.focused.empty,
 	.wc-block-gateway-input:not(.empty) {
-		padding: $gap-large $gap $gap-smallest;
+		padding: calc(1.25em + #{$gap-smallest}) $gap 0.25em; // With a font-size of 16px, this will be `24px 16px 4px`.
 		& + label {
 			transform: translateY(#{$gap-smallest}) scale(0.75);
 		}

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -128,7 +128,7 @@
 
 	.wc-block-gateway-input.focused.empty,
 	.wc-block-gateway-input:not(.empty) {
-		padding: calc(1.25em + #{$gap-smallest}) $gap 0.25em; // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: calc(rem(20px) + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
 		& + label {
 			transform: translateY(#{$gap-smallest}) scale(0.75);
 		}

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -128,7 +128,7 @@
 
 	.wc-block-gateway-input.focused.empty,
 	.wc-block-gateway-input:not(.empty) {
-		padding: calc(rem(20px) + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: calc(#{rem(20px)} + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
 		& + label {
 			transform: translateY(#{$gap-smallest}) scale(0.75);
 		}

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -128,7 +128,7 @@
 
 	.wc-block-gateway-input.focused.empty,
 	.wc-block-gateway-input:not(.empty) {
-		padding: calc(#{rem(20px)} + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: rem($gap-large) $gap rem($gap-smallest);
 		& + label {
 			transform: translateY(#{$gap-smallest}) scale(0.75);
 		}

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -69,17 +69,17 @@
 	}
 
 	.wc-block-gateway-input {
+		@include font-size(16);
 		background-color: #fff;
 		padding: $gap-small $gap;
 		border-radius: 4px;
 		border: 1px solid $input-border-gray;
 		width: 100%;
-		font-size: 16px;
-		line-height: 22px;
+		line-height: 1.375;
 		font-family: inherit;
 		margin: 0;
 		box-sizing: border-box;
-		height: 48px;
+		height: 3em;
 		color: $input-text-active;
 
 		&:focus {
@@ -92,13 +92,13 @@
 	}
 
 	label {
+		@include font-size(16);
 		position: absolute;
 		transform: translateY(#{$gap-small});
 		left: 0;
 		top: 0;
 		transform-origin: top left;
-		font-size: 16px;
-		line-height: 22px;
+		line-height: 1.375;
 		color: $gray-50;
 		transition: transform 200ms ease;
 		margin: 0 $gap;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -69,13 +69,12 @@
 	}
 
 	.wc-block-gateway-input {
-		@include font-size(16);
+		@include font-size(16, 22);
 		background-color: #fff;
 		padding: $gap-small $gap;
 		border-radius: 4px;
 		border: 1px solid $input-border-gray;
 		width: 100%;
-		line-height: 1.375;
 		font-family: inherit;
 		margin: 0;
 		box-sizing: border-box;
@@ -92,13 +91,12 @@
 	}
 
 	label {
-		@include font-size(16);
+		@include font-size(16, 22);
 		position: absolute;
 		transform: translateY(0.75em);
 		left: 0;
 		top: 0;
 		transform-origin: top left;
-		line-height: 1.375;
 		color: $gray-50;
 		transition: transform 200ms ease;
 		margin: 0 $gap;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -94,7 +94,7 @@
 	label {
 		@include font-size(16);
 		position: absolute;
-		transform: translateY(#{$gap-small});
+		transform: translateY(0.75em);
 		left: 0;
 		top: 0;
 		transform-origin: top left;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -47,7 +47,7 @@
 		letter-spacing: inherit;
 		line-height: 1;
 		overflow: hidden;
-		padding: calc(rem(20px) + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: calc(#{rem(20px)} + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
 		text-overflow: ellipsis;
 		text-transform: none;
 		white-space: nowrap;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -6,10 +6,10 @@
 	label {
 		@include font-size(16);
 		position: absolute;
-		transform: translateY(#{$gap-small});
+		transform: translateY(0.75em);
 		transform-origin: top left;
 		transition: all 200ms ease;
-		line-height: 22px;
+		line-height: 1.375;
 		color: $gray-50;
 		z-index: 1;
 		margin: 0 $gap;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -4,12 +4,11 @@
 	margin-bottom: $gap-large;
 
 	label {
-		@include font-size(16);
+		@include font-size(16, 22);
 		position: absolute;
 		transform: translateY(0.75em);
 		transform-origin: top left;
 		transition: all 200ms ease;
-		line-height: 1.375;
 		color: $gray-50;
 		z-index: 1;
 		margin: 0 $gap;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -47,7 +47,7 @@
 		letter-spacing: inherit;
 		line-height: 1;
 		overflow: hidden;
-		padding: calc(#{rem(20px)} + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: rem($gap-large) $gap rem($gap-smallest);
 		text-overflow: ellipsis;
 		text-transform: none;
 		white-space: nowrap;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -47,7 +47,7 @@
 		letter-spacing: inherit;
 		line-height: 1;
 		overflow: hidden;
-		padding: calc(1.25em + #{$gap-smallest}) $gap 0.25em; // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: calc(rem(20px) + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
 		text-overflow: ellipsis;
 		text-transform: none;
 		white-space: nowrap;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -48,7 +48,7 @@
 		letter-spacing: inherit;
 		line-height: 1;
 		overflow: hidden;
-		padding: $gap-large $gap $gap-smallest;
+		padding: calc(1.25em + #{$gap-smallest}) $gap 0.25em; // With a font-size of 16px, this will be `24px 16px 4px`.
 		text-overflow: ellipsis;
 		text-transform: none;
 		white-space: nowrap;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,5 +1,5 @@
 .wc-block-select {
-	height: 48px;
+	height: 3em;
 	position: relative;
 	margin-bottom: $gap-large;
 

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -57,7 +57,7 @@
 	&.is-active input[type="url"],
 	&.is-active input[type="text"],
 	&.is-active input[type="email"] {
-		padding: $gap-large $gap $gap-smallest;
+		padding: calc(1.25em + #{$gap-smallest}) $gap 0.25em; // With a font-size of 16px, this will be `24px 16px 4px`.
 	}
 
 	&.has-error input {

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -57,7 +57,7 @@
 	&.is-active input[type="url"],
 	&.is-active input[type="text"],
 	&.is-active input[type="email"] {
-		padding: calc(#{rem(20px)} + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: rem($gap-large) $gap rem($gap-smallest);
 	}
 
 	&.has-error input {

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -6,7 +6,7 @@
 	label {
 		@include font-size(16);
 		position: absolute;
-		transform: translateY(#{$gap-small});
+		transform: translateY(0.75em);
 		left: 0;
 		top: 0;
 		transform-origin: top left;

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -57,7 +57,7 @@
 	&.is-active input[type="url"],
 	&.is-active input[type="text"],
 	&.is-active input[type="email"] {
-		padding: calc(rem(20px) + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: calc(#{rem(20px)} + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
 	}
 
 	&.has-error input {

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -57,7 +57,7 @@
 	&.is-active input[type="url"],
 	&.is-active input[type="text"],
 	&.is-active input[type="email"] {
-		padding: calc(1.25em + #{$gap-smallest}) $gap 0.25em; // With a font-size of 16px, this will be `24px 16px 4px`.
+		padding: calc(rem(20px) + #{$gap-smallest}) $gap rem(4px); // With a font-size of 16px, this will be `24px 16px 4px`.
 	}
 
 	&.has-error input {

--- a/assets/js/blocks/attribute-filter/editor.scss
+++ b/assets/js/blocks/attribute-filter/editor.scss
@@ -22,9 +22,8 @@
 		padding-top: 0;
 	}
 	.wc-block-attribute-filter__add_attribute_button {
-		@include font-size(14);
+		@include font-size(14, 24);
 		margin: 0 0 1em;
-		line-height: 1.714;
 		vertical-align: middle;
 		height: auto;
 		padding: 0.5em 1em;

--- a/assets/js/blocks/attribute-filter/editor.scss
+++ b/assets/js/blocks/attribute-filter/editor.scss
@@ -13,7 +13,7 @@
 		display: block; /* Disable flex box */
 
 		p {
-			font-size: 14px;
+			@include font-size(14);
 		}
 	}
 	.woocommerce-search-list__search {
@@ -22,11 +22,11 @@
 		padding-top: 0;
 	}
 	.wc-block-attribute-filter__add_attribute_button {
+		@include font-size(14);
 		margin: 0 0 1em;
-		line-height: 24px;
+		line-height: 1.714;
 		vertical-align: middle;
 		height: auto;
-		font-size: 14px;
 		padding: 0.5em 1em;
 
 		svg {

--- a/assets/js/blocks/cart-checkout/checkout/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/editor.scss
@@ -1,6 +1,6 @@
 .editor-styles-wrapper {
 	.wp-block h4.wc-block-checkout-step__title {
-		font-size: 16px;
+		@include font-size(16);
 		line-height: 24px;
 		margin: 0 $gap-small 0 0;
 	}

--- a/assets/js/blocks/cart-checkout/checkout/no-shipping-placeholder/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/no-shipping-placeholder/style.scss
@@ -14,9 +14,9 @@
 		}
 
 		.wc-block-checkout__no-shipping-placeholder-description {
+			@include font-size(13);
 			display: block;
 			margin: 0.25em 0 1em 0;
-			font-size: 13px;
 		}
 	}
 }

--- a/assets/js/blocks/price-filter/editor.scss
+++ b/assets/js/blocks/price-filter/editor.scss
@@ -24,15 +24,15 @@
 		display: block; /* Disable flex box */
 
 		p {
-			font-size: 14px;
+			@include font-size(14);
 		}
 	}
 	.wc-block-price-slider__add_product_button {
+		@include font-size(14);
 		margin: 0 0 1em;
-		line-height: 24px;
+		line-height: 1.714;
 		vertical-align: middle;
 		height: auto;
-		font-size: 14px;
 		padding: 0.5em 1em;
 
 		svg {

--- a/assets/js/blocks/price-filter/editor.scss
+++ b/assets/js/blocks/price-filter/editor.scss
@@ -28,9 +28,8 @@
 		}
 	}
 	.wc-block-price-slider__add_product_button {
-		@include font-size(14);
+		@include font-size(14, 24);
 		margin: 0 0 1em;
-		line-height: 1.714;
 		vertical-align: middle;
 		height: auto;
 		padding: 0.5em 1em;

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -68,11 +68,11 @@
 	border: none;
 	cursor: pointer;
 	background: none;
-	padding: 0.615em;
+	padding: rem(8, 13);
 	color: #555d66;
 	position: relative;
 	overflow: hidden;
-	border-radius: 0.308em;
+	border-radius: rem(4, 13);
 	svg {
 		fill: currentColor;
 		outline: none;

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -63,16 +63,16 @@
 	display: flex;
 	align-items: center;
 	text-decoration: none;
-	font-size: 13px;
+	@include font-size(13);
 	margin: 0;
 	border: none;
 	cursor: pointer;
 	background: none;
-	padding: 8px;
+	padding: 0.615em;
 	color: #555d66;
 	position: relative;
 	overflow: hidden;
-	border-radius: 4px;
+	border-radius: 0.308em;
 	svg {
 		fill: currentColor;
 		outline: none;

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -8,10 +8,10 @@
 		flex-grow: 1;
 	}
 	.wc-block-product-search__button {
+		@include font-size(13);
 		display: flex;
 		align-items: center;
 		text-decoration: none;
-		font-size: 13px;
 		margin: 0 0 0 6px;
 		border: none;
 		cursor: pointer;

--- a/assets/js/blocks/products/editor.scss
+++ b/assets/js/blocks/products/editor.scss
@@ -17,9 +17,8 @@
 		}
 	}
 	.wc-block-products__add_product_button {
-		@include font-size(14);
+		@include font-size(14, 24);
 		margin: 0 0 1em;
-		line-height: 1.714;
 		vertical-align: middle;
 		height: auto;
 		padding: 0.5em 1em;

--- a/assets/js/blocks/products/editor.scss
+++ b/assets/js/blocks/products/editor.scss
@@ -13,15 +13,15 @@
 		display: block; /* Disable flex box */
 
 		p {
-			font-size: 14px;
+			@include font-size(14);
 		}
 	}
 	.wc-block-products__add_product_button {
+		@include font-size(14);
 		margin: 0 0 1em;
-		line-height: 24px;
+		line-height: 1.714;
 		vertical-align: middle;
 		height: auto;
-		font-size: 14px;
 		padding: 0.5em 1em;
 
 		svg {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-element-options.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-element-options.js
@@ -8,6 +8,27 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
  */
 
 /**
+ * Returns the CSS value of the specified property in the document element.
+ *
+ * @param {string} property     Name of the property to retrieve the style
+ *                              value from.
+ * @param {string} defaultValue Fallback value if the value for the property
+ *                              could not be retrieved.
+ *
+ * @return {string} The style value of that property in the document element.
+ */
+const getDocumentStyle = ( property, defaultValue ) => {
+	let documentStyle = {};
+	if (
+		typeof window === 'object' &&
+		typeof window.getComputedStyle === 'function'
+	) {
+		documentStyle = window.getComputedStyle( document.documentElement );
+	}
+	return documentStyle[ property ] || defaultValue;
+};
+
+/**
  * Default options for the stripe elements.
  */
 const elementOptions = {
@@ -15,7 +36,8 @@ const elementOptions = {
 		base: {
 			iconColor: '#666EE8',
 			color: '#31325F',
-			fontSize: '15px',
+			fontSize: getDocumentStyle( 'fontSize', '16px' ),
+			lineHeight: 1.375,
 			'::placeholder': {
 				color: '#fff',
 			},

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-element-options.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-element-options.js
@@ -37,7 +37,7 @@ const elementOptions = {
 			iconColor: '#666EE8',
 			color: '#31325F',
 			fontSize: getDocumentStyle( 'fontSize', '16px' ),
-			lineHeight: 1.375,
+			lineHeight: 1.375, // With a font-size of 16px, line-height will be 22px.
 			'::placeholder': {
 				color: '#fff',
 			},

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -82,3 +82,11 @@ Or exclude blocks of CSS:
 The build process will split SCSS from within the blocks library directory into two separate CSS files when Webpack runs.
 
 Styles placed in a `style.scss` file will be built into `build/style.css`, to load on the front end theme as well as in the editor. If you need additional styles specific to the block's display in the editor, add them to an `editor.scss`.
+
+### Accessible font sizes
+
+We want our font sizes to be declared with rem or em units instead of hardcoded px. That's important for accessibility because it allows users to make the text bigger and easier to read.
+
+We have a mixin named `font-size()` that helps converting px font sizes to rem. It accepts a second parameter which is the `line-height`. Notice `line-height` will need to be relative (no units) or rem/em as well. Setting a line-height with a px value when the font-size uses rem/em might cause the text to overlap when made bigger.
+
+In parallel to that, consider whether other size/distance units in your CSS need to be rem/em instead of px. In general, rem/em should be preferred if it doesn't break the design with big font sizes.

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -87,6 +87,6 @@ Styles placed in a `style.scss` file will be built into `build/style.css`, to lo
 
 We want our font sizes to be declared with rem or em units instead of hardcoded px. That's important for accessibility because it allows users to make the text bigger and easier to read.
 
-We have a mixin named `font-size()` that helps converting px font sizes to rem. It accepts a second parameter which is the `line-height`. Notice `line-height` will need to be relative (no units) or rem/em as well. Setting a line-height with a px value when the font-size uses rem/em might cause the text to overlap when made bigger.
+We have a mixin named `font-size()` that given a number of the font size in px, it converts it to rem. It accepts a second parameter which is the line height, it will be divided by the font-size and the result will be the relative units for the `line-height` CSS property.
 
-In parallel to that, consider whether other size/distance units in your CSS need to be rem/em instead of px. In general, rem/em should be preferred if it doesn't break the design with big font sizes.
+In parallel to that, consider whether other size/distance units in your CSS need to be rem/em instead of px. In general, rem/em should be preferred if it doesn't break the design with big font sizes. There is another mixin named `rem()` that helps converting px units to rem (given a px size and optionally a base size).


### PR DESCRIPTION
Fixes #2284.

Follow-up of #2283.

* Add docs about preferring the `font-size()` mixin instead of px font-sizes.
* Switch all remaining px font-sizes to the mixin.
* Fixes the alignment of input box labels.

### Screenshots

_Before:_
<img src="https://user-images.githubusercontent.com/3616980/80341685-332dc980-8863-11ea-9642-16e485dffdb8.png" width="373.5" alt="" />

_After:_
<img src="https://user-images.githubusercontent.com/3616980/80341729-4476d600-8863-11ea-9498-caf362f18519.png" width="372" alt="" />

### How to test the changes in this Pull Request:

Most of the font-sizes changed in this PR affect the editor, where Gutenberg and many themes reset the font size, so it's hard to test. I opened an issue for Storefront, see #1337.

Something to test in the frontend:
1. Create a page with the _Checkout_ block.
2. Change your browser default font size and visit that page in the frontend.
3. Verify input fields are accessible and properly aligned.