### PR TITLE
ensure checkout submit button doesn't get pushed offscreen by big spenders

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -400,15 +400,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 							</FormStep>
 						) }
 					</CheckoutForm>
-				</Main>
-				<Sidebar className="wc-block-checkout__sidebar">
-					<CheckoutSidebar
-						cartCoupons={ cartCoupons }
-						cartItems={ cartItems }
-						cartTotals={ cartTotals }
-					/>
-				</Sidebar>
-				<Main className="wc-block-checkout__main-totals">
 					<div className="wc-block-checkout__actions">
 						{ attributes.showReturnToCart && (
 							<ReturnToCartButton
@@ -422,6 +413,13 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 					</div>
 					{ attributes.showPolicyLinks && <Policies /> }
 				</Main>
+				<Sidebar className="wc-block-checkout__sidebar">
+					<CheckoutSidebar
+						cartCoupons={ cartCoupons }
+						cartItems={ cartItems }
+						cartTotals={ cartTotals }
+					/>
+				</Sidebar>
 			</SidebarLayout>
 		</>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -260,10 +260,6 @@
 		margin-bottom: $gap-largest;
 		order: 0;
 	}
-
-	.wc-block-checkout__main-totals {
-		order: 2;
-	}
 }
 
 @include breakpoint( ">480px" ) {


### PR DESCRIPTION
Fixes #2321

Tweaks the DOM for checkout so the submit button and related content (e.g. privacy/terms and back to cart links) are in the same container as the checkout payment form. This ensures that a long list of detailed products in the order summary (sidebar) doesn't push the submit button down into no-person's land.

### Screenshots

<img width="1486" alt="Screen Shot 2020-05-05 at 3 28 50 PM" src="https://user-images.githubusercontent.com/4167300/81033101-5224ff00-8ee6-11ea-865b-8abdf7953fe9.png">
<img width="1486" alt="Screen Shot 2020-05-05 at 3 31 34 PM" src="https://user-images.githubusercontent.com/4167300/81033102-53562c00-8ee6-11ea-8938-257bfa02bdeb.png">
<img width="1348" alt="Screen Shot 2020-05-05 at 3 31 41 PM" src="https://user-images.githubusercontent.com/4167300/81033105-551fef80-8ee6-11ea-84dd-45f3b2f52c82.png">

![IMG_142BF84106FF-1](https://user-images.githubusercontent.com/4167300/81033228-dd05f980-8ee6-11ea-9c51-4784c05ae101.jpg)


### How to test the changes in this Pull Request:

0. Ensure you are using checkout block (not shortcode).
1. Add everything in the store to your cart. **BUY IT ALL!** 💰
2. Proceed through cart and checkout.
3. Confirm that the checkout is easy to complete, the submit button is readily apparent.
7. Bonus points for checking a range of devices, screen sizes, and themes.
