### PR TITLE
Only set to pristine when checkout is idle, not when idle status changes

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -268,7 +268,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 	// When checkout is returned to idle, set payment status to pristine
 	// but only if payment status is already not finished.
 	useEffect( () => {
-		if ( ! currentStatus.isSuccessful ) {
+		if ( checkoutIsIdle && ! currentStatus.isSuccessful ) {
 			dispatch( statusOnly( PRISTINE ) );
 		}
 	}, [ checkoutIsIdle, currentStatus.isSuccessful ] );


### PR DESCRIPTION
This appears to be have been caused by an overzealous useEffect hook. Rather than firing when the checkout is idle, it was firing on all changes to `checkoutIsIdle` and `currentStatus.isSuccessful`.

From what I can tell, saved payment methods are always `currentStatus.isSuccessful`, meaning this would run on first mount and reset saved methods to pristine state.

Fixes #2483

### How to test the changes in this Pull Request:

See #2483