### PR TITLE
Don't show checkout block for logged out users unless store is configured to allow guest checkout

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -48,6 +48,7 @@ import {
 import { getSetting } from '@woocommerce/settings';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 import {
+	CURRENT_USER_LOGGED_IN,
 	CHECKOUT_SHOW_LOGIN_REMINDER,
 	CHECKOUT_ALLOWS_GUEST,
 	CHECKOUT_ALLOWS_SIGNUP,
@@ -161,6 +162,17 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;
+	}
+
+	if (
+		! CURRENT_USER_LOGGED_IN &&
+		! CHECKOUT_ALLOWS_GUEST &&
+		! CHECKOUT_ALLOWS_SIGNUP
+	) {
+		return __(
+			'You must be logged in to checkout.',
+			'woo-gutenberg-products-block'
+		);
 	}
 
 	const loginPrompt = () =>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -164,9 +164,19 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	}
 
 	if ( ! CURRENT_USER_LOGGED_IN && ! CHECKOUT_ALLOWS_GUEST ) {
-		return __(
-			'You must be logged in to checkout.',
-			'woo-gutenberg-products-block'
+		return (
+			<>
+				{ __(
+					'You must be logged in to checkout. ',
+					'woo-gutenberg-products-block'
+				) }
+				<a href="/wp-login.php">
+					{ __(
+						'Click here to log in.',
+						'woo-gutenberg-products-block'
+					) }
+				</a>
+			</>
 		);
 	}
 

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -163,6 +163,10 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		return <CheckoutOrderError />;
 	}
 
+	const loginToCheckoutUrl = `/wp-login.php?redirect_to=${ encodeURIComponent(
+		window.location.href
+	) }`;
+
 	if ( ! customerId && ! CHECKOUT_ALLOWS_GUEST ) {
 		return (
 			<>
@@ -170,7 +174,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 					'You must be logged in to checkout. ',
 					'woo-gutenberg-products-block'
 				) }
-				<a href="/wp-login.php">
+				<a href={ loginToCheckoutUrl }>
 					{ __(
 						'Click here to log in.',
 						'woo-gutenberg-products-block'
@@ -188,7 +192,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 					'Already have an account? ',
 					'woo-gutenberg-products-block'
 				) }
-				<a href="/wp-login.php">
+				<a href={ loginToCheckoutUrl }>
 					{ __( 'Log in.', 'woo-gutenberg-products-block' ) }
 				</a>
 			</>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -51,7 +51,6 @@ import {
 	CURRENT_USER_LOGGED_IN,
 	CHECKOUT_SHOW_LOGIN_REMINDER,
 	CHECKOUT_ALLOWS_GUEST,
-	CHECKOUT_ALLOWS_SIGNUP,
 } from '@woocommerce/block-settings';
 
 /**
@@ -164,11 +163,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		return <CheckoutOrderError />;
 	}
 
-	if (
-		! CURRENT_USER_LOGGED_IN &&
-		! CHECKOUT_ALLOWS_GUEST &&
-		! CHECKOUT_ALLOWS_SIGNUP
-	) {
+	if ( ! CURRENT_USER_LOGGED_IN && ! CHECKOUT_ALLOWS_GUEST ) {
 		return __(
 			'You must be logged in to checkout.',
 			'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -171,7 +171,8 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	}
 
 	const loginPrompt = () =>
-		CHECKOUT_SHOW_LOGIN_REMINDER && (
+		CHECKOUT_SHOW_LOGIN_REMINDER &&
+		! CURRENT_USER_LOGGED_IN && (
 			<>
 				{ __(
 					'Already have an account? ',

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -48,7 +48,6 @@ import {
 import { getSetting } from '@woocommerce/settings';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 import {
-	CURRENT_USER_LOGGED_IN,
 	CHECKOUT_SHOW_LOGIN_REMINDER,
 	CHECKOUT_ALLOWS_GUEST,
 } from '@woocommerce/block-settings';
@@ -82,6 +81,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		hasError: checkoutHasError,
 		isIdle: checkoutIsIdle,
 		isProcessing: checkoutIsProcessing,
+		customerId,
 	} = useCheckoutContext();
 	const {
 		hasValidationErrors,
@@ -163,7 +163,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		return <CheckoutOrderError />;
 	}
 
-	if ( ! CURRENT_USER_LOGGED_IN && ! CHECKOUT_ALLOWS_GUEST ) {
+	if ( ! customerId && ! CHECKOUT_ALLOWS_GUEST ) {
 		return (
 			<>
 				{ __(
@@ -182,7 +182,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 
 	const loginPrompt = () =>
 		CHECKOUT_SHOW_LOGIN_REMINDER &&
-		! CURRENT_USER_LOGGED_IN && (
+		! customerId && (
 			<>
 				{ __(
 					'Already have an account? ',

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -47,7 +47,11 @@ import {
 } from '@woocommerce/base-components/sidebar-layout';
 import { getSetting } from '@woocommerce/settings';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import { CHECKOUT_SHOW_LOGIN_REMINDER } from '@woocommerce/block-settings';
+import {
+	CHECKOUT_SHOW_LOGIN_REMINDER,
+	CHECKOUT_ALLOWS_GUEST,
+	CHECKOUT_ALLOWS_SIGNUP,
+} from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -3,10 +3,6 @@
  */
 import { getSetting } from '@woocommerce/settings';
 
