### PR TITLE
Update wp.editor references, bump min version support

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -12,7 +12,7 @@ import {
 	PanelColorSettings,
 	withColors,
 	RichText,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 import {
 	Button,
 	FocalPointPicker,

--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { DEFAULT_HEIGHT } from '@woocommerce/block-settings';
 import { Icon, folderStarred } from '@woocommerce/icons';

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -12,7 +12,7 @@ import {
 	PanelColorSettings,
 	withColors,
 	RichText,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 import {
 	Button,

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { DEFAULT_HEIGHT } from '@woocommerce/block-settings';
 import { Icon, star } from '@woocommerce/icons';

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -2,11 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	BlockControls,
-	InspectorControls,
-	ServerSideRender,
-} from '@wordpress/editor';
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
-import { InspectorControls, ServerSideRender } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import { InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
 import { Icon, list } from '@woocommerce/icons';

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
-import { InspectorControls, ServerSideRender } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
 import { Icon, list } from '@woocommerce/icons';

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -2,11 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	BlockControls,
-	InspectorControls,
-	ServerSideRender,
-} from '@wordpress/editor';
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
-import { InspectorControls, ServerSideRender } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody, Placeholder } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody, Placeholder } from '@wordpress/components';
-import { InspectorControls, ServerSideRender } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { InspectorControls, PlainText } from '@wordpress/editor';
+import { InspectorControls, PlainText } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -2,11 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	BlockControls,
-	InspectorControls,
-	ServerSideRender,
-} from '@wordpress/editor';
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
-import { InspectorControls, ServerSideRender } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/block-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import ServerSideRender from '@wordpress/server-side-render';
+import { ServerSideRender } from '@wordpress/editor';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -2,11 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	BlockControls,
-	InspectorControls,
-	ServerSideRender,
-} from '@wordpress/editor';
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/reviews/all-reviews/edit.js
+++ b/assets/js/blocks/reviews/all-reviews/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -10,7 +10,7 @@ import {
 	RangeControl,
 	SelectControl,
 } from '@wordpress/components';
-import { BlockControls } from '@wordpress/editor';
+import { BlockControls } from '@wordpress/block-editor';
 import { getAdminLink } from '@woocommerce/settings';
 import {
 	REVIEW_RATINGS_ENABLED,

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	PanelBody,

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/editor';
+import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
 	PanelBody,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,6 +1337,7 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
       "integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
+      "dev": true,
       "requires": {
         "@emotion/primitives-core": "10.0.27"
       }
@@ -1345,6 +1346,7 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
       "integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
+      "dev": true,
       "requires": {
         "css-to-react-native": "^2.2.1"
       }
@@ -7068,37 +7070,27 @@
       }
     },
     "@wordpress/server-side-render": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.11.0.tgz",
-      "integrity": "sha512-4TzynacfBJwNd10jX9SrWzP7lLWfzZ83V5cLB4toC2GBKasaT0E/KgHHyL/vVBmmD0c/xN5L39MUQt78Ds/Tbg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.10.1.tgz",
+      "integrity": "sha512-Fagu/5uOZc3O9usK//8AyfBN5Et9skHJcCpi/chJPdeYtwX3OZjhicoDWr1yrYqtptrYmZhjx4mnErpdnla3hg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
-        "@wordpress/api-fetch": "^3.14.0",
-        "@wordpress/components": "^9.5.0",
-        "@wordpress/data": "^4.17.0",
+        "@wordpress/api-fetch": "^3.13.1",
+        "@wordpress/components": "^9.4.1",
+        "@wordpress/data": "^4.16.1",
         "@wordpress/deprecated": "^2.8.0",
         "@wordpress/element": "^2.13.1",
-        "@wordpress/i18n": "^3.12.0",
-        "@wordpress/url": "^2.14.0",
+        "@wordpress/i18n": "^3.11.0",
+        "@wordpress/url": "^2.13.0",
         "lodash": "^4.17.15"
       },
       "dependencies": {
-        "@wordpress/api-fetch": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.14.0.tgz",
-          "integrity": "sha512-wcQs3mdTyJtgrqq7iGaDRd/TFPKg49aopSJSXLGkUQxOd5ZxzpHGbMeuC78uWtJEw9++1oTCcR9MTnOFsdgfcw==",
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@wordpress/deprecated": "^2.8.0",
-            "@wordpress/element": "^2.13.1",
-            "@wordpress/i18n": "^3.12.0",
-            "@wordpress/url": "^2.14.0"
-          }
-        },
         "@wordpress/components": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.5.0.tgz",
