### PR TITLE
Payment methods `placeOrderButtonLabel` config

### DIFF
--- a/assets/js/base/components/cart-checkout/place-order-button/index.js
+++ b/assets/js/base/components/cart-checkout/place-order-button/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useCheckoutContext } from '@woocommerce/base-context';
+import { useCheckoutSubmit } from '@woocommerce/base-hooks';
 import { Icon, done } from '@woocommerce/icons';
 
 /**
@@ -12,27 +12,20 @@ import Button from '../button';
 
 const PlaceOrderButton = () => {
 	const {
-		submitLabel,
+		submitButtonText,
 		onSubmit,
 		isCalculating,
-		isBeforeProcessing,
-		isProcessing,
-		isAfterProcessing,
-		isComplete,
-		hasError,
-	} = useCheckoutContext();
-
-	const waitingForProcessing =
-		isProcessing || isAfterProcessing || isBeforeProcessing;
-	const waitingForRedirect = isComplete && ! hasError;
-	const disabled =
-		isCalculating || waitingForProcessing || waitingForRedirect;
+		waitingForProcessing,
+		waitingForRedirect,
+	} = useCheckoutSubmit();
 
 	return (
 		<Button
 			className="wc-block-components-checkout-place-order-button"
 			onClick={ onSubmit }
-			disabled={ disabled }
+			disabled={
+				isCalculating || waitingForProcessing || waitingForRedirect
+			}
 			showSpinner={ waitingForProcessing }
 		>
 			{ waitingForRedirect ? (
@@ -41,7 +34,7 @@ const PlaceOrderButton = () => {
 					alt={ __( 'Done', 'woo-gutenberg-products-block' ) }
 				/>
 			) : (
-				submitLabel
+				submitButtonText
 			) }
 		</Button>
 	);

--- a/assets/js/base/context/cart-checkout/cart/index.js
+++ b/assets/js/base/context/cart-checkout/cart/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { ShippingDataProvider } from '../shipping';
@@ -15,25 +10,15 @@ import { PaymentMethodDataProvider } from '../payment-methods';
  * This wraps the Cart and provides an api interface for the Cart to
  * children via various hooks.
  *
- * @param {Object}  props                     Incoming props for the provider.
- * @param {Object}  [props.children]          The children being wrapped.
- * @param {string}  [props.redirectUrl]       Initialize what the cart will
- *                                            redirect to after successful
- *                                            submit.
- * @param {string}  [props.submitLabel]       What will be used for the cart
- *                                            submit button label.
+ * @param {Object}  props               Incoming props for the provider.
+ * @param {Object}  [props.children]    The children being wrapped.
+ * @param {string}  [props.redirectUrl] Initialize what the cart will
+ *                                      redirect to after successful
+ *                                      submit.
  */
