### PR TITLE
respect stripe saved cards store setting

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -57,7 +57,7 @@ const stripeCcPaymentMethod = {
 		'woo-gutenberg-products-block'
 	),
 	supports: {
-		savePaymentInfo: getStripeServerData().allowSavedCards === 'yes',
+		savePaymentInfo: getStripeServerData().allowSavedCards,
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -7,7 +7,7 @@ import { useEffect, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { loadStripe } from '../stripe-utils';
+import { getStripeServerData, loadStripe } from '../stripe-utils';
 import { StripeCreditCard, getStripeCreditCardIcons } from './payment-method';
 import { PAYMENT_METHOD_NAME } from './constants';
 
@@ -57,7 +57,7 @@ const stripeCcPaymentMethod = {
 		'woo-gutenberg-products-block'
 	),
 	supports: {
-		savePaymentInfo: true,
+		savePaymentInfo: getStripeServerData().allowSavedCards === 'yes',
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -22,7 +22,7 @@ const StripeComponent = ( props ) => {
 				setErrorMessage( error.message );
 			}
 		} );
-	}, [] );
+	}, [ setErrorMessage ] );
 
 	useEffect( () => {
 		if ( errorMessage ) {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -58,6 +58,8 @@ const CreditCardComponent = ( {
 		}
 		setSourceId( '0' );
 	};
+	const showSaveCardCheckbox =
+		customerId > 0 && getStripeServerData().allowSavedCards === 'yes';
 	const cardIcons = getStripeCreditCardIcons();
 
 	const renderedCardElement = getStripeServerData().inline_cc_form ? (

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -58,8 +58,6 @@ const CreditCardComponent = ( {
 		}
 		setSourceId( '0' );
 	};
-	const showSaveCardCheckbox =
-		customerId > 0 && getStripeServerData().allowSavedCards === 'yes';
 	const cardIcons = getStripeCreditCardIcons();
 
 	const renderedCardElement = getStripeServerData().inline_cc_form ? (

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -114,8 +114,10 @@ final class Stripe extends AbstractPaymentMethodType {
 	 * @return bool True if merchant allows shopper to save card (payment method) during checkout).
 	 */
 	private function get_allow_saved_cards() {
-		// We may also want to check `supports( 'tokenization' )`.
-		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 .
+		// This assumes that Stripe supports `tokenization` - currently this is true, based on
+		// https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95 .
+		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and
+		// https://github.com/woocommerce/woocommerce/wiki/Payment-Token-API .
 		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $this->settings['saved_cards'] );
 	}
 

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -104,7 +104,19 @@ final class Stripe extends AbstractPaymentMethodType {
 			],
 			'inline_cc_form'   => $this->get_inline_cc_form(),
 			'icons'            => $this->get_icons(),
+			'allowSavedCards'  => $this->get_allow_saved_cards(),
 		];
+	}
+
+	/**
+	 * Determine if store allows payment via saved cards (and save card during checkout).
+	 *
+	 * @return bool True if merchant allows shopper to save card (payment method) during checkout).
+	 */
+	private function get_allow_saved_cards() {
+		// We may also want to check `supports( 'tokenization' )`.
+		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 .
+		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $this->settings['saved_cards'] );
 	}
 
 	/**

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -109,7 +109,7 @@ final class Stripe extends AbstractPaymentMethodType {
 	}
 
 	/**
-	 * Determine if store allows payment via saved cards (and save card during checkout).
+	 * Determine if store allows cards to be saved during checkout.
 	 *
 	 * @return bool True if merchant allows shopper to save card (payment method) during checkout).
 	 */

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -118,7 +118,7 @@ final class Stripe extends AbstractPaymentMethodType {
 		// https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95 .
 		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and
 		// https://github.com/woocommerce/woocommerce/wiki/Payment-Token-API .
-		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $this->settings['saved_cards'] );
+		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $this->settings['saved_cards'], FILTER_VALIDATE_BOOLEAN ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2426

This PR adds support for the Stripe `Enable Payment via Saved Cards` option.

- The option is exposed to the client as `allowSavedCards`.
- If it's disabled by merchant, the `Save my card` checkbox is hidden in the checkout.

Note: in previous checkout, the Stripe option controls whether stripe saved cards are displayed - i.e. can be used to pay. In the checkout block, we're displaying saved payment methods independent of Stripe, so they're displayed even if merchant disables `allowSavedCards` - saved payment methods could be from other gateways. If we want to change this behaviour, or add a store option for wholesale disable of saved payment methods, I think we should look at that as follow up (maybe after v1, if there's feedback etc).

Note 2: this code assumes that Stripe `supports( tokenization )`. I've added a comment about this - I think it's ok to assume for now, when Stripe is refactored out to an extension this should be considered.

See also related PRs: #2453 #2425

### How to test the changes in this Pull Request:

1. Clone this branch, get checkout block set up, add stuff to cart, proceed to checkout.
2. Disable `Enable Payment via Saved Cards` setting in Woo Stripe config. 
3. Refresh checkout, the `Save my payment info` checkbox should not be available.
2. Enable `Enable Payment via Saved Cards` setting in Woo Stripe config. 
3. Refresh checkout, the `Save my payment info` checkbox should not be visible; if selected, card should be saved to `My account` and work as a saved payment option for future purchases.

Also test around this:

- `Save my payment info` should only be available if the user is logged in.
- Saved card feature should work correctly, e.g. default saved card, delete in my account etc.
- Paying with Stripe CC with box unticked should **not save the card** :)
- etc

