### PR TITLE
Allow shopper to save Stripe payment method in user account for subsequent purchases

### DIFF
--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -16,10 +16,12 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
+	useCheckoutContext,
 	useEditorContext,
 	usePaymentMethodDataContext,
 } from '@woocommerce/base-context';
 import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
+import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 
 /**
  * Internal dependencies
@@ -67,6 +69,8 @@ const PaymentMethods = () => {
 	const [ selectedToken, setSelectedToken ] = useState( '0' );
 	const { noticeContexts } = useEmitResponse();
 	const { removeNotice } = useStoreNotices();
+	const { customerId } = useCheckoutContext();
+	const [ shouldSavePayment, setShouldSavePayment ] = useState( false );
 
 	// update ref on change.
 	useEffect( () => {
@@ -81,16 +85,38 @@ const PaymentMethods = () => {
 				currentPaymentMethods.current,
 				isEditor
 			);
+			const { options } = currentPaymentMethods.current[
+				activePaymentMethod
+			];
 			return paymentMethod ? (
 				<PaymentMethodErrorBoundary isEditor={ isEditor }>
 					{ cloneElement( paymentMethod, {
 						activePaymentMethod,
 						...currentPaymentMethodInterface.current,
 					} ) }
+					{ customerId > 0 && options.allowSavePaymentToken && (
+						<CheckboxControl
+							className="wc-block-checkout__save-card-info"
+							label={ __(
+								'Save payment information to my account for future purchases.',
+								'woo-gutenberg-products-block'
+							) }
+							checked={ shouldSavePayment }
+							onChange={ () =>
+								setShouldSavePayment( ! shouldSavePayment )
+							}
+						/>
+					) }
 				</PaymentMethodErrorBoundary>
 			) : null;
 		},
-		[ isEditor, activePaymentMethod ]
+		[
+			isEditor,
+			activePaymentMethod,
+			shouldSavePayment,
+			setShouldSavePayment,
+			customerId,
+		]
 	);
 
 	if (

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -86,7 +86,7 @@ const PaymentMethods = () => {
 				currentPaymentMethods.current,
 				isEditor
 			);
-			const { options } = currentPaymentMethods.current[
+			const { supports } = currentPaymentMethods.current[
 				activePaymentMethod
 			];
 			return paymentMethod ? (
@@ -95,7 +95,7 @@ const PaymentMethods = () => {
 						activePaymentMethod,
 						...currentPaymentMethodInterface.current,
 					} ) }
-					{ customerId > 0 && options.allowSavePaymentInfo && (
+					{ customerId > 0 && supports.savePaymentInfo && (
 						<CheckboxControl
 							className="wc-block-checkout__save-card-info"
 							label={ __(

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -58,6 +58,8 @@ const PaymentMethods = () => {
 	const {
 		customerPaymentMethods = {},
 		setActivePaymentMethod,
+		shouldSavePayment,
+		setShouldSavePayment,
 	} = usePaymentMethodDataContext();
 	const { isInitialized, paymentMethods } = usePaymentMethods();
 	const currentPaymentMethods = useRef( paymentMethods );
@@ -70,7 +72,6 @@ const PaymentMethods = () => {
 	const { noticeContexts } = useEmitResponse();
 	const { removeNotice } = useStoreNotices();
 	const { customerId } = useCheckoutContext();
-	const [ shouldSavePayment, setShouldSavePayment ] = useState( false );
 
 	// update ref on change.
 	useEffect( () => {

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -95,7 +95,7 @@ const PaymentMethods = () => {
 						activePaymentMethod,
 						...currentPaymentMethodInterface.current,
 					} ) }
-					{ customerId > 0 && options.allowSavePaymentToken && (
+					{ customerId > 0 && options.allowSavePaymentInfo && (
 						<CheckboxControl
 							className="wc-block-checkout__save-card-info"
 							label={ __(

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -28,15 +28,23 @@ import { useStoreCart, useStoreNotices } from '@woocommerce/base-hooks';
  *
  * @param {Object} paymentData Arbitrary payment data provided by the payment
  *                             method.
+ * @param {boolean} shouldSave Whether to save the payment method info to
+ *                             user account.
  *
  * @return {PaymentDataItem[]} Returns the payment data as an array of
- *                                 PaymentDataItem objects.
+ *                             PaymentDataItem objects.
  */
