### PR TITLE
Add an inline skeleton sizing script

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -155,8 +155,8 @@ abstract class AbstractBlock {
 
 			if ( containers.length ) {
 				Array.prototype.forEach.call( containers, function( el, i ) {
-					var w = el.offsetWidth;
-					var classname = '';
+					const w = el.offsetWidth;
+					let classname = '';
 
 					if ( w > 700 )
 						classname = 'is-large';

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -143,4 +143,37 @@ abstract class AbstractBlock {
 	protected function enqueue_scripts( array $attributes = [] ) {
 		// noop. Child classes should override this if needed.
 	}
+
+	/**
+	 * Script to append the correct sizing class to a block skeleton.
+	 *
+	 * @return string
+	 */
+	protected function get_skeleton_inline_script() {
+		return "<script>
+			const containers = document.querySelectorAll( 'div.wc-block-skeleton' );
+
+			if ( containers.length ) {
+				Array.prototype.forEach.call( containers, function( el, i ) {
+					var w = el.offsetWidth;
+					var classname = '';
+
+					if ( w > 700 )
+						classname = 'is-large';
+					else if ( w > 520 )
+						classname = 'is-medium';
+					else if ( w > 400 )
+						classname = 'is-small';
+					else
+						classname = 'is-mobile';
+
+					if ( ! el.classList.contains( classname ) )  {
+						el.classList.add( classname );
+					}
+
+					el.classList.remove( 'hidden' );
+				} );
+			}
+		</script>";
+	}
 }

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -130,7 +130,7 @@ class Cart extends AbstractBlock {
 	 */
 	protected function get_skeleton() {
 		return '
-			<div class="wc-block-sidebar-layout wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton is-large" aria-hidden="true">
+			<div class="wc-block-skeleton wc-block-sidebar-layout wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton hidden" aria-hidden="true">
 				<div class="wc-block-main wc-block-cart__main">
 					<h2><span></span></h2>
 					<table class="wc-block-cart-items">
@@ -207,6 +207,6 @@ class Cart extends AbstractBlock {
 					<div class="components-card"></div>
 				</div>
 			</div>
-		';
+		' . $this->get_skeleton_inline_script();
 	}
 }

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -170,7 +170,7 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function get_skeleton() {
 		return '
-			<div class="wc-block-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton is-large" aria-hidden="true">
+			<div class="wc-block-skeleton wc-block-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton hidden" aria-hidden="true">
 				<div class="wc-block-main wc-block-checkout__main">
 					<div class="wc-block-component-express-checkout"></div>
 					<div class="wc-block-component-express-checkout-continue-rule"><span></span></div>
@@ -198,7 +198,7 @@ class Checkout extends AbstractBlock {
 					</div>
 				</div>
 			</div>
-		';
+		' . $this->get_skeleton_inline_script();
 	}
 
 	/**


### PR DESCRIPTION
Similar to our script to `renderFrontend`, this PR adds an inline script to add a classname to the skeleton as soon as possible, based on container size, as soon as the skeleton is rendered.

Fixes #2402

### How to test the changes in this Pull Request:

1. Resize window so you are seeing medium/cart sized cart or checkout.
2. Inspect source.
3. Check the skeleton markup has the correct class, e.g. `is-small`.

I tested this by console logging also. 
