### PR TITLE
Checkout steps improvements

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -14,9 +14,11 @@ const StepHeading = ( { title, stepHeadingContent } ) => (
 		<h4 aria-hidden="true" className="wc-block-checkout-step__title">
 			{ title }
 		</h4>
-		<span className="wc-block-checkout-step__heading-content">
-			{ stepHeadingContent }
-		</span>
+		{ !! stepHeadingContent && (
+			<span className="wc-block-checkout-step__heading-content">
+				{ stepHeadingContent }
+			</span>
+		) }
 	</div>
 );
 

--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -11,9 +11,9 @@ import './style.scss';
 
 const StepHeading = ( { title, stepHeadingContent } ) => (
 	<div className="wc-block-checkout-step__heading">
-		<h4 aria-hidden="true" className="wc-block-checkout-step__title">
+		<h2 aria-hidden="true" className="wc-block-checkout-step__title">
 			{ title }
-		</h4>
+		</h2>
 		{ !! stepHeadingContent && (
 			<span className="wc-block-checkout-step__heading-content">
 				{ stepHeadingContent }

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -59,6 +59,7 @@ $line-offset-from-circle-size: 8px;
 	@include font-size(14px);
 	counter-increment: checkout-step;
 	content: counter(checkout-step);
+	content: counter(checkout-step) / "";
 	position: absolute;
 	width: $circle-size;
 	height: $circle-size;


### PR DESCRIPTION
Small fixes to the Checkout steps:
- Don't render step heading content if it's empty (eba6f611ccf3fb88df0f9a7ed3f8ca4dc4322cdb).
- Make checkout step headings `<h2>` (2ae2a78250ac7364ebb94987da130c63f88667af). Even though they are `aria-hidden`, I still think it's better to follow the proper heading hierarchy.
- Add empty alt value to form step counter (cd13fe2c6fafc372ce03097d78c14fe2fca506da). The number was a bit confusing when it was read by screen readers. Notice alt text in generated content is [not supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/CSS/content#Browser_compatibility) so we need to keep the `content` declaration with no alt text as a fallback.

### How to test the changes in this Pull Request:

There is not much to test. Basically go to the _Checkout_ block and verify there are no regressions with the steps.