### PR TITLE
Fix 'Try reloading the page' button styles

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -52,7 +52,7 @@ const getErrorBoundaryProps = () => {
 			{
 				button: (
 					<button
-						className="wp-block-link-button"
+						className="wc-block-link-button"
 						onClick={ reloadPage }
 					/>
 				),

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -54,7 +54,7 @@ const CheckoutFrontend = ( props ) => {
 						{
 							button: (
 								<button
-									className="wp-block-link-button"
+									className="wc-block-link-button"
 									onClick={ reloadPage }
 								/>
 							),
@@ -90,7 +90,7 @@ const getErrorBoundaryProps = () => {
 			{
 				button: (
 					<button
-						className="wp-block-link-button"
+						className="wc-block-link-button"
 						onClick={ reloadPage }
 					/>
 				),


### PR DESCRIPTION
In #2105 we converted the `Try reloading the page` links to buttons and added a reset class so they looked like text links. However, there was a mismatch in the class name, in the CSS it was [`.wc-block-link-button`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/css/style.scss#L1) and in the components `wp-block-link-button` (my bad! :facepalm: ).

This PR fixes that, so components have the correct class name.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/81304053-d4dfc280-907c-11ea-948a-d4dbed67fe8e.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/81303927-a6fa7e00-907c-11ea-84bd-c139ae81c53e.png)

### How to test the changes in this Pull Request:

1. In `blocks/cart-checkout/checkout/frontend.js` [line 39](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/js/blocks/cart-checkout/checkout/frontend.js#L39), add something like `throw new Error( 'test' )` to force the error boundary to appear.
2. Load a page with the _Checkout_ block.
3. Click on `Try reloading the page` and verify the page is reloaded.