### PR TITLE
Remove order note

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -347,13 +347,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										}
 									/>
 								) }
-								{ /*@todo This is not implemented*/ }
-								<CheckboxControl
-									className="wc-block-checkout__add-note"
-									label="Add order notes?"
-									checked={ false }
-									onChange={ () => null }
-								/>
 							</FormStep>
 						) }
 						{ cartNeedsPayment && (


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The checkbox for order note was there in we did the skeleton for the checkout, we never implemented but it’s still visible.
We will tackle this later, for now, I'm deleting it so people don't experience a broken feature.
<!-- Reference any related issues or PRs here -->
Fixes #2308

![image](https://user-images.githubusercontent.com/6165348/80378840-2a55eb80-8895-11ea-80e6-0c96e2717331.png)
