### PR TITLE
Add "edit product" card to single product block sidebar

### DIFF
--- a/assets/js/blocks/single-product/edit/edit-product-link.js
+++ b/assets/js/blocks/single-product/edit/edit-product-link.js
@@ -4,36 +4,33 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@woocommerce/icons';
 import { ADMIN_URL } from '@woocommerce/settings';
-import { Card, CardBody } from '@wordpress/components';
 
 /**
  * Component to render an edit product link in the sidebar.
  */
 const EditProductLink = ( { productId } ) => {
 	return (
-		<Card className="wc-block-single-product-edit-card">
-			<CardBody>
-				<div className="wc-block-single-product-edit-card-title">
-					<a
-						href={ `${ ADMIN_URL }post.php?post=${ productId }&action=edit` }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{ __(
-							"Edit this product's details",
-							'woo-gutenberg-products-block'
-						) }
-						<Icon srcElement={ external } size={ 16 } />
-					</a>
-				</div>
-				<div className="wc-block-single-product-edit-card-description">
+		<div className="wc-block-single-product__edit-card">
+			<div className="wc-block-single-product__edit-card-title">
+				<a
+					href={ `${ ADMIN_URL }post.php?post=${ productId }&action=edit` }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
 					{ __(
-						'Edit details such as title, price, description and more.',
+						"Edit this product's details",
 						'woo-gutenberg-products-block'
 					) }
-				</div>
-			</CardBody>
-		</Card>
+					<Icon srcElement={ external } size={ 16 } />
+				</a>
+			</div>
+			<div className="wc-block-single-product__edit-card-description">
+				{ __(
+					'Edit details such as title, price, description and more.',
+					'woo-gutenberg-products-block'
+				) }
+			</div>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/single-product/edit/edit-product-link.js
+++ b/assets/js/blocks/single-product/edit/edit-product-link.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon, external } from '@woocommerce/icons';
+import { ADMIN_URL } from '@woocommerce/settings';
+import { Card, CardBody } from '@wordpress/components';
+
+/**
+ * Component to render an edit product link in the sidebar.
+ */
+const EditProductLink = ( { productId } ) => {
+	return (
+		<Card className="wc-block-single-product-edit-card">
+			<CardBody>
+				<div className="wc-block-single-product-edit-card-title">
+					<a
+						href={ `${ ADMIN_URL }post.php?post=${ productId }&action=edit` }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ __(
+							"Edit this product's details",
+							'woo-gutenberg-products-block'
+						) }
+						<Icon srcElement={ external } size={ 16 } />
+					</a>
+				</div>
+				<div className="wc-block-single-product-edit-card-description">
+					{ __(
+						'Edit details such as title, price, description and more.',
+						'woo-gutenberg-products-block'
+					) }
+				</div>
+			</CardBody>
+		</Card>
+	);
+};
+
+export default EditProductLink;

--- a/assets/js/blocks/single-product/edit/editor.scss
+++ b/assets/js/blocks/single-product/edit/editor.scss
@@ -8,3 +8,11 @@
 		margin-right: 4px;
 	}
 }
+.wc-block-single-product__edit-card {
+	padding: 16px;
+	border-top: 1px solid #e2e4e7;
+
+	.wc-block-single-product__edit-card-title {
+		margin: 0 0 $gap;
+	}
+}

--- a/assets/js/blocks/single-product/edit/index.js
+++ b/assets/js/blocks/single-product/edit/index.js
@@ -17,6 +17,7 @@ import ApiError from './api-error';
 import SharedProductControl from './shared-product-control';
 import EditorBlockControls from './editor-block-controls';
 import LayoutEditor from './layout-editor';
+import EditProductLink from './edit-product-link';
 import { BLOCK_TITLE, BLOCK_ICON, BLOCK_DESCRIPTION } from '../constants';
 
 /**
@@ -98,6 +99,7 @@ const Editor = ( {
 									setAttributes={ setAttributes }
 								/>
 							</PanelBody>
+							<EditProductLink productId={ productId } />
 						</InspectorControls>
 						<LayoutEditor
 							clientId={ clientId }


### PR DESCRIPTION
Adds a card which links to the edit product page to the sidebar of the Single Product Block.

Fixes #2519

Some slight deviations from the design (known):

- Shown above the advanced tab due to no available slot fill below it
- Link text has underline for admin consistency
- Link icon is different due to us already having this icon in our blocks

### Screenshots

![Edit Page ‹ Local Testing — WordPress 2020-05-28 13-46-11](https://user-images.githubusercontent.com/90977/83143478-ecddbb80-a0e9-11ea-9035-79ecfc683f81.png)

### How to test the changes in this Pull Request:

1. Insert single product block.
2. Select a product.
3. View the sidebar; you should see the new component.
4. Check the link goes to the correct place in a new tab
