### PR TITLE
Fix saved payment method selection not working for purchases.

### DIFF
--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -106,9 +106,7 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 	const updateToken = useCallback(
 		( token ) => {
 			if ( token !== '0' ) {
-				// @todo this will need updated when the signature changes to
-				// allow no billing data included.
-				setPaymentStatus().success( null, {
+				setPaymentStatus().success( {
 					payment_method: activePaymentMethod,
 					savedPaymentMethodToken: token,
 				} );

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -139,7 +139,12 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 				name: `wc-saved-payment-method-token-new`,
 			} );
 		}
-	}, [ customerPaymentMethods, selectedToken ] );
+	}, [
+		customerPaymentMethods,
+		selectedToken,
+		setActivePaymentMethod,
+		setPaymentStatus,
+	] );
 	const updateToken = useCallback(
 		( token ) => {
 			if ( token === '0' ) {
@@ -148,7 +153,7 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 			setSelectedToken( token );
 			onSelect( token );
 		},
-		[ setSelectedToken, setPaymentStatus, onSelect, activePaymentMethod ]
+		[ setSelectedToken, setPaymentStatus, onSelect ]
 	);
 	useEffect( () => {
 		if ( selectedToken && currentOptions.current.length > 0 ) {

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -105,23 +105,26 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 				if ( paymentMethods.length > 0 ) {
 					options = options.concat(
 						paymentMethods.map( ( paymentMethod ) => {
+							const option =
+								type === 'cc' || type === 'echeck'
+									? getCcOrEcheckPaymentMethodOption(
+											paymentMethod,
+											setActivePaymentMethod,
+											setPaymentStatus
+									  )
+									: getDefaultPaymentMethodOptions(
+											paymentMethod,
+											setActivePaymentMethod,
+											setPaymentStatus
+									  );
 							if (
 								paymentMethod.is_default &&
 								selectedToken === ''
 							) {
 								setSelectedToken( paymentMethod.tokenId + '' );
+								option.onChange( paymentMethod.tokenId );
 							}
-							return type === 'cc' || type === 'echeck'
-								? getCcOrEcheckPaymentMethodOption(
-										paymentMethod,
-										setActivePaymentMethod,
-										setPaymentStatus
-								  )
-								: getDefaultPaymentMethodOptions(
-										paymentMethod,
-										setActivePaymentMethod,
-										setPaymentStatus
-								  );
+							return option;
 						} )
 					);
 				}

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -57,6 +57,7 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 	const {
 		setPaymentStatus,
 		customerPaymentMethods,
+		setActivePaymentMethod,
 		activePaymentMethod,
 	} = usePaymentMethodDataContext();
 	const [ selectedToken, setSelectedToken ] = useState( '' );
@@ -106,6 +107,7 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 	const updateToken = useCallback(
 		( token ) => {
 			if ( token !== '0' ) {
+				setActivePaymentMethod( activePaymentMethod );
 				setPaymentStatus().success( {
 					payment_method: activePaymentMethod,
 					savedPaymentMethodToken: token,

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -32,7 +32,12 @@ const RadioControl = ( {
 						name={ `radio-control-${ radioControlId }` }
 						checked={ option.value === selected }
 						option={ option }
-						onChange={ onChange }
+						onChange={ ( value ) => {
+							onChange( value );
+							if ( typeof option.onChange === 'function' ) {
+								option.onChange( value );
+							}
+						} }
 					/>
 				) ) }
 			</div>

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -248,10 +248,13 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		setPaymentStatus,
 	] );
 
-	// when checkout is returned to idle, set payment status to pristine.
+	// When checkout is returned to idle, set payment status to pristine
+	// but only if payment status is already not finished.
 	useEffect( () => {
-		dispatch( statusOnly( PRISTINE ) );
-	}, [ checkoutIsIdle ] );
+		if ( ! currentStatus.isSuccessful ) {
+			dispatch( statusOnly( PRISTINE ) );
+		}
+	}, [ checkoutIsIdle, currentStatus.isSuccessful ] );
 
 	// set initial active payment method if it's undefined.
 	useEffect( () => {

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -135,6 +135,15 @@ class Api {
 			return;
 		}
 
+		// if we have savedPaymentMethodToken in the request, then convert into
+		// the format expected by the post.
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_POST['savedpaymentmethodtoken'] ) ) {
+			$token_key = 'wc-' . $context->payment_method . '-payment-token';
+			// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress . Security . ValidatedSanitizedInput . InputNotSanitized
+			$_POST[ $token_key ] = wc_clean( $_POST['savedpaymentmethodtoken'] );
+		}
+
 		$payment_method_object->validate_fields();
 
 		// If errors were thrown, we need to abort.

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -135,15 +135,6 @@ class Api {
 			return;
 		}
 
-		// if we have savedPaymentMethodToken in the request, then convert into
-		// the format expected by the post.
-		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( isset( $_POST['savedpaymentmethodtoken'] ) ) {
-			$token_key = 'wc-' . $context->payment_method . '-payment-token';
-			// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress . Security . ValidatedSanitizedInput . InputNotSanitized
-			$_POST[ $token_key ] = wc_clean( $_POST['savedpaymentmethodtoken'] );
-		}
-
 		$payment_method_object->validate_fields();
 
 		// If errors were thrown, we need to abort.


### PR DESCRIPTION
Fixes: #2350

Originally I was just going to investigate and report findings to @haszari for #2350 so he could finish it off, but once I figured out the problem, the fixes were fairly easy and I figured just adding it and pushing for review would save time.

This pull fixes the issue where a selected saved payment method token would not work for completing the purchase. The following is done in this pull:

- Fixed incorrect arguments used for changing the payment status to success for saved payment method selection (I missed this todo with some refactoring that was done).
- Fixed the payment status getting set to `PRISTINE` too liberally. We only want that to happen if the payment status is not already successful. Otherwise the payment method token that is in the state would get wiped.
- Added saved payment token handling to the server (this is agnostic to payment method so _any_ saved payment method processing should "just work" - but I didn't test non supported payment methods for now).

## To test

- You have to setup a saved payment method via the shortcode cart for now because of #2411 
- Try making a purchase with that saved payment method, it should complete without issue.
- Try making a purchase with Stripe CC, it should complete without issue.
- Try making a purchase with Cheque, it should complete without issue.
- Try making a purchase with Chrome Pay or Apple Pay, either should complete without issue.
- Try breaking things (example, in checkout switch between saved payment method and selecting a payment method and then back again).
- Try making purchases in incognito mode. Should complete without issue.

I tested all of the above except the last one because I hit stripe rate limiting (likely because of #2424).