### PR TITLE
Store billing address to local state and persist globally to prevent loss of data

### DIFF
--- a/assets/js/base/components/select/validated.js
+++ b/assets/js/base/components/select/validated.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { useValidationContext } from '@woocommerce/base-context';
+import { useShallowEqual } from '@woocommerce/base-hooks';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
@@ -30,13 +31,18 @@ const ValidatedSelect = ( {
 } ) => {
 	const selectId = id || 'select-' + instanceId;
 	errorId = errorId || selectId;
+
+	// Prevents re-renders when value is an object, e.g. {key: "NY", name: "New York"}
+	const currentValue = useShallowEqual( value );
+
 	const {
 		getValidationError,
 		setValidationErrors,
 		clearValidationError,
 	} = useValidationContext();
+
 	const validateSelect = () => {
-		if ( ! required || value ) {
+		if ( ! required || currentValue ) {
 			clearValidationError( errorId );
 		} else {
 			setValidationErrors( {
@@ -50,7 +56,7 @@ const ValidatedSelect = ( {
 
 	useEffect( () => {
 		validateSelect();
-	}, [ value ] );
+	}, [ currentValue ] );
 
 	// Remove validation errors when unmounted.
 	useEffect( () => {
@@ -68,7 +74,7 @@ const ValidatedSelect = ( {
 				'has-error': error.message && ! error.hidden,
 			} ) }
 			feedback={ <ValidationInputError propertyName={ errorId } /> }
-			value={ value }
+			value={ currentValue }
 			{ ...rest }
 		/>
 	);

--- a/assets/js/base/components/select/validated.js
+++ b/assets/js/base/components/select/validated.js
@@ -63,7 +63,7 @@ const ValidatedSelect = ( {
 		return () => {
 			clearValidationError( errorId );
 		};
-	}, [] );
+	}, [ errorId ] );
 
 	const error = getValidationError( errorId ) || {};
 

--- a/assets/js/base/components/select/validated.js
+++ b/assets/js/base/components/select/validated.js
@@ -63,7 +63,7 @@ const ValidatedSelect = ( {
 		return () => {
 			clearValidationError( errorId );
 		};
-	}, [] );
+	}, [ clearValidationError ] );
 
 	const error = getValidationError( errorId ) || {};
 

--- a/assets/js/base/components/select/validated.js
+++ b/assets/js/base/components/select/validated.js
@@ -63,7 +63,7 @@ const ValidatedSelect = ( {
 		return () => {
 			clearValidationError( errorId );
 		};
-	}, [ clearValidationError ] );
+	}, [] );
 
 	const error = getValidationError( errorId ) || {};
 

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,15 +30,7 @@ const StateInput = ( {
 				name: decodeEntities( countryStates[ key ] ),
 		  } ) )
 		: [];
