### PR TITLE
Add 'Handpicked Products' block keyword

### DIFF
--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -20,7 +20,10 @@ registerBlockType( 'woocommerce/handpicked-products', {
 		foreground: '#96588a',
 	},
 	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	keywords: [
+		__( 'Handpicked Products', 'woo-gutenberg-products-block' ),
+		__( 'WooCommerce', 'woo-gutenberg-products-block' ),
+	],
 	description: __(
 		'Display a selection of hand-picked products in a grid.',
 		'woo-gutenberg-products-block'


### PR DESCRIPTION
Add an alias to the `Hand-picked Products` block so it appears when writing its name without the hyphen.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/81591375-9fa8dc80-93bc-11ea-8429-858436ee762c.png)

### How to test the changes in this Pull Request:

1. Write `/handpicked` in the editor and verify the `Hand-picked Products` block is suggested.