### PR TITLE
Import TwentyTwenty block styles from Core

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -20,10 +20,6 @@
 			list-style: none;
 			margin: 0 (-$gap/2) $gap;
 
-			.wp-block-button__link {
-				color: inherit;
-			}
-
 			.wc-block-grid__product {
 				margin: 0 0 $gap-large 0;
 			}

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -217,7 +217,6 @@
 	}
 }
 
-.editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wc-block-grid__product-onsale,
 .wc-block-grid__product-onsale {
 	border: 1px solid #43454b;
 	color: #43454b;
@@ -234,6 +233,7 @@
 	position: relative;
 	margin: $gap-smaller auto;
 }
+
 .editor-styles-wrapper .wc-block-grid__products .wc-block-grid__product .wc-block-grid__product-image,
 .wc-block-grid__product-image {
 	.wc-block-grid__product-onsale {
@@ -398,6 +398,10 @@
 			font-family: $twentytwenty-headings;
 			font-size: 1.8rem;
 		}
+
+		del {
+			opacity: 0.5;
+		}
 	}
 
 	.wc-block-grid__product-rating {
@@ -405,6 +409,10 @@
 		.star-rating {
 			font-size: 0.7em;
 		}
+	}
+
+	.wc-block-grid__product-add-to-cart > .wp-block-button__link {
+		font-family: $twentytwenty-headings;
 	}
 
 	.wc-block-grid__products .wc-block-grid__product-onsale {

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -360,6 +360,7 @@
 		}
 	}
 }
+
 .theme-twentynineteen {
 	.wc-block-grid__product {
 		font-size: 0.88889em;
@@ -374,5 +375,67 @@
 	}
 	.wc-block-grid__product-onsale {
 		line-height: 1;
+	}
+}
+
+.theme-twentytwenty {
+	$twentytwenty-headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-serif;
+	$twentytwenty-highlights-color: #cd2653;
+
+	.wc-block-grid__product-link {
+		color: #000;
+	}
+
+	.wc-block-grid__product-title {
+		font-family: $twentytwenty-headings;
+		color: #000;
+		font-size: 2.5rem;
+	}
+
+	.wc-block-grid__product-price {
+		.wc-block-grid__product-price__value,
+		.woocommerce-Price-amount {
+			font-family: $twentytwenty-headings;
+			font-size: 1.8rem;
+		}
+	}
+
+	.wc-block-grid__product-rating {
+		.wc-block-grid__product-rating__stars,
+		.star-rating {
+			font-size: 0.7em;
+		}
+	}
+
+	.wc-block-grid__product-onsale {
+		position: absolute;
+		right: 4px;
+		top: 4px;
+		display: inline-block;
+		background: $twentytwenty-highlights-color;
+		color: #fff;
+		font-family: $twentytwenty-headings;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		line-height: 1.2;
+		text-transform: uppercase;
+		z-index: 1;
+		font-size: 1.5rem;
+		margin: 0;
+		padding: 1rem;
+	}
+
+	@media only screen and (min-width: 768px) {
+		.wc-block-grid__product-onsale {
+			font-size: 1.5rem;
+			padding: 1rem;
+		}
+	}
+
+	@media only screen and (min-width: 1168px) {
+		.wc-block-grid__product-onsale {
+			font-size: 1.7rem;
+			padding: 1.5rem;
+		}
 	}
 }

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -389,14 +389,14 @@
 	.wc-block-grid__product-title {
 		font-family: $twentytwenty-headings;
 		color: #000;
-		font-size: 2.5rem;
+		font-size: 1.2em;
 	}
 
 	.wc-block-grid__product-price {
 		.wc-block-grid__product-price__value,
 		.woocommerce-Price-amount {
 			font-family: $twentytwenty-headings;
-			font-size: 1.8rem;
+			font-size: 0.9em;
 		}
 
 		del {
@@ -435,15 +435,15 @@
 
 	@media only screen and (min-width: 768px) {
 		.wc-block-grid__product-onsale {
-			font-size: 1.5rem;
+			font-size: 0.75em;
 			padding: 1rem;
 		}
 	}
 
 	@media only screen and (min-width: 1168px) {
 		.wc-block-grid__product-onsale {
-			font-size: 1.7rem;
-			padding: 1.5rem;
+			font-size: 0.85em;
+			padding: 0.75em;
 		}
 	}
 }

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -407,7 +407,7 @@
 		}
 	}
 
-	.wc-block-grid__product-onsale {
+	.wc-block-grid__products .wc-block-grid__product-onsale {
 		position: absolute;
 		right: 4px;
 		top: 4px;

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -26,6 +26,7 @@ class Assets {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'register_assets' ) );
 		add_action( 'body_class', array( __CLASS__, 'add_theme_body_class' ), 1 );
+		add_action( 'admin_body_class', array( __CLASS__, 'add_theme_admin_body_class' ), 1 );
 		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'get_wc_block_data' ) );
 	}
 
@@ -91,6 +92,17 @@ class Assets {
 	 */
 	public static function add_theme_body_class( $classes = [] ) {
 		$classes[] = 'theme-' . get_template();
+		return $classes;
+	}
+
+	/**
+	 * Add theme class to admin body.
+	 *
+	 * @param array $classes String with the CSS classnames.
+	 * @return array Modified string of CSS classnames.
+	 */
+	public static function add_theme_admin_body_class( $classes = '' ) {
+		$classes .= ' theme-' . get_template();
 		return $classes;
 	}
 


### PR DESCRIPTION
Part of #2418.

### How to test the changes in this Pull Request:

1. With WooCommerce Core in `master`, verify there are no visual regressions.
2. With WooCommerce Core in https://github.com/woocommerce/woocommerce/pull/26516 branch (`fix/twenty-twenty-block-styles`), verify:
  2.1 In 'legacy' product grid blocks the `Sale!` badge is aligned to the top right.
  2.2 In 'legacy' product grid blocks the link underline is black.
  2.3 In _All Products_ block, prices are displayed with the correct font-family and font-sizes look the same as 'legacy' product grid blocks.
  2.4 In _All Products_ block, when there is a product with a long description, the layout is not broken.

### Screenshots
_Hand-Picked Products:_
| Before | After |
|---|---|
| ![imatge](https://user-images.githubusercontent.com/3616980/81954189-d8d58c80-9608-11ea-9b83-790105cd1d80.png) | ![imatge](https://user-images.githubusercontent.com/3616980/81954337-06bad100-9609-11ea-959f-d8c8a76585b0.png) |

_All Products:_
| Before | After |
|---|---|
| ![imatge](https://user-images.githubusercontent.com/3616980/81954078-b479b000-9608-11ea-95b2-a1723f7052b6.png) | ![imatge](https://user-images.githubusercontent.com/3616980/81956479-a5483180-960b-11ea-8665-4416443ca4e4.png) |

<!-- If you can, add the appropriate labels -->

### Changelog

> Improvements to the display of product grid blocks in Twenty Twenty.