### PR TITLE
decode html entities in ProductName component

### DIFF
--- a/assets/js/base/components/cart-checkout/product-name/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -17,7 +18,7 @@ const ProductName = ( { name, permalink, disabled } ) => {
 			href={ permalink }
 			tabIndex={ disabled ? -1 : 0 }
 		>
-			{ name }
+			{ decodeEntities( name ) }
 		</a>
 	);
 };


### PR DESCRIPTION
Fixes #2356

Interesting characters such as ampersand `&` are entity-encoded in Store API responses. Product names slipped through the cracks, so entities were displayed in product names in cart (cart items) and checkout (order summary).

This PR uses `decodeEntities` in the `ProductName` component so these are decoded as close to display as possible.

### How to test the changes in this Pull Request:

1. Add some interesting characters to product names.
2. Add those products to cart.
3. Proceed through cart & checkout and ensure products are displayed correctly.
