### PR TITLE
Update API status codes

### DIFF
--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -106,7 +106,7 @@ abstract class AbstractRoute implements RouteInterface {
 		}
 
 		if ( null === $nonce ) {
-			throw new RouteException( 'woocommerce_rest_missing_nonce', __( 'Missing the X-WC-Store-API-Nonce header. This endpoint requires a valid nonce.', 'woo-gutenberg-products-block' ), 403 );
+			throw new RouteException( 'woocommerce_rest_missing_nonce', __( 'Missing the X-WC-Store-API-Nonce header. This endpoint requires a valid nonce.', 'woo-gutenberg-products-block' ), 401 );
 		}
 
 		$valid_nonce = wp_verify_nonce( $nonce, 'wc_store_api' );

--- a/src/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/CartRemoveCoupon.php
@@ -63,7 +63,7 @@ class CartRemoveCoupon extends AbstractCartRoute {
 		$coupon      = new \WC_Coupon( $coupon_code );
 
 		if ( $coupon->get_code() !== $coupon_code || ! $coupon->is_valid() ) {
-			throw new RouteException( 'woocommerce_rest_cart_coupon_error', __( 'Invalid coupon code.', 'woo-gutenberg-products-block' ), 403 );
+			throw new RouteException( 'woocommerce_rest_cart_coupon_error', __( 'Invalid coupon code.', 'woo-gutenberg-products-block' ), 400 );
 		}
 
 		if ( ! $controller->has_coupon( $coupon_code ) ) {

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -64,7 +64,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 		}
 
 		if ( ! isset( $request['package_id'] ) || ! is_numeric( $request['package_id'] ) ) {
-			throw new RouteException( 'woocommerce_rest_cart_missing_package_id', __( 'Invalid Package ID.', 'woo-gutenberg-products-block' ), 403 );
+			throw new RouteException( 'woocommerce_rest_cart_missing_package_id', __( 'Invalid Package ID.', 'woo-gutenberg-products-block' ), 400 );
 		}
 
 		$controller = new CartController();

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -64,7 +64,7 @@ class CartController {
 						__( '"%s" is already inside your cart.', 'woo-gutenberg-products-block' ),
 						$product->get_name()
 					),
-					403
+					400
 				);
 			}
 			wc()->cart->set_quantity( $existing_cart_id, $request['quantity'] + wc()->cart->cart_contents[ $existing_cart_id ]['quantity'], true );
@@ -133,7 +133,7 @@ class CartController {
 					__( '"%s" is already inside your cart.', 'woo-gutenberg-products-block' ),
 					$product->get_name()
 				),
-				403
+				400
 			);
 		}
 
@@ -161,7 +161,7 @@ class CartController {
 					__( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'woo-gutenberg-products-block' ),
 					$product->get_name()
 				),
-				403
+				400
 			);
 		}
 
@@ -178,7 +178,7 @@ class CartController {
 						$product->get_name(),
 						wc_format_stock_quantity_for_display( $qty_remaining, $product )
 					),
-					403
+					400
 				);
 			}
 		}
@@ -270,7 +270,7 @@ class CartController {
 					__( 'There are too many &quot;%s&quot; in the cart. Only 1 can be purchased.', 'woo-gutenberg-products-block' ),
 					$product->get_name()
 				),
-				403
+				400
 			);
 		}
 
@@ -282,7 +282,7 @@ class CartController {
 					__( '&quot;%s&quot; is out of stock and cannot be purchased.', 'woo-gutenberg-products-block' ),
 					$product->get_name()
 				),
-				403
+				400
 			);
 		}
 
@@ -304,7 +304,7 @@ class CartController {
 						wc_format_stock_quantity_for_display( $qty_remaining, $product ),
 						$product->get_name()
 					),
-					403
+					400
 				);
 			}
 		}
@@ -518,7 +518,7 @@ class CartController {
 					__( '"%s" is an invalid coupon code.', 'woo-gutenberg-products-block' ),
 					esc_html( $coupon_code )
 				),
-				403
+				400
 			);
 		}
 
@@ -530,7 +530,7 @@ class CartController {
 					__( 'Coupon code "%s" has already been applied.', 'woo-gutenberg-products-block' ),
 					esc_html( $coupon_code )
 				),
-				403
+				400
 			);
 		}
 
@@ -538,7 +538,7 @@ class CartController {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
 				wp_strip_all_tags( $coupon->get_error_message() ),
-				403
+				400
 			);
 		}
 
@@ -561,7 +561,7 @@ class CartController {
 						__( '"%s" has already been applied and cannot be used in conjunction with other coupons.', 'woo-gutenberg-products-block' ),
 						$code
 					),
-					403
+					400
 				);
 			}
 		}
@@ -654,7 +654,7 @@ class CartController {
 			throw new RouteException(
 				'woocommerce_rest_cart_invalid_product',
 				__( 'This product cannot be added to the cart.', 'woo-gutenberg-products-block' ),
-				403
+				400
 			);
 		}
 
@@ -696,7 +696,7 @@ class CartController {
 				__( '&quot;%s&quot; is not available for purchase.', 'woo-gutenberg-products-block' ),
 				$product->get_name()
 			),
-			403
+			400
 		);
 	}
 
@@ -903,7 +903,7 @@ class CartController {
 			throw new RouteException(
 				'woocommerce_rest_cart_invalid_parent_product',
 				__( 'This product cannot be added to the cart.', 'woo-gutenberg-products-block' ),
-				403
+				400
 			);
 		}
 

--- a/src/StoreApi/Utilities/ReserveStock.php
+++ b/src/StoreApi/Utilities/ReserveStock.php
@@ -90,7 +90,7 @@ final class ReserveStock {
 							__( '&quot;%s&quot; is out of stock and cannot be purchased.', 'woo-gutenberg-products-block' ),
 							$product->get_name()
 						),
-						403
+						400
 					);
 				}
 
@@ -184,7 +184,7 @@ final class ReserveStock {
 					__( 'Not enough units of %s are available in stock to fulfil this order.', 'woo-gutenberg-products-block' ),
 					$product ? $product->get_name() : '#' . $product_id
 				),
-				403
+				400
 			);
 		}
 	}

--- a/src/StoreApi/docs/cart.md
+++ b/src/StoreApi/docs/cart.md
@@ -259,7 +259,7 @@ If a cart action cannot be performed, an error response will be returned. This w
   "code": "woocommerce_rest_cart_invalid_product",
   "message": "This product cannot be added to the cart.",
   "data": {
-    "status": 403
+    "status": 400
   }
 }
 ```

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -332,7 +332,7 @@ class Cart extends TestCase {
 		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 400, $response->get_status() );
 
 		// Applied coupon.
 		$request = new WP_REST_Request( 'POST', '/wc/store/cart/remove-coupon' );

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -148,7 +148,7 @@ class CartItems extends TestCase {
 		);
 		$response = $this->server->dispatch( $request );
 
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 400, $response->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
This PR switches the bulk of client error codes over to `400 Bad Request` to avoid issues when hosts replace the 403 error page.

A 403 error is still used for nonce errors since it's the most appropriate.

This PR also catches JSON parse errors in `API_FETCH_WITH_HEADERS` to ensure a message is returned instead of a fatal token error.

Fixes #2323

### How to test the changes in this Pull Request:

Try applying an invalid coupon on Pressable (see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2323)
