### PR TITLE
Add context support to Atomic Blocks

### DIFF
--- a/assets/js/atomic/blocks/product/button/block.js
+++ b/assets/js/atomic/blocks/product/button/block.js
@@ -3,14 +3,45 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { _n, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
 import { useStoreAddToCart } from '@woocommerce/base-hooks';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import {
+	useInnerBlockLayoutContext,
+	useProductDataContext,
+} from '@woocommerce/shared-context';
 import { decodeEntities } from '@wordpress/html-entities';
 import { triggerFragmentRefresh } from '@woocommerce/base-utils';
 
-const ProductButton = ( { product, className } ) => {
+const ProductButton = ( props ) => {
+	const mergedProps = { ...useProductDataContext(), ...props };
+	const { product, className } = mergedProps;
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
+	const componentClass = `${ layoutStyleClassPrefix }__product-add-to-cart`;
+
+	return (
+		<div
+			className={ classnames(
+				className,
+				componentClass,
+				'wp-block-button',
+				{
+					'is-loading': ! product,
+				}
+			) }
+		>
+			{ product ? (
+				<AddToCartButton product={ product } />
+			) : (
+				<AddToCartButtonPlaceholder />
+			) }
+		</div>
+	);
+};
+
+const AddToCartButton = ( { product } ) => {
+	const firstMount = useRef( true );
+
 	const {
 		id,
 		permalink,
@@ -19,31 +50,13 @@ const ProductButton = ( { product, className } ) => {
 		is_purchasable: isPurchasable,
 		is_in_stock: isInStock,
 	} = product;
+
 	const {
 		cartQuantity,
 		addingToCart,
 		cartIsLoading,
 		addToCart,
 	} = useStoreAddToCart( id );
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
-	const addedToCart = Number.isFinite( cartQuantity ) && cartQuantity > 0;
-	const getButtonText = () => {
-		if ( addedToCart ) {
-			return sprintf(
-				// translators: %s number of products in cart.
-				_n(
-					'%d in cart',
-					'%d in cart',
-					cartQuantity,
-					'woo-gutenberg-products-block'
-				),
-				cartQuantity
-			);
-		}
-		return decodeEntities( productCartDetails.text );
-	};
-
-	const firstMount = useRef( true );
 
 	useEffect( () => {
 		// Avoid running on first mount when cart quantity is first set.
@@ -54,61 +67,85 @@ const ProductButton = ( { product, className } ) => {
 		triggerFragmentRefresh();
 	}, [ cartQuantity ] );
 
-	const wrapperClasses = classnames(
-		className,
-		`${ layoutStyleClassPrefix }__product-add-to-cart`,
-		'wp-block-button'
-	);
+	if ( cartIsLoading ) {
+		return <AddToCartButtonPlaceholder />;
+	}
 
-	const buttonClasses = classnames(
-		'wp-block-button__link',
-		'add_to_cart_button',
-		{
-			loading: addingToCart,
-			added: addedToCart,
-		}
+	const addedToCart = Number.isFinite( cartQuantity ) && cartQuantity > 0;
+	const allowAddToCart = ! hasOptions && isPurchasable && isInStock;
+	const buttonAriaLabel = decodeEntities(
+		productCartDetails?.description || ''
 	);
+	const buttonText = addedToCart
+		? sprintf(
+				// translators: %s number of products in cart.
+				_n(
+					'%d in cart',
+					'%d in cart',
+					cartQuantity,
+					'woo-gutenberg-products-block'
+				),
+				cartQuantity
+		  )
+		: decodeEntities(
+				productCartDetails?.text ||
+					__( 'Add to cart', 'woo-gutenberg-products-block' )
+		  );
 
-	if ( Object.keys( product ).length === 0 || cartIsLoading ) {
+	if ( ! allowAddToCart ) {
 		return (
-			<div className={ wrapperClasses }>
-				<button className={ buttonClasses } disabled={ true } />
-			</div>
+			<a
+				href={ permalink }
+				aria-label={ buttonAriaLabel }
+				className={ classnames(
+					'wp-block-button__link',
+					'add_to_cart_button',
+					{
+						loading: addingToCart,
+						added: addedToCart,
+					}
+				) }
+				rel="nofollow"
+			>
+				{ buttonText }
+			</a>
 		);
 	}
-	const allowAddToCart = ! hasOptions && isPurchasable && isInStock;
+
 	return (
-		<div className={ wrapperClasses }>
-			{ allowAddToCart ? (
-				<button
-					onClick={ addToCart }
-					aria-label={ decodeEntities(
-						productCartDetails.description
-					) }
-					className={ buttonClasses }
-					disabled={ addingToCart }
-				>
-					{ getButtonText() }
-				</button>
-			) : (
-				<a
-					href={ permalink }
-					aria-label={ decodeEntities(
-						productCartDetails.description
-					) }
-					className={ buttonClasses }
-					rel="nofollow"
-				>
-					{ getButtonText() }
-				</a>
+		<button
+			onClick={ addToCart }
+			aria-label={ buttonAriaLabel }
+			className={ classnames(
+				'wp-block-button__link',
+				'add_to_cart_button',
+				{
+					loading: addingToCart,
+					added: addedToCart,
+				}
 			) }
-		</div>
+			disabled={ addingToCart }
+		>
+			{ buttonText }
+		</button>
+	);
+};
+
+const AddToCartButtonPlaceholder = () => {
+	return (
+		<button
+			className={ classnames(
+				'wp-block-button__link',
+				'add_to_cart_button'
+			) }
+			disabled={ true }
+		/>
 	);
 };
 
 ProductButton.propTypes = {
 	className: PropTypes.string,
-	product: PropTypes.object.isRequired,
+	product: PropTypes.object,
 };
 
 export default ProductButton;

--- a/assets/js/atomic/blocks/product/button/block.js
+++ b/assets/js/atomic/blocks/product/button/block.js
@@ -23,9 +23,10 @@ import {
  * @return {*} The component.
  */
 const ProductButton = ( { className, ...props } ) => {
-	const productDataContext = { ...useProductDataContext(), ...props };
+	const productDataContext = useProductDataContext();
+	const { product } = productDataContext || props;
+
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const { product } = productDataContext;
 	const componentClass = `${ layoutStyleClassPrefix }__product-add-to-cart`;
 
 	return (

--- a/assets/js/atomic/blocks/product/button/block.js
+++ b/assets/js/atomic/blocks/product/button/block.js
@@ -24,7 +24,7 @@ import {
  */
 const ProductButton = ( { className, ...props } ) => {
 	const productDataContext = useProductDataContext();
-	const { product } = productDataContext || props;
+	const product = props.product || productDataContext.product;
 
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const componentClass = `${ layoutStyleClassPrefix }__product-add-to-cart`;

--- a/assets/js/atomic/blocks/product/button/block.js
+++ b/assets/js/atomic/blocks/product/button/block.js
@@ -6,17 +6,26 @@ import classnames from 'classnames';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEffect, useRef } from '@wordpress/element';
 import { useStoreAddToCart } from '@woocommerce/base-hooks';
+import { decodeEntities } from '@wordpress/html-entities';
+import { triggerFragmentRefresh } from '@woocommerce/base-utils';
 import {
 	useInnerBlockLayoutContext,
 	useProductDataContext,
 } from '@woocommerce/shared-context';
-import { decodeEntities } from '@wordpress/html-entities';
-import { triggerFragmentRefresh } from '@woocommerce/base-utils';
 
-const ProductButton = ( props ) => {
-	const mergedProps = { ...useProductDataContext(), ...props };
-	const { product, className } = mergedProps;
+/**
+ * Product Button Block Component.
+ *
+ * @param {Object} props             Incoming props.
+ * @param {string} [props.className] CSS Class name for the component.
+ * @param {Object} [props.product]   Optional product object. Product from context will be used if
+ *                                   this is not provided.
+ * @return {*} The component.
+ */
+const ProductButton = ( { className, ...props } ) => {
+	const productDataContext = { ...useProductDataContext(), ...props };
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
+	const { product } = productDataContext;
 	const componentClass = `${ layoutStyleClassPrefix }__product-add-to-cart`;
 
 	return (
@@ -114,7 +123,7 @@ const AddToCartButton = ( { product } ) => {
 
 	return (
 		<button
-			onClick={ addToCart }
+			onClick={ () => addToCart }
 			aria-label={ buttonAriaLabel }
 			className={ classnames(
 				'wp-block-button__link',

--- a/assets/js/atomic/blocks/product/button/block.js
+++ b/assets/js/atomic/blocks/product/button/block.js
@@ -123,7 +123,7 @@ const AddToCartButton = ( { product } ) => {
 
 	return (
 		<button
-			onClick={ () => addToCart }
+			onClick={ addToCart }
 			aria-label={ buttonAriaLabel }
 			className={ classnames(
 				'wp-block-button__link',

--- a/assets/js/atomic/blocks/product/image/attributes.js
+++ b/assets/js/atomic/blocks/product/image/attributes.js
@@ -1,13 +1,4 @@
-/**
- * External dependencies
- */
-import { previewProducts } from '@woocommerce/resource-previews';
-
 export const blockAttributes = {
-	product: {
-		type: 'object',
-		default: previewProducts[ 0 ],
-	},
 	productLink: {
 		type: 'boolean',
 		default: true,

--- a/assets/js/atomic/blocks/product/image/block.js
+++ b/assets/js/atomic/blocks/product/image/block.js
@@ -34,10 +34,12 @@ const ProductImage = ( {
 	saleBadgeAlign = 'right',
 	...props
 } ) => {
-	const productDataContext = { ...useProductDataContext(), ...props };
+	const productDataContext = useProductDataContext();
+	const { product } = productDataContext || props;
+
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const { product } = productDataContext;
 	const componentClass = `${ layoutStyleClassPrefix }__product-image`;
+
 	const [ imageLoaded, setImageLoaded ] = useState( false );
 
 	if ( ! product ) {

--- a/assets/js/atomic/blocks/product/image/block.js
+++ b/assets/js/atomic/blocks/product/image/block.js
@@ -35,7 +35,7 @@ const ProductImage = ( {
 	...props
 } ) => {
 	const productDataContext = useProductDataContext();
-	const { product } = productDataContext || props;
+	const product = props.product || productDataContext.product;
 
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const componentClass = `${ layoutStyleClassPrefix }__product-image`;

--- a/assets/js/atomic/blocks/product/image/block.js
+++ b/assets/js/atomic/blocks/product/image/block.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Fragment, useState } from '@wordpress/element';
 import classnames from 'classnames';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/block-settings';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 
 /**
  * Internal dependencies
@@ -56,7 +56,7 @@ const ProductImage = ( {
 	saleBadgeAlign = 'right',
 } ) => {
 	const [ imageLoaded, setImageLoaded ] = useState( false );
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const image =
 		product.images && product.images.length ? product.images[ 0 ] : null;
 

--- a/assets/js/atomic/blocks/product/image/block.js
+++ b/assets/js/atomic/blocks/product/image/block.js
@@ -2,101 +2,129 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import classnames from 'classnames';
 import { PLACEHOLDER_IMG_SRC } from '@woocommerce/block-settings';
-import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
+import {
+	useInnerBlockLayoutContext,
+	useProductDataContext,
+} from '@woocommerce/shared-context';
 
 /**
  * Internal dependencies
  */
-import ProductSaleBadge from '../sale-badge/block';
+import ProductSaleBadge from '../sale-badge/block.js';
 
-const SaleBadge = ( { product, saleBadgeAlign, shouldRender } ) => {
-	return shouldRender ? (
-		<ProductSaleBadge product={ product } align={ saleBadgeAlign } />
-	) : null;
-};
-
-const Image = ( { layoutPrefix, loaded, image, onLoad } ) => {
-	const cssClass = classnames( `${ layoutPrefix }__product-image__image`, {
-		[ `${ layoutPrefix }__product-image__image_placeholder` ]:
-			! loaded && ! image,
-	} );
-	const { thumbnail, srcset, sizes, alt } = image || {};
-	return (
-		<Fragment>
-			{ image && (
-				<img
-					className={ cssClass }
-					src={ thumbnail }
-					srcSet={ srcset }
-					sizes={ sizes }
-					alt={ alt }
-					onLoad={ onLoad }
-					hidden={ ! loaded }
-				/>
-			) }
-			{ ! loaded && (
-				<img
-					className={ cssClass }
-					src={ PLACEHOLDER_IMG_SRC }
-					alt=""
-				/>
-			) }
-		</Fragment>
-	);
-};
-
+/**
+ * Product Image Block Component.
+ *
+ * @param {Object} props                  Incoming props.
+ * @param {string} [props.className]      CSS Class name for the component.
+ * @param {boolean} [props.productLink]   Whether or not to display a link to the product page.
+ * @param {boolean} [props.showSaleBadge] Whether or not to display the on sale badge.
+ * @param {string} [props.saleBadgeAlign] How should the sale badge be aligned if displayed.
+ * @param {Object} [props.product]        Optional product object. Product from context will be used if
+ *                                        this is not provided.
+ * @return {*} The component.
+ */
 const ProductImage = ( {
 	className,
-	product,
 	productLink = true,
 	showSaleBadge = true,
 	saleBadgeAlign = 'right',
+	...props
 } ) => {
-	const [ imageLoaded, setImageLoaded ] = useState( false );
+	const productDataContext = { ...useProductDataContext(), ...props };
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const image =
-		product.images && product.images.length ? product.images[ 0 ] : null;
+	const { product } = productDataContext;
+	const componentClass = `${ layoutStyleClassPrefix }__product-image`;
+	const [ imageLoaded, setImageLoaded ] = useState( false );
 
-	const renderedSalesAndImage = (
-		<Fragment>
-			<SaleBadge
-				product={ product }
-				saleBadgeAlign={ saleBadgeAlign }
-				shouldRender={ showSaleBadge }
-			/>
-			<Image
-				layoutPrefix={ layoutStyleClassPrefix }
-				loaded={ imageLoaded }
-				image={ image }
-				onLoad={ () => setImageLoaded( true ) }
-			/>
-		</Fragment>
-	);
+	if ( ! product ) {
+		return (
+			<div
+				className={ classnames(
+					className,
+					componentClass,
+					'is-loading'
+				) }
+			>
+				<ImagePlaceholder componentClass={ componentClass } />
+			</div>
+		);
+	}
+
+	const image =
+		product?.images && product.images.length ? product.images[ 0 ] : null;
 
 	return (
-		<div
-			className={ classnames(
-				className,
-				`${ layoutStyleClassPrefix }__product-image`
-			) }
-		>
+		<div className={ classnames( className, componentClass ) }>
 			{ productLink ? (
 				<a href={ product.permalink } rel="nofollow">
-					{ renderedSalesAndImage }
+					{ showSaleBadge && (
+						<ProductSaleBadge align={ saleBadgeAlign } />
+					) }
+					<Image
+						componentClass={ componentClass }
+						image={ image }
+						onLoad={ () => setImageLoaded( true ) }
+						loaded={ imageLoaded }
+					/>
 				</a>
 			) : (
-				renderedSalesAndImage
+				<>
+					{ showSaleBadge && (
+						<ProductSaleBadge align={ saleBadgeAlign } />
+					) }
+					<Image
+						componentClass={ componentClass }
+						image={ image }
+						onLoad={ () => setImageLoaded( true ) }
+						loaded={ imageLoaded }
+					/>
+				</>
 			) }
 		</div>
 	);
 };
 
+const ImagePlaceholder = ( { componentClass } ) => {
+	return (
+		<img
+			className={ classnames(
+				`${ componentClass }__image`,
+				`${ componentClass }__image_placeholder`
+			) }
+			src={ PLACEHOLDER_IMG_SRC }
+			alt=""
+		/>
+	);
+};
+
+const Image = ( { componentClass, image, onLoad, loaded } ) => {
+	const { thumbnail, srcset, sizes, alt } = image || {};
+
+	return (
+		<>
+			<img
+				className={ classnames( `${ componentClass }__image` ) }
+				src={ thumbnail }
+				srcSet={ srcset }
+				sizes={ sizes }
+				alt={ alt }
+				onLoad={ onLoad }
+				hidden={ ! loaded }
+			/>
+			{ ! loaded && (
+				<ImagePlaceholder componentClass={ componentClass } />
+			) }
+		</>
+	);
+};
+
 ProductImage.propTypes = {
 	className: PropTypes.string,
-	product: PropTypes.object.isRequired,
+	product: PropTypes.object,
 	productLink: PropTypes.bool,
 	showSaleBadge: PropTypes.bool,
 	saleBadgeAlign: PropTypes.string,

--- a/assets/js/atomic/blocks/product/price/block.js
+++ b/assets/js/atomic/blocks/product/price/block.js
@@ -21,7 +21,7 @@ import {
  */
 const ProductPrice = ( { className, ...props } ) => {
 	const productDataContext = useProductDataContext();
-	const { product } = productDataContext || props;
+	const product = props.product || productDataContext.product;
 
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const componentClass = `${ layoutStyleClassPrefix }__product-price`;

--- a/assets/js/atomic/blocks/product/price/block.js
+++ b/assets/js/atomic/blocks/product/price/block.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 
 const ProductPrice = ( { className, product } ) => {
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const prices = product.prices || {};
 	const currency = getCurrencyFromPriceResponse( prices );
 

--- a/assets/js/atomic/blocks/product/price/block.js
+++ b/assets/js/atomic/blocks/product/price/block.js
@@ -20,9 +20,10 @@ import {
  * @return {*} The component.
  */
 const ProductPrice = ( { className, ...props } ) => {
-	const productDataContext = { ...useProductDataContext(), ...props };
+	const productDataContext = useProductDataContext();
+	const { product } = productDataContext || props;
+
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const { product } = productDataContext;
 	const componentClass = `${ layoutStyleClassPrefix }__product-price`;
 
 	if ( ! product ) {

--- a/assets/js/atomic/blocks/product/rating/block.js
+++ b/assets/js/atomic/blocks/product/rating/block.js
@@ -4,11 +4,11 @@
 import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 
 const ProductRating = ( { className, product } ) => {
 	const rating = parseFloat( product.average_rating );
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 
 	if ( ! Number.isFinite( rating ) || rating === 0 ) {
 		return null;

--- a/assets/js/atomic/blocks/product/rating/block.js
+++ b/assets/js/atomic/blocks/product/rating/block.js
@@ -4,13 +4,28 @@
 import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
+import {
+	useInnerBlockLayoutContext,
+	useProductDataContext,
+} from '@woocommerce/shared-context';
 
-const ProductRating = ( { className, product } ) => {
-	const rating = parseFloat( product.average_rating );
+/**
+ * Product Rating Block Component.
+ *
+ * @param {Object} props             Incoming props.
+ * @param {string} [props.className] CSS Class name for the component.
+ * @param {Object} [props.product]   Optional product object. Product from context will be used if
+ *                                   this is not provided.
+ * @return {*} The component.
+ */
+const ProductRating = ( { className, ...props } ) => {
+	const productDataContext = { ...useProductDataContext(), ...props };
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
+	const { product } = productDataContext;
+	const componentClass = `${ layoutStyleClassPrefix }__product-rating`;
+	const rating = getAverageRating( product );
 
-	if ( ! Number.isFinite( rating ) || rating === 0 ) {
+	if ( ! rating ) {
 		return null;
 	}
 
@@ -24,14 +39,9 @@ const ProductRating = ( { className, product } ) => {
 	);
 
 	return (
-		<div
-			className={ classnames(
-				className,
-				`${ layoutStyleClassPrefix }__product-rating`
-			) }
-		>
+		<div className={ classnames( className, componentClass ) }>
 			<div
-				className={ `${ layoutStyleClassPrefix }__product-rating__stars` }
+				className={ `${ componentClass }__stars` }
 				role="img"
 				aria-label={ ratingText }
 			>
@@ -41,9 +51,16 @@ const ProductRating = ( { className, product } ) => {
 	);
 };
 
+const getAverageRating = ( product ) => {
+	// eslint-disable-next-line camelcase
+	const rating = parseFloat( product?.average_rating || 0 );
+
+	return Number.isFinite( rating ) && rating > 0 ? rating : 0;
+};
+
 ProductRating.propTypes = {
 	className: PropTypes.string,
-	product: PropTypes.object.isRequired,
+	product: PropTypes.object,
 };
 
 export default ProductRating;

--- a/assets/js/atomic/blocks/product/rating/block.js
+++ b/assets/js/atomic/blocks/product/rating/block.js
@@ -19,10 +19,12 @@ import {
  * @return {*} The component.
  */
 const ProductRating = ( { className, ...props } ) => {
-	const productDataContext = { ...useProductDataContext(), ...props };
+	const productDataContext = useProductDataContext();
+	const { product } = productDataContext || props;
+
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const { product } = productDataContext;
 	const componentClass = `${ layoutStyleClassPrefix }__product-rating`;
+
 	const rating = getAverageRating( product );
 
 	if ( ! rating ) {

--- a/assets/js/atomic/blocks/product/rating/block.js
+++ b/assets/js/atomic/blocks/product/rating/block.js
@@ -20,7 +20,7 @@ import {
  */
 const ProductRating = ( { className, ...props } ) => {
 	const productDataContext = useProductDataContext();
-	const { product } = productDataContext || props;
+	const product = props.product || productDataContext.product;
 
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const componentClass = `${ layoutStyleClassPrefix }__product-rating`;

--- a/assets/js/atomic/blocks/product/sale-badge/block.js
+++ b/assets/js/atomic/blocks/product/sale-badge/block.js
@@ -3,11 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import Label from '@woocommerce/base-components/label';
 
 const ProductSaleBadge = ( { className, product, align } ) => {
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const alignClass =
 		typeof align === 'string'
 			? `${ layoutStyleClassPrefix }__product-onsale--align${ align }`

--- a/assets/js/atomic/blocks/product/sale-badge/block.js
+++ b/assets/js/atomic/blocks/product/sale-badge/block.js
@@ -1,40 +1,62 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import Label from '@woocommerce/base-components/label';
+import {
+	useInnerBlockLayoutContext,
+	useProductDataContext,
+} from '@woocommerce/shared-context';
 
-const ProductSaleBadge = ( { className, product, align } ) => {
+/**
+ * Product Sale Badge Block Component.
+ *
+ * @param {Object} props             Incoming props.
+ * @param {string} [props.className] CSS Class name for the component.
+ * @param {string} [props.align]     Alignment of the badge.
+ * @param {Object} [props.product]   Optional product object. Product from context will be used if
+ *                                   this is not provided.
+ * @return {*} The component.
+ */
+const ProductSaleBadge = ( { className, align, ...props } ) => {
+	const productDataContext = { ...useProductDataContext(), ...props };
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const alignClass =
-		typeof align === 'string'
-			? `${ layoutStyleClassPrefix }__product-onsale--align${ align }`
-			: '';
+	const { product } = productDataContext;
+	const componentClass = `${ layoutStyleClassPrefix }__product-onsale`;
 
-	if ( product && product.on_sale ) {
-		return (
-			<div
-				className={ classnames(
-					'wc-block-component__sale-badge',
-					className,
-					alignClass,
-					`${ layoutStyleClassPrefix }__product-onsale`
-				) }
-			>
-				<Label
-					label={ __( 'Sale', 'woo-gutenberg-products-block' ) }
-					screenReaderLabel={ __(
-						'Product on sale',
-						'woo-gutenberg-products-block'
-					) }
-				/>
-			</div>
-		);
+	if ( ! product || ! product.on_sale ) {
+		return null;
 	}
 
-	return null;
+	const alignClass =
+		typeof align === 'string' ? `${ componentClass }--align${ align }` : '';
+
+	return (
+		<div
+			className={ classnames(
+				'wc-block-component__sale-badge',
+				className,
+				alignClass,
+				componentClass
+			) }
+		>
+			<Label
+				label={ __( 'Sale', 'woo-gutenberg-products-block' ) }
+				screenReaderLabel={ __(
+					'Product on sale',
+					'woo-gutenberg-products-block'
+				) }
+			/>
+		</div>
+	);
+};
+
+ProductSaleBadge.propTypes = {
+	className: PropTypes.string,
+	align: PropTypes.string,
+	product: PropTypes.object,
 };
 
 export default ProductSaleBadge;

--- a/assets/js/atomic/blocks/product/sale-badge/block.js
+++ b/assets/js/atomic/blocks/product/sale-badge/block.js
@@ -21,9 +21,10 @@ import {
  * @return {*} The component.
  */
 const ProductSaleBadge = ( { className, align, ...props } ) => {
-	const productDataContext = { ...useProductDataContext(), ...props };
+	const productDataContext = useProductDataContext();
+	const { product } = productDataContext || props;
+
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const { product } = productDataContext;
 	const componentClass = `${ layoutStyleClassPrefix }__product-onsale`;
 
 	if ( ! product || ! product.on_sale ) {

--- a/assets/js/atomic/blocks/product/sale-badge/block.js
+++ b/assets/js/atomic/blocks/product/sale-badge/block.js
@@ -22,7 +22,7 @@ import {
  */
 const ProductSaleBadge = ( { className, align, ...props } ) => {
 	const productDataContext = useProductDataContext();
-	const { product } = productDataContext || props;
+	const product = props.product || productDataContext.product;
 
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const componentClass = `${ layoutStyleClassPrefix }__product-onsale`;

--- a/assets/js/atomic/blocks/product/shared-config.js
+++ b/assets/js/atomic/blocks/product/shared-config.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon, grid } from '@woocommerce/icons';
-import { previewProducts } from '@woocommerce/resource-previews';
 
 /**
  * Holds default config for this collection of blocks.
@@ -19,11 +18,5 @@ export default {
 		html: false,
 	},
 	parent: [ 'woocommerce/all-products', 'woocommerce/single-product' ],
-	attributes: {
-		product: {
-			type: 'object',
-			default: previewProducts[ 0 ],
-		},
-	},
 	save() {},
 };

--- a/assets/js/atomic/blocks/product/summary/block.js
+++ b/assets/js/atomic/blocks/product/summary/block.js
@@ -3,12 +3,40 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import Summary from '@woocommerce/base-components/summary';
 import { getSetting } from '@woocommerce/settings';
+import {
+	useInnerBlockLayoutContext,
+	useProductDataContext,
+} from '@woocommerce/shared-context';
 
-const ProductSummary = ( { className, product } ) => {
+/**
+ * Product Summary Block Component.
+ *
+ * @param {Object} props             Incoming props.
+ * @param {string} [props.className] CSS Class name for the component.
+ * @param {Object} [props.product]   Optional product object. Product from context will be used if
+ *                                   this is not provided.
+ * @return {*} The component.
+ */
+const ProductSummary = ( { className, ...props } ) => {
+	const productDataContext = { ...useProductDataContext(), ...props };
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
+	const { product } = productDataContext;
+	const componentClass = `${ layoutStyleClassPrefix }__product-summary`;
+
+	if ( ! product ) {
+		return (
+			<div
+				className={ classnames(
+					className,
+					componentClass,
+					'is-loading'
+				) }
+			/>
+		);
+	}
+
 	const source = product.short_description
 		? product.short_description
 		: product.description;
@@ -21,10 +49,7 @@ const ProductSummary = ( { className, product } ) => {
 
 	return (
 		<Summary
-			className={ classnames(
-				className,
-				`${ layoutStyleClassPrefix }__product-summary`
-			) }
+			className={ classnames( className, componentClass ) }
 			source={ source }
 			maxLength={ 150 }
 			countType={ countType }
@@ -34,7 +59,7 @@ const ProductSummary = ( { className, product } ) => {
 
 ProductSummary.propTypes = {
 	className: PropTypes.string,
-	product: PropTypes.object.isRequired,
+	product: PropTypes.object,
 };
 
 export default ProductSummary;

--- a/assets/js/atomic/blocks/product/summary/block.js
+++ b/assets/js/atomic/blocks/product/summary/block.js
@@ -20,9 +20,10 @@ import {
  * @return {*} The component.
  */
 const ProductSummary = ( { className, ...props } ) => {
-	const productDataContext = { ...useProductDataContext(), ...props };
+	const productDataContext = useProductDataContext();
+	const { product } = productDataContext || props;
+
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const { product } = productDataContext;
 	const componentClass = `${ layoutStyleClassPrefix }__product-summary`;
 
 	if ( ! product ) {

--- a/assets/js/atomic/blocks/product/summary/block.js
+++ b/assets/js/atomic/blocks/product/summary/block.js
@@ -3,12 +3,12 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import Summary from '@woocommerce/base-components/summary';
 import { getSetting } from '@woocommerce/settings';
 
 const ProductSummary = ( { className, product } ) => {
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const source = product.short_description
 		? product.short_description
 		: product.description;

--- a/assets/js/atomic/blocks/product/title/attributes.js
+++ b/assets/js/atomic/blocks/product/title/attributes.js
@@ -1,16 +1,4 @@
-/**
- * External dependencies
- */
-import { previewProducts } from '@woocommerce/resource-previews';
-
-/**
- * Internal dependencies
- */
 export const blockAttributes = {
-	product: {
-		type: 'object',
-		default: previewProducts[ 0 ],
-	},
 	headingLevel: {
 		type: 'number',
 		default: 2,

--- a/assets/js/atomic/blocks/product/title/block.js
+++ b/assets/js/atomic/blocks/product/title/block.js
@@ -3,30 +3,57 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import { decodeEntities } from '@wordpress/html-entities';
+import {
+	useInnerBlockLayoutContext,
+	useProductDataContext,
+} from '@woocommerce/shared-context';
 
+/**
+ * Product Title Block Component.
+ *
+ * @param {Object}  props                Incoming props.
+ * @param {string}  [props.className]    CSS Class name for the component.
+ * @param {number}  [props.headingLevel] Heading level (h1, h2 etc)
+ * @param {boolean} [props.productLink]  Whether or not to display a link to the product page.
+ * @param {Object}  [props.product ]     Optional product object. Product from context will be used if
+ *                                       this is not provided.
+ * @return {*} The component.
+ */
 const ProductTitle = ( {
 	className,
-	product,
 	headingLevel = 2,
 	productLink = true,
+	...props
 } ) => {
+	const productDataContext = { ...useProductDataContext(), ...props };
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	if ( ! product.name ) {
-		return null;
+	const { product } = productDataContext;
+	const TagName = `h${ headingLevel }`;
+	const componentClass = `${ layoutStyleClassPrefix }__product-title`;
+
+	if ( ! product ) {
+		return (
+			<TagName
+				// @ts-ignore
+				className={ classnames(
+					className,
+					componentClass,
+					'is-loading'
+				) }
+			/>
+		);
 	}
 
 	const productName = decodeEntities( product.name );
-	const TagName = `h${ headingLevel }`;
+
+	if ( ! productName ) {
+		return null;
+	}
 
 	return (
-		<TagName
-			className={ classnames(
-				className,
-				`${ layoutStyleClassPrefix }__product-title`
-			) }
-		>
+		// @ts-ignore
+		<TagName className={ classnames( className, componentClass ) }>
 			{ productLink ? (
 				<a href={ product.permalink } rel="nofollow">
 					{ productName }
@@ -40,7 +67,7 @@ const ProductTitle = ( {
 
 ProductTitle.propTypes = {
 	className: PropTypes.string,
-	product: PropTypes.object.isRequired,
+	product: PropTypes.object,
 	headingLevel: PropTypes.number,
 	productLink: PropTypes.bool,
 };

--- a/assets/js/atomic/blocks/product/title/block.js
+++ b/assets/js/atomic/blocks/product/title/block.js
@@ -16,7 +16,7 @@ import {
  * @param {string}  [props.className]    CSS Class name for the component.
  * @param {number}  [props.headingLevel] Heading level (h1, h2 etc)
  * @param {boolean} [props.productLink]  Whether or not to display a link to the product page.
- * @param {Object}  [props.product ]     Optional product object. Product from context will be used if
+ * @param {Object}  [props.product]      Optional product object. Product from context will be used if
  *                                       this is not provided.
  * @return {*} The component.
  */

--- a/assets/js/atomic/blocks/product/title/block.js
+++ b/assets/js/atomic/blocks/product/title/block.js
@@ -27,7 +27,7 @@ const ProductTitle = ( {
 	...props
 } ) => {
 	const productDataContext = useProductDataContext();
-	const { product } = productDataContext || props;
+	const product = props.product || productDataContext.product;
 
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const componentClass = `${ layoutStyleClassPrefix }__product-title`;

--- a/assets/js/atomic/blocks/product/title/block.js
+++ b/assets/js/atomic/blocks/product/title/block.js
@@ -47,10 +47,6 @@ const ProductTitle = ( {
 
 	const productName = decodeEntities( product.name );
 
-	if ( ! productName ) {
-		return null;
-	}
-
 	return (
 		// @ts-ignore
 		<TagName className={ classnames( className, componentClass ) }>

--- a/assets/js/atomic/blocks/product/title/block.js
+++ b/assets/js/atomic/blocks/product/title/block.js
@@ -26,11 +26,13 @@ const ProductTitle = ( {
 	productLink = true,
 	...props
 } ) => {
-	const productDataContext = { ...useProductDataContext(), ...props };
+	const productDataContext = useProductDataContext();
+	const { product } = productDataContext || props;
+
 	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
-	const { product } = productDataContext;
-	const TagName = `h${ headingLevel }`;
 	const componentClass = `${ layoutStyleClassPrefix }__product-title`;
+
+	const TagName = `h${ headingLevel }`;
 
 	if ( ! product ) {
 		return (

--- a/assets/js/atomic/blocks/product/title/block.js
+++ b/assets/js/atomic/blocks/product/title/block.js
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import { decodeEntities } from '@wordpress/html-entities';
 
 const ProductTitle = ( {
@@ -12,7 +12,7 @@ const ProductTitle = ( {
 	headingLevel = 2,
 	productLink = true,
 } ) => {
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	if ( ! product.name ) {
 		return null;
 	}

--- a/assets/js/base/components/product-list-item/index.js
+++ b/assets/js/base/components/product-list-item/index.js
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 
 /**
@@ -13,10 +13,7 @@ import { renderProductLayout } from './utils';
 
 const ProductListItem = ( { product, attributes, instanceId } ) => {
 	const { layoutConfig } = attributes;
-	const {
-		layoutStyleClassPrefix,
-		parentName,
-	} = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix, parentName } = useInnerBlockLayoutContext();
 	const isLoading = Object.keys( product ).length === 0;
 	const classes = classnames( `${ layoutStyleClassPrefix }__product`, {
 		'is-loading': isLoading,

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -16,7 +16,7 @@ import {
 	useQueryStateByKey,
 } from '@woocommerce/base-hooks';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import { speak } from '@wordpress/a11y';
 
 /**
@@ -114,7 +114,7 @@ const ProductList = ( {
 	const { products, totalProducts, productsLoading } = useStoreProducts(
 		queryState
 	);
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	const totalQuery = extractPaginationAndSortAttributes( queryState );
 
 	// These are possible filters.

--- a/assets/js/base/components/product-list/no-matching-products.js
+++ b/assets/js/base/components/product-list/no-matching-products.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import { Icon, search } from '@woocommerce/icons';
 
 const NoMatchingProducts = ( { resetCallback = () => {} } ) => {
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	return (
 		<div className={ `${ layoutStyleClassPrefix }__no-products` }>
 			<Icon

--- a/assets/js/base/components/product-list/no-products.js
+++ b/assets/js/base/components/product-list/no-products.js
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useInnerBlockConfigurationContext } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import { Icon, notice } from '@woocommerce/icons';
 
 const NoProducts = () => {
-	const { layoutStyleClassPrefix } = useInnerBlockConfigurationContext();
+	const { layoutStyleClassPrefix } = useInnerBlockLayoutContext();
 	return (
 		<div className={ `${ layoutStyleClassPrefix }__no-products` }>
 			<Icon

--- a/assets/js/blocks/products/all-products/block.js
+++ b/assets/js/blocks/products/all-products/block.js
@@ -4,7 +4,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import ProductListContainer from '@woocommerce/base-components/product-list/container';
-import { useInnerBlockLayoutContextProvider } from '@woocommerce/shared-context';
+import { InnerBlockLayoutContextProvider } from '@woocommerce/shared-context';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 
 /**
@@ -32,7 +32,7 @@ class Block extends Component {
 		 * wc-block-{$this->block_name},
 		 */
 		return (
-			<useInnerBlockLayoutContextProvider
+			<InnerBlockLayoutContextProvider
 				parentName="woocommerce/all-products"
 				layoutStyleClassPrefix="wc-block-grid"
 			>
@@ -40,7 +40,7 @@ class Block extends Component {
 					attributes={ attributes }
 					urlParameterSuffix={ urlParameterSuffix }
 				/>
-			</useInnerBlockLayoutContextProvider>
+			</InnerBlockLayoutContextProvider>
 		);
 	}
 }

--- a/assets/js/blocks/products/all-products/block.js
+++ b/assets/js/blocks/products/all-products/block.js
@@ -4,7 +4,7 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 import ProductListContainer from '@woocommerce/base-components/product-list/container';
-import { InnerBlockConfigurationProvider } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContextProvider } from '@woocommerce/shared-context';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 
 /**
@@ -32,7 +32,7 @@ class Block extends Component {
 		 * wc-block-{$this->block_name},
 		 */
 		return (
-			<InnerBlockConfigurationProvider
+			<useInnerBlockLayoutContextProvider
 				parentName="woocommerce/all-products"
 				layoutStyleClassPrefix="wc-block-grid"
 			>
@@ -40,7 +40,7 @@ class Block extends Component {
 					attributes={ attributes }
 					urlParameterSuffix={ urlParameterSuffix }
 				/>
-			</InnerBlockConfigurationProvider>
+			</useInnerBlockLayoutContextProvider>
 		);
 	}
 }

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -25,8 +25,12 @@ import PropTypes from 'prop-types';
 import { Icon, grid } from '@woocommerce/icons';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import { HAS_PRODUCTS } from '@woocommerce/block-settings';
-import { useInnerBlockLayoutContextProvider } from '@woocommerce/shared-context';
+import {
+	InnerBlockLayoutContextProvider,
+	ProductDataContextProvider,
+} from '@woocommerce/shared-context';
 import { getBlockMap } from '@woocommerce/atomic-utils';
+import { previewProducts } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
@@ -203,7 +207,11 @@ class Editor extends Component {
 					<div className="wc-block-grid has-1-columns">
 						<ul className="wc-block-grid__products">
 							<li className="wc-block-grid__product">
-								<InnerBlocks { ...InnerBlockProps } />
+								<ProductDataContextProvider
+									product={ previewProducts[ 0 ] }
+								>
+									<InnerBlocks { ...InnerBlockProps } />
+								</ProductDataContextProvider>
 							</li>
 						</ul>
 					</div>
@@ -272,7 +280,7 @@ class Editor extends Component {
 		}
 
 		return (
-			<useInnerBlockLayoutContextProvider
+			<InnerBlockLayoutContextProvider
 				parentName="woocommerce/all-products"
 				layoutStyleClassPrefix="wc-block-grid"
 			>
@@ -288,7 +296,7 @@ class Editor extends Component {
 						? this.renderEditMode()
 						: this.renderViewMode() }
 				</div>
-			</useInnerBlockLayoutContextProvider>
+			</InnerBlockLayoutContextProvider>
 		);
 	};
 }

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
 import { Icon, grid } from '@woocommerce/icons';
 import GridLayoutControl from '@woocommerce/block-components/grid-layout-control';
 import { HAS_PRODUCTS } from '@woocommerce/block-settings';
-import { InnerBlockConfigurationProvider } from '@woocommerce/shared-context';
+import { useInnerBlockLayoutContextProvider } from '@woocommerce/shared-context';
 import { getBlockMap } from '@woocommerce/atomic-utils';
 
 /**
@@ -272,7 +272,7 @@ class Editor extends Component {
 		}
 
 		return (
-			<InnerBlockConfigurationProvider
+			<useInnerBlockLayoutContextProvider
 				parentName="woocommerce/all-products"
 				layoutStyleClassPrefix="wc-block-grid"
 			>
@@ -288,7 +288,7 @@ class Editor extends Component {
 						? this.renderEditMode()
 						: this.renderViewMode() }
 				</div>
-			</InnerBlockConfigurationProvider>
+			</useInnerBlockLayoutContextProvider>
 		);
 	};
 }

--- a/assets/js/blocks/single-product/edit/layout-editor.js
+++ b/assets/js/blocks/single-product/edit/layout-editor.js
@@ -6,7 +6,7 @@ import { useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import {
-	useInnerBlockLayoutContextProvider,
+	InnerBlockLayoutContextProvider,
 	ProductDataContextProvider,
 } from '@woocommerce/shared-context';
 import { createBlocksFromTemplate } from '@woocommerce/atomic-utils';
@@ -39,7 +39,7 @@ const LayoutEditor = ( { product, clientId, isLoading } ) => {
 	}, [ clientId, replaceInnerBlocks ] );
 
 	return (
-		<useInnerBlockLayoutContextProvider
+		<InnerBlockLayoutContextProvider
 			parentName={ BLOCK_NAME }
 			layoutStyleClassPrefix={ baseClassName }
 		>
@@ -79,7 +79,7 @@ const LayoutEditor = ( { product, clientId, isLoading } ) => {
 					/>
 				</div>
 			</ProductDataContextProvider>
-		</useInnerBlockLayoutContextProvider>
+		</InnerBlockLayoutContextProvider>
 	);
 };
 

--- a/assets/js/blocks/single-product/edit/layout-editor.js
+++ b/assets/js/blocks/single-product/edit/layout-editor.js
@@ -6,7 +6,7 @@ import { useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { InnerBlocks, InspectorControls } from '@wordpress/block-editor';
 import {
-	InnerBlockConfigurationProvider,
+	useInnerBlockLayoutContextProvider,
 	ProductDataContextProvider,
 } from '@woocommerce/shared-context';
 import { createBlocksFromTemplate } from '@woocommerce/atomic-utils';
@@ -39,7 +39,7 @@ const LayoutEditor = ( { product, clientId, isLoading } ) => {
 	}, [ clientId, replaceInnerBlocks ] );
 
 	return (
-		<InnerBlockConfigurationProvider
+		<useInnerBlockLayoutContextProvider
 			parentName={ BLOCK_NAME }
 			layoutStyleClassPrefix={ baseClassName }
 		>
@@ -79,7 +79,7 @@ const LayoutEditor = ( { product, clientId, isLoading } ) => {
 					/>
 				</div>
 			</ProductDataContextProvider>
-		</InnerBlockConfigurationProvider>
+		</useInnerBlockLayoutContextProvider>
 	);
 };
 

--- a/assets/js/shared/context/index.js
+++ b/assets/js/shared/context/index.js
@@ -1,2 +1,2 @@
-export * from './inner-block-configuration-context';
+export * from './inner-block-layout-context';
 export * from './product-data-context';

--- a/assets/js/shared/context/inner-block-layout-context.js
+++ b/assets/js/shared/context/inner-block-layout-context.js
@@ -19,7 +19,7 @@ const InnerBlockLayoutContext = createContext( {
 export const useInnerBlockLayoutContext = () =>
 	useContext( InnerBlockLayoutContext );
 
-export const useInnerBlockLayoutContextProvider = ( {
+export const InnerBlockLayoutContextProvider = ( {
 	parentName = '',
 	layoutStyleClassPrefix = '',
 	children,
@@ -36,7 +36,7 @@ export const useInnerBlockLayoutContextProvider = ( {
 	);
 };
 
-useInnerBlockLayoutContextProvider.propTypes = {
+InnerBlockLayoutContextProvider.propTypes = {
 	children: PropTypes.node,
 	parentName: PropTypes.string,
 	layoutStyleClassPrefix: PropTypes.string,

--- a/assets/js/shared/context/inner-block-layout-context.js
+++ b/assets/js/shared/context/inner-block-layout-context.js
@@ -9,17 +9,17 @@ import { createContext, useContext } from '@wordpress/element';
  * all children blocks in a given tree contained in the context with information
  * about the parent block. Typically this is used for extensibility features.
  *
- * @member {Object} InnerBlockConfigurationContext A react context object
+ * @member {Object} InnerBlockLayoutContext A react context object
  */
-const InnerBlockConfigurationContext = createContext( {
+const InnerBlockLayoutContext = createContext( {
 	parentName: '',
 	layoutStyleClassPrefix: '',
 } );
 
-export const useInnerBlockConfigurationContext = () =>
-	useContext( InnerBlockConfigurationContext );
+export const useInnerBlockLayoutContext = () =>
+	useContext( InnerBlockLayoutContext );
 
-export const InnerBlockConfigurationProvider = ( {
+export const useInnerBlockLayoutContextProvider = ( {
 	parentName = '',
 	layoutStyleClassPrefix = '',
 	children,
@@ -30,13 +30,13 @@ export const InnerBlockConfigurationProvider = ( {
 	};
 
 	return (
-		<InnerBlockConfigurationContext.Provider value={ contextValue }>
+		<InnerBlockLayoutContext.Provider value={ contextValue }>
 			{ children }
-		</InnerBlockConfigurationContext.Provider>
+		</InnerBlockLayoutContext.Provider>
 	);
 };
 
-InnerBlockConfigurationProvider.propTypes = {
+useInnerBlockLayoutContextProvider.propTypes = {
 	children: PropTypes.node,
 	parentName: PropTypes.string,
 	layoutStyleClassPrefix: PropTypes.string,

--- a/assets/js/shared/context/product-data-context.js
+++ b/assets/js/shared/context/product-data-context.js
@@ -13,8 +13,7 @@ const ProductDataContext = createContext( {
 	product: null,
 } );
 
-export const useProductDataContextContext = () =>
-	useContext( ProductDataContext );
+export const useProductDataContext = () => useContext( ProductDataContext );
 
 export const ProductDataContextProvider = ( { product = null, children } ) => {
 	const contextValue = {


### PR DESCRIPTION
#2399 is a mammoth PR so I'm breaking out some fixes and changes to review separately.

This PR makes our Atomic Blocks context ready. The context support is backwards compatible with the old way of passing a product as a prop - that takes priority if used.

Changes:

- Refactored Atomic Blocks to not break when no product is given - this is important whilst context is loaded.
- Renamed `useProductDataContextContext` to `useProductDataContext`
- Renamed `useInnerBlockConfigurationContext` to `useInnerBlockLayoutContext` to better reflect its use.
- Added context handling to each Atomic Block
- Removed default "preview" data and instead injected it via the new context!

### How to test the changes in this Pull Request:

1. Using All Products Block, check there are no regressions in the layout edit view, in particular, check the preview data is shown correctly since this is now coming from context.
2. Check frontend view of All Products for regressions. Add to cart buttons etc.

That should cover it. Nothing else is using context except the layout edit preview data, so just testing all works as before is all thats needed.