### PR TITLE
Quantity badge white separator + center tweak

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -71,6 +71,9 @@
 		background: #fff;
 		border: 2px solid currentColor;
 		border-radius: 50%;
+		// Use box-shadow to apply an extra border to the quantity.
+		// This distinguishes it from the product image.
+		box-shadow: 0 0 0 2px #fff;
 		display: flex;
 		min-height: 22px;
 		position: absolute;

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -78,8 +78,8 @@
 		min-height: 22px;
 		position: absolute;
 		justify-content: center;
-		right: -6px;
-		top: #{$gap - 6px};
+		right: -11px;
+		top: #{$gap - 11px};
 		min-width: 22px;
 	}
 


### PR DESCRIPTION
Fixes #2303

This PR adds a white border to the checkout quantity badges, so they are visually distinct from the product image. Note that this is hard coded to white to match the card background; on mobile, with a background colour, this will look like an extra border. I'm open to ideas about how to choose this colour so it works well with different theme colour customisations, or other themes :) Might be possible to use SVG to mask the image .. though that's probably too complicated!

Also I noticed in @garymurray issue the designs have the circle centred on the image top right corner, so I've made that change in this PR too. cc @LevinMedia - happy to roll this back 


### Screenshots

<img width="1147" alt="Screen Shot 2020-04-29 at 5 22 26 PM" src="https://user-images.githubusercontent.com/4167300/80563270-a475a400-8a3e-11ea-994e-d254b47bafaa.png">

### How to test the changes in this Pull Request:

1. Publish a page with checkout block. 
2. Add some products to cart in various quantities.
3. View checkout block - confirm quantity badge is visually distinct from product image and looks good in all browsers/viewports.

