### PR TITLE
Exclude three more files from the build ZIP

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -83,6 +83,9 @@ copy_dest_files() {
 		--exclude=package.json \
 		--exclude=package-lock.json \
 		--exclude=none \
+		--exclude=blocks.ini \
+		--exclude=docker-compose.yml \
+		--exclude=tsconfig.json \
 		--exclude=woocommerce-gutenberg-products-block.zip \
 		--exclude="zip-file/"
 	status "Done copying files!"

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -62,7 +62,10 @@ copy_dest_files() {
 	--exclude="*.config.json" \
 	--exclude=package.json \
 	--exclude=package-lock.json \
-	--exclude=none
+	--exclude=none \
+	--exclude=blocks.ini \
+	--exclude=docker-compose.yml \
+	--exclude=tsconfig.json
   output 2 "Done copying files!"
   cd "$3" || exit
 }


### PR DESCRIPTION
When releasing RC1 I noticed we were including three unnecessary files in the generated ZIP: `blocks.ini`, `docker-compose.yml` and `tsconfig.json`. This PR excludes them in the build scripts.

### How to test the changes in this Pull Request:

1. Run `npm run package-plugin`.
2. Verify the generated zip files doesn't include those files.