### PR TITLE
Fix registered payment methods not recognized by Checkout block on initial insertion into content

### DIFF
--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -52,7 +52,7 @@ class Api {
 	 * Initialize class features.
 	 */
 	protected function init() {
-		add_action( 'init', array( $this->payment_method_registry, 'initialize' ) );
+		add_action( 'init', array( $this->payment_method_registry, 'initialize' ), 5 );
 		add_filter( 'woocommerce_blocks_register_script_dependencies', array( $this, 'add_payment_method_script_dependencies' ), 10, 2 );
 		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'add_payment_method_script_data' ) );
 		add_action( 'woocommerce_blocks_cart_enqueue_data', array( $this, 'add_payment_method_script_data' ) );


### PR DESCRIPTION
Fixes: #2576 

The issue here was that the registered payment methods were not being initialized before the checkout block assets were registered. So this meant when the checkout block assets were registered for the block editor, the script handles for registered payment method handles were not added to the block asset dependencies and thus not loaded with that asset.

By changing the priority on the payment method registration initialization, the issue is fixed.

## To Test

To reproduce, you can follow the steps outlined by Albert in #2576.

- Verify that the following the reproduction steps demonstrate the issue is fixed.
- Verify that you can complete a Stripe CC or cheque payment and there are no console errors when interacting with the Checkout block on the frontend or in the editor.