### PR TITLE
Use named font sizes instead of values in px

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -121,7 +121,7 @@ $font-sizes: (
 	-ms-word-break: break-all;
 }
 
-// Converts a px unit to rem.
-@function rem($size, $base: 16px) {
-	@return $size / $base * 1rem;
+// Converts a px unit to em.
+@function em($size, $base: 16px) {
+	@return $size / $base * 1em;
 }

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,10 +1,14 @@
-// Converts a font-size in px to rem and optionally sets a relative line-height.
-@mixin font-size($sizeValue: 16px, $lineHeight: false) {
-	font-size: ($sizeValue / 16px) * 1rem;
+$font-sizes: (
+	"smaller": 0.75,
+	"small": 0.875,
+	"regular": 1,
+	"large": 1.25,
+	"larger": 2,
+);
 
-	@if ($lineHeight) {
-		line-height: $lineHeight / $sizeValue;
-	}
+// Maps a named font-size to its em equivalent.
+@mixin font-size($sizeName) {
+	font-size: map-get($font-sizes, $sizeName) * 1em;
 }
 
 @keyframes loading-fade {

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,4 +1,4 @@
-$font-sizes: (
+$fontSizes: (
 	"smaller": 0.75,
 	"small": 0.875,
 	"regular": 1,
@@ -8,7 +8,7 @@ $font-sizes: (
 
 // Maps a named font-size to its em equivalent.
 @mixin font-size($sizeName) {
-	font-size: map-get($font-sizes, $sizeName) * 1em;
+	font-size: map-get($fontSizes, $sizeName) * 1em;
 }
 
 @keyframes loading-fade {

--- a/assets/js/base/components/block-error-boundary/style.scss
+++ b/assets/js/base/components/block-error-boundary/style.scss
@@ -9,7 +9,7 @@
 }
 
 .wc-block-error__header {
-	font-size: 2em;
+	@include font-size(larger);
 	font-weight: bold;
 	margin: 0;
 }

--- a/assets/js/base/components/cart-checkout/button/style.scss
+++ b/assets/js/base/components/cart-checkout/button/style.scss
@@ -5,7 +5,7 @@
 	color: $white;
 	display: flex;
 	font-weight: bold;
-	min-height: rem(48px); // 16px * 3 = 48px, same height as text-input
+	min-height: 3em;
 	justify-content: center;
 	line-height: 1;
 	padding: 0 $gap-small;

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -29,7 +29,7 @@ $line-offset-from-circle-size: 8px;
 	margin-bottom: $gap-smaller;
 
 	.wc-block-checkout-step__title {
-		@include font-size(16px);
+		@include font-size(regular);
 		line-height: 1.5;
 		color: $gray-80;
 		font-weight: 400;
@@ -38,7 +38,7 @@ $line-offset-from-circle-size: 8px;
 }
 
 .wc-block-checkout-step__heading-content {
-	@include font-size(12px);
+	@include font-size(smaller);
 	line-height: 2;
 	color: $gray-80;
 
@@ -49,14 +49,14 @@ $line-offset-from-circle-size: 8px;
 }
 
 .wc-block-checkout-step__description {
-	@include font-size(14px);
+	@include font-size(small);
 	line-height: 1.25;
 	color: $gray-60;
 	margin-bottom: $gap;
 }
 
 .wc-block-checkout-step::before {
-	@include font-size(14px);
+	@include font-size(small);
 	counter-increment: checkout-step;
 	content: counter(checkout-step);
 	position: absolute;

--- a/assets/js/base/components/cart-checkout/policies/style.scss
+++ b/assets/js/base/components/cart-checkout/policies/style.scss
@@ -1,6 +1,6 @@
 .editor-styles-wrapper .wc-block-components-checkout-policies,
 .wc-block-components-checkout-policies {
-	@include font-size(12px);
+	@include font-size(smaller);
 	text-align: center;
 	list-style: none outside;
 	line-height: 1;

--- a/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
@@ -1,5 +1,5 @@
 .wc-block-low-stock-badge {
-	@include font-size(12px);
+	@include font-size(smaller);
 	background-color: $white;
 	border-radius: 3px;
 	border: 1px solid $black;

--- a/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -1,5 +1,5 @@
 .wc-block-product-metadata {
-	@include font-size(12px);
+	@include font-size(smaller);
 	color: $core-grey-dark-400;
 
 	p,

--- a/assets/js/base/components/cart-checkout/product-name/style.scss
+++ b/assets/js/base/components/cart-checkout/product-name/style.scss
@@ -1,5 +1,5 @@
 .wc-block-product-name {
-	@include font-size(16px);
+	@include font-size(regular);
 	@include wrap-break-word();
 	display: block;
 	max-width: max-content;

--- a/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
@@ -1,5 +1,5 @@
 .wc-block-sale-badge {
-	@include font-size(12px);
+	@include font-size(smaller);
 	background-color: $core-grey-dark-600;
 	border-radius: 2px;
 	color: $white;

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
@@ -3,7 +3,7 @@
 }
 
 .wc-block-shipping-rates-control__package-items {
-	@include font-size(14px);
+	@include font-size(small);
 	color: $core-grey-dark-400;
 	display: block;
 	list-style: none;

--- a/assets/js/base/components/cart-checkout/totals/totals-footer-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-footer-item/style.scss
@@ -1,8 +1,8 @@
 .wc-block-totals-footer-item {
 	.wc-block-totals-table-item__value,
 	.wc-block-totals-table-item__label {
+		@include font-size(large);
 		color: #000;
-		font-size: 1.25em;
 	}
 
 	.wc-block-totals-table-item__label {

--- a/assets/js/base/components/cart-checkout/totals/totals-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-item/style.scss
@@ -15,6 +15,6 @@
 }
 
 .wc-block-totals-table-item__description {
-	@include font-size(14px);
+	@include font-size(small);
 	width: 100%;
 }

--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -22,12 +22,12 @@
 		padding-right: 0.5em;
 	}
 	.wc-block-components-chip__remove {
+		@include font-size(smaller);
 		background: transparent;
 		border: 0;
 		appearance: none;
 		float: none;
 		vertical-align: middle;
-		font-size: 0.75em; // If chip is 16px, this is 12px.
 		line-height: 1.33em;
 		padding: 0.66em; // Should equate to ~8px; chip has ~6px padding, and font size difference/2 is 2px.
 		margin: -0.66em;

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -4,9 +4,9 @@
 
 .wc-block-pagination-page,
 .wc-block-pagination-ellipsis {
+	@include font-size(regular);
 	color: #333;
 	display: inline-block;
-	font-size: 1em;
 	font-weight: normal;
 }
 

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -69,7 +69,8 @@
 	}
 
 	.wc-block-gateway-input {
-		@include font-size(16px, 22px);
+		@include font-size(regular);
+		line-height: 1.375;
 		background-color: #fff;
 		padding: $gap-small $gap;
 		border-radius: 4px;
@@ -92,7 +93,8 @@
 
 	label {
 		@include reset-typography();
-		@include font-size(16px, 22px);
+		@include font-size(regular);
+		line-height: 1.375;
 		position: absolute;
 		transform: translateY(0.75em);
 		left: 0;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -70,7 +70,7 @@
 
 	.wc-block-gateway-input {
 		@include font-size(regular);
-		line-height: 1.375;
+		line-height: 1.375; // =22px when font-size is 16px.
 		background-color: #fff;
 		padding: em($gap-small) $gap;
 		border-radius: 4px;
@@ -94,7 +94,7 @@
 	label {
 		@include reset-typography();
 		@include font-size(regular);
-		line-height: 1.375;
+		line-height: 1.375; // =22px when font-size is 16px.
 		position: absolute;
 		transform: translateY(0.75em);
 		left: 0;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -72,7 +72,7 @@
 		@include font-size(regular);
 		line-height: 1.375;
 		background-color: #fff;
-		padding: $gap-small $gap;
+		padding: em($gap-small) $gap;
 		border-radius: 4px;
 		border: 1px solid $input-border-gray;
 		width: 100%;
@@ -131,7 +131,7 @@
 
 	.wc-block-gateway-input.focused.empty,
 	.wc-block-gateway-input:not(.empty) {
-		padding: rem($gap-large) $gap rem($gap-smallest);
+		padding: em($gap-large) $gap em($gap-smallest);
 		& + label {
 			transform: translateY(#{$gap-smallest}) scale(0.75);
 		}

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -19,7 +19,7 @@
 
 	// Extra label for specificity needed in the editor.
 	input.wc-block-quantity-selector__input {
-		@include font-size(16px);
+		@include font-size(regular);
 		order: 2;
 		min-width: 40px;
 		flex: 1 1 auto;
@@ -49,7 +49,7 @@
 	}
 	.wc-block-quantity-selector__button {
 		@include reset-button;
-		@include font-size(16px);
+		@include font-size(regular);
 		min-width: 30px;
 		cursor: pointer;
 		color: $core-grey-dark-700;

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -50,7 +50,7 @@
 
 	.wc-block-radio-control__description,
 	.wc-block-radio-control__secondary-description {
-		font-size: 0.875em;
+		@include font-size(small);
 		line-height: 20px;
 		color: $core-grey-dark-400;
 	}

--- a/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/assets/js/base/components/reviews/review-list-item/style.scss
@@ -13,7 +13,7 @@
 		.wc-block-review-list-item__meta {
 			.wc-block-review-list-item__author {
 				@include placeholder();
-				font-size: 1em;
+				@include font-size(regular);
 				width: 80px;
 			}
 
@@ -156,13 +156,13 @@
 	order: 2;
 
 	> .wc-block-review-list-item__rating__stars {
+		@include font-size(regular);
 		display: inline-block;
 		top: 0;
 		overflow: hidden;
 		position: relative;
 		height: 1.618em;
 		line-height: 1.618;
-		font-size: 1em;
 		width: 5.3em;
 		font-family: star; /* stylelint-disable-line */
 		font-weight: 400;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -6,7 +6,7 @@
 	label {
 		@include reset-typography();
 		@include font-size(regular);
-		line-height: 1.375;
+		line-height: 1.375; // =22px when font-size is 16px.
 		position: absolute;
 		transform: translateY(0.75em);
 		transform-origin: top left;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,5 +1,5 @@
 .wc-block-select {
-	height: rem(48px);
+	height: 3em;
 	position: relative;
 	margin-bottom: rem($gap-large);
 
@@ -45,11 +45,11 @@
 		color: $input-text-active;
 		font-family: inherit;
 		font-weight: normal;
-		height: rem(48px);
+		height: 3em;
 		letter-spacing: inherit;
 		line-height: 1;
 		overflow: hidden;
-		padding: rem($gap-large) $gap rem($gap-smallest);
+		padding: em($gap-large) $gap em($gap-smallest);
 		text-overflow: ellipsis;
 		text-transform: none;
 		white-space: nowrap;

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -5,7 +5,8 @@
 
 	label {
 		@include reset-typography();
-		@include font-size(16px, 22px);
+		@include font-size(regular);
+		line-height: 1.375;
 		position: absolute;
 		transform: translateY(0.75em);
 		transform-origin: top left;
@@ -38,7 +39,7 @@
 	}
 
 	.components-custom-select-control__button {
-		@include font-size(16px);
+		@include font-size(regular);
 		background-color: #fff;
 		box-shadow: none;
 		color: $input-text-active;
@@ -79,7 +80,7 @@
 	}
 
 	.components-custom-select-control__item {
-		@include font-size(16px);
+		@include font-size(regular);
 		margin-left: 0;
 		padding-left: $gap;
 	}

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -25,7 +25,8 @@
 				outline: 1px dotted $gray-60;
 			}
 			.wc-block-components-tabs__item-content {
-				@include font-size(16px, 16px);
+				@include font-size(regular);
+				line-height: 1;
 				width: fit-content;
 				display: inline-block;
 				font-weight: bold;

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -1,6 +1,6 @@
 .wc-block-text-input {
 	position: relative;
-	margin-bottom: rem($gap-large);
+	margin-bottom: em($gap-large);
 	white-space: nowrap;
 
 	label {
@@ -38,7 +38,7 @@
 	input[type="email"] {
 		@include font-size(regular);
 		background-color: #fff;
-		padding: rem($gap-small) $gap;
+		padding: em($gap-small) $gap;
 		border-radius: 4px;
 		border: 1px solid $input-border-gray;
 		width: 100%;
@@ -46,7 +46,7 @@
 		font-family: inherit;
 		margin: 0;
 		box-sizing: border-box;
-		height: rem(48px);
+		height: 3em;
 		min-height: 0;
 		color: $input-text-active;
 
@@ -59,7 +59,7 @@
 	&.is-active input[type="url"],
 	&.is-active input[type="text"],
 	&.is-active input[type="email"] {
-		padding: rem($gap-large) 0 rem($gap-smallest) $gap;
+		padding: em($gap-large) 0 em($gap-smallest) $gap;
 	}
 
 	&.has-error input {

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -5,7 +5,7 @@
 
 	label {
 		@include reset-typography();
-		@include font-size(16px);
+		@include font-size(regular);
 		position: absolute;
 		transform: translateY(0.75em);
 		left: 0;
@@ -36,7 +36,7 @@
 	input[type="url"],
 	input[type="text"],
 	input[type="email"] {
-		@include font-size(16px);
+		@include font-size(regular);
 		background-color: #fff;
 		padding: rem($gap-small) $gap;
 		border-radius: 4px;

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -11,7 +11,7 @@
 		left: 0;
 		top: 0;
 		transform-origin: top left;
-		line-height: 1.375;
+		line-height: 1.375; // =22px when font-size is 16px.
 		color: $gray-50;
 		transition: transform 200ms ease;
 		margin: 0 0 0 #{$gap + 1px};
@@ -42,7 +42,7 @@
 		border-radius: 4px;
 		border: 1px solid $input-border-gray;
 		width: 100%;
-		line-height: 1.375;
+		line-height: 1.375; // =22px when font-size is 16px.
 		font-family: inherit;
 		margin: 0;
 		box-sizing: border-box;

--- a/assets/js/base/components/title/style.scss
+++ b/assets/js/base/components/title/style.scss
@@ -1,5 +1,5 @@
 // Extra class for specificity to overwrite editor styles.
 .wc-block-component__title.wc-block-component__title {
-	@include font-size(20px);
+	@include font-size(large);
 	font-weight: normal;
 }

--- a/assets/js/base/components/validation/style.scss
+++ b/assets/js/base/components/validation/style.scss
@@ -1,6 +1,6 @@
 .wc-block-form-input-validation-error {
+	@include font-size(smaller);
 	color: $error-red;
-	@include font-size(12px);
 	max-width: 100%;
 	position: absolute;
 	top: calc(100% - 1px);

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -237,7 +237,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 				) }
 			</p>
 			<Button
-				className="wc-block-attribute-filter__add_attribute_button"
+				className="wc-block-attribute-filter__add-attribute-button"
 				isDefault
 				isLarge
 				href={ getAdminLink(

--- a/assets/js/blocks/attribute-filter/editor.scss
+++ b/assets/js/blocks/attribute-filter/editor.scss
@@ -11,10 +11,6 @@
 	}
 	.components-placeholder__fieldset {
 		display: block; /* Disable flex box */
-
-		p {
-			@include font-size(14px);
-		}
 	}
 	.woocommerce-search-list__search {
 		border-top: 0;
@@ -22,7 +18,6 @@
 		padding-top: 0;
 	}
 	.wc-block-attribute-filter__add_attribute_button {
-		@include font-size(14px, 24px);
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/attribute-filter/editor.scss
+++ b/assets/js/blocks/attribute-filter/editor.scss
@@ -17,7 +17,7 @@
 		margin-top: 0;
 		padding-top: 0;
 	}
-	.wc-block-attribute-filter__add_attribute_button {
+	.wc-block-attribute-filter__add-attribute-button {
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -50,7 +50,7 @@ table.wc-block-cart-items {
 		padding-right: 0;
 	}
 	.wc-block-cart-items__header {
-		@include font-size(12px);
+		@include font-size(smaller);
 		text-transform: uppercase;
 
 		.wc-block-cart-items__header-image {
@@ -76,7 +76,7 @@ table.wc-block-cart-items {
 		.wc-block-cart-item__quantity {
 			.wc-block-cart-item__remove-link {
 				@include link-button;
-				@include font-size(12px);
+				@include font-size(smaller);
 
 				color: $core-grey-dark-400;
 				text-transform: none;
@@ -94,7 +94,7 @@ table.wc-block-cart-items {
 			}
 		}
 		.wc-block-cart-item__total {
-			@include font-size(16px);
+			@include font-size(regular);
 			text-align: right;
 			line-height: 1.25;
 

--- a/assets/js/blocks/cart-checkout/checkout/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/editor.scss
@@ -1,6 +1,6 @@
 .editor-styles-wrapper {
 	.wp-block h4.wc-block-checkout-step__title {
-		@include font-size(16px);
+		@include font-size(regular);
 		line-height: 24px;
 		margin: 0 $gap-small 0 0;
 	}

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -106,7 +106,6 @@
 		padding-left: $gap-large;
 		padding-top: $gap;
 		padding-bottom: $gap;
-		line-height: $gap-large;
 
 		p,
 		.wc-block-product-metadata {

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -106,10 +106,11 @@
 		padding-left: $gap-large;
 		padding-top: $gap;
 		padding-bottom: $gap;
+		line-height: 1.375;
 
 		p,
 		.wc-block-product-metadata {
-			line-height: $gap;
+			line-height: 1.375;
 			margin-top: #{ ( $gap-large - $gap ) / 2 };
 		}
 	}

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -84,7 +84,7 @@
 	}
 
 	.wc-block-order-summary-item__quantity {
-		@include font-size(12px);
+		@include font-size(smaller);
 		align-items: center;
 		background: #fff;
 		border: 2px solid currentColor;

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -133,7 +133,7 @@ export default function( { attributes, setAttributes } ) {
 				) }
 			</p>
 			<Button
-				className="wc-block-price-slider__add_product_button"
+				className="wc-block-price-slider__add-product-button"
 				isDefault
 				isLarge
 				href={ getAdminLink( 'post-new.php?post_type=product' ) }

--- a/assets/js/blocks/price-filter/editor.scss
+++ b/assets/js/blocks/price-filter/editor.scss
@@ -23,7 +23,7 @@
 	.components-placeholder__fieldset {
 		display: block; /* Disable flex box */
 	}
-	.wc-block-price-slider__add_product_button {
+	.wc-block-price-slider__add-product-button {
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/price-filter/editor.scss
+++ b/assets/js/blocks/price-filter/editor.scss
@@ -22,13 +22,8 @@
 	}
 	.components-placeholder__fieldset {
 		display: block; /* Disable flex box */
-
-		p {
-			@include font-size(14px);
-		}
 	}
 	.wc-block-price-slider__add_product_button {
-		@include font-size(14px, 24px);
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -67,11 +67,11 @@
 	border: none;
 	cursor: pointer;
 	background: none;
-	padding: 0 rem(8, 13);
+	padding: 0 0.5em;
 	color: #555d66;
 	position: relative;
 	overflow: hidden;
-	border-radius: rem(4, 13);
+	border-radius: 0.25em;
 	svg {
 		fill: currentColor;
 		outline: none;

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -15,11 +15,11 @@
 		border: none;
 		cursor: pointer;
 		background: none;
-		padding: 8px;
+		padding: 0 0.5em;
 		color: #555d66;
 		position: relative;
 		overflow: hidden;
-		border-radius: 4px;
+		border-radius: 0.25em;
 		svg {
 			fill: currentColor;
 			outline: none;

--- a/assets/js/blocks/products/editor.scss
+++ b/assets/js/blocks/products/editor.scss
@@ -11,13 +11,8 @@
 	}
 	.components-placeholder__fieldset {
 		display: block; /* Disable flex box */
-
-		p {
-			@include font-size(14px);
-		}
 	}
 	.wc-block-products__add_product_button {
-		@include font-size(14px, 24px);
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/products/editor.scss
+++ b/assets/js/blocks/products/editor.scss
@@ -12,7 +12,7 @@
 	.components-placeholder__fieldset {
 		display: block; /* Disable flex box */
 	}
-	.wc-block-products__add_product_button {
+	.wc-block-products__add-product-button {
 		margin: 0 0 1em;
 		vertical-align: middle;
 		height: auto;

--- a/assets/js/blocks/products/utils.js
+++ b/assets/js/blocks/products/utils.js
@@ -32,7 +32,7 @@ export const renderNoProductsPlaceholder = ( blockTitle, blockIcon ) => (
 			) }
 		</p>
 		<Button
-			className="wc-block-products__add_product_button"
+			className="wc-block-products__add-product-button"
 			isDefault
 			isLarge
 			href={ adminUrl + 'post-new.php?post_type=product' }

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -85,9 +85,7 @@ Styles placed in a `style.scss` file will be built into `build/style.css`, to lo
 
 ### Accessible font sizes
 
-We want our font sizes to be declared with rem or em units instead of hardcoded px. That's important for accessibility because it allows users to make the text bigger and easier to read.
-
-We have a mixin named `font-size()` that given a number of the font size in px, it converts it to rem. It accepts a second parameter which is the line height, it will be divided by the font-size and the result will be the relative units for the `line-height` CSS property.
+Font sizes must be defined using the `font-size()` mixin, it takes a size name (`smaller`, `small`, `regular`, `large`. `larger`) and returns a font-size declaration in em units. This allows having a consistent set of font sizes we use across blocks and using em means they are accessible and fit better in different themes.
 
 In parallel to that, consider whether other size/distance units in your CSS need to be rem/em instead of px. In general, rem/em should be preferred if it doesn't break the design with big font sizes. There is another mixin named `rem()` that helps converting px units to rem (given a px size and optionally a base size).
 

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -85,7 +85,7 @@ Styles placed in a `style.scss` file will be built into `build/style.css`, to lo
 
 ### Accessible font sizes
 
-Font sizes must be defined using the `font-size()` mixin, it takes a size name (`smaller`, `small`, `regular`, `large`. `larger`) and returns a font-size declaration in em units. This allows having a consistent set of font sizes we use across blocks and using em means they are accessible and fit better in different themes.
+Font sizes must be defined using the `font-size()` mixin, it takes a named size (`smaller`, `small`, `regular`, `large`. `larger`) and returns a font-size declaration in `em` units. This provides a consistent set of font sizes to be used across blocks, and by using `em` it increases the likelihood that blocks are accessible and fit better within different themes.
 
 In parallel to that, consider whether other size/distance units in your CSS need to be em instead of px. In general, em should be preferred if it doesn't break the layout with big font sizes. There is another mixin named `em()` that helps converting px units to em (given a px size and optionally a base size).
 

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -87,7 +87,7 @@ Styles placed in a `style.scss` file will be built into `build/style.css`, to lo
 
 Font sizes must be defined using the `font-size()` mixin, it takes a size name (`smaller`, `small`, `regular`, `large`. `larger`) and returns a font-size declaration in em units. This allows having a consistent set of font sizes we use across blocks and using em means they are accessible and fit better in different themes.
 
-In parallel to that, consider whether other size/distance units in your CSS need to be em instead of px. In general, em should be preferred if it doesn't break the design with big font sizes. There is another mixin named `em()` that helps converting px units to em (given a px size and optionally a base size).
+In parallel to that, consider whether other size/distance units in your CSS need to be em instead of px. In general, em should be preferred if it doesn't break the layout with big font sizes. There is another mixin named `em()` that helps converting px units to em (given a px size and optionally a base size).
 
 ### CSS specificity wars with 3rd party themes
 

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -87,7 +87,7 @@ Styles placed in a `style.scss` file will be built into `build/style.css`, to lo
 
 Font sizes must be defined using the `font-size()` mixin, it takes a size name (`smaller`, `small`, `regular`, `large`. `larger`) and returns a font-size declaration in em units. This allows having a consistent set of font sizes we use across blocks and using em means they are accessible and fit better in different themes.
 
-In parallel to that, consider whether other size/distance units in your CSS need to be rem/em instead of px. In general, rem/em should be preferred if it doesn't break the design with big font sizes. There is another mixin named `rem()` that helps converting px units to rem (given a px size and optionally a base size).
+In parallel to that, consider whether other size/distance units in your CSS need to be em instead of px. In general, em should be preferred if it doesn't break the design with big font sizes. There is another mixin named `em()` that helps converting px units to em (given a px size and optionally a base size).
 
 ### CSS specificity wars with 3rd party themes
 


### PR DESCRIPTION
Part of #2458.

This PR updates the `font-size` mixin to use named font sizes instead of px values.

The font size names are `smaller`, `small`, `regular`, `large` and `larger`, I chose this ones so it's consistent with the `$gap-xyz` [variables](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/assets/css/abstracts/_variables.scss#L1-L7) we have for margins/paddings.

Searching & replacing seemed to work quite well in most cases. :ok_hand: But I did some manual changes as well, I tried to comment all of them inline with the code. I didn't modify yet the _All Products_ and filter blocks until we agree on how to map their font sizes to the named ones (#2536).

### How to test the changes in this Pull Request:

1. Open the _Cart_ and _Checkout_ blocks and verify they look the same as they did.
2. It would be good to smoke test some other blocks as well to verify there are no regressions (no need to test the _All Products_ and filter blocks, they will be handled in another pull).
