### PR TITLE
Fix broken dynamic address fields dependent on locale for selected country.

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -94,6 +94,7 @@ const AddressForm = ( {
 		countryValidationError,
 		setValidationErrors,
 		clearValidationError,
+		type,
 	] );
 
 	id = id || instanceId;

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -136,9 +136,8 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		setShippingAsBilling,
 		showBillingFields,
 	} = useCheckoutAddress();
-	const addressFields = useMemo( () => {
+	const addressFieldsConfig = useMemo( () => {
 		return {
-			...defaultAddressFields,
 			company: {
 				...defaultAddressFields.company,
 				hidden: ! attributes.showCompanyField,
@@ -253,8 +252,10 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									id="shipping"
 									onChange={ setShippingFields }
 									values={ shippingFields }
-									fields={ Object.keys( addressFields ) }
-									fieldConfig={ addressFields }
+									fields={ Object.keys(
+										defaultAddressFields
+									) }
+									fieldConfig={ addressFieldsConfig }
 								/>
 								{ attributes.showPhoneField && (
 									<ValidatedTextInput
@@ -311,8 +312,10 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									onChange={ setBillingFields }
 									type="billing"
 									values={ billingFields }
-									fields={ Object.keys( addressFields ) }
-									fieldConfig={ addressFields }
+									fields={ Object.keys(
+										defaultAddressFields
+									) }
+									fieldConfig={ addressFieldsConfig }
 								/>
 							</FormStep>
 						) }


### PR DESCRIPTION
Fixes: #2541

Albert noted in #2541 that the dynamic address fields feature was broken. This feature updated the address fields according to the locale settings for the selected country. I traced this to a regression introduced in #2374, and specifically this introduced code in f96b4b52a4c8:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/f96b4b52a4c87b97bfb585a25ad6afe6e6e4b61a/assets/js/blocks/cart-checkout/checkout/block.js#L143-L156

What was missed with that commit is that the address configuration fed to `AddressInput`  overrides any locale data set in `AddressInput` (because all the configuration fields were being passed through instead of just specific fields for which the configuration was being updated).

![Screen Recording 2020-05-23 at 10 46 AM](https://user-images.githubusercontent.com/1429108/82733593-cb906000-9ce2-11ea-8f40-6a6d2da22a8a.gif)

## To test

_For all the below, keep your console.log open and verify there are no warnings and/or errors_

- Verify the missing feature is now present (switch through different countries and ensure expected labels and fields update).
- Verify validation of missing fields still works as expected.
- Verify both shipping AND billing fields are fixed.
- Verify Cart address changes show expected fields
- Verify the block in the editor works as expected.
- Verify `Company` and `Phone` fields work as expected according to how they are configured by the block settings (visible, required, optional etc).
- Verify there is no regression with what was done in #2374 for keeping track of already set billing address.
- Make sure you test in incognito mode too.
- Verify purchase works without issue for all payment methods.
- Verify Express Payment method address updates work as expected.

