### PR TITLE
Include `onSubmit` handler for CheckoutForm component.

### DIFF
--- a/assets/js/base/components/cart-checkout/form/index.js
+++ b/assets/js/base/components/cart-checkout/form/index.js
@@ -9,9 +9,20 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 
-const CheckoutForm = ( { className, children } ) => {
+const CheckoutForm = ( {
+	className,
+	children,
+	onSubmit = ( event ) => void event,
+} ) => {
+	const formOnSubmit = ( event ) => {
+		event.preventDefault();
+		onSubmit( event );
+	};
 	return (
-		<form className={ classnames( 'wc-block-checkout-form', className ) }>
+		<form
+			className={ classnames( 'wc-block-checkout-form', className ) }
+			onSubmit={ formOnSubmit }
+		>
 			{ children }
 		</form>
 	);
@@ -20,6 +31,7 @@ const CheckoutForm = ( { className, children } ) => {
 CheckoutForm.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node,
+	onSubmit: PropTypes.func,
 };
 
 export default CheckoutForm;

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -305,8 +305,7 @@ export const CheckoutStateProvider = ( {
 		isSuccessResponse,
 	] );
 
-	const onSubmit = useCallback( ( event ) => {
-		event.preventDefault();
+	const onSubmit = useCallback( () => {
 		dispatch( actions.setBeforeProcessing() );
 	}, [] );
 

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -305,7 +305,8 @@ export const CheckoutStateProvider = ( {
 		isSuccessResponse,
 	] );
 
-	const onSubmit = useCallback( () => {
+	const onSubmit = useCallback( ( event ) => {
+		event.preventDefault();
 		dispatch( actions.setBeforeProcessing() );
 	}, [] );
 

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -111,6 +111,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		isIdle: checkoutIsIdle,
 		isProcessing: checkoutIsProcessing,
 		customerId,
+		onSubmit,
 	} = useCheckoutContext();
 	const {
 		hasValidationErrors,
@@ -206,7 +207,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 			<SidebarLayout className="wc-block-checkout">
 				<Main className="wc-block-checkout__main">
 					{ cartNeedsPayment && <ExpressCheckoutFormControl /> }
-					<CheckoutForm>
+					<CheckoutForm onSubmit={ onSubmit }>
 						<FormStep
 							id="contact-fields"
 							disabled={ checkoutIsProcessing }


### PR DESCRIPTION
Fixes: #2529.

See #2529 for background.

Currently the checkout form does not have a submit handler defined for the form itself. It appears that Firefox assumes a default event handler for the submit action if it's not explicitly defined.

Besides the fact that this caused unexpected reloads of the page in Firefox, there are also some potential a11y implications here for pressing the enter key (which is an alternative way for submitting a form) doing nothing.

The resolution for this is to include receiving an `onSubmit` event handler in the `CheckoutForm` component and preventing default behaviour in favor of the passed in event handler if it exists. Then I just ensured to pass through the `onSubmit` callback from the Checkout context state.

Note, while this fixes the reported Firefox bug, and _also_ adds submit handling when the Enter key is pressed in while a stripe field has focus, I was a bit surprised that if any other fields in the form have focus, enter key submission is not respected. I suspect this is because it is mapped for other uses by the fields. I don't think that should hold up this pull getting merged though (and am uncertain whether it's something we need to be concerned about for initial release).

## To test

- See the reproducing steps in #2529 and verify while checked out on this branch that the issue reported there is fixed.
- You should also notice that any validation will run.
- Verify clicking the submit button doesn't cause any issues.
- Verify using enter in the coupon code field doesn't cause any issues.