### PR TITLE
align cart main heading and totals sidebar heading

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -6,6 +6,11 @@
 		font-weight: normal;
 	}
 
+	.wc-block-cart__main,
+	.wc-block-cart__sidebar .components-card__body.is-size-medium {
+		padding-top: 1.3em;
+	}
+
 	.wc-block-cart__item-count {
 		float: right;
 	}


### PR DESCRIPTION
Fixes #2296

This PR aligns the main cart heading and the totals card heading. Previously the main heading had no padding, and aligned with the top of the cart bounding box, so was "aligned" with the totals card box.

This PR sets a `padding-top` value for the main cart heading, and overrides the card styles to use the same value for `padding-top`. This override is necessary because the card padding is not provided by WooCommerce Blocks – I think it's coming directly from the [Gutenberg card component](https://github.com/WordPress/gutenberg/tree/master/packages/components/src/card). The padding is chosen to match the card padding, but expressed as em so it's more dynamic when the browser is zoomed.


#### Accessibility

- [x] I've tested with a range of browser zoom values

### Screenshots

<img width="1187" alt="Screen Shot 2020-04-29 at 4 54 14 PM" src="https://user-images.githubusercontent.com/4167300/80561897-15ff2380-8a3a-11ea-8e02-c411865a82bb.png">


### How to test the changes in this Pull Request:

1. Add cart block to a page or post.
2. Check cart block in editor and front end in different browsers and screen sizes.

Cart headings should align nicely.

Bonus points for testing other core / important themes (e.g. Twenty Twenty).

