### PR TITLE
Avoid const and let in inline JS

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -151,12 +151,12 @@ abstract class AbstractBlock {
 	 */
 	protected function get_skeleton_inline_script() {
 		return "<script>
-			const containers = document.querySelectorAll( 'div.wc-block-skeleton' );
+			var containers = document.querySelectorAll( 'div.wc-block-skeleton' );
 
 			if ( containers.length ) {
 				Array.prototype.forEach.call( containers, function( el, i ) {
-					const w = el.offsetWidth;
-					let classname = '';
+					var w = el.offsetWidth;
+					var classname = '';
 
 					if ( w > 700 )
 						classname = 'is-large';


### PR DESCRIPTION
Since these inline scripts can be loaded in multiple times, avoid `const` and `let`.

Fixes #2439

### How to test the changes in this Pull Request:

1. Add cart and checkout blocks to a page
2. View console errors on frontend.