### PR TITLE
Use container queries to load Cart and Checkout responsive styles

### DIFF
--- a/assets/css/abstracts/_breakpoints.scss
+++ b/assets/css/abstracts/_breakpoints.scss
@@ -5,7 +5,7 @@
 
 // Think very carefully before adding a new breakpoint.
 // The list below is based on wp-admin's main breakpoints
-// See https://github.com/WordPress/gutenberg/tree/master/packages/viewport#breakpoints
+// See https://github.com/WordPress/gutenberg/tree/master/packages/viewport#usage
 $breakpoints: 480px, 600px, 782px, 960px, 1280px, 1440px;
 
 @mixin breakpoint( $sizes... ) {

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -12,8 +12,8 @@ $line-offset-from-circle-size: 8px;
 	background: none;
 	margin: 0;
 
-	@include breakpoint( ">782px" ) {
-		padding-right: $gap-larger;
+	.is-large & {
+		padding-right: $gap-large;
 	}
 }
 

--- a/assets/js/base/components/sidebar-layout/sidebar-layout.js
+++ b/assets/js/base/components/sidebar-layout/sidebar-layout.js
@@ -3,6 +3,7 @@
  */
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { useContainerQueries } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -10,8 +11,17 @@ import PropTypes from 'prop-types';
 import './style.scss';
 
 const SidebarLayout = ( { children, className } ) => {
+	const [ resizeListener, containerQueryClassName ] = useContainerQueries();
+
 	return (
-		<div className={ classNames( 'wc-block-sidebar-layout', className ) }>
+		<div
+			className={ classNames(
+				'wc-block-sidebar-layout',
+				className,
+				containerQueryClassName
+			) }
+		>
+			{ resizeListener }
 			{ children }
 		</div>
 	);

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -6,14 +6,14 @@
 
 	.wc-block-main {
 		margin: 0;
-		padding-right: $gap-largest;
+		padding-right: percentage($gap-largest / 1060px); // ~1060px is the default width of the content area in Storefront.
 		width: 65%;
 	}
 }
 
 .wc-block-sidebar {
 	margin: 0;
-	padding-left: $gap-largest;
+	padding-left: percentage($gap-largest / 1060px);
 	width: 35%;
 
 	// Reset Gutenberg <Panel> styles when used in the sidebar.

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	margin: 0 auto $gap;
+	position: relative;
 
 	.wc-block-main {
 		margin: 0;
@@ -60,8 +61,10 @@
 	}
 }
 
-@include breakpoint( "<782px" ) {
-	.wc-block-sidebar-layout {
+.is-medium,
+.is-small,
+.is-mobile {
+	&.wc-block-sidebar-layout {
 		flex-direction: column;
 		margin: 0 0 $gap;
 

--- a/assets/js/base/hooks/index.js
+++ b/assets/js/base/hooks/index.js
@@ -6,6 +6,7 @@ export * from './shipping';
 export * from './use-collection';
 export * from './use-collection-header';
 export * from './use-collection-data';
+export * from './use-container-queries';
 export * from './use-previous';
 export * from './use-shallow-equal';
 export * from './use-store-products';

--- a/assets/js/base/hooks/use-container-queries.js
+++ b/assets/js/base/hooks/use-container-queries.js
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { useResizeObserver } from 'wordpress-compose';
+
+/**
+ * Returns a resizeListener element and a class name based on its width.
+ * Class names are based on the smaller of the breakpoints:
+ * https://github.com/WordPress/gutenberg/tree/master/packages/viewport#usage
+ * _Note: `useContainerQueries` will return an empty class name `` until after
+ * first render_
+ *
+ * @return {Array} An array of {Element} `resizeListener` and {string} `className`.
+ *
+ * @example
+ *
+ * ```js
+ * const App = () => {
+ * 	const [ resizeListener, containerQueryClassName ] = useContainerQueries();
+ *
+ * 	return (
+ * 		<div className={ containerQueryClassName }>
+ * 			{ resizeListener }
+ * 			Your content here
+ * 		</div>
+ * 	);
+ * };
+ * ```
+ */
+export const useContainerQueries = () => {
+	const [ resizeListener, { width } ] = useResizeObserver();
+
+	let className = '';
+	if ( width > 782 ) {
+		className = 'is-large';
+	} else if ( width > 600 ) {
+		className = 'is-medium';
+	} else if ( width > 480 ) {
+		className = 'is-small';
+	} else if ( width ) {
+		className = 'is-mobile';
+	}
+
+	return [ resizeListener, className ];
+};

--- a/assets/js/base/hooks/use-container-queries.js
+++ b/assets/js/base/hooks/use-container-queries.js
@@ -7,6 +7,8 @@ import { useResizeObserver } from 'wordpress-compose';
  * Returns a resizeListener element and a class name based on its width.
  * Class names are based on the smaller of the breakpoints:
  * https://github.com/WordPress/gutenberg/tree/master/packages/viewport#usage
+ * Values are also based on those breakpoints minus ~80px which is aproximately
+ * the left + right margin in Storefront with a font-size of 16px.
  * _Note: `useContainerQueries` will return an empty class name `` until after
  * first render_
  *
@@ -31,11 +33,11 @@ export const useContainerQueries = () => {
 	const [ resizeListener, { width } ] = useResizeObserver();
 
 	let className = '';
-	if ( width > 782 ) {
+	if ( width > 700 ) {
 		className = 'is-large';
-	} else if ( width > 600 ) {
+	} else if ( width > 520 ) {
 		className = 'is-medium';
-	} else if ( width > 480 ) {
+	} else if ( width > 400 ) {
 		className = 'is-small';
 	} else if ( width ) {
 		className = 'is-mobile';

--- a/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
@@ -34,11 +34,3 @@
 		position: static;
 	}
 }
-
-@include breakpoint( "<782px" ) {
-	.editor-styles-wrapper {
-		table td.wc-block-cart-item__total {
-			vertical-align: bottom;
-		}
-	}
-}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -179,9 +179,10 @@ table.wc-block-cart-items {
 	display: flex;
 }
 
-// Mobile styles.
-@include breakpoint( "<782px" ) {
-	.wc-block-cart {
+.is-medium,
+.is-small,
+.is-mobile {
+	&.wc-block-cart {
 		.wc-block-sidebar {
 			.wc-block-cart__totals-title {
 				display: none;
@@ -247,7 +248,9 @@ table.wc-block-cart-items {
 			}
 		}
 	}
+}
 
+@include breakpoint( "<782px" ) {
 	// Submit button is sticky to bottom of screen on mobile.
 	.wc-block-cart__submit-container {
 		background: $white;
@@ -264,15 +267,13 @@ table.wc-block-cart-items {
 	}
 }
 
-@include breakpoint( ">782px" ) {
-	.wc-block-cart {
-		.wc-block-radio-control__option {
-			padding-left: $gap-large;
-		}
+.is-large.wc-block-cart {
+	.wc-block-radio-control__option {
+		padding-left: $gap-large;
+	}
 
-		.wc-block-radio-control__input {
-			left: 0;
-		}
+	.wc-block-radio-control__input {
+		left: 0;
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -237,7 +237,7 @@
 	}
 }
 
-@include breakpoint( "<480px" ) {
+.is-mobile {
 	.wc-block-checkout__actions {
 		.wc-block-components-checkout-return-to-cart-button {
 			display: none;
@@ -249,7 +249,9 @@
 	}
 }
 
-@include breakpoint( "<782px" ) {
+.is-mobile,
+.is-small,
+.is-medium {
 	.wc-block-checkout__main {
 		order: 1;
 	}
@@ -264,7 +266,9 @@
 	}
 }
 
-@include breakpoint( ">480px" ) {
+.is-small,
+.is-medium,
+.is-large {
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {
 		.wc-block-address-form {
@@ -307,7 +311,7 @@
 	}
 }
 
-@include breakpoint( ">782px" ) {
+.is-large {
 	.wc-block-checkout__sidebar {
 		.wc-block-order-summary {
 			margin: -20px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -30367,15 +30367,16 @@
       }
     },
     "wordpress-compose": {
-      "version": "npm:@wordpress/compose@3.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.11.0.tgz",
-      "integrity": "sha512-CNbLn9NtG2A0X71wjEux126uEHpWp3v546FtSgMoWlq73z3LEEBDoEeS2glIPAbIK6e1X2UibsKrn5Tn651tlg==",
+      "version": "npm:@wordpress/compose@3.13.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.13.1.tgz",
+      "integrity": "sha512-RlPWcePmsnVj6jxPIq92lh7zbc3vPJzZC5BCHC9v38zUxUSd0pd7q+vvs/Wzpv4t4pYy0saslUM9HTq+bS6nxA==",
       "requires": {
-        "@babel/runtime": "^7.8.3",
-        "@wordpress/element": "^2.11.0",
-        "@wordpress/is-shallow-equal": "^1.8.0",
+        "@babel/runtime": "^7.9.2",
+        "@wordpress/element": "^2.13.1",
+        "@wordpress/is-shallow-equal": "^2.0.0",
         "lodash": "^4.17.15",
-        "mousetrap": "^1.6.2"
+        "mousetrap": "^1.6.2",
+        "react-resize-aware": "^3.0.0"
       },
       "dependencies": {
         "@wordpress/element": {
@@ -30391,11 +30392,11 @@
           }
         },
         "@wordpress/is-shallow-equal": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-          "integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.0.0.tgz",
+          "integrity": "sha512-Xv8b3Jno/3Td6nyj1J+skW96sbyfX7W4sk0TLwN2C2Pz6iQTSTQyGrXmTZWShITt4SOeA8gKpP6kAwSZ4O0HOQ==",
           "requires": {
-            "@babel/runtime": "^7.8.3"
+            "@babel/runtime": "^7.9.2"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
 		"trim-html": "0.1.9",
 		"use-debounce": "3.4.0",
 		"wordpress-components": "npm:@wordpress/components@8.5.0",
-		"wordpress-compose": "npm:@wordpress/compose@3.11.0",
+		"wordpress-compose": "npm:@wordpress/compose@3.13.1",
 		"wordpress-element": "npm:@wordpress/element@2.11.0"
 	},
 	"husky": {

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -130,7 +130,7 @@ class Cart extends AbstractBlock {
 	 */
 	protected function get_skeleton() {
 		return '
-			<div class="wc-block-sidebar-layout wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton" aria-hidden="true">
+			<div class="wc-block-sidebar-layout wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton is-large" aria-hidden="true">
 				<div class="wc-block-main wc-block-cart__main">
 					<h2><span></span></h2>
 					<table class="wc-block-cart-items">

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -170,7 +170,7 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function get_skeleton() {
 		return '
-			<div class="wc-block-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton" aria-hidden="true">
+			<div class="wc-block-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton is-large" aria-hidden="true">
 				<div class="wc-block-main wc-block-checkout__main">
 					<div class="wc-block-component-express-checkout"></div>
 					<div class="wc-block-component-express-checkout-continue-rule"><span></span></div>


### PR DESCRIPTION
Fixes #2274.
Fixes #2357.

This PR introduces a new hook: `useContainerQueries()` which allows setting a class name dynamically based on the container width. This will allow our blocks to be responsive based on the container width instead of the viewport width.

### Advantages
* Users might add the _Cart_ or _Checkout_ block in narrow containers (like in #2274, imagine the _Cart_ and _Checkout_ blocks inside a column block). In those cases, blocks will display the mobile styles so they don't break.

| Before | After |
| ------------- | ------------- |
| ![imatge](https://user-images.githubusercontent.com/3616980/80713579-0217f800-8af4-11ea-8d48-01d8aa89a010.png) | ![imatge](https://user-images.githubusercontent.com/3616980/80713433-b82f1200-8af3-11ea-84f4-027383d620b9.png) |

* Some themes main content area is very narrow and the _Cart_ and _Checkout_ blocks were not playing well. For example, TwentyTwenty.

* With the last Gutenberg release, which allows previewing for `tablet` and `mobile`, our blocks will adapt to the display width so they give a more accurate preview :tada: :

| Before | After |
| ------------- | ------------- |
| ![imatge](https://user-images.githubusercontent.com/3616980/80712698-a731d100-8af2-11ea-84f2-34d6b9ebb567.png) | ![imatge](https://user-images.githubusercontent.com/3616980/80712800-c7619000-8af2-11ea-88bf-0af87629d5d4.png) |

* Knowing the block width in the JS side could potentially simplify our markup/styles. If we know a component is only rendered in desktop, we will no longer need to always render it and hide it on mobile with `display: none`.

### A drawback
We lose the opportunity to have responsive 'skeletons'. Skeletons are added from the PHP side so there is no way to know the container width in advance.
![Peek 2020-04-30 15-06](https://user-images.githubusercontent.com/3616980/80714171-d0536100-8af4-11ea-9acd-bc928a17d728.gif)

Some ideas:
* We could completely remove the skeleton from the PHP side and instead rely on JS loading states. We lose the advantage of the skeleton being loaded immediately, but that would fix the issue completely and we would be able to remove some code.
* Always default to one of the sizes, for example, always showing the `large` layout even on mobile (this is how it's currently done, see screenshot above). That will make the skeleton not to look good in some sizes.
* Use native CSS mediaqueries for the skeleton. That would mean we would need to duplicate a lot of CSS (that could be done with a mixin, but it would still add complexity to the codebase). In addition, it will not fix the issue completely, because mediaqueries will still differ from container queries.

Personally, I would go for the first option. But wanted to get some feedback from the theme before proceeding. cc @mikejolley for feedback as well because if I'm not wrong, you worked on those skeletons. :point_up_2: 

### Next steps

All in all, I think the advantages overpass the drawback. But happy to discuss. :slightly_smiling_face: 

If this PR is accepted, I think we could open a follow-up in order to update all other blocks to use container queries instead of media queries when possible.

### Testing steps

1. Test the _Cart_ and _Checkout_ blocks in different viewport sizes.
2. Verify they still have responsive styles and those are applied according to the container width.