### PR TITLE
Ensure all inline @todos in code are covered by issues and obsolete @todos removed.

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -44,12 +44,11 @@ $error-red: #d94f4f;
 $box-shadow-blue: #5b9dd9;
 $core-orange: #ca4a1f;
 
-// @todo: replace those colors with the correct values once we settle on a design system palette.
 $gray-10: #c3c4c7;
 $gray-20: #a7aaad;
 $gray-50: #646970;
 $gray-60: #50575e;
 $gray-80: #2c3338;
-// @todo: align those colors with what we have
+
 $input-border-gray: #8d96a0;
 $input-text-active: #2b2d2f;

--- a/assets/js/base/components/payment-methods/express-checkout.js
+++ b/assets/js/base/components/payment-methods/express-checkout.js
@@ -34,8 +34,6 @@ const ExpressCheckoutContainer = ( { children } ) => {
 const ExpressCheckoutFormControl = () => {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
 
-	// determine whether we even show this
-	// @todo if in the editor we probably would want to show a placeholder maybe?
 	if (
 		! isInitialized ||
 		( isInitialized && Object.keys( paymentMethods ).length === 0 )

--- a/assets/js/base/hooks/order/use-store-order.js
+++ b/assets/js/base/hooks/order/use-store-order.js
@@ -1,6 +1,3 @@
-// @todo finish out this hook which will return a store draft order id and
-// order loading (likely from payment data context).
-
 export const useStoreOrder = () => {
 	const orderId = 0;
 	return {

--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -79,9 +79,6 @@ export const prepareTotalItems = ( totals, needsShipping ) => {
 	return newTotals;
 };
 
-// @todo This will expose the consistent properties used as the payment method
-// interface pulled from the various contexts exposing data for the interface.
-// @todo need to also include notices interfaces here (maybe?).
 /**
  * @return {RegisteredPaymentMethodProps} Interface to use as payment method props.
  */

--- a/assets/js/base/hooks/test/use-query-state.js
+++ b/assets/js/base/hooks/test/use-query-state.js
@@ -204,7 +204,7 @@ describe( 'Testing Query State Hooks', () => {
 			}
 		);
 	} );
-	// @todo, these tests only add partial coverage because the state is not
+	// Note: these tests only add partial coverage because the state is not
 	// actually updated by the action dispatch via our mocks.
 	describe( 'useSynchronizedQueryState', () => {
 		const TestComponent = getTestComponent( useSynchronizedQueryState, [

--- a/assets/js/blocks-registry/payment-methods/assertions.js
+++ b/assets/js/blocks-registry/payment-methods/assertions.js
@@ -7,7 +7,6 @@ export const assertValidPaymentMethodComponent = (
 	component,
 	componentName
 ) => {
-	// @todo detect if functional component (not render prop)
 	if ( typeof component !== 'function' ) {
 		throw new TypeError(
 			`The ${ componentName } property for the payment method must be a functional component`

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/normalize.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/normalize.js
@@ -38,8 +38,6 @@ const normalizeLineItems = ( cartTotalItems, pending = false ) => {
  * @return {StripeShippingOption[]}  An array of Stripe shipping option items.
  */
 const normalizeShippingOptions = ( shippingOptions ) => {
-	// @todo, note this currently does not handle multiple packages and this
-	// will need to be dealt with in a followup.
 	const rates = shippingOptions[ 0 ].shipping_rates;
 	return rates.map( ( rate ) => {
 		return {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -17,11 +17,6 @@ import { __ } from '@wordpress/i18n';
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').PreparedCartTotalItem} CartTotalItem
  */
 
-// @todo this can't be in the file because the block might not show up unless it's
-// rendered! (which also means it won't get passed from the server until it is rendered).
-// so we need to work out a loading process for when the cart or checkout hasn't been added to the
-// content yet - definitely don't want to load stripe without the block in the page. So that means
-// checkout will need to have some sort of editor preview for stripe.
 /**
  * Stripe data comes form the server passed on a global object.
  *

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -50,7 +50,7 @@ class Checkout extends AbstractBlock {
 	 */
 	public function render( $attributes = array(), $content = '' ) {
 		if ( $this->is_checkout_endpoint() ) {
-			// @todo Currently the block only takes care of the main checkout form -- if an endpoint is set, refer to the
+			// Note: Currently the block only takes care of the main checkout form -- if an endpoint is set, refer to the
 			// legacy shortcode instead and do not render block.
 			return '[woocommerce_checkout]';
 		}

--- a/src/Library.php
+++ b/src/Library.php
@@ -65,7 +65,7 @@ class Library {
 			'ProductSearch',
 			'ProductTag',
 		];
-		// @todo after refactoring dynamic block registration, this will be moved
+		// Note: as a part of refactoring dynamic block registration, this will be moved
 		// to block level config.
 		if ( version_compare( $wp_version, '5.2', '>' ) ) {
 			$blocks[] = 'AllProducts';

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -274,7 +274,6 @@ abstract class AbstractRoute implements RouteInterface {
 	 */
 	protected function maybe_load_cart() {
 		if ( ! did_action( 'woocommerce_load_cart_from_session' ) && function_exists( 'wc_load_cart' ) ) {
-			// @todo Load Dependencies for wc_load_cart(). See https://github.com/woocommerce/woocommerce/pull/26219
 			include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
 			include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
 			wc_load_cart();

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -363,7 +363,6 @@ class CartItemSchema extends ProductSchema {
 
 		$draft_order = wc()->session->get( 'store_api_draft_order', 0 );
 
-		// @todo Remove once min support for WC reaches 4.1.0.
 		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {
 			$reserve_stock = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
 		} else {

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -626,7 +626,6 @@ class CartController {
 	 * @return int
 	 */
 	protected function get_remaining_stock_for_product( $product ) {
-		// @todo Remove once min support for WC reaches 4.1.0.
 		if ( \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ) {
 			$reserve_stock_controller = new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock();
 		} else {


### PR DESCRIPTION
Now that we have a [todo Github Action workflow](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/.github/workflows/project-management-automations.yml) in place, I thought it'd be good to go through all the inline todos found in our code and make sure:

- if they are still valid, there's a corresponding issue created in the project for it (then remove the todo).
- If the todo has already been handled, remove it.

This pull takes care of that. There are no changes to user facing code so this won't impact any builds.

For review, it's probably easiest to go commit by commit because the commits are descriptive about the change in them.