### PR TITLE
Improve readme.txt with note about nature of feature plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![Travis](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block.svg?branch=master)](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block)
 [![View](https://img.shields.io/badge/Project%20Components-brightgreen.svg?style=flat)](https://woocommerce.github.io/woocommerce-gutenberg-products-block)
 
-Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks for WooCommerce, and how WooCommerce might work with the block editor.
+Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks and updates to existing blocks for WooCommerce, and how WooCommerce might work with the block editor.
 
-If you're just looking to use these blocks, update to the latest version of WooCommerce! The blocks are bundled into WooCommerce since version 3.6, and can be added from the "WooCommerce" section in the block inserter.
+Use this plugin if you want access to the bleeding edge of available blocks for WooCommerce. However, stable blocks are bundled into WooCommerce, and can be added from the "WooCommerce" section in the block inserter.
 
 ## Documentation
 
@@ -16,14 +16,13 @@ If you want to see what we're working on for future versions, or want to help ou
 
 ## Table of Contents
 
--   [Installing the stable version](#installing-the-stable-version)
--   [Installing the development version](#installing-the-development-version)
--   [Getting started with block development](#getting-started-with-block-development)
--   [Contributing](docs)
-    -   [Publishing a release](docs/releases/readme.md)
--   Code Documentation
-    -   [Blocks](assets/js/blocks)
-    -   [Components](assets/js/components)
+- [WooCommerce Product Blocks](#woocommerce-product-blocks)
+  - [Documentation](#documentation)
+  - [Table of Contents](#table-of-contents)
+  - [Installing the stable version](#installing-the-stable-version)
+  - [Installing the development version](#installing-the-development-version)
+  - [Getting started with block development](#getting-started-with-block-development)
+  - [Vision for the Feature](#vision-for-the-feature)
 
 ## Installing the stable version
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WooCommerce Product Blocks
+# WooCommerce Product Blocks <!-- omit in toc -->
 
 [![Latest Tag](https://img.shields.io/github/tag/woocommerce/woocommerce-gutenberg-products-block.svg?style=flat&label=Latest%20Tag)](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases)
 [![Travis](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block.svg?branch=master)](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block)
@@ -8,21 +8,34 @@ Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to ite
 
 Use this plugin if you want access to the bleeding edge of available blocks for WooCommerce. However, stable blocks are bundled into WooCommerce, and can be added from the "WooCommerce" section in the block inserter.
 
+## Table of Contents <!-- omit in toc -->
+
+- [Documentation](#documentation)
+  - [Code Documentation](#code-documentation)
+  - [Contributing](#contributing)
+- [Contributing](#contributing-1)
+- [Installing the stable version](#installing-the-stable-version)
+- [Installing the development version](#installing-the-development-version)
+- [Getting started with block development](#getting-started-with-block-development)
+- [Vision for the Feature](#vision-for-the-feature)
+
 ## Documentation
 
 To find out more about the blocks and how to use them, [check out the documentation on WooCommerce.com](https://docs.woocommerce.com/document/woocommerce-blocks/).
 
 If you want to see what we're working on for future versions, or want to help out, read on.
 
-## Table of Contents
+### Code Documentation
 
-- [WooCommerce Product Blocks](#woocommerce-product-blocks)
-  - [Documentation](#documentation)
-  - [Table of Contents](#table-of-contents)
-  - [Installing the stable version](#installing-the-stable-version)
-  - [Installing the development version](#installing-the-development-version)
-  - [Getting started with block development](#getting-started-with-block-development)
-  - [Vision for the Feature](#vision-for-the-feature)
+- [Blocks](./assets/js/blocks)
+- [Components](assets/js/components)
+- [Other Docs](./docs)
+
+### Contributing
+
+- [Publishing a release](docs/releases/readme.md)
+
+## Contributing
 
 ## Installing the stable version
 

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,9 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages! This
 
-**Note: This is the feature plugin for WooCommerce Blocks which has the bleeding edge new blocks and updates to existing blocks for wider usage and testing before we release them in WooCommerce Core.**
+**Note: Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks and updates to existing blocks for WooCommerce, and how WooCommerce might work with the block editor.**
+
+Use this plugin if you want access to the bleeding edge of available blocks for WooCommerce. However, stable blocks are bundled into WooCommerce, and can be added from the "WooCommerce" section in the block inserter.
 
 **Featured Product Block**
 Select and display a single product in a new, high impact fashion. Control text alignment, hide or show the price and description, add a color overlay, change the button call to action, and override the product photo.

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Blocks ===
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia, aljullu, mikejolley, nerrad, joshuawold, assassinateur, haszari
 Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
-Requires at least: 5.0
-Tested up to: 5.3
+Requires at least: 5.2
+Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: 2.6.0-rc1
 License: GPLv3
@@ -10,7 +10,9 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 == Description ==
 
-WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages!
+WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages! This
+
+**Note: This is the feature plugin for WooCommerce Blocks which has the bleeding edge new blocks and updates to existing blocks for wider usage and testing before we release them in WooCommerce Core.**
 
 **Featured Product Block**
 Select and display a single product in a new, high impact fashion. Control text alignment, hide or show the price and description, add a color overlay, change the button call to action, and override the product photo.

--- a/readme.txt
+++ b/readme.txt
@@ -10,7 +10,7 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 == Description ==
 
-WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages! This
+WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages!
 
 **Note: Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks and updates to existing blocks for WooCommerce, and how WooCommerce might work with the block editor.**
 


### PR DESCRIPTION
The readme.txt file parsed for `wp.org` does not have any clear indication that it is a Feature plugin. I think it's important we highlight:

- It is a feature plugin where we experiment/iterate on new blocks and updates to existing blocks before they land in WooCommerce core.
- Only folks comfortable with using the bleeding edge of blocks should use this plugin.
- The _stable_ blocks are bundled with WooCommerce core

I also took the opportunity to update the README.md content in here to align with what is in readm.txt.