### PR TITLE
only show checkout login prompt if store allows it

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -160,7 +160,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	}
 
 	const loginPrompt = () =>
-		! CHECKOUT_SHOW_LOGIN_REMINDER ? null : (
+		CHECKOUT_SHOW_LOGIN_REMINDER && (
 			<>
 				{ __(
 					'Already have an account? ',

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Fragment, useState, useCallback, useEffect } from '@wordpress/element';
+import { useState, useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import defaultAddressFields from '@woocommerce/base-components/cart-checkout/address-form/default-address-fields';
 import {
@@ -47,6 +47,7 @@ import {
 } from '@woocommerce/base-components/sidebar-layout';
 import { getSetting } from '@woocommerce/settings';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
+import { CHECKOUT_SHOW_LOGIN_REMINDER } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -158,6 +159,19 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		return <CheckoutOrderError />;
 	}
 
+	const loginPrompt = () =>
+		! CHECKOUT_SHOW_LOGIN_REMINDER ? null : (
+			<>
+				{ __(
+					'Already have an account? ',
+					'woo-gutenberg-products-block'
+				) }
+				<a href="/wp-login.php">
+					{ __( 'Log in.', 'woo-gutenberg-products-block' ) }
+				</a>
+			</>
+		);
+
 	return (
 		<>
 			<SidebarLayout className="wc-block-checkout">
@@ -176,20 +190,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								"We'll use this email to send you details and updates about your order.",
 								'woo-gutenberg-products-block'
 							) }
-							stepHeadingContent={ () => (
-								<Fragment>
-									{ __(
-										'Already have an account? ',
-										'woo-gutenberg-products-block'
-									) }
-									<a href="/wp-login.php">
-										{ __(
-											'Log in.',
-											'woo-gutenberg-products-block'
-										) }
-									</a>
-								</Fragment>
-							) }
+							stepHeadingContent={ loginPrompt }
 						>
 							<ValidatedTextInput
 								id="email"

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -59,6 +59,11 @@ export const SHIPPING_METHODS_EXIST = getSetting(
 	false
 );
 
+export const CHECKOUT_SHOW_LOGIN_REMINDER = getSetting(
+	'checkoutShowLoginReminder',
+	true
+);
+
 const defaultPage = {
 	id: 0,
 	title: '',

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -132,6 +132,7 @@ class Assets {
 				'displayItemizedTaxes'          => 'itemized' === get_option( 'woocommerce_tax_total_display' ),
 				'displayShopPricesIncludingTax' => 'incl' === get_option( 'woocommerce_tax_display_shop' ),
 				'displayCartPricesIncludingTax' => 'incl' === get_option( 'woocommerce_tax_display_cart' ),
+				'checkoutShowLoginReminder'     => 'yes' === get_option( 'woocommerce_enable_checkout_login_reminder' ),
 				'showAvatars'                   => '1' === get_option( 'show_avatars' ),
 				'reviewRatingsEnabled'          => wc_review_ratings_enabled(),
 				'productCount'                  => array_sum( (array) $product_counts ),


### PR DESCRIPTION
Fixes #2325

At the top of checkout a login prompt is displayed. In Woo settings there's an option to disable this under `Guest checkout` section. This PR exposes this setting to the block, and only shows the prompt if the merchant has configured site to do so.

### Screenshots

<img width="981" alt="Screen Shot 2020-04-30 at 4 11 34 PM" src="https://user-images.githubusercontent.com/4167300/80671207-478cf300-8afd-11ea-95bc-e8bfab353e2f.png">

### How to test the changes in this Pull Request:

1. Publish a page with checkout block, add some stuff to your cart, view checkout block on front end.
2. Toggle `Allow customers to log into an existing account during checkout` option in `WooCommerce > Settings > Accounts & Privacy`.
3. Refresh checkout page - the log in prompt should only show if you have the option ticked. 
2. Toggle it back, refresh, and repeat :)
