### PR TITLE
Fix misalignment between value and label in form components

### DIFF
--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -100,7 +100,7 @@
 		transform-origin: top left;
 		color: $gray-50;
 		transition: transform 200ms ease;
-		margin: 0 $gap;
+		margin: 0 0 0 calc(#{$gap} + 1px);
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: calc(100% - #{2 * $gap});

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -100,7 +100,7 @@
 		transform-origin: top left;
 		color: $gray-50;
 		transition: transform 200ms ease;
-		margin: 0 0 0 calc(#{$gap} + 1px);
+		margin: 0 0 0 #{$gap + 1px};
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: calc(100% - #{2 * $gap});

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -12,10 +12,10 @@
 		transition: all 200ms ease;
 		color: $gray-50;
 		z-index: 1;
-		margin: 0 $gap;
+		margin: 0 0 0 calc(#{$gap} + 1px);
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: calc(100% - #{  2 * $gap });
+		max-width: calc(100% - #{2 * $gap});
 		white-space: nowrap;
 
 		@media screen and (prefers-reduced-motion: reduce) {

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -12,7 +12,7 @@
 		transition: all 200ms ease;
 		color: $gray-50;
 		z-index: 1;
-		margin: 0 0 0 calc(#{$gap} + 1px);
+		margin: 0 0 0 #{$gap + 1px};
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: calc(100% - #{2 * $gap});

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -14,10 +14,10 @@
 		line-height: 1.375;
 		color: $gray-50;
 		transition: transform 200ms ease;
-		margin: 0 $gap;
+		margin: 0 0 0 calc(#{$gap} + 1px);
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: calc(100% - #{  2 * $gap });
+		max-width: calc(100% - #{2 * $gap});
 
 		@media screen and (prefers-reduced-motion: reduce) {
 			transition: none;

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -14,7 +14,7 @@
 		line-height: 1.375;
 		color: $gray-50;
 		transition: transform 200ms ease;
-		margin: 0 0 0 calc(#{$gap} + 1px);
+		margin: 0 0 0 #{$gap + 1px};
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: calc(100% - #{2 * $gap});


### PR DESCRIPTION
Fixes #2516.

We needed to add 1px to the left margin to account for the border.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/82430758-1a918780-9a8e-11ea-94ce-20edd3b65018.png)

### How to test the changes in this Pull Request:

1. Go to the _Checkout_ block and fill some inputs.
2. Verify there are no style regressions and inputs and selects values are correctly aligned with the labels.