### PR TITLE
Change when InnerBlocks are rendered to fix image alignment issues in empty cart

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -141,6 +141,11 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 
 /**
  * Component to handle edit mode of "Cart Block".
+ *
+ * Note: We need to always render `<InnerBlocks>` in the editor. Otherwise,
+ *       if the user saves the page without having triggered the 'Empty Cart'
+ *       view, inner blocks would not be saved and they wouldn't be visible
+ *       in the frontend.
  */
 const CartEditor = ( { className, attributes, setAttributes } ) => {
 	if ( attributes.isPreview ) {
@@ -194,9 +199,10 @@ const CartEditor = ( { className, attributes, setAttributes } ) => {
 										</CartProvider>
 									</Disabled>
 								</EditorProvider>
+								<EmptyCartEdit hidden={ true } />
 							</>
 						) }
-						<EmptyCartEdit hidden={ currentView === 'full' } />
+						{ currentView === 'empty' && <EmptyCartEdit /> }
 					</BlockErrorBoundary>
 				) }
 			/>

--- a/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
@@ -15,13 +15,7 @@ import './style.scss';
 /**
  * Component to handle edit mode for the Cart block when cart is empty.
  */
-const EmptyCartEdit = ( { hidden } ) => {
-	// We need to always render `<InnerBlocks>` in the editor.
-	// Otherwise, if the user saves the page without having
-	// triggered the 'Empty Cart' view, inner blocks would not
-	// be saved and they wouldn't be visible in the frontend.
-	// We wrap them in a hidden `<div>` if the user is in
-	// the editor 'Full Cart' view so they are not visible.
+const EmptyCartEdit = ( { hidden = false } ) => {
 	return (
 		<div hidden={ hidden }>
 			<InnerBlocks


### PR DESCRIPTION
There were image alignment issues in the cart block, but I found this was not due to missing styles and was actually caused by initialization of the InnerBlocks whilst hidden.

To fix this, we can render the empty InnerState when switching views. To ensure InnerBlocks are always saved regardless of view, we render it hidden in full view.

This fixes initialization issues and didn't seem to impact performance.

Fixes #2297

### How to test the changes in this Pull Request:

1. Edit the cart page - view empty state. Confirm alignment.
2. Make changes to state, save, check changes persist.
3. Insert new cart block. Save without editing empty state. Check default template is used.
