### PR TITLE
Ensure email and phone are persisted through `setBillingData`

### DIFF
--- a/assets/js/base/context/cart-checkout/billing/index.js
+++ b/assets/js/base/context/cart-checkout/billing/index.js
@@ -29,15 +29,12 @@ export const useBillingDataContext = () => {
 export const BillingDataProvider = ( { children } ) => {
 	const [ billingData, setBillingDataState ] = useState( DEFAULT_STATE );
 
-	const setBillingData = useCallback(
-		( newData ) => {
-			setBillingDataState( ( prevState ) => ( {
-				...prevState,
-				...newData,
-			} ) );
-		},
-		[ setBillingDataState ]
-	);
+	const setBillingData = useCallback( ( newData ) => {
+		setBillingDataState( ( prevState ) => ( {
+			...prevState,
+			...newData,
+		} ) );
+	}, [] );
 
 	/**
 	 * @type {BillingDataContext}

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -58,9 +58,13 @@ export const useCheckoutAddress = () => {
 			setShippingAddress( shippingFields );
 		}
 
-		const newBillingData = shippingAsBilling
-			? shippingFields
-			: billingFields;
+		// Uses shipping or billing fields depending on shippingAsBilling checkbox, but ensures
+		// billing only fields are also included.
+		const newBillingData = {
+			...( shippingAsBilling ? shippingFields : billingFields ),
+			email: billingFields.email,
+			phone: billingFields.phone,
+		};
 
 		if ( ! isEqual( newBillingData, billingData ) ) {
 			setBillingData( newBillingData );

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -53,7 +53,6 @@ export const useCheckoutAddress = () => {
 	);
 
 	// Pushes to global state when changes are made locally.
-	// setBillingData and setShippingAddress are memoized from the contexts.
 	useEffect( () => {
 		if ( ! isEqual( shippingFields, shippingAddress ) ) {
 			setShippingAddress( shippingFields );
@@ -70,13 +69,14 @@ export const useCheckoutAddress = () => {
 		if ( ! isEqual( newBillingData, billingData ) ) {
 			setBillingData( newBillingData );
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		shippingFields,
 		billingFields,
 		shippingAsBilling,
 		billingData,
 		shippingAddress,
+		setBillingData,
+		setShippingAddress,
 	] );
 
 	/**

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -53,6 +53,7 @@ export const useCheckoutAddress = () => {
 	);
 
 	// Pushes to global state when changes are made locally.
+	// setBillingData and setShippingAddress are memoized from the contexts.
 	useEffect( () => {
 		if ( ! isEqual( shippingFields, shippingAddress ) ) {
 			setShippingAddress( shippingFields );
@@ -69,7 +70,14 @@ export const useCheckoutAddress = () => {
 		if ( ! isEqual( newBillingData, billingData ) ) {
 			setBillingData( newBillingData );
 		}
-	}, [ shippingFields, billingFields, shippingAsBilling ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		shippingFields,
+		billingFields,
+		shippingAsBilling,
+		billingData,
+		shippingAddress,
+	] );
 
 	/**
 	 * Wrapper for updateBillingFields (from useState) which handles merging.


### PR DESCRIPTION
This should resolve 2474 by ensuring email and phone fields are passed to billingData at all times. This is needed because shippingFields do not contain this data.

Fixes #2474

### How to test the changes in this Pull Request:

I'm not sure how to test this fully. I was console logging what was persisted to setBillingData and verifying email was included in various cases.