### PR TITLE
Run e2e tests serially in travis to increase speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ jobs:
               - npm run test:e2e:up
               - composer install
               - npm run build:e2e-test
-              - npm run test:e2e
+              - npm run test:e2e:ci
           env:
               - WOOCOMMERCE_BLOCKS_PHASE=experimental
         - stage: deploy

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"test:e2e:up": "docker-compose up -d",
 		"test:e2e:up:build": "docker-compose up --build -d",
 		"test:e2e": "./tests/bin/e2e-test-integration.js",
+		"test:e2e:ci": "npm run test:e2e -- --runInBand",
 		"test:e2e-dev": "./tests/bin/e2e-test-integration.js --dev",
 		"test:e2e:update": "./tests/bin/e2e-test-integration.js -- --updateSnapshot",
 		"test:help": "wp-scripts test-unit-js --help",


### PR DESCRIPTION
Based on [this piece of docs in Jest](https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server) and[ jest-puppeteer](https://github.com/smooth-code/jest-puppeteer#running-puppeteer-in-ci-environments) running tests one at a team will actually increase the speed and reduce the timeout since e2e servers are different from your local SSD machine.

steps to test:
- Travis should pass.