### PR TITLE
Fix long product names regression

### DIFF
--- a/assets/js/base/components/cart-checkout/product-name/style.scss
+++ b/assets/js/base/components/cart-checkout/product-name/style.scss
@@ -2,5 +2,5 @@
 	@include font-size(16);
 	@include wrapBreakWord();
 	display: block;
-	width: max-content;
+	max-width: max-content;
 }

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -117,6 +117,7 @@
 	.wc-block-order-summary-item__header {
 		display: flex;
 		flex-wrap: wrap;
+		justify-content: space-between;
 	}
 
 	.wc-block-product-name {


### PR DESCRIPTION
Fixes #2376.

Fixes a regression introduced in #2348, which was making long product names to overflow in the _Cart_ and _Checkout_ blocks.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/80952015-46a7da00-8df9-11ea-9681-9d634e19bc71.png)

### How to test the changes in this Pull Request:

1. Edit a product so it has a name with a very long word and add it to your cart.
2. Go to the _Cart_ and _Checkout_ blocks and make sure it doesn't break the layout.
