### PR TITLE
Updates for the abstract block class

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -37,8 +37,13 @@ abstract class AbstractBlock {
 
 	/**
 	 * Constructor
+	 *
+	 * @param string $block_name Optional set block name during construct.
 	 */
-	public function __construct() {
+	public function __construct( $block_name = '' ) {
+		if ( $block_name ) {
+			$this->block_name = $block_name;
+		}
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );
 	}
 
@@ -102,7 +107,7 @@ abstract class AbstractBlock {
 	 * @return string Rendered block with data attributes.
 	 */
 	protected function inject_html_data_attributes( $content, array $attributes ) {
-		return preg_replace( '/<div /', '<div ' . $this->get_html_data_attributes( $attributes ), $content, 1 );
+		return preg_replace( '/<div /', '<div ' . $this->get_html_data_attributes( $attributes ) . ' ', $content, 1 );
 	}
 
 	/**
@@ -117,6 +122,9 @@ abstract class AbstractBlock {
 		foreach ( $attributes as $key => $value ) {
 			if ( is_bool( $value ) ) {
 				$value = $value ? 'true' : 'false';
+			}
+			if ( ! is_scalar( $value ) ) {
+				$value = wp_json_encode( $value );
 			}
 			$data[] = 'data-' . esc_attr( strtolower( preg_replace( '/(?<!\ )[A-Z]/', '-$0', $key ) ) ) . '="' . esc_attr( $value ) . '"';
 		}


### PR DESCRIPTION
_[#2399](_https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/) is a mammoth PR so I'm breaking out some fixes and changes to review separately._

This updates the Abstract Block class to:

1. Allow the block name to be added via the constructor. I will need this to register Atomic Blocks later on to allow class reuse, otherwise I'd need a class per atomic block.
2. Fixes a white space issue in the attributes replacement.
3. Fixes array/object handling - they need converting to JSON before appending to the HTML.

These are under the hood changes for future use, so nothing specific to test against so long as tests pass and no obvious regressions occur.