### PR TITLE
Remove some unique font-size

### DIFF
--- a/assets/js/base/components/payment-methods/no-payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/no-payment-methods/style.scss
@@ -14,7 +14,6 @@
 		}
 
 		.wc-block-checkout__no-payment-methods-placeholder-description {
-			@include font-size(13px);
 			display: block;
 			margin: 0.25em 0 1em 0;
 		}

--- a/assets/js/blocks/cart-checkout/checkout/no-shipping-placeholder/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/no-shipping-placeholder/style.scss
@@ -14,7 +14,6 @@
 		}
 
 		.wc-block-checkout__no-shipping-placeholder-description {
-			@include font-size(13px);
 			display: block;
 			margin: 0.25em 0 1em 0;
 		}

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -84,7 +84,7 @@
 	}
 
 	.wc-block-order-summary-item__quantity {
-		@include font-size(11px);
+		@include font-size(12px);
 		align-items: center;
 		background: #fff;
 		border: 2px solid currentColor;

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -63,7 +63,6 @@
 	display: flex;
 	align-items: center;
 	text-decoration: none;
-	@include font-size(13px);
 	margin: 0;
 	border: none;
 	cursor: pointer;

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -8,7 +8,6 @@
 		flex-grow: 1;
 	}
 	.wc-block-product-search__button {
-		@include font-size(13px);
 		display: flex;
 		align-items: center;
 		text-decoration: none;


### PR DESCRIPTION
This PR removes all instances of `11px` or `13px` font-sizes as a first step to reduce the number of different font-sizes used in our blocks.

* fb9c78adbb89dcfc2b6db25826ef3807b00a0f0e: removes a couple of them that were already inherited from the placeholder styles, so there was no reason to declare them again.
* 9c92227f4d0e658fa25fb9b878ae562f099fadf0: removes the font-sizes of the _Product Search_ and _Product Categories_ buttons. They had no text inside them (only a SVG), so removing it doesn't make any difference.
![imatge](https://user-images.githubusercontent.com/3616980/82073062-f8d48100-96d8-11ea-9274-9be47b255ed7.png)
* 142a0fa7e30a8dccea785c410d258ac4e00611b1: increases the font-size of the _Order summary_ quantity circles from 11px to 12px. Tagging @LevinMedia for feedback/awareness: in the designs that font was 11px but making it 12px aligns it with several other texts in the _Checkout_ block and the visual difference is minimal (I could barely see any difference in the screenshots below).

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/82072831-967b8080-96d8-11ea-880f-a4a3cd9feaca.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/82072865-a4310600-96d8-11ea-8779-c908dc5ca404.png)

### How to test the changes in this Pull Request:

1. Add the _Product Search_ and _Product Categories_ (select the _Dropdown_ display) and verify there are no regressions with the button.
2. Make sure there are no regression either with the _Checkout_ block placeholders when there are no shipping or payment methods.