### PR TITLE
Add arguments to wc_get_shipping_method_count()

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -108,7 +108,7 @@ class Checkout extends AbstractBlock {
 			$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : false;
 
 			if ( $screen && $screen->is_block_editor() && ! $data_registry->exists( 'shippingMethodsExist' ) ) {
-				$methods_exist = wc_get_shipping_method_count() > 0;
+				$methods_exist = wc_get_shipping_method_count( false, true ) > 0;
 				$data_registry->add( 'shippingMethodsExist', $methods_exist );
 			}
 		}


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce/pull/25753 we added an `$enabled_only` argument to `wc_get_shipping_method_count()`, so it only counts enabled shipping methods.

When deciding whether to display the 'no shipping methods' placeholder in the _Checkout_ block, we don't want to account for disabled methods, so we need to set that argument to true.

### How to test the changes in this Pull Request:

1. Make sure  you have the latest `master` of WooCommerce.
2. Disabled all shipping methods from your store.
3. Edit a page with the _Checkout_ block and verify the 'no shipping methods' placeholder appears.