### PR TITLE
Fix shipping rate and address handling in Stripe payment request payment method.

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -8,6 +8,7 @@ import {
 	useRef,
 	useMemo,
 	useEffect,
+	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useStoreNotices, useEmitResponse } from '@woocommerce/base-hooks';
@@ -304,9 +305,9 @@ export const CheckoutStateProvider = ( {
 		isSuccessResponse,
 	] );
 
-	const onSubmit = () => {
+	const onSubmit = useCallback( () => {
 		dispatch( actions.setBeforeProcessing() );
-	};
+	}, [] );
 
 	/**
 	 * @type {CheckoutDataContext}

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -75,7 +75,7 @@ const CheckoutProcessor = () => {
 		paymentMethods,
 		shouldSavePayment,
 	} = usePaymentMethodDataContext();
-	const { addErrorNotice, removeNotice } = useStoreNotices();
+	const { addErrorNotice, removeNotice, setIsSuppressed } = useStoreNotices();
 	const currentBillingData = useRef( billingData );
 	const currentShippingAddress = useRef( shippingAddress );
 	const currentRedirectUrl = useRef( redirectUrl );
@@ -93,6 +93,11 @@ const CheckoutProcessor = () => {
 		( hasValidationErrors && ! expressPaymentMethodActive ) ||
 		currentPaymentStatus.hasError ||
 		shippingErrorStatus.hasError;
+
+	// If express payment method is active, let's suppress notices
+	useEffect( () => {
+		setIsSuppressed( expressPaymentMethodActive );
+	}, [ expressPaymentMethodActive, setIsSuppressed ] );
 
 	useEffect( () => {
 		if (

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -233,11 +233,11 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 				billingData = null,
 				shippingData = null
 			) => {
-				if ( shippingData !== null && shippingData?.address ) {
-					setShippingAddress( shippingData.address );
-				}
 				if ( billingData ) {
 					setBillingData( billingData );
+				}
+				if ( shippingData !== null && shippingData?.address ) {
+					setShippingAddress( shippingData.address );
 				}
 				dispatch(
 					success( {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -150,19 +150,22 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		[ dispatch ]
 	);
 
-	const setExpressPaymentError = ( message ) => {
-		if ( message ) {
-			addErrorNotice( message, {
-				context: 'wc/express-payment-area',
-				id: 'wc-express-payment-error',
-			} );
-		} else {
-			removeNotice(
-				'wc-express-payment-error',
-				'wc/express-payment-area'
-			);
-		}
-	};
+	const setExpressPaymentError = useCallback(
+		( message ) => {
+			if ( message ) {
+				addErrorNotice( message, {
+					context: 'wc/express-payment-area',
+					id: 'wc-express-payment-error',
+				} );
+			} else {
+				removeNotice(
+					'wc-express-payment-error',
+					'wc/express-payment-area'
+				);
+			}
+		},
+		[ addErrorNotice, removeNotice ]
+	);
 	// ensure observers are always current.
 	useEffect( () => {
 		currentObservers.current = observers;

--- a/assets/js/base/context/cart-checkout/shipping/constants.js
+++ b/assets/js/base/context/cart-checkout/shipping/constants.js
@@ -13,6 +13,12 @@ export const ERROR_TYPES = {
 	UNKNOWN: 'unknown_error',
 };
 
+export const shippingErrorCodes = {
+	INVALID_COUNTRY: 'woocommerce_rest_cart_shipping_rates_invalid_country',
+	MISSING_COUNTRY: 'woocommerce_rest_cart_shipping_rates_missing_country',
+	INVALID_STATE: 'woocommerce_rest_cart_shipping_rates_invalid_state',
+};
+
 /**
  * @type {CartShippingAddress}
  */

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -167,10 +167,18 @@ export const ShippingDataProvider = ( { children } ) => {
 			emitEvent(
 				currentObservers.current,
 				EMIT_TYPES.SHIPPING_RATES_FAIL,
-				currentErrorStatus
+				{
+					hasInvalidAddress: currentErrorStatus.hasInvalidAddress,
+					hasError: currentErrorStatus.hasError,
+				}
 			);
 		}
-	}, [ shippingRates, shippingRatesLoading, currentErrorStatus ] );
+	}, [
+		shippingRates,
+		shippingRatesLoading,
+		currentErrorStatus.hasError,
+		currentErrorStatus.hasInvalidAddress,
+	] );
 
 	useEffect( () => {
 		if (
@@ -192,10 +200,18 @@ export const ShippingDataProvider = ( { children } ) => {
 			emitEvent(
 				currentObservers.current,
 				EMIT_TYPES.SHIPPING_RATE_SELECT_FAIL,
-				currentErrorStatus
+				{
+					hasError: currentErrorStatus.hasError,
+					hasInvalidAddress: currentErrorStatus.hasInvalidAddress,
+				}
 			);
 		}
-	}, [ selectedRates, isSelectingRate, currentErrorStatus ] );
+	}, [
+		selectedRates,
+		isSelectingRate,
+		currentErrorStatus.hasError,
+		currentErrorStatus.hasInvalidAddress,
+	] );
 
 	useEffect( () => {
 		if (

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -105,7 +105,7 @@ export const ShippingDataProvider = ( { children } ) => {
 		} else {
 			dispatchActions.decrementCalculating();
 		}
-	}, [ shippingRatesLoading ] );
+	}, [ shippingRatesLoading, dispatchActions ] );
 
 	// increment/decrement checkout calculating counts when shipping rates are
 	// being selected.
@@ -115,7 +115,7 @@ export const ShippingDataProvider = ( { children } ) => {
 		} else {
 			dispatchActions.decrementCalculating();
 		}
