### PR TITLE
clarify various checkout block editor sidebar wording

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -229,7 +229,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						}
 						labels={ {
 							title: __(
-								'Return to cart button',
+								'Return to Cart button',
 								'woo-gutenberg-products-block'
 							),
 							default: __(

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -76,11 +76,14 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				</Notice>
 			) }
 			<PanelBody
-				title={ __( 'Form options', 'woo-gutenberg-products-block' ) }
+				title={ __(
+					'Address options',
+					'woo-gutenberg-products-block'
+				) }
 			>
 				<p className="wc-block-checkout__controls-text">
 					{ __(
-						'Choose whether your checkout form requires extra information from customers.',
+						'Include additional address fields in the checkout form.',
 						'woo-gutenberg-products-block'
 					) }
 				</p>
@@ -146,21 +149,18 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				) }
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				title={ __(
+					'Navigation options',
+					'woo-gutenberg-products-block'
+				) }
 			>
-				<p className="wc-block-checkout__controls-text">
-					{ __(
-						'Choose additional content to display.',
-						'woo-gutenberg-products-block'
-					) }
-				</p>
 				<ToggleControl
 					label={ __(
 						'Show links to policies',
 						'woo-gutenberg-products-block'
 					) }
 					help={ __(
-						'Shows a list of links to your "terms and conditions" and "privacy policy" pages.',
+						'Shows links to your "terms and conditions" and "privacy policy" pages.',
 						'woo-gutenberg-products-block'
 					) }
 					checked={ showPolicyLinks }
@@ -207,7 +207,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				) }
 				<ToggleControl
 					label={ __(
-						'Show a "return to cart" link',
+						'Show a "Return to Cart" link',
 						'woo-gutenberg-products-block'
 					) }
 					checked={ showReturnToCart }
@@ -229,7 +229,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						}
 						labels={ {
 							title: __(
-								'Return to Cart button',
+								'Return to cart button',
 								'woo-gutenberg-products-block'
 							),
 							default: __(

--- a/assets/js/blocks/cart-checkout/checkout/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/index.js
@@ -22,7 +22,7 @@ const settings = {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Display the checkout experience for customers.',
+		'Display a checkout form so your customers can submit orders.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {


### PR DESCRIPTION
Fixes #2341

This PR makes a few changes to Checkout block sidebar wording based on #2341. I've aimed for simplicity and clarity. The goal is to make it super clear what the options do, and keep the wording to a minimum. A related goal is to use categories (panels) in the sidebar to provide a more context, and to keep the number of sidebar panels to a minimum.


### Screenshots
New wording:
<img width="286" alt="Screen Shot 2020-05-05 at 4 21 59 PM" src="https://user-images.githubusercontent.com/4167300/81034863-a29f5b00-8eec-11ea-93cd-1478b09e3c63.png">

Previous wording:
<img width="289" alt="Screen Shot 2020-05-05 at 4 23 17 PM" src="https://user-images.githubusercontent.com/4167300/81034884-bd71cf80-8eec-11ea-8531-135fffb2916d.png">

What's changed?

- Block description: `Display a checkout form so your customers can submit orders.`  ~~`Display the checkout experience for customers.`~~
- Address options panel: 
  - `Address options` ~~`Form options`~~
  -  `Include additional address fields in the checkout form.` ~~`Choose whether your checkout form requires extra information from customers`~~
- Navigation / links panel: 
  - `Navigation options` ~~`Content`~~ 
  - Removed the redundant description ~~`Choose additional content to display.`~~
  - Streamlined policy link description `Shows links to your "terms and conditions" and "privacy policy" pages.` ~~`Shows a list of links to your "terms and conditions" and "privacy policy" pages.`~~

Also, I think `Return to cart` (the editor UI and the link itself) should probably be sentence case? (Currently title case.)

### How to test the changes in this Pull Request:
1. Go to block editor, add or edit a Checkout block.
2. Read through the sidebar options – is it clear what they do and why they might be useful for particular store use cases?
