### PR TITLE
Fix Cart block interaction in the editor (mobile)

### DIFF
--- a/assets/js/base/components/store-notices-container/snackbar-notices.js
+++ b/assets/js/base/components/store-notices-container/snackbar-notices.js
@@ -3,12 +3,18 @@
  */
 import { SnackbarList } from 'wordpress-components';
 import { useStoreNotices } from '@woocommerce/base-hooks';
+import { useEditorContext } from '@woocommerce/base-context';
 
 const NoticesContainer = () => {
+	const { isEditor } = useEditorContext();
 	const { notices, removeNotice } = useStoreNotices();
 	const snackbarNotices = notices.filter(
 		( notice ) => notice.type === 'snackbar'
 	);
+
+	if ( isEditor ) {
+		return null;
+	}
 	return (
 		<SnackbarList
 			notices={ snackbarNotices }

--- a/assets/js/base/components/store-notices-container/style.scss
+++ b/assets/js/base/components/store-notices-container/style.scss
@@ -25,7 +25,7 @@
 	}
 }
 
-.components-snackbar-list {
+.wc-block-notices__snackbar {
 	position: fixed;
 	bottom: 20px;
 	left: 16px;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
@@ -28,6 +28,11 @@
 	.wc-block-coupon-code .components-button {
 		opacity: 1;
 	}
+
+	.wc-block-cart__submit-container {
+		box-shadow: none;
+		position: static;
+	}
 }
 
 @include breakpoint( "<782px" ) {


### PR DESCRIPTION
Fixes #2314.

### Screenshots

_Before:_
<img src="https://user-images.githubusercontent.com/3616980/80604082-8f464880-8a31-11ea-8723-e386c354fdcb.png" width="375" alt=""/>

_After:_
<img src="https://user-images.githubusercontent.com/3616980/80604150-a5540900-8a31-11ea-8a6a-3795b1441689.png" width="375" alt=""/>

### How to test the changes in this Pull Request:

1. Open the _Cart_ block in the editor in a narrow viewport.
2. Verify the _Proceed to Checkout_ button is not fixed to the bottom of the page.
3. Verify you can scroll/click/interact with the page.