### PR TITLE
Assets/Block settings: Only lookup page if ID > 0

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -165,7 +165,7 @@ class Assets {
 		if ( is_numeric( $page ) && $page > 0 ) {
 			$page = get_post( $page );
 		}
-		if ( ! $page ) {
+		if ( ! is_a( $page, '\WP_Post' ) ) {
 			return [
 				'id'        => 0,
 				'title'     => '',

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -162,7 +162,7 @@ class Assets {
 	 * @return array
 	 */
 	protected static function format_page_resource( $page ) {
-		if ( is_numeric( $page ) ) {
+		if ( is_numeric( $page ) && $page > 0 ) {
 			$page = get_post( $page );
 		}
 		if ( ! $page ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,7 +56,7 @@ function wc_blocks_install() {
  * Adds WooCommerce testing framework classes.
  */
 function wc_test_includes() {
-	$wc_tests_framework_base_dir = wc_dir() . '/tests';
+	$wc_tests_framework_base_dir = wc_dir() . '/tests/legacy';
 	// WooCommerce test classes.
 	// Framework.
 	require_once $wc_tests_framework_base_dir . '/framework/class-wc-unit-test-factory.php';


### PR DESCRIPTION
The assets file was incorrectly getting a page if the ID was 0. This lead to a "terms and conditions" page being shown erroneously if the page was not configured.

Fixes #2339

### How to test the changes in this Pull Request:

1. Unset the terms and conditons page in WC > Settings > Advanced
2. Confirm no page is rendered in the privacy footer section on the checkout page
