### PR TITLE
Allow validated text inputs to focus on mount

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
@@ -85,6 +85,7 @@ const TotalsCouponCodeInput = ( {
 								setCouponValue( newCouponValue );
 							} }
 							validateOnMount={ false }
+							focusOnMount={ true }
 							showError={ false }
 						/>
 						<Button

--- a/assets/js/base/components/text-input/validated.js
+++ b/assets/js/base/components/text-input/validated.js
@@ -22,6 +22,7 @@ const ValidatedTextInput = ( {
 	ariaDescribedBy,
 	errorId,
 	validateOnMount = true,
+	focusOnMount = false,
 	onChange,
 	showError = true,
 	...rest
@@ -52,6 +53,12 @@ const ValidatedTextInput = ( {
 			} );
 		}
 	};
+
+	useEffect( () => {
+		if ( focusOnMount ) {
+			inputRef.current.focus();
+		}
+	}, [ focusOnMount ] );
 
 	useEffect( () => {
 		if ( validateOnMount ) {
@@ -103,6 +110,7 @@ ValidatedTextInput.propTypes = {
 	ariaDescribedBy: PropTypes.string,
 	errorId: PropTypes.string,
 	validateOnMount: PropTypes.bool,
+	focusOnMount: PropTypes.bool,
 	showError: PropTypes.bool,
 };
 


### PR DESCRIPTION
Adds a prop for focussing inputs on mount, and enables it for the coupon form.

Fixes #2338

### Screenshots

![2020-05-06 12 40 11](https://user-images.githubusercontent.com/90977/81172751-bf906880-8f96-11ea-9ac9-f9a321fdce51.gif)

### How to test the changes in this Pull Request:

1. Toggle the coupon form on cart/checkout
2. Input should gain focus