### PR TITLE
Fixes to Twenty Twenty product grid styles

### DIFF
--- a/assets/js/atomic/blocks/product/sale-badge/block.js
+++ b/assets/js/atomic/blocks/product/sale-badge/block.js
@@ -17,6 +17,7 @@ const ProductSaleBadge = ( { className, product, align } ) => {
 		return (
 			<div
 				className={ classnames(
+					'wc-block-component__sale-badge',
 					className,
 					alignClass,
 					`${ layoutStyleClassPrefix }__product-onsale`

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -431,13 +431,15 @@
 	}
 
 	// Override style from WC Core that set its position to absolute.
-	// This ruleset can be removed once https://github.com/woocommerce/woocommerce/pull/26516 is released.
-	.wc-block-grid__products .wc-block-grid__product-onsale.wc-block-component__sale-badge {
+	// These rulesets can be removed once https://github.com/woocommerce/woocommerce/pull/26516 is released.
+	.wc-block-grid__products .wc-block-component__sale-badge {
 		position: static;
+	}
+	.wc-block-grid__products .wc-block-grid__product-image .wc-block-component__sale-badge {
+		position: absolute;
 	}
 
 	// These styles are not applied to the All Products atomic block, so it can be positioned normally.
-	.wc-block-grid__products .wc-block-grid__product-onsale.wc-block-grid__product-onsale--alignright,
 	.wc-block-grid__products .wc-block-grid__product-onsale:not(.wc-block-component__sale-badge) {
 		position: absolute;
 		right: 4px;

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -420,10 +420,6 @@
 	}
 
 	.wc-block-grid__products .wc-block-grid__product-onsale {
-		position: absolute;
-		right: 4px;
-		top: 4px;
-		display: inline-block;
 		background: $twentytwenty-highlights-color;
 		color: #fff;
 		font-family: $twentytwenty-headings;
@@ -431,10 +427,17 @@
 		letter-spacing: -0.02em;
 		line-height: 1.2;
 		text-transform: uppercase;
-		z-index: 1;
 		font-size: 1.5rem;
+	}
+
+	// These styles are not applied to the All Products atomic block, so it can be positioned normally.
+	.wc-block-grid__products .wc-block-grid__product-onsale:not(.wc-block-component__sale-badge) {
+		position: absolute;
+		right: 4px;
+		top: 4px;
 		margin: 0;
 		padding: 1rem;
+		z-index: 1;
 	}
 
 	@media only screen and (min-width: 768px) {

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -437,6 +437,7 @@
 	}
 
 	// These styles are not applied to the All Products atomic block, so it can be positioned normally.
+	.wc-block-grid__products .wc-block-grid__product-onsale.wc-block-grid__product-onsale--alignright,
 	.wc-block-grid__products .wc-block-grid__product-onsale:not(.wc-block-component__sale-badge) {
 		position: absolute;
 		right: 4px;

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -430,6 +430,12 @@
 		font-size: 1.5rem;
 	}
 
+	// Override style from WC Core that set its position to absolute.
+	// This ruleset can be removed once https://github.com/woocommerce/woocommerce/pull/26516 is released.
+	.wc-block-grid__products .wc-block-grid__product-onsale.wc-block-component__sale-badge {
+		position: static;
+	}
+
 	// These styles are not applied to the All Products atomic block, so it can be positioned normally.
 	.wc-block-grid__products .wc-block-grid__product-onsale:not(.wc-block-component__sale-badge) {
 		position: absolute;

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -402,6 +402,10 @@
 		del {
 			opacity: 0.5;
 		}
+
+		ins {
+			text-decoration: none;
+		}
 	}
 
 	.wc-block-grid__product-rating {


### PR DESCRIPTION
Fixes #2537.
Fixes #2421.

Related pull in Core: https://github.com/woocommerce/woocommerce/issues/26608.

### Screenshots
#### Hand-Picked Products
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/83013318-1bda2b80-a01d-11ea-997a-44c2fe9545a1.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/83013599-8e4b0b80-a01d-11ea-88ab-a1537110c4e2.png)

#### All Products
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/83013089-b5550d80-a01c-11ea-8112-fa165a50a43a.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/83013870-fef22800-a01d-11ea-8ea8-21229285d10a.png)
(notice there are some alignment/marging issues, but those are being handled/tracked in https://github.com/woocommerce/woocommerce/pull/26516 and https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2565)

### How to test the changes in this Pull Request:

1. Switch to the Twenty Twenty theme.
2. Add an _All Products_ block, edit it and add an _On Sale_ badge below the title.
3. Verify it's correctly positioned.
4. Add a _Hand-picked Products_ block and select a product on sale.
5. Verify the discounted price is not underlined.

### Changelog

> Fixes to the product grid blocks in Twenty Twenty: discounted prices are no longer underlined and the On Sale badge is correctly positioned in the All Products block.