### PR TITLE
Update WordPress version in E2E to 5.4

### DIFF
--- a/bin/docker/wordpress/Dockerfile
+++ b/bin/docker/wordpress/Dockerfile
@@ -1,1 +1,1 @@
-FROM wordpress:5.3
+FROM wordpress:5.4


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Part of updating our test setup, this updates WP to 5.4, just making sure it doesn't break anything, the goal later is to cover 5.3 and 5.2 as well.