### PR TITLE
Remove CURRENT_TIMESTAMP default on the stock table

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -58,8 +58,8 @@ class Installer {
 				`order_id` bigint(20) NOT NULL,
 				`product_id` bigint(20) NOT NULL,
 				`stock_quantity` double NOT NULL DEFAULT 0,
-				`timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-				`expires` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				`timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+				`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 				PRIMARY KEY  (`order_id`, `product_id`)
 			) $collate;
 			"

--- a/src/StoreApi/Utilities/ReserveStock.php
+++ b/src/StoreApi/Utilities/ReserveStock.php
@@ -162,9 +162,10 @@ final class ReserveStock {
 		$result = $wpdb->query(
 			$wpdb->prepare(
 				"
-				REPLACE INTO {$wpdb->wc_reserved_stock} ( order_id, product_id, stock_quantity, expires )
-				SELECT %d, %d, %d, ( NOW() + INTERVAL %d MINUTE ) from DUAL
+				INSERT INTO {$wpdb->wc_reserved_stock} ( `order_id`, `product_id`, `stock_quantity`, `timestamp`, `expires` )
+				SELECT %d, %d, %d, NOW(), ( NOW() + INTERVAL %d MINUTE ) FROM DUAL
 				WHERE ( $query_for_stock FOR UPDATE ) - ( $query_for_reserved_stock FOR UPDATE ) >= %d
+				ON DUPLICATE KEY UPDATE `expires` = VALUES( `expires` )
 				",
 				$order->get_id(),
 				$product_id,


### PR DESCRIPTION
CURRENT_TIMESTAMP as a default value for datetime fields is not supported until MySQL 5.6.5. The minimum required version for WordPress is 5.6. 

To fix this we had two choices;

1. Change the column type to `timestamp`
2. Remove the default and handle on insert

I wanted to avoid changing the type of the column since `timestamp` itself has limitations, so in this PR I removed the default.

To ensure the timestamp is only set on first insert, we can change the REPLACE INTO (which deletes the existing row and inserts a new row) into a `ON DUPLICATE KEY` query. [There is prior art for this in core too found here.](https://github.com/woocommerce/woocommerce/blob/dd49f89e77acaaa097251fe0a5dd69320ded48c6/includes/class-wc-session-handler.php#L251-L252)

Fixes #2589

cc @vedanshujain r/e the draft PR https://github.com/woocommerce/woocommerce/pull/26395 which will need updating after this merges.
 
This will need cherry picking into 2.6 cc @nerrad 

### How to test the changes in this Pull Request:

1. View your stock table in the database
2. Go to checkout with some items in the cart
3. Check the stock table is updated with a new row
4. Refresh the checkout page.
5. Check that the `expires` column is updated only 

<!-- If you can, add the appropriate labels -->

### Changelog

> Updated the wc_reserved_stock table for compatibility with versions of MySql < 5.6.5.
