### PR TITLE
Fix low stock badge not breaking in a new line

### DIFF
--- a/assets/js/base/components/cart-checkout/product-name/style.scss
+++ b/assets/js/base/components/cart-checkout/product-name/style.scss
@@ -1,4 +1,6 @@
 .wc-block-product-name {
 	@include font-size(16);
 	@include wrapBreakWord();
+	display: block;
+	width: max-content;
 }


### PR DESCRIPTION
Fixes #2342.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/80579925-0e745600-8a0b-11ea-98cd-c61fbb0b7799.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/80579904-06b4b180-8a0b-11ea-95ed-a56ec5d1319c.png)

### How to test the changes in this Pull Request:

1. Open the _Cart_ block with a product that is low in stock.
2. Verify the low stock badge renders in its own line (instead of next to the product name).