### PR TITLE
Refactor E2E setup routine

### DIFF
--- a/tests/e2e-tests/config/jest.setup.js
+++ b/tests/e2e-tests/config/jest.setup.js
@@ -55,7 +55,7 @@ async function setupBrowser() {
  */
 async function importSampleProducts() {
 	await switchUserToAdmin();
-	// Visit `/wp-admin/edit.php?post_type=product` so we can see a list of products and delete them.
+	// Visit `/wp-admin/edit.php?post_type=product` so we can see a list of products and decide if we should import them or not.
 	await visitAdminPage( 'edit.php', 'post_type=product' );
 	const emptyState = await page.evaluate( () =>
 		window.find( 'Ready to start selling something awesome' )

--- a/tests/e2e-tests/config/jest.setup.js
+++ b/tests/e2e-tests/config/jest.setup.js
@@ -3,7 +3,6 @@
  */
 import { get } from 'lodash';
 import {
-	clearLocalStorage,
 	enablePageDialogAccept,
 	isOfflineMode,
 	setBrowserViewport,
@@ -46,66 +45,7 @@ const OBSERVED_CONSOLE_MESSAGE_TYPES = {
 };
 
 async function setupBrowser() {
-	await clearLocalStorage();
 	await setBrowserViewport( 'large' );
-}
-
-/**
- * Navigates to the post listing screen and bulk-trashes any posts which exist.
- *
- * @return {Promise} Promise resolving once posts have been trashed.
- */
-async function trashExistingPosts() {
-	await switchUserToAdmin();
-	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
-	await visitAdminPage( 'edit.php' );
-
-	// If this selector doesn't exist there are no posts for us to delete.
-	const bulkSelector = await page.$( '#bulk-action-selector-top' );
-	if ( ! bulkSelector ) {
-		return;
-	}
-
-	// Select all posts.
-	await page.waitForSelector( '#cb-select-all-1' );
-	await page.click( '#cb-select-all-1' );
-	// Select the "bulk actions" > "trash" option.
-	await page.select( '#bulk-action-selector-top', 'trash' );
-	// Submit the form to send all draft/scheduled/published posts to the trash.
-	await page.click( '#doaction' );
-	await page.waitForXPath(
-		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
-	);
-	await switchUserToTest();
-}
-
-/**
- * Navigates to the product listing screen and bulk-trashes any product which exist.
- *
- * @return {Promise} Promise resolving once products have been trashed.
- */
-async function trashExistingProducts() {
-	await switchUserToAdmin();
-	// Visit `/wp-admin/edit.php?post_type=product` so we can see a list of products and delete them.
-	await visitAdminPage( 'edit.php', 'post_type=product' );
-
-	// If this selector doesn't exist there are no products for us to delete.
-	const bulkSelector = await page.$( '#bulk-action-selector-top' );
-	if ( ! bulkSelector ) {
-		return;
-	}
-
-	// Select all products.
-	await page.waitForSelector( '#cb-select-all-1' );
-	await page.click( '#cb-select-all-1' );
-	// Select the "bulk actions" > "trash" option.
-	await page.select( '#bulk-action-selector-top', 'trash' );
-	// Submit the form to send all draft/scheduled/published posts to the trash.
-	await page.click( '#doaction' );
-	await page.waitForXPath(
-		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
-	);
-	await switchUserToTest();
 }
 
 /**
@@ -115,28 +55,38 @@ async function trashExistingProducts() {
  */
 async function importSampleProducts() {
 	await switchUserToAdmin();
-	// Visit Import Products page.
-	await visitAdminPage(
-		'edit.php',
-		'post_type=product&page=product_importer'
+	// Visit `/wp-admin/edit.php?post_type=product` so we can see a list of products and delete them.
+	await visitAdminPage( 'edit.php', 'post_type=product' );
+	const emptyState = await page.evaluate( () =>
+		window.find( 'Ready to start selling something awesome' )
 	);
-	await page.click( 'a.woocommerce-importer-toggle-advanced-options' );
-	await page.focus( '#woocommerce-importer-file-url' );
-	// local path for sample data that is included with woo.
-	await page.keyboard.type(
-		'wp-content/plugins/woocommerce/sample-data/sample_products.csv'
+	const noProduct = await page.evaluate( () =>
+		window.find( 'No products found' )
 	);
-	await page.click( '.wc-actions .button-next' );
-	await page.waitForSelector( '.wc-importer-mapping-table' );
-	await page.select(
-		'.wc-importer-mapping-table tr:nth-child(29) select',
-		''
-	);
-	await page.click( '.wc-actions .button-next' );
-	await page.waitForXPath(
-		"//*[@class='woocommerce-importer-done' and contains(., 'Import complete! ')]"
-	);
-	await switchUserToTest();
+	if ( emptyState || noProduct ) {
+		// Visit Import Products page.
+		await visitAdminPage(
+			'edit.php',
+			'post_type=product&page=product_importer'
+		);
+		await page.click( 'a.woocommerce-importer-toggle-advanced-options' );
+		await page.focus( '#woocommerce-importer-file-url' );
+		// local path for sample data that is included with woo.
+		await page.keyboard.type(
+			'wp-content/plugins/woocommerce/sample-data/sample_products.csv'
+		);
+		await page.click( '.wc-actions .button-next' );
+		await page.waitForSelector( '.wc-importer-mapping-table' );
+		await page.select(
+			'.wc-importer-mapping-table tr:nth-child(29) select',
+			''
+		);
+		await page.click( '.wc-actions .button-next' );
+		await page.waitForXPath(
+			"//*[@class='woocommerce-importer-done' and contains(., 'Import complete! ')]"
+		);
+		await switchUserToTest();
+	}
 }
 
 /**
@@ -256,8 +206,6 @@ beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
 	observeConsoleLogging();
-	await trashExistingPosts();
-	await trashExistingProducts();
 	await setupBrowser();
 	await importSampleProducts();
 } );


### PR DESCRIPTION
This PR does some things:

1- Remove unnecessary setup routine from jest-setup (delete posts and delete products), our tests don't affect those things so there is no need to run that, I ported them when I was setting things from Gutenberg.
2- It checks if we already have products before importing, this means we won't delete and import product on each test, reduce the time since we will cover 28 block.
3- Removes `clearLocalStorage` because it won't work unless I delete pages? didn't make sense to me, it was throwing `LocalStorage access denied` we don't manipulate local storage in our e2e tests, so this should be fine.
4- I tried to use [pptr-testing-library](https://github.com/testing-library/pptr-testing-library) didn't work well, seems that one is not fully stable yet for prep tests, causing ` Error: Execution context was destroyed, most likely because of a navigation.` when used.

Note, this test will also be deleted once we import Products via JSON, writing that json is tedious and I don't want it to block me right now while I ensure other blocks work fine.

No testing instructions required, this is safe as long as travis is green.