### PR TITLE
Delete orders using delete method in batches of 20

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -135,7 +135,7 @@ class Library {
 		$batch_size = 20;
 		$orders     = wc_get_orders(
 			[
-				'date_modified' => '<' . strtotime( '-1 DAY' ),
+				'date_modified' => '<=' . strtotime( '-1 DAY' ),
 				'limit'         => $batch_size,
 				'status'        => 'wc-checkout-draft',
 				'type'          => 'shop_order',

--- a/src/Library.php
+++ b/src/Library.php
@@ -131,15 +131,16 @@ class Library {
 	 * Ran on a daily cron schedule.
 	 */
 	public static function delete_expired_draft_orders() {
-		$orders = wc_get_orders(
+		$count      = 0;
+		$batch_size = 20;
+		$orders     = wc_get_orders(
 			[
 				'date_modified' => '<' . strtotime( '-1 DAY' ),
-				'limit'         => 20,
+				'limit'         => $batch_size,
 				'status'        => 'wc-checkout-draft',
 				'type'          => 'shop_order',
 			]
 		);
-		$count  = 0;
 
 		if ( $orders ) {
 			foreach ( $orders as $order ) {
@@ -148,7 +149,7 @@ class Library {
 			}
 		}
 
-		if ( 20 === $count && function_exists( 'as_enqueue_async_action' ) ) {
+		if ( $batch_size === $count && function_exists( 'as_enqueue_async_action' ) ) {
 			as_enqueue_async_action( 'woocommerce_cleanup_draft_orders' );
 		}
 	}

--- a/src/Library.php
+++ b/src/Library.php
@@ -144,7 +144,7 @@ class Library {
 
 		if ( $orders ) {
 			foreach ( $orders as $order ) {
-				$order->delete( false );
+				$order->delete( true );
 				$count ++;
 			}
 		}


### PR DESCRIPTION
Removes the custom SQL query and replaces it with a batch delete of 20 orders per run. Schedules more events if the number of delete orders matches the batch limit.

Fixes #2570

### How to test the changes in this Pull Request:

1. Create draft orders
2. Run job manually in Tools > Scheduled actions. 
3. Change order dates, re-run to ensure orders are deleted.

I've tested with a handful of orders. Currently testing with > 20 (will follow up with results).