-          "integrity": "sha512-lfIcVKwzwaFdjpNvlTnNmTvCpO+PBv60N53TkIc0pYM4oAP5YGMp1dYve4xLdTfuVzOkNQ32gs84iysc2GhqFg==",
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.4.1.tgz",
+          "integrity": "sha512-geUBZn9ESpkXGEpC2pXbY9uOGedPYawZRSVd0sT8ZOAZ4JDhXj7f0qqULTF/Q6PdYUItlTFvgGtGSAQUIZfZdQ==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@emotion/core": "^10.0.22",
@@ -7106,17 +7098,17 @@
             "@emotion/native": "^10.0.22",
             "@emotion/styled": "^10.0.23",
             "@wordpress/a11y": "^2.9.0",
-            "@wordpress/compose": "^3.14.0",
+            "@wordpress/compose": "^3.13.1",
             "@wordpress/deprecated": "^2.8.0",
             "@wordpress/dom": "^2.9.0",
             "@wordpress/element": "^2.13.1",
             "@wordpress/hooks": "^2.8.0",
-            "@wordpress/i18n": "^3.12.0",
-            "@wordpress/icons": "^1.4.0",
+            "@wordpress/i18n": "^3.11.0",
+            "@wordpress/icons": "^1.3.1",
             "@wordpress/is-shallow-equal": "^2.0.0",
-            "@wordpress/keycodes": "^2.12.0",
-            "@wordpress/primitives": "^1.4.0",
-            "@wordpress/rich-text": "^3.15.0",
+            "@wordpress/keycodes": "^2.11.0",
+            "@wordpress/primitives": "^1.3.1",
+            "@wordpress/rich-text": "^3.14.1",
             "@wordpress/warning": "^1.1.0",
             "classnames": "^2.2.5",
             "clipboard": "^2.0.1",
@@ -7136,9 +7128,10 @@
           }
         },
         "@wordpress/compose": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.14.0.tgz",
-          "integrity": "sha512-DdFIkb1Ko/7iMGcDX8j6BQWA123yvLISzaFalcF9QOW2bP30QhJiSCFyYGBU7QScnRBhY6Rl0Chh9wkAV032GA==",
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.13.1.tgz",
+          "integrity": "sha512-RlPWcePmsnVj6jxPIq92lh7zbc3vPJzZC5BCHC9v38zUxUSd0pd7q+vvs/Wzpv4t4pYy0saslUM9HTq+bS6nxA==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@wordpress/element": "^2.13.1",
@@ -7148,31 +7141,11 @@
             "react-resize-aware": "^3.0.0"
           }
         },
-        "@wordpress/data": {
-          "version": "4.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.17.0.tgz",
-          "integrity": "sha512-cq3dHjhGUHfolLJfZ8cdLINDPZjmsmnjX0KLTSXH8eHreDSG09M3Mq5sckE2o/omzrm/CIqsRHuHePOrYF+IHA==",
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@wordpress/compose": "^3.14.0",
-            "@wordpress/deprecated": "^2.8.0",
-            "@wordpress/element": "^2.13.1",
-            "@wordpress/is-shallow-equal": "^2.0.0",
-            "@wordpress/priority-queue": "^1.6.0",
-            "@wordpress/redux-routine": "^3.8.0",
-            "equivalent-key-map": "^0.2.2",
-            "is-promise": "^2.1.0",
-            "lodash": "^4.17.15",
-            "memize": "^1.1.0",
-            "redux": "^4.0.0",
-            "turbo-combine-reducers": "^1.0.2",
-            "use-memo-one": "^1.1.1"
-          }
-        },
         "@wordpress/element": {
           "version": "2.13.1",
           "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.13.1.tgz",
           "integrity": "sha512-7bP6ewZ5jogV8wltaNA0Y1yDrPF5zGHprX/zyz8KyQyn5b40YTuoi32HZ1ssYxDa9fFHwbBeFGwVJcyGeKyLpw==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@wordpress/escape-html": "^1.8.0",
@@ -7182,9 +7155,10 @@
           }
         },
         "@wordpress/i18n": {
-          "version": "3.12.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.12.0.tgz",
-          "integrity": "sha512-QkdHd2Z2yTFItBnnzzjMW4IXJlofWMivct4BkgwRivrG7kLxE7nd2xMG3+hFkkdYGdzE67u8vmin0gmQ+14yPA==",
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.11.0.tgz",
+          "integrity": "sha512-wcu8NBxaSu8b4Bj+Nt4dMQvziQrfdgTeEGSRy9GzJChTVpFdyZT88zAaPbK+W8yqFaX3zMSf4rHpZSP6QvWkQg==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "gettext-parser": "^1.3.1",
@@ -7194,78 +7168,31 @@
             "tannin": "^1.2.0"
           }
         },
