### PR TITLE
Remove class 'button' from Button component

### DIFF
--- a/assets/js/base/components/cart-checkout/button/index.js
+++ b/assets/js/base/components/cart-checkout/button/index.js
@@ -15,7 +15,6 @@ import './style.scss';
  */
 const Button = ( { className, showSpinner = false, children, ...props } ) => {
 	const buttonClassName = classNames(
-		'button',
 		'wc-block-components-button',
 		className,
 		{

--- a/assets/js/base/components/cart-checkout/button/style.scss
+++ b/assets/js/base/components/cart-checkout/button/style.scss
@@ -1,4 +1,4 @@
-.button.wc-block-components-button:not(.is-link) {
+.wc-block-components-button:not(.is-link) {
 	align-items: center;
 	background-color: $black;
 	color: $white;


### PR DESCRIPTION
Fixes #2435.

This PR removes the class `button` from the `<Button>` component as @mikejolley suggested in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2435#issuecomment-627381312. The class was probably added so we would inherit theme styles for buttons, but given that we were hardcoding the background color, font color, etc. there was little reason to inherit other styles.

I did a test of what happened removing that class with ~10 themes and in fact it was fixing several other style conflicts, so I think that's the way to go.

In the future, when we have some documentation for 3rd-party themes, we should document that our buttons use the `.wc-block-components-button` class name instead of `.button`.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/82043066-3d492800-96ab-11ea-842a-bf7e58721483.png)

### How to test the changes in this Pull Request:
0. You will probably need to `git co fix/2491-set-is-suppressed-editor` first so the _Checkout_ block appears in the editor (see #2492).
1. Edit a page with the _Checkout_ block and verify the _Place Order_ button has the same styles as in the frontend.
2. Verify there are no other regressions when viewing the button in the frontend or with other themes.