### PR TITLE
Rename the discount section when discount total is zero

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-discount-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-discount-item/index.js
@@ -30,6 +30,9 @@ const TotalsDiscountItem = ( {
 	}
 
 	const discountTaxValue = parseInt( totalDiscountTax, 10 );
+	const displayDiscountValue = DISPLAY_CART_PRICES_INCLUDING_TAX
+		? discountValue + discountTaxValue
+		: discountValue;
 
 	return (
 		<TotalsItem
@@ -69,12 +72,12 @@ const TotalsDiscountItem = ( {
 					</LoadingMask>
 				)
 			}
-			label={ __( 'Discount', 'woo-gutenberg-products-block' ) }
-			value={
-				( DISPLAY_CART_PRICES_INCLUDING_TAX
-					? discountValue + discountTaxValue
-					: discountValue ) * -1
+			label={
+				displayDiscountValue
+					? __( 'Discount', 'woo-gutenberg-products-block' )
+					: __( 'Coupons', 'woo-gutenberg-products-block' )
 			}
+			value={ displayDiscountValue ? displayDiscountValue * -1 : '-' }
 		/>
 	);
 };

--- a/assets/js/base/components/cart-checkout/totals/totals-discount-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-discount-item/index.js
@@ -30,7 +30,7 @@ const TotalsDiscountItem = ( {
 	}
 
 	const discountTaxValue = parseInt( totalDiscountTax, 10 );
-	const displayDiscountValue = DISPLAY_CART_PRICES_INCLUDING_TAX
+	const discountTotalValue = DISPLAY_CART_PRICES_INCLUDING_TAX
 		? discountValue + discountTaxValue
 		: discountValue;
 
@@ -73,11 +73,11 @@ const TotalsDiscountItem = ( {
 				)
 			}
 			label={
-				displayDiscountValue
+				!! discountTotalValue
 					? __( 'Discount', 'woo-gutenberg-products-block' )
 					: __( 'Coupons', 'woo-gutenberg-products-block' )
 			}
-			value={ displayDiscountValue ? displayDiscountValue * -1 : '-' }
+			value={ discountTotalValue ? discountTotalValue * -1 : '-' }
 		/>
 	);
 };

--- a/assets/js/base/components/formatted-monetary-amount/index.js
+++ b/assets/js/base/components/formatted-monetary-amount/index.js
@@ -41,9 +41,13 @@ const FormattedMonetaryAmount = ( {
 	onValueChange,
 	...props
 } ) => {
+	if ( value === '-' ) {
+		return null;
+	}
+
 	const priceValue = value / 10 ** currency.minorUnit;
 
-	if ( ! Number.isFinite( priceValue ) && priceValue === '-' ) {
+	if ( ! Number.isFinite( priceValue ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
This is awaiting feedback from @garymurray to see if it satisfies the issue or not.

If the Discount total is 0, this renames the total row to "Coupons" which keeps coupon display in the same place, but avoids inferring there is 0 discount.

Fixes #2302

This is instead of splitting out shipping coupons as suggested in the issue, because:

- We don’t have a way in the API right now to return if a coupon grants free shipping.
- Some free shipping coupons might also give a $ discount, so we’d have to also consider that
- We’d have to render 2 coupon sections and feed two separate lists of coupons

Additionally, I have not touched shipping rate ordering since this is user controlled (drag and drop) in WP admin. They can move free shipping first in the list to do what was suggested in #2302

### Screenshots

![screenshot_2020-04-30_at_12 38 48](https://user-images.githubusercontent.com/90977/80709710-a6467280-8ae5-11ea-9e81-0bd556a51d81.png)
![screenshot_2020-04-30_at_12 38 26](https://user-images.githubusercontent.com/90977/80709714-a6df0900-8ae5-11ea-8c30-756a1c2ed496.png)

### How to test the changes in this Pull Request:

1. Apply a free shipping coupon
2. Confirm matches screenshots