### PR TITLE
Refactor `usePaymentMethodRegistration` to ensure payment methods are populated once initialization is true

### DIFF
--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -121,7 +121,7 @@ const PaymentMethods = () => {
 	);
 
 	if (
-		! isInitialized ||
+		isInitialized &&
 		Object.keys( currentPaymentMethods.current ).length === 0
 	) {
 		return <NoPaymentMethods />;

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -122,13 +122,23 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		},
 		[ setActive, dispatch ]
 	);
-	const paymentMethodsInitialized = usePaymentMethods( ( paymentMethods ) =>
-		dispatch( setRegisteredPaymentMethods( paymentMethods ) )
+	const paymentMethodsDispatcher = useCallback(
+		( paymentMethods ) => {
+			dispatch( setRegisteredPaymentMethods( paymentMethods ) );
+		},
+		[ dispatch ]
 	);
-	const expressPaymentMethodsInitialized = useExpressPaymentMethods(
+	const expressPaymentMethodsDispatcher = useCallback(
 		( paymentMethods ) => {
 			dispatch( setRegisteredExpressPaymentMethods( paymentMethods ) );
-		}
+		},
+		[ dispatch ]
+	);
+	const paymentMethodsInitialized = usePaymentMethods(
+		paymentMethodsDispatcher
+	);
+	const expressPaymentMethodsInitialized = useExpressPaymentMethods(
+		expressPaymentMethodsDispatcher
 	);
 	const { setValidationErrors } = useValidationContext();
 	const { addErrorNotice, removeNotice } = useStoreNotices();


### PR DESCRIPTION
This is a refactor of `usePaymentMethodRegistration` to change how initialization of payment methods occurs.

Before, there were a series of `useEffect` calls which initialized methods, then dispatched those methods once initialization was complete (after all promises resolved). Since `useEffect` runs after renders, there were 1 or 2 renders where `isInitialized` was `true`, but `paymentMethods` was an empty `{}`.

I've changed the logic slightly so `isInitialized` is only set to true at the same time as the call to the `dispatcher`.

Fixes #2449

### How to test the changes in this Pull Request:

1. Smoke test payments - ensure methods are displayed and rendered correctly
2. Console log as explained in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2449 - with this PR you should see the list of paymentMethods populated at the same time as isInitialized being true.
