### PR TITLE
Checkout Block Order Summary Styles

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary-item.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary-item.js
@@ -27,8 +27,6 @@ const CheckoutOrderSummaryItem = ( { cartItem } ) => {
 	} = cartItem;
 
 	const currency = getCurrency( prices );
-	const regularPrice = parseInt( prices.regular_price, 10 );
-	const purchasePrice = parseInt( prices.price, 10 );
 	const linePrice = Dinero( {
 		amount: parseInt( prices.raw_prices.price, 10 ),
 		precision: parseInt( prices.raw_prices.precision, 10 ),
@@ -59,13 +57,6 @@ const CheckoutOrderSummaryItem = ( { cartItem } ) => {
 						className="wc-block-order-summary-item__total-price"
 						currency={ currency }
 						value={ linePrice }
-					/>
-				</div>
-				<div className="wc-block-order-summary-item__prices">
-					<ProductPrice
-						currency={ currency }
-						regularValue={ regularPrice }
-						value={ purchasePrice }
 					/>
 				</div>
 				<ProductLowStockBadge lowStockRemaining={ lowStockRemaining } />

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary-item.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary-item.js
@@ -40,7 +40,6 @@ const CheckoutOrderSummaryItem = ( { cartItem } ) => {
 	return (
 		<div className="wc-block-order-summary-item">
 			<div className="wc-block-order-summary-item__image">
-				<ProductImage image={ images.length ? images[ 0 ] : {} } />
 				<div className="wc-block-order-summary-item__quantity">
 					<Label
 						label={ quantity }
@@ -51,6 +50,7 @@ const CheckoutOrderSummaryItem = ( { cartItem } ) => {
 						) }
 					/>
 				</div>
+				<ProductImage image={ images.length ? images[ 0 ] : {} } />
 			</div>
 			<div className="wc-block-order-summary-item__description">
 				<div className="wc-block-order-summary-item__header">

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -13,6 +13,12 @@
 	}
 }
 
+.wc-block-checkout__main {
+	fieldset.wc-block-checkout-step:first-child {
+		margin-top: $gap-small;
+	}
+}
+
 .wc-block-checkout__sidebar {
 	.wc-block-order-summary {
 		border: none;
@@ -49,20 +55,32 @@
 
 	.wc-block-order-summary-item {
 		display: table-row;
+		> div {
+			border-bottom: 1px solid $core-grey-light-600;
+		}
+		&:last-child {
+			> div {
+				border-bottom: none;
+			}
+		}
 	}
 
 	.wc-block-order-summary-item__image,
 	.wc-block-order-summary-item__description {
-		border-bottom: 1px solid $core-grey-light-600;
 		display: table-cell;
-		padding-top: $gap;
 		vertical-align: top;
 	}
 
 	.wc-block-order-summary-item__image {
 		width: 72px;
+		padding-top: #{$gap + 6px}; // Slight offset to account for line height.
 		padding-bottom: $gap;
 		position: relative;
+
+		> img {
+			width: 72px;
+			max-width: 72px;
+		}
 	}
 
 	.wc-block-order-summary-item__quantity {
@@ -78,22 +96,23 @@
 		min-height: 22px;
 		position: absolute;
 		justify-content: center;
-		right: -11px;
-		top: #{$gap - 11px};
 		min-width: 22px;
+		right: -10px;
+		margin: -10px 0 0 0;
 	}
 
 	.wc-block-order-summary-item__description {
-		padding-left: $gap;
+		padding-left: $gap-large;
+		padding-top: $gap;
 	}
 
 	.wc-block-order-summary-item__header {
 		display: flex;
+		flex-wrap: wrap;
 	}
 
 	.wc-block-product-name {
 		flex-grow: 1;
-		margin-right: 0.5em;
 		// Required by IE11.
 		flex-basis: 0;
 	}
@@ -337,24 +356,14 @@
 			padding: 0 $gap;
 		}
 
-		.wc-block-order-summary-item:last-child {
-			.wc-block-order-summary-item__image,
-			.wc-block-order-summary-item__description {
-				border-bottom: none;
-			}
-		}
-
 		.wc-block-order-summary-item__image {
 			width: 48px;
 
 			// Required by IE11.
 			> img {
 				width: 48px;
+				max-width: 48px;
 			}
-		}
-
-		.wc-block-order-summary-item__description {
-			padding-left: $gap-small;
 		}
 	}
 }

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -72,14 +72,14 @@
 	}
 
 	.wc-block-order-summary-item__image {
-		width: 72px;
-		padding-top: #{$gap + 6px}; // Slight offset to account for line height.
+		width: #{$gap-large * 2};
+		padding-top: $gap;
 		padding-bottom: $gap;
 		position: relative;
 
 		> img {
-			width: 72px;
-			max-width: 72px;
+			width: #{$gap-large * 2};
+			max-width: #{$gap-large * 2};
 		}
 	}
 
@@ -104,6 +104,12 @@
 	.wc-block-order-summary-item__description {
 		padding-left: $gap-large;
 		padding-top: $gap;
+		line-height: $gap-large;
+
+		.wc-block-product-metadata {
+			line-height: $gap;
+			margin-top: #{ ( $gap-large - $gap ) / 2 };
+		}
 	}
 
 	.wc-block-order-summary-item__header {
@@ -115,10 +121,6 @@
 		flex-grow: 1;
 		// Required by IE11.
 		flex-basis: 0;
-	}
-
-	.wc-block-order-summary-item__prices {
-		font-size: 0.875em;
 	}
 }
 
@@ -354,16 +356,6 @@
 
 		.wc-block-order-summary__row {
 			padding: 0 $gap;
-		}
-
-		.wc-block-order-summary-item__image {
-			width: 48px;
-
-			// Required by IE11.
-			> img {
-				width: 48px;
-				max-width: 48px;
-			}
 		}
 	}
 }


### PR DESCRIPTION
This PR contains fixes for order summary/checkout styling.

- Removes last item border in order summary table. Fixes #2305
- Adds a small margin to top of checkout for alignment (see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2346)
- Fixes padding in order summary box, as well as image aignment and padding to match comps. Fixes #2304 
- Remove the item total from order summary as discussed with @garymurray 

### Screenshots

Before:

![Screenshot 2020-04-29 at 13 36 30](https://user-images.githubusercontent.com/90977/80605885-89e5ff80-8a2b-11ea-9d62-34ade9229710.png)
![Screenshot 2020-04-29 at 13 39 55](https://user-images.githubusercontent.com/90977/80605887-8a7e9600-8a2b-11ea-8b88-4fa216599137.png)

After: 

![Screenshot 2020-04-29 at 15 07 25](https://user-images.githubusercontent.com/90977/80605868-83f01e80-8a2b-11ea-9205-9421c492e5de.png)
![Screenshot 2020-04-29 at 15 00 12](https://user-images.githubusercontent.com/90977/80605876-85b9e200-8a2b-11ea-879d-2b7548dc8e1a.png)