-        "@wordpress/icons": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.4.0.tgz",
-          "integrity": "sha512-YNW1ocZddZ6c40QHiR/Q3yIPYzh4Fdcq/J4sJIkegwqEXltVknYa90RNaDG9xr+qMvXN5/wotYaLA+AP6pUfHA==",
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@wordpress/element": "^2.13.1",
-            "@wordpress/primitives": "^1.4.0"
-          }
-        },
         "@wordpress/is-shallow-equal": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.0.0.tgz",
           "integrity": "sha512-Xv8b3Jno/3Td6nyj1J+skW96sbyfX7W4sk0TLwN2C2Pz6iQTSTQyGrXmTZWShITt4SOeA8gKpP6kAwSZ4O0HOQ==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2"
           }
         },
         "@wordpress/keycodes": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.12.0.tgz",
-          "integrity": "sha512-7fUwfquRLmE4CvJahZTHdNn31heoDcyZ4acgEQR4iKYsKjX6dF1coZjUe693xbf/4r8GmsOg0/uYDImMdDm+1Q==",
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.11.0.tgz",
+          "integrity": "sha512-qSjUmFCJztu5iQr2kK+1giGG4bKziIo7F0mnMCZtdg+eA09dGwDAv+mc7lxEpKMtttE7qi6+PtGWEnl1ewk/wg==",
+          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
-            "@wordpress/i18n": "^3.12.0",
+            "@wordpress/i18n": "^3.11.0",
             "lodash": "^4.17.15"
-          }
-        },
-        "@wordpress/primitives": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.4.0.tgz",
-          "integrity": "sha512-mlP7ikqBw761VK37RL7q5+tnjJujGFuDfJhjhxCXacM/06CpddPSfX+XctWTTn0Oaw1XI/nzK1wlqlIj7uwlrg==",
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@wordpress/element": "^2.13.1",
-            "classnames": "^2.2.5"
-          }
-        },
-        "@wordpress/rich-text": {
-          "version": "3.15.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.15.0.tgz",
-          "integrity": "sha512-fFA2c6CmcIKFpuqzWf+nS/fTfOHDfp+9eoODymrDZIhwmCzYwmUWIHjd96TSWWF38mKdIm/bc3scIupsksIpfQ==",
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "@wordpress/compose": "^3.14.0",
-            "@wordpress/data": "^4.17.0",
-            "@wordpress/deprecated": "^2.8.0",
-            "@wordpress/element": "^2.13.1",
-            "@wordpress/escape-html": "^1.8.0",
-            "@wordpress/is-shallow-equal": "^2.0.0",
-            "@wordpress/keycodes": "^2.12.0",
-            "classnames": "^2.2.5",
-            "lodash": "^4.17.15",
-            "memize": "^1.1.0",
-            "rememo": "^3.0.0"
-          }
-        },
-        "@wordpress/url": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.14.0.tgz",
-          "integrity": "sha512-TSp6vDpmBTiYTwhlc5mleT4g3mOsw2w5bu5AcqiX344o48rju+ktuTZBQofNIhl3m04zYtl6YR14M1dsXKTsNQ==",
-          "requires": {
-            "@babel/runtime": "^7.9.2",
-            "lodash": "^4.17.15",
-            "qs": "^6.5.2",
-            "react-native-url-polyfill": "^1.1.2"
           }
         },
         "uuid": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true
         }
       }
     },
@@ -7316,7 +7243,8 @@
     "@wordpress/warning": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.1.0.tgz",
