### PR TITLE
Add fixtures data for all entities.

### DIFF
--- a/.env
+++ b/.env
@@ -6,6 +6,7 @@ WORDPRESS_DB_PASSWORD=wordpress
 
 # WordPress CLI environment
 WORDPRESS_PORT=8084
+WORDPRESS_BASE_URL=http://localhost
 WORDPRESS_HOST=wordpress-www:80
 WORDPRESS_TITLE=WooCommerce Core E2E Test Suite
 WORDPRESS_LOGIN=admin

--- a/bin/docker/wordpress/Dockerfile
+++ b/bin/docker/wordpress/Dockerfile
@@ -1,1 +1,1 @@
-FROM wordpress:5.3
+FROM wordpress:5.4

--- a/bin/docker/wp-cli/entrypoint.sh
+++ b/bin/docker/wp-cli/entrypoint.sh
@@ -46,7 +46,9 @@ else
         --admin_email=${WORDPRESS_EMAIL} \
         --skip-email
 fi
+# WC Rest API needs pretty links to work
 wp rewrite structure "/%postname%/" --hard
+# we cannot create API keys for the API, so we using basic auth, this plugin allows that.
 wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 wp plugin install woocommerce --activate
 wp plugin activate woocommerce-gutenberg-products-block

--- a/bin/docker/wp-cli/entrypoint.sh
+++ b/bin/docker/wp-cli/entrypoint.sh
@@ -46,7 +46,7 @@ else
         --admin_email=${WORDPRESS_EMAIL} \
         --skip-email
 fi
-wp rewrite structure `/%postname%/`
+wp rewrite structure "/%postname%/" --hard
 wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 wp plugin install woocommerce --activate
 wp plugin activate woocommerce-gutenberg-products-block

--- a/bin/docker/wp-cli/entrypoint.sh
+++ b/bin/docker/wp-cli/entrypoint.sh
@@ -47,9 +47,10 @@ else
         --skip-email
 fi
 
+wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 wp plugin install woocommerce --activate
 wp plugin activate woocommerce-gutenberg-products-block
-wp theme install twentynineteen --activate
+wp theme install storefront --activate
 wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=customer --path=/var/www/html
 wp post create --post_type=page --post_status=publish --post_title='Ready' --post_content='E2E-tests.'
 

--- a/bin/docker/wp-cli/entrypoint.sh
+++ b/bin/docker/wp-cli/entrypoint.sh
@@ -46,7 +46,7 @@ else
         --admin_email=${WORDPRESS_EMAIL} \
         --skip-email
 fi
-wp rewrite structure `/%postname%/` --hard
+wp rewrite structure `/%postname%/`
 wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 wp plugin install woocommerce --activate
 wp plugin activate woocommerce-gutenberg-products-block

--- a/bin/docker/wp-cli/entrypoint.sh
+++ b/bin/docker/wp-cli/entrypoint.sh
@@ -46,7 +46,7 @@ else
         --admin_email=${WORDPRESS_EMAIL} \
         --skip-email
 fi
-
+wp rewrite structure `/%postname%/` --hard
 wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 wp plugin install woocommerce --activate
 wp plugin activate woocommerce-gutenberg-products-block

--- a/package-lock.json
+++ b/package-lock.json
@@ -7212,22 +7212,41 @@
       "integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w==",
       "dev": true
     },
-    "@woocommerce/woocommerce-rest-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@woocommerce/woocommerce-rest-api/-/woocommerce-rest-api-1.0.1.tgz",
-      "integrity": "sha512-YBk3EEYE0zax/egx6Rhpbu6hcCFyZpYQrjH9JO4NUGU3n3T0W9Edn7oAUbjL/c7Oezcg+UaQluCaKjY/B3zwxg==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.19.0",
-        "create-hmac": "^1.1.7",
-        "oauth-1.0a": "^2.2.6",
-        "url-parse": "^1.4.7"
-      }
+    "@svgr/babel-plugin-replace-jsx-attribute-value": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
+      "integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w==",
+      "dev": true
     },
-    "@wordpress/a11y": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.9.0.tgz",
-      "integrity": "sha512-1YBqy+yrAnCnQAayvQ6kx4O3vHq4EAyFh8UdNwbK0ZE4f+2Kzj/fD5QoICaTPl3vMzHb8ISeFyGFTxzqqBZh1g==",
+    "@svgr/babel-plugin-svg-dynamic-title": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.3.tgz",
+      "integrity": "sha512-w3Be6xUNdwgParsvxkkeZb545VhXEwjGMwExMVBIdPQJeyMQHqm9Msnb2a1teHBqUYL66qtwfhNkbj1iarCG7w==",
+      "dev": true
+    },
+    "@svgr/babel-plugin-svg-em-dimensions": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
+      "integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w==",
+      "dev": true
+    },
+    "@svgr/babel-plugin-transform-react-native-svg": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
+      "integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw==",
+      "dev": true
+    },
+    "@svgr/babel-plugin-transform-svg-component": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
+      "integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw==",
+      "dev": true
+    },
+    "@svgr/babel-preset": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.3.3.tgz",
+      "integrity": "sha512-6PG80tdz4eAlYUN3g5GZiUjg2FMcp+Wn6rtnz5WJG9ITGEF1pmFdzq02597Hn0OmnQuCVaBYQE1OVFAnwOl+0A==",
+      "dev": true,
       "requires": {
         "@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
         "@svgr/babel-plugin-remove-jsx-attribute": "^4.2.0",
@@ -8366,6 +8385,18 @@
       "requires": {
         "@babel/runtime-corejs2": "7.7.4",
         "locutus": "2.0.11"
+      }
+    },
+    "@woocommerce/woocommerce-rest-api": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@woocommerce/woocommerce-rest-api/-/woocommerce-rest-api-1.0.1.tgz",
+      "integrity": "sha512-YBk3EEYE0zax/egx6Rhpbu6hcCFyZpYQrjH9JO4NUGU3n3T0W9Edn7oAUbjL/c7Oezcg+UaQluCaKjY/B3zwxg==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.0",
+        "create-hmac": "^1.1.7",
+        "oauth-1.0a": "^2.2.6",
+        "url-parse": "^1.4.7"
       }
     },
     "@wordpress/a11y": {
@@ -9543,78 +9574,17 @@
               }
             }
           }
-        }
-      }
-    },
-    "autosize": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
-      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-    },
-    "axe-core": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
-      "integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==",
-      "dev": true
-    },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10"
-      }
-    },
-    "axobject-query": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
-      "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
         },
         "@wordpress/compose": {
-          "version": "3.15.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.15.0.tgz",
-          "integrity": "sha512-v174JYkPLECIfS5ebaKPengCG5FTyi9Ie6r6Mn2qJYsYXegvEdqCSreLsA3JViPvqC3Shx8MHnXBraz+kqYqQQ==",
+          "version": "3.16.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.16.0.tgz",
+          "integrity": "sha512-441spdHY6fBqDq3/MWFnhY8Q2MJTNTNK74mR06X1PXvVoQxuhW8SHJbb7+uHL9JiHAF5MRpqMTrslHC/iBD81A==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
             "@wordpress/element": "^2.14.0",
             "@wordpress/is-shallow-equal": "^2.0.0",
+            "clipboard": "^2.0.1",
             "lodash": "^4.17.15",
             "mousetrap": "^1.6.2",
             "react-resize-aware": "^3.0.0"
@@ -9656,20 +9626,20 @@
           }
         },
         "@wordpress/keycodes": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.12.0.tgz",
-          "integrity": "sha512-7fUwfquRLmE4CvJahZTHdNn31heoDcyZ4acgEQR4iKYsKjX6dF1coZjUe693xbf/4r8GmsOg0/uYDImMdDm+1Q==",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.13.0.tgz",
+          "integrity": "sha512-Bm3N4Qf5qLXds+eflM+JXD15VEW/7IQ7eqWt9/UhsssuDTMTMbXnYjxOAh5zoVi2toAMSMs8EYpV28V+Qv0ZjA==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
-            "@wordpress/i18n": "^3.12.0",
+            "@wordpress/i18n": "^3.13.0",
             "lodash": "^4.17.15"
           },
           "dependencies": {
             "@wordpress/i18n": {
-              "version": "3.12.0",
-              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.12.0.tgz",
-              "integrity": "sha512-QkdHd2Z2yTFItBnnzzjMW4IXJlofWMivct4BkgwRivrG7kLxE7nd2xMG3+hFkkdYGdzE67u8vmin0gmQ+14yPA==",
+              "version": "3.13.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.13.0.tgz",
+              "integrity": "sha512-eMlOvg2vYKmGV4C1vPrWuOEyskxMeCGoQJ0N3mQ6t7iWKs4bKWAJGlGL5QXMwN7xJJ863h3L7mrbLM3zKVrF1g==",
               "dev": true,
               "requires": {
                 "@babel/runtime": "^7.9.2",
@@ -9695,15 +9665,61 @@
           }
         },
         "@wordpress/viewport": {
-          "version": "2.17.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.17.0.tgz",
-          "integrity": "sha512-dTgYZY8O7S2/Cs5vXT2eTSlCcWMbqJvYcfO+MEGXdD2AoMyMm/8ERNLcaaVEi4TAFCFBLQSWJya6XIY8GGvW9g==",
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.18.0.tgz",
+          "integrity": "sha512-uJhcbEtFWYvm/QEVeBUaUzDVOHXzqKP9frunzI/VvwjgduGXY1h+ntPXGD+KKPDtsj9ORgPn9BMrpPNmHI2VjQ==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.9.2",
-            "@wordpress/compose": "^3.15.0",
-            "@wordpress/data": "^4.18.0",
+            "@wordpress/compose": "^3.16.0",
+            "@wordpress/data": "^4.19.0",
             "lodash": "^4.17.15"
+          },
+          "dependencies": {
+            "@wordpress/data": {
+              "version": "4.19.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.19.0.tgz",
+              "integrity": "sha512-WdTBlro46qbkGDGx1ORKmL74KGR1ApKc5g1lJk6jtHVZZ/atw4Kler4eqkkYQZORt8lDJWBEDdonTBzSneUkmg==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.9.2",
+                "@wordpress/compose": "^3.16.0",
+                "@wordpress/deprecated": "^2.8.0",
+                "@wordpress/element": "^2.14.0",
+                "@wordpress/is-shallow-equal": "^2.0.0",
+                "@wordpress/priority-queue": "^1.6.0",
+                "@wordpress/redux-routine": "^3.9.0",
+                "equivalent-key-map": "^0.2.2",
+                "is-promise": "^4.0.0",
+                "lodash": "^4.17.15",
+                "memize": "^1.1.0",
+                "redux": "^4.0.0",
+                "turbo-combine-reducers": "^1.0.2",
+                "use-memo-one": "^1.1.1"
+              }
+            },
+            "@wordpress/element": {
+              "version": "2.14.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.14.0.tgz",
+              "integrity": "sha512-msSkGecq2Z8lBoj95D0vxj64lbGx7c7Q8VxsNLA3G813HVybeY5gYeWFokWKfok+tszCwjJI4ZgR4DxRsYNTig==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.9.2",
+                "@wordpress/escape-html": "^1.8.0",
+                "lodash": "^4.17.15",
+                "react": "^16.9.0",
+                "react-dom": "^16.9.0"
+              }
+            },
+            "@wordpress/is-shallow-equal": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.0.0.tgz",
+              "integrity": "sha512-Xv8b3Jno/3Td6nyj1J+skW96sbyfX7W4sk0TLwN2C2Pz6iQTSTQyGrXmTZWShITt4SOeA8gKpP6kAwSZ4O0HOQ==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.9.2"
+              }
+            }
           }
         },
         "uuid": {
@@ -12166,6 +12182,15 @@
       "integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==",
       "dev": true
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "axobject-query": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
@@ -14111,37 +14136,10 @@
         "tslib": "^1.9.0"
       }
     },