-export const CURRENT_USER_LOGGED_IN = getSetting(
-	'currentUserLoggedIn',
-	false
-);
 export const CURRENT_USER_IS_ADMIN = getSetting( 'currentUserIsAdmin', false );
 export const REVIEW_RATINGS_ENABLED = getSetting(
 	'reviewRatingsEnabled',

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -3,6 +3,10 @@
  */
 import { getSetting } from '@woocommerce/settings';
 
+export const CURRENT_USER_LOGGED_IN = getSetting(
+	'currentUserLoggedIn',
+	false
+);
 export const CURRENT_USER_IS_ADMIN = getSetting( 'currentUserIsAdmin', false );
 export const REVIEW_RATINGS_ENABLED = getSetting(
 	'reviewRatingsEnabled',

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -89,3 +89,9 @@ export const TERMS_PAGE_NAME = storePages.terms.title;
 
 export const CART_PAGE_ID = storePages.cart.id;
 export const CART_URL = storePages.cart.permalink;
+
+export const CHECKOUT_ALLOWS_GUEST = getSetting( 'checkoutAllowsGuest', false );
+export const CHECKOUT_ALLOWS_SIGNUP = getSetting(
+	'checkoutAllowsSignup',
+	false
+);

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -152,6 +152,8 @@ class Assets {
 					'privacy'  => self::format_page_resource( $page_ids['privacy'] ),
 					'terms'    => self::format_page_resource( $page_ids['terms'] ),
 				],
+				'checkoutAllowsGuest'           => 'yes' === get_option( 'woocommerce_enable_guest_checkout' ),
+				'checkoutAllowsSignup'          => 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout' ),
 				'baseLocation'                  => wc_get_base_location(),
 			]
 		);

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -112,6 +112,7 @@ class Assets {
 		return array_merge(
 			$settings,
 			[
+				'currentUserLoggedIn'           => is_user_logged_in(),
 				'currentUserIsAdmin'            => is_user_logged_in() && current_user_can( 'manage_woocommerce' ),
 				'min_columns'                   => wc_get_theme_support( 'product_blocks::min_columns', 1 ),
 				'max_columns'                   => wc_get_theme_support( 'product_blocks::max_columns', 6 ),

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -112,7 +112,6 @@ class Assets {
 		return array_merge(
 			$settings,
 			[
-				'currentUserLoggedIn'           => is_user_logged_in(),
 				'currentUserIsAdmin'            => is_user_logged_in() && current_user_can( 'manage_woocommerce' ),
 				'min_columns'                   => wc_get_theme_support( 'product_blocks::min_columns', 1 ),
 				'max_columns'                   => wc_get_theme_support( 'product_blocks::max_columns', 6 ),


### PR DESCRIPTION
Fixes #2252

Fixes #2349

There are a few existing options affecting checkout when user is logged out - this PR handles `Allow customers to place orders without an account`. If this is not enabled, then the checkout is only displayed when users are logged in.

This PR also has a fix for #2349 - easy to fix here since it also needs `CURRENT_USER_LOGGED_IN`. 

See also related issue #2325.

### Screenshots

<img width="524" alt="Screen Shot 2020-05-04 at 11 21 35 AM" src="https://user-images.githubusercontent.com/4167300/80928549-73f48800-8df9-11ea-9620-5bbc8961bd91.png">


### How to test the changes 
#### Test #2252 - guest checkout store option works correctly for checkout block
1. Set up a page with checkout block. 
2. Go to `WooCommerce > Settings > Accounts & Privacy` and toggle `Allow customers to place orders without an account`.
3. View checkout page when logged in and logged out / anon (use incognito window or other browser. Ensure that checkout is not available when logged out as per your store settings.

Compare with existing checkout. Note that the checkout shortcode allows user to sign up as part of checkout - so that behaviour is different (see [comment](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2252#issuecomment-622208649) and new issue #2377).

#### Test #2349 - checkout should only show login prompt when appropriate and necessary
1. Go to `WooCommerce > Settings > Accounts & Privacy` and enable `Allow customers to log into an existing account during checkout`.
2. Add products to cart & view checkout when logged in and anon. Should show login prompt as appropriate.



