### PR TITLE
All Products Block: Update sorting labels to match frontend options

### DIFF
--- a/assets/js/blocks/products/edit.js
+++ b/assets/js/blocks/products/edit.js
@@ -38,42 +38,39 @@ export const getSharedListControls = ( attributes, setAttributes ) => {
 			options={ [
 				{
 					label: __(
-						'Newness - newest first',
+						'Default sorting (menu order)',
 						'woo-gutenberg-products-block'
 					),
+					value: 'menu_order',
+				},
+				{
+					label: __( 'Popularity', 'woo-gutenberg-products-block' ),
+					value: 'popularity',
+				},
+				{
+					label: __(
+						'Average rating',
+						'woo-gutenberg-products-block'
+					),
+					value: 'rating',
+				},
+				{
+					label: __( 'Latest', 'woo-gutenberg-products-block' ),
 					value: 'date',
 				},
 				{
 					label: __(
-						'Price - low to high',
+						'Price: low to high',
 						'woo-gutenberg-products-block'
 					),
 					value: 'price',
 				},
 				{
 					label: __(
-						'Price - high to low',
+						'Price: high to low',
 						'woo-gutenberg-products-block'
 					),
 					value: 'price-desc',
-				},
-				{
-					label: __(
-						'Rating - highest first',
-						'woo-gutenberg-products-block'
-					),
-					value: 'rating',
-				},
-				{
-					label: __(
-						'Sales - most first',
-						'woo-gutenberg-products-block'
-					),
-					value: 'popularity',
-				},
-				{
-					label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
-					value: 'menu_order',
 				},
 			] }
 			onChange={ ( orderby ) => setAttributes( { orderby } ) }


### PR DESCRIPTION
Updates the **labels** used in the inspector for sorting to match the _frontend labels_ for the sort component. 

The only difference is the "Default Sorting" option since that is unclear for the admin user - therefore I used "Default Sorting (menu order)" so it's clearer for the merchant.

Fixes #1496

### How to test the changes in this Pull Request:

1. Edit the All Products block
2. View the default sorting options
3. Ensure those options change the preview correctly