### PR TITLE
Use named font sizes in filter block styles

### DIFF
--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -19,14 +19,14 @@
 }
 
 .wc-block-dropdown-selector__placeholder {
-	font-size: 0.8em;
+	@include font-size(small);
 	height: 1.8em;
 	margin: 0 $gap-smallest;
 	white-space: nowrap;
 }
 
 .wc-block-dropdown-selector__input {
-	font-size: 0.8em;
+	@include font-size(small);
 	height: 1.8em;
 	min-width: 0;
 
@@ -126,7 +126,7 @@
 
 	.wc-block-dropdown-selector__selected-value__label,
 	.wc-block-dropdown-selector__selected-chip__label {
-		font-size: 0.8em;
+		@include font-size(small);
 		flex-grow: 1;
 		padding: 0;
 		text-align: left;
@@ -160,9 +160,9 @@
 }
 
 .wc-block-dropdown-selector__list-item {
+	@include font-size(small);
 	color: $core-grey-dark-600;
 	cursor: default;
-	font-size: 0.8em;
 	list-style: none;
 	margin: 0;
 	padding: 0 $gap-smallest;

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -3,13 +3,13 @@
 	overflow: hidden;
 
 	.wc-block-active-filters__clear-all {
+		@include font-size(regular);
 		float: right;
 		background: transparent none;
 		border: none;
 		padding: 0;
 		text-decoration: underline;
 		cursor: pointer;
-		font-size: 1em;
 
 		&:hover {
 			background: transparent none;
@@ -33,8 +33,8 @@
 			}
 
 			.wc-block-active-filters__list-item-type {
+				@include font-size(smaller);
 				text-transform: uppercase;
-				font-size: 0.7em;
 				letter-spacing: 0.1em;
 				margin: $gap 0 0;
 				display: block;


### PR DESCRIPTION
Fixes #2536.

### Screenshots

![Screenshot from 2020-05-29 12-26-50](https://user-images.githubusercontent.com/3616980/83250140-f168a980-a1a7-11ea-9d3d-9caff82e364d.png)

### How to test the changes in this Pull Request:

In a page with the _All Products_, _Attribute Filters_ (with dropdown style and query type AND and OR) and _Active Filter_ blocks, verify there are no regressions and filter blocks look like in the screenshot.

### Changelog

> Filter block font sizes have been adjusted to be in line with other blocks.