### PR TITLE
Fix undefined index for `saved_cards`

### DIFF
--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -114,6 +114,7 @@ final class Stripe extends AbstractPaymentMethodType {
 	 * @return bool True if merchant allows shopper to save card (payment method) during checkout).
 	 */
 	private function get_allow_saved_cards() {
+		$saved_cards = isset( $this->settings['saved_cards'] ) ? $this->settings['saved_cards'] : false;
 		// This assumes that Stripe supports `tokenization` - currently this is true, based on
 		// https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95 .
 		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and


### PR DESCRIPTION
Fixes: #2575 

See the report in #2575. The fix in this pull is fairly straightforward. 

## To Test

There's not a whole lot to test here, the code is basic defensive programming. However as a confidence check, you can smoke check that saved payment methods still show up in the checkout block on the frontend if the logged in user has any.