### PR TITLE
Fix Products by Category JSON response error

### DIFF
--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -163,7 +163,7 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 	 * @param mixed $value Value to convert to an int.
 	 * @return int
 	 */
-	protected function get_intval( $value ) {
+	public function get_intval( $value ) {
 		return intval( $value, 10 );
 	}
 }

--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -41,7 +41,7 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 			'type'              => 'integer',
 			'minimum'           => 0,
 			'maximum'           => 100,
-			'sanitize_callback' => [$this, 'get_intval' ],
+			'sanitize_callback' => [ $this, 'get_intval' ],
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
@@ -164,6 +164,6 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 	 * @return int
 	 */
 	public function get_intval( $value ) {
-		return intval( $value, 10 );
+		return intval( $value );
 	}
 }

--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -41,7 +41,7 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 			'type'              => 'integer',
 			'minimum'           => 0,
 			'maximum'           => 100,
-			'sanitize_callback' => 'absint',
+			'sanitize_callback' => [$this, 'get_intval' ],
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 
@@ -155,5 +155,15 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 		$count_args = $args;
 		unset( $count_args['number'], $count_args['offset'] );
 		return (int) wp_count_terms( $taxonomy, $count_args );
+	}
+
+	/**
+	 * Wrapper of the `intval` function that only accepts one parameter.
+	 *
+	 * @param mixed $value Value to convert to an int.
+	 * @return int
+	 */
+	protected function get_intval( $value ) {
+		return intval( $value, 10 );
 	}
 }

--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -41,7 +41,7 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 			'type'              => 'integer',
 			'minimum'           => 0,
 			'maximum'           => 100,
-			'sanitize_callback' => 'intval',
+			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 


### PR DESCRIPTION
I'm not sure what are the exact steps to reproduce this issue, I found it in a random test site I have but everything was working fine in all others. After adding the _Products by Category_ block, the list of categories doesn't appear and instead it shows an error (`The response is not a valid JSON response.`):
![imatge](https://user-images.githubusercontent.com/3616980/82795335-260cf600-9e74-11ea-92de-a6bd2d0f18af.png)

Inspecting the JSON response, it's like this:
```JSON
Warning: intval() expects at most 2 parameters, 3 given in .../wp-includes/rest-api/class-wp-rest-request.php on line 804
[{"id":21,"name":"Accessories","slug":"accessories","description":"","parent":18,"count":5,"image":null,"review_count":0, ...}, ...]
```

After this PR, everything works fine again:
![imatge](https://user-images.githubusercontent.com/3616980/82795395-3de47a00-9e74-11ea-9fda-5397983ad768.png)

Tagging this as `blocker` because I was unable to reproduce it in 2.5.15, so it must be a regression in 2.6.

### How to test the changes in this Pull Request:

1. Add a _Products by Category_ block and verify there are no errors and you can select a category.