### PR TITLE
Change summary word count via API parameters

### DIFF
--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -55,6 +55,7 @@ const generateQuery = ( { sortValue, currentPage, attributes } ) => {
 		catalog_visibility: 'catalog',
 		per_page: columns * rows,
 		page: currentPage,
+		summary_max_words: 150,
 	};
 };
 

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -316,7 +316,9 @@ const FeaturedProduct = ( {
 						<div
 							className="wc-block-featured-product__description"
 							dangerouslySetInnerHTML={ {
-								__html: product.summary,
+								__html: !! product.short_description
+									? product.short_description
+									: product.description,
 							} }
 						/>
 					) }

--- a/assets/js/hocs/test/with-product.js
+++ b/assets/js/hocs/test/with-product.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TestRenderer from 'react-test-renderer';
+import { create, act } from 'react-test-renderer';
 
 /**
  * Internal dependencies
@@ -10,15 +10,10 @@ import withProduct from '../with-product';
 import * as mockUtils from '../../components/utils';
 import * as mockBaseUtils from '../../base/utils/errors';
 
-jest.mock( '../../components/utils', () => ( {
-	getProduct: jest.fn(),
-} ) );
+jest.mock( '../../components/utils' );
+jest.mock( '../../base/utils/errors' );
 
-jest.mock( '../../base/utils/errors', () => ( {
-	formatError: jest.fn(),
-} ) );
-
-const mockProduct = { name: 'T-Shirt' };
+const mockProduct = { id: 1, name: 'T-Shirt' };
 const attributes = { productId: 1 };
 const TestComponent = withProduct( ( props ) => {
 	return (
@@ -30,90 +25,51 @@ const TestComponent = withProduct( ( props ) => {
 		/>
 	);
 } );
-const render = () => {
-	return TestRenderer.create( <TestComponent attributes={ attributes } /> );
-};
 
 describe( 'withProduct Component', () => {
-	let renderer;
-	afterEach( () => {
-		mockUtils.getProduct.mockReset();
-	} );
-
-	describe( 'lifecycle events', () => {
-		beforeEach( () => {
-			mockUtils.getProduct.mockImplementation( () => Promise.resolve() );
-			renderer = render();
-		} );
-
-		it( 'getProduct is called on mount with passed in product id', () => {
-			const { getProduct } = mockUtils;
-
-			expect( getProduct ).toHaveBeenCalledWith( attributes.productId );
-			expect( getProduct ).toHaveBeenCalledTimes( 1 );
-		} );
-
-		it( 'getProduct is called on component update', () => {
-			const { getProduct } = mockUtils;
-			const newAttributes = { ...attributes, productId: 2 };
-			renderer.update( <TestComponent attributes={ newAttributes } /> );
-
-			expect( getProduct ).toHaveBeenNthCalledWith(
-				2,
-				newAttributes.productId
-			);
-			expect( getProduct ).toHaveBeenCalledTimes( 2 );
-		} );
-
-		it( 'getProduct is hooked to the prop', () => {
-			const { getProduct } = mockUtils;
-			const props = renderer.root.findByType( 'div' ).props;
-
-			props.getProduct();
-
-			expect( getProduct ).toHaveBeenCalledTimes( 2 );
-		} );
-	} );
+	let component;
 
 	describe( 'when the API returns product data', () => {
-		beforeEach( () => {
-			mockUtils.getProduct.mockImplementation( ( productId ) =>
-				Promise.resolve( { ...mockProduct, id: productId } )
-			);
-			renderer = render();
+		beforeEach( async () => {
+			mockUtils.getProduct.mockResolvedValue( mockProduct );
+
+			await act( async () => {
+				component = create(
+					<TestComponent attributes={ attributes } />
+				);
+			} );
 		} );
 
 		it( 'sets the product props', () => {
-			const props = renderer.root.findByType( 'div' ).props;
+			const props = component.root.findByType( 'div' ).props;
 
 			expect( props.error ).toBeNull();
 			expect( typeof props.getProduct ).toBe( 'function' );
 			expect( props.isLoading ).toBe( false );
 			expect( props.product ).toEqual( {
 				...mockProduct,
-				id: attributes.productId,
 			} );
 		} );
 	} );
 
 	describe( 'when the API returns an error', () => {
 		const error = { message: 'There was an error.' };
-		const getProductPromise = Promise.reject( error );
 		const formattedError = { message: 'There was an error.', type: 'api' };
 
-		beforeEach( () => {
-			mockUtils.getProduct.mockImplementation( () => getProductPromise );
-			mockBaseUtils.formatError.mockImplementation(
-				() => formattedError
-			);
-			renderer = render();
+		beforeEach( async () => {
+			mockUtils.getProduct.mockRejectedValue( error );
+			mockBaseUtils.formatError.mockReturnValue( formattedError );
+
+			await act( async () => {
+				component = create(
+					<TestComponent attributes={ attributes } />
+				);
+			} );
 		} );
 
-		test( 'sets the error prop', async () => {
-			await expect( () => getProductPromise() ).toThrow();
-
+		it( 'sets the error prop', async () => {
 			const { formatError } = mockBaseUtils;
-			const props = renderer.root.findByType( 'div' ).props;
+			const props = component.root.findByType( 'div' ).props;
 
 			expect( formatError ).toHaveBeenCalledWith( error );
 			expect( formatError ).toHaveBeenCalledTimes( 1 );

--- a/src/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/AbstractCartRoute.php
@@ -53,13 +53,14 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	/**
 	 * Get route response when something went wrong.
 	 *
-	 * @param string $error_code String based error code.
-	 * @param string $error_message User facing error message.
-	 * @param int    $http_status_code HTTP status. Defaults to 500.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param string           $error_code String based error code.
+	 * @param string           $error_message User facing error message.
+	 * @param int              $http_status_code HTTP status. Defaults to 500.
+	 * @param array            $additional_data  Extra data (key value pairs) to expose in the error response.
 	 * @return \WP_Error WP Error object.
 	 */