-    "focus-lock": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.8.tgz",
-      "integrity": "sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==",
-      "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "for-in": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -18138,6 +18136,26 @@
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.8.tgz",
       "integrity": "sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7212,41 +7212,22 @@
       "integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w==",
       "dev": true
     },
-    "@svgr/babel-plugin-replace-jsx-attribute-value": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
-      "integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w==",
-      "dev": true
-    },
-    "@svgr/babel-plugin-svg-dynamic-title": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.3.tgz",
-      "integrity": "sha512-w3Be6xUNdwgParsvxkkeZb545VhXEwjGMwExMVBIdPQJeyMQHqm9Msnb2a1teHBqUYL66qtwfhNkbj1iarCG7w==",
-      "dev": true
-    },
-    "@svgr/babel-plugin-svg-em-dimensions": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
-      "integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w==",
-      "dev": true
-    },
-    "@svgr/babel-plugin-transform-react-native-svg": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
-      "integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw==",
-      "dev": true
-    },
-    "@svgr/babel-plugin-transform-svg-component": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
-      "integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw==",
-      "dev": true
-    },
-    "@svgr/babel-preset": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.3.3.tgz",
-      "integrity": "sha512-6PG80tdz4eAlYUN3g5GZiUjg2FMcp+Wn6rtnz5WJG9ITGEF1pmFdzq02597Hn0OmnQuCVaBYQE1OVFAnwOl+0A==",
+    "@woocommerce/woocommerce-rest-api": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@woocommerce/woocommerce-rest-api/-/woocommerce-rest-api-1.0.1.tgz",
+      "integrity": "sha512-YBk3EEYE0zax/egx6Rhpbu6hcCFyZpYQrjH9JO4NUGU3n3T0W9Edn7oAUbjL/c7Oezcg+UaQluCaKjY/B3zwxg==",
       "dev": true,
+      "requires": {
+        "axios": "^0.19.0",
+        "create-hmac": "^1.1.7",
+        "oauth-1.0a": "^2.2.6",
+        "url-parse": "^1.4.7"
+      }
+    },
+    "@wordpress/a11y": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.9.0.tgz",
+      "integrity": "sha512-1YBqy+yrAnCnQAayvQ6kx4O3vHq4EAyFh8UdNwbK0ZE4f+2Kzj/fD5QoICaTPl3vMzHb8ISeFyGFTxzqqBZh1g==",
       "requires": {
         "@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
         "@svgr/babel-plugin-remove-jsx-attribute": "^4.2.0",
@@ -9562,6 +9543,68 @@
               }
             }
           }
+        }
+      }
+    },
+    "autosize": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
+      "integrity": "sha512-jnSyH2d+qdfPGpWlcuhGiHmqBJ6g3X+8T+iRwFrHPLVcdoGJE/x6Qicm6aDHfTsbgZKxyV8UU/YB2p4cjKDRRA==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+    },
+    "axe-core": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.3.tgz",
+      "integrity": "sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "axobject-query": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
+      "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
         },
         "@wordpress/compose": {
           "version": "3.15.0",
@@ -14068,10 +14111,37 @@
         "tslib": "^1.9.0"
       }
     },
-    "ci-info": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    "focus-lock": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.8.tgz",
+      "integrity": "sha512-vkHTluRCoq9FcsrldC0ulQHiyBYgVJB2CX53I8r0nTC6KnEij7Of0jpBspjt3/CuNb6fyoj3aOh9J2HgQUM0og==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -28450,6 +28520,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+    },
+    "oauth-1.0a": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+      "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"@types/react": "16.9.35",
 		"@types/wordpress__data": "4.6.7",
 		"@types/wordpress__element": "2.4.1",
+		"@woocommerce/woocommerce-rest-api": "^1.0.1",
 		"@wordpress/babel-preset-default": "4.10.0",
 		"@wordpress/base-styles": "1.4.0",
 		"@wordpress/blocks": "6.12.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"@types/react": "16.9.35",
 		"@types/wordpress__data": "4.6.7",
 		"@types/wordpress__element": "2.4.1",
-		"@woocommerce/woocommerce-rest-api": "^1.0.1",
+		"@woocommerce/woocommerce-rest-api": "1.0.1",
 		"@wordpress/babel-preset-default": "4.10.0",
 		"@wordpress/base-styles": "1.4.0",
 		"@wordpress/blocks": "6.12.0",

--- a/tests/e2e-tests/config/default.json
+++ b/tests/e2e-tests/config/default.json
@@ -1,62 +1,62 @@
 {
-  "url": "http://localhost:8084/",
-  "users": {
-    "admin": {
-      "username": "admin",
-      "password": "password"
-    },
-    "customer": {
-      "username": "customer",
-      "password": "password"
-    }
-  },
-  "products": {
-    "simple": {
-      "name": "Simple product"
-    },
-    "variable": {
-      "name": "Variable Product with Three Variations"
-    }
-  },
-  "addresses": {
-    "admin": {
-      "store": {
-        "firstname": "John",
-        "lastname": "Doe",
-        "company": "Automattic",
-        "country": "United States (US)",
-        "addressfirstline": "addr 1",
-        "addresssecondline": "addr 2",
-        "city": "San Francisco",
-        "state": "CA",
-        "postcode": "94107"
-      }
-    },
-    "customer": {
-      "billing": {
-        "firstname": "John",
-        "lastname": "Doe",
-        "company": "Automattic",
-        "country": "United States (US)",
-        "addressfirstline": "addr 1",
-        "addresssecondline": "addr 2",
-        "city": "San Francisco",
-        "state": "CA",
-        "postcode": "94107",
-        "phone": "123456789",
-        "email": "john.doe@example.com"
-      },
-      "shipping": {
-        "firstname": "John",
-        "lastname": "Doe",
-        "company": "Automattic",
-        "country": "United States (US)",
-        "addressfirstline": "addr 1",
-        "addresssecondline": "addr 2",
-        "city": "San Francisco",
-        "state": "CA",
-        "postcode": "94107"
-      }
-    }
-  }
+	"url": "http://localhost:8084/",
+	"users": {
+		"admin": {
+			"username": "admin",
+			"password": "password"
+		},
+		"customer": {
+			"username": "customer",
+			"password": "password"
+		}
+	},
+	"products": {
+		"simple": {
+			"name": "Simple product"
+		},
+		"variable": {
+			"name": "Variable Product with Three Variations"
+		}
+	},
+	"addresses": {
+		"admin": {
+			"store": {
+				"firstname": "John",
+				"lastname": "Doe",
+				"company": "Automattic",
+				"country": "United States (US)",
+				"addressfirstline": "addr 1",
+				"addresssecondline": "addr 2",
+				"city": "San Francisco",
+				"state": "CA",
+				"postcode": "94107"
+			}
+		},
+		"customer": {
+			"billing": {
+				"firstname": "John",
+				"lastname": "Doe",
+				"company": "Automattic",
+				"country": "United States (US)",
+				"addressfirstline": "addr 1",
+				"addresssecondline": "addr 2",
+				"city": "San Francisco",
+				"state": "CA",
+				"postcode": "94107",
+				"phone": "123456789",
+				"email": "john.doe@example.com"
+			},
+			"shipping": {
+				"firstname": "John",
+				"lastname": "Doe",
+				"company": "Automattic",
+				"country": "United States (US)",
+				"addressfirstline": "addr 1",
+				"addresssecondline": "addr 2",
+				"city": "San Francisco",
+				"state": "CA",
+				"postcode": "94107"
+			}
+		}
+	}
 }

