### PR TITLE
Fix missing Checkout order summary component

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
@@ -15,7 +15,7 @@ import CheckoutOrderSummaryItem from './order-summary-item.js';
 const CheckoutOrderSummary = ( { cartItems = [] } ) => {
 	const { isLarge, hasContainerWidth } = useContainerWidthContext();
 
-	if ( hasContainerWidth ) {
+	if ( ! hasContainerWidth ) {
 		return null;
 	}
 


### PR DESCRIPTION
The order summary is not currently shown. I suspect this is because the escape clause checking that the container width context is backward - if `hasContainerWidth` then we are good to render, if not, return early.

This PR fixes the logic with a `!` :)

### Screenshots

Bug:
<img width="1222" alt="Screen Shot 2020-05-13 at 9 27 22 AM" src="https://user-images.githubusercontent.com/4167300/81747293-f6690000-94fb-11ea-89cf-5d7fb23659c3.png">

Fix:
<img width="1195" alt="Screen Shot 2020-05-13 at 9 27 59 AM" src="https://user-images.githubusercontent.com/4167300/81747340-0aacfd00-94fc-11ea-9ec4-5e0df45656cd.png">


### How to test the changes in this Pull Request:

1. Check out this branch.
2. View checkout - ensure order summary active.
3. View checkout in smaller window/mobile (refresh page), ensure order summary is collapsed by default.
5. Check other responsive/container width related behaviour and ensure this is all 👌 

