### PR TITLE
remove radius from checkout submit button (use theme button style)

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -157,7 +157,6 @@
 	.wc-block-components-checkout-place-order-button {
 		width: 50%;
 		padding: 1em;
-		border-radius: 3px;
 		height: auto;
 		margin-left: auto;
 


### PR DESCRIPTION
Fixes #2306

In Storefront, the checkout submit button had rounded corners, as opposed to square corners for cart submit and add coupon buttons. 

This was because the Checkout block had css to set a border-radius for the checkout submit button - i.e. an "opinionated" style rule.

We need the blocks to work well in a range of themes. Many themes have a (valid) opinion for button styling. In this PR I've removed our opinionated border-radius to leave it up to the theme. This way the buttons in the checkout should look more consistent (same border radius) with other buttons on the site. 

cc @Aljullu @garymurray  for feedback on this approach - defer to current theme for button radius, since it's safe and consistent to do so.

### Screenshots

Storefront – note square buttons throughout cart/checkout, consistent with other site buttons (e.g. my account):

<img width="648" alt="Screen Shot 2020-05-04 at 3 22 43 PM" src="https://user-images.githubusercontent.com/4167300/80934484-8c29ce80-8e1c-11ea-8d60-429319773513.png">
<img width="823" alt="Screen Shot 2020-05-04 at 3 22 53 PM" src="https://user-images.githubusercontent.com/4167300/80934487-8fbd5580-8e1c-11ea-8f13-51b1c982d38f.png">
<img width="869" alt="Screen Shot 2020-05-04 at 3 32 38 PM" src="https://user-images.githubusercontent.com/4167300/80934489-93e97300-8e1c-11ea-8b25-14ceadc9c2ae.png">

Bistro (Storefront child theme) has rounded buttons:

<img width="1153" alt="Screen Shot 2020-05-04 at 3 23 58 PM" src="https://user-images.githubusercontent.com/4167300/80934521-afed1480-8e1c-11ea-80a2-a52b1dd89d01.png">
<img width="1010" alt="Screen Shot 2020-05-04 at 3 34 28 PM" src="https://user-images.githubusercontent.com/4167300/80934543-c09d8a80-8e1c-11ea-9044-fbf79f77daf5.png">


### How to test the changes in this Pull Request:

1. Publish pages with cart/checkout blocks. Add stuff to cart and view cart, checkout.
2. Confirm buttons have consistent appearance and look appropriate within checkout.
3. Confirm buttons are broadly consistent with other buttons on the front end of the site.

Note that this relies on the theme having sufficiently robust rules targeting all the varieties of buttons (`<button>` or `<a>` tags with various classes). 

I tested in Storefront (2.5.6 RC), Bistro (Storefront child theme, Twenty Twenty, Twenty Sixteen and Twenty Sixteen. The buttons were consistent with eachother and the theme in all cases except Twenty Sixteen. (Note that there were other styling/typography/layout issues in Twenty/core themes - we should address those separately.)

In my testing I noticed that Twenty Sixteen shows the original issue – I'd view this as a theme issue (maybe worth reporting to Twenty Sixteen).
