### PR TITLE
Fix regression for payment methods in incognito mode.

### DIFF
--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -80,16 +80,18 @@ const PaymentMethods = () => {
 	}, [ paymentMethods, paymentMethodInterface, activePaymentMethod ] );
 
 	const getRenderedTab = useCallback(
-		() => ( selectedTab ) => {
+		( selectedTab ) => {
 			const paymentMethod = getPaymentMethod(
 				selectedTab,
 				currentPaymentMethods.current,
 				isEditor
 			);
-			const { supports } = currentPaymentMethods.current[
-				activePaymentMethod
-			];
-			return paymentMethod ? (
+			const { supports = {} } =
+				paymentMethod &&
+				currentPaymentMethods.current[ activePaymentMethod ]
+					? currentPaymentMethods.current[ activePaymentMethod ]
+					: {};
+			return paymentMethod && activePaymentMethod ? (
 				<PaymentMethodErrorBoundary isEditor={ isEditor }>
 					{ cloneElement( paymentMethod, {
 						activePaymentMethod,
@@ -133,23 +135,19 @@ const PaymentMethods = () => {
 				setActivePaymentMethod( tabName );
 				removeNotice( 'wc-payment-error', noticeContexts.PAYMENTS );
 			} }
-			tabs={ Object.keys( currentPaymentMethods.current ).map(
-				( name ) => {
-					const { label, ariaLabel } = currentPaymentMethods.current[
-						name
-					];
-					return {
-						name,
-						title:
-							typeof label === 'string'
-								? label
-								: cloneElement( label, {
-										components: { PaymentMethodIcons },
-								  } ),
-						ariaLabel,
-					};
-				}
-			) }
+			tabs={ Object.keys( paymentMethods ).map( ( name ) => {
+				const { label, ariaLabel } = paymentMethods[ name ];
+				return {
+					name,
+					title:
+						typeof label === 'string'
+							? label
+							: cloneElement( label, {
+									components: { PaymentMethodIcons },
+							  } ),
+					ariaLabel,
+				};
+			} ) }
 			initialTabName={ activePaymentMethod }
 			ariaLabel={ __(
 				'Payment Methods',
@@ -157,7 +155,7 @@ const PaymentMethods = () => {
 			) }
 			id="wc-block-payment-methods"
 		>
-			{ getRenderedTab() }
+			{ getRenderedTab }
 		</Tabs>
 	);
 

--- a/assets/js/base/components/tabs/index.js
+++ b/assets/js/base/components/tabs/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
@@ -24,8 +24,17 @@ const Tabs = ( {
 	id,
 } ) => {
 	const [ selected, setSelected ] = useState(
-		initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : '' )
+		() => initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : '' )
 	);
+	// Maybe set selected tab if it's empty but we have tabs or an initial tab
+	// This covers instances when the selected value isn't initialized on mount.
+	useEffect( () => {
+		if ( ! selected && tabs.length > 0 ) {
+			setSelected(
+				initialTabName || ( tabs.length > 0 ? tabs[ 0 ].name : '' )
+			);
+		}
+	}, [ selected, tabs, initialTabName ] );
 	if ( ! selected ) {
 		return null;
 	}


### PR DESCRIPTION
This fixes a regression introduced by #2467 (see @haszari's [comment](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2467#issuecomment-627647336)).  After investigation, it's more that after simplifying and reducing the number of unnecessary renders, it exposed some incorrect assumptions being made elsewhere for the tab rendering.

While Rua reported it only happens for incognito mode, it's actually unrelated to incognito and more related to whether there are saved payment methods (incognito just never has them so it's more visible there).

## To test

- Ensure you have no saved payment methods (best way to test is using incognito).
- Verify that any configured payment method options appear
- Verify you can complete a purchase successfully.

**Note**: while testing this pull I discovered a new issue that I can't find the source for and is puzzling because when I git checkout commits in the history where I know it worked before, it's still not working 😕 .  The issue is:

- while logged out
- submit a payment with cheque or stripe (happens with either) with all valid fields filled out.
- the server is returning a 400 error code for me with the following:

<img width="1143" alt="Image 2020-05-12 at 9 11 35 PM" src="https://user-images.githubusercontent.com/1429108/81760452-3648cc80-9495-11ea-89c9-6789866c92ae.png">

And the actual error message in the network request is:

```
{"code":"rest_invalid_param","message":"Invalid parameter(s): billing_address","data":{"status":400,"params":{"billing_address":"Invalid email address."}}}
```

There definitely is an email address.

What's odder is while logged in it works (I suspect because it's using a customer that already has an email address server side).
