### PR TITLE
Update shipping endpoint should extend the correct route

### DIFF
--- a/src/StoreApi/Routes/CartUpdateShipping.php
+++ b/src/StoreApi/Routes/CartUpdateShipping.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 /**
  * CartUpdateShipping class.
  */
-class CartUpdateShipping extends AbstractRoute {
+class CartUpdateShipping extends AbstractCartRoute {
 	/**
 	 * Get the namespace for this route.
 	 *


### PR DESCRIPTION
This was my bad - this route should be extending the cart route, otherwise the cart object won't be available. Cart is only init on cart routes to avoid impacting performance on non-cart routes.

Fixes #2317

### How to test the changes in this Pull Request:

1. Change country on checkout to trigger shipping update
2. Shipping rates should refresh, no console errors