-	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
+	protected function get_route_error_response( \WP_REST_Request $request, $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
 		switch ( $http_status_code ) {
 			case 409:
 				// If there was a conflict, return the cart so the client can resolve it.
@@ -73,7 +74,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 						$additional_data,
 						[
 							'status' => $http_status_code,
-							'cart'   => $this->schema->get_item_response( $cart ),
+							'cart'   => $this->schema->get_item_response( $cart, $request ),
 						]
 					)
 				);

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -81,9 +81,9 @@ abstract class AbstractRoute implements RouteInterface {
 				$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
 			}
 		} catch ( RouteException $error ) {
-			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
+			$response = $this->get_route_error_response( $request, $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
-			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
+			$response = $this->get_route_error_response( $request, 'unknown_server_error', $error->getMessage(), 500 );
 		}
 		return $response;
 	}
@@ -167,13 +167,14 @@ abstract class AbstractRoute implements RouteInterface {
 	/**
 	 * Get route response when something went wrong.
 	 *
-	 * @param string $error_code String based error code.
-	 * @param string $error_message User facing error message.
-	 * @param int    $http_status_code HTTP status. Defaults to 500.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param string           $error_code String based error code.
+	 * @param string           $error_message User facing error message.
+	 * @param int              $http_status_code HTTP status. Defaults to 500.
+	 * @param array            $additional_data  Extra data (key value pairs) to expose in the error response.
 	 * @return \WP_Error WP Error object.
 	 */
-	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
+	protected function get_route_error_response( \WP_REST_Request $request, $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
 		return new \WP_Error( $error_code, $error_message, array_merge( $additional_data, [ 'status' => $http_status_code ] ) );
 	}
 
@@ -185,7 +186,7 @@ abstract class AbstractRoute implements RouteInterface {
 	 * @return \WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $item, \WP_REST_Request $request ) {
-		$response = rest_ensure_response( $this->schema->get_item_response( $item ) );
+		$response = rest_ensure_response( $this->schema->get_item_response( $item, $request ) );
 		$response->add_links( $this->prepare_links( $item, $request ) );
 
 		return $response;

--- a/src/StoreApi/Routes/Cart.php
+++ b/src/StoreApi/Routes/Cart.php
@@ -34,9 +34,7 @@ class Cart extends AbstractCartRoute {
 			[
 				'methods'  => \WP_REST_Server::READABLE,
 				'callback' => [ $this, 'get_response' ],
-				'args'     => [
-					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
-				],
+				'args'     => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];
@@ -53,6 +51,28 @@ class Cart extends AbstractCartRoute {
 		$controller = new CartController();
 		$cart       = $controller->get_cart_instance();
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
+	}
+
+	/**
+	 * Get the query params for collections of products.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                       = [];
+		$params['context']            = $this->get_context_param();
+		$params['context']['default'] = 'view';
+
+		$params['summary_max_words'] = array(
+			'description'       => __( 'Limits the word count of the summary field from the product. Defaults to 20.', 'woo-gutenberg-products-block' ),
+			'type'              => 'integer',
+			'default'           => 20,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		);
+
+		return $params;
 	}
 }

--- a/src/StoreApi/Routes/Cart.php
+++ b/src/StoreApi/Routes/Cart.php
@@ -65,9 +65,9 @@ class Cart extends AbstractCartRoute {
 		$params['context']['default'] = 'view';
 
 		$params['summary_max_words'] = array(
-			'description'       => __( 'Limits the word count of the summary field from the product. Defaults to 20.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'Limits the word count of the summary field from the product. Defaults to 15.', 'woo-gutenberg-products-block' ),
 			'type'              => 'integer',
-			'default'           => 20,
+			'default'           => 15,
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,

--- a/src/StoreApi/Routes/CartAddItem.php
+++ b/src/StoreApi/Routes/CartAddItem.php
@@ -100,7 +100,7 @@ class CartAddItem extends AbstractCartRoute {
 			]
 		);
 
-		$response = rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		$response = rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
 		$response->set_status( 201 );
 		return $response;
 	}

--- a/src/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/CartApplyCoupon.php
@@ -67,6 +67,6 @@ class CartApplyCoupon extends AbstractCartRoute {
 			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
 		}
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
 	}
 }

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -65,7 +65,7 @@ class CartCoupons extends AbstractRoute {
 		$items        = [];
 
 		foreach ( $cart_coupons as $coupon_code ) {
-			$response = rest_ensure_response( $this->schema->get_item_response( $coupon_code ) );
+			$response = rest_ensure_response( $this->schema->get_item_response( $coupon_code, $request ) );
 			$response->add_links( $this->prepare_links( $coupon_code, $request ) );
 
 			$response = $this->prepare_response_for_collection( $response );

--- a/src/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/CartRemoveCoupon.php
@@ -74,6 +74,6 @@ class CartRemoveCoupon extends AbstractCartRoute {
 		$cart->remove_coupon( $coupon_code );
 		$cart->calculate_totals();
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
 	}
 }

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -63,6 +63,6 @@ class CartRemoveItem extends AbstractCartRoute {
 
 		$cart->remove_cart_item( $request['key'] );
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
 	}
 }

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -83,6 +83,6 @@ class CartSelectShippingRate extends AbstractCartRoute {
 		$cart->calculate_shipping();
 		$cart->calculate_totals();
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
 	}
 }

--- a/src/StoreApi/Routes/CartUpdateItem.php
+++ b/src/StoreApi/Routes/CartUpdateItem.php
@@ -64,6 +64,6 @@ class CartUpdateItem extends AbstractCartRoute {
 			$controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 		}
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
 	}
 }

--- a/src/StoreApi/Routes/CartUpdateShipping.php
+++ b/src/StoreApi/Routes/CartUpdateShipping.php
@@ -142,7 +142,7 @@ class CartUpdateShipping extends AbstractCartRoute {
 		$cart->calculate_shipping();
 		$cart->calculate_totals();
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, $request ) );
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -42,9 +42,9 @@ class Checkout extends AbstractRoute {
 			$this->check_nonce( $request );
 			$response = parent::get_response( $request );
 		} catch ( RouteException $error ) {
-			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode() );
+			$response = $this->get_route_error_response( $request, $error->getErrorCode(), $error->getMessage(), $error->getCode() );
 		} catch ( \Exception $error ) {
-			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
+			$response = $this->get_route_error_response( $request, 'unknown_server_error', $error->getMessage(), 500 );
 		}
 		return $response;
 	}
@@ -202,13 +202,14 @@ class Checkout extends AbstractRoute {
 	/**
 	 * Get route response when something went wrong.
 	 *
-	 * @param string $error_code String based error code.
-	 * @param string $error_message User facing error message.
-	 * @param int    $http_status_code HTTP status. Defaults to 500.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 * @param \WP_REST_Request $request Request object.
+	 * @param string           $error_code String based error code.
+	 * @param string           $error_message User facing error message.
+	 * @param int              $http_status_code HTTP status. Defaults to 500.
+	 * @param array            $additional_data  Extra data (key value pairs) to expose in the error response.
 	 * @return \WP_Error WP Error object.
 	 */
-	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
+	protected function get_route_error_response( \WP_REST_Request $request, $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
 		switch ( $http_status_code ) {
 			case 409:
 				// If there was a conflict, return the cart so the client can resolve it.

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -135,7 +135,7 @@ class ProductCollectionData extends AbstractRoute {
 			}
 		}
 
-		return rest_ensure_response( $this->schema->get_item_response( $data ) );
+		return rest_ensure_response( $this->schema->get_item_response( $data, $request ) );
 	}
 
 	/**

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -380,6 +380,15 @@ class Products extends AbstractRoute {
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
 
+		$params['summary_max_words'] = array(
+			'description'       => __( 'Limits the word count of the summary field from the product. Defaults to 20.', 'woo-gutenberg-products-block' ),
+			'type'              => 'integer',
+			'default'           => 20,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		);
+
 		return $params;
 	}
 }

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -381,9 +381,9 @@ class Products extends AbstractRoute {
 		);
 
 		$params['summary_max_words'] = array(
-			'description'       => __( 'Limits the word count of the summary field from the product. Defaults to 20.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'Limits the word count of the summary field from the product. Defaults to 15.', 'woo-gutenberg-products-block' ),
 			'type'              => 'integer',
-			'default'           => 20,
+			'default'           => 15,
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -59,7 +59,7 @@ class Products extends AbstractRoute {
 			$response_objects = [];
 
 			foreach ( $query_results['objects'] as $object ) {
-				$data               = rest_ensure_response( $this->schema->get_item_response( $object ) );
+				$data               = rest_ensure_response( $this->schema->get_item_response( $object, $request ) );
 				$response_objects[] = $this->prepare_response_for_collection( $data );
 			}
 

--- a/src/StoreApi/Routes/ProductsById.php
+++ b/src/StoreApi/Routes/ProductsById.php
@@ -65,6 +65,6 @@ class ProductsById extends AbstractRoute {
 			throw new RouteException( 'woocommerce_rest_product_invalid_id', __( 'Invalid product ID.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
-		return rest_ensure_response( $this->schema->get_item_response( $object ) );
+		return rest_ensure_response( $this->schema->get_item_response( $object, $request ) );
 	}
 }

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -116,6 +116,21 @@ abstract class AbstractSchema {
 	}
 
 	/**
+	 * Converts an array of objects to an array of items in schema format.
+	 *
+	 * @param array            $objects List of Item objects..
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	public function get_item_responses( $objects, \WP_REST_Request $request ) {
+		$responses = [];
+		foreach ( $objects as $object ) {
+			$responses[] = $this->get_item_response( $object, $request );
+		}
+		return array_values( array_filter( $responses ) );
+	}
+
+	/**
 	 * Force all schema properties to be readonly.
 	 *
 	 * @param array $properties Schema.

--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -94,11 +94,11 @@ class BillingAddressSchema extends AbstractSchema {
 	 * Convert a term object into an object suitable for the response.
 	 *
 	 * @param \WC_Order|\WC_Customer $address An object with billing address.
-	 *
+	 * @param \WP_REST_Request       $request Request object.
 	 * @throws RouteException When the invalid object types are provided.
 	 * @return stdClass
 	 */
-	public function get_item_response( $address ) {
+	public function get_item_response( $address, \WP_REST_Request $request = null ) {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
 			return (object) $this->prepare_html_response(
 				[

--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -98,7 +98,7 @@ class BillingAddressSchema extends AbstractSchema {
 	 * @throws RouteException When the invalid object types are provided.
 	 * @return stdClass
 	 */
-	public function get_item_response( $address, \WP_REST_Request $request = null ) {
+	public function get_item_response( $address, \WP_REST_Request $request ) {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
 			return (object) $this->prepare_html_response(
 				[

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -84,7 +84,7 @@ class CartCouponSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $coupon_code, \WP_REST_Request $request = null ) {
+	public function get_item_response( $coupon_code, \WP_REST_Request $request ) {
 		$controller           = new CartController();
 		$cart                 = $controller->get_cart_instance();
 		$total_discounts      = $cart->get_coupon_discount_totals();

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -80,10 +80,11 @@ class CartCouponSchema extends AbstractSchema {
 	/**
 	 * Convert a WooCommerce cart item to an object suitable for the response.
 	 *
-	 * @param string $coupon_code Coupon code from the cart.
+	 * @param string           $coupon_code Coupon code from the cart.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $coupon_code ) {
+	public function get_item_response( $coupon_code, \WP_REST_Request $request = null ) {
 		$controller           = new CartController();
 		$cart                 = $controller->get_cart_instance();
 		$total_discounts      = $cart->get_coupon_discount_totals();

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -285,7 +285,7 @@ class CartItemSchema extends ProductSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $cart_item, \WP_REST_Request $request = null ) {
+	public function get_item_response( $cart_item, \WP_REST_Request $request ) {
 		$product = $cart_item['data'];
 
 		return [
@@ -294,7 +294,7 @@ class CartItemSchema extends ProductSchema {
 			'quantity'            => wc_stock_amount( $cart_item['quantity'] ),
 			'quantity_limit'      => $this->get_product_quantity_limit( $product ),
 			'name'                => $this->prepare_html_response( $product->get_title() ),
-			'summary'             => $this->prepare_html_response( ( new ProductSummary( $product ) )->get_summary( 150 ) ),
+			'summary'             => $this->prepare_html_response( ( new ProductSummary( $product ) )->get_summary( $request['summary_max_words'] ) ),
 			'short_description'   => $this->prepare_html_response( wc_format_content( $product->get_short_description() ) ),
 			'description'         => $this->prepare_html_response( wc_format_content( $product->get_description() ) ),
 			'sku'                 => $this->prepare_html_response( $product->get_sku() ),
@@ -302,7 +302,7 @@ class CartItemSchema extends ProductSchema {
 			'backorders_allowed'  => (bool) $product->backorders_allowed(),
 			'sold_individually'   => $product->is_sold_individually(),
 			'permalink'           => $product->get_permalink(),
-			'images'              => $this->get_images( $product ),
+			'images'              => $this->get_images( $product, $request ),
 			'variation'           => $this->format_variation_data( $cart_item['variation'], $product ),
 			'prices'              => (object) $this->prepare_product_price_response( $product, get_option( 'woocommerce_tax_display_cart' ) ),
 			'totals'              => (object) array_merge(

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -281,10 +281,11 @@ class CartItemSchema extends ProductSchema {
 	/**
 	 * Convert a WooCommerce cart item to an object suitable for the response.
 	 *
-	 * @param array $cart_item Cart item array.
+	 * @param array            $cart_item Cart item array.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $cart_item ) {
+	public function get_item_response( $cart_item, \WP_REST_Request $request = null ) {
 		$product = $cart_item['data'];
 
 		return [

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -267,17 +267,17 @@ class CartSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $cart, \WP_REST_Request $request = null ) {
+	public function get_item_response( $cart, \WP_REST_Request $request ) {
 		$controller = new CartController();
 
 		// Get cart errors first so if recalculations are performed, it's reflected in the response.
 		$cart_errors = $this->get_cart_errors( $cart );
 
 		return [
-			'coupons'          => array_values( array_map( [ $this->coupon_schema, 'get_item_response' ], array_filter( $cart->get_applied_coupons() ) ) ),
-			'shipping_rates'   => array_values( array_map( [ $this->shipping_rate_schema, 'get_item_response' ], $controller->get_shipping_packages() ) ),
+			'coupons'          => $this->coupon_schema->get_item_responses( array_filter( $cart->get_applied_coupons() ), $request ),
+			'shipping_rates'   => $this->shipping_rate_schema->get_item_responses( $controller->get_shipping_packages(), $request ),
 			'shipping_address' => $this->shipping_address_schema->get_item_response( wc()->customer, $request ),
-			'items'            => array_values( array_map( [ $this->item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
+			'items'            => $this->item_schema->get_item_responses( array_filter( $cart->get_cart() ), $request ),
 			'items_count'      => $cart->get_cart_contents_count(),
 			'items_weight'     => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
 			'needs_payment'    => $cart->needs_payment(),

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -263,10 +263,11 @@ class CartSchema extends AbstractSchema {
 	/**
 	 * Convert a woo cart into an object suitable for the response.
 	 *
-	 * @param \WC_Cart $cart Cart class instance.
+	 * @param \WC_Cart         $cart Cart class instance.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $cart ) {
+	public function get_item_response( $cart, \WP_REST_Request $request = null ) {
 		$controller = new CartController();
 
 		// Get cart errors first so if recalculations are performed, it's reflected in the response.
@@ -275,7 +276,7 @@ class CartSchema extends AbstractSchema {
 		return [
 			'coupons'          => array_values( array_map( [ $this->coupon_schema, 'get_item_response' ], array_filter( $cart->get_applied_coupons() ) ) ),
 			'shipping_rates'   => array_values( array_map( [ $this->shipping_rate_schema, 'get_item_response' ], $controller->get_shipping_packages() ) ),
-			'shipping_address' => $this->shipping_address_schema->get_item_response( wc()->customer ),
+			'shipping_address' => $this->shipping_address_schema->get_item_response( wc()->customer, $request ),
 			'items'            => array_values( array_map( [ $this->item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
 			'items_count'      => $cart->get_cart_contents_count(),
 			'items_weight'     => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -217,7 +217,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $package, \WP_REST_Request $request = null ) {
+	public function get_item_response( $package, \WP_REST_Request $request ) {
 		// Add product names and quantities.
 		$items = array();
 		foreach ( $package['contents'] as $item_id => $values ) {

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -213,10 +213,11 @@ class CartShippingRateSchema extends AbstractSchema {
 	/**
 	 * Convert a shipping rate from WooCommerce into a valid response.
 	 *
-	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @param array            $package Shipping package complete with rates from WooCommerce.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $package ) {
+	public function get_item_response( $package, \WP_REST_Request $request = null ) {
 		// Add product names and quantities.
 		$items = array();
 		foreach ( $package['contents'] as $item_id => $values ) {

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -145,17 +145,18 @@ class CheckoutSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $item, \WP_REST_Request $request ) {
-		return $this->get_checkout_response( $item->order, $item->payment_result );
+		return $this->get_checkout_response( $item->order, $item->payment_result, $request );
 	}
 
 	/**
 	 * Get the checkout response based on the current order and any payments.
 	 *
-	 * @param \WC_Order     $order Order object.
-	 * @param PaymentResult $payment_result Payment result object.
+	 * @param \WC_Order        $order Order object.
+	 * @param PaymentResult    $payment_result Payment result object.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null ) {
+	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null, \WP_REST_Request $request ) {
 		return [
 			'order_id'         => $order->get_id(),
 			'status'           => $order->get_status(),

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -140,10 +140,11 @@ class CheckoutSchema extends AbstractSchema {
 	/**
 	 * Return the response for checkout.
 	 *
-	 * @param object $item Results from checkout action.
+	 * @param object           $item Results from checkout action.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $item ) {
+	public function get_item_response( $item, \WP_REST_Request $request = null ) {
 		return $this->get_checkout_response( $item->order, $item->payment_result );
 	}
 
@@ -161,8 +162,8 @@ class CheckoutSchema extends AbstractSchema {
 			'order_key'        => $order->get_order_key(),
 			'customer_note'    => $order->get_customer_note(),
 			'customer_id'      => $order->get_customer_id(),
-			'billing_address'  => $this->billing_address_schema->get_item_response( $order ),
-			'shipping_address' => $this->shipping_address_schema->get_item_response( $order ),
+			'billing_address'  => $this->billing_address_schema->get_item_response( $order, $request ),
+			'shipping_address' => $this->shipping_address_schema->get_item_response( $order, $request ),
 			'payment_method'   => $order->get_payment_method(),
 			'payment_result'   => [
 				'payment_status'  => $payment_result->status,

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -144,7 +144,7 @@ class CheckoutSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $item, \WP_REST_Request $request = null ) {
+	public function get_item_response( $item, \WP_REST_Request $request ) {
 		return $this->get_checkout_response( $item->order, $item->payment_result );
 	}
 

--- a/src/StoreApi/Schemas/ErrorSchema.php
+++ b/src/StoreApi/Schemas/ErrorSchema.php
@@ -51,7 +51,7 @@ class ErrorSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( \WP_Error $error, \WP_REST_Request $request = null ) {
+	public function get_item_response( \WP_Error $error, \WP_REST_Request $request ) {
 		return [
 			'code'    => $this->prepare_html_response( $error->get_error_code() ),
 			'message' => $this->prepare_html_response( $error->get_error_message() ),

--- a/src/StoreApi/Schemas/ErrorSchema.php
+++ b/src/StoreApi/Schemas/ErrorSchema.php
@@ -47,10 +47,11 @@ class ErrorSchema extends AbstractSchema {
 	/**
 	 * Convert a WooCommerce product into an object suitable for the response.
 	 *
-	 * @param \WP_Error $error Error object.
+	 * @param \WP_Error        $error Error object.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( \WP_Error $error ) {
+	public function get_item_response( \WP_Error $error, \WP_REST_Request $request = null ) {
 		return [
 			'code'    => $this->prepare_html_response( $error->get_error_code() ),
 			'message' => $this->prepare_html_response( $error->get_error_message() ),

--- a/src/StoreApi/Schemas/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/ImageAttachmentSchema.php
@@ -70,10 +70,11 @@ class ImageAttachmentSchema extends AbstractSchema {
 	/**
 	 * Convert a WooCommerce product into an object suitable for the response.
 	 *
-	 * @param int $attachment_id Image attachment ID.
+	 * @param int              $attachment_id Image attachment ID.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array|null
 	 */
-	public function get_item_response( $attachment_id ) {
+	public function get_item_response( $attachment_id, \WP_REST_Request $request = null ) {
 		if ( ! $attachment_id ) {
 			return null;
 		}

--- a/src/StoreApi/Schemas/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/ImageAttachmentSchema.php
@@ -74,7 +74,7 @@ class ImageAttachmentSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array|null
 	 */
-	public function get_item_response( $attachment_id, \WP_REST_Request $request = null ) {
+	public function get_item_response( $attachment_id, \WP_REST_Request $request ) {
 		if ( ! $attachment_id ) {
 			return null;
 		}

--- a/src/StoreApi/Schemas/OrderCouponSchema.php
+++ b/src/StoreApi/Schemas/OrderCouponSchema.php
@@ -63,9 +63,10 @@ class OrderCouponSchema extends AbstractSchema {
 	 * Convert an order coupon to an object suitable for the response.
 	 *
 	 * @param \WC_Order_Item_Coupon $coupon Order coupon array.
+	 * @param \WP_REST_Request      $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( \WC_Order_Item_Coupon $coupon ) {
+	public function get_item_response( \WC_Order_Item_Coupon $coupon, \WP_REST_Request $request = null ) {
 		return [
 			'code'   => $coupon->get_code(),
 			'totals' => (object) array_merge(

--- a/src/StoreApi/Schemas/OrderCouponSchema.php
+++ b/src/StoreApi/Schemas/OrderCouponSchema.php
@@ -66,7 +66,7 @@ class OrderCouponSchema extends AbstractSchema {
 	 * @param \WP_REST_Request      $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( \WC_Order_Item_Coupon $coupon, \WP_REST_Request $request = null ) {
+	public function get_item_response( \WC_Order_Item_Coupon $coupon, \WP_REST_Request $request ) {
 		return [
 			'code'   => $coupon->get_code(),
 			'totals' => (object) array_merge(

--- a/src/StoreApi/Schemas/ProductAttributeSchema.php
+++ b/src/StoreApi/Schemas/ProductAttributeSchema.php
@@ -81,7 +81,7 @@ class ProductAttributeSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $attribute, \WP_REST_Request $request = null ) {
+	public function get_item_response( $attribute, \WP_REST_Request $request ) {
 		return [
 			'id'           => (int) $attribute->id,
 			'name'         => $this->prepare_html_response( $attribute->name ),

--- a/src/StoreApi/Schemas/ProductAttributeSchema.php
+++ b/src/StoreApi/Schemas/ProductAttributeSchema.php
@@ -77,10 +77,11 @@ class ProductAttributeSchema extends AbstractSchema {
 	/**
 	 * Convert an attribute object into an object suitable for the response.
 	 *
-	 * @param object $attribute Attribute object.
+	 * @param object           $attribute Attribute object.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $attribute ) {
+	public function get_item_response( $attribute, \WP_REST_Request $request = null ) {
 		return [
 			'id'           => (int) $attribute->id,
 			'name'         => $this->prepare_html_response( $attribute->name ),

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -69,18 +69,19 @@ class ProductCategorySchema extends TermSchema {
 	/**
 	 * Convert a term object into an object suitable for the response.
 	 *
-	 * @param \WP_Term $term Term object.
+	 * @param \WP_Term         $term Term object.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $term ) {
-		$response = parent::get_item_response( $term );
+	public function get_item_response( $term, \WP_REST_Request $request = null ) {
+		$response = parent::get_item_response( $term, $request );
 		$count    = get_term_meta( $term->term_id, 'product_count_product_cat', true );
 
 		if ( $count ) {
 			$response['count'] = (int) $count;
 		}
 
-		$response['image']        = $this->image_attachment_schema->get_item_response( get_term_meta( $term->term_id, 'thumbnail_id', true ) );
+		$response['image']        = $this->image_attachment_schema->get_item_response( get_term_meta( $term->term_id, 'thumbnail_id', true ), $request );
 		$response['review_count'] = $this->get_category_review_count( $term );
 		$response['permalink']    = get_term_link( $term->term_id, 'product_cat' );
 

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -73,7 +73,7 @@ class ProductCategorySchema extends TermSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $term, \WP_REST_Request $request = null ) {
+	public function get_item_response( $term, \WP_REST_Request $request ) {
 		$response = parent::get_item_response( $term, $request );
 		$count    = get_term_meta( $term->term_id, 'product_count_product_cat', true );
 

--- a/src/StoreApi/Schemas/ProductCollectionDataSchema.php
+++ b/src/StoreApi/Schemas/ProductCollectionDataSchema.php
@@ -108,7 +108,7 @@ class ProductCollectionDataSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $data, \WP_REST_Request $request = null ) {
+	public function get_item_response( $data, \WP_REST_Request $request ) {
 		return [
 			'price_range'      => ! is_null( $data['min_price'] ) && ! is_null( $data['max_price'] ) ? (object) array_merge(
 				$this->get_store_currency_response(),

--- a/src/StoreApi/Schemas/ProductCollectionDataSchema.php
+++ b/src/StoreApi/Schemas/ProductCollectionDataSchema.php
@@ -104,10 +104,11 @@ class ProductCollectionDataSchema extends AbstractSchema {
 	/**
 	 * Format data.
 	 *
-	 * @param array $data Collection data to format and return.
+	 * @param array            $data Collection data to format and return.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $data ) {
+	public function get_item_response( $data, \WP_REST_Request $request = null ) {
 		return [
 			'price_range'      => ! is_null( $data['min_price'] ) && ! is_null( $data['max_price'] ) ? (object) array_merge(
 				$this->get_store_currency_response(),

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -149,10 +149,11 @@ class ProductReviewSchema extends AbstractSchema {
 	/**
 	 * Convert a WooCommerce product into an object suitable for the response.
 	 *
-	 * @param \WP_Comment $review Product review object.
+	 * @param \WP_Comment      $review Product review object.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( \WP_Comment $review ) {
+	public function get_item_response( \WP_Comment $review, \WP_REST_Request $request = null ) {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$rating  = get_comment_meta( $review->comment_ID, 'rating', true ) === '' ? null : (int) get_comment_meta( $review->comment_ID, 'rating', true );
 		$data    = [
@@ -163,7 +164,7 @@ class ProductReviewSchema extends AbstractSchema {
 			'product_id'             => (int) $review->comment_post_ID,
 			'product_name'           => get_the_title( (int) $review->comment_post_ID ),
 			'product_permalink'      => get_permalink( (int) $review->comment_post_ID ),
-			'product_image'          => $this->image_attachment_schema->get_item_response( get_post_thumbnail_id( (int) $review->comment_post_ID ) ),
+			'product_image'          => $this->image_attachment_schema->get_item_response( get_post_thumbnail_id( (int) $review->comment_post_ID ), $request ),
 			'reviewer'               => $review->comment_author,
 			'review'                 => $review->comment_content,
 			'rating'                 => $rating,

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -153,7 +153,7 @@ class ProductReviewSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( \WP_Comment $review, \WP_REST_Request $request = null ) {
+	public function get_item_response( \WP_Comment $review, \WP_REST_Request $request ) {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$rating  = get_comment_meta( $review->comment_ID, 'rating', true ) === '' ? null : (int) get_comment_meta( $review->comment_ID, 'rating', true );
 		$data    = [

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -238,7 +238,7 @@ class ProductSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $product, \WP_REST_Request $request = null ) {
+	public function get_item_response( $product, \WP_REST_Request $request ) {
 		return [
 			'id'                  => $product->get_id(),
 			'name'                => $this->prepare_html_response( $product->get_title() ),
@@ -246,7 +246,7 @@ class ProductSchema extends AbstractSchema {
 			'variation'           => $this->prepare_html_response( $product->is_type( 'variation' ) ? wc_get_formatted_variation( $product, true, true, false ) : '' ),
 			'permalink'           => $product->get_permalink(),
 			'sku'                 => $this->prepare_html_response( $product->get_sku() ),
-			'summary'             => $this->prepare_html_response( ( new ProductSummary( $product ) )->get_summary( 150 ) ),
+			'summary'             => $this->prepare_html_response( ( new ProductSummary( $product ) )->get_summary( $request['summary_max_words'] ) ),
 			'short_description'   => $this->prepare_html_response( wc_format_content( $product->get_short_description() ) ),
 			'description'         => $this->prepare_html_response( wc_format_content( $product->get_description() ) ),
 			'on_sale'             => $product->is_on_sale(),
@@ -254,7 +254,7 @@ class ProductSchema extends AbstractSchema {
 			'price_html'          => $product->get_price_html(),
 			'average_rating'      => $product->get_average_rating(),
 			'review_count'        => $product->get_review_count(),
-			'images'              => $this->get_images( $product ),
+			'images'              => $this->get_images( $product, $request ),
 			'variations'          => $product->is_type( 'variable' ) ? $product->get_visible_children() : [],
 			'has_options'         => $product->has_options(),
 			'is_purchasable'      => $product->is_purchasable(),
@@ -272,13 +272,14 @@ class ProductSchema extends AbstractSchema {
 	/**
 	 * Get list of product images.
 	 *
-	 * @param \WC_Product $product Product instance.
+	 * @param \WC_Product      $product Product instance.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	protected function get_images( \WC_Product $product ) {
+	protected function get_images( \WC_Product $product, \WP_REST_Request $request ) {
 		$attachment_ids = array_merge( [ $product->get_image_id() ], $product->get_gallery_image_ids() );
 
-		return array_filter( array_map( [ $this->image_attachment_schema, 'get_item_response' ], $attachment_ids ) );
+		return $this->image_attachment_schema->get_item_responses( $attachment_ids, $request );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -234,10 +234,11 @@ class ProductSchema extends AbstractSchema {
 	/**
 	 * Convert a WooCommerce product into an object suitable for the response.
 	 *
-	 * @param \WC_Product $product Product instance.
+	 * @param \WC_Product      $product Product instance.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $product ) {
+	public function get_item_response( $product, \WP_REST_Request $request = null ) {
 		return [
 			'id'                  => $product->get_id(),
 			'name'                => $this->prepare_html_response( $product->get_title() ),

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -85,11 +85,11 @@ class ShippingAddressSchema extends AbstractSchema {
 	 * Convert a term object into an object suitable for the response.
 	 *
 	 * @param \WC_Order|\WC_Customer $address An object with shipping address.
-	 *
+	 * @param \WP_REST_Request       $request Request object.
 	 * @throws RouteException When the invalid object types are provided.
 	 * @return stdClass
 	 */
-	public function get_item_response( $address ) {
+	public function get_item_response( $address, \WP_REST_Request $request = null ) {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
 			return (object) $this->prepare_html_response(
 				[

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -89,7 +89,7 @@ class ShippingAddressSchema extends AbstractSchema {
 	 * @throws RouteException When the invalid object types are provided.
 	 * @return stdClass
 	 */
-	public function get_item_response( $address, \WP_REST_Request $request = null ) {
+	public function get_item_response( $address, \WP_REST_Request $request ) {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
 			return (object) $this->prepare_html_response(
 				[

--- a/src/StoreApi/Schemas/TermSchema.php
+++ b/src/StoreApi/Schemas/TermSchema.php
@@ -75,7 +75,7 @@ class TermSchema extends AbstractSchema {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $term, \WP_REST_Request $request = null ) {
+	public function get_item_response( $term, \WP_REST_Request $request ) {
 		return [
 			'id'          => (int) $term->term_id,
 			'name'        => $this->prepare_html_response( $term->name ),

--- a/src/StoreApi/Schemas/TermSchema.php
+++ b/src/StoreApi/Schemas/TermSchema.php
@@ -71,10 +71,11 @@ class TermSchema extends AbstractSchema {
 	/**
 	 * Convert a term object into an object suitable for the response.
 	 *
-	 * @param \WP_Term $term Term object.
+	 * @param \WP_Term         $term Term object.
+	 * @param \WP_REST_Request $request Request object.
 	 * @return array
 	 */
-	public function get_item_response( $term ) {
+	public function get_item_response( $term, \WP_REST_Request $request = null ) {
 		return [
 			'id'          => (int) $term->term_id,
 			'name'        => $this->prepare_html_response( $term->name ),

--- a/src/StoreApi/Utilities/ProductSummary.php
+++ b/src/StoreApi/Utilities/ProductSummary.php
@@ -101,7 +101,11 @@ final class ProductSummary {
 		$paragraph = \strstr( $content_p, '</p>' ) ? \substr( $content_p, 0, \strpos( $content_p, '</p>' ) + 4 ) : $content;
 
 		if ( $this->get_word_count( $paragraph ) > $max_words ) {
-			return \wp_trim_words( $paragraph, $max_words );
+			$trimmed_content = trim( \wp_trim_words( $paragraph, $max_words, '' ) );
+			if ( '.' !== substr( $trimmed_content, -1 ) ) {
+				$trimmed_content .= '&hellip;';
+			}
+			return $trimmed_content;
 		}
 
 		return $paragraph;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,7 +56,12 @@ function wc_blocks_install() {
  * Adds WooCommerce testing framework classes.
  */
 function wc_test_includes() {
-	$wc_tests_framework_base_dir = wc_dir() . '/tests/legacy';
+	$wc_tests_framework_base_dir = wc_dir() . '/tests';
+
+	if ( ! file_exists( $wc_tests_framework_base_dir . '/framework/class-wc-unit-test-factory.php' ) ) {
+		$wc_tests_framework_base_dir = wc_dir() . '/tests/legacy';
+	}
+
 	// WooCommerce test classes.
 	// Framework.
 	require_once $wc_tests_framework_base_dir . '/framework/class-wc-unit-test-factory.php';


### PR DESCRIPTION
This PR allows the summary word count returned from the API (for products and cart items) to be changed based on a new param. Example usage:

```curl
GET https://local.wordpress.test/wp-json/wc/store/products/32?summary_max_words=10
```

The default is 15, and this is what cart will be using right now.

Fixes #2293

What has changed in this PR:

- Added `summary_max_words` param to cart and product APIs.
- API classes have a `get_item_response` method. This was changed thoughout to accept the request parameter.
- Added `get_item_responses` method to handle collections more easily.
- In thinking we needed to support this in `withProduct` HOC for the Featured Product block, I refactored that as a functional component and updated tests. Yay!...
- ...however, after doing this I found out the Featured Product block was using `summary` when it should be using `short_description` like the PHP frontend 🤦 In changed that to the correct description but left the updated HOC in place because it's an improvement.
- Made sure All Products block requests 150 word limit like before. In a future iteration we could perhaps make this configurable.

### How to test the changes in this Pull Request:

1. Give a product a long short description and add it to your cart.
2. Check cart and checkout page limits it's length
3. Check all products block (with a summary inner block) shows more of the description. 150 words like before.
4. Test the endpoint (example above) adjusts the summary.

Note: The summary logic returns the first paragraph if the content contains several paragraphs of text. This is not word limited and already has tests.
