### PR TITLE
fix broken cart styles in Editor

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
@@ -8,10 +8,6 @@
 		padding-top: 0.5rem;
 	}
 
-	.is-large table.wc-block-cart-items td {
-		border-top: 1px solid $core-grey-light-600;
-	}
-
 	table th.wc-block-cart-items__header-total,
 	table td.wc-block-cart-item__total {
 		text-align: right;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/editor.scss
@@ -8,7 +8,7 @@
 		padding-top: 0.5rem;
 	}
 
-	table.wc-block-cart-items td {
+	.is-large table.wc-block-cart-items td {
 		border-top: 1px solid $core-grey-light-600;
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
We do have a reset for this in frontend
https://github.com/woocommerce/woocommerce-gutenberg-products-block//blob/5a3eb61be2360a988d465e4413a23c3b64f546d5/assets/js/blocks/cart-checkout/cart/full-cart/style.scss#L195

However, the editor styles beat it to the punch, possible fixes:
- we can try loading editor before loading styles.
- Increase our styles.scss specificity.
- Decrease our editor.scss specificity.
- Limit that rule to `is-large` only. (previous solution).
- Keep all cosmetic styles in styles.scss and only have editor specific resets in editor.scss. (Current solution).

<!-- Reference any related issues or PRs here -->
Fixes #2430

### How to test
Make sure nothing is broken in the editor style wise.

### Screenshots
![localhost_8889_wp-admin_post php_post=81 action=edit(iPhone X) (1)](https://user-images.githubusercontent.com/6165348/81430078-c06ff880-9156-11ea-9044-8bc7d4ab9212.png)
