### PR TITLE
Fix payment method error notices issues

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -140,7 +140,10 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 				id: 'wc-express-payment-error',
 			} );
 		} else {
-			removeNotice( 'wc-express-payment-error' );
+			removeNotice(
+				'wc-express-payment-error',
+				'wc/express-payment-area'
+			);
 		}
 	};
 	// ensure observers are always current.
@@ -274,7 +277,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		// allows for other observers that return true for continuing through
 		// to the next observer (or bailing if there's a problem).
 		if ( currentStatus.isProcessing ) {
-			removeNotice( 'wc-payment-error' );
+			removeNotice( 'wc-payment-error', noticeContexts.PAYMENTS );
 			emitEventWithAbort(
 				currentObservers.current,
 				EMIT_TYPES.PAYMENT_PROCESSING,

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -312,7 +312,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 				}
 			} );
 		}
-	}, [ currentStatus, setValidationErrors, setPaymentStatus ] );
+	}, [ currentStatus.isProcessing, setValidationErrors, setPaymentStatus ] );
 
 	/**
 	 * @type {PaymentMethodDataContext}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -274,6 +274,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		// allows for other observers that return true for continuing through
 		// to the next observer (or bailing if there's a problem).
 		if ( currentStatus.isProcessing ) {
+			removeNotice( 'wc-payment-error' );
 			emitEventWithAbort(
 				currentObservers.current,
 				EMIT_TYPES.PAYMENT_PROCESSING,
@@ -287,6 +288,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 					);
 				} else if ( isFailResponse( response ) ) {
 					addErrorNotice( response?.message, {
+						id: 'wc-payment-error',
 						context:
 							response?.messageContext || noticeContexts.PAYMENTS,
 					} );
@@ -297,6 +299,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 					);
 				} else if ( isErrorResponse( response ) ) {
 					addErrorNotice( response?.message, {
+						id: 'wc-payment-error',
 						context:
 							response?.messageContext || noticeContexts.PAYMENTS,
 					} );

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
-import { createContext, useContext, useState } from '@wordpress/element';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useState,
+} from '@wordpress/element';
 import { omit, pickBy } from 'lodash';
 
 /**
@@ -71,22 +76,25 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *                           validation error is for and values are the
 	 *                           validation error message displayed to the user.
 	 */
-	const setValidationErrors = ( newErrors ) => {
-		if ( ! newErrors ) {
-			return;
-		}
-		// all values must be a string.
-		newErrors = pickBy(
-			newErrors,
-			( { message } ) => typeof message === 'string'
-		);
-		if ( Object.values( newErrors ).length > 0 ) {
-			updateValidationErrors( ( prevErrors ) => ( {
-				...prevErrors,
-				...newErrors,
-			} ) );
-		}
-	};
+	const setValidationErrors = useCallback(
+		( newErrors ) => {
+			if ( ! newErrors ) {
+				return;
+			}
+			// all values must be a string.
+			newErrors = pickBy(
+				newErrors,
+				( { message } ) => typeof message === 'string'
+			);
+			if ( Object.values( newErrors ).length > 0 ) {
+				updateValidationErrors( ( prevErrors ) => ( {
+					...prevErrors,
+					...newErrors,
+				} ) );
+			}
+		},
+		[ updateValidationErrors ]
+	);
 
 	const updateValidationError = ( property, newError ) => {
 		updateValidationErrors( ( prevErrors ) => {

--- a/assets/js/base/context/store-notices-context.js
+++ b/assets/js/base/context/store-notices-context.js
@@ -13,7 +13,7 @@ const StoreNoticesContext = createContext( {
 	notices: [],
 	createNotice: ( status, text, props ) => void { status, text, props },
 	createSnackBarNotice: () => void null,
-	removeNotice: ( id ) => void id,
+	removeNotice: ( id, ctxt ) => void { id, ctxt },
 	context: 'wc/core',
 } );
 
@@ -50,8 +50,8 @@ export const StoreNoticesProvider = ( {
 	);
 
 	const removeNoticeWithContext = useCallback(
-		( id ) => {
-			removeNotice( id, context );
+		( id, ctxt = context ) => {
+			removeNotice( id, ctxt );
 		},
 		[ createNotice, context ]
 	);


### PR DESCRIPTION
Fixes #2217.
Fixes #2327.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/80582815-a96f2f00-8a0f-11ea-8522-afd556974345.png)

_After:_
![Peek 2020-04-29 11-43](https://user-images.githubusercontent.com/3616980/80582810-a7a56b80-8a0f-11ea-8a99-024f49a626a0.gif)

### How to test the changes in this Pull Request:

1. Go to the _Checkout_ page fill the form but leave the credit card details empty.
2. Click on _Place order_.
3. Verify only one error appears.
4. Fill the credit card details with an expired card (for example: `4242424242424242`, `11/11`, `111`).
5. Verify the previous error disappeared and it was replaced by another one.