--- a/tests/e2e-tests/config/fixture-loaders.js
+++ b/tests/e2e-tests/config/fixture-loaders.js
@@ -1,0 +1,291 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-console */
+/**
+ * External dependencies
+ */
+const WooCommerceRestApi = require( '@woocommerce/woocommerce-rest-api' )
+	.default;
+
+const WooCommerce = new WooCommerceRestApi( {
+	url: 'http://localhost:8084/', // Your store URL
+	consumerKey: 'consumer_key', // Your consumer key
+	consumerSecret: 'consumer_secret', // Your consumer secret
+	version: 'wc/v3', // WooCommerce WP REST API version
+	axiosConfig: {
+		auth: {
+			username: 'admin',
+			password: 'password',
+		},
+	},
+} );
+
+const setupSettings = () => {
+	WooCommerce.post( 'settings/general/batch', {
+		update: [
+			{
+				id: 'woocommerce_store_address',
+				value: '60 29th Street #343',
+			},
+			{
+				id: 'woocommerce_store_city',
+				value: 'San Francisco',
+			},
+			{
+				id: 'woocommerce_store_country',
+				value: 'US:CA',
+			},
+			{
+				id: 'woocommerce_store_postcode',
+				value: '94110',
+			},
+			{
+				id: 'woocommerce_allowed_countries',
+				value: 'specific',
+			},
+			{
+				id: 'woocommerce_specific_allowed_countries',
+				value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
+			},
+			{
+				id: 'woocommerce_ship_to_countries',
+				value: 'specific',
+			},
+			{
+				id: 'woocommerce_specific_ship_to_countries',
+				value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
+			},
+			{
+				id: 'woocommerce_enable_coupons',
+				value: 'yes',
+			},
+			{
+				id: 'woocommerce_calc_taxes',
+				value: 'yes',
+			},
+			{
+				id: 'woocommerce_currency',
+				value: 'USD',
+			},
+		],
+	} ).catch( ( error ) => console.log( error ) );
+};
+
+const createTaxes = () => {
+	return WooCommerce.post( 'taxes/batch', {
+		create: [
+			{
+				country: 'US',
+				rate: '5.0000',
+				name: 'State Tax',
+				shipping: false,
+				priority: 1,
+			},
+			{
+				country: 'US',
+				rate: '10.000',
+				name: 'Sale Tax',
+				shipping: false,
+				priority: 2,
+			},
+			{
+				country: 'UK',
+				rate: '20.000',
+				name: 'VAT',
+				shipping: false,
+			},
+		],
+	} )
+		.then( ( response ) =>
+			response.data.create.map( ( taxes ) => taxes.id )
+		)
+		.catch( ( error ) => console.log( error ) );
+};
+
+const deleteTaxes = ( ids ) => {
+	WooCommerce.post( 'taxes/batch', {
+		delete: ids,
+	} ).catch( ( error ) => console.log( error ) );
+};
+const createCoupons = () => {
+	const coupons = [
+		{
+			code: 'coupon',
+			discount_type: 'fixed_cart',
+			amount: '5',
+		},
+		{
+			code: 'oldcoupon',
+			discount_type: 'fixed_cart',
+			amount: '5',
+			date_expires: '2020-01-01',
+		},
+		{
+			code: 'below100',
+			discount_type: 'percent',
+			amount: '20',
+			maximum_amount: '100.00',
+		},
+		{
+			code: 'above50',
+			discount_type: 'percent',
+			amount: '20',
+			minimum_amount: '50.00',
+		},
+		{
+			code: 'a12s',
+			discount_type: 'percent',
+			amount: '100',
+			individual_use: true,
+			email_restrictions: '*@automattic.com%2C *@a8c.com',
+		},
+		{
+			code: 'freeshipping',
+			discount_type: 'percent',
+			amount: '0',
+			free_shipping: true,
+		},
+	];
+	return WooCommerce.post( 'coupons/batch', { create: coupons } )
+		.then( ( response ) =>
+			response.data.create.map( ( coupon ) => coupon.id )
+		)
+		.catch( ( e ) => console.log( e.response.data.message ) );
+};
+const deleteCoupons = ( ids ) => {
+	return WooCommerce.post( 'coupons/batch', {
+		delete: ids,
+	} ).catch( ( error ) => console.log( error ) );
+};
+// currently this only creates a single product for the sake of review
+// more products will be added later
+const createProducts = () => {
+	return WooCommerce.post( 'products/batch', {
+		create: [
+			{
+				name: 'Woo Single #1',
+				type: 'simple',
+				regular_price: '21.99',
+				virtual: true,
+				downloadable: true,
+				downloads: [
+					{
+						name: 'Woo Single',
+						file:
+							'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/cd_4_angle.jpg',
+					},
+				],
+				images: [
+					{
+						src:
+							'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/cd_4_angle.jpg',
+					},
+				],
+			},
+		],
+	} )
+		.then( ( products ) => {
+			createReviews( products.data.create[ 0 ].id );
+			return products.data.create.map( ( product ) => product.id );
+		} )
+		.catch( ( e ) => console.log( e.response.data.message ) );
+};
+// deleting products will also delete review.
+const deleteProducts = ( ids ) => {
+	WooCommerce.post( 'products/batch', {
+		delete: ids,
+	} ).catch( ( error ) => console.log( error ) );
+};
+const createReviews = ( id ) => {
+	return WooCommerce.post( 'products/reviews/batch', {
+		create: [
+			{
+				product_id: id,
+				review: 'Looks fine',
+				reviewer: 'John Doe',
+				reviewer_email: 'john.doe@example.com',
+				rating: 4,
+			},
+			{
+				product_id: id,
+				review: 'I love this album',
+				reviewer: 'John Doe',
+				reviewer_email: 'john.doe@example.com',
+				rating: 5,
+			},
+			{
+				product_id: id,
+				review: 'a fine review',
+				reviewer: "John Doe' niece",
+				reviewer_email: 'john.doe@example.com',
+				rating: 5,
+			},
+		],
+	} ).catch( ( e ) => console.log( e.response.data.message ) );
+};
+const enableCheque = () => {
+	return WooCommerce.post( 'payment_gateways/cheque', {
+		enabled: true,
+	} ).catch( ( error ) => console.log( error ) );
+};
+const enablePaypal = () => {
+	return WooCommerce.post( 'payment_gateways/paypal', {
+		enabled: true,
+	} ).catch( ( error ) => console.log( error ) );
+};
+
+const enablePaymentGateways = () => {
+	Promise.all( [ enableCheque(), enablePaypal() ] );
+};
+
+const createShippingMethods = () => {
+	return WooCommerce.post( 'shipping/zones', { name: 'UK' } )
+		.then( ( response ) => {
+			return response.data.id;
+		} )
+		.then( ( zoneId ) => {
+			WooCommerce.put( `shipping/zones/${ zoneId }/locations`, {
+				code: 'UK',
+			} );
+			return zoneId;
+		} )
+		.then( ( zoneId ) => {
+			WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
+				method_id: 'flat_rate',
+				settings: {
+					title: 'Normal Shipping',
+					cost: '20.00',
+				},
+			} );
+			return zoneId;
+		} )
+		.then( ( zoneId ) => {
+			WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
+				method_id: 'free_shipping',
+				settings: {
+					title: 'Free Shipping',
+					cost: '00.00',
+					requires: 'coupon',
+				},
+			} );
+			return zoneId;
+		} )
+		.catch( ( e ) => console.log( e.response.data.message ) );
+};
+// deleting a zone will also delete methods and locations.
+const deleteShippingZone = ( id ) => {
+	WooCommerce.delete( `shipping/zones/${ id }`, {
+		force: true,
+	} ).catch( ( error ) => console.log( error ) );
+};
+module.exports = {
+	setupSettings,
+	createTaxes,
+	deleteTaxes,
+	createCoupons,
+	deleteCoupons,
+	createProducts,
+	deleteProducts,
+	enablePaymentGateways,
+	createShippingMethods,
+	deleteShippingZone,
+};

--- a/tests/e2e-tests/config/fixture-loaders.js
+++ b/tests/e2e-tests/config/fixture-loaders.js
@@ -238,44 +238,49 @@ const enablePaymentGateways = () => {
 };
 
 const createShippingMethods = () => {
-	return WooCommerce.post( 'shipping/zones', { name: 'UK' } )
-		.then( ( response ) => {
-			return response.data.id;
-		} )
-		.then( ( zoneId ) => {
-			WooCommerce.put( `shipping/zones/${ zoneId }/locations`, {
-				code: 'UK',
-			} );
-			return zoneId;
-		} )
-		.then( ( zoneId ) => {
-			WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
-				method_id: 'flat_rate',
-				settings: {
-					title: 'Normal Shipping',
-					cost: '20.00',
-				},
-			} );
-			return zoneId;
-		} )
-		.then( ( zoneId ) => {
-			WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
-				method_id: 'free_shipping',
-				settings: {
-					title: 'Free Shipping',
-					cost: '00.00',
-					requires: 'coupon',
-				},
-			} );
-			return zoneId;
-		} )
-		.catch( ( e ) => console.log( e.response.data.message ) );
+	const UKShipping = () =>
+		WooCommerce.post( 'shipping/zones', { name: 'UK' } )
+			.then( ( response ) => {
+				return response.data.id;
+			} )
+			.then( ( zoneId ) => {
+				WooCommerce.put( `shipping/zones/${ zoneId }/locations`, {
+					code: 'UK',
+				} );
+				return zoneId;
+			} )
+			.then( ( zoneId ) => {
+				WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
+					method_id: 'flat_rate',
+					settings: {
+						title: 'Normal Shipping',
+						cost: '20.00',
+					},
+				} );
+				return zoneId;
+			} )
+			.then( ( zoneId ) => {
+				WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
+					method_id: 'free_shipping',
+					settings: {
+						title: 'Free Shipping',
+						cost: '00.00',
+						requires: 'coupon',
+					},
+				} );
+				return zoneId;
+			} )
+			.catch( ( e ) => console.log( e.response.data.message ) );
+
+	return Promise.all( [ UKShipping() ] );
 };
 // deleting a zone will also delete methods and locations.