-	// @todo: remove this code block when issue https://github.com/woocommerce/woocommerce/issues/25854 is merged
-	// Defaults to the first state when selecting a country with states, this is here
-	// until a bug in Woo core is fixed.
-	// see: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1919
-	useEffect( () => {
-		if ( ! value && options.length ) {
-			onChangeState( options[ 0 ].key );
-		}
-	}, [ country ] );
+
 	/**
 	 * Handles state selection onChange events. Finds a matching state by key or value.
 	 *

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -37,6 +37,7 @@ const ValidatedTextInput = ( {
 
 	const textInputId = id || 'textinput-' + instanceId;
 	errorId = errorId || textInputId;
+
 	const validateInput = ( errorsHidden = true ) => {
 		if ( inputRef.current.checkValidity() ) {
 			clearValidationError( errorId );
@@ -63,7 +64,7 @@ const ValidatedTextInput = ( {
 		return () => {
 			clearValidationError( errorId );
 		};
-	}, [] );
+	}, [ clearValidationError ] );
 
 	const errorMessage = getValidationError( errorId ) || {};
 	const hasError = errorMessage.message && ! errorMessage.hidden;

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -64,7 +64,7 @@ const ValidatedTextInput = ( {
 		return () => {
 			clearValidationError( errorId );
 		};
-	}, [] );
+	}, [ errorId ] );
 
 	const errorMessage = getValidationError( errorId ) || {};
 	const hasError = errorMessage.message && ! errorMessage.hidden;

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -64,7 +64,7 @@ const ValidatedTextInput = ( {
 		return () => {
 			clearValidationError( errorId );
 		};
-	}, [ clearValidationError ] );
+	}, [] );
 
 	const errorMessage = getValidationError( errorId ) || {};
 	const hasError = errorMessage.message && ! errorMessage.hidden;

--- a/assets/js/base/context/cart-checkout/billing/constants.js
+++ b/assets/js/base/context/cart-checkout/billing/constants.js
@@ -27,7 +27,6 @@ export const DEFAULT_BILLING_DATA = {
 	country: '',
 	email: '',
 	phone: '',
-	shippingAsBilling: true,
 };
 
 const billingAddress = mapValues( checkoutData.billing_address, ( value ) =>

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -8,6 +8,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { omit, pickBy } from 'lodash';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * @typedef { import('@woocommerce/type-defs/contexts').ValidationContext } ValidationContext
@@ -102,10 +103,19 @@ export const ValidationContextProvider = ( { children } ) => {
 	);
 
 	const updateValidationError = ( property, newError ) => {
+		if (
+			isShallowEqual( validationErrors[ property ], {
+				...validationErrors[ property ],
+				...newError,
+			} )
+		) {
+			return;
+		}
 		updateValidationErrors( ( prevErrors ) => {
 			if ( ! prevErrors.hasOwnProperty( property ) ) {
 				return prevErrors;
 			}
+
 			return {
 				...prevErrors,
 				[ property ]: {
@@ -124,14 +134,9 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *                           value to true.
 	 */
 	const hideValidationError = ( property ) => {
-		if (
-			validationErrors[ property ] &&
-			validationErrors[ property ].hidden !== true
-		) {
-			updateValidationError( property, {
-				hidden: true,
-			} );
-		}
+		updateValidationError( property, {
+			hidden: true,
+		} );
 	};
 
 	/**
@@ -142,14 +147,9 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *                           value to false.
 	 */
 	const showValidationError = ( property ) => {
-		if (
-			validationErrors[ property ] &&
-			validationErrors[ property ].hidden !== false
-		) {
-			updateValidationError( property, {
-				hidden: false,
-			} );
-		}
+		updateValidationError( property, {
+			hidden: false,
+		} );
 	};
 
 	/**

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -185,7 +185,6 @@ export const ValidationContextProvider = ( { children } ) => {
 	};
 
 	const context = {
-		validationErrors,
 		getValidationError,
 		setValidationErrors,
 		clearValidationError,

--- a/assets/js/base/context/cart-checkout/validation/index.js
+++ b/assets/js/base/context/cart-checkout/validation/index.js
@@ -58,11 +58,16 @@ export const ValidationContextProvider = ( { children } ) => {
 	 * @param {string} property  The name of the property to clear if exists in
 	 *                           validation error state.
 	 */
