### PR TITLE
Fix Cart style discrepancies (editor-frontend)

### DIFF
--- a/assets/js/base/components/cart-checkout/button/style.scss
+++ b/assets/js/base/components/cart-checkout/button/style.scss
@@ -1,10 +1,9 @@
 .wc-block-components-button:not(.is-link) {
+	@include reset-typography();
 	align-items: center;
 	background-color: $black;
-	border: 0;
 	color: $white;
 	display: flex;
-	font-size: inherit;
 	font-weight: bold;
 	min-height: rem(48px); // 16px * 3 = 48px, same height as text-input
 	justify-content: center;

--- a/assets/js/base/components/cart-checkout/button/style.scss
+++ b/assets/js/base/components/cart-checkout/button/style.scss
@@ -1,6 +1,7 @@
 .wc-block-components-button:not(.is-link) {
 	align-items: center;
 	background-color: $black;
+	border: 0;
 	color: $white;
 	display: flex;
 	font-size: inherit;

--- a/assets/js/base/components/title/index.js
+++ b/assets/js/base/components/title/index.js
@@ -12,12 +12,12 @@ import './style.scss';
 /**
  * Component that renders a block title.
  */
-const Title = ( { children, className, level, ...props } ) => {
+const Title = ( { children, className, headingLevel, ...props } ) => {
 	const buttonClassName = classNames(
 		'wc-block-component__title',
 		className
 	);
-	const TagName = `h${ level }`;
+	const TagName = `h${ headingLevel }`;
 
 	return (
 		<TagName className={ buttonClassName } { ...props }>
@@ -27,7 +27,8 @@ const Title = ( { children, className, level, ...props } ) => {
 };
 
 Title.propTypes = {
-	level: PropTypes.oneOf( [ '1', '2', '3', '4', '5', '6' ] ).isRequired,
+	headingLevel: PropTypes.oneOf( [ '1', '2', '3', '4', '5', '6' ] )
+		.isRequired,
 	className: PropTypes.string,
 	children: PropTypes.node,
 };

--- a/assets/js/base/components/title/index.js
+++ b/assets/js/base/components/title/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Component that renders a block title.
+ */
+const Title = ( { children, className, level, ...props } ) => {
+	const buttonClassName = classNames(
+		'wc-block-component__title',
+		className
+	);
+	const TagName = `h${ level }`;
+
+	return (
+		<TagName className={ buttonClassName } { ...props }>
+			{ children }
+		</TagName>
+	);
+};
+
+Title.propTypes = {
+	level: PropTypes.oneOf( [ '1', '2', '3', '4', '5', '6' ] ).isRequired,
+	className: PropTypes.string,
+	children: PropTypes.node,
+};
+
+export default Title;

--- a/assets/js/base/components/title/style.scss
+++ b/assets/js/base/components/title/style.scss
@@ -1,0 +1,5 @@
+// Extra class for specificity to overwrite editor styles.
+.wc-block-component__title.wc-block-component__title {
+	@include font-size(20px);
+	font-weight: normal;
+}

--- a/assets/js/blocks/cart-checkout/cart/checkout-button/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/checkout-button/style.scss
@@ -1,8 +1,10 @@
-.wc-block-cart__submit-button {
-	width: 100%;
-	margin: 0 0 $gap;
+.wc-block-cart {
+	.wc-block-cart__submit-button {
+		width: 100%;
+		margin: 0 0 $gap;
 
-	&:last-child {
-		margin-bottom: 0;
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/checkout-button/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/checkout-button/style.scss
@@ -1,10 +1,8 @@
-.wc-block-cart {
-	.wc-block-cart__submit-button {
-		width: 100%;
-		margin: 0 0 $gap;
+.wc-block-cart__submit-button {
+	width: 100%;
+	margin: 0 0 $gap;
 
-		&:last-child {
-			margin-bottom: 0;
-		}
+	&:last-child {
+		margin-bottom: 0;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
@@ -16,7 +16,7 @@ const CartLineItemsTitle = ( {
 	const readableHeading = `${ title } – ${ itemCountHeading }`;
 
 	return (
-		<Title level="2" aria-label={ readableHeading }>
+		<Title headingLevel="2" aria-label={ readableHeading }>
 			<span>{ title } </span>
 			{ !! itemCount && (
 				<span className="wc-block-cart__item-count">

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
@@ -15,7 +15,7 @@ const CartLineItemsTitle = ( {
 	const readableHeading = `${ title } – ${ itemCountHeading }`;
 
 	return (
-		<h2 aria-label={ readableHeading }>
+		<h2 className="wc-block-cart__title" aria-label={ readableHeading }>
 			<span>{ title } </span>
 			{ !! itemCount && (
 				<span className="wc-block-cart__item-count">

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
@@ -3,6 +3,7 @@
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
+import Title from '@woocommerce/base-components/title';
 
 const CartLineItemsTitle = ( {
 	title = __( 'Shopping cart', 'woo-gutenberg-products-block' ),
@@ -15,14 +16,14 @@ const CartLineItemsTitle = ( {
 	const readableHeading = `${ title } – ${ itemCountHeading }`;
 
 	return (
-		<h2 className="wc-block-cart__title" aria-label={ readableHeading }>
+		<Title level="2" aria-label={ readableHeading }>
 			<span>{ title } </span>
 			{ !! itemCount && (
 				<span className="wc-block-cart__item-count">
 					{ itemCountHeading }
 				</span>
 			) }
-		</h2>
+		</Title>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -96,7 +96,7 @@ const Cart = ( { attributes } ) => {
 			<Sidebar className="wc-block-cart__sidebar">
 				<Card isElevated={ true }>
 					<CardBody>
-						<h2 className="wc-block-cart__totals-title">
+						<h2 className="wc-block-cart__title wc-block-cart__totals-title">
 							{ __(
 								'Cart totals',
 								'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -98,7 +98,7 @@ const Cart = ( { attributes } ) => {
 				<Card isElevated={ true }>
 					<CardBody>
 						<Title
-							level="2"
+							headingLevel="2"
 							className="wc-block-cart__totals-title"
 						>
 							{ __(

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -30,6 +30,7 @@ import {
 	SidebarLayout,
 	Main,
 } from '@woocommerce/base-components/sidebar-layout';
+import Title from '@woocommerce/base-components/title';
 import { getSetting } from '@woocommerce/settings';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -96,12 +97,15 @@ const Cart = ( { attributes } ) => {
 			<Sidebar className="wc-block-cart__sidebar">
 				<Card isElevated={ true }>
 					<CardBody>
-						<h2 className="wc-block-cart__title wc-block-cart__totals-title">
+						<Title
+							level="2"
+							className="wc-block-cart__totals-title"
+						>
 							{ __(
 								'Cart totals',
 								'woo-gutenberg-products-block'
 							) }
-						</h2>
+						</Title>
 						<SubtotalsItem
 							currency={ totalsCurrency }
 							values={ cartTotals }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,7 +1,7 @@
 .wc-block-cart {
 	color: $core-grey-dark-600;
 
-	h2 {
+	.wc-block-cart__title {
 		@include font-size(20px);
 		font-weight: normal;
 	}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,11 +1,6 @@
 .wc-block-cart {
 	color: $core-grey-dark-600;
 
-	.wc-block-cart__title {
-		@include font-size(20px);
-		font-weight: normal;
-	}
-
 	.wc-block-cart__main,
 	.wc-block-cart__sidebar .components-card__body.is-size-medium {
 		padding-top: 1.3em;


### PR DESCRIPTION
Fixes #2344.

Fixes discrepancies in the _Cart_ block between the editor and the frontend. In Storefront, product links don't have the underline, but I think that's caused by this issue https://github.com/woocommerce/storefront/issues/1339.

There is still the issue that form elements look disabled in the editor (quantity selector, radio controls...), that can be tackled in a separate issue: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2487.

### Screenshots
_Frontend:_
![imatge](https://user-images.githubusercontent.com/3616980/81926524-5df97b00-95e2-11ea-88a0-1cefeed1c044.png)

_Editor (before):_
![imatge](https://user-images.githubusercontent.com/3616980/81926566-71a4e180-95e2-11ea-8c43-7a5064831e5b.png)

_Editor (after):_
![imatge](https://user-images.githubusercontent.com/3616980/81926959-24753f80-95e3-11ea-8cd4-6374ff3870ce.png)

### How to test the changes in this Pull Request:

1. View the _Cart_ block in the frontend and the editor and verify there are no visual differences: headings must be the same size and `Proceed to Checkout` button should have no border and correct margin (at least, on Storefront).
