### PR TITLE
Update placeholder styles

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -55,3 +55,12 @@
 .components-placeholder .woocommerce-search-list__list {
 	border: 1px solid $core-grey-light-500;
 }
+
+// Work-around to make the SearchList component work fine with the last versions of @wordpress/components.
+// Ideally it should be possible to remove this once this issue is fixed in WC Admin:
+// https://github.com/woocommerce/woocommerce-admin/issues/4349
+.components-placeholder .woocommerce-search-list__list .woocommerce-search-list__item {
+	border-radius: 0;
+	height: auto;
+	text-align: left;
+}

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -50,3 +50,8 @@
 		margin: -$gap 0 $gap-small;
 	}
 }
+
+// Adds border to placeholder lists, so they can be distinguished from the white background.
+.components-placeholder .woocommerce-search-list__list {
+	border: 1px solid $core-grey-light-500;
+}

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -369,7 +369,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			>
 				<div className="wc-block-attribute-filter__selection">
 					{ renderAttributeControl() }
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -214,7 +214,7 @@ const FeaturedCategory = ( {
 						} }
 						isSingle
 					/>
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>

--- a/assets/js/blocks/featured-category/editor.scss
+++ b/assets/js/blocks/featured-category/editor.scss
@@ -1,9 +1,4 @@
 .wc-block-featured-category {
-	&.components-placeholder {
-		// Reset the background for the placeholders.
-		background-color: rgba(139, 139, 150, 0.1);
-	}
-
 	.components-resizable-box__handle {
 		z-index: 10;
 	}

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -109,7 +109,7 @@ const FeaturedProduct = ( {
 								} );
 							} }
 						/>
-						<Button isDefault onClick={ onDone }>
+						<Button isPrimary onClick={ onDone }>
 							{ __( 'Done', 'woo-gutenberg-products-block' ) }
 						</Button>
 					</div>

--- a/assets/js/blocks/featured-product/editor.scss
+++ b/assets/js/blocks/featured-product/editor.scss
@@ -1,9 +1,4 @@
 .wc-block-featured-product {
-	&.components-placeholder {
-		// Reset the background for the placeholders.
-		background-color: rgba(139, 139, 150, 0.1);
-	}
-
 	.components-resizable-box__handle {
 		z-index: 10;
 	}

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -148,7 +148,7 @@ class ProductsBlock extends Component {
 							setAttributes( { products: ids } );
 						} }
 					/>
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -222,7 +222,7 @@ class ProductByCategoryBlock extends Component {
 							this.setChangedAttributes( { catOperator: value } )
 						}
 					/>
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 					<Button

--- a/assets/js/blocks/product-category/editor.scss
+++ b/assets/js/blocks/product-category/editor.scss
@@ -1,9 +1,7 @@
 .wc-block-products-category__selection {
 	width: 100%;
 }
+
 .wc-block-products-category__cancel-button.is-tertiary {
 	margin: 1em auto 0;
-	display: block;
-	text-align: center;
-	font-size: 1em;
 }

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -205,7 +205,7 @@ class ProductsByTagBlock extends Component {
 							this.setChangedAttributes( { tagOperator: value } )
 						}
 					/>
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 					<Button

--- a/assets/js/blocks/product-tag/editor.scss
+++ b/assets/js/blocks/product-tag/editor.scss
@@ -1,9 +1,7 @@
 .wc-block-product-tag__selection {
 	width: 100%;
 }
+
 .wc-block-product-tag__cancel-button.is-tertiary {
 	margin: 1em auto 0;
-	display: block;
-	text-align: center;
-	font-size: 1em;
 }

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -148,7 +148,7 @@ class ProductsByAttributeBlock extends Component {
 							setAttributes( { attrOperator: value } )
 						}
 					/>
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -155,7 +155,7 @@ const ReviewsByCategoryEditor = ( {
 						} }
 						showReviewCount={ true }
 					/>
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -143,7 +143,7 @@ const ReviewsByProductEditor = ( {
 						} }
 						renderItem={ renderProductControlItem }
 					/>
-					<Button isDefault onClick={ onDone }>
+					<Button isPrimary onClick={ onDone }>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }
 					</Button>
 				</div>

--- a/assets/js/components/product-attribute-term-control/style.scss
+++ b/assets/js/components/product-attribute-term-control/style.scss
@@ -2,6 +2,11 @@
 	.components-base-control__help {
 		@include visually-hidden;
 	}
+
+	.components-base-control__label {
+		margin-bottom: 0;
+		margin-right: 0.5em;
+	}
 }
 
 .components-panel {

--- a/assets/js/components/product-category-control/style.scss
+++ b/assets/js/components/product-category-control/style.scss
@@ -2,6 +2,11 @@
 	.components-base-control__help {
 		@include visually-hidden;
 	}
+
+	.components-base-control__label {
+		margin-bottom: 0;
+		margin-right: 0.5em;
+	}
 }
 
 .components-panel {

--- a/assets/js/components/product-tag-control/style.scss
+++ b/assets/js/components/product-tag-control/style.scss
@@ -2,6 +2,11 @@
 	.components-base-control__help {
 		@include visually-hidden;
 	}
+
+	.components-base-control__label {
+		margin-bottom: 0;
+		margin-right: 0.5em;
+	}
 }
 
 .components-panel {


### PR DESCRIPTION
Fixes #2408.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/81543406-4fa72700-9376-11ea-9f1b-f59cfbb1048b.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/81542984-c4c62c80-9375-11ea-8d82-99c4b8712f91.png)

_(notice chip styles are broken, that's being tracked in: #2407)_

### How to test the changes in this Pull Request:

1. Activate the latest version of Gutenberg.
2. Add a _Products by Category_ and a _Featured Product_ block in a post.
3. Verify the placeholder background is white, buttons are aligned, there is a border around the list, etc.
3. Deactivate Gutenberg and verify styles still look good and nothing is broken.

### Changelog

> Updated the placeholder styles to match the core block styles.