-	const clearValidationError = ( property ) => {
-		if ( validationErrors[ property ] ) {
-			updateValidationErrors( omit( validationErrors, [ property ] ) );
-		}
-	};
+	const clearValidationError = useCallback(
+		( property ) => {
+			if ( validationErrors[ property ] ) {
+				updateValidationErrors(
+					omit( validationErrors, [ property ] )
+				);
+			}
+		},
+		[ validationErrors, updateValidationErrors ]
+	);
 
 	/**
 	 * Clears the entire validation error state.
@@ -119,9 +124,14 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *                           value to true.
 	 */
 	const hideValidationError = ( property ) => {
-		updateValidationError( property, {
-			hidden: true,
-		} );
+		if (
+			validationErrors[ property ] &&
+			validationErrors[ property ].hidden !== true
+		) {
+			updateValidationError( property, {
+				hidden: true,
+			} );
+		}
 	};
 
 	/**
@@ -132,9 +142,14 @@ export const ValidationContextProvider = ( { children } ) => {
 	 *                           value to false.
 	 */
 	const showValidationError = ( property ) => {
-		updateValidationError( property, {
-			hidden: false,
-		} );
+		if (
+			validationErrors[ property ] &&
+			validationErrors[ property ].hidden !== false
+		) {
+			updateValidationError( property, {
+				hidden: false,
+			} );
+		}
 	};
 
 	/**
@@ -170,6 +185,7 @@ export const ValidationContextProvider = ( { children } ) => {
 	};
 
 	const context = {
+		validationErrors,
 		getValidationError,
 		setValidationErrors,
 		clearValidationError,

--- a/assets/js/base/hooks/checkout/index.js
+++ b/assets/js/base/hooks/checkout/index.js
@@ -1,3 +1,4 @@
 export * from './use-checkout-redirect-url';
+export * from './use-checkout-address';
 export * from './use-checkout-submit';
 export * from './use-emit-response';

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -73,16 +73,16 @@ export const useCheckoutAddress = () => {
 
 	const setEmail = useCallback(
 		( value ) => {
-			setBillingData( { email: value } );
+			setBillingFields( { email: value } );
 		},
-		[ setBillingData ]
+		[ setBillingFields ]
 	);
 
 	const setPhone = useCallback(
 		( value ) => {
-			setBillingData( { phone: value } );
+			setBillingFields( { phone: value } );
 		},
-		[ setBillingData ]
+		[ setBillingFields ]
 	);
 
 	return {

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -17,7 +17,9 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  * @param {Object} address2 Second address.
  */
 const isSameAddress = ( address1, address2 ) => {
-	return Object.keys( defaultAddressFields ).every( ( field ) => address1[ field ] === address2[ field ] );
+	return Object.keys( defaultAddressFields ).every(
+		( field ) => address1[ field ] === address2[ field ]
+	);
 };
 
 /**

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import defaultAddressFields from '@woocommerce/base-components/cart-checkout/address-form/default-address-fields';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import {
+	useShippingDataContext,
+	useBillingDataContext,
+	useCheckoutContext,
+} from '@woocommerce/base-context';
+
+/**
+ * Compare two addresses and see if they are the same.
+ *
+ * @param {Object} address1 First address.
+ * @param {Object} address2 Second address.
+ */
+const isSameAddress = ( address1, address2 ) => {
+	const diff = Object.keys( defaultAddressFields ).filter( ( field ) => {
+		return address1[ field ] !== address2[ field ];
+	} );
+	return diff.length === 0;
+};
+
+/**
+ * Custom hook for tracking address field state on checkout and persisting it to
+ * context globally on change.
+ */
+export const useCheckoutAddress = () => {
+	const { customerId } = useCheckoutContext();
+	const {
+		shippingAddress,
+		setShippingAddress,
+		needsShipping,
+	} = useShippingDataContext();
+	const { billingData, setBillingData } = useBillingDataContext();
+
+	// These are the local states of address fields, which are persisted
+	// globally when changed. They default to the global shipping address which
+	// is populated from the current customer data or default location.
+	const [ shippingFields, setShippingFields ] = useState( shippingAddress );
+	const [ billingFields, setBillingFields ] = useState( billingData );
+
+	// This tracks the state of the "shipping as billing" address checkbox. It's
+	// initial value is true (if shipping is needed), however, if the user is
+	// logged in and they have a different billing address, we can toggle this off.
+	const [ shippingAsBilling, setShippingAsBilling ] = useState(
+		() =>
+			needsShipping &&
+			( ! customerId || isSameAddress( shippingAddress, billingData ) )
+	);
+
+	// Pushes to global state when changes are made locally.
+	useEffect( () => {
+		setShippingAddress( shippingFields );
+
+		if ( shippingAsBilling ) {
+			setBillingData( shippingFields );
+		}
+	}, [ shippingFields ] );
+
+	useEffect( () => {
+		setBillingData( billingFields );
+	}, [ billingFields ] );
+
+	useEffect( () => {
+		if ( shippingAsBilling ) {
+			setBillingData( shippingFields );
+		} else {
+			setBillingData( billingFields );
+		}
+	}, [ shippingAsBilling ] );
+
+	const setEmail = useCallback(
+		( value ) => {
+			setBillingData( { email: value } );
+		},
+		[ setBillingData ]
+	);
+
+	const setPhone = useCallback(
+		( value ) => {
+			setBillingData( { phone: value } );
+		},
+		[ setBillingData ]
+	);
+
+	return {
+		defaultAddressFields,
+		shippingFields,
+		setShippingFields,
+		billingFields,
+		setBillingFields,
+		setEmail,
+		setPhone,
+		shippingAsBilling,
+		setShippingAsBilling,
+		showBillingFields: ! needsShipping || ! shippingAsBilling,
+	};
+};

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -8,7 +8,7 @@ import {
 	useBillingDataContext,
 	useCheckoutContext,
 } from '@woocommerce/base-context';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import { isEqual } from 'lodash';
 
 /**
  * Compare two addresses and see if they are the same.
@@ -54,7 +54,7 @@ export const useCheckoutAddress = () => {
 
 	// Pushes to global state when changes are made locally.
 	useEffect( () => {
-		if ( ! isShallowEqual( shippingFields, shippingAddress ) ) {
+		if ( ! isEqual( shippingFields, shippingAddress ) ) {
 			setShippingAddress( shippingFields );
 		}
 
@@ -62,7 +62,7 @@ export const useCheckoutAddress = () => {
 			? shippingFields
 			: billingFields;
 
-		if ( ! isShallowEqual( newBillingData, billingData ) ) {
+		if ( ! isEqual( newBillingData, billingData ) ) {
 			setBillingData( newBillingData );
 		}
 	}, [ shippingFields, billingFields, shippingAsBilling ] );

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -17,10 +17,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  * @param {Object} address2 Second address.
  */
 const isSameAddress = ( address1, address2 ) => {
-	const diff = Object.keys( defaultAddressFields ).filter( ( field ) => {
-		return address1[ field ] !== address2[ field ];
-	} );
-	return diff.length === 0;
+	return Object.keys( defaultAddressFields ).every( ( field ) => address1[ field ] === address2[ field ] );
 };
 
 /**

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -8,6 +8,7 @@ import {
 	useBillingDataContext,
 	useCheckoutContext,
 } from '@woocommerce/base-context';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Compare two addresses and see if they are the same.
@@ -52,24 +53,19 @@ export const useCheckoutAddress = () => {
 
 	// Pushes to global state when changes are made locally.
 	useEffect( () => {
-		setShippingAddress( shippingFields );
-
-		if ( shippingAsBilling ) {
-			setBillingData( shippingFields );
+		// Update shipping address if it doesn't match local state.
+		if ( ! isShallowEqual( shippingFields, shippingAddress ) ) {
+			setShippingAddress( shippingFields );
 		}
-	}, [ shippingFields ] );
 
-	useEffect( () => {
-		setBillingData( billingFields );
-	}, [ billingFields ] );
+		const billingDataToSet = shippingAsBilling
+			? shippingFields
+			: billingFields;
 
-	useEffect( () => {
-		if ( shippingAsBilling ) {
-			setBillingData( shippingFields );
-		} else {
-			setBillingData( billingFields );
+		if ( ! isShallowEqual( billingDataToSet, billingData ) ) {
+			setBillingData( billingDataToSet );
 		}
-	}, [ shippingAsBilling ] );
+	}, [ shippingFields, billingFields, shippingAsBilling ] );
 
 	const setEmail = useCallback(
 		( value ) => {

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -60,6 +60,12 @@ import CheckoutOrderError from './checkout-order-error';
 import NoShippingPlaceholder from './no-shipping-placeholder';
 import './style.scss';
 
+/**
+ * Renders the Checkout block wrapped within the CheckoutProvider.
+ *
+ * @param {Object} props Component props.
+ * @return {*} The component.
+ */
 const Block = ( props ) => {
 	return (
 		<CheckoutProvider>
@@ -68,6 +74,30 @@ const Block = ( props ) => {
 	);
 };
 
+/**
+ * Renders a shipping rate control option.
+ *
+ * @param {Object} option Shipping Rate.
+ */
+const renderShippingRatesControlOption = ( option ) => ( {
+	label: decodeEntities( option.name ),
+	value: option.rate_id,
+	description: decodeEntities( option.description ),
+	secondaryLabel: (
+		<FormattedMonetaryAmount
+			currency={ getCurrencyFromPriceResponse( option ) }
+			value={ option.price }
+		/>
+	),
+	secondaryDescription: decodeEntities( option.delivery_time ),
+} );
+
+/**
+ * Main Checkout Component.
+ *
+ * @param {Object} props Component props.
+ * @return {*} The component.
+ */
 const Checkout = ( { attributes, scrollToTop } ) => {
 	const { isEditor } = useEditorContext();
 	const {
@@ -102,19 +132,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		needsShipping
 	);
 
-	const renderShippingRatesControlOption = ( option ) => ( {
-		label: decodeEntities( option.name ),
-		value: option.rate_id,
-		description: decodeEntities( option.description ),
-		secondaryLabel: (
-			<FormattedMonetaryAmount
-				currency={ getCurrencyFromPriceResponse( option ) }
-				value={ option.price }
-			/>
-		),
-		secondaryDescription: decodeEntities( option.delivery_time ),
-	} );
-
 	const showBillingFields = ! needsShipping || ! shippingAsBilling;
 	const addressFields = {
 		...defaultAddressFields,
@@ -140,11 +157,10 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		},
 		[ setShippingAddress, setBillingData, shippingAsBilling ]
 	);
+
 	useEffect( () => {
 		if ( shippingAsBilling ) {
-			setBillingData( { ...shippingAddress, shippingAsBilling } );
-		} else {
-			setBillingData( { shippingAsBilling } );
+			setBillingData( { ...shippingAddress } );
 		}
 	}, [ shippingAsBilling, setBillingData ] );
 
@@ -152,6 +168,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		checkoutIsIdle &&
 		checkoutHasError &&
 		( hasValidationErrors || hasNoticesOfType( 'default' ) );
+
 	useEffect( () => {
 		if ( hasErrorsToDisplay ) {
 			showAllValidationErrors();

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -228,11 +228,9 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Email address',
 									'woo-gutenberg-products-block'
 								) }
-								value={ billingData.email }
+								value={ billingFields.email }
 								autoComplete="email"
-								onChange={ ( newValue ) =>
-									setBillingData( { email: newValue } )
-								}
+								onChange={ setEmail }
 								required={ true }
 							/>
 						</FormStep>
@@ -253,7 +251,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								<AddressForm
 									id="shipping"
 									onChange={ setShippingFields }
-									values={ shippingAddress }
+									values={ shippingFields }
 									fields={ Object.keys( addressFields ) }
 									fieldConfig={ addressFields }
 								/>
@@ -272,13 +270,9 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 														'woo-gutenberg-products-block'
 												  )
 										}
