### PR TITLE
Add Todo Probot config

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,3 @@
+todo:
+  blobLines: 10
+  label: false

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -40,7 +40,9 @@ const preparePaymentData = ( paymentData ) => {
 };
 
 /**
- * CheckoutProcessor component. @todo Needs to consume all contexts.
+ * CheckoutProcessor component.
+ *
+ * @todo Needs to consume all contexts.
  *
  * Subscribes to checkout context and triggers processing via the API.
  */


### PR DESCRIPTION
I installed the [`@todo` probot github app to our repo](https://github.com/JasonEtco/todo) for managing todos. The idea here is that we'll ensure any pulls merged with @todo comment blocks will have issues automatically created for them. This ensures follow-ups are documented.

I edited a todo in a file to see how this will work. Note:

- When `@todo` comment (case-insensitive) is in a commit pushed to a pull, the pull will just receive a comment. After the pull is merged, any remaining incomplete todos will have issues created for them. This ensures that you can have _in progress_ work in a pull with todos that get handled before merge.
- If you include `@body` after the todo, the text following that tag will get added as additional text in the comment (or issue description).