-const deleteShippingZone = ( id ) => {
-	WooCommerce.delete( `shipping/zones/${ id }`, {
-		force: true,
-	} ).catch( ( error ) => console.log( error ) );
+const deleteShippingZones = ( ids ) => {
+	const deleteZone = ( id ) =>
+		WooCommerce.delete( `shipping/zones/${ id }`, {
+			force: true,
+		} ).catch( ( error ) => console.log( error ) );
+	return Promise.all( ids.map( deleteZone ) );
 };
 module.exports = {
 	setupSettings,
@@ -287,5 +292,5 @@ module.exports = {
 	deleteProducts,
 	enablePaymentGateways,
 	createShippingMethods,
-	deleteShippingZone,
+	deleteShippingZones,
 };

--- a/tests/e2e-tests/config/fixture-loaders.js
+++ b/tests/e2e-tests/config/fixture-loaders.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable no-console */
 /**
  * External dependencies
@@ -6,15 +5,17 @@
 const WooCommerceRestApi = require( '@woocommerce/woocommerce-rest-api' )
 	.default;
 
+require( 'dotenv' ).config();
+
 const WooCommerce = new WooCommerceRestApi( {
-	url: 'http://localhost:8084/', // Your store URL
+	url: `${ process.env.WORDPRESS_BASE_URL }:${ process.env.WORDPRESS_PORT }/`, // Your store URL
 	consumerKey: 'consumer_key', // Your consumer key
 	consumerSecret: 'consumer_secret', // Your consumer secret
 	version: 'wc/v3', // WooCommerce WP REST API version
 	axiosConfig: {
 		auth: {
-			username: 'admin',
-			password: 'password',
+			username: process.env.WORDPRESS_LOGIN,
+			password: process.env.WORDPRESS_PASSWORD,
 		},
 	},
 } );

--- a/tests/e2e-tests/config/fixture-loaders.js
+++ b/tests/e2e-tests/config/fixture-loaders.js
@@ -2,8 +2,7 @@
 /**
  * External dependencies
  */
-const WooCommerceRestApi = require( '@woocommerce/woocommerce-rest-api' )
-	.default;
+import WooCommerceRestApi from '@woocommerce/woocommerce-rest-api';
 
 require( 'dotenv' ).config();
 

--- a/tests/e2e-tests/config/fixture-loaders.js
+++ b/tests/e2e-tests/config/fixture-loaders.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /**
  * External dependencies
  */
@@ -6,11 +5,15 @@ import WooCommerceRestApi from '@woocommerce/woocommerce-rest-api';
 
 require( 'dotenv' ).config();
 
+/**
+ * ConsumerKey and ConsumerSecret are not used, we use basic auth, but
+ * not providing them will throw an error.
+ */
 const WooCommerce = new WooCommerceRestApi( {
-	url: `${ process.env.WORDPRESS_BASE_URL }:${ process.env.WORDPRESS_PORT }/`, // Your store URL
+	url: `${ process.env.WORDPRESS_BASE_URL }:${ process.env.WORDPRESS_PORT }/`,
 	consumerKey: 'consumer_key', // Your consumer key
 	consumerSecret: 'consumer_secret', // Your consumer secret
-	version: 'wc/v3', // WooCommerce WP REST API version
+	version: 'wc/v3',
 	axiosConfig: {
 		auth: {
 			username: process.env.WORDPRESS_LOGIN,
@@ -19,7 +22,13 @@ const WooCommerce = new WooCommerceRestApi( {
 	},
 } );
 
-const setupSettings = () => {
+/**
+ * prepare some store settings.
+ *
+ * @return {Promise} return a promise that resolves to the created data or
+ * reject if the request failed.
+ */
+const setupSettings = () =>
 	WooCommerce.post( 'settings/general/batch', {
 		update: [
 			{
@@ -67,11 +76,16 @@ const setupSettings = () => {
 				value: 'USD',
 			},
 		],
-	} ).catch( ( error ) => console.log( error ) );
-};
+	} );
 
-const createTaxes = () => {
-	return WooCommerce.post( 'taxes/batch', {
+/**
+ * Create taxes.
+ *
+ * @return {Promise} a promise that resolves to an array of newly created taxes,
+ * or rejects if the request failed.
+ */
+const createTaxes = () =>
+	WooCommerce.post( 'taxes/batch', {
 		create: [
 			{
 				country: 'US',
@@ -94,18 +108,28 @@ const createTaxes = () => {
 				shipping: false,
 			},
 		],
-	} )
-		.then( ( response ) =>
-			response.data.create.map( ( taxes ) => taxes.id )
-		)
-		.catch( ( error ) => console.log( error ) );
-};
-
-const deleteTaxes = ( ids ) => {
+	} ).then( ( response ) =>
+		response.data.create.map( ( taxes ) => taxes.id )
+	);
+/**
+ * Delete taxes.
+ *
+ * @param {number[]} ids an array of taxes IDs to delete.
+ *
+ * @return {Promise} return a promise that resolves to the deleted data or
+ * reject if the request failed.
+ */
+const deleteTaxes = ( ids ) =>
 	WooCommerce.post( 'taxes/batch', {
 		delete: ids,
-	} ).catch( ( error ) => console.log( error ) );
-};
+	} );
+
+/**
+ * Create Coupons.
+ *
+ * @return {Promise} a promise that resolves to an array of newly created coupons,
+ * or rejects if the request failed.
+ */
 const createCoupons = () => {
 	const coupons = [
 		{
@@ -145,21 +169,36 @@ const createCoupons = () => {
 			free_shipping: true,
 		},
 	];
-	return WooCommerce.post( 'coupons/batch', { create: coupons } )
-		.then( ( response ) =>
-			response.data.create.map( ( coupon ) => coupon.id )
-		)
-		.catch( ( e ) => console.log( e.response.data.message ) );
-};
-const deleteCoupons = ( ids ) => {
 	return WooCommerce.post( 'coupons/batch', {
-		delete: ids,
-	} ).catch( ( error ) => console.log( error ) );
+		create: coupons,
+	} ).then( ( response ) =>
+		response.data.create.map( ( coupon ) => coupon.id )
+	);
 };
-// currently this only creates a single product for the sake of review
-// more products will be added later
-const createProducts = () => {
-	return WooCommerce.post( 'products/batch', {
+
+/**
+ * Delete coupons.
+ *
+ * @param {number[]} ids an array of coupons IDs to delete.
+ *
+ * @return {Promise} return a promise that resolves to the deleted data or
+ * reject if the request failed.
+ */
+const deleteCoupons = ( ids ) =>
+	WooCommerce.post( 'coupons/batch', {
+		delete: ids,
+	} );
+/**
+ * Create Products and call createReviews.
+ *
+ * @return {Promise} a promise that resolves to an array of newly created products,
+ * or rejects if the request failed.
+ *
+ * currently this only creates a single product for the sake of reviews.
+ * @todo: add more products to e2e fixtures data.
+ */
+const createProducts = () =>
+	WooCommerce.post( 'products/batch', {
 		create: [
 			{
 				name: 'Woo Single #1',
@@ -182,21 +221,39 @@ const createProducts = () => {
 				],
 			},
 		],
-	} )
-		.then( ( products ) => {
-			createReviews( products.data.create[ 0 ].id );
-			return products.data.create.map( ( product ) => product.id );
-		} )
-		.catch( ( e ) => console.log( e.response.data.message ) );
-};
-// deleting products will also delete review.
-const deleteProducts = ( ids ) => {
+	} ).then( ( products ) => {
+		createReviews( products.data.create[ 0 ].id );
+		return products.data.create.map( ( product ) => product.id );
+	} );
+
+/**
+ * Delete products.
+ *
+ * Deleting products will also delete review.
+ *
+ * @param {number[]} ids an array of products IDs to delete.
+ *
+ * @return {Promise} return a promise that resolves to the deleted data or
+ * reject if the request failed.
+ */
+const deleteProducts = ( ids ) =>
 	WooCommerce.post( 'products/batch', {
 		delete: ids,
-	} ).catch( ( error ) => console.log( error ) );
-};
-const createReviews = ( id ) => {
-	return WooCommerce.post( 'products/reviews/batch', {
+	} );
+
+/**
+ * Create Reviews.
+ *
+ * This is not called directly but is called within createProducts.
+ *
+ * @param {number} id product id to assign reviews to.
+ *
+ * @return {Promise} a promise that resolves to an server response data, or
+ * rejects if the request failed.
+ *
+ */
+const createReviews = ( id ) =>
+	WooCommerce.post( 'products/reviews/batch', {
 		create: [
 			{
 				product_id: id,
@@ -220,24 +277,56 @@ const createReviews = ( id ) => {
 				rating: 5,
 			},
 		],
-	} ).catch( ( e ) => console.log( e.response.data.message ) );
-};
-const enableCheque = () => {
-	return WooCommerce.post( 'payment_gateways/cheque', {
-		enabled: true,
-	} ).catch( ( error ) => console.log( error ) );
-};
-const enablePaypal = () => {
-	return WooCommerce.post( 'payment_gateways/paypal', {
-		enabled: true,
-	} ).catch( ( error ) => console.log( error ) );
-};
+	} );
 
-const enablePaymentGateways = () => {
+/**
+ * Enable Cheque payments.
+ *
+ * This is not called directly but is called within enablePaymentGateways.
+ *
+ * @return {Promise} a promise that resolves to an server response data, or
+ * rejects if the request failed.
+ */
+const enableCheque = () =>
+	WooCommerce.post( 'payment_gateways/cheque', {
+		enabled: true,
+	} );
+
+/**
+ * Enable Paypal payments.
+ *
+ * This is not called directly but is called within enablePaymentGateways.
+ *
+ * @return {Promise} a promise that resolves to an server response data, or
+ * rejects if the request failed.
+ */
+const enablePaypal = () =>
+	WooCommerce.post( 'payment_gateways/paypal', {
+		enabled: true,
+	} );
+
+/**
+ * Enable payment gateways.
+ *
+ * It calls other individual payment gateway functions.
+ *
+ * @return {Promise} a promise that resolves to an array of server response
+ * data, or rejects if the request failed.
+ */
+const enablePaymentGateways = () =>
 	Promise.all( [ enableCheque(), enablePaypal() ] );
-};
 
-const createShippingMethods = () => {
+/**
+ * Create shipping zones.
+ *
+ * Shipping locations need to be assigned to a zone, and shipping methods need
+ * to be assigned to a shipping location, this create a shipping zone and location
+ * and methods.
+ *
+ * @return {Promise} a promise that resolves to an array of newly created shipping
+ * zones IDs, or rejects if the request failed.
+ */
+const createShippingZones = () => {
 	const UKShipping = () =>
 		WooCommerce.post( 'shipping/zones', { name: 'UK' } )
 			.then( ( response ) => {
@@ -269,19 +358,29 @@ const createShippingMethods = () => {
 					},
 				} );
 				return zoneId;
-			} )
-			.catch( ( e ) => console.log( e.response.data.message ) );
+			} );
 
 	return Promise.all( [ UKShipping() ] );
 };
