### PR TITLE
Import from `@woocommerce/settings` in `@woocommerce/block-settings`

### DIFF
--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { getSetting } from '../shared';
+import { getSetting } from '@woocommerce/settings';
 
 export const CURRENT_USER_IS_ADMIN = getSetting( 'currentUserIsAdmin', false );
 export const REVIEW_RATINGS_ENABLED = getSetting(

--- a/assets/js/settings/blocks/store-api-nonce.js
+++ b/assets/js/settings/blocks/store-api-nonce.js
@@ -2,11 +2,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-
-/**
- * Internal dependencies
- */
-import { getSetting } from '../shared';
+import { getSetting } from '@woocommerce/settings';
 
 // Cache for the initial nonce initialized from hydration.
 let nonce = getSetting( 'storeApiNonce' );


### PR DESCRIPTION
Fixes #2329 

See #2329 for details. This pull should shave some bytes off of built bundles.

## To test

This impacts anything that utilizes server values passed through as block settings (so anything that imports data from `@woocommerce/block-settings`. It should be immediately clear if something is awry in testing involving components that use that alias (which include All Products, Checkout, Cart blocks etc).