### PR TITLE
Add eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
 		'plugin:@wordpress/eslint-plugin/recommended',
 		'prettier',
 		'plugin:jest/recommended',
+		'plugin:react-hooks/recommended',
 	],
 	env: {
 		'jest/globals': true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6007,6 +6007,12 @@
             "@typescript-eslint/experimental-utils": "^1.13.0"
           }
         },
+        "eslint-plugin-react-hooks": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
+          "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+          "dev": true
+        },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -12393,9 +12399,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.0.tgz",
+      "integrity": "sha512-YKBY+kilK5wrwIdQnCF395Ya6nDro3EAMoe+2xFkmyklyhF16fH83TrQOo9zbZIDxBsXFgBbywta/0JKRNFDkw==",
       "dev": true
     },
     "eslint-plugin-woocommerce": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
 		"eslint": "6.8.0",
 		"eslint-config-prettier": "6.11.0",
 		"eslint-plugin-jest": "23.9.0",
+		"eslint-plugin-react-hooks": "^4.0.0",
 		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",
 		"husky": "2.4.1",
 		"ignore-loader": "0.1.2",


### PR DESCRIPTION
This pull adds the [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks) package so that we can get warned when there may be missing dependencies for hooks.

I've noticed that a frequent conversation that has come up in pull reviews and in slack for the team is around the usage of dependencies and it's also something that I (and others) have missed in reviews. Adding this eslint config will help with alerting us when we're not adding necessary dependencies (which can lead to subtle bugs that can turn up over time).

Note:

- This is set to `warn` not `error`. There _may_ be the occasional _rare_ case where dependencies are not included but that should be documented with the code.
- Currently there are ~60 warnings in the code with linting running after adding this. I think the best plan here would be to fix those warnings as we work in the related code (or tackle them in individual pulls) otherwise we have a lot of testing to do to cover all the impacted things (vs doing it in smaller chunks that will already be tested).

## Testing

Since I didn't make any actual code changes with this pull, there's no impact to existing logic.