### PR TITLE
Fix decimal ratings not correctly displayed

### DIFF
--- a/assets/js/atomic/components/product/rating/index.js
+++ b/assets/js/atomic/components/product/rating/index.js
@@ -19,7 +19,7 @@ const ProductRating = ( { className, product } ) => {
 	};
 
 	const ratingText = sprintf(
-		__( 'Rated %d out of 5', 'woo-gutenberg-products-block' ),
+		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
 		rating
 	);
 

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -195,6 +195,7 @@
 			position: absolute;
 			opacity: 0.5;
 			color: #aaa;
+			white-space: nowrap;
 		}
 		span {
 			overflow: hidden;
@@ -211,6 +212,7 @@
 			right: 0;
 			position: absolute;
 			color: #000;
+			white-space: nowrap;
 		}
 	}
 }

--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -137,7 +137,7 @@ function getReviewRating( review ) {
 				<span style={ starStyle }>
 					{ sprintf(
 						__(
-							'Rated %d out of 5',
+							'Rated %f out of 5',
 							'woo-gutenberg-products-block'
 						),
 						rating


### PR DESCRIPTION
I split this off from #2428 so it's not blocked by the other changes in that PR.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/82312491-6af1e200-99c7-11ea-97e5-73e951fbbe28.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/82312718-bb693f80-99c7-11ea-8a0e-12954803e3eb.png)


### How to test the changes in this Pull Request:

1. Make sure you have at least one product with an average rating with decimals, ie 4.5.
2. View the _All Products_ block or a legacy product grid block in the frontend.
3. Verify the number of stars is correct.

### Changelog

> Fix star ratings in product grid blocks so it correctly displays non-integer ratings.