### PR TITLE
Fix summary styles and margins/padding #2340

### DIFF
--- a/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -1,5 +1,9 @@
 .wc-block-product-metadata {
 	@include font-size(12);
 	color: $core-grey-dark-400;
-	margin-top: 0.25em;
+
+	p,
+	.wc-block-product-variation-data {
+		margin: 0.25em 0 0 0;
+	}
 }

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -104,8 +104,10 @@
 	.wc-block-order-summary-item__description {
 		padding-left: $gap-large;
 		padding-top: $gap;
+		padding-bottom: $gap;
 		line-height: $gap-large;
 
+		p,
 		.wc-block-product-metadata {
 			line-height: $gap;
 			margin-top: #{ ( $gap-large - $gap ) / 2 };


### PR DESCRIPTION
Small CSS fix to ensure summary and variation text has correct margins/padding in frontend and editor.

Fixes #2340

![Screenshot 2020-04-30 at 13 46 55](https://user-images.githubusercontent.com/90977/80712382-d6901000-8ae9-11ea-8fdb-f7072ea33c50.png)
