### PR TITLE
Update Cart & Checkout heading styles

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -73,6 +73,7 @@ $fontSizes: (
 	color: inherit;
 	font-family: inherit;
 	font-size: inherit;
+	font-style: inherit;
 	font-weight: inherit;
 	letter-spacing: inherit;
 	line-height: inherit;

--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
+import Title from '@woocommerce/base-components/title';
 
 /**
  * Internal dependencies
@@ -11,9 +12,13 @@ import './style.scss';
 
 const StepHeading = ( { title, stepHeadingContent } ) => (
 	<div className="wc-block-checkout-step__heading">
-		<h2 aria-hidden="true" className="wc-block-checkout-step__title">
+		<Title
+			aria-hidden="true"
+			className="wc-block-checkout-step__title"
+			headingLevel="2"
+		>
 			{ title }
-		</h2>
+		</Title>
 		{ !! stepHeadingContent && (
 			<span className="wc-block-checkout-step__heading-content">
 				{ stepHeadingContent }

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -29,10 +29,7 @@ $line-offset-from-circle-size: 8px;
 	margin-bottom: $gap-smaller;
 
 	.wc-block-checkout-step__title {
-		@include font-size(regular);
 		line-height: 1.5;
-		color: $gray-80;
-		font-weight: 400;
 		margin: 0 $gap-small 0 0;
 	}
 }

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -27,6 +27,7 @@ $line-offset-from-circle-size: 8px;
 	align-content: center;
 	flex-wrap: wrap;
 	margin-bottom: $gap-smaller;
+	position: relative;
 
 	.wc-block-checkout-step__title {
 		line-height: 1.5;
@@ -36,8 +37,9 @@ $line-offset-from-circle-size: 8px;
 
 .wc-block-checkout-step__heading-content {
 	@include font-size(smaller);
-	line-height: 2;
 	color: $gray-80;
+	position: absolute;
+	right: 0;
 
 	a {
 		font-weight: bold;

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
@@ -81,8 +81,8 @@ const Package = ( {
 		return (
 			<DisclosureWidget
 				className="wc-block-shipping-rates-control__package"
-				buttonContent={ header }
 				initialOpen={ true }
+				title={ header }
 			>
 				{ body }
 			</DisclosureWidget>

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
@@ -6,7 +6,7 @@ import { _n, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import Label from '@woocommerce/base-components/label';
 import Title from '@woocommerce/base-components/title';
-import DisclosureWidget from '@woocommerce/base-components/disclosure-widget';
+import Panel from '@woocommerce/base-components/panel';
 import classNames from 'classnames';
 
 /**
@@ -79,13 +79,13 @@ const Package = ( {
 	);
 	if ( collapsible ) {
 		return (
-			<DisclosureWidget
+			<Panel
 				className="wc-block-shipping-rates-control__package"
 				initialOpen={ true }
 				title={ header }
 			>
 				{ body }
-			</DisclosureWidget>
+			</Panel>
 		);
 	}
 	return (

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
@@ -5,8 +5,9 @@ import PropTypes from 'prop-types';
 import { _n, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import Label from '@woocommerce/base-components/label';
+import Title from '@woocommerce/base-components/title';
+import DisclosureWidget from '@woocommerce/base-components/disclosure-widget';
 import classNames from 'classnames';
-import { PanelBody, PanelRow } from 'wordpress-components';
 
 /**
  * Internal dependencies
@@ -28,9 +29,12 @@ const Package = ( {
 	const header = (
 		<>
 			{ title && (
-				<div className="wc-block-shipping-rates-control__package-title">
+				<Title
+					className="wc-block-shipping-rates-control__package-title"
+					headingLevel="3"
+				>
 					{ title }
-				</div>
+				</Title>
 			) }
 			{ showItems && (
 				<ul className="wc-block-shipping-rates-control__package-items">
@@ -75,13 +79,13 @@ const Package = ( {
 	);
 	if ( collapsible ) {
 		return (
-			<PanelBody
+			<DisclosureWidget
 				className="wc-block-shipping-rates-control__package"
-				title={ header }
+				buttonContent={ header }
 				initialOpen={ true }
 			>
-				<PanelRow>{ body }</PanelRow>
-			</PanelBody>
+				{ body }
+			</DisclosureWidget>
 		);
 	}
 	return (

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
@@ -1,9 +1,15 @@
+.wc-block-shipping-rates-control__package {
+	.wc-block-shipping-rates-control__package-title {
+		margin: 0;
+	}
+}
+
 .wc-block-shipping-rates-control__package-items {
 	@include font-size(small);
 	color: $core-grey-dark-400;
 	display: block;
 	list-style: none;
-	margin: 0 0 $gap-small;
+	margin: 0;
 	padding: 0;
 }
 
@@ -25,7 +31,7 @@
 }
 
 .components-notice.wc-block-shipping-rates-control__no-results-notice {
-	margin-bottom: $gap;
+	margin-bottom: 0;
 }
 
 // Resets when it's inside a panel.
@@ -36,15 +42,6 @@
 		&,
 		&.is-opened {
 			padding-bottom: 0;
-		}
-
-		.components-panel__body-title {
-			margin-bottom: 0;
-		}
-
-		.components-panel__body-toggle {
-			padding-bottom: 14px;
-			padding-top: 14px;
 		}
 
 		.wc-block-shipping-rates-control__package-items {

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
@@ -1,7 +1,3 @@
-.wc-block-shipping-rates-control__package-title {
-	font-weight: bold;
-}
-
 .wc-block-shipping-rates-control__package-items {
 	@include font-size(small);
 	color: $core-grey-dark-400;
@@ -49,10 +45,6 @@
 		.components-panel__body-toggle {
 			padding-bottom: 14px;
 			padding-top: 14px;
-		}
-
-		.wc-block-shipping-rates-control__package-title {
-			font-weight: normal;
 		}
 
 		.wc-block-shipping-rates-control__package-items {

--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef } from '@wordpress/element';
-import { PanelBody, PanelRow } from 'wordpress-components';
 import { Button } from '@woocommerce/base-components/cart-checkout';
 import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
 import Label from '@woocommerce/base-components/label';
@@ -12,6 +11,7 @@ import LoadingMask from '@woocommerce/base-components/loading-mask';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 import { useValidationContext } from '@woocommerce/base-context';
+import DisclosureWidget from '@woocommerce/base-components/disclosure-widget';
 
 /**
  * Internal dependencies
@@ -42,9 +42,8 @@ const TotalsCouponCodeInput = ( {
 	const textInputId = `wc-block-coupon-code__input-${ instanceId }`;
 
 	return (
-		<PanelBody
-			className="wc-block-coupon-code"
-			title={
+		<DisclosureWidget
+			buttonContent={
 				<Label
 					label={ __(
 						'Coupon Code?',
@@ -57,6 +56,8 @@ const TotalsCouponCodeInput = ( {
 					htmlFor={ textInputId }
 				/>
 			}
+			buttonWrapperTag="h2"
+			className="wc-block-coupon-code"
 			initialOpen={ initialOpen }
 		>
 			<LoadingMask
@@ -67,7 +68,7 @@ const TotalsCouponCodeInput = ( {
 				isLoading={ isLoading }
 				showSpinner={ false }
 			>
-				<PanelRow className="wc-block-coupon-code__row">
+				<div className="wc-block-coupon-code__content">
 					<form className="wc-block-coupon-code__form">
 						<ValidatedTextInput
 							id={ textInputId }
@@ -105,9 +106,9 @@ const TotalsCouponCodeInput = ( {
 						propertyName="coupon"
 						elementId={ textInputId }
 					/>
-				</PanelRow>
+				</div>
 			</LoadingMask>
-		</PanelBody>
+		</DisclosureWidget>
 	);
 };
 

--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
@@ -11,7 +11,7 @@ import LoadingMask from '@woocommerce/base-components/loading-mask';
 import PropTypes from 'prop-types';
 import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
 import { useValidationContext } from '@woocommerce/base-context';
-import DisclosureWidget from '@woocommerce/base-components/disclosure-widget';
+import Panel from '@woocommerce/base-components/panel';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ const TotalsCouponCodeInput = ( {
 	const textInputId = `wc-block-coupon-code__input-${ instanceId }`;
 
 	return (
-		<DisclosureWidget
+		<Panel
 			className="wc-block-coupon-code"
 			initialOpen={ initialOpen }
 			title={
@@ -108,7 +108,7 @@ const TotalsCouponCodeInput = ( {
 					/>
 				</div>
 			</LoadingMask>
-		</DisclosureWidget>
+		</Panel>
 	);
 };
 

--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
@@ -43,7 +43,9 @@ const TotalsCouponCodeInput = ( {
 
 	return (
 		<DisclosureWidget
-			buttonContent={
+			className="wc-block-coupon-code"
+			initialOpen={ initialOpen }
+			title={
 				<Label
 					label={ __(
 						'Coupon Code?',
@@ -56,9 +58,7 @@ const TotalsCouponCodeInput = ( {
 					htmlFor={ textInputId }
 				/>
 			}
-			buttonWrapperTag="h2"
-			className="wc-block-coupon-code"
-			initialOpen={ initialOpen }
+			titleTag="h2"
 		>
 			<LoadingMask
 				screenReaderLabel={ __(

--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/style.scss
@@ -19,8 +19,9 @@
 	}
 }
 
-.wc-block-coupon-code__row {
+.wc-block-coupon-code__content {
 	flex-direction: column;
+	position: relative;
 
 	.wc-block-form-input-validation-error {
 		margin-top: $gap-smaller;

--- a/assets/js/base/components/disclosure-widget/index.js
+++ b/assets/js/base/components/disclosure-widget/index.js
@@ -29,6 +29,7 @@ const DisclosureWidget = ( {
 		>
 			<TitleTag>
 				<button
+					aria-expanded={ isOpen }
 					className="wc-blocks-components-disclosure-widget__button"
 					onClick={ () => setIsOpen( ! isOpen ) }
 				>

--- a/assets/js/base/components/disclosure-widget/index.js
+++ b/assets/js/base/components/disclosure-widget/index.js
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import { Icon, chevronUp, chevronDown } from '@woocommerce/icons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const DisclosureWidget = ( {
+	buttonContent,
+	buttonWrapperTag = 'div',
+	children,
+	className,
+	initialOpen = false,
+} ) => {
+	const [ isOpen, setIsOpen ] = useState( initialOpen );
+
+	const TagName = `${ buttonWrapperTag }`;
+	return (
+		<div
+			className={ classNames(
+				className,
+				'wc-blocks-components-disclosure-widget'
+			) }
+		>
+			<TagName>
+				<button
+					className="wc-blocks-components-disclosure-widget__button"
+					onClick={ () => setIsOpen( ! isOpen ) }
+				>
+					<Icon
+						aria-hidden="true"
+						className="wc-blocks-components-disclosure-widget__button-icon"
+						srcElement={ isOpen ? chevronUp : chevronDown }
+					/>
+					{ buttonContent }
+				</button>
+			</TagName>
+			<div
+				className="wc-blocks-components-disclosure-widget__content"
+				hidden={ ! isOpen }
+			>
+				{ children }
+			</div>
+		</div>
+	);
+};
+
+DisclosureWidget.propTypes = {
+	buttonContent: PropTypes.element,
+	buttonWrapperTag: PropTypes.string,
+	className: PropTypes.string,
+	initialOpen: PropTypes.bool,
+};
+
+export default DisclosureWidget;

--- a/assets/js/base/components/disclosure-widget/index.js
+++ b/assets/js/base/components/disclosure-widget/index.js
@@ -12,15 +12,15 @@ import { Icon, chevronUp, chevronDown } from '@woocommerce/icons';
 import './style.scss';
 
 const DisclosureWidget = ( {
-	buttonContent,
-	buttonWrapperTag = 'div',
 	children,
 	className,
 	initialOpen = false,
+	title,
+	titleTag = 'div',
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( initialOpen );
 
-	const TagName = `${ buttonWrapperTag }`;
+	const TagName = `${ titleTag }`;
 	return (
 		<div
 			className={ classNames(
@@ -38,7 +38,7 @@ const DisclosureWidget = ( {
 						className="wc-blocks-components-disclosure-widget__button-icon"
 						srcElement={ isOpen ? chevronUp : chevronDown }
 					/>
-					{ buttonContent }
+					{ title }
 				</button>
 			</TagName>
 			<div
@@ -52,10 +52,10 @@ const DisclosureWidget = ( {
 };
 
 DisclosureWidget.propTypes = {
-	buttonContent: PropTypes.element,
-	buttonWrapperTag: PropTypes.string,
 	className: PropTypes.string,
 	initialOpen: PropTypes.bool,
+	title: PropTypes.element,
+	titleTag: PropTypes.string,
 };
 
 export default DisclosureWidget;

--- a/assets/js/base/components/disclosure-widget/index.js
+++ b/assets/js/base/components/disclosure-widget/index.js
@@ -16,11 +16,10 @@ const DisclosureWidget = ( {
 	className,
 	initialOpen = false,
 	title,
-	titleTag = 'div',
+	titleTag: TitleTag = 'div',
 } ) => {
 	const [ isOpen, setIsOpen ] = useState( initialOpen );
 
-	const TagName = `${ titleTag }`;
 	return (
 		<div
 			className={ classNames(
@@ -28,7 +27,7 @@ const DisclosureWidget = ( {
 				'wc-blocks-components-disclosure-widget'
 			) }
 		>
-			<TagName>
+			<TitleTag>
 				<button
 					className="wc-blocks-components-disclosure-widget__button"
 					onClick={ () => setIsOpen( ! isOpen ) }
@@ -40,7 +39,7 @@ const DisclosureWidget = ( {
 					/>
 					{ title }
 				</button>
-			</TagName>
+			</TitleTag>
 			<div
 				className="wc-blocks-components-disclosure-widget__content"
 				hidden={ ! isOpen }

--- a/assets/js/base/components/disclosure-widget/style.scss
+++ b/assets/js/base/components/disclosure-widget/style.scss
@@ -1,0 +1,33 @@
+.wc-blocks-components-disclosure-widget__button {
+	&,
+	&:hover,
+	&:focus,
+	&:active {
+		@include reset-box();
+		@include reset-typography();
+		background: transparent;
+		box-shadow: none;
+		height: auto;
+		padding-bottom: em($gap-small);
+		padding-top: em($gap-small);
+		position: relative;
+		text-align: left;
+		width: 100%;
+	}
+
+	> .wc-blocks-components-disclosure-widget__button-icon {
+		position: absolute;
+		right: 0;
+		top: 50%;
+		transform: translateY(-50%);
+		width: auto;
+	}
+}
+
+.wc-blocks-components-disclosure-widget__content {
+	padding-bottom: em($gap);
+}
+
+.theme-twentytwenty .wc-blocks-components-disclosure-widget__button {
+	background: transparent;
+}

--- a/assets/js/base/components/panel/index.js
+++ b/assets/js/base/components/panel/index.js
@@ -11,7 +11,7 @@ import { Icon, chevronUp, chevronDown } from '@woocommerce/icons';
  */
 import './style.scss';
 
-const DisclosureWidget = ( {
+const Panel = ( {
 	children,
 	className,
 	initialOpen = false,
@@ -22,27 +22,24 @@ const DisclosureWidget = ( {
 
 	return (
 		<div
-			className={ classNames(
-				className,
-				'wc-blocks-components-disclosure-widget'
-			) }
+			className={ classNames( className, 'wc-blocks-components-panel' ) }
 		>
 			<TitleTag>
 				<button
 					aria-expanded={ isOpen }
-					className="wc-blocks-components-disclosure-widget__button"
+					className="wc-blocks-components-panel__button"
 					onClick={ () => setIsOpen( ! isOpen ) }
 				>
 					<Icon
 						aria-hidden="true"
-						className="wc-blocks-components-disclosure-widget__button-icon"
+						className="wc-blocks-components-panel__button-icon"
 						srcElement={ isOpen ? chevronUp : chevronDown }
 					/>
 					{ title }
 				</button>
 			</TitleTag>
 			<div
-				className="wc-blocks-components-disclosure-widget__content"
+				className="wc-blocks-components-panel__content"
 				hidden={ ! isOpen }
 			>
 				{ children }
@@ -51,11 +48,11 @@ const DisclosureWidget = ( {
 	);
 };
 
-DisclosureWidget.propTypes = {
+Panel.propTypes = {
 	className: PropTypes.string,
 	initialOpen: PropTypes.bool,
 	title: PropTypes.element,
 	titleTag: PropTypes.string,
 };
 
-export default DisclosureWidget;
+export default Panel;

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -8,11 +8,13 @@
 		background: transparent;
 		box-shadow: none;
 		height: auto;
-		padding-bottom: em($gap-small);
-		padding-top: em($gap-small);
+		padding-bottom: em($gap-small - 6px);
+		padding-top: em($gap-small - 6px);
 		position: relative;
 		text-align: left;
 		width: 100%;
+		margin-bottom: em(6px);
+		margin-top: em(6px);
 	}
 
 	> .wc-blocks-components-panel__button-icon {

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -8,13 +8,14 @@
 		background: transparent;
 		box-shadow: none;
 		height: auto;
+		line-height: 1;
+		margin-bottom: em(6px);
+		margin-top: em(6px);
 		padding-bottom: em($gap-small - 6px);
 		padding-top: em($gap-small - 6px);
 		position: relative;
 		text-align: left;
 		width: 100%;
-		margin-bottom: em(6px);
-		margin-top: em(6px);
 	}
 
 	> .wc-blocks-components-panel__button-icon {

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -1,4 +1,4 @@
-.wc-blocks-components-disclosure-widget__button {
+.wc-blocks-components-panel__button {
 	&,
 	&:hover,
 	&:focus,
@@ -15,7 +15,7 @@
 		width: 100%;
 	}
 
-	> .wc-blocks-components-disclosure-widget__button-icon {
+	> .wc-blocks-components-panel__button-icon {
 		position: absolute;
 		right: 0;
 		top: 50%;
@@ -24,10 +24,10 @@
 	}
 }
 
-.wc-blocks-components-disclosure-widget__content {
+.wc-blocks-components-panel__content {
 	padding-bottom: em($gap);
 }
 
-.theme-twentytwenty .wc-blocks-components-disclosure-widget__button {
+.theme-twentytwenty .wc-blocks-components-panel__button {
 	background: transparent;
 }

--- a/assets/js/base/components/payment-methods/express-checkout.js
+++ b/assets/js/base/components/payment-methods/express-checkout.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useExpressPaymentMethods } from '@woocommerce/base-hooks';
 import { StoreNoticesProvider } from '@woocommerce/base-context';
+import Title from '@woocommerce/base-components/title';
 
 /**
  * Internal dependencies
@@ -15,9 +16,12 @@ const ExpressCheckoutContainer = ( { children } ) => {
 	return (
 		<>
 			<div className="wc-block-component-express-checkout">
-				<div className="wc-block-component-express-checkout__title">
+				<Title
+					className="wc-block-component-express-checkout__title"
+					headingLevel="2"
+				>
 					{ __( 'Express checkout', 'woo-gutenberg-products-block' ) }
-				</div>
+				</Title>
 				<div className="wc-block-component-express-checkout__content">
 					<StoreNoticesProvider context="wc/express-payment-area">
 						{ children }

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -187,3 +187,12 @@
 		margin-left: $gap-smaller;
 	}
 }
+
+// For Twenty Twenty we need to increase specificity of the title.
+.theme-twentytwenty {
+	.wc-block-component-express-checkout .wc-block-component-express-checkout__title {
+		padding-left: $gap-small;
+		padding-right: $gap-small;
+		margin-left: $gap-small;
+	}
+}

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -3,9 +3,9 @@
 	border: 2px solid $black;
 	border-radius: 5px;
 	padding: 8px;
+	position: relative;
 
 	.wc-block-component-express-checkout__title {
-		position: relative;
 		background-color: $white;
 		padding-left: $gap-small;
 		padding-right: $gap-small;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -9,17 +9,16 @@
 		background-color: $white;
 		padding-left: $gap-small;
 		padding-right: $gap-small;
-		margin-top: -24px;
 		margin-left: $gap-small;
-		margin-bottom: $gap-small;
-		color: $black;
-		font-weight: bold;
 		display: inline-block;
 		vertical-align: middle;
+		transform: translateY(-50%);
+		position: absolute;
+		top: 0;
 	}
 
 	.wc-block-component-express-checkout__content {
-		padding: 0 $gap-large;
+		padding: $gap $gap-large 0;
 	}
 
 	.wc-block-component-express-checkout-payment-event-buttons {

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -35,8 +35,8 @@
 	}
 
 	.components-panel__body-title {
-		@include text-heading();
 		background: transparent;
+		display: inline;
 
 		&:hover,
 		&:focus,
@@ -45,11 +45,14 @@
 		}
 	}
 
-	.components-panel__body-toggle {
+	.components-panel__body-toggle,
+	// This selector is needed to reset styles from `@wordpress/components`.
+	.components-panel__body-toggle.components-button:focus:not(:disabled):not([aria-disabled="true"]) {
 		@include reset-typography();
+	}
+
+	.components-panel__body-toggle {
 		background: transparent;
-		font-weight: normal;
-		font-size: inherit;
 		padding-left: 0;
 		padding-right: 36px;
 

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -16,11 +16,11 @@
 	padding-left: percentage($gap-large / 1060px);
 	width: 35%;
 
-	.wc-blocks-components-disclosure-widget {
+	.wc-blocks-components-panel {
 		border-top: 1px solid $core-grey-light-600;
 		border-bottom: 1px solid $core-grey-light-600;
 
-		+ .wc-blocks-components-disclosure-widget {
+		+ .wc-blocks-components-panel {
 			border-top: none;
 		}
 
@@ -30,7 +30,7 @@
 		}
 	}
 
-	.wc-blocks-components-disclosure-widget__button {
+	.wc-blocks-components-panel__button {
 		min-height: 3em;
 
 		> svg {
@@ -60,8 +60,8 @@
 .is-large {
 	.wc-block-sidebar {
 		.wc-block-totals-table-item,
-		.wc-blocks-components-disclosure-widget__button,
-		.wc-blocks-components-disclosure-widget__content {
+		.wc-blocks-components-panel__button,
+		.wc-blocks-components-panel__content {
 			padding-left: $gap;
 			padding-right: $gap;
 		}

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -25,14 +25,12 @@
 		}
 
 		> h2 {
-			@include font-size(regular);
+			@include font-size(large);
 			@include reset-box();
 		}
 	}
 
 	.wc-blocks-components-panel__button {
-		min-height: 3em;
-
 		> svg {
 			padding-right: $gap;
 		}
@@ -71,7 +69,7 @@
 // For Twenty Twenty we need to increase specificity a bit more.
 .theme-twentytwenty {
 	.wc-block-sidebar .wc-blocks-components-panel > h2 {
-		@include font-size(regular);
+		@include font-size(large);
 		@include reset-box();
 	}
 }

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -67,3 +67,11 @@
 		}
 	}
 }
+
+// For Twenty Twenty we need to increase specificity a bit more.
+.theme-twentytwenty {
+	.wc-block-sidebar .wc-blocks-components-panel > h2 {
+		@include font-size(regular);
+		@include reset-box();
+	}
+}

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -13,57 +13,28 @@
 
 .wc-block-sidebar {
 	margin: 0;
-	padding-left: percentage($gap-largest / 1060px);
+	padding-left: percentage($gap-large / 1060px);
 	width: 35%;
 
-	// Reset Gutenberg <Panel> styles when used in the sidebar.
-	.components-panel__body {
+	.wc-blocks-components-disclosure-widget {
 		border-top: 1px solid $core-grey-light-600;
 		border-bottom: 1px solid $core-grey-light-600;
 
-		&.is-opened {
-			padding-left: 0;
-			padding-right: 0;
-			padding-top: 0;
+		+ .wc-blocks-components-disclosure-widget {
+			border-top: none;
+		}
 
-			> .components-panel__body-title {
-				margin-bottom: 0;
-				margin-left: 0;
-				margin-right: 0;
-			}
+		> h2 {
+			@include font-size(regular);
+			@include reset-box();
 		}
 	}
 
-	.components-panel__body-title {
-		background: transparent;
-		display: inline;
+	.wc-blocks-components-disclosure-widget__button {
+		min-height: 3em;
 
-		&:hover,
-		&:focus,
-		&:active {
-			background: transparent;
-		}
-	}
-
-	.components-panel__body-toggle,
-	// This selector is needed to reset styles from `@wordpress/components`.
-	.components-panel__body-toggle.components-button:focus:not(:disabled):not([aria-disabled="true"]) {
-		@include reset-typography();
-	}
-
-	.components-panel__body-toggle {
-		background: transparent;
-		padding-left: 0;
-		padding-right: 36px;
-
-		&:hover,
-		&:focus,
-		&:active {
-			background: transparent;
-		}
-
-		.components-panel__arrow {
-			right: 0;
+		> svg {
+			padding-right: $gap;
 		}
 	}
 }
@@ -82,17 +53,17 @@
 		.wc-block-sidebar {
 			padding: 0;
 			width: 100%;
+		}
+	}
+}
 
-			// Reset card component styling on mobile.
-			.components-card {
-				background: transparent;
-				box-shadow: none;
-				border: none;
-			}
-			.components-card__body {
-				border: none;
-				padding: 0;
-			}
+.is-large {
+	.wc-block-sidebar {
+		.wc-block-totals-table-item,
+		.wc-blocks-components-disclosure-widget__button,
+		.wc-blocks-components-disclosure-widget__content {
+			padding-left: $gap;
+			padding-right: $gap;
 		}
 	}
 }

--- a/assets/js/base/components/title/style.scss
+++ b/assets/js/base/components/title/style.scss
@@ -1,5 +1,4 @@
 // Extra class for specificity to overwrite editor styles.
 .wc-block-component__title.wc-block-component__title {
-	@include font-size(large);
-	font-weight: normal;
+	@include font-size(regular);
 }

--- a/assets/js/base/components/title/style.scss
+++ b/assets/js/base/components/title/style.scss
@@ -1,13 +1,13 @@
 // Extra class for specificity to overwrite editor styles.
 .wc-block-component__title.wc-block-component__title {
 	@include reset-box();
-	@include font-size(regular);
+	@include font-size(large);
 }
 
 // For Twenty Twenty we need to increase specificity a bit more.
 .theme-twentytwenty {
 	.wc-block-component__title.wc-block-component__title {
 		@include reset-box();
-		@include font-size(regular);
+		@include font-size(large);
 	}
 }

--- a/assets/js/base/components/title/style.scss
+++ b/assets/js/base/components/title/style.scss
@@ -1,4 +1,13 @@
 // Extra class for specificity to overwrite editor styles.
 .wc-block-component__title.wc-block-component__title {
+	@include reset-box();
 	@include font-size(regular);
+}
+
+// For Twenty Twenty we need to increase specificity a bit more.
+.theme-twentytwenty {
+	.wc-block-component__title.wc-block-component__title {
+		@include reset-box();
+		@include font-size(regular);
+	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -18,7 +18,6 @@ import {
 	DISPLAY_CART_PRICES_INCLUDING_TAX,
 } from '@woocommerce/block-settings';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
-import { Card, CardBody } from 'wordpress-components';
 import {
 	useStoreCartCoupons,
 	useStoreCart,
@@ -95,66 +94,54 @@ const Cart = ( { attributes } ) => {
 				/>
 			</Main>
 			<Sidebar className="wc-block-cart__sidebar">
-				<Card isElevated={ true }>
-					<CardBody>
-						<Title
-							headingLevel="2"
-							className="wc-block-cart__totals-title"
-						>
-							{ __(
-								'Cart totals',
-								'woo-gutenberg-products-block'
-							) }
-						</Title>
-						<SubtotalsItem
-							currency={ totalsCurrency }
-							values={ cartTotals }
-						/>
-						<TotalsFeesItem
-							currency={ totalsCurrency }
-							values={ cartTotals }
-						/>
-						<TotalsDiscountItem
-							cartCoupons={ appliedCoupons }
-							currency={ totalsCurrency }
-							isRemovingCoupon={ isRemovingCoupon }
-							removeCoupon={ removeCoupon }
-							values={ cartTotals }
-						/>
-						{ cartNeedsShipping && (
-							<TotalsShippingItem
-								showCalculator={ isShippingCalculatorEnabled }
-								showRatesWithoutAddress={
-									! isShippingCostHidden
-								}
-								values={ cartTotals }
-								currency={ totalsCurrency }
-							/>
-						) }
-						{ ! DISPLAY_CART_PRICES_INCLUDING_TAX && (
-							<TotalsTaxesItem
-								currency={ totalsCurrency }
-								values={ cartTotals }
-							/>
-						) }
-						{ COUPONS_ENABLED && (
-							<TotalsCouponCodeInput
-								onSubmit={ applyCoupon }
-								isLoading={ isApplyingCoupon }
-							/>
-						) }
-						<TotalsFooterItem
-							currency={ totalsCurrency }
-							values={ cartTotals }
-						/>
-						<CheckoutButton
-							link={ getSetting(
-								'page-' + attributes?.checkoutPageId,
-								false
-							) }
-						/>
-					</CardBody>
-				</Card>
+				<Title headingLevel="2" className="wc-block-cart__totals-title">
+					{ __( 'Cart totals', 'woo-gutenberg-products-block' ) }
+				</Title>
+				<SubtotalsItem
+					currency={ totalsCurrency }
+					values={ cartTotals }
+				/>
+				<TotalsFeesItem
+					currency={ totalsCurrency }
+					values={ cartTotals }
+				/>
+				<TotalsDiscountItem
+					cartCoupons={ appliedCoupons }
+					currency={ totalsCurrency }
+					isRemovingCoupon={ isRemovingCoupon }
+					removeCoupon={ removeCoupon }
+					values={ cartTotals }
+				/>
+				{ cartNeedsShipping && (
+					<TotalsShippingItem
+						showCalculator={ isShippingCalculatorEnabled }
+						showRatesWithoutAddress={ ! isShippingCostHidden }
+						values={ cartTotals }
+						currency={ totalsCurrency }
+					/>
+				) }
+				{ ! DISPLAY_CART_PRICES_INCLUDING_TAX && (
+					<TotalsTaxesItem
+						currency={ totalsCurrency }
+						values={ cartTotals }
+					/>
+				) }
+				{ COUPONS_ENABLED && (
+					<TotalsCouponCodeInput
+						onSubmit={ applyCoupon }
+						isLoading={ isApplyingCoupon }
+					/>
+				) }
+				<TotalsFooterItem
+					currency={ totalsCurrency }
+					values={ cartTotals }
+				/>
+				<CheckoutButton
+					link={ getSetting(
+						'page-' + attributes?.checkoutPageId,
+						false
+					) }
+				/>
 			</Sidebar>
 		</SidebarLayout>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -269,6 +269,8 @@ table.wc-block-cart-items {
 
 	.wc-block-sidebar {
 		> .wc-block-cart__totals-title,
+		.wc-block-cart__shipping-calculator,
+		.wc-block-shipping-totals__fieldset,
 		> .wc-block-cart__submit-container {
 			padding-left: $gap;
 			padding-right: $gap;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,11 +1,6 @@
 .wc-block-cart {
 	color: $core-grey-dark-600;
 
-	.wc-block-cart__main,
-	.wc-block-cart__sidebar .components-card__body.is-size-medium {
-		padding-top: 1.3em;
-	}
-
 	.wc-block-cart__item-count {
 		float: right;
 	}
@@ -26,6 +21,7 @@ table.wc-block-cart-items td {
 	background: none !important;
 	// Remove borders on default themes.
 	border: 0;
+	margin: 0;
 }
 
 .editor-styles-wrapper table.wc-block-cart-items,
@@ -269,6 +265,14 @@ table.wc-block-cart-items {
 
 	.wc-block-radio-control__input {
 		left: 0;
+	}
+
+	.wc-block-sidebar {
+		> .wc-block-cart__totals-title,
+		> .wc-block-cart__submit-container {
+			padding-left: $gap;
+			padding-right: $gap;
+		}
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
@@ -2,10 +2,9 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody, PanelBody, PanelRow } from 'wordpress-components';
-import { Icon, cart } from '@woocommerce/icons';
 import PropTypes from 'prop-types';
 import { useContainerWidthContext } from '@woocommerce/base-context';
+import DisclosureWidget from '@woocommerce/base-components/disclosure-widget';
 
 /**
  * Internal dependencies
@@ -20,39 +19,27 @@ const CheckoutOrderSummary = ( { cartItems = [] } ) => {
 	}
 
 	return (
-		<Card isElevated={ true }>
-			<CardBody>
-				<PanelBody
-					className="wc-block-order-summary"
-					title={
-						<>
-							<Icon
-								className="wc-block-order-summary__button-icon"
-								srcElement={ cart }
-							/>
-							<span className="wc-block-order-summary__button-text">
-								{ __(
-									'Order summary',
-									'woo-gutenberg-products-block'
-								) }
-							</span>
-						</>
-					}
-					initialOpen={ isLarge }
-				>
-					<PanelRow className="wc-block-order-summary__row">
-						{ cartItems.map( ( cartItem ) => {
-							return (
-								<CheckoutOrderSummaryItem
-									key={ cartItem.key }
-									cartItem={ cartItem }
-								/>
-							);
-						} ) }
-					</PanelRow>
-				</PanelBody>
-			</CardBody>
-		</Card>
+		<DisclosureWidget
+			className="wc-block-order-summary"
+			buttonContent={
+				<span className="wc-block-order-summary__button-text">
+					{ __( 'Order summary', 'woo-gutenberg-products-block' ) }
+				</span>
+			}
+			initialOpen={ isLarge }
+			buttonWrapperTag="h2"
+		>
+			<div className="wc-block-order-summary__content">
+				{ cartItems.map( ( cartItem ) => {
+					return (
+						<CheckoutOrderSummaryItem
+							key={ cartItem.key }
+							cartItem={ cartItem }
+						/>
+					);
+				} ) }
+			</div>
+		</DisclosureWidget>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { useContainerWidthContext } from '@woocommerce/base-context';
-import DisclosureWidget from '@woocommerce/base-components/disclosure-widget';
+import Panel from '@woocommerce/base-components/panel';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ const CheckoutOrderSummary = ( { cartItems = [] } ) => {
 	}
 
 	return (
-		<DisclosureWidget
+		<Panel
 			className="wc-block-order-summary"
 			initialOpen={ isLarge }
 			title={
@@ -39,7 +39,7 @@ const CheckoutOrderSummary = ( { cartItems = [] } ) => {
 					);
 				} ) }
 			</div>
-		</DisclosureWidget>
+		</Panel>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/order-summary.js
@@ -21,13 +21,13 @@ const CheckoutOrderSummary = ( { cartItems = [] } ) => {
 	return (
 		<DisclosureWidget
 			className="wc-block-order-summary"
-			buttonContent={
+			initialOpen={ isLarge }
+			title={
 				<span className="wc-block-order-summary__button-text">
 					{ __( 'Order summary', 'woo-gutenberg-products-block' ) }
 				</span>
 			}
-			initialOpen={ isLarge }
-			buttonWrapperTag="h2"
+			titleTag="h2"
 		>
 			<div className="wc-block-order-summary__content">
 				{ cartItems.map( ( cartItem ) => {

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -20,47 +20,31 @@
 }
 
 .wc-block-checkout__sidebar {
-	.wc-block-order-summary {
-		border: none;
-
-		&.is-opened {
-			padding-bottom: 0;
-		}
-
-		> .components-panel__body-title > .components-panel__body-toggle {
-			padding: $gap-small 0;
-		}
-
-		.components-panel__body-toggle {
-			padding: 0;
-		}
-	}
-
 	.wc-block-product-name {
 		color: inherit;
 	}
 
-	.wc-block-order-summary__button-icon {
-		vertical-align: middle;
+	.wc-block-order-summary {
+		border: 0;
 	}
 
-	.wc-block-order-summary__button-text {
-		margin-left: $gap;
-	}
-
-	.wc-block-order-summary__row {
+	.wc-block-order-summary__content {
 		display: table;
 		width: 100%;
 	}
 
 	.wc-block-order-summary-item {
 		display: table-row;
+		width: 100%;
+
 		> div {
 			border-bottom: 1px solid $core-grey-light-600;
 		}
+
 		&:last-child {
 			> div {
 				border-bottom: none;
+				padding-bottom: 0;
 			}
 		}
 	}
@@ -311,12 +295,6 @@
 }
 
 .is-large {
-	.wc-block-checkout__sidebar {
-		.wc-block-order-summary {
-			margin: -20px;
-		}
-	}
-
 	.wc-block-checkout__actions {
 		padding-right: 36px;
 	}
@@ -324,41 +302,6 @@
 	.wc-block-checkout__shipping-option {
 		.wc-block-radio-control__input {
 			margin-left: -8px;
-		}
-	}
-
-	.wc-block-checkout__sidebar {
-		.wc-block-totals-table-item {
-			padding-left: $gap;
-			padding-right: $gap;
-		}
-
-		.wc-block-coupon-code .components-panel__body-toggle {
-			padding-left: $gap;
-
-			.components-panel__arrow {
-				right: $gap-small;
-			}
-		}
-
-		.wc-block-coupon-code__row {
-			padding-left: $gap;
-			padding-right: $gap;
-
-		}
-
-		.wc-block-order-summary {
-			> .components-panel__body-title > .components-panel__body-toggle {
-				padding-left: $gap;
-
-				.components-panel__arrow {
-					right: $gap-small;
-				}
-			}
-		}
-
-		.wc-block-order-summary__row {
-			padding: 0 $gap;
 		}
 	}
 }

--- a/assets/js/icons/index.js
+++ b/assets/js/icons/index.js
@@ -6,6 +6,8 @@ export { default as bill } from './library/bill';
 export { default as card } from './library/card';
 export { default as cart } from './library/cart';
 export { default as checkPayment } from './library/check-payment';
+export { default as chevronDown } from './library/chevron-down';
+export { default as chevronUp } from './library/chevron-up';
 export { default as comment } from './library/comment';
 export { default as done } from './library/done';
 export { default as discussion } from './library/discussion';

--- a/assets/js/icons/library/chevron-down.js
+++ b/assets/js/icons/library/chevron-down.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const chevronDown = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<path d="M17 9.4L12 14 7 9.4l-1 1.2 6 5.4 6-5.4z" />
+	</SVG>
+);
+
+export default chevronDown;

--- a/assets/js/icons/library/chevron-up.js
+++ b/assets/js/icons/library/chevron-up.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const chevronUp = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<path d="M12 8l-6 5.4 1 1.2 5-4.6 5 4.6 1-1.2z" />
+	</SVG>
+);
+
+export default chevronUp;

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -111,7 +111,6 @@ const stableMainEntry = {
 	blocks: './assets/js/index.js',
 
 	// @wordpress/components styles
-	'panel-style': './node_modules/wordpress-components/src/panel/style.scss',
 	'custom-select-control-style':
 		'./node_modules/wordpress-components/src/custom-select-control/style.scss',
 	'spinner-style':


### PR DESCRIPTION
Fixes #2562.
Closes #2141.
Closes #2142.
Part of #2459.
Part of #2605.

This PR:
* Removes all hard-coded colors, font weight, font family, etc. from headings. So they are inherited from the theme.
* I replaced the `<Panel>` component from Gutenberg with a `<DisclosureWidget>`. `Panel` had some issues:
  * It was forcing the button to be an `<h2>`, that was not semantically correct because in some cases it needed to be an `<h3>` (shipping packages, for example).
  * Its styles were really influenced by their presence in the editor and it had some hard-coded colors. Resetting them in the frontend was getting harder and harder.
* I removed the `<Card>` component following to the designs in: pbIy4N-dY-p2.
#### Accessibility
- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots

_Cart:_
![imatge](https://user-images.githubusercontent.com/3616980/83417007-ca1d1100-a421-11ea-852e-1e0b77321874.png)

_Checkout:_
![imatge](https://user-images.githubusercontent.com/3616980/83418282-a35fda00-a423-11ea-832a-08441e64ab02.png)

### How to test the changes in this Pull Request:

1. In Storefront, go to _Appearance_ > _Customize_ and change the _Heading_ color.
2. Visit the _Cart_ and _Checkout_ blocks and verify the heading color is applied to the headings.
3. Verify there are no regressions related to the `Panel` → `DisclosureWidget` change. Click on the `Order Summary` title, the `Coupon?`, etc.
4. Verify the _Cart_ and _Checkout_ blocks don't have `Card`s in the sidebar.
5. Feel free to try with other themes and verify the heading styles are correctly applied to the blocks.

### Changelog

> The Cart and Checkout blocks now use the heading styles provided by the theme.