-      "integrity": "sha512-n1GDCX2yxxhFF9PeXWq1bInvdwYkYqbeBLHPIChGrS+B57FY4vWebVfKQbOoxZ8CZD1RBIj/KOv/sihuAdHDhg=="
+      "integrity": "sha512-n1GDCX2yxxhFF9PeXWq1bInvdwYkYqbeBLHPIChGrS+B57FY4vWebVfKQbOoxZ8CZD1RBIj/KOv/sihuAdHDhg==",
+      "dev": true
     },
     "@wordpress/wordcount": {
       "version": "2.8.0",
@@ -8879,7 +8807,8 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
     },
     "batch-processor": {
       "version": "1.0.0",
@@ -9496,7 +9425,8 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
+      "dev": true
     },
     "can-use-dom": {
       "version": "0.1.0",
@@ -10612,7 +10542,8 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
+      "dev": true
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -10723,6 +10654,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
       "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
+      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -10732,7 +10664,8 @@
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+          "dev": true
         }
       }
     },
@@ -14562,7 +14495,8 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "iferr": {
       "version": "0.1.5",
@@ -23707,6 +23641,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.1.2.tgz",
       "integrity": "sha512-RPYwjW+4udnAf26xUCQP2dn4t2tnRFo3Ii4s/hy7Ivpe7xYtXp7CMVX505CR8X3p0f8NKmOJ4MQEFMMnbd/Y/Q==",
+      "dev": true,
       "requires": {
         "buffer": "^5.4.3",
         "whatwg-url-without-unicode": "8.0.0-1"
@@ -23716,6 +23651,7 @@
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
           "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -29143,7 +29079,8 @@
     "webidl-conversions": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+      "dev": true
     },
     "webpack": {
       "version": "4.42.0",
@@ -29722,6 +29659,7 @@
       "version": "8.0.0-1",
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-1.tgz",
       "integrity": "sha512-0Uy8mjsG5O8Y53327XL+ZqsrMdxO1CL/6m840SmW5iyRWFvU2zlxS2RzpD3pFFVKYOKCmsKn5JKzWxQ+bImnWA==",
+      "dev": true,
       "requires": {
         "webidl-conversions": "^5.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1337,7 +1337,6 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/native/-/native-10.0.27.tgz",
       "integrity": "sha512-3qxR2XFizGfABKKbX9kAYc0PHhKuCEuyxshoq3TaMEbi9asWHdQVChg32ULpblm4XAf9oxaitAU7J9SfdwFxtw==",
-      "dev": true,
       "requires": {
         "@emotion/primitives-core": "10.0.27"
       }
@@ -1346,7 +1345,6 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/primitives-core/-/primitives-core-10.0.27.tgz",
       "integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
-      "dev": true,
       "requires": {
         "css-to-react-native": "^2.2.1"
       }
@@ -7073,7 +7071,6 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.11.0.tgz",
       "integrity": "sha512-4TzynacfBJwNd10jX9SrWzP7lLWfzZ83V5cLB4toC2GBKasaT0E/KgHHyL/vVBmmD0c/xN5L39MUQt78Ds/Tbg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@wordpress/api-fetch": "^3.14.0",
@@ -7086,11 +7083,22 @@
         "lodash": "^4.17.15"
       },
       "dependencies": {
+        "@wordpress/api-fetch": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.14.0.tgz",
+          "integrity": "sha512-wcQs3mdTyJtgrqq7iGaDRd/TFPKg49aopSJSXLGkUQxOd5ZxzpHGbMeuC78uWtJEw9++1oTCcR9MTnOFsdgfcw==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "@wordpress/deprecated": "^2.8.0",
+            "@wordpress/element": "^2.13.1",
+            "@wordpress/i18n": "^3.12.0",
+            "@wordpress/url": "^2.14.0"
+          }
+        },
         "@wordpress/components": {
           "version": "9.5.0",
           "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-9.5.0.tgz",
           "integrity": "sha512-lfIcVKwzwaFdjpNvlTnNmTvCpO+PBv60N53TkIc0pYM4oAP5YGMp1dYve4xLdTfuVzOkNQ32gs84iysc2GhqFg==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@emotion/core": "^10.0.22",
@@ -7131,7 +7139,6 @@
           "version": "3.14.0",
           "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.14.0.tgz",
           "integrity": "sha512-DdFIkb1Ko/7iMGcDX8j6BQWA123yvLISzaFalcF9QOW2bP30QhJiSCFyYGBU7QScnRBhY6Rl0Chh9wkAV032GA==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@wordpress/element": "^2.13.1",
@@ -7141,11 +7148,31 @@
             "react-resize-aware": "^3.0.0"
           }
         },