-// deleting a zone will also delete methods and locations.
+
+/**
+ * Delete Shipping zones.
+ *
+ * Deleting a shipping will also delete location and methods defined within it.
+ *
+ * @param {number[]} ids an array of shipping zones IDs to delete.
+ *
+ * @return {Promise} return a promise that resolves to an array of deleted data or
+ * reject if the request failed.
+ */
 const deleteShippingZones = ( ids ) => {
 	const deleteZone = ( id ) =>
 		WooCommerce.delete( `shipping/zones/${ id }`, {
 			force: true,
-		} ).catch( ( error ) => console.log( error ) );
+		} );
 	return Promise.all( ids.map( deleteZone ) );
 };
+
 module.exports = {
 	setupSettings,
 	createTaxes,
@@ -291,6 +390,6 @@ module.exports = {
 	createProducts,
 	deleteProducts,
 	enablePaymentGateways,
-	createShippingMethods,
+	createShippingZones,
 	deleteShippingZones,
 };

--- a/tests/e2e-tests/config/jest.config.js
+++ b/tests/e2e-tests/config/jest.config.js
@@ -14,7 +14,8 @@ module.exports = {
 
 	// Where to look for test files
 	roots: [ '<rootDir>/tests/e2e-tests/specs' ],
-
+	globalSetup: '<rootDir>/tests/e2e-tests/config/setup.js',
+	globalTeardown: '<rootDir>/tests/e2e-tests/config/teardown.js',
 	setupFiles: [ '<rootDir>/tests/e2e-tests/config/env.setup.js' ],
 	// A list of paths to modules that run some code to configure or set up the testing framework
 	// before each test

--- a/tests/e2e-tests/config/setup.js
+++ b/tests/e2e-tests/config/setup.js
@@ -13,7 +13,7 @@ import {
 	createProducts,
 	createShippingZones,
 	enablePaymentGateways,
-} from './fixture-loaders';
+} from '../fixtures/fixture-loaders';
 
 module.exports = async ( globalConfig ) => {
 	// we need to load puppeteer global setup here.

--- a/tests/e2e-tests/config/setup.js
+++ b/tests/e2e-tests/config/setup.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * External dependencies
  */
@@ -10,26 +11,35 @@ import {
 	createTaxes,
 	createCoupons,
 	createProducts,
-	createShippingMethods,
+	createShippingZones,
 	enablePaymentGateways,
 } from './fixture-loaders';
 
 module.exports = async ( globalConfig ) => {
+	// we need to load puppeteer global setup here.
 	await setupPuppeteer( globalConfig );
-	Promise.all( [
+
+	/**
+	 * Promise.all will return an array of all promises resolved values.
+	 * Some functions like setupSettings and enablePaymentGateways resolve
+	 * to server data so we ignore the values here.
+	 */
+	return Promise.all( [
 		setupSettings(),
 		createTaxes(),
 		createCoupons(),
 		createProducts(),
-		createShippingMethods(),
+		createShippingZones(),
 		enablePaymentGateways(),
-	] ).then( ( results ) => {
-		const [ , taxes, coupons, products, shippingMethods ] = results;
-		global.wc = {
-			taxes,
-			coupons,
-			products,
-			shippingMethods,
-		};
-	} );
+	] )
+		.then( ( results ) => {
+			const [ , taxes, coupons, products, shippingZones ] = results;
+			global.wc = {
+				taxes,
+				coupons,
+				products,
+				shippingZones,
+			};
+		} )
+		.catch( console.log );
 };

--- a/tests/e2e-tests/config/setup.js
+++ b/tests/e2e-tests/config/setup.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+const {
+	setupSettings,
+	createTaxes,
+	createCoupons,
+	createProducts,
+	createShippingMethods,
+	enablePaymentGateways,
+} = require( './fixture-loaders' );
+const { setup: setupPuppeteer } = require( 'jest-environment-puppeteer' );
+
+module.exports = async ( globalConfig ) => {
+	await setupPuppeteer( globalConfig );
+	Promise.all( [
+		setupSettings(),
+		createTaxes(),
+		createCoupons(),
+		createProducts(),
+		createShippingMethods(),
+		enablePaymentGateways(),
+	] ).then( ( results ) => {
+		const [ , taxes, coupons, products, shippingMethod ] = results;
+		global.wc = {
+			taxes,
+			coupons,
+			products,
+			shippingMethod,
+		};
+	} );
+};

--- a/tests/e2e-tests/config/setup.js
+++ b/tests/e2e-tests/config/setup.js
@@ -1,15 +1,18 @@
 /**
+ * External dependencies
+ */
+import { setup as setupPuppeteer } from 'jest-environment-puppeteer';
+/**
  * Internal dependencies
  */
-const {
+import {
 	setupSettings,
 	createTaxes,
 	createCoupons,
 	createProducts,
 	createShippingMethods,
 	enablePaymentGateways,
-} = require( './fixture-loaders' );
-const { setup: setupPuppeteer } = require( 'jest-environment-puppeteer' );
+} from './fixture-loaders';
 
 module.exports = async ( globalConfig ) => {
 	await setupPuppeteer( globalConfig );

--- a/tests/e2e-tests/config/setup.js
+++ b/tests/e2e-tests/config/setup.js
@@ -21,12 +21,12 @@ module.exports = async ( globalConfig ) => {
 		createShippingMethods(),
 		enablePaymentGateways(),
 	] ).then( ( results ) => {
-		const [ , taxes, coupons, products, shippingMethod ] = results;
+		const [ , taxes, coupons, products, shippingMethods ] = results;
 		global.wc = {
 			taxes,
 			coupons,
 			products,
-			shippingMethod,
+			shippingMethods,
 		};
 	} );
 };

--- a/tests/e2e-tests/config/setup.js
+++ b/tests/e2e-tests/config/setup.js
@@ -33,8 +33,14 @@ module.exports = async ( globalConfig ) => {
 		enablePaymentGateways(),
 	] )
 		.then( ( results ) => {
+			/**
+			 * We save our data in global so we can share it with teardown test.
+			 * It is relativity safe to hold this data in global since the context
+			 * in which setup and teardown run in is separate from the one our
+			 * test use, so there is no risk of data bleeding.
+			 */
 			const [ , taxes, coupons, products, shippingZones ] = results;
-			global.wc = {
+			global.fixtureData = {
 				taxes,
 				coupons,
 				products,

--- a/tests/e2e-tests/config/teardown.js
+++ b/tests/e2e-tests/config/teardown.js
@@ -12,7 +12,7 @@ import {
 	deleteCoupons,
 	deleteProducts,
 	deleteShippingZones,
-} from './fixture-loaders';
+} from '../fixtures/fixture-loaders';
 
 module.exports = async ( globalConfig ) => {
 	await teardownPuppeteer( globalConfig );

--- a/tests/e2e-tests/config/teardown.js
+++ b/tests/e2e-tests/config/teardown.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * External dependencies
  */
@@ -15,11 +16,11 @@ import {
 
 module.exports = async ( globalConfig ) => {
 	await teardownPuppeteer( globalConfig );
-	const { taxes, coupons, products, shippingMethods } = global.wc;
-	Promise.all( [
+	const { taxes, coupons, products, shippingZones } = global.wc;
+	return Promise.all( [
 		deleteTaxes( taxes ),
 		deleteCoupons( coupons ),
 		deleteProducts( products ),
-		deleteShippingZones( shippingMethods ),
-	] );
+		deleteShippingZones( shippingZones ),
+	] ).catch( console.log );
 };

--- a/tests/e2e-tests/config/teardown.js
+++ b/tests/e2e-tests/config/teardown.js
@@ -5,16 +5,16 @@ const {
 	deleteTaxes,
 	deleteCoupons,
 	deleteProducts,
-	deleteShippingZone,
+	deleteShippingZones,
 } = require( './fixture-loaders' );
 const { teardown: teardownPuppeteer } = require( 'jest-environment-puppeteer' );
 module.exports = async ( globalConfig ) => {
 	await teardownPuppeteer( globalConfig );
-	const { taxes, coupons, products, shippingMethod } = global.wc;
+	const { taxes, coupons, products, shippingMethods } = global.wc;
 	Promise.all( [
 		deleteTaxes( taxes ),
 		deleteCoupons( coupons ),
 		deleteProducts( products ),
-		deleteShippingZone( shippingMethod ),
+		deleteShippingZones( shippingMethods ),
 	] );
 };

--- a/tests/e2e-tests/config/teardown.js
+++ b/tests/e2e-tests/config/teardown.js
@@ -16,7 +16,7 @@ import {
 
 module.exports = async ( globalConfig ) => {
 	await teardownPuppeteer( globalConfig );
-	const { taxes, coupons, products, shippingZones } = global.wc;
+	const { taxes, coupons, products, shippingZones } = global.fixtureData;
 	return Promise.all( [
 		deleteTaxes( taxes ),
 		deleteCoupons( coupons ),

--- a/tests/e2e-tests/config/teardown.js
+++ b/tests/e2e-tests/config/teardown.js
@@ -1,13 +1,18 @@
 /**
+ * External dependencies
+ */
+import { teardown as teardownPuppeteer } from 'jest-environment-puppeteer';
+
+/**
  * Internal dependencies
  */
-const {
+import {
 	deleteTaxes,
 	deleteCoupons,
 	deleteProducts,
 	deleteShippingZones,
-} = require( './fixture-loaders' );
-const { teardown: teardownPuppeteer } = require( 'jest-environment-puppeteer' );
+} from './fixture-loaders';
+
 module.exports = async ( globalConfig ) => {
 	await teardownPuppeteer( globalConfig );
 	const { taxes, coupons, products, shippingMethods } = global.wc;

--- a/tests/e2e-tests/config/teardown.js
+++ b/tests/e2e-tests/config/teardown.js
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+const {
+	deleteTaxes,
+	deleteCoupons,
+	deleteProducts,
+	deleteShippingZone,
+} = require( './fixture-loaders' );
+const { teardown: teardownPuppeteer } = require( 'jest-environment-puppeteer' );
+module.exports = async ( globalConfig ) => {
+	await teardownPuppeteer( globalConfig );
+	const { taxes, coupons, products, shippingMethod } = global.wc;
+	Promise.all( [
+		deleteTaxes( taxes ),
+		deleteCoupons( coupons ),
+		deleteProducts( products ),
+		deleteShippingZone( shippingMethod ),
+	] );
+};

--- a/tests/e2e-tests/fixtures/fixture-data.js
+++ b/tests/e2e-tests/fixtures/fixture-data.js
@@ -1,3 +1,14 @@
+/**
+ * The default fixtures data is shaped according to WC REST API
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs|WooCommerce REST API}
+ */
+
+/**
+ * Coupons fixture data, using the create batch endpoint
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-coupons|Batch update coupons}
+ */
 const Coupons = () => [
 	{
 		code: 'coupon',
@@ -37,6 +48,12 @@ const Coupons = () => [
 	},
 ];
 
+/**
+ * Reviews fixture data, using the create batch endpoint
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-product-reviews|Batch update product reviews}
+ * @param {number} id Product ID to add reviews to.
+ */
 const ReviewsInProduct = ( id ) => [
 	{
 		product_id: id,
@@ -61,6 +78,11 @@ const ReviewsInProduct = ( id ) => [
 	},
 ];
 
+/**
+ * Product fixture data, using the create batch endpoint
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-products|Batch update products}
+ */
 const Products = () => [
 	{
 		name: 'Woo Single #1',
@@ -84,6 +106,11 @@ const Products = () => [
 	},
 ];
 
+/**
+ * Settings fixture data, using the update batch endpoint.
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-setting-options|Batch update setting options}
+ */
 const Settings = () => [
 	{
 		id: 'woocommerce_store_address',
@@ -131,6 +158,14 @@ const Settings = () => [
 	},
 ];
 
+/**
+ * Shipping Zones fixture data, using the shipping zone endpoint, shipping
+ * location, and shipping method endpoint.
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#create-a-shipping-zone|Create a shipping zone}
+ *  * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#update-a-locations-of-a-shipping-zone|Update a locations of a shipping zone}
+ *  * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#include-a-shipping-method-to-a-shipping-zone|Include a shipping method to a shipping zone}
+ */
 const Shipping = () => [
 	{
 		name: 'UK',
@@ -159,6 +194,11 @@ const Shipping = () => [
 	},
 ];
 
+/**
+ * Taxes rates fixture data, using the create batch endpoint.
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-tax-rates|Batch update tax rates}
+ */
 const Taxes = () => [
 	{
 		country: 'US',

--- a/tests/e2e-tests/fixtures/fixture-data.js
+++ b/tests/e2e-tests/fixtures/fixture-data.js
@@ -37,7 +37,7 @@ const Coupons = () => [
 	},
 ];
 
-const Reviews = ( id ) => [
+const ReviewsInProduct = ( id ) => [
 	{
 		product_id: id,
 		review: 'Looks fine',
@@ -184,7 +184,7 @@ const Taxes = () => [
 
 module.exports = {
 	Coupons,
-	Reviews,
+	ReviewsInProduct,
 	Products,
 	Settings,
 	Shipping,

--- a/tests/e2e-tests/fixtures/fixture-data.js
+++ b/tests/e2e-tests/fixtures/fixture-data.js
@@ -1,4 +1,67 @@
-export const Products = () => [
+const Coupons = () => [
+	{
+		code: 'coupon',
+		discount_type: 'fixed_cart',
+		amount: '5',
+	},
+	{
+		code: 'oldcoupon',
+		discount_type: 'fixed_cart',
+		amount: '5',
+		date_expires: '2020-01-01',
+	},
+	{
+		code: 'below100',
+		discount_type: 'percent',
+		amount: '20',
+		maximum_amount: '100.00',
+	},
+	{
+		code: 'above50',
+		discount_type: 'percent',
+		amount: '20',
+		minimum_amount: '50.00',
+	},
+	{
+		code: 'a12s',
+		discount_type: 'percent',
+		amount: '100',
+		individual_use: true,
+		email_restrictions: '*@automattic.com%2C *@a8c.com',
+	},
+	{
+		code: 'freeshipping',
+		discount_type: 'percent',
+		amount: '0',
+		free_shipping: true,
+	},
+];
+
+const Reviews = ( id ) => [
+	{
+		product_id: id,
+		review: 'Looks fine',
+		reviewer: 'John Doe',
+		reviewer_email: 'john.doe@example.com',
+		rating: 4,
+	},
+	{
+		product_id: id,
+		review: 'I love this album',
+		reviewer: 'John Doe',
+		reviewer_email: 'john.doe@example.com',
+		rating: 5,
+	},
+	{
+		product_id: id,
+		review: 'a fine review',
+		reviewer: "John Doe' niece",
+		reviewer_email: 'john.doe@example.com',
+		rating: 5,
+	},
+];
+
+const Products = () => [
 	{
 		name: 'Woo Single #1',
 		type: 'simple',
@@ -20,7 +83,8 @@ export const Products = () => [
 		],
 	},
 ];
-export const Settings = () => [
+
+const Settings = () => [
 	{
 		id: 'woocommerce_store_address',
 		value: '60 29th Street #343',
@@ -66,91 +130,8 @@ export const Settings = () => [
 		value: 'USD',
 	},
 ];
-export const Coupons = () => [
-	{
-		code: 'coupon',
-		discount_type: 'fixed_cart',
-		amount: '5',
-	},
-	{
-		code: 'oldcoupon',
-		discount_type: 'fixed_cart',
-		amount: '5',
-		date_expires: '2020-01-01',
-	},
-	{
-		code: 'below100',
-		discount_type: 'percent',
-		amount: '20',
-		maximum_amount: '100.00',
-	},
-	{
-		code: 'above50',
-		discount_type: 'percent',
-		amount: '20',
-		minimum_amount: '50.00',
-	},
-	{
-		code: 'a12s',
-		discount_type: 'percent',
-		amount: '100',
-		individual_use: true,
-		email_restrictions: '*@automattic.com%2C *@a8c.com',
-	},
-	{
-		code: 'freeshipping',
-		discount_type: 'percent',
-		amount: '0',
-		free_shipping: true,
-	},
-];
-export const Reviews = ( id ) => [
-	{
-		product_id: id,
-		review: 'Looks fine',
-		reviewer: 'John Doe',
-		reviewer_email: 'john.doe@example.com',
-		rating: 4,
-	},
-	{
-		product_id: id,
-		review: 'I love this album',
-		reviewer: 'John Doe',
-		reviewer_email: 'john.doe@example.com',
-		rating: 5,
-	},
-	{
-		product_id: id,
-		review: 'a fine review',
-		reviewer: "John Doe' niece",
-		reviewer_email: 'john.doe@example.com',
-		rating: 5,
-	},
-];
-export const Taxes = () => [
-	{
-		country: 'US',
-		rate: '5.0000',
-		name: 'State Tax',
-		shipping: false,
-		priority: 1,
-	},
-	{
-		country: 'US',
-		rate: '10.000',
-		name: 'Sale Tax',
-		shipping: false,
-		priority: 2,
-	},
-	{
-		country: 'UK',
-		rate: '20.000',
-		name: 'VAT',
-		shipping: false,
-	},
-];
 
-export const Shipping = () => [
+const Shipping = () => [
 	{
 		name: 'UK',
 		locations: [
@@ -177,3 +158,35 @@ export const Shipping = () => [
 		],
 	},
 ];
+
+const Taxes = () => [
+	{
+		country: 'US',
+		rate: '5.0000',
+		name: 'State Tax',
+		shipping: false,
+		priority: 1,
+	},
+	{
+		country: 'US',
+		rate: '10.000',
+		name: 'Sale Tax',
+		shipping: false,
+		priority: 2,
+	},
+	{
+		country: 'UK',
+		rate: '20.000',
+		name: 'VAT',
+		shipping: false,
+	},
+];
+
+module.exports = {
+	Coupons,
+	Reviews,
+	Products,
+	Settings,
+	Shipping,
+	Taxes,
+};

--- a/tests/e2e-tests/fixtures/fixture-data.js
+++ b/tests/e2e-tests/fixtures/fixture-data.js
@@ -1,0 +1,179 @@
+export const Products = () => [
+	{
+		name: 'Woo Single #1',
+		type: 'simple',
+		regular_price: '21.99',
+		virtual: true,
+		downloadable: true,
+		downloads: [
+			{
+				name: 'Woo Single',
+				file:
+					'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/cd_4_angle.jpg',
+			},
+		],
+		images: [
+			{
+				src:
+					'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/cd_4_angle.jpg',
+			},
+		],
+	},
+];
+export const Settings = () => [
+	{
+		id: 'woocommerce_store_address',
+		value: '60 29th Street #343',
+	},
+	{
+		id: 'woocommerce_store_city',
+		value: 'San Francisco',
+	},
+	{
+		id: 'woocommerce_store_country',
+		value: 'US:CA',
+	},
+	{
+		id: 'woocommerce_store_postcode',
+		value: '94110',
+	},
+	{
+		id: 'woocommerce_allowed_countries',
+		value: 'specific',
+	},
+	{
+		id: 'woocommerce_specific_allowed_countries',
+		value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
+	},
+	{
+		id: 'woocommerce_ship_to_countries',
+		value: 'specific',
+	},
+	{
+		id: 'woocommerce_specific_ship_to_countries',
+		value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
+	},
+	{
+		id: 'woocommerce_enable_coupons',
+		value: 'yes',
+	},
+	{
+		id: 'woocommerce_calc_taxes',
+		value: 'yes',
+	},
+	{
+		id: 'woocommerce_currency',
+		value: 'USD',
+	},
+];
+export const Coupons = () => [
+	{
+		code: 'coupon',
+		discount_type: 'fixed_cart',
+		amount: '5',
+	},
+	{
+		code: 'oldcoupon',
+		discount_type: 'fixed_cart',
+		amount: '5',
+		date_expires: '2020-01-01',
+	},
+	{
+		code: 'below100',
+		discount_type: 'percent',
+		amount: '20',
+		maximum_amount: '100.00',
+	},
+	{
+		code: 'above50',
+		discount_type: 'percent',
+		amount: '20',
+		minimum_amount: '50.00',
+	},
+	{
+		code: 'a12s',
+		discount_type: 'percent',
+		amount: '100',
+		individual_use: true,
+		email_restrictions: '*@automattic.com%2C *@a8c.com',
+	},
+	{
+		code: 'freeshipping',
+		discount_type: 'percent',
+		amount: '0',
+		free_shipping: true,
+	},
+];
+export const Reviews = ( id ) => [
+	{
+		product_id: id,
+		review: 'Looks fine',
+		reviewer: 'John Doe',
+		reviewer_email: 'john.doe@example.com',
+		rating: 4,
+	},
+	{
+		product_id: id,
+		review: 'I love this album',
+		reviewer: 'John Doe',
+		reviewer_email: 'john.doe@example.com',
+		rating: 5,
+	},
+	{
+		product_id: id,
+		review: 'a fine review',
+		reviewer: "John Doe' niece",
+		reviewer_email: 'john.doe@example.com',
+		rating: 5,
+	},
+];
+export const Taxes = () => [
+	{
+		country: 'US',
+		rate: '5.0000',
+		name: 'State Tax',
+		shipping: false,
+		priority: 1,
+	},
+	{
+		country: 'US',
+		rate: '10.000',
+		name: 'Sale Tax',
+		shipping: false,
+		priority: 2,
+	},
+	{
+		country: 'UK',
+		rate: '20.000',
+		name: 'VAT',
+		shipping: false,
+	},
+];
+
+export const Shipping = () => [
+	{
+		name: 'UK',
+		locations: [
+			{
+				code: 'UK',
+			},
+		],
+		methods: [
+			{
+				method_id: 'flat_rate',
+				settings: {
+					title: 'Normal Shipping',
+					cost: '20.00',
+				},
+			},
+			{
+				method_id: 'free_shipping',
+				settings: {
+					title: 'Free Shipping',
+					cost: '00.00',
+					requires: 'coupon',
+				},
+			},
+		],
+	},
+];

--- a/tests/e2e-tests/fixtures/fixture-loaders.js
+++ b/tests/e2e-tests/fixtures/fixture-loaders.js
@@ -249,7 +249,6 @@ const deleteShippingZones = ( ids ) => {
 	return Promise.all( ids.map( deleteZone ) );
 };
 
-deleteShippingZones( [ 16, 17, 18, 19, 20 ] );
 module.exports = {
 	setupSettings,
 	createTaxes,

--- a/tests/e2e-tests/fixtures/fixture-loaders.js
+++ b/tests/e2e-tests/fixtures/fixture-loaders.js
@@ -135,7 +135,7 @@ const deleteProducts = ( ids ) =>
  */
 const createReviews = ( id ) =>
 	WooCommerce.post( 'products/reviews/batch', {
-		create: fixtures.Reviews( id ),
+		create: fixtures.ReviewsInProduct( id ),
 	} );
 
 /**

--- a/tests/e2e-tests/fixtures/fixture-loaders.js
+++ b/tests/e2e-tests/fixtures/fixture-loaders.js
@@ -6,6 +6,12 @@ import WooCommerceRestApi from '@woocommerce/woocommerce-rest-api';
 require( 'dotenv' ).config();
 
 /**
+ * Internal dependencies
+ */
+
+import * as fixtures from './fixture-data';
+
+/**
  * ConsumerKey and ConsumerSecret are not used, we use basic auth, but
  * not providing them will throw an error.
  */
@@ -30,52 +36,7 @@ const WooCommerce = new WooCommerceRestApi( {
  */
 const setupSettings = () =>
 	WooCommerce.post( 'settings/general/batch', {
-		update: [
-			{
-				id: 'woocommerce_store_address',
-				value: '60 29th Street #343',
-			},
-			{
-				id: 'woocommerce_store_city',
-				value: 'San Francisco',
-			},
-			{
-				id: 'woocommerce_store_country',
-				value: 'US:CA',
-			},
-			{
-				id: 'woocommerce_store_postcode',
-				value: '94110',
-			},
-			{
-				id: 'woocommerce_allowed_countries',
-				value: 'specific',
-			},
-			{
-				id: 'woocommerce_specific_allowed_countries',
-				value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
-			},
-			{
-				id: 'woocommerce_ship_to_countries',
-				value: 'specific',
-			},
-			{
-				id: 'woocommerce_specific_ship_to_countries',
-				value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
-			},
-			{
-				id: 'woocommerce_enable_coupons',
-				value: 'yes',
-			},
-			{
-				id: 'woocommerce_calc_taxes',
-				value: 'yes',
-			},
-			{
-				id: 'woocommerce_currency',
-				value: 'USD',
-			},
-		],
+		update: fixtures.Settings(),
 	} );
 
 /**
@@ -86,28 +47,7 @@ const setupSettings = () =>
  */
 const createTaxes = () =>
 	WooCommerce.post( 'taxes/batch', {
-		create: [
-			{
-				country: 'US',
-				rate: '5.0000',
-				name: 'State Tax',
-				shipping: false,
-				priority: 1,
-			},
-			{
-				country: 'US',
-				rate: '10.000',
-				name: 'Sale Tax',
-				shipping: false,
-				priority: 2,
-			},
-			{
-				country: 'UK',
-				rate: '20.000',
-				name: 'VAT',
-				shipping: false,
-			},
-		],
+		create: fixtures.Taxes(),
 	} ).then( ( response ) =>
 		response.data.create.map( ( taxes ) => taxes.id )
 	);
@@ -130,51 +70,12 @@ const deleteTaxes = ( ids ) =>
  * @return {Promise} a promise that resolves to an array of newly created coupons,
  * or rejects if the request failed.
  */
-const createCoupons = () => {
-	const coupons = [
-		{
-			code: 'coupon',
-			discount_type: 'fixed_cart',
-			amount: '5',
-		},
-		{
-			code: 'oldcoupon',
-			discount_type: 'fixed_cart',
-			amount: '5',
-			date_expires: '2020-01-01',
-		},
-		{
-			code: 'below100',
-			discount_type: 'percent',
-			amount: '20',
-			maximum_amount: '100.00',
-		},
-		{
-			code: 'above50',
-			discount_type: 'percent',
-			amount: '20',
-			minimum_amount: '50.00',
-		},
-		{
-			code: 'a12s',
-			discount_type: 'percent',
-			amount: '100',
-			individual_use: true,
-			email_restrictions: '*@automattic.com%2C *@a8c.com',
-		},
-		{
-			code: 'freeshipping',
-			discount_type: 'percent',
-			amount: '0',
-			free_shipping: true,
-		},
-	];
-	return WooCommerce.post( 'coupons/batch', {
-		create: coupons,
+const createCoupons = () =>
+	WooCommerce.post( 'coupons/batch', {
+		create: fixtures.Coupons(),
 	} ).then( ( response ) =>
 		response.data.create.map( ( coupon ) => coupon.id )
 	);
-};
 
 /**
  * Delete coupons.
@@ -199,28 +100,7 @@ const deleteCoupons = ( ids ) =>
  */
 const createProducts = () =>
 	WooCommerce.post( 'products/batch', {
-		create: [
-			{
-				name: 'Woo Single #1',
-				type: 'simple',
-				regular_price: '21.99',
-				virtual: true,
-				downloadable: true,
-				downloads: [
-					{
-						name: 'Woo Single',
-						file:
-							'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/cd_4_angle.jpg',
-					},
-				],
-				images: [
-					{
-						src:
-							'http://demo.woothemes.com/woocommerce/wp-content/uploads/sites/56/2013/06/cd_4_angle.jpg',
-					},
-				],
-			},
-		],
+		create: fixtures.Products(),
 	} ).then( ( products ) => {
 		createReviews( products.data.create[ 0 ].id );
 		return products.data.create.map( ( product ) => product.id );
@@ -254,29 +134,7 @@ const deleteProducts = ( ids ) =>
  */
 const createReviews = ( id ) =>
 	WooCommerce.post( 'products/reviews/batch', {
-		create: [
-			{
-				product_id: id,
-				review: 'Looks fine',
-				reviewer: 'John Doe',
-				reviewer_email: 'john.doe@example.com',
-				rating: 4,
-			},
-			{
-				product_id: id,
-				review: 'I love this album',
-				reviewer: 'John Doe',
-				reviewer_email: 'john.doe@example.com',
-				rating: 5,
-			},
-			{
-				product_id: id,
-				review: 'a fine review',
-				reviewer: "John Doe' niece",
-				reviewer_email: 'john.doe@example.com',
-				rating: 5,
-			},
-		],
+		create: fixtures.Reviews( id ),
 	} );
 
 /**
@@ -327,40 +185,38 @@ const enablePaymentGateways = () =>
  * zones IDs, or rejects if the request failed.
  */
 const createShippingZones = () => {
-	const UKShipping = () =>
-		WooCommerce.post( 'shipping/zones', { name: 'UK' } )
-			.then( ( response ) => {
-				return response.data.id;
-			} )
-			.then( ( zoneId ) => {
-				WooCommerce.put( `shipping/zones/${ zoneId }/locations`, {
-					code: 'UK',
-				} );
-				return zoneId;
-			} )
-			.then( ( zoneId ) => {
-				WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
-					method_id: 'flat_rate',
-					settings: {
-						title: 'Normal Shipping',
-						cost: '20.00',
-					},
-				} );
-				return zoneId;
-			} )
-			.then( ( zoneId ) => {
-				WooCommerce.post( `shipping/zones/${ zoneId }/methods`, {
-					method_id: 'free_shipping',
-					settings: {
-						title: 'Free Shipping',
-						cost: '00.00',
-						requires: 'coupon',
-					},
-				} );
-				return zoneId;
-			} );
+	return Promise.all(
+		fixtures.Shipping().map( ( { name, locations, methods } ) => {
+			return WooCommerce.post( 'shipping/zones', { name } )
+				.then( ( response ) => {
+					return response.data.id;
+				} )
+				.then( ( zoneId ) => {
+					const locationsPromise = WooCommerce.put(
+						`shipping/zones/${ zoneId }/locations`,
+						locations
+					);
 
-	return Promise.all( [ UKShipping() ] );
+					return [ zoneId, locationsPromise ];
+				} )
+				.then( ( [ zoneId, locationsPromise ] ) => {
+					const methodPromise = Promise.all(
+						methods.map( ( method ) =>
+							WooCommerce.post(
+								`shipping/zones/${ zoneId }/methods`,
+								method
+							)
+						)
+					);
+					return [ zoneId, methodPromise, locationsPromise ];
+				} )
+				.then( ( [ zoneId, methodPromise, locationsPromise ] ) =>
+					Promise.all( [ methodPromise, locationsPromise ] ).then(
+						() => zoneId
+					)
+				);
+		} )
+	);
 };
 
 /**

--- a/tests/e2e-tests/fixtures/fixture-loaders.js
+++ b/tests/e2e-tests/fixtures/fixture-loaders.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import WooCommerceRestApi from '@woocommerce/woocommerce-rest-api';
+const WooCommerceRestApi = require( '@woocommerce/woocommerce-rest-api' )
+	.default;
 
 require( 'dotenv' ).config();
 
@@ -9,7 +10,7 @@ require( 'dotenv' ).config();
  * Internal dependencies
  */
 
-import * as fixtures from './fixture-data';
+const fixtures = require( './fixture-data' );
 
 /**
  * ConsumerKey and ConsumerSecret are not used, we use basic auth, but
@@ -237,6 +238,7 @@ const deleteShippingZones = ( ids ) => {
 	return Promise.all( ids.map( deleteZone ) );
 };
 
+deleteShippingZones( [ 16, 17, 18, 19, 20 ] );
 module.exports = {
 	setupSettings,
 	createTaxes,

--- a/tests/e2e-tests/fixtures/fixture-loaders.js
+++ b/tests/e2e-tests/fixtures/fixture-loaders.js
@@ -32,23 +32,27 @@ const WooCommerce = new WooCommerceRestApi( {
 /**
  * prepare some store settings.
  *
+ * @param {Object[]} fixture An array of objects describing our data, defaults
+ *                           to our fixture.
  * @return {Promise} return a promise that resolves to the created data or
  * reject if the request failed.
  */
-const setupSettings = () =>
+const setupSettings = ( fixture = fixtures.Settings() ) =>
 	WooCommerce.post( 'settings/general/batch', {
-		update: fixtures.Settings(),
+		update: fixture,
 	} );
 
 /**
  * Create taxes.
  *
+ * @param {Object[]} fixture An array of objects describing our data, defaults
+ * to our fixture.
  * @return {Promise} a promise that resolves to an array of newly created taxes,
  * or rejects if the request failed.
  */
-const createTaxes = () =>
+const createTaxes = ( fixture = fixtures.Taxes() ) =>
 	WooCommerce.post( 'taxes/batch', {
-		create: fixtures.Taxes(),
+		create: fixture,
 	} ).then( ( response ) =>
 		response.data.create.map( ( taxes ) => taxes.id )
 	);
@@ -68,12 +72,14 @@ const deleteTaxes = ( ids ) =>
 /**
  * Create Coupons.
  *
+ * @param {Object[]} fixture An array of objects describing our data, defaults
+ * to our fixture.
  * @return {Promise} a promise that resolves to an array of newly created coupons,
  * or rejects if the request failed.
  */
-const createCoupons = () =>
+const createCoupons = ( fixture = fixtures.Coupons() ) =>
 	WooCommerce.post( 'coupons/batch', {
-		create: fixtures.Coupons(),
+		create: fixture,
 	} ).then( ( response ) =>
 		response.data.create.map( ( coupon ) => coupon.id )
 	);
@@ -93,15 +99,17 @@ const deleteCoupons = ( ids ) =>
 /**
  * Create Products and call createReviews.
  *
+ * @param {Object[]} fixture An array of objects describing our data, defaults
+ * to our fixture.
  * @return {Promise} a promise that resolves to an array of newly created products,
  * or rejects if the request failed.
  *
  * currently this only creates a single product for the sake of reviews.
  * @todo: add more products to e2e fixtures data.
  */
-const createProducts = () =>
+const createProducts = ( fixture = fixtures.Products() ) =>
 	WooCommerce.post( 'products/batch', {
-		create: fixtures.Products(),
+		create: fixture,
 	} ).then( ( products ) => {
 		createReviews( products.data.create[ 0 ].id );
 		return products.data.create.map( ( product ) => product.id );
@@ -124,18 +132,18 @@ const deleteProducts = ( ids ) =>
 
 /**
  * Create Reviews.
+ 
+This is not called directly but is called within createProducts.
  *
- * This is not called directly but is called within createProducts.
- *
- * @param {number} id product id to assign reviews to.
- *
+ * @param {number}   id      product id to assign reviews to.
+ * @param {Object[]} fixture An array of objects describing our reviews, defaults
+ *                           to our fixture.
  * @return {Promise} a promise that resolves to an server response data, or
  * rejects if the request failed.
- *
  */
-const createReviews = ( id ) =>
+const createReviews = ( id, fixture = fixtures.ReviewsInProduct( id ) ) =>
 	WooCommerce.post( 'products/reviews/batch', {
-		create: fixtures.ReviewsInProduct( id ),
+		create: fixture,
 	} );
 
 /**
@@ -177,17 +185,20 @@ const enablePaymentGateways = () =>
 
 /**
  * Create shipping zones.
+ 
+Shipping locations need to be assigned to a zone, and shipping methods need
+to be assigned to a shipping location, this create a shipping zone and location
+and methods.
  *
- * Shipping locations need to be assigned to a zone, and shipping methods need
- * to be assigned to a shipping location, this create a shipping zone and location
- * and methods.
- *
+ * @param {Object[]} fixture An array of objects describing our data, defaults
+ *                           to our fixture.
  * @return {Promise} a promise that resolves to an array of newly created shipping
  * zones IDs, or rejects if the request failed.
+ 
  */
-const createShippingZones = () => {
+const createShippingZones = ( fixture = fixtures.Shipping() ) => {
 	return Promise.all(
-		fixtures.Shipping().map( ( { name, locations, methods } ) => {
+		fixture.map( ( { name, locations, methods } ) => {
 			return WooCommerce.post( 'shipping/zones', { name } )
 				.then( ( response ) => {
 					return response.data.id;


### PR DESCRIPTION
This PR depends (on builds upon https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2544) I set it against master so that travis can run.

This was a huge blocker for me, glad I get it done (almost).

ِAdds fixture data for settings, taxes, coupons, shipping, payment, reviews, and a single product (needed for reviews).

those items are loaded from WC REST API, so this is done very quickly.
the code is run only once before all tests start, after finishing tests, all created items will be deleted, for reference, only the created ones will get deleted.
If you happen to create something in a test, make sure to delete it yourself or append it to the delete queue.

```js
beforeAll( async () => {
// you created a product here
// single item
global.wc.products.push( productId );
// many items
global.wc.products = [ ...productIds, global.wc.products ];
});
```
Same applies for taxes, coupons, and shipping zones, each one is exposes in an array in:

```js
global.wc {
    coupons,
    products,
    taxes,
    shippingMethods,
}
```

### How to test the changes in this Pull Request:
* Start the docker instance `npm run test:e2e:up:build`
* build the blocks to the latest version `npm run build`
* run some e2e tests `npm run test:e2e`
* When tests end, visit http://localhost:8084
* Make sure there are no coupons, products,  shipping zones, or taxes.
* Make sure fixtures actually loaded, this is done by checking the store address, it will be `60 29th Street #343`.
* Stop the docker, by running `npm run test:e2e:down`

What will follow is more tests and more fixtures for products, for now, we will still use the standard routine we had from before.