### PR TITLE
Ensure default selected tab is set for payment methods selection ui.

### DIFF
--- a/assets/js/base/components/tabs/index.js
+++ b/assets/js/base/components/tabs/index.js
@@ -20,12 +20,10 @@ const Tabs = ( {
 	instanceId,
 	id,
 } ) => {
-	const initialTab =
-		( initialTabName || !! tabs.length ) &&
-		`${ instanceId }-${ initialTabName ? initialTabName : tabs[ 0 ].name }`;
-	const tabState = useTabState( {
-		selectedId: initialTab,
-	} );
+	const initialTab = initialTabName
+		? { selectedId: `${ instanceId }-${ initialTabName }` }
+		: undefined;
+	const tabState = useTabState( initialTab );
 	if ( tabs.length === 0 ) {
 		return null;
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2531 (see for details).

The solution here was to just use the built-in functionality Reakit has for setting the default tab.

<!-- Don't forget to update the title with something descriptive. -->

## To test

- In incognito mode, make sure that the payment methods tabs has the default selected tab to the first tab.
- Next, while logged in as a users with saved payment methods, make sure that when you select the "Use a new payment method option", the payment methods tabs show with the first tab selected.