### PR TITLE
Accept object parameters in renderFrontend utility

### DIFF
--- a/assets/js/base/utils/index.js
+++ b/assets/js/base/utils/index.js
@@ -3,3 +3,4 @@ export * from './price';
 export * from './address';
 export * from './shipping-rates';
 export * from './legacy-events';
+export * from './render-frontend';

--- a/assets/js/base/utils/render-frontend.js
+++ b/assets/js/base/utils/render-frontend.js
@@ -38,20 +38,18 @@ export const getAttributesFromDataset = ( blockAttributes, dataset ) => {
 /**
  * Renders a block component in the place of a specified set of selectors.
  *
- * @param {string}   selector                CSS selector to match the elements
- * to replace.
- * @param {Function} Block                   React block to use as a replacement.
- * @param {Function} [getProps]              Function to generate the props
- * object for the block.
- * @param {Function} [getErrorBoundaryProps] Function to generate the props
- * object for the error boundary.
+ * @param {Object}   props                         Render props.
+ * @param {string}   props.selector                CSS selector to match the elements to replace.
+ * @param {Function} props.Block                   React component to use as a replacement.
+ * @param {Function} [props.getProps ]             Function to generate the props object for the block.
+ * @param {Function} [props.getErrorBoundaryProps] Function to generate the props object for the error boundary.
  */
-export const renderFrontend = (
+export const renderFrontend = ( {
 	selector,
 	Block,
 	getProps = () => {},
-	getErrorBoundaryProps = () => {}
-) => {
+	getErrorBoundaryProps = () => {},
+} ) => {
 	const containers = document.querySelectorAll( selector );
 
 	if ( containers.length ) {

--- a/assets/js/blocks/active-filters/frontend.js
+++ b/assets/js/blocks/active-filters/frontend.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { withRestApiHydration } from '@woocommerce/block-hocs';
+import { renderFrontend } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
  */
 import Block from './block.js';
-import renderFrontend from '../../utils/render-frontend.js';
 
 const getProps = ( el ) => {
 	return {
@@ -19,8 +19,8 @@ const getProps = ( el ) => {
 	};
 };
 
-renderFrontend(
-	'.wp-block-woocommerce-active-filters',
-	withRestApiHydration( Block ),
-	getProps
-);
+renderFrontend( {
+	selector: '.wp-block-woocommerce-active-filters',
+	Block: withRestApiHydration( Block ),
+	getProps,
+} );

--- a/assets/js/blocks/attribute-filter/frontend.js
+++ b/assets/js/blocks/attribute-filter/frontend.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { withRestApiHydration } from '@woocommerce/block-hocs';
+import { renderFrontend } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
  */
 import Block from './block.js';
-import renderFrontend from '../../utils/render-frontend.js';
 
 const getProps = ( el ) => {
 	return {
@@ -23,8 +23,8 @@ const getProps = ( el ) => {
 	};
 };
 
-renderFrontend(
-	'.wp-block-woocommerce-attribute-filter',
-	withRestApiHydration( Block ),
-	getProps
-);
+renderFrontend( {
+	selector: '.wp-block-woocommerce-attribute-filter',
+	Block: withRestApiHydration( Block ),
+	getProps,
+} );

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -9,16 +9,16 @@ import { __ } from '@wordpress/i18n';
 import { StoreNoticesProvider } from '@woocommerce/base-context';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
+import {
+	renderFrontend,
+	getAttributesFromDataset,
+} from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
  */
 import Block from './block.js';
 import blockAttributes from './attributes';
-import {
-	getAttributesFromDataset,
-	renderFrontend,
-} from '../../../utils/render-frontend.js';
 
 const reloadPage = () => void window.location.reload( true );
 /**
@@ -62,9 +62,9 @@ const getErrorBoundaryProps = () => {
 	};
 };
 
-renderFrontend(
-	'.wp-block-woocommerce-cart',
-	withStoreCartApiHydration( withRestApiHydration( CartFrontend ) ),
+renderFrontend( {
+	selector: '.wp-block-woocommerce-cart',
+	Block: withStoreCartApiHydration( withRestApiHydration( CartFrontend ) ),
 	getProps,
-	getErrorBoundaryProps
-);
+	getErrorBoundaryProps,
+} );

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -14,16 +14,16 @@ import {
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
+import {
+	renderFrontend,
+	getAttributesFromDataset,
+} from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
  */
 import Block from './block.js';
 import blockAttributes from './attributes';
-import {
-	getAttributesFromDataset,
-	renderFrontend,
-} from '../../../utils/render-frontend.js';
 import EmptyCart from './empty-cart/index.js';
 
 const reloadPage = () => void window.location.reload( true );
@@ -100,9 +100,11 @@ const getErrorBoundaryProps = () => {
 	};
 };
 
-renderFrontend(
-	'.wp-block-woocommerce-checkout',
-	withStoreCartApiHydration( withRestApiHydration( CheckoutFrontend ) ),
+renderFrontend( {
+	selector: '.wp-block-woocommerce-checkout',
+	Block: withStoreCartApiHydration(
+		withRestApiHydration( CheckoutFrontend )
+	),
 	getProps,
-	getErrorBoundaryProps
-);
+	getErrorBoundaryProps,
+} );

--- a/assets/js/blocks/price-filter/frontend.js
+++ b/assets/js/blocks/price-filter/frontend.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { withRestApiHydration } from '@woocommerce/block-hocs';
+import { renderFrontend } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
  */
-import renderFrontend from '../../utils/render-frontend.js';
 import Block from './block.js';
 
 const getProps = ( el ) => {
@@ -18,8 +18,8 @@ const getProps = ( el ) => {
 	};
 };
 
-renderFrontend(
-	'.wp-block-woocommerce-price-filter',
-	withRestApiHydration( Block ),
-	getProps
-);
+renderFrontend( {
+	selector: '.wp-block-woocommerce-price-filter',
+	Block: withRestApiHydration( Block ),
+	getProps,
+} );

--- a/assets/js/blocks/products/all-products/frontend.js
+++ b/assets/js/blocks/products/all-products/frontend.js
@@ -3,12 +3,12 @@
  */
 import { withRestApiHydration } from '@woocommerce/block-hocs';
 import { StoreNoticesProvider } from '@woocommerce/base-context';
+import { renderFrontend } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
  */
 import Block from './block';
-import renderFrontend from '../../../utils/render-frontend.js';
 
 /**
  * Wrapper component to supply the notice provider.
@@ -27,8 +27,8 @@ const getProps = ( el ) => ( {
 	attributes: JSON.parse( el.dataset.attributes ),
 } );
 
-renderFrontend(
-	'.wp-block-woocommerce-all-products',
-	withRestApiHydration( AllProductsFrontend ),
-	getProps
-);
+renderFrontend( {
+	selector: '.wp-block-woocommerce-all-products',
+	Block: withRestApiHydration( AllProductsFrontend ),
+	getProps,
+} );

--- a/assets/js/blocks/reviews/frontend.js
+++ b/assets/js/blocks/reviews/frontend.js
@@ -1,8 +1,12 @@
 /**
+ * External dependencies
+ */
+import { renderFrontend } from '@woocommerce/base-utils';
+
+/**
  * Internal dependencies
  */
 import FrontendContainerBlock from './frontend-container-block.js';
-import renderFrontend from '../../utils/render-frontend.js';
 
 const selector = `
 	.wp-block-woocommerce-all-reviews,
@@ -23,4 +27,4 @@ const getProps = ( el ) => {
 	};
 };
 
-renderFrontend( selector, FrontendContainerBlock, getProps );
+renderFrontend( { selector, Block: FrontendContainerBlock, getProps } );


### PR DESCRIPTION
_#2399 is a mammoth PR so I'm breaking out some fixes and changes to review separately._

Changes the parameters passed in `renderFrontend` to an object. As the function grows in size, using an object will be easier and more flexible. I've updated the docblock and usage.

Also moves the utility to base-utils and updated imports; this is shared and would be easier to import from there. I will be adding more to this utility with the Atomic block updates coming soon.

**To test:**

If unit tests pass, check to ensure frontend blocks are rendering (cart, checkout, and some product blocks).