### PR TITLE
Ensure stripe payment request "canMakePayment" configuration uses site country.

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { getSetting } from '@woocommerce/settings';
+
+/**
  * Internal dependencies
  */
 import { PAYMENT_METHOD_NAME } from './constants';
@@ -27,7 +32,7 @@ const PaymentRequestPaymentMethod = {
 					label: 'Test total',
 					amount: 1000,
 				},
-				country: cartData?.shippingAddress?.country,
+				country: getSetting( 'baseLocation', {} )?.country,
 				// eslint-disable-next-line camelcase
 				currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
 			} );

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/payment-request-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/payment-request-express.js
@@ -27,6 +27,7 @@ import {
 	useStripe,
 } from '@stripe/react-stripe-js';
 import { __ } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe
@@ -94,7 +95,7 @@ const PaymentRequestExpressComponent = ( {
 				getPaymentRequest( {
 					total: billing.cartTotal,
 					currencyCode: billing.currency.code.toLowerCase(),
-					countryCode: shippingData.shippingAddress.country,
+					countryCode: getSetting( 'baseLocation', {} )?.country,
 					shippingRequired: shippingData.needsShipping,
 					cartTotalItems: billing.cartTotalItems,
 					stripe,
@@ -115,7 +116,6 @@ const PaymentRequestExpressComponent = ( {
 	}, [
 		billing.cartTotal,
 		billing.currency.code,
-		shippingData.shippingAddress.country,
 		shippingData.needsShipping,
 		billing.cartTotalItems,
 		stripe,

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -152,6 +152,7 @@ class Assets {
 					'privacy'  => self::format_page_resource( $page_ids['privacy'] ),
 					'terms'    => self::format_page_resource( $page_ids['terms'] ),
 				],
+				'baseLocation'                  => wc_get_base_location(),
 			]
 		);
 	}


### PR DESCRIPTION
Fixes: #2292

In this pull the `canMakePayment` configuration for the stripe payment request api is switched to use the `base_location['country']` value returned from the `wc_get_base_location`function and exposed via the server via the `baseLocation` property in `@woocommerce/settings`.

## To test

The stripe payment request api will now be initialized from this value in the WooCommerce general settings for your test site:

<img width="886" alt="Image 2020-04-30 at 2 40 48 PM" src="https://user-images.githubusercontent.com/1429108/80747040-c7609080-8af0-11ea-978e-b94faacb2473.png">

So if you have that value set to any country that is supported by the Stripe Payment request api, then you should see the express payment for the browser you have loaded ([chrome pay](https://stripe.com/docs/stripe-js/elements/payment-request-button#react-testing-chrome), in the chrome browser, [Apple Pay](https://stripe.com/docs/stripe-js/elements/payment-request-button#react-testing-safari) in Safari)

You should be able to complete a purchase using the express payment method for your browser (assuming you have all required conditions met).