-	}, [ isSelectingRate ] );
+	}, [ isSelectingRate, dispatchActions ] );
 
 	const currentErrorStatus = useMemo(
 		() => ( {
@@ -138,7 +138,7 @@ export const ShippingDataProvider = ( { children } ) => {
 				currentErrorStatus
 			);
 		}
-	}, [ shippingRates, shippingRatesLoading, currentErrorStatus.hasError ] );
+	}, [ shippingRates, shippingRatesLoading, currentErrorStatus ] );
 
 	useEffect( () => {
 		if (
@@ -163,7 +163,7 @@ export const ShippingDataProvider = ( { children } ) => {
 				currentErrorStatus
 			);
 		}
-	}, [ selectedRates, isSelectingRate, currentErrorStatus.hasError ] );
+	}, [ selectedRates, isSelectingRate, currentErrorStatus ] );
 
 	useEffect( () => {
 		if (

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -131,7 +131,10 @@ export const ShippingDataProvider = ( { children } ) => {
 
 	// emit events.
 	useEffect( () => {
-		if ( ! shippingRatesLoading && currentErrorStatus.hasError ) {
+		if (
+			! shippingRatesLoading &&
+			( shippingRates.length === 0 || currentErrorStatus.hasError )
+		) {
 			emitEvent(
 				currentObservers.current,
 				EMIT_TYPES.SHIPPING_RATES_FAIL,
@@ -143,7 +146,7 @@ export const ShippingDataProvider = ( { children } ) => {
 	useEffect( () => {
 		if (
 			! shippingRatesLoading &&
-			shippingRates &&
+			shippingRates.length > 0 &&
 			! currentErrorStatus.hasError
 		) {
 			emitEvent(

--- a/assets/js/base/context/store-notices-context.js
+++ b/assets/js/base/context/store-notices-context.js
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { createContext, useContext, useCallback } from '@wordpress/element';
+import {
+	createContext,
+	useContext,
+	useCallback,
+	useState,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	StoreNoticesContainer,
@@ -47,6 +52,7 @@ export const StoreNoticesProvider = ( {
 	context = 'wc/core',
 } ) => {
 	const { createNotice, removeNotice } = useDispatch( 'core/notices' );
+	const [ isSuppressed, setIsSuppressed ] = useState( false );
 
 	const createNoticeWithContext = useCallback(
 		( status = 'default', content = '', options = {} ) => {
@@ -90,18 +96,25 @@ export const StoreNoticesProvider = ( {
 		createSnackbarNotice,
 		removeNotice: removeNoticeWithContext,
 		context,
+		setIsSuppressed,
 	};
+
+	const noticeOutput = isSuppressed ? null : (
+		<StoreNoticesContainer
+			className={ className }
+			notices={ contextValue.notices }
+		/>
+	);
+
+	const snackbarNoticeOutput = isSuppressed ? null : (
+		<SnackbarNoticesContainer />
+	);
 
 	return (
 		<StoreNoticesContext.Provider value={ contextValue }>
-			{ createNoticeContainer && (
-				<StoreNoticesContainer
-					className={ className }
-					notices={ contextValue.notices }
-				/>
-			) }
+			{ createNoticeContainer && noticeOutput }
 			{ children }
-			<SnackbarNoticesContainer />
+			{ snackbarNoticeOutput }
 		</StoreNoticesContext.Provider>
 	);
 };

--- a/assets/js/base/hooks/shipping/constants.js
+++ b/assets/js/base/hooks/shipping/constants.js
@@ -1,5 +1,0 @@
-export const shippingErrorCodes = {
-	INVALID_COUNTRY: 'woocommerce_rest_cart_shipping_rates_invalid_country',
-	MISSING_COUNTRY: 'woocommerce_rest_cart_shipping_rates_missing_country',
-	INVALID_STATE: 'woocommerce_rest_cart_shipping_rates_invalid_state',
-};

--- a/assets/js/base/hooks/use-store-notices.js
+++ b/assets/js/base/hooks/use-store-notices.js
@@ -10,6 +10,7 @@ export const useStoreNotices = () => {
 		createNotice,
 		removeNotice,
 		createSnackbarNotice,
+		setIsSuppressed,
 	} = useStoreNoticesContext();
 	// Added to a ref so the surface for notices doesn't change frequently
 	// and thus can be used as dependencies on effects.
@@ -73,5 +74,6 @@ export const useStoreNotices = () => {
 		notices,
 		...noticesApi,
 		...noticeCreators,
+		setIsSuppressed,
 	};
 };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/payment-request-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/payment-request-express.js
@@ -1,33 +1,14 @@
 /**
  * Internal dependencies
  */
-import { DEFAULT_STRIPE_EVENT_HANDLERS } from './constants';
-import {
-	getStripeServerData,
-	getPaymentRequest,
-	updatePaymentRequest,
-	canDoPaymentRequest,
-	getTotalPaymentItem,
-	getBillingData,
-	getPaymentMethodData,
-	getShippingData,
-	normalizeShippingAddressForCheckout,
-	normalizeShippingOptions,
-	normalizeLineItems,
-	normalizeShippingOptionSelectionsForCheckout,
-} from '../stripe-utils';
+import { getStripeServerData } from '../stripe-utils';
+import { useInitialization } from './use-initialization';
+import { useCheckoutSubscriptions } from './use-checkout-subscriptions';
 
 /**
  * External dependencies
  */
-import { useRef, useState, useEffect } from '@wordpress/element';
-import {
-	Elements,
-	PaymentRequestButtonElement,
-	useStripe,
-} from '@stripe/react-stripe-js';
-import { __ } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
+import { Elements, PaymentRequestButtonElement } from '@stripe/react-stripe-js';
 
 /**
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe
@@ -60,295 +41,37 @@ const PaymentRequestExpressComponent = ( {
 	onClick,
 	onClose,
 } ) => {
-	/**
-	 * @type {[ StripePaymentRequest|null, function( StripePaymentRequest ):StripePaymentRequest|null]}
-	 */
-	// @ts-ignore
-	const [ paymentRequest, setPaymentRequest ] = useState( null );
-	const stripe = useStripe();
-	const [ canMakePayment, setCanMakePayment ] = useState( false );
-	const [ paymentRequestType, setPaymentRequestType ] = useState( '' );
-	const [ isProcessing, setIsProcessing ] = useState( false );
-	const [ isFinished, setIsFinished ] = useState( false );
-	const eventHandlers = useRef( DEFAULT_STRIPE_EVENT_HANDLERS );
-	const currentBilling = useRef( billing );
-	const currentShipping = useRef( shippingData );
-	const currentPaymentRequest = useRef( paymentRequest );
-
-	// update refs when any change.
-	useEffect( () => {
-		currentBilling.current = billing;
-		currentShipping.current = shippingData;
-		currentPaymentRequest.current = paymentRequest;
-	}, [ billing, shippingData, paymentRequest ] );
-
-	// set paymentRequest.
-	useEffect( () => {
-		// can't do anything if stripe isn't available yet or we have zero total.
-		if ( ! stripe || ! billing.cartTotal.value ) {
-			return;
-		}
-
-		// if payment request hasn't been set yet then set it.
-		if ( ! currentPaymentRequest.current && ! isFinished ) {
-			setPaymentRequest(
-				getPaymentRequest( {
-					total: billing.cartTotal,
-					currencyCode: billing.currency.code.toLowerCase(),
-					countryCode: getSetting( 'baseLocation', {} )?.country,
-					shippingRequired: shippingData.needsShipping,
-					cartTotalItems: billing.cartTotalItems,
-					stripe,
-				} )
-			);
-		}
-		// otherwise we just update it (but only if payment processing hasn't
-		// already started).
-		if ( ! isProcessing && currentPaymentRequest.current && ! isFinished ) {
-			updatePaymentRequest( {
-				// @ts-ignore
-				paymentRequest: currentPaymentRequest.current,
-				total: billing.cartTotal,
-				currencyCode: billing.currency.code.toLowerCase(),
-				cartTotalItems: billing.cartTotalItems,
-			} );
-		}
-	}, [
-		billing.cartTotal,
-		billing.currency.code,
-		shippingData.needsShipping,
-		billing.cartTotalItems,
-		stripe,
+	const {
+		paymentRequest,
+		paymentRequestEventHandlers,
+		clearPaymentRequestEventHandler,
 		isProcessing,
-		isFinished,
-	] );
-
-	// whenever paymentRequest changes, then we need to update whether
-	// payment can be made.
-	useEffect( () => {
-		if ( paymentRequest ) {
-			canDoPaymentRequest( paymentRequest ).then( ( result ) => {
-				if ( result.requestType ) {
-					setPaymentRequestType( result.requestType );
-				}
-				setCanMakePayment( result.canPay );
-			} );
-		}
-	}, [ paymentRequest ] );
-
-	// kick off payment processing.
-	const onButtonClick = () => {
-		setIsProcessing( true );
-		setIsFinished( false );
-		setExpressPaymentError( '' );
-		onClick();
-	};
-
-	const abortPayment = ( paymentMethod, message ) => {
-		const response = {
-			fail: {
-				message,
-				billingData: getBillingData( paymentMethod ),
-				paymentMethodData: getPaymentMethodData(
-					paymentMethod,
-					paymentRequestType
-				),
-			},
-		};
-		paymentMethod.complete( 'fail' );
-		setIsProcessing( false );
-		setIsFinished( true );
-		return response;
-	};
-
-	const completePayment = ( paymentMethod ) => {
-		paymentMethod.complete( 'success' );
-		setIsFinished( true );
-		setIsProcessing( false );
-	};
-
-	// event callbacks.
-	const onShippingRatesEvent = ( forSuccess = true ) => ( shippingRates ) => {
-		const handlers = eventHandlers.current;
-		const billingData = currentBilling.current;
-		if ( handlers.shippingAddressChange && isProcessing ) {
-			handlers.shippingAddressChange.updateWith( {
-				status: forSuccess ? 'success' : 'fail',
-				shippingOptions: normalizeShippingOptions( shippingRates ),
-				total: getTotalPaymentItem( billingData.cartTotal ),
-				displayItems: normalizeLineItems( billingData.cartTotalItems ),
-			} );
-			handlers.shippingAddressChange = null;
-		}
-	};
-
-	const onShippingSelectedRate = ( forSuccess = true ) => () => {
-		const handlers = eventHandlers.current;
-		const shipping = currentShipping.current;
-		const billingData = currentBilling.current;
-		if (
-			handlers.shippingOptionChange &&
-			! shipping.isSelectingRate &&
-			isProcessing
-		) {
-			const updateObject = forSuccess
-				? {
-						status: 'success',
-						total: getTotalPaymentItem( billingData.cartTotal ),
-						displayItems: normalizeLineItems(
-							billingData.cartTotalItems
-						),
-				  }
-				: {
-						status: 'fail',
-				  };
-			handlers.shippingOptionChange.updateWith( updateObject );
-			handlers.shippingOptionChange = null;
-		}
-	};
-
-	const onPaymentProcessing = () => {
-		const handlers = eventHandlers.current;
-		if ( handlers.sourceEvent && isProcessing ) {
-			const response = {
-				type: emitResponse.responseTypes.SUCCESS,
-				meta: {
-					billingData: getBillingData( handlers.sourceEvent ),
-					paymentMethodData: getPaymentMethodData(
-						handlers.sourceEvent,
-						paymentRequestType
-					),
-					shippingData: getShippingData( handlers.sourceEvent ),
-				},
-			};
-			return response;
-		}
-		return { type: emitResponse.responseTypes.SUCCESS };
-	};
-
-	const onCheckoutComplete = ( checkoutResponse ) => {
-		const handlers = eventHandlers.current;
-		let response = { type: emitResponse.responseTypes.SUCCESS };
-		if ( handlers.sourceEvent && isProcessing ) {
-			const { paymentStatus, paymentDetails } = checkoutResponse;
-			if ( paymentStatus === emitResponse.responseTypes.SUCCESS ) {
-				completePayment( handlers.sourceEvent );
-			}
-			if (
-				paymentStatus === emitResponse.responseTypes.ERROR ||
-				paymentStatus === emitResponse.responseTypes.FAIL
-			) {
-				const paymentResponse = abortPayment(
-					handlers.sourceEvent,
-					paymentDetails?.errorMessage
-				);
-				response = {
-					type: emitResponse.responseTypes.ERROR,
-					message: paymentResponse.message,
-					messageContext:
-						emitResponse.noticeContexts.EXPRESS_PAYMENTS,
-					retry: true,
-				};
-			}
-			handlers.sourceEvent = null;
-		}
-		return response;
-	};
-
-	// when canMakePayment is true, then we set listeners on payment request for
-	// handling updates.
-	useEffect( () => {
-		if ( paymentRequest && canMakePayment && isProcessing ) {
-			paymentRequest.on( 'shippingaddresschange', ( event ) => {
-				// @todo check if there is an address change, and if not, then
-				// just call updateWith and don't call setShippingAddress here
-				// because the state won't change upstream.
-				currentShipping.current.setShippingAddress(
-					normalizeShippingAddressForCheckout( event.shippingAddress )
-				);
-				eventHandlers.current.shippingAddressChange = event;
-			} );
-			paymentRequest.on( 'shippingoptionchange', ( event ) => {
-				currentShipping.current.setSelectedRates(
-					normalizeShippingOptionSelectionsForCheckout(
-						event.shippingOption
-					)
-				);
-				eventHandlers.current.shippingOptionChange = event;
-			} );
-			paymentRequest.on( 'source', ( paymentMethod ) => {
-				if (
-					// eslint-disable-next-line no-undef
-					! getStripeServerData().allowPrepaidCard &&
-					paymentMethod.source.card.funding
-				) {
-					setExpressPaymentError(
-						__(
-							"Sorry, we're not accepting prepaid cards at this time.",
-							'woocommerce-gateway-stripe'
-						)
-					);
-					return;
-				}
-				eventHandlers.current.sourceEvent = paymentMethod;
-				// kick off checkout processing step.
-				onSubmit();
-			} );
-			paymentRequest.on( 'cancel', () => {
-				setIsFinished( true );
-				setIsProcessing( false );
-				onClose();
-			} );
-		}
-	}, [ paymentRequest, canMakePayment, isProcessing, onClose ] );
-
-	// subscribe to events.
-	useEffect( () => {
-		if ( canMakePayment && isProcessing ) {
-			const subscriber = eventRegistration;
-			const unsubscribeShippingRateSuccess = subscriber.onShippingRateSuccess(
-				onShippingRatesEvent()
-			);
-			const unsubscribeShippingRateFail = subscriber.onShippingRateFail(
-				onShippingRatesEvent( false )
-			);
-			const unsubscribeShippingRateSelectSuccess = subscriber.onShippingRateSelectSuccess(
-				onShippingSelectedRate()
-			);
-			const unsubscribeShippingRateSelectFail = subscriber.onShippingRateSelectFail(
-				onShippingRatesEvent( false )
-			);
-			const unsubscribePaymentProcessing = subscriber.onPaymentProcessing(
-				onPaymentProcessing
-			);
-			const unsubscribeCheckoutCompleteSuccess = subscriber.onCheckoutAfterProcessingWithSuccess(
-				onCheckoutComplete
-			);
-			const unsubscribeCheckoutCompleteFail = subscriber.onCheckoutAfterProcessingWithError(
-				onCheckoutComplete
-			);
-			return () => {
-				unsubscribeCheckoutCompleteFail();
-				unsubscribeCheckoutCompleteSuccess();
-				unsubscribePaymentProcessing();
-				unsubscribeShippingRateFail();
-				unsubscribeShippingRateSuccess();
-				unsubscribeShippingRateSelectSuccess();
-				unsubscribeShippingRateSelectFail();
-			};
-		}
-		return undefined;
-	}, [
+		canMakePayment,
+		onButtonClick,
+		abortPayment,
+		completePayment,
+		paymentRequestType,
+	} = useInitialization( {
+		billing,
+		shippingData,
+		setExpressPaymentError,
+		onClick,
+		onClose,
+		onSubmit,
+	} );
+	useCheckoutSubscriptions( {
 		canMakePayment,
 		isProcessing,
-		eventRegistration.onShippingRateSuccess,
-		eventRegistration.onShippingRateFail,
-		eventRegistration.onShippingRateSelectSuccess,
-		eventRegistration.onShippingRateSelectFail,
-		eventRegistration.onPaymentProcessing,
-		eventRegistration.onCheckoutAfterProcessingWithSuccess,
-		eventRegistration.onCheckoutAfterProcessingWithError,
-	] );
+		eventRegistration,
+		paymentRequestEventHandlers,
+		clearPaymentRequestEventHandler,
+		billing,
+		shippingData,
+		emitResponse,
+		paymentRequestType,
+		completePayment,
+		abortPayment,
+	} );
 
 	// locale is not a valid value for the paymentRequestButton style.
 	const { theme } = getStripeServerData().button;
@@ -365,7 +88,9 @@ const PaymentRequestExpressComponent = ( {
 		<PaymentRequestButtonElement
 			onClick={ onButtonClick }
 			options={ {
+				// @ts-ignore
 				style: paymentRequestButtonStyle,
+				// @ts-ignore
 				paymentRequest,
 			} }
 		/>

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
@@ -33,7 +33,7 @@ import {
  *                                                                       registering observers to
  *                                                                       events.
  * @param {Object}                 props.paymentRequestEventHandlers     Cached handlers registered
- * \                                                                     for paymentRequest events.
+ *                                                                       for paymentRequest events.
  * @param {function(string):void}  props.clearPaymentRequestEventHandler Clears the cached payment
  *                                                                       request event handler.
  * @param {BillingDataProps}       props.billing

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
@@ -1,0 +1,231 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	normalizeShippingOptions,
+	getTotalPaymentItem,
+	normalizeLineItems,
+	getBillingData,
+	getPaymentMethodData,
+	getShippingData,
+} from '../stripe-utils';
+
+/**
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').EventRegistrationProps} EventRegistrationProps
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').BillingDataProps} BillingDataProps
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').ShippingDataProps} ShippingDataProps
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').EmitResponseProps} EmitResponseProps
+ */
+
+/**
+ * @param {Object} props
+ *
+ * @param {boolean}                props.canMakePayment                  Whether the payment request
+ *                                                                       can make payment or not.
+ * @param {boolean}                props.isProcessing                    Whether the express payment
+ *                                                                       method is processing or not.
+ * @param {EventRegistrationProps} props.eventRegistration               Various functions for
+ *                                                                       registering observers to
+ *                                                                       events.
+ * @param {Object}                 props.paymentRequestEventHandlers     Cached handlers registered
+ * \                                                                     for paymentRequest events.
+ * @param {function(string):void}  props.clearPaymentRequestEventHandler Clears the cached payment
+ *                                                                       request event handler.
+ * @param {BillingDataProps}       props.billing
+ * @param {ShippingDataProps}      props.shippingData
+ * @param {EmitResponseProps}      props.emitResponse
+ * @param {string}                 props.paymentRequestType              The derived payment request
+ *                                                                       type for the express
+ *                                                                       payment being processed.
+ * @param {function(any):void}     props.completePayment                 This is a callback
+ *                                                                       receiving the source event
+ *                                                                       and setting it to
+ *                                                                       successful payment.
+ * @param {function(any,string):any}     props.abortPayment                    This is a callback
+ *                                                                       receiving the source
+ *                                                                       event and setting it to
+ *                                                                       failed payment.
+ */
+export const useCheckoutSubscriptions = ( {
+	canMakePayment,
+	isProcessing,
+	eventRegistration,
+	paymentRequestEventHandlers,
+	clearPaymentRequestEventHandler,
+	billing,
+	shippingData,
+	emitResponse,
+	paymentRequestType,
+	completePayment,
+	abortPayment,
+} ) => {
+	const {
+		onShippingRateSuccess,
+		onShippingRateFail,
+		onShippingRateSelectSuccess,
+		onShippingRateSelectFail,
+		onPaymentProcessing,
+		onCheckoutAfterProcessingWithSuccess,
+		onCheckoutAfterProcessingWithError,
+	} = eventRegistration;
+	const { noticeContexts, responseTypes } = emitResponse;
+	const eventHandlers = useRef( paymentRequestEventHandlers );
+	const currentBilling = useRef( billing );
+	const currentShipping = useRef( shippingData );
+	const currentPaymentRequestType = useRef( paymentRequestType );
+
+	useEffect( () => {
+		eventHandlers.current = paymentRequestEventHandlers;
+		currentBilling.current = billing;
+		currentShipping.current = shippingData;
+		currentPaymentRequestType.current = paymentRequestType;
+	}, [
+		paymentRequestEventHandlers,
+		billing,
+		shippingData,
+		paymentRequestType,
+	] );
+
+	// subscribe to events.
+	useEffect( () => {
+		const onShippingRatesEvent = ( forSuccess = true ) => (
+			shippingRates
+		) => {
+			const handlers = eventHandlers.current;
+			const billingData = currentBilling.current;
+			if ( handlers.shippingAddressChange && isProcessing ) {
+				handlers.shippingAddressChange.updateWith( {
+					status: forSuccess ? 'success' : 'fail',
+					shippingOptions: normalizeShippingOptions( shippingRates ),
+					total: getTotalPaymentItem( billingData.cartTotal ),
+					displayItems: normalizeLineItems(
+						billingData.cartTotalItems
+					),
+				} );
+				clearPaymentRequestEventHandler( 'shippingAddressChange' );
+			}
+		};
+		const onShippingSelectedRate = ( forSuccess = true ) => () => {
+			const handlers = eventHandlers.current;
+			const shipping = currentShipping.current;
+			const billingData = currentBilling.current;
+			if (
+				handlers.shippingOptionChange &&
+				! shipping.isSelectingRate &&
+				isProcessing
+			) {
+				const updateObject = forSuccess
+					? {
+							status: 'success',
+							total: getTotalPaymentItem( billingData.cartTotal ),
+							displayItems: normalizeLineItems(
+								billingData.cartTotalItems
+							),
+					  }
+					: {
+							status: 'fail',
+					  };
+				handlers.shippingOptionChange.updateWith( updateObject );
+				clearPaymentRequestEventHandler( 'shippingOptionChange' );
+			}
+		};
+		const onProcessingPayment = () => {
+			const handlers = eventHandlers.current;
+			if ( handlers.sourceEvent && isProcessing ) {
+				const response = {
+					type: responseTypes.SUCCESS,
+					meta: {
+						billingData: getBillingData( handlers.sourceEvent ),
+						paymentMethodData: getPaymentMethodData(
+							handlers.sourceEvent,
+							currentPaymentRequestType.current
+						),
+						shippingData: getShippingData( handlers.sourceEvent ),
+					},
+				};
+				return response;
+			}
+			return { type: responseTypes.SUCCESS };
+		};
+		const onCheckoutComplete = ( checkoutResponse ) => {
+			const handlers = eventHandlers.current;
+			let response = { type: responseTypes.SUCCESS };
+			if ( handlers.sourceEvent && isProcessing ) {
+				const { paymentStatus, paymentDetails } = checkoutResponse;
+				if ( paymentStatus === responseTypes.SUCCESS ) {
+					completePayment( handlers.sourceEvent );
+				}
+				if (
+					paymentStatus === responseTypes.ERROR ||
+					paymentStatus === responseTypes.FAIL
+				) {
+					const paymentResponse = abortPayment(
+						handlers.sourceEvent,
+						paymentDetails?.errorMessage
+					);
+					response = {
+						type: responseTypes.ERROR,
+						message: paymentResponse.message,
+						messageContext: noticeContexts.EXPRESS_PAYMENTS,
+						retry: true,
+					};
+				}
+				clearPaymentRequestEventHandler( 'sourceEvent' );
+			}
+			return response;
+		};
+		if ( canMakePayment && isProcessing ) {
+			const unsubscribeShippingRateSuccess = onShippingRateSuccess(
+				onShippingRatesEvent()
+			);
+			const unsubscribeShippingRateFail = onShippingRateFail(
+				onShippingRatesEvent( false )
+			);
+			const unsubscribeShippingRateSelectSuccess = onShippingRateSelectSuccess(
+				onShippingSelectedRate()
+			);
+			const unsubscribeShippingRateSelectFail = onShippingRateSelectFail(
+				onShippingRatesEvent( false )
+			);
+			const unsubscribePaymentProcessing = onPaymentProcessing(
+				onProcessingPayment
+			);
+			const unsubscribeCheckoutCompleteSuccess = onCheckoutAfterProcessingWithSuccess(
+				onCheckoutComplete
+			);
+			const unsubscribeCheckoutCompleteFail = onCheckoutAfterProcessingWithError(
+				onCheckoutComplete
+			);
+			return () => {
+				unsubscribeCheckoutCompleteFail();
+				unsubscribeCheckoutCompleteSuccess();
+				unsubscribePaymentProcessing();
+				unsubscribeShippingRateFail();
+				unsubscribeShippingRateSuccess();
+				unsubscribeShippingRateSelectSuccess();
+				unsubscribeShippingRateSelectFail();
+			};
+		}
+		return undefined;
+	}, [
+		canMakePayment,
+		isProcessing,
+		onShippingRateSuccess,
+		onShippingRateFail,
+		onShippingRateSelectSuccess,
+		onShippingRateSelectFail,
+		onPaymentProcessing,
+		onCheckoutAfterProcessingWithSuccess,
+		onCheckoutAfterProcessingWithError,
+		responseTypes,
+		noticeContexts,
+		completePayment,
+		abortPayment,
+		clearPaymentRequestEventHandler,
+	] );
+};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-event-handlers.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-event-handlers.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_STRIPE_EVENT_HANDLERS } from './constants';
+
+/**
+ * A utility hook for maintaining an event handler cache.
+ */
+export const useEventHandlers = () => {
+	const [ paymentRequestEventHandlers, setEventHandlers ] = useState(
+		DEFAULT_STRIPE_EVENT_HANDLERS
+	);
+
+	const setPaymentRequestEventHandler = useCallback(
+		( eventName, handler ) => {
+			setEventHandlers( ( prevEventHandlers ) => {
+				return {
+					...prevEventHandlers,
+					[ eventName ]: handler,
+				};
+			} );
+		},
+		[ setEventHandlers ]
+	);
+
+	const clearPaymentRequestEventHandler = useCallback(
+		( eventName ) => {
+			// @ts-ignore
+			setEventHandlers( ( prevEventHandlers ) => {
+				// @ts-ignore
+				// eslint-disable-next-line no-unused-vars
+				const { [ eventName ]: __, ...newHandlers } = prevEventHandlers;
+				return newHandlers;
+			} );
+		},
+		[ setEventHandlers ]
+	);
+	return {
+		paymentRequestEventHandlers,
+		setPaymentRequestEventHandler,
+		clearPaymentRequestEventHandler,
+	};
+};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
@@ -1,0 +1,216 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useState, useRef, useCallback } from '@wordpress/element';
+import { useStripe } from '@stripe/react-stripe-js';
+import { getSetting } from '@woocommerce/settings';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+	getPaymentRequest,
+	updatePaymentRequest,
+	canDoPaymentRequest,
+	getBillingData,
+	getPaymentMethodData,
+	normalizeShippingAddressForCheckout,
+	normalizeShippingOptionSelectionsForCheckout,
+	getStripeServerData,
+} from '../stripe-utils';
+import { useEventHandlers } from './use-event-handlers';
+
+/**
+ * @typedef {import('../stripe-utils/type-defs').StripePaymentRequest} StripePaymentRequest
+ */
+
+export const useInitialization = ( {
+	billing,
+	shippingData,
+	setExpressPaymentError,
+	onClick,
+	onClose,
+	onSubmit,
+} ) => {
+	const stripe = useStripe();
+	/**
+	 * @type {[ StripePaymentRequest|null, function( StripePaymentRequest ):void]}
+	 */
+	// @ts-ignore
+	const [ paymentRequest, setPaymentRequest ] = useState( null );
+	const [ isFinished, setIsFinished ] = useState( false );
+	const [ isProcessing, setIsProcessing ] = useState( false );
+	const [ canMakePayment, setCanMakePayment ] = useState( false );
+
+	const currentPaymentRequest = useRef( paymentRequest );
+	const currentPaymentRequestType = useRef( '' );
+	const currentShipping = useRef( shippingData );
+
+	const {
+		paymentRequestEventHandlers,
+		clearPaymentRequestEventHandler,
+		setPaymentRequestEventHandler,
+	} = useEventHandlers();
+
+	// Update refs when any change.
+	useEffect( () => {
+		currentPaymentRequest.current = paymentRequest;
+		currentShipping.current = shippingData;
+	}, [ paymentRequest, shippingData ] );
+
+	// set paymentRequest.
+	useEffect( () => {
+		// can't do anything if stripe isn't available yet or we have zero total.
+		if ( ! stripe || ! billing.cartTotal.value ) {
+			return;
+		}
+
+		// if payment request hasn't been set yet then set it.
+		if ( ! currentPaymentRequest.current && ! isFinished ) {
+			setPaymentRequest(
+				getPaymentRequest( {
+					total: billing.cartTotal,
+					currencyCode: billing.currency.code.toLowerCase(),
+					countryCode: getSetting( 'baseLocation', {} )?.country,
+					shippingRequired: shippingData.needsShipping,
+					cartTotalItems: billing.cartTotalItems,
+					stripe,
+				} )
+			);
+		}
+		// otherwise we just update it (but only if payment processing hasn't
+		// already started).
+		if ( ! isProcessing && currentPaymentRequest.current && ! isFinished ) {
+			updatePaymentRequest( {
+				// @ts-ignore
+				paymentRequest: currentPaymentRequest.current,
+				total: billing.cartTotal,
+				currencyCode: billing.currency.code.toLowerCase(),
+				cartTotalItems: billing.cartTotalItems,
+			} );
+		}
+	}, [
+		billing.cartTotal,
+		billing.currency.code,
+		shippingData.needsShipping,
+		billing.cartTotalItems,
+		stripe,
+		isProcessing,
+		isFinished,
+	] );
+
+	// whenever paymentRequest changes, then we need to update whether
+	// payment can be made.
+	useEffect( () => {
+		if ( paymentRequest ) {
+			canDoPaymentRequest( paymentRequest ).then( ( result ) => {
+				if ( result.requestType ) {
+					currentPaymentRequestType.current = result.requestType;
+				}
+				setCanMakePayment( result.canPay );
+			} );
+		}
+	}, [ paymentRequest ] );
+
+	// kick off payment processing.
+	const onButtonClick = () => {
+		setIsProcessing( true );
+		setIsFinished( false );
+		setExpressPaymentError( '' );
+		onClick();
+	};
+
+	const abortPayment = useCallback( ( paymentMethod, message ) => {
+		const response = {
+			fail: {
+				message,
+				billingData: getBillingData( paymentMethod ),
+				paymentMethodData: getPaymentMethodData(
+					paymentMethod,
+					currentPaymentRequestType.current
+				),
+			},
+		};
+		paymentMethod.complete( 'fail' );
+		setIsProcessing( false );
+		setIsFinished( true );
+		return response;
+	}, [] );
+
+	const completePayment = useCallback( ( paymentMethod ) => {
+		paymentMethod.complete( 'success' );
+		setIsFinished( true );
+		setIsProcessing( false );
+	}, [] );
+
+	// when canMakePayment is true, then we set listeners on payment request for
+	// handling updates.
+	useEffect( () => {
+		if ( paymentRequest && canMakePayment && isProcessing ) {
+			// @ts-ignore
+			paymentRequest.on( 'shippingaddresschange', ( event ) => {
+				// @todo check if there is an address change, and if not, then
+				// just call updateWith and don't call setShippingAddress here
+				// because the state won't change upstream.
+				currentShipping.current.setShippingAddress(
+					normalizeShippingAddressForCheckout( event.shippingAddress )
+				);
+				setPaymentRequestEventHandler( 'shippingAddressChange', event );
+			} );
+			// @ts-ignore
+			paymentRequest.on( 'shippingoptionchange', ( event ) => {
+				currentShipping.current.setSelectedRates(
+					normalizeShippingOptionSelectionsForCheckout(
+						event.shippingOption
+					)
+				);
+				setPaymentRequestEventHandler( 'shippingOptionChange', event );
+			} );
+			// @ts-ignore
+			paymentRequest.on( 'source', ( paymentMethod ) => {
+				if (
+					// eslint-disable-next-line no-undef
+					! getStripeServerData().allowPrepaidCard &&
+					paymentMethod.source.card.funding
+				) {
+					setExpressPaymentError(
+						__(
+							"Sorry, we're not accepting prepaid cards at this time.",
+							'woocommerce-gateway-stripe'
+						)
+					);
+					return;
+				}
+				setPaymentRequestEventHandler( 'sourceEvent', paymentMethod );
+				// kick off checkout processing step.
+				onSubmit();
+			} );
+			// @ts-ignore
+			paymentRequest.on( 'cancel', () => {
+				setIsFinished( true );
+				setIsProcessing( false );
+				onClose();
+			} );
+		}
+	}, [
+		paymentRequest,
+		canMakePayment,
+		isProcessing,
+		onClose,
+		setPaymentRequestEventHandler,
+		setExpressPaymentError,
+		onSubmit,
+	] );
+	return {
+		paymentRequest,
+		paymentRequestEventHandlers,
+		clearPaymentRequestEventHandler,
+		isProcessing,
+		canMakePayment,
+		onButtonClick,
+		abortPayment,
+		completePayment,
+		paymentRequestType: currentPaymentRequestType.current,
+	};
+};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
@@ -249,18 +249,18 @@
 /**
  * @typedef {Object} StripePaymentRequest Stripe payment request object.
  *
- * @property {Function<Promise>} canMakePayment Returns a promise that resolves
- *                                              with an object detailing if a
- *                                              browser payment API is
- *                                              available.
- * @property {Function}          show           Shows the browser's payment
- *                                              interface (called automatically
- *                                              if payment request button in
- *                                              use)
- * @property {Function}          update         Used to update a PaymentRequest
- *                                              object.
- * @property {Function}          on             For registering callbacks on
- *                                              payment request events.
+ * @property {function():Promise} canMakePayment Returns a promise that resolves
+ *                                               with an object detailing if a
+ *                                               browser payment API is
+ *                                               available.
+ * @property {function()}         show           Shows the browser's payment
+ *                                               interface (called automatically
+ *                                               if payment request button in
+ *                                               use)
+ * @property {function()}         update         Used to update a PaymentRequest
+ *                                               object.
+ * @property {function()}         on             For registering callbacks on
+ *                                               payment request events.
  */
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -253,6 +253,21 @@ const getErrorMessageForTypeAndCode = ( type, code = '' ) => {
 	return null;
 };
 
+/**
+ * pluckAddress takes a full address object and returns relevant fields for calculating
+ * shipping, so we can track when one of them change to update rates.
+ *
+ * @param {Object} address          An object containing all address information
+ *
+ * @return {Object} pluckedAddress  An object containing shipping address that are needed to fetch an address.
+ */
+const pluckAddress = ( { country, state, city, postcode } ) => ( {
+	country,
+	state,
+	city,
+	postcode: postcode.replace( ' ', '' ).toUpperCase(),
+} );
+
 export {
 	getStripeServerData,
 	getApiKey,
@@ -261,4 +276,5 @@ export {
 	updatePaymentRequest,
 	canDoPaymentRequest,
 	getErrorMessageForTypeAndCode,
+	pluckAddress,
 };

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -304,6 +304,8 @@
  * @property {string}                                context              The current context
  *                                                                        identifier for the notice
  *                                                                        provider
+ * @property {function(boolean):void}                setSuppressed        Consumers can use this
+ *                                                                        setter to suppress
  */
 
 /**

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -146,17 +146,17 @@
  *                                                              will fire when checkout begins
  *                                                              processing (as a part of the
  *                                                              processing process).
- * @property {function()}           onShippingRateSuccess       Used to subscribe callbacks that
+ * @property {function(function())} onShippingRateSuccess       Used to subscribe callbacks that
  *                                                              will fire when shipping rates for a
  *                                                              given address have been received
  *                                                              successfully.
- * @property {function()}           onShippingRateFail          Used to subscribe callbacks that
+ * @property {function(function())} onShippingRateFail          Used to subscribe callbacks that
  *                                                              will fire when retrieving shipping
  *                                                              rates failed.
- * @property {function()}           onShippingRateSelectSuccess Used to subscribe callbacks that
+ * @property {function(function())} onShippingRateSelectSuccess Used to subscribe callbacks that
  *                                                              will fire after selecting a
  *                                                              shipping rate successfully.
- * @property {function()}           onShippingRateSelectFail    Used to subscribe callbacks that
+ * @property {function(function())} onShippingRateSelectFail    Used to subscribe callbacks that
  *                                                              will fire after selecting a shipping
  *                                                              rate unsuccessfully.
  * @property {function(function())} onPaymentProcessing         Event registration callback for
@@ -211,6 +211,17 @@
  *                                                                 message string) for express
  *                                                                 payment methods. Does not change
  *                                                                 payment status.
+ * @property {function()}                 [onClick]                Provided to express payment
+ *                                                                 methods that should be triggered
+ *                                                                 when the payment method button
+ *                                                                 is clicked (which will signal to
+ *                                                                 checkout the payment method has
+ *                                                                 taken over payment processing)
+ * @property {function()}                 [onClose]                Provided to express payment
+ *                                                                 methods that should be triggered
+ *                                                                 when the express payment method
+ *                                                                 modal closes and control is
+ *                                                                 returned to checkout.
  */
 
 export {};


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2240 
Fixes #2180 

You can review the above listed issues for description of the problems being solved. In this pull:

- address an issue where if the same shipping address as what is already set in the checkout is selected during the payment request, then the modal would time out and rates would be unavailable. This is because the checkout would consider the addresses the same when the attempt is made to change the state and not trigger an update request (which in turn would not trigger a rates update). So the fix is to have the payment method integration compare addresses before deciding to send the state update and only do so if necessary. Note: ideally it'd be nice to just pre-select the shipping address on payment request trigger, but that's not doable with the api.
- address an issue where if a payment request method (notably Apple Pay) allows for the submission of an address that does not have rates, we send trigger a fail for that payment method. Currently we don't have control over what error appears for the payment method but it will usually show something like "There are no available rates for this address". We're somewhat limited by what we can do here.
- address an issue where if a payment request method (notably Apple Pay) allows for the submission of an invalid address (state, address or postcode), the shipping context provider detects that, sets the shipping error status to invalid address, and triggers the appropriate shipping fail handle. With Apple Pay the result will be something like this:

<img width="541" alt="Image 2020-05-14 at 9 56 16 AM" src="https://user-images.githubusercontent.com/1429108/81980792-41b70780-95fd-11ea-8e71-da2ac1cbdce3.png">

- Along with that, this pull adds a new state and setter to the store notices context provider to allow for suppressing displayed notices. With this checkout can suppress notices while the express payment modal is open and then restore them when it is closed. It prevents things like this:

<img width="1435" alt="Image 2020-05-14 at 8 29 40 AM" src="https://user-images.githubusercontent.com/1429108/81980911-7925b400-95fd-11ea-9307-25059e7999ab.png">

- finally one other things I noticed and fixed in this pull while testing (and debugging) express payment methods is that if you opened the payment request modal and then closed it, then opened it again, the listeners (I called them "handlers" in the code) registered to  `paymentRequest.on` would get _re-registered_ which of course meant when the event fired, the listeners would fire for every time the modal was closed and re-opened! With the fix, handlers are only registered once and are removed from the event when the modal is closed (or unmounted).


Also in this pull I refactored the stripe payment request integration so various logic is split out into more discrete files. This makes it easier to debug and improves readability. 

- `use-checkout-subscriptions.js`: this is mirrored off of the same thing I did for the Stripe CC integration and contains all the subscriptions to checkout events.
- `use-initialization.js`: This contains all the payment request initialization and setting of event handlers on Stripe PaymentRequest API events.
- `use-event-handlers.js`: This contains all the logic for managing the event handler cache for the handlers registered to the Stripe PaymentRequest API events.

Also in this pull is some fixing of dependencies in the payment request integration and in the shipping data context.

## To test

This impacts:

- deriving shipping rates from the server
- shipping address fields (and billing data fields)
- purchasing "regular" payment methods (Stripe CC, cheque, paypal) - but you only have to verify one of those. Basically your just verifying that making a purchase with either of these has the shipping data and totals appropriately applied.
- purchasing via express payment methods (ChromePay or ApplePay). To assist with testing I've updated my [ephemeral site with the production build of this branch](https://ephemeral-nerrad-20200302.atomicsites.blog). ApplePay is enabled on this site in test mode, so you can visit in safari and you should see the ApplePay button if you are in a supported region.

Special instructions:

- Both ChromePay and ApplePay need tested.
- Both logged in and logged out (or incognito) contexts must be tested.
- Besides checking that expected behaviour for normal purchases isn't affected, you also need to test behaviour when shipping rates aren't returned. I don't know if you can configure to have only rates for a specific country etc in Woo but what I did was just changed [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/85f8f1b11890e0dc0544c8bf2fdc3496b8afcc1d/src/StoreApi/Schemas/CartSchema.php#L277) to return an empty array for rates (after opening the ChromePay modal and before selecting an address). You should see the modal return a message about there being no rates for the selected address.  
- You can also test invalid state entered using ApplePay which will test the error handling. When you do this, also try cancelling the modal in the error condition, and you should see the error notice appear in checkout after the modal is closed.
- Also need to verify that when logged in (and only logged in, doesn't apply for non-logged in or incognito), and there's already a shipping address filled in. If you select the same shipping address in the express payment method, that it selects immediately and shows you the rates for that address (without any wait).

**Note:** Keep in mind that for Payment Request purchases, it is expected that when you select a new address in the payment request modal, it's only sending Country, state, Postal Code and City to checkout (even if the address has street). So it may appear it's broken if you notice changes in the underlying checkout form as things react to the express payment, but it's not. That's a privacy feature of the payment request api to not provide the full address on initial selection. When the `Pay` button is clicked in the modal, the API exposes the full billing info and shipping data - so the integration is able to send that back to checkout. The thing to watch for is that you can complete purchase in varying conditions and the final order has the correct data.