-export const CartProvider = ( {
-	children,
-	redirectUrl,
-	submitLabel = __( 'Proceed to Checkout', 'woo-gutenberg-products-block' ),
-} ) => {
+export const CartProvider = ( { children, redirectUrl } ) => {
 	return (
-		<CheckoutStateProvider
-			redirectUrl={ redirectUrl }
-			isCart={ true }
-			submitLabel={ submitLabel }
-		>
+		<CheckoutStateProvider redirectUrl={ redirectUrl } isCart={ true }>
 			<ShippingDataProvider>
 				<PaymentMethodDataProvider>
 					{ children }

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -33,8 +33,6 @@ import { useValidationContext } from '../validation';
  */
 
 const CheckoutContext = createContext( {
-	submitLabel: '',
-	onSubmit: () => void null,
 	isComplete: false,
 	isIdle: false,
 	isCalculating: false,
@@ -45,6 +43,7 @@ const CheckoutContext = createContext( {
 	redirectUrl: '',
 	orderId: 0,
 	customerId: 0,
+	onSubmit: () => void null,
 	onCheckoutAfterProcessingWithSuccess: ( callback ) => void callback,
 	onCheckoutAfterProcessingWithError: ( callback ) => void callback,
 	onCheckoutBeforeProcessing: ( callback ) => void callback,
@@ -78,8 +77,6 @@ export const useCheckoutContext = () => {
  * @param {string}  props.redirectUrl         Initialize what the checkout will
  *                                            redirect to after successful
  *                                            submit.
- * @param {string}  props.submitLabel         What will be used for the checkout
- *                                            submit button label.
  * @param {boolean} props.isCart              If context provider is being used
  *                                            in cart context.
  */
@@ -87,7 +84,6 @@ export const CheckoutStateProvider = ( {
 	children,
 	redirectUrl,
 	isCart = false,
-	submitLabel = __( 'Place Order', 'woo-gutenberg-product-block' ),
 } ) => {
 	// note, this is done intentionally so that the default state now has
 	// the redirectUrl for when checkout is reset to PRISTINE state.
@@ -291,7 +287,7 @@ export const CheckoutStateProvider = ( {
 		checkoutState.status,
 		checkoutState.hasError,
 		checkoutState.redirectUrl,
-		checkoutState.orderId,
+		checkoutState.redirectUrl,
 		checkoutState.customerId,
 		checkoutState.customerNote,
 		checkoutState.processingResponse,
@@ -306,7 +302,6 @@ export const CheckoutStateProvider = ( {
 	 * @type {CheckoutDataContext}
 	 */
 	const checkoutData = {
-		submitLabel,
 		onSubmit,
 		isComplete: checkoutState.status === STATUS.COMPLETE,
 		isIdle: checkoutState.status === STATUS.IDLE,

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -287,7 +287,7 @@ export const CheckoutStateProvider = ( {
 		checkoutState.status,
 		checkoutState.hasError,
 		checkoutState.redirectUrl,
-		checkoutState.redirectUrl,
+		checkoutState.orderId,
 		checkoutState.customerId,
 		checkoutState.customerNote,
 		checkoutState.processingResponse,

--- a/assets/js/base/context/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { PaymentMethodDataProvider } from '../payment-methods';
@@ -17,25 +12,15 @@ import CheckoutProcessor from './processor';
  * This wraps the checkout and provides an api interface for the checkout to
  * children via various hooks.
  *
- * @param {Object}  props                       Incoming props for the provider.
- * @param {Object}  props.children              The children being wrapped.
- * @param {string}  [props.redirectUrl]         Initialize what the checkout will
- *                                              redirect to after successful
- *                                              submit.
- * @param {string}  [props.submitLabel]         What will be used for the checkout
- *                                              submit button label.
+ * @param {Object}  props               Incoming props for the provider.
+ * @param {Object}  props.children      The children being wrapped.
+ * @param {string}  [props.redirectUrl] Initialize what the checkout will
+ *                                      redirect to after successful
+ *                                      submit.
  */
-export const CheckoutProvider = ( {
-	children,
-	redirectUrl,
-	submitLabel = __( 'Place Order', 'woo-gutenberg-products-block' ),
-} ) => {
+export const CheckoutProvider = ( { children, redirectUrl } ) => {
 	return (
-		<CheckoutStateProvider
-			redirectUrl={ redirectUrl }
-			isCart={ false }
-			submitLabel={ submitLabel }
-		>
+		<CheckoutStateProvider redirectUrl={ redirectUrl } isCart={ false }>
 			<BillingDataProvider>
 				<ShippingDataProvider>
 					<PaymentMethodDataProvider>

--- a/assets/js/base/hooks/checkout/test/use-checkout-submit.js
+++ b/assets/js/base/hooks/checkout/test/use-checkout-submit.js
@@ -9,13 +9,19 @@ import { createRegistry, RegistryProvider } from '@wordpress/data';
  */
 import { useCheckoutSubmit } from '../use-checkout-submit';
 
-const mockSubmitLabel = 'Submit!';
 const mockUseCheckoutContext = {
-	submitLabel: mockSubmitLabel,
 	onSubmit: jest.fn(),
+};
+const mockUsePaymentMethodDataContext = {};
+const mockUsePaymentMethods = {
+	paymentMethods: {},
 };
 jest.mock( '@woocommerce/base-context', () => ( {
 	useCheckoutContext: () => mockUseCheckoutContext,
+	usePaymentMethodDataContext: () => mockUsePaymentMethodDataContext,
+} ) );
+jest.mock( '@woocommerce/base-hooks', () => ( {
+	usePaymentMethods: () => mockUsePaymentMethods,
 } ) );
 
 describe( 'useCheckoutSubmit', () => {
@@ -35,20 +41,6 @@ describe( 'useCheckoutSubmit', () => {
 	beforeEach( () => {
 		registry = createRegistry();
 		renderer = null;
-	} );
-
-	it( 'submitLabel matches the value provided by the checkout context', () => {
-		const TestComponent = getTestComponent();
-
-		act( () => {
-			renderer = TestRenderer.create(
-				getWrappedComponents( TestComponent )
-			);
-		} );
-
-		const { submitLabel } = renderer.root.findByType( 'div' ).props;
-
-		expect( submitLabel ).toBe( mockSubmitLabel );
 	} );
 
 	it( 'onSubmit calls the correct action in the checkout context', () => {

--- a/assets/js/base/hooks/checkout/use-checkout-submit.js
+++ b/assets/js/base/hooks/checkout/use-checkout-submit.js
@@ -1,12 +1,39 @@
 /**
  * External dependencies
  */
-import { useCheckoutContext } from '@woocommerce/base-context';
+import { __ } from '@wordpress/i18n';
+import {
+	useCheckoutContext,
+	usePaymentMethodDataContext,
+} from '@woocommerce/base-context';
+import { usePaymentMethods } from '@woocommerce/base-hooks';
 
 /**
- * Returns the submitLabel and onSubmit interface from the checkout context
+ * Returns the submitButtonText, onSubmit interface from the checkout context,
+ * and an indication of submission status.
  */
 export const useCheckoutSubmit = () => {
-	const { submitLabel, onSubmit } = useCheckoutContext();
-	return { submitLabel, onSubmit };
+	const {
+		onSubmit,
+		isCalculating,
+		isBeforeProcessing,
+		isProcessing,
+		isAfterProcessing,
+		isComplete,
+		hasError,
+	} = useCheckoutContext();
+	const { paymentMethods } = usePaymentMethods();
+	const { activePaymentMethod } = usePaymentMethodDataContext();
+	const paymentMethod = paymentMethods[ activePaymentMethod ] || {};
+
+	return {
+		submitButtonText:
+			paymentMethod?.placeOrderButtonLabel ||
+			__( 'Place Order', 'woo-gutenberg-products-block' ),
+		onSubmit,
+		isCalculating,
+		waitingForProcessing:
+			isProcessing || isAfterProcessing || isBeforeProcessing,
+		waitingForRedirect: isComplete && ! hasError,
+	};
 };

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -13,6 +13,7 @@ export default class PaymentMethodConfig {
 		PaymentMethodConfig.assertValidConfig( config );
 		this.name = config.name;
 		this.label = config.label;
+		this.placeOrderButtonLabel = config.placeOrderButtonLabel;
 		this.ariaLabel = config.ariaLabel;
 		this.content = config.content;
 		this.icons = config.icons;
@@ -50,6 +51,14 @@ export default class PaymentMethodConfig {
 		) {
 			throw new Error(
 				'The paymentMethodId property for the payment method must be a string or undefined (in which case it will be the value of the name property).'
+			);
+		}
+		if (
+			typeof config.placeOrderButtonLabel !== 'string' &&
+			typeof config.placeOrderButtonLabel !== 'undefined'
+		) {
+			throw new TypeError(
+				'The placeOrderButtonLabel property for the payment method must be a string'
 			);
 		}
 		assertValidElementOrString( config.label, 'label' );

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -34,6 +34,10 @@ const paypalPaymentMethod = {
 			) }
 		/>
 	),
+	placeOrderButtonLabel: __(
+		'Proceed to PayPal',
+		'woo-gutenberg-products-block'
+	),
 	content: <Content />,
 	edit: <Content />,
 	icons: null,

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -211,8 +211,6 @@
 /**
  * @typedef {Object} CheckoutDataContext
  *
- * @property {string}                       submitLabel                The label to use for the
- *                                                                     submit checkout button.
  * @property {function()}                   onSubmit                   The callback to register with
  *                                                                     the checkout submit button.
  * @property {boolean}                      isComplete                 True when checkout is complete

--- a/docs/block-client-apis/checkout/checkout-api.md
+++ b/docs/block-client-apis/checkout/checkout-api.md
@@ -83,14 +83,12 @@ The payment method data context exposes the api interfaces for the following thi
 
 This context is the main one. Internally via the `<CheckoutProvider>` it handles wrapping children in `<ShippingMethodDataProvider>`, `<BillingDataProvider>` and `<PaymentMethodDataProvider>`. So the checkout components just need to be wrapped by `<CheckoutProvider>`.
 
-The provider receives two props:
+The provider receives the following props:
 
 -   `redirectUrl`: A string, this is used to indicate where the checkout redirects to when it is complete. This is optional and can be used to set a default url to redirect to.
--   `submitLabel`: This allows for customizing the checkout submit button label. It defaults to `Place Order`.
 
 Via `useCheckoutContext`, the following are exposed:
 
--   `submitLabel`: This is whatever label was passed via the provider.
 -   `onSubmit`: This is a callback to be invoked either by submitting the checkout button, or by express payment methods to start checkout processing after they have finished their initialization process when their button has been clicked.
 -   `isComplete`: True when checkout has finished processing and the subscribed checkout processing callbacks have all been invoked along with a successful processing of the checkout by the server.
 -   `isIdle`: When the checkout status is `IDLE` this flag is true. Checkout will be this status after any change to checkout state after the block is loaded. It will also be this status when retrying a purchase is possible after processing happens with an error.


### PR DESCRIPTION
Removes the `submitLabel` property from checkout context (which wasn't used by cart nor checkout, despite being implemented) and replaces it with text controllable by Payment Methods/

Since this needs various contexts to work (payments being the main one), I added this to the `useCheckoutSubmit` hook, and then implemented `useCheckoutSubmit` in the Place Order Button component.

For gateways, they just need to include `placeOrderButtonLabel` in the config. When active, this value will be used. Otherwise, the default "Place Order" will be used instead.

Fixes #2326

### Screenshots

![2020-04-29 17 40 55](https://user-images.githubusercontent.com/90977/80622948-6cbc2b80-8a41-11ea-9814-3633e302f7e2.gif)

### How to test the changes in this Pull Request:

1. Go to checkout, ensure place order button reads "Place Order"
2. Select PayPal. Order button should update.