### PR TITLE
Fix X-WC-Store-API-Nonce updates 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,7 @@ module.exports = {
 	},
 	globals: {
 		wcSettings: 'readonly',
+		wcStoreApiNonce: 'readonly',
 		page: true,
 		browser: true,
 		context: true,

--- a/assets/js/middleware/index.js
+++ b/assets/js/middleware/index.js
@@ -1,4 +1,4 @@
 /**
  * Internal dependencies
  */
-export * from './constants';
+import './store-api-nonce';

--- a/assets/js/middleware/store-api-nonce.js
+++ b/assets/js/middleware/store-api-nonce.js
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { getSetting } from '@woocommerce/settings';
 
+// @ts-ignore wcStoreApiNonce is window global
 // Cache for the initial nonce initialized from hydration.
-let nonce = getSetting( 'storeApiNonce' );
+let nonce = wcStoreApiNonce || '';
 
 /**
  * Returns whether or not this is a non GET wc/store API request.

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -44,11 +44,18 @@ class Assets {
 		wp_style_add_data( 'wc-block-style', 'rtl', 'replace' );
 
 		// Shared libraries and components across all blocks.
-		self::register_script( 'wc-blocks-data-store', plugins_url( 'build/wc-blocks-data.js', __DIR__ ), [], false );
+		self::register_script( 'wc-blocks-middleware', plugins_url( 'build/wc-blocks-middleware.js', __DIR__ ), [], false );
+		self::register_script( 'wc-blocks-data-store', plugins_url( 'build/wc-blocks-data.js', __DIR__ ), [ 'wc-blocks-middleware' ], false );
 		self::register_script( 'wc-blocks', plugins_url( self::get_block_asset_build_path( 'blocks' ), __DIR__ ), [], false );
 		self::register_script( 'wc-vendors', plugins_url( self::get_block_asset_build_path( 'vendors' ), __DIR__ ), [], false );
-
 		self::register_script( 'wc-blocks-registry', plugins_url( 'build/wc-blocks-registry.js', __DIR__ ), [], false );
+
+		// Inline data.
+		wp_add_inline_script(
+			'wc-blocks-middleware',
+			"var wcStoreApiNonce = '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "';",
+			'before'
+		);
 
 		// Individual blocks.
 		$block_dependencies = array( 'wc-vendors', 'wc-blocks' );
@@ -143,7 +150,6 @@ class Assets {
 				'restApiRoutes'                 => [
 					'/wc/store' => array_keys( Package::container()->get( RestApi::class )->get_routes_from_namespace( 'wc/store' ) ),
 				],
-				'storeApiNonce'                 => wp_create_nonce( 'wc_store_api' ),
 				'homeUrl'                       => esc_url( home_url( '/' ) ),
 				'storePages'                    => [
 					'shop'     => self::format_page_resource( $page_ids['shop'] ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ const CoreConfig = {
 		wcBlocksRegistry: './assets/js/blocks-registry/index.js',
 		wcSettings: './assets/js/settings/shared/index.js',
 		wcBlocksData: './assets/js/data/index.js',
+		wcBlocksMiddleware: './assets/js/middleware/index.js',
 	},
 	output: {
 		filename: ( chunkData ) => {


### PR DESCRIPTION
The `X-WC-Store-API-Nonce` refreshes after API requests if the customer session changes - this is more apparent for guests in incognito with no cart.

This process works fine, however, the `nonce` variable cache was not updating correctly because the `store-api-nonce.js` file was imported several times on the same page.

To fix this, and to ensure there is only ever one nonce stored, I've moved this into a separate script with it's own handle that is a dependency of the `data-store` script which uses needs this for `API_FETCH_WITH_HEADERS`.

Fixes #2406

### How to test the changes in this Pull Request:

The instructions in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2406 are correct; ensure you are not running PayPal express extension and have nothing in your cart!