### PR TITLE
SCSS mixins cleanup

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,6 +1,6 @@
 // Converts a font-size in px to rem and optionally sets a relative line-height.
 @mixin font-size($sizeValue: 16px, $lineHeight: false) {
-	font-size: ($sizeValue / 16px) + rem;
+	font-size: ($sizeValue / 16px) * 1rem;
 
 	@if ($lineHeight) {
 		line-height: $lineHeight / $sizeValue;
@@ -44,7 +44,7 @@
 	}
 }
 
-// Hide an element from sighted users, but availble to screen reader users.
+// Hide an element from sighted users, but available to screen reader users.
 @mixin visually-hidden() {
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
@@ -92,6 +92,7 @@
 	-ms-word-break: break-all;
 }
 
+// Converts a px unit to rem.
 @function rem($size, $base: 16px) {
 	@return $size / $base * 1rem;
 }

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -7,14 +7,6 @@
 	}
 }
 
-@mixin hover-state() {
-	&:hover,
-	&:active,
-	&:focus {
-		@content;
-	}
-}
-
 @keyframes loading-fade {
 	0% {
 		opacity: 0.7;

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,7 +1,7 @@
 // Converts a font-size in px to rem and optionally sets a relative line-height.
-@mixin font-size($sizeValue: 16, $lineHeight: false ) {
-	font-size: $sizeValue + px;
-	font-size: ($sizeValue / 16) + rem;
+@mixin font-size($sizeValue: 16px, $lineHeight: false) {
+	font-size: ($sizeValue / 16px) + rem;
+
 	@if ($lineHeight) {
 		line-height: $lineHeight / $sizeValue;
 	}

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -7,7 +7,7 @@
 	}
 }
 
-@mixin hover-state {
+@mixin hover-state() {
 	&:hover,
 	&:active,
 	&:focus {
@@ -52,15 +52,6 @@
 	}
 }
 
-// Adds animation to transforms
-@mixin animate-transform( $duration: 0.2s ) {
-	transition: transform ease $duration;
-
-	@media screen and (prefers-reduced-motion: reduce) {
-		transition: none;
-	}
-}
-
 // Hide an element from sighted users, but availble to screen reader users.
 @mixin visually-hidden() {
 	clip: rect(1px, 1px, 1px, 1px);
@@ -72,16 +63,6 @@
 	/* Many screen reader and browser combinations announce broken words as they would appear visually. */
 	overflow-wrap: normal !important;
 	word-wrap: normal !important;
-}
-
-// Unhide a visually hidden element
-@mixin visually-shown() {
-	clip: auto;
-	clip-path: none;
-	height: auto;
-	width: auto;
-	margin: unset;
-	overflow: hidden;
 }
 
 // Reset <button> style so we can use link style for action buttons.
@@ -110,7 +91,7 @@
 }
 
 // Makes sure long words are broken if they overflow the container.
-@mixin wrapBreakWord {
+@mixin wrap-break-word() {
 	// This is the current standard, works in most browsers.
 	overflow-wrap: anywhere;
 	// Safari supports word-break.
@@ -119,6 +100,6 @@
 	-ms-word-break: break-all;
 }
 
-@function rem($size, $base: 16px ) {
+@function rem($size, $base: 16px) {
 	@return $size / $base * 1rem;
 }

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -30,7 +30,7 @@ $line-offset-from-circle-size: 8px;
 }
 
 .wc-block-checkout-step__title {
-	@include font-size(16);
+	@include font-size(16px);
 	line-height: 1.5;
 	color: $gray-80;
 	font-weight: 400;
@@ -38,7 +38,7 @@ $line-offset-from-circle-size: 8px;
 }
 
 .wc-block-checkout-step__heading-content {
-	@include font-size(12);
+	@include font-size(12px);
 	line-height: 2;
 	color: $gray-80;
 
@@ -49,14 +49,14 @@ $line-offset-from-circle-size: 8px;
 }
 
 .wc-block-checkout-step__description {
-	@include font-size(14);
+	@include font-size(14px);
 	line-height: 1.25;
 	color: $gray-60;
 	margin-bottom: $gap;
 }
 
 .wc-block-checkout-step::before {
-	@include font-size(14);
+	@include font-size(14px);
 	counter-increment: checkout-step;
 	content: counter(checkout-step);
 	position: absolute;

--- a/assets/js/base/components/cart-checkout/policies/style.scss
+++ b/assets/js/base/components/cart-checkout/policies/style.scss
@@ -1,6 +1,6 @@
 .editor-styles-wrapper .wc-block-components-checkout-policies,
 .wc-block-components-checkout-policies {
-	@include font-size(12);
+	@include font-size(12px);
 	text-align: center;
 	list-style: none outside;
 	line-height: 1;

--- a/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
@@ -1,5 +1,5 @@
 .wc-block-low-stock-badge {
-	@include font-size(12);
+	@include font-size(12px);
 	background-color: $white;
 	border-radius: 3px;
 	border: 1px solid $black;

--- a/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -1,5 +1,5 @@
 .wc-block-product-metadata {
-	@include font-size(12);
+	@include font-size(12px);
 	color: $core-grey-dark-400;
 
 	p,

--- a/assets/js/base/components/cart-checkout/product-name/style.scss
+++ b/assets/js/base/components/cart-checkout/product-name/style.scss
@@ -1,5 +1,5 @@
 .wc-block-product-name {
-	@include font-size(16);
+	@include font-size(16px);
 	@include wrap-break-word();
 	display: block;
 	max-width: max-content;

--- a/assets/js/base/components/cart-checkout/product-name/style.scss
+++ b/assets/js/base/components/cart-checkout/product-name/style.scss
@@ -1,6 +1,6 @@
 .wc-block-product-name {
 	@include font-size(16);
-	@include wrapBreakWord();
+	@include wrap-break-word();
 	display: block;
 	max-width: max-content;
 }

--- a/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
@@ -1,5 +1,5 @@
 .wc-block-sale-badge {
-	@include font-size(12);
+	@include font-size(12px);
 	background-color: $core-grey-dark-600;
 	border-radius: 2px;
 	color: $white;

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
@@ -3,9 +3,9 @@
 }
 
 .wc-block-shipping-rates-control__package-items {
+	@include font-size(14px);
 	color: $core-grey-dark-400;
 	display: block;
-	font-size: 0.875em;
 	list-style: none;
 	margin: 0 0 $gap-small;
 	padding: 0;

--- a/assets/js/base/components/cart-checkout/totals/totals-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-item/style.scss
@@ -15,6 +15,6 @@
 }
 
 .wc-block-totals-table-item__description {
-	@include font-size(14);
+	@include font-size(14px);
 	width: 100%;
 }

--- a/assets/js/base/components/payment-methods/no-payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/no-payment-methods/style.scss
@@ -14,7 +14,7 @@
 		}
 
 		.wc-block-checkout__no-payment-methods-placeholder-description {
-			@include font-size(13);
+			@include font-size(13px);
 			display: block;
 			margin: 0.25em 0 1em 0;
 		}

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -69,7 +69,7 @@
 	}
 
 	.wc-block-gateway-input {
-		@include font-size(16, 22);
+		@include font-size(16px, 22px);
 		background-color: #fff;
 		padding: $gap-small $gap;
 		border-radius: 4px;
@@ -91,7 +91,7 @@
 	}
 
 	label {
-		@include font-size(16, 22);
+		@include font-size(16px, 22px);
 		position: absolute;
 		transform: translateY(0.75em);
 		left: 0;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -4,7 +4,7 @@
 	margin-bottom: $gap-large;
 
 	label {
-		@include font-size(16, 22);
+		@include font-size(16px, 22px);
 		position: absolute;
 		transform: translateY(0.75em);
 		transform-origin: top left;
@@ -37,7 +37,7 @@
 	}
 
 	.components-custom-select-control__button {
-		@include font-size(16);
+		@include font-size(16px);
 		background-color: #fff;
 		box-shadow: none;
 		color: $input-text-active;
@@ -78,7 +78,7 @@
 	}
 
 	.components-custom-select-control__item {
-		@include font-size(16);
+		@include font-size(16px);
 		margin-left: 0;
 		padding-left: $gap;
 	}

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -4,7 +4,7 @@
 	white-space: nowrap;
 
 	label {
-		@include font-size(16);
+		@include font-size(16px);
 		position: absolute;
 		transform: translateY(0.75em);
 		left: 0;
@@ -35,7 +35,7 @@
 	input[type="url"],
 	input[type="text"],
 	input[type="email"] {
-		@include font-size(16);
+		@include font-size(16px);
 		background-color: #fff;
 		padding: $gap-small $gap;
 		border-radius: 4px;

--- a/assets/js/base/components/validation/style.scss
+++ b/assets/js/base/components/validation/style.scss
@@ -1,6 +1,6 @@
 .wc-block-form-input-validation-error {
 	color: $error-red;
-	@include font-size(12);
+	@include font-size(12px);
 	max-width: 100%;
 	position: absolute;
 	top: calc(100% - 1px);

--- a/assets/js/blocks/attribute-filter/editor.scss
+++ b/assets/js/blocks/attribute-filter/editor.scss
@@ -13,7 +13,7 @@
 		display: block; /* Disable flex box */
 
 		p {
-			@include font-size(14);
+			@include font-size(14px);
 		}
 	}
 	.woocommerce-search-list__search {
@@ -22,7 +22,7 @@
 		padding-top: 0;
 	}
 	.wc-block-attribute-filter__add_attribute_button {
-		@include font-size(14, 24);
+		@include font-size(14px, 24px);
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -2,7 +2,7 @@
 	color: $core-grey-dark-600;
 
 	h2 {
-		@include font-size(20);
+		@include font-size(20px);
 		font-weight: normal;
 	}
 
@@ -55,7 +55,7 @@ table.wc-block-cart-items {
 		padding-right: 0;
 	}
 	.wc-block-cart-items__header {
-		@include font-size(12);
+		@include font-size(12px);
 		text-transform: uppercase;
 
 		.wc-block-cart-items__header-image {
@@ -81,7 +81,7 @@ table.wc-block-cart-items {
 		.wc-block-cart-item__quantity {
 			.wc-block-cart-item__remove-link {
 				@include link-button;
-				@include font-size(12);
+				@include font-size(12px);
 
 				color: $core-grey-dark-400;
 				text-transform: none;
@@ -99,7 +99,7 @@ table.wc-block-cart-items {
 			}
 		}
 		.wc-block-cart-item__total {
-			@include font-size(16);
+			@include font-size(16px);
 			text-align: right;
 			line-height: 1.25;
 

--- a/assets/js/blocks/cart-checkout/checkout/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/editor.scss
@@ -1,6 +1,6 @@
 .editor-styles-wrapper {
 	.wp-block h4.wc-block-checkout-step__title {
-		@include font-size(16);
+		@include font-size(16px);
 		line-height: 24px;
 		margin: 0 $gap-small 0 0;
 	}

--- a/assets/js/blocks/cart-checkout/checkout/no-shipping-placeholder/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/no-shipping-placeholder/style.scss
@@ -14,7 +14,7 @@
 		}
 
 		.wc-block-checkout__no-shipping-placeholder-description {
-			@include font-size(13);
+			@include font-size(13px);
 			display: block;
 			margin: 0.25em 0 1em 0;
 		}

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -84,7 +84,7 @@
 	}
 
 	.wc-block-order-summary-item__quantity {
-		@include font-size(11);
+		@include font-size(11px);
 		align-items: center;
 		background: #fff;
 		border: 2px solid currentColor;

--- a/assets/js/blocks/price-filter/editor.scss
+++ b/assets/js/blocks/price-filter/editor.scss
@@ -24,11 +24,11 @@
 		display: block; /* Disable flex box */
 
 		p {
-			@include font-size(14);
+			@include font-size(14px);
 		}
 	}
 	.wc-block-price-slider__add_product_button {
-		@include font-size(14, 24);
+		@include font-size(14px, 24px);
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -63,7 +63,7 @@
 	display: flex;
 	align-items: center;
 	text-decoration: none;
-	@include font-size(13);
+	@include font-size(13px);
 	margin: 0;
 	border: none;
 	cursor: pointer;

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -8,7 +8,7 @@
 		flex-grow: 1;
 	}
 	.wc-block-product-search__button {
-		@include font-size(13);
+		@include font-size(13px);
 		display: flex;
 		align-items: center;
 		text-decoration: none;

--- a/assets/js/blocks/products/editor.scss
+++ b/assets/js/blocks/products/editor.scss
@@ -13,11 +13,11 @@
 		display: block; /* Disable flex box */
 
 		p {
-			@include font-size(14);
+			@include font-size(14px);
 		}
 	}
 	.wc-block-products__add_product_button {
-		@include font-size(14, 24);
+		@include font-size(14px, 24px);
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/components/product-attribute-term-control/style.scss
+++ b/assets/js/components/product-attribute-term-control/style.scss
@@ -24,7 +24,9 @@
 	}
 
 	&.is-not-active {
-		@include hover-state {
+		&:hover,
+		&:active,
+		&:focus {
 			background: $white;
 		}
 	}

--- a/assets/js/components/product-control/style.scss
+++ b/assets/js/components/product-control/style.scss
@@ -13,7 +13,9 @@
 	}
 
 	&.is-not-active {
-		@include hover-state {
+		&:hover,
+		&:active,
+		&:focus {
 			background: $white;
 		}
 	}


### PR DESCRIPTION
This PR:
- Removes some mixins that were not used anywhere (`animate-transform` and `visually-shown`).
- Removes the `hover-state` mixin, I think it doesn't add much value and it was inconsistently used.
- Updates the `font-size()` mixin so its parameter have units. That's to solve a signature difference with the `rem()` function, which receives parameters with use. I don't have a strong preference whether we should use parameters with or without units, but I do think it makes sense to be consistent. I went for using parameters with units because I think it makes the mixins purpose easier to understand, but happy to discuss. :slightly_smiling_face: 
- In the `font-size()` mixin, it removes the `px` fallback. IE>=9 and all other modern browsers [support `rem` units](https://caniuse.com/#feat=rem), so there is no need for the fallback.

### How to test the changes in this Pull Request:

Changes are quite safe so making sure `npm run start` doesn't break and smoke testing some blocks should be enough.