+        "@wordpress/data": {
+          "version": "4.17.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.17.0.tgz",
+          "integrity": "sha512-cq3dHjhGUHfolLJfZ8cdLINDPZjmsmnjX0KLTSXH8eHreDSG09M3Mq5sckE2o/omzrm/CIqsRHuHePOrYF+IHA==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "@wordpress/compose": "^3.14.0",
+            "@wordpress/deprecated": "^2.8.0",
+            "@wordpress/element": "^2.13.1",
+            "@wordpress/is-shallow-equal": "^2.0.0",
+            "@wordpress/priority-queue": "^1.6.0",
+            "@wordpress/redux-routine": "^3.8.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^2.1.0",
+            "lodash": "^4.17.15",
+            "memize": "^1.1.0",
+            "redux": "^4.0.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
         "@wordpress/element": {
           "version": "2.13.1",
           "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.13.1.tgz",
           "integrity": "sha512-7bP6ewZ5jogV8wltaNA0Y1yDrPF5zGHprX/zyz8KyQyn5b40YTuoi32HZ1ssYxDa9fFHwbBeFGwVJcyGeKyLpw==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@wordpress/escape-html": "^1.8.0",
@@ -7158,7 +7185,6 @@
           "version": "3.12.0",
           "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.12.0.tgz",
           "integrity": "sha512-QkdHd2Z2yTFItBnnzzjMW4IXJlofWMivct4BkgwRivrG7kLxE7nd2xMG3+hFkkdYGdzE67u8vmin0gmQ+14yPA==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "gettext-parser": "^1.3.1",
@@ -7168,11 +7194,20 @@
             "tannin": "^1.2.0"
           }
         },
+        "@wordpress/icons": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-1.4.0.tgz",
+          "integrity": "sha512-YNW1ocZddZ6c40QHiR/Q3yIPYzh4Fdcq/J4sJIkegwqEXltVknYa90RNaDG9xr+qMvXN5/wotYaLA+AP6pUfHA==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "@wordpress/element": "^2.13.1",
+            "@wordpress/primitives": "^1.4.0"
+          }
+        },
         "@wordpress/is-shallow-equal": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.0.0.tgz",
           "integrity": "sha512-Xv8b3Jno/3Td6nyj1J+skW96sbyfX7W4sk0TLwN2C2Pz6iQTSTQyGrXmTZWShITt4SOeA8gKpP6kAwSZ4O0HOQ==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2"
           }
@@ -7181,18 +7216,56 @@
           "version": "2.12.0",
           "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.12.0.tgz",
           "integrity": "sha512-7fUwfquRLmE4CvJahZTHdNn31heoDcyZ4acgEQR4iKYsKjX6dF1coZjUe693xbf/4r8GmsOg0/uYDImMdDm+1Q==",
-          "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@wordpress/i18n": "^3.12.0",
             "lodash": "^4.17.15"
           }
         },
+        "@wordpress/primitives": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.4.0.tgz",
+          "integrity": "sha512-mlP7ikqBw761VK37RL7q5+tnjJujGFuDfJhjhxCXacM/06CpddPSfX+XctWTTn0Oaw1XI/nzK1wlqlIj7uwlrg==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "@wordpress/element": "^2.13.1",
+            "classnames": "^2.2.5"
+          }
+        },
+        "@wordpress/rich-text": {
+          "version": "3.15.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.15.0.tgz",
+          "integrity": "sha512-fFA2c6CmcIKFpuqzWf+nS/fTfOHDfp+9eoODymrDZIhwmCzYwmUWIHjd96TSWWF38mKdIm/bc3scIupsksIpfQ==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "@wordpress/compose": "^3.14.0",
+            "@wordpress/data": "^4.17.0",
+            "@wordpress/deprecated": "^2.8.0",
+            "@wordpress/element": "^2.13.1",
+            "@wordpress/escape-html": "^1.8.0",
+            "@wordpress/is-shallow-equal": "^2.0.0",
+            "@wordpress/keycodes": "^2.12.0",
+            "classnames": "^2.2.5",
+            "lodash": "^4.17.15",
+            "memize": "^1.1.0",
+            "rememo": "^3.0.0"
+          }
+        },
+        "@wordpress/url": {
+          "version": "2.14.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.14.0.tgz",
+          "integrity": "sha512-TSp6vDpmBTiYTwhlc5mleT4g3mOsw2w5bu5AcqiX344o48rju+ktuTZBQofNIhl3m04zYtl6YR14M1dsXKTsNQ==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "lodash": "^4.17.15",
+            "qs": "^6.5.2",
+            "react-native-url-polyfill": "^1.1.2"
+          }
+        },
         "uuid": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-          "dev": true
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         }
       }
     },
@@ -7243,8 +7316,7 @@
     "@wordpress/warning": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.1.0.tgz",
-      "integrity": "sha512-n1GDCX2yxxhFF9PeXWq1bInvdwYkYqbeBLHPIChGrS+B57FY4vWebVfKQbOoxZ8CZD1RBIj/KOv/sihuAdHDhg==",
-      "dev": true
+      "integrity": "sha512-n1GDCX2yxxhFF9PeXWq1bInvdwYkYqbeBLHPIChGrS+B57FY4vWebVfKQbOoxZ8CZD1RBIj/KOv/sihuAdHDhg=="
     },
     "@wordpress/wordcount": {
       "version": "2.8.0",
@@ -8807,8 +8879,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "batch-processor": {
       "version": "1.0.0",
@@ -9425,8 +9496,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=",
-      "dev": true
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "can-use-dom": {
       "version": "0.1.0",
@@ -10542,8 +10612,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=",
-      "dev": true
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -10654,7 +10723,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.3.2.tgz",
       "integrity": "sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==",
-      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -10664,8 +10732,7 @@
         "postcss-value-parser": {
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
         }
       }
     },
@@ -14495,8 +14562,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -23641,7 +23707,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.1.2.tgz",
       "integrity": "sha512-RPYwjW+4udnAf26xUCQP2dn4t2tnRFo3Ii4s/hy7Ivpe7xYtXp7CMVX505CR8X3p0f8NKmOJ4MQEFMMnbd/Y/Q==",
-      "dev": true,
       "requires": {
         "buffer": "^5.4.3",
         "whatwg-url-without-unicode": "8.0.0-1"
@@ -23651,7 +23716,6 @@
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
           "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -29079,8 +29143,7 @@
     "webidl-conversions": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "dev": true
+      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
     },
     "webpack": {
       "version": "4.42.0",
@@ -29659,7 +29722,6 @@
       "version": "8.0.0-1",
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-1.tgz",
       "integrity": "sha512-0Uy8mjsG5O8Y53327XL+ZqsrMdxO1CL/6m840SmW5iyRWFvU2zlxS2RzpD3pFFVKYOKCmsKn5JKzWxQ+bImnWA==",
-      "dev": true,
       "requires": {
         "webidl-conversions": "^5.0.0"
       }
@@ -29771,7 +29833,7 @@
       }
     },
     "woocommerce": {
-      "version": "git+https://github.com/woocommerce/woocommerce.git#f2cce7f03780b2843f6b1b0e798dd952d51afb53",
+      "version": "git+https://github.com/woocommerce/woocommerce.git#5a746a0775d8407127e314ffde73d5ebb15284bf",
       "from": "git+https://github.com/woocommerce/woocommerce.git#release/4.1",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -155,7 +155,6 @@
 		"@woocommerce/components": "4.0.0",
 		"@wordpress/autop": "^2.7.0",
 		"@wordpress/notices": "2.0.0",
-		"@wordpress/server-side-render": "^1.11.0",
 		"@wordpress/wordcount": "^2.8.0",
 		"classnames": "2.2.6",
 		"compare-versions": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
 		"@woocommerce/components": "4.0.0",
 		"@wordpress/autop": "^2.7.0",
 		"@wordpress/notices": "2.0.0",
+		"@wordpress/server-side-render": "^1.11.0",
 		"@wordpress/wordcount": "^2.8.0",
 		"classnames": "2.2.6",
 		"compare-versions": "3.6.0",

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * Requires at least: 5.0
+ * Requires at least: 5.2
  * Requires PHP: 5.6
  * WC requires at least: 4.0
  * WC tested up to: 4.0

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$minimum_wp_version = '5.0';
+$minimum_wp_version = '5.2';
 
 /**
  * Whether notices must be displayed in the current page (plugins and WooCommerce pages).


### PR DESCRIPTION
Updates our imports of `@wordpress/editor` to `@wordpress/block-editor` where applicable.

Had to leave existing imports in place for `ServerSideRender` since the `@wordpress/server-side-render` package was available from 5.3+.

This PR also bumps the min supported version of WordPress in the readme file to 5.2.

Fixes #620

### How to test the changes in this Pull Request:

- Successful build
- Smoke test legacy/grid blocks
- Smoke test same blocks on WP 5.2