-const preparePaymentData = ( paymentData ) => {
-	return Object.keys( paymentData ).map( ( property ) => {
+const preparePaymentData = ( paymentData, shouldSave ) => {
+	const apiData = Object.keys( paymentData ).map( ( property ) => {
 		const value = paymentData[ property ];
 		return { key: property, value };
 	}, [] );
+	const savePaymentMethodKey = `wc-${ paymentData.paymentMethod }-new-payment-method`;
+	apiData.push( {
+		key: savePaymentMethodKey,
+		value: shouldSave,
+	} );
+	return apiData;
 };
 
 /**
@@ -66,6 +74,7 @@ const CheckoutProcessor = () => {
 		paymentMethodData,
 		expressPaymentMethods,
 		paymentMethods,
+		shouldSavePayment,
 	} = usePaymentMethodDataContext();
 	const { addErrorNotice, removeNotice } = useStoreNotices();
 	const currentBillingData = useRef( billingData );
@@ -179,7 +188,10 @@ const CheckoutProcessor = () => {
 			data = {
 				...data,
 				payment_method: paymentMethodId,
-				payment_data: preparePaymentData( paymentMethodData ),
+				payment_data: preparePaymentData(
+					paymentMethodData,
+					shouldSavePayment
+				),
 			};
 		}
 		triggerFetch( {
@@ -234,6 +246,7 @@ const CheckoutProcessor = () => {
 		removeNotice,
 		paymentMethodId,
 		paymentMethodData,
+		shouldSavePayment,
 		cartNeedsPayment,
 		receiveCart,
 		dispatchActions,

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -26,20 +26,19 @@ import { useStoreCart, useStoreNotices } from '@woocommerce/base-hooks';
 /**
  * Utility function for preparing payment data for the request.
  *
- * @param {Object} paymentData Arbitrary payment data provided by the payment
- *                             method.
- * @param {boolean} shouldSave Whether to save the payment method info to
- *                             user account.
+ * @param {Object}  paymentData          Arbitrary payment data provided by the payment method.
+ * @param {boolean} shouldSave           Whether to save the payment method info to user account.
+ * @param {Object}  activePaymentMethod  The current active payment method.
  *
  * @return {PaymentDataItem[]} Returns the payment data as an array of
  *                             PaymentDataItem objects.
  */
-const preparePaymentData = ( paymentData, shouldSave ) => {
+const preparePaymentData = ( paymentData, shouldSave, activePaymentMethod ) => {
 	const apiData = Object.keys( paymentData ).map( ( property ) => {
 		const value = paymentData[ property ];
 		return { key: property, value };
 	}, [] );
-	const savePaymentMethodKey = `wc-${ paymentData.paymentMethod }-new-payment-method`;
+	const savePaymentMethodKey = `wc-${ activePaymentMethod }-new-payment-method`;
 	apiData.push( {
 		key: savePaymentMethodKey,
 		value: shouldSave,
@@ -190,7 +189,8 @@ const CheckoutProcessor = () => {
 				payment_method: paymentMethodId,
 				payment_data: preparePaymentData(
 					paymentMethodData,
-					shouldSavePayment
+					shouldSavePayment,
+					activePaymentMethod
 				),
 			};
 		}
@@ -245,6 +245,7 @@ const CheckoutProcessor = () => {
 		addErrorNotice,
 		removeNotice,
 		paymentMethodId,
+		activePaymentMethod,
 		paymentMethodData,
 		shouldSavePayment,
 		cartNeedsPayment,

--- a/assets/js/base/context/cart-checkout/payment-methods/actions.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/actions.js
@@ -13,6 +13,7 @@ const {
 	SUCCESS,
 	SET_REGISTERED_PAYMENT_METHODS,
 	SET_REGISTERED_EXPRESS_PAYMENT_METHODS,
+	SET_SHOULD_SAVE_PAYMENT_METHOD,
 } = ACTION_TYPES;
 
 /**
@@ -99,4 +100,16 @@ export const setRegisteredPaymentMethods = ( paymentMethods ) => ( {
 export const setRegisteredExpressPaymentMethods = ( paymentMethods ) => ( {
 	type: SET_REGISTERED_EXPRESS_PAYMENT_METHODS,
 	paymentMethods,
+} );
+
+/**
+ * Set a flag indicating that the payment method info (e.g. a payment card)
+ * should be saved to user account after order completion.
+ *
+ * @param {boolean} shouldSavePaymentMethod
+ * @return {Object} An action object.
+ */
+export const setShouldSavePaymentMethod = ( shouldSavePaymentMethod ) => ( {
+	type: SET_SHOULD_SAVE_PAYMENT_METHOD,
+	shouldSavePaymentMethod,
 } );

--- a/assets/js/base/context/cart-checkout/payment-methods/constants.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/constants.js
@@ -17,14 +17,18 @@ export const ACTION_TYPES = {
 	SET_REGISTERED_PAYMENT_METHODS: 'set_registered_payment_methods',
 	SET_REGISTERED_EXPRESS_PAYMENT_METHODS:
 		'set_registered_express_payment_methods',
+	SET_SHOULD_SAVE_PAYMENT_METHOD: 'set_should_save_payment_method',
 };
 
 /**
  * @todo do typedefs for the payment event state.
  */
 
+// Note - if fields are added/shape is changed, you may want to update
+// PRISTINE reducer clause to preserve your new field.
 export const DEFAULT_PAYMENT_DATA = {
 	currentStatus: STATUS.PRISTINE,
+	shouldSavePaymentMethod: false,
 	paymentMethodData: {
 		payment_method: '',
 		// arbitrary data the payment method

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -14,6 +14,7 @@ import {
 	success,
 	setRegisteredPaymentMethods,
 	setRegisteredExpressPaymentMethods,
+	setShouldSavePaymentMethod,
 } from './actions';
 import {
 	usePaymentMethods,
@@ -132,6 +133,12 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 	const { setValidationErrors } = useValidationContext();
 	const { addErrorNotice, removeNotice } = useStoreNotices();
 	const { setShippingAddress } = useShippingDataContext();
+	const setShouldSavePayment = useCallback(
+		( shouldSave ) => {
+			dispatch( setShouldSavePaymentMethod( shouldSave ) );
+		},
+		[ dispatch ]
+	);
 
 	const setExpressPaymentError = ( message ) => {
 		if ( message ) {
@@ -358,6 +365,8 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		paymentMethodsInitialized,
 		expressPaymentMethodsInitialized,
 		setExpressPaymentError,
+		shouldSavePayment: paymentData.shouldSavePaymentMethod,
+		setShouldSavePayment,
 	};
 	return (
 		<PaymentMethodDataContext.Provider value={ paymentContextData }>

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -12,6 +12,7 @@ const {
 	COMPLETE,
 	SET_REGISTERED_PAYMENT_METHODS,
 	SET_REGISTERED_EXPRESS_PAYMENT_METHODS,
+	SET_SHOULD_SAVE_PAYMENT_METHOD,
 } = ACTION_TYPES;
 
 /**
@@ -22,7 +23,13 @@ const {
  */
 const reducer = (
 	state = DEFAULT_PAYMENT_DATA,
-	{ type, paymentMethodData, errorMessage, paymentMethods }
+	{
+		type,
+		paymentMethodData,
+		shouldSavePaymentMethod,
+		errorMessage,
+		paymentMethods,
+	}
 ) => {
 	switch ( type ) {
 		case STARTED:
@@ -86,6 +93,7 @@ const reducer = (
 				expressPaymentMethods: {
 					...state.expressPaymentMethods,
 				},
+				shouldSavePaymentMethod: state.shouldSavePaymentMethod,
 			};
 		case SET_REGISTERED_PAYMENT_METHODS:
 			return {
@@ -102,6 +110,11 @@ const reducer = (
 					...state.expressPaymentMethods,
 					...paymentMethods,
 				},
+			};
+		case SET_SHOULD_SAVE_PAYMENT_METHOD:
+			return {
+				...state,
+				shouldSavePaymentMethod,
 			};
 	}
 	return state;

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -12,7 +12,6 @@ import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import { useEffect, useRef } from '@wordpress/element';
 import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 import { ValidationInputError } from '@woocommerce/base-components/validation';
-import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 import { useEmitResponse } from '@woocommerce/base-hooks';
 import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
 
@@ -187,7 +186,6 @@ export const usePaymentMethodInterface = () => {
 		},
 		components: {
 			ValidationInputError,
-			CheckboxControl, // @todo Can we remove this now - I think it's only here for "save card for next time".
 			PaymentMethodIcons,
 		},
 		emitResponse: {

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -187,7 +187,7 @@ export const usePaymentMethodInterface = () => {
 		},
 		components: {
 			ValidationInputError,
-			CheckboxControl,
+			CheckboxControl, // @todo Can we remove this now - I think it's only here for "save card for next time".
 			PaymentMethodIcons,
 		},
 		emitResponse: {

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -21,7 +21,7 @@ export default class PaymentMethodConfig {
 		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
 		this.options = {
-			allowSavePaymentToken: false,
+			allowSavePaymentInfo: false,
 			...config.options,
 		};
 	}

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -20,9 +20,8 @@ export default class PaymentMethodConfig {
 		this.edit = config.edit;
 		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
-		this.options = {
-			allowSavePaymentInfo: false,
-			...config.options,
+		this.supports = {
+			savePaymentInfo: config?.supports?.savePaymentInfo || false,
 		};
 	}
 
@@ -76,6 +75,15 @@ export default class PaymentMethodConfig {
 		if ( typeof config.canMakePayment !== 'function' ) {
 			throw new TypeError(
 				'The canMakePayment property for the payment method must be a function.'
+			);
+		}
+		if (
+			config.supports &&
+			typeof config.supports.savePaymentInfo !== 'undefined' &&
+			typeof config.supports.savePaymentInfo !== 'boolean'
+		) {
+			throw new TypeError(
+				'If the payment method includes the `supports.savePaymentInfo` property, it must be a boolean'
 			);
 		}
 	};

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -20,6 +20,10 @@ export default class PaymentMethodConfig {
 		this.edit = config.edit;
 		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
+		this.options = {
+			allowSavePaymentToken: false,
+			...config.options,
+		};
 	}
 
 	static assertValidConfig = ( config ) => {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -55,8 +55,8 @@ const stripeCcPaymentMethod = {
 		'Stripe Credit Card payment method',
 		'woo-gutenberg-products-block'
 	),
-	options: {
-		allowSavePaymentInfo: true,
+	supports: {
+		savePaymentInfo: true,
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -55,6 +55,9 @@ const stripeCcPaymentMethod = {
 		'Stripe Credit Card payment method',
 		'woo-gutenberg-products-block'
 	),
+	options: {
+		allowSavePaymentToken: true,
+	},
 };
 
 export default stripeCcPaymentMethod;

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -56,7 +56,7 @@ const stripeCcPaymentMethod = {
 		'woo-gutenberg-products-block'
 	),
 	options: {
-		allowSavePaymentToken: true,
+		allowSavePaymentInfo: true,
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -34,9 +34,9 @@ const CreditCardComponent = ( {
 	const { customerId } = billing;
 	const [ sourceId, setSourceId ] = useState( '' );
 	const stripe = useStripe();
-	const [ shouldSavePayment, setShouldSavePayment ] = useState(
-		customerId ? true : false
-	);
+	// Saving payment method is always opt-in (based on previous/shortcode
+	// behaviour); so default to false.
+	const [ shouldSavePayment, setShouldSavePayment ] = useState( false );
 	const onStripeError = useCheckoutSubscriptions(
 		eventRegistration,
 		billing,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -11,7 +11,6 @@ import { InlineCard, CardElements } from './elements';
  */
 import { Elements, useStripe } from '@stripe/react-stripe-js';
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe
@@ -30,19 +29,16 @@ const CreditCardComponent = ( {
 	emitResponse,
 	components,
 } ) => {
-	const { ValidationInputError, CheckboxControl } = components;
-	const { customerId } = billing;
+	const { ValidationInputError } = components;
 	const [ sourceId, setSourceId ] = useState( '' );
 	const stripe = useStripe();
-	// Saving payment method is always opt-in (based on previous/shortcode
-	// behaviour); so default to false.
-	const [ shouldSavePayment, setShouldSavePayment ] = useState( false );
+	const shouldSavePayment = false;
 	const onStripeError = useCheckoutSubscriptions(
 		eventRegistration,
 		billing,
 		sourceId,
 		setSourceId,
-		shouldSavePayment,
+		shouldSavePayment, // @todo I think we can get rid of this?
 		emitResponse,
 		stripe
 	);
@@ -63,24 +59,7 @@ const CreditCardComponent = ( {
 			inputErrorComponent={ ValidationInputError }
 		/>
 	);
-	return (
-		<>
-			{ renderedCardElement }
-			{ customerId > 0 && (
-				<CheckboxControl
-					className="wc-block-checkout__save-card-info"
-					label={ __(
-						'Save payment information to my account for future purchases.',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ shouldSavePayment }
-					onChange={ () =>
-						setShouldSavePayment( ! shouldSavePayment )
-					}
-				/>
-			) }
-		</>
-	);
+	return renderedCardElement;
 };
 
 export const StripeCreditCard = ( props ) => {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -32,13 +32,11 @@ const CreditCardComponent = ( {
 	const { ValidationInputError } = components;
 	const [ sourceId, setSourceId ] = useState( '' );
 	const stripe = useStripe();
-	const shouldSavePayment = false;
 	const onStripeError = useCheckoutSubscriptions(
 		eventRegistration,
 		billing,
 		sourceId,
 		setSourceId,
-		shouldSavePayment, // @todo I think we can get rid of this?
 		emitResponse,
 		stripe
 	);

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
@@ -25,7 +25,6 @@ import { usePaymentProcessing } from './use-payment-processing';
  * @param {BillingDataProps}       billing           Various billing data items.
  * @param {string}                 sourceId          Current set stripe source id.
  * @param {SourceIdDispatch}       setSourceId       Setter for stripe source id.
- * @param {boolean}                shouldSavePayment Whether to save the payment or not.
  * @param {EmitResponseProps}      emitResponse      Various helpers for usage with observer
  *                                                   response objects.
  * @param {Stripe}                 stripe            The stripe.js object.
@@ -37,7 +36,6 @@ export const useCheckoutSubscriptions = (
 	billing,
 	sourceId,
 	setSourceId,
-	shouldSavePayment,
 	emitResponse,
 	stripe
 ) => {
@@ -68,7 +66,6 @@ export const useCheckoutSubscriptions = (
 		emitResponse,
 		sourceId,
 		setSourceId,
-		shouldSavePayment,
 		onPaymentProcessing
 	);
 	// hook into and register callbacks for events.

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
@@ -92,9 +92,6 @@ export const usePaymentProcessing = (
 								paymentMethod: PAYMENT_METHOD_NAME,
 								paymentRequestType: 'cc',
 								stripe_source: sourceId,
-								// I think this is a saved token, so `shouldSavePayment`
-								// is redundant.
-								// 'wc-stripe-new-payment-method': shouldSavePayment,
 							},
 							billingData,
 						},
@@ -133,7 +130,6 @@ export const usePaymentProcessing = (
 					);
 				}
 				setSourceId( response.source.id );
-				const savePaymentMethodKey = `wc-${ PAYMENT_METHOD_NAME }-new-payment-method`;
 				return {
 					type: emitResponse.responseTypes.SUCCESS,
 					meta: {
@@ -141,7 +137,6 @@ export const usePaymentProcessing = (
 							stripe_source: response.source.id,
 							paymentMethod: PAYMENT_METHOD_NAME,
 							paymentRequestType: 'cc',
-							[ savePaymentMethodKey ]: shouldSavePayment,
 						},
 						billingData,
 					},

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
@@ -92,7 +92,9 @@ export const usePaymentProcessing = (
 								paymentMethod: PAYMENT_METHOD_NAME,
 								paymentRequestType: 'cc',
 								stripe_source: sourceId,
-								shouldSavePayment,
+								// I think this is a saved token, so `shouldSavePayment`
+								// is redundant.
+								// 'wc-stripe-new-payment-method': shouldSavePayment,
 							},
 							billingData,
 						},
@@ -138,7 +140,7 @@ export const usePaymentProcessing = (
 							stripe_source: response.source.id,
 							paymentMethod: PAYMENT_METHOD_NAME,
 							paymentRequestType: 'cc',
-							shouldSavePayment,
+							'wc-stripe-new-payment-method': shouldSavePayment,
 						},
 						billingData,
 					},

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
@@ -43,7 +43,6 @@ import { errorTypes } from '../stripe-utils/constants';
  *                                                   response objects.
  * @param {string}               sourceId            Current set stripe source id.
  * @param {SourceIdDispatch}     setSourceId         Setter for stripe source id.
- * @param {boolean}              shouldSavePayment   Whether to save the payment or not.
  * @param {EventRegistration}    onPaymentProcessing The event emitter for processing payment.
  */
 export const usePaymentProcessing = (
@@ -54,7 +53,6 @@ export const usePaymentProcessing = (
 	emitResponse,
 	sourceId,
 	setSourceId,
-	shouldSavePayment,
 	onPaymentProcessing
 ) => {
 	const elements = useElements();
@@ -158,7 +156,6 @@ export const usePaymentProcessing = (
 		stripe,
 		sourceId,
 		setSourceId,
-		shouldSavePayment,
 		onStripeError,
 		error,
 		emitResponse.noticeContexts.PAYMENTS,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-processing.js
@@ -133,6 +133,7 @@ export const usePaymentProcessing = (
 					);
 				}
 				setSourceId( response.source.id );
+				const savePaymentMethodKey = `wc-${ PAYMENT_METHOD_NAME }-new-payment-method`;
 				return {
 					type: emitResponse.responseTypes.SUCCESS,
 					meta: {
@@ -140,7 +141,7 @@ export const usePaymentProcessing = (
 							stripe_source: response.source.id,
 							paymentMethod: PAYMENT_METHOD_NAME,
 							paymentRequestType: 'cc',
-							'wc-stripe-new-payment-method': shouldSavePayment,
+							[ savePaymentMethodKey ]: shouldSavePayment,
 						},
 						billingData,
 					},

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -150,7 +150,7 @@
  *                                                                          error.
  * @property {string}                      activePaymentMethod              The active payment
  *                                                                          method slug.
- * @property {function()}                  setActivePaymentMethod           A function for setting
+ * @property {function(string)}            setActivePaymentMethod           A function for setting
  *                                                                          the active payment
  *                                                                          method.
  * @property {SavedCustomerPaymentMethods} customerPaymentMethods           Returns the customer
@@ -178,6 +178,13 @@
  *                                                                          It receives an error
  *                                                                          message string. Does not
  *                                                                          change payment status.
+ * @property {function(boolean):void}      setShouldSavePayment             A function used to set
+ *                                                                          the shouldSavePayment
+ *                                                                          value.
+ * @property {boolean}                     shouldSavePayment                True means that
+ *                                                                          the configured payment
+ *                                                                          method option is saved
+ *                                                                          for the customer.
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -169,8 +169,8 @@
  *
  * @property {function(Object):Object} ValidationInputError  A container for holding validation
  *                                                           errors
- * @property {function(Object):Object} CheckboxControl       A checkbox control, usually used for
- *                                                           saved payment method functionality
+ * @property {function(Object):Object} PaymentMethodIcons    A component used for displaying payment
+ *                                                           method icons.
  */
 
 /**


### PR DESCRIPTION
Fixes #2411

This PR allows shoppers to save payment details to their account so they can checkout future purchases quicker (by using a saved payment method).

The API had generic support for this, as `paymentMethodData` is passed through to the Stripe payment processing handler server side. This code looks for `wc-stripe-new-payment-method` in `POST` and if specified the payment method is saved to the user account (via [`$customer->add_source()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L622).

So in this PR the fix is to pass `shouldSavePayment` using this existing key.

Also in this PR I've set the checkbox to be unchecked by default, consistent with previous (shortcode checkout) behaviour. I'm not sure if this is intentional/by design, going with opt-in as the safest option. We can switch this to enabled by default if needed.

Note there's a commented out section when (I _think_) saved card is used. This is untested (other PR in flight for using saved card to pay - #2425). If this is a saved method, then it's not appropriate to send `wc-stripe-new-payment-method`/`shouldSaveCard` - as it's not a new payment method, is already saved.

See also related PRs/issues: #2425 #2426 

And #2450 (merged)

### How to test the changes in this Pull Request:

1. Add something to cart, proceed to checkout.
2. Select new stripe card payment option and enter [test card details](https://stripe.com/docs/testing#cards).
3. Check `Save payment information to my account` checkbox.
6. Submit purchase.

Confirm that the card is saved - should see it in `My account` and on subsequent purchases should be available as a saved payment option (checkout block and shortcode). Should work as a payment option in shortcode checkout.

Note that #2425 is in progress - saved payment options don't currently work in checkout block.