-										value={ billingData.phone }
+										value={ billingFields.phone }
 										autoComplete="tel"
-										onChange={ ( newValue ) =>
-											setBillingData( {
-												phone: newValue,
-											} )
-										}
+										onChange={ setPhone }
 										required={
 											attributes.requirePhoneField
 										}
@@ -313,9 +307,9 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 							>
 								<AddressForm
 									id="billing"
-									onChange={ setBillingData }
+									onChange={ setBillingFields }
 									type="billing"
-									values={ billingData }
+									values={ billingFields }
 									fields={ Object.keys( addressFields ) }
 									fieldConfig={ addressFields }
 								/>
@@ -340,30 +334,13 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										: ''
 								}
 							>
-								{ getShippingRatesPackageCount(
+								{ isEditor &&
+								! getShippingRatesPackageCount(
 									shippingRates
-								) === 0 && isEditor ? (
+								) ? (
 									<NoShippingPlaceholder />
 								) : (
 									<ShippingRatesControl
-										address={
-											shippingAddress.country
-												? {
-														address_1:
-															shippingAddress.address_1,
-														address_2:
-															shippingAddress.address_2,
-														city:
-															shippingAddress.city,
-														state:
-															shippingAddress.state,
-														postcode:
-															shippingAddress.postcode,
-														country:
-															shippingAddress.country,
-												  }
-												: null
-										}
 										noResultsMessage={ __(
 											'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.',
 											'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState, useCallback, useEffect } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import defaultAddressFields from '@woocommerce/base-components/cart-checkout/address-form/default-address-fields';
 import {
@@ -93,6 +93,19 @@ const renderShippingRatesControlOption = ( option ) => ( {
 } );
 
 /**
+ * Compare two addresses and see if they are the same.
+ *
+ * @param {object} address1 First address.
+ * @param {object} address2 Second address.
+ */
+const isSameAddress = ( address1, address2 ) => {
+	const diff = Object.keys( defaultAddressFields ).filter( ( field ) => {
+		return address1[ field ] !== address2[ field ];
+	} );
+	return diff.length === 0;
+};
+
+/**
  * Main Checkout Component.
  *
  * @param {Object} props Component props.
@@ -127,42 +140,20 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	const { billingData, setBillingData } = useBillingDataContext();
 	const { paymentMethods } = usePaymentMethods();
 	const { hasNoticesOfType } = useStoreNotices();
-
-	const [ shippingAsBilling, setShippingAsBilling ] = useState(
-		needsShipping
-	);
-
-	const showBillingFields = ! needsShipping || ! shippingAsBilling;
-	const addressFields = {
-		...defaultAddressFields,
-		company: {
-			...defaultAddressFields.company,
-			hidden: ! attributes.showCompanyField,
-			required: attributes.requireCompanyField,
-		},
-		address_2: {
-			...defaultAddressFields.address_2,
-			hidden: ! attributes.showApartmentField,
-		},
-	};
-
-	const setShippingFields = useCallback(
-		( address ) => {
-			if ( shippingAsBilling ) {
-				setShippingAddress( address );
-				setBillingData( address );
-			} else {
-				setShippingAddress( address );
-			}
-		},
-		[ setShippingAddress, setBillingData, shippingAsBilling ]
-	);
-
-	useEffect( () => {
-		if ( shippingAsBilling ) {
-			setBillingData( { ...shippingAddress } );
-		}
-	}, [ shippingAsBilling, setBillingData ] );
+	const addressFields = useMemo( () => {
+		return {
+			...defaultAddressFields,
+			company: {
+				...defaultAddressFields.company,
+				hidden: ! attributes.showCompanyField,
+				required: attributes.requireCompanyField,
+			},
+			address_2: {
+				...defaultAddressFields.address_2,
+				hidden: ! attributes.showApartmentField,
+			},
+		};
+	}, [ defaultAddressFields, attributes ] );
 
 	const hasErrorsToDisplay =
 		checkoutIsIdle &&
@@ -175,6 +166,45 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 		}
 	}, [ hasErrorsToDisplay ] );
+
+	// These are the local states of address fields, which are persisted
+	// globally when changed. They default to the global shipping address which
+	// is populated from the current customer data or default location.
+	const [ shippingFields, setShippingFields ] = useState( shippingAddress );
+	const [ billingFields, setBillingFields ] = useState( billingData );
+
+	// This tracks the state of the "shipping as billing" address checkbox. It's
+	// initial value is true (if shipping is needed), however, if the user is
+	// logged in and they have a different billing address, we can toggle this off.
+	const [ shippingAsBilling, setShippingAsBilling ] = useState(
+		() =>
+			needsShipping &&
+			( ! customerId || isSameAddress( shippingAddress, billingData ) )
+	);
+
+	// Pushes to global state when changes are made locally.
+	useEffect( () => {
+		setShippingAddress( shippingFields );
+
+		if ( shippingAsBilling ) {
+			setBillingData( shippingFields );
+		}
+	}, [ shippingFields ] );
+
+	useEffect( () => {
+		setBillingData( billingFields );
+	}, [ billingFields ] );
+
+	useEffect( () => {
+		if ( shippingAsBilling ) {
+			setBillingData( shippingFields );
+		} else {
+			setBillingData( billingFields );
+		}
+	}, [ shippingAsBilling ] );
+
+	// Track if billing fields are visible.
+	const showBillingFields = ! needsShipping || ! shippingAsBilling;
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;

--- a/assets/js/type-defs/billing.js
+++ b/assets/js/type-defs/billing.js
@@ -1,19 +1,17 @@
 /**
  * @typedef {Object} BillingData
  *
- * @property {string} email              The email for the billing address
- * @property {string} first_name         First name of billing customer
- * @property {string} last_name          Last name of billing customer
- * @property {string} company            Company name for the billing address
- * @property {string} address_1          First line of the billing address
- * @property {string} address_2          Second line of the billing address
- * @property {string} city               The city of the billing address
- * @property {string} state              The state of the billing address (ISO or name)
- * @property {string} postcode           The postal or zip code for the billing address
- * @property {string} country            The country for the billing address (ISO)
- * @property {string} phone              The phone number for the billing address
- * @property {boolean} shippingAsBilling Whether the shipping and billing
- *                                       address are the same.
+ * @property {string} email      The email for the billing address
+ * @property {string} first_name First name of billing customer
+ * @property {string} last_name  Last name of billing customer
+ * @property {string} company    Company name for the billing address
+ * @property {string} address_1  First line of the billing address
+ * @property {string} address_2  Second line of the billing address
+ * @property {string} city       The city of the billing address
+ * @property {string} state      The state of the billing address (ISO or name)
+ * @property {string} postcode   The postal or zip code for the billing address
+ * @property {string} country    The country for the billing address (ISO)
+ * @property {string} phone      The phone number for the billing address
  */
 
 export {};

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -43,7 +43,7 @@
  *                                                        selected.
  * @property {CartShippingAddress}  shippingAddress       The current set
  *                                                        address for shipping.
- * @property {function()}           setShippingAddress    A function for setting
+ * @property {function}             setShippingAddress    A function for setting
  *                                                        the shipping address.
  * @property {function()}           onShippingRateSuccess Used to register a
  *                                                        callback to be invoked

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -43,7 +43,7 @@
  *                                                        selected.
  * @property {CartShippingAddress}  shippingAddress       The current set
  *                                                        address for shipping.
- * @property {function}             setShippingAddress    A function for setting
+ * @property {Function}             setShippingAddress    A function for setting
  *                                                        the shipping address.
  * @property {function()}           onShippingRateSuccess Used to register a
  *                                                        callback to be invoked


### PR DESCRIPTION
Finally done. Took longer than I wanted but I managed to fix some other issues at the same time.

1. This PR adds a local state for address data in the form of `useCheckoutAddress`. This hook persists data globally, but also stores local values so billing address is never lost.
2. If logged in, if you have a billing address separate from shipping address, the "use shipping as billing" checkbox is automatically unticked
3. I found an issue that triggered validation on all fields on change. I fixed this by using shallow equal for state/country data which are objects such as `{key: "NY", name: "New York"}`. Now validation runs on the current field only. Performance++
4. I found the issue that was causing validation to be stale once fields were unmounted. We were missing a dependency in the `useEffect` call doing the unmount 🤦 cc @Aljullu 

Fixes #2361

### How to test the changes in this Pull Request:

Smoke testing checkout, but also covering these cases:

1. Guest user. On checkout you should have the usual behaviour where "use shipping as billing" is ticked and billing is blank.
2. Logged in user. Edit your profile and use a different billing address. On checkout, "use shipping as billing" is unchecked, and both addresses are populated in the form.
3. Test inputting address and confirming validation is working and values are persisted.
