### PR TITLE
Update Stripe Method to display generic icon and text in label, with cards below

### DIFF
--- a/assets/js/base/components/cart-checkout/index.js
+++ b/assets/js/base/components/cart-checkout/index.js
@@ -17,4 +17,5 @@ export { default as ShippingCalculator } from './shipping-calculator';
 export { default as ShippingLocation } from './shipping-location';
 export { default as ShippingRatesControl } from './shipping-rates-control';
 export { default as PaymentMethodIcons } from './payment-method-icons';
+export { default as PaymentMethodLabel } from './payment-method-label';
 export * from './totals/index.js';

--- a/assets/js/base/components/cart-checkout/payment-method-icons/index.js
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import PaymentMethodIcon from './payment-method-icon';
@@ -13,15 +18,20 @@ import './style.scss';
  * @param {Object} props Component props.
  * @param {Array} props.icons  Array of icons object configs or ids as strings.
  */
-export const PaymentMethodIcons = ( { icons = [] } ) => {
+export const PaymentMethodIcons = ( { icons = [], align = 'center' } ) => {
 	const iconConfigs = normalizeIconConfig( icons );
 
 	if ( iconConfigs.length === 0 ) {
 		return null;
 	}
 
+	const containerClass = classnames( 'wc-block-cart__payment-method-icons', {
+		'wc-block-cart__payment-method-icons--align-left': align === 'left',
+		'wc-block-cart__payment-method-icons--align-right': align === 'right',
+	} );
+
 	return (
-		<div className="wc-block-cart__payment-method-icons">
+		<div className={ containerClass }>
 			{ iconConfigs.map( ( icon ) => {
 				const iconProps = {
 					...icon,

--- a/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
@@ -1,14 +1,45 @@
 .wc-block-cart__payment-method-icons {
 	display: block;
 	text-align: center;
-	margin: $gap 0 0;
+	margin: 0 0 #{$gap - 2px};
 
 	.wc-blocks-payment-method-icon {
 		display: inline-block;
-		margin: 1px 2px;
+		margin: 0 4px 2px;
 		padding: 0;
 		width: auto;
-		height: 26px;
+		height: 24px;
 		vertical-align: middle;
+	}
+
+	&--align-left {
+		text-align: left;
+
+		.wc-blocks-payment-method-icon {
+			margin-left: 0;
+			margin-right: 8px;
+		}
+	}
+
+	&--align-right {
+		text-align: right;
+
+		.wc-blocks-payment-method-icon {
+			margin-right: 0;
+			margin-left: 8px;
+		}
+	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.is-mobile,
+.is-small {
+	.wc-block-cart__payment-method-icons {
+		.wc-blocks-payment-method-icon {
+			height: 16px;
+		}
 	}
 }

--- a/assets/js/base/components/cart-checkout/payment-method-label/index.js
+++ b/assets/js/base/components/cart-checkout/payment-method-label/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Icon, bank, bill, card, checkPayment } from '@woocommerce/icons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const namedIcons = {
+	bank,
+	bill,
+	card,
+	checkPayment,
+};
+
+/**
+ * Exposed to payment methods for the label shown on checkout. Allows icons to be added as well as
+ * text.
+ *
+ * @param {Object} props Component props.
+ * @param {*} props.icon Show an icon beside the text if provided. Can be a string to use a named
+ *                       icon, or an SVG element.
+ * @param {string} props.text Text shown next to icon.
+ */
+export const PaymentMethodLabel = ( { icon = '', text = '' } ) => {
+	const hasIcon = !! icon;
+	const hasNamedIcon =
+		hasIcon && typeof icon === 'string' && namedIcons[ icon ];
+	const className = classnames( 'wc-block-cart__payment-method-label', {
+		'wc-block-cart__payment-method-label--with-icon': hasIcon,
+	} );
+
+	return (
+		<span className={ className }>
+			{ hasNamedIcon ? <Icon srcElement={ namedIcons[ icon ] } /> : icon }
+			{ text }
+		</span>
+	);
+};
+
+export default PaymentMethodLabel;

--- a/assets/js/base/components/cart-checkout/payment-method-label/style.scss
+++ b/assets/js/base/components/cart-checkout/payment-method-label/style.scss
@@ -1,0 +1,19 @@
+.wc-block-cart__payment-method-label--with-icon {
+	display: inline-block;
+	vertical-align: middle;
+	> img,
+	> svg {
+		vertical-align: middle;
+		margin: -2px 4px 0 0;
+	}
+}
+
+.is-mobile,
+.is-small {
+	.wc-block-cart__payment-method-label--with-icon {
+		> img,
+		> svg {
+			display: none;
+		}
+	}
+}

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -143,7 +143,7 @@ const PaymentMethods = () => {
 							? label
 							: cloneElement( label, {
 									activePaymentMethod,
-									...currentPaymentMethodInterface.current,
+									components: { ...currentPaymentMethodInterface.current.components },
 							  } ),
 					ariaLabel,
 				};

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -142,8 +142,10 @@ const PaymentMethods = () => {
 						typeof label === 'string'
 							? label
 							: cloneElement( label, {
-									activePaymentMethod,
-									components: { ...currentPaymentMethodInterface.current.components },
+									components: {
+										...currentPaymentMethodInterface.current
+											.components,
+									},
 							  } ),
 					ariaLabel,
 				};

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -20,7 +20,6 @@ import {
 	useEditorContext,
 	usePaymentMethodDataContext,
 } from '@woocommerce/base-context';
-import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 
 /**
@@ -143,7 +142,8 @@ const PaymentMethods = () => {
 						typeof label === 'string'
 							? label
 							: cloneElement( label, {
-									components: { PaymentMethodIcons },
+									activePaymentMethod,
+									...currentPaymentMethodInterface.current,
 							  } ),
 					ariaLabel,
 				};

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -142,10 +142,9 @@ const PaymentMethods = () => {
 						typeof label === 'string'
 							? label
 							: cloneElement( label, {
-									components: {
-										...currentPaymentMethodInterface.current
+									components:
+										currentPaymentMethodInterface.current
 											.components,
-									},
 							  } ),
 					ariaLabel,
 				};

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -55,7 +55,7 @@
 
 .wc-block-gateway-container {
 	position: relative;
-	margin-bottom: $gap-large;
+	margin-bottom: $gap;
 	white-space: nowrap;
 
 	&.wc-card-number-element {

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -37,6 +37,16 @@
 					margin: 0.2em 0 -0.2em;
 				}
 
+				.payment-method-label-with-icon {
+					display: inline-block;
+					vertical-align: middle;
+					> img,
+					> svg {
+						vertical-align: middle;
+						margin: -2px 4px 0 0;
+					}
+				}
+
 				.wc-block-cart__payment-method-icons {
 					margin: 0.2em 0 -0.2em;
 
@@ -50,5 +60,15 @@
 	}
 	.wc-block-components-tabs__content {
 		padding: $gap 0;
+	}
+}
+
+.is-mobile,
+.is-small {
+	.wc-block-components-tabs .wc-block-components-tabs__list .wc-block-components-tabs__item .wc-block-components-tabs__item-content .payment-method-label-with-icon {
+		> img,
+		> svg {
+			display: none;
+		}
 	}
 }

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -37,16 +37,6 @@
 					margin: 0.2em 0 -0.2em;
 				}
 
-				.payment-method-label-with-icon {
-					display: inline-block;
-					vertical-align: middle;
-					> img,
-					> svg {
-						vertical-align: middle;
-						margin: -2px 4px 0 0;
-					}
-				}
-
 				.wc-block-cart__payment-method-icons {
 					margin: 0.2em 0 -0.2em;
 
@@ -60,15 +50,5 @@
 	}
 	.wc-block-components-tabs__content {
 		padding: $gap 0;
-	}
-}
-
-.is-mobile,
-.is-small {
-	.wc-block-components-tabs .wc-block-components-tabs__list .wc-block-components-tabs__item .wc-block-components-tabs__item-content .payment-method-label-with-icon {
-		> img,
-		> svg {
-			display: none;
-		}
 	}
 }

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -13,7 +13,10 @@ import { useEffect, useRef } from '@wordpress/element';
 import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 import { ValidationInputError } from '@woocommerce/base-components/validation';
 import { useEmitResponse } from '@woocommerce/base-hooks';
-import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
+import {
+	PaymentMethodIcons,
+	PaymentMethodLabel,
+} from '@woocommerce/base-components/cart-checkout';
 
 /**
  * Internal dependencies
@@ -187,6 +190,7 @@ export const usePaymentMethodInterface = () => {
 		components: {
 			ValidationInputError,
 			PaymentMethodIcons,
+			PaymentMethodLabel,
 		},
 		emitResponse: {
 			noticeContexts,

--- a/assets/js/blocks/cart-checkout/cart/checkout-button/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/checkout-button/style.scss
@@ -1,3 +1,8 @@
 .wc-block-cart__submit-button {
 	width: 100%;
+	margin: 0 0 $gap;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
 }

--- a/assets/js/icons/index.js
+++ b/assets/js/icons/index.js
@@ -1,9 +1,11 @@
 export { default as Icon } from './icon';
 
 export { default as arrowBack } from './library/arrow-back';
+export { default as bank } from './library/bank';
 export { default as bill } from './library/bill';
 export { default as card } from './library/card';
 export { default as cart } from './library/cart';
+export { default as checkPayment } from './library/check-payment';
 export { default as comment } from './library/comment';
 export { default as done } from './library/done';
 export { default as discussion } from './library/discussion';

--- a/assets/js/icons/library/bank.js
+++ b/assets/js/icons/library/bank.js
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const bank = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<path fill="none" d="M0 0h24v24H0z" />
+		<path d="M4 10h3v7H4zM10.5 10h3v7h-3zM2 19h20v3H2zM17 10h3v7h-3zM12 1L2 6v2h20V6z" />
+	</SVG>
+);
+
+export default bank;

--- a/assets/js/icons/library/check-payment.js
+++ b/assets/js/icons/library/check-payment.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const checkPayment = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<g fill="none" fillRule="evenodd">
+			<path d="M0 0h24v24H0z" />
+			<path
+				fill="#000"
+				fillRule="nonzero"
+				d="M17.3 8v1c1 .2 1.4.9 1.4 1.7h-1c0-.6-.3-1-1-1-.8 0-1.3.4-1.3.9 0 .4.3.6 1.4 1 1 .2 2 .6 2 1.9 0 .9-.6 1.4-1.5 1.5v1H16v-1c-.9-.1-1.6-.7-1.7-1.7h1c0 .6.4 1 1.3 1 1 0 1.2-.5 1.2-.8 0-.4-.2-.8-1.3-1.1-1.3-.3-2.1-.8-2.1-1.8 0-.9.7-1.5 1.6-1.6V8h1.3zM12 10v1H6v-1h6zm2-2v1H6V8h8zM2 4v16h20V4H2zm2 14V6h16v12H4z"
+			/>
+			<path
+				stroke="#000"
+				strokeLinecap="round"
+				d="M6 16c2.6 0 3.9-3 1.7-3-2 0-1 3 1.5 3 1 0 1-.8 2.8-.8"
+			/>
+		</g>
+	</SVG>
+);
+
+export default checkPayment;

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -27,11 +27,21 @@ const Content = () => {
 };
 
 /**
+ * Label component
+ *
+ * @param {*} props Props from payment API.
+ */
+const Label = ( props ) => {
+	const { PaymentMethodLabel } = props.components;
+	return <PaymentMethodLabel icon="checkPayment" text={ label } />;
+};
+
+/**
  * Cheque payment method config object.
  */
 const offlineChequePaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
-	label,
+	label: <Label />,
 	content: <Content />,
 	edit: <Content />,
 	icons: null,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
-import { Icon, card } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -34,12 +33,14 @@ const StripeComponent = ( props ) => {
 	return <StripeCreditCard stripe={ stripePromise } { ...props } />;
 };
 
-const StripeLabel = () => {
+const StripeLabel = ( props ) => {
+	const { PaymentMethodLabel } = props.components;
+
 	return (
-		<span className="payment-method-label-with-icon">
-			<Icon srcElement={ card } />
-			{ __( 'Credit / Debit Card', 'woo-gutenberg-products-block' ) }
-		</span>
+		<PaymentMethodLabel
+			icon="card"
+			text={ __( 'Credit / Debit Card', 'woo-gutenberg-products-block' ) }
+		/>
 	);
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
+import { Icon, card } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -15,13 +16,14 @@ const stripePromise = loadStripe();
 
 const StripeComponent = ( props ) => {
 	const [ errorMessage, setErrorMessage ] = useState( '' );
+
 	useEffect( () => {
 		Promise.resolve( stripePromise ).then( ( { error } ) => {
 			if ( error ) {
 				setErrorMessage( error.message );
 			}
 		} );
-	}, [ stripePromise, setErrorMessage ] );
+	}, [] );
 
 	useEffect( () => {
 		if ( errorMessage ) {
@@ -32,18 +34,16 @@ const StripeComponent = ( props ) => {
 	return <StripeCreditCard stripe={ stripePromise } { ...props } />;
 };
 
-const StripeLabel = ( { components = {} } ) => {
-	const { PaymentMethodIcons } = components;
-
-	if ( ! PaymentMethodIcons || cardIcons.length === 0 ) {
-		return __( 'Credit/Debit Card', 'woo-gutenberg-products-block' );
-	}
-
-	return <PaymentMethodIcons icons={ cardIcons } />;
+const StripeLabel = () => {
+	return (
+		<span className="payment-method-label-with-icon">
+			<Icon srcElement={ card } />
+			{ __( 'Credit / Debit Card', 'woo-gutenberg-products-block' ) }
+		</span>
+	);
 };
 
 const cardIcons = getStripeCreditCardIcons();
-
 const stripeCcPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
 	label: <StripeLabel />,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -18,6 +18,18 @@ import { useState } from '@wordpress/element';
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
  */
 
+export const getStripeCreditCardIcons = () => {
+	return Object.entries( getStripeServerData().icons ).map(
+		( [ id, { src, alt } ] ) => {
+			return {
+				id,
+				src,
+				alt,
+			};
+		}
+	);
+};
+
 /**
  * Stripe Credit Card component
  *
@@ -29,7 +41,7 @@ const CreditCardComponent = ( {
 	emitResponse,
 	components,
 } ) => {
-	const { ValidationInputError } = components;
+	const { ValidationInputError, PaymentMethodIcons } = components;
 	const [ sourceId, setSourceId ] = useState( '' );
 	const stripe = useStripe();
 	const onStripeError = useCheckoutSubscriptions(
@@ -46,6 +58,8 @@ const CreditCardComponent = ( {
 		}
 		setSourceId( '0' );
 	};
+	const cardIcons = getStripeCreditCardIcons();
+
 	const renderedCardElement = getStripeServerData().inline_cc_form ? (
 		<InlineCard
 			onChange={ onChange }
@@ -57,7 +71,14 @@ const CreditCardComponent = ( {
 			inputErrorComponent={ ValidationInputError }
 		/>
 	);
-	return renderedCardElement;
+	return (
+		<>
+			{ renderedCardElement }
+			{ PaymentMethodIcons && cardIcons.length && (
+				<PaymentMethodIcons icons={ cardIcons } align="left" />
+			) }
+		</>
+	);
 };
 
 export const StripeCreditCard = ( props ) => {
@@ -69,16 +90,4 @@ export const StripeCreditCard = ( props ) => {
 			<CreditCardComponent { ...props } />
 		</Elements>
 	) : null;
-};
-
-export const getStripeCreditCardIcons = () => {
-	return Object.entries( getStripeServerData().icons ).map(
-		( [ id, { src, alt } ] ) => {
-			return {
-				id,
-				src,
-				alt,
-			};
-		}
-	);
 };

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -171,6 +171,8 @@
  *                                                           errors
  * @property {function(Object):Object} PaymentMethodIcons    A component used for displaying payment
  *                                                           method icons.
+ * @property {function(Object):Object} PaymentMethodLabel    A component used for displaying payment
+ *                                                           method labels, including an icon.
  */
 
 /**


### PR DESCRIPTION
This PR makes some changes to the Stripe payment method labelling, with some supporting changes.
 
- Adds `align` support to `PaymentMethodIcons`
- Changes Stripe label to include generic CC icon (desktop only)
- Moves full list of payment icons to Stripe content
- Updates desktop and mobile styles

Fixes #2438

### Screenshots

Mobile:
![Screenshot 2020-05-12 at 12 55 05](https://user-images.githubusercontent.com/90977/81686946-b0a32d80-9450-11ea-8638-616cce99a268.png)

Desktop:
![Screenshot 2020-05-12 at 12 55 52](https://user-images.githubusercontent.com/90977/81686969-b39e1e00-9450-11ea-8430-cea423d3c1e7.png)

### How to test the changes in this Pull Request:

1. With Stripe enabled, view the cart - check icon appearance
2. View checkout, check icon appearance
3. Check mobile and desktop views
