### PR TITLE
Use display table instead of flex in radio control group

### DIFF
--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -7,10 +7,9 @@
 	}
 
 	.wc-block-radio-control__option-layout {
+		display: table;
+		width: 100%;
 		border-bottom: 1px solid $core-grey-light-600;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
 		padding-bottom: $gap-small;
 	}
 
@@ -24,6 +23,21 @@
 		top: $gap-small;
 	}
 
+	.wc-block-radio-control__label-group,
+	.wc-block-radio-control__description-group {
+		display: table-row;
+
+		span {
+			display: table-cell;
+		}
+
+		.wc-block-radio-control__secondary-label,
+		.wc-block-radio-control__secondary-description {
+			text-align: right;
+			min-width: 50%;
+		}
+	}
+
 	.wc-block-radio-control__label,
 	.wc-block-radio-control__secondary-label {
 		line-height: 20px;
@@ -31,7 +45,6 @@
 		// See: https://github.com/sass/sass/issues/2378#issuecomment-367490840
 		line-height: unquote("max(1rem, 20px)");
 		color: $core-grey-dark-600;
-		flex-basis: 50%;
 	}
 
 	.wc-block-radio-control__description,
@@ -39,12 +52,6 @@
 		font-size: 0.875em;
 		line-height: 20px;
 		color: $core-grey-dark-400;
-		flex-basis: 50%;
-	}
-
-	.wc-block-radio-control__secondary-label,
-	.wc-block-radio-control__secondary-description {
-		text-align: right;
 	}
 }
 

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -27,7 +27,7 @@
 	.wc-block-radio-control__description-group {
 		display: table-row;
 
-		span {
+		> span {
 			display: table-cell;
 		}
 

--- a/assets/js/base/components/radio-control/option-layout.js
+++ b/assets/js/base/components/radio-control/option-layout.js
@@ -7,38 +7,42 @@ const OptionLayout = ( {
 } ) => {
 	return (
 		<div className="wc-block-radio-control__option-layout">
-			{ label && (
-				<span
-					id={ id ? `${ id }__label` : null }
-					className="wc-block-radio-control__label"
-				>
-					{ label }
-				</span>
-			) }
-			{ secondaryLabel && (
-				<span
-					id={ id ? `${ id }__secondary-label` : null }
-					className="wc-block-radio-control__secondary-label"
-				>
-					{ secondaryLabel }
-				</span>
-			) }
-			{ description && (
-				<span
-					id={ id ? `${ id }__description` : null }
-					className="wc-block-radio-control__description"
-				>
-					{ description }
-				</span>
-			) }
-			{ secondaryDescription && (
-				<span
-					id={ id ? `${ id }__secondary-description` : null }
-					className="wc-block-radio-control__secondary-description"
-				>
-					{ secondaryDescription }
-				</span>
-			) }
+			<div className="wc-block-radio-control__label-group">
+				{ label && (
+					<span
+						id={ id ? `${ id }__label` : null }
+						className="wc-block-radio-control__label"
+					>
+						{ label }
+					</span>
+				) }
+				{ secondaryLabel && (
+					<span
+						id={ id ? `${ id }__secondary-label` : null }
+						className="wc-block-radio-control__secondary-label"
+					>
+						{ secondaryLabel }
+					</span>
+				) }
+			</div>
+			<div className="wc-block-radio-control__description-group">
+				{ description && (
+					<span
+						id={ id ? `${ id }__description` : null }
+						className="wc-block-radio-control__description"
+					>
+						{ description }
+					</span>
+				) }
+				{ secondaryDescription && (
+					<span
+						id={ id ? `${ id }__secondary-description` : null }
+						className="wc-block-radio-control__secondary-description"
+					>
+						{ secondaryDescription }
+					</span>
+				) }
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes label wrapping (see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2425#pullrequestreview-409165842) in radio components.

Before: 
![81566459-d2d67600-9392-11ea-8678-b72bbdf07e4f](https://user-images.githubusercontent.com/90977/81572204-d53cce00-939a-11ea-8926-65266e6514e6.png)

After:
![Screenshot 2020-05-11 at 15 14 45](https://user-images.githubusercontent.com/90977/81572225-da9a1880-939a-11ea-93a2-64ec6e17ec3d.png)
![Screenshot 2020-05-11 at 15 13 54](https://user-images.githubusercontent.com/90977/81572233-dbcb4580-939a-11ea-8287-a41114d8f27c.png)

