### PR TITLE
Add aria-expanded to Change address button

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/index.js
@@ -104,6 +104,7 @@ const TotalsShippingItem = ( {
 										! isShippingCalculatorOpen
 									);
 								} }
+								aria-expanded={ isShippingCalculatorOpen }
 							>
 								{ __(
 									'(change address)',


### PR DESCRIPTION
Adding `aria-expanded` to the `Change address` button in the _Cart_ block will make screen readers announce it's an expandable button and whether the associated content is currently expanded or not.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### How to test the changes in this Pull Request:

1. With a screen reader navigate the _Cart_ block and verify when the `Change address` button is focused, it correctly announces whether it's expanded or not.

### Changelog

> Added aria-expanded attribute to Change address button in the Cart block