### PR TITLE
Update item count badge styles

### DIFF
--- a/assets/js/base/components/cart-checkout/index.js
+++ b/assets/js/base/components/cart-checkout/index.js
@@ -2,6 +2,7 @@ export { default as AddressForm } from './address-form';
 export { default as Button } from './button';
 export { default as CheckoutForm } from './form';
 export { default as FormStep } from './form-step';
+export { default as OrderSummary } from './order-summary';
 export { default as PlaceOrderButton } from './place-order-button';
 export { default as Policies } from './policies';
 export { default as ProductImage } from './product-image';

--- a/assets/js/base/components/cart-checkout/order-summary/index.js
+++ b/assets/js/base/components/cart-checkout/order-summary/index.js
@@ -9,9 +9,9 @@ import Panel from '@woocommerce/base-components/panel';
 /**
  * Internal dependencies
  */
-import CheckoutOrderSummaryItem from './order-summary-item.js';
+import OrderSummaryItem from './order-summary-item.js';
 
-const CheckoutOrderSummary = ( { cartItems = [] } ) => {
+const OrderSummary = ( { cartItems = [] } ) => {
 	const { isLarge, hasContainerWidth } = useContainerWidthContext();
 
 	if ( ! hasContainerWidth ) {
@@ -20,19 +20,19 @@ const CheckoutOrderSummary = ( { cartItems = [] } ) => {
 
 	return (
 		<Panel
-			className="wc-block-order-summary"
+			className="wc-block-components-order-summary"
 			initialOpen={ isLarge }
 			title={
-				<span className="wc-block-order-summary__button-text">
+				<span className="wc-block-components-order-summary__button-text">
 					{ __( 'Order summary', 'woo-gutenberg-products-block' ) }
 				</span>
 			}
 			titleTag="h2"
 		>
-			<div className="wc-block-order-summary__content">
+			<div className="wc-block-order-components-summary__content">
 				{ cartItems.map( ( cartItem ) => {
 					return (
-						<CheckoutOrderSummaryItem
+						<OrderSummaryItem
 							key={ cartItem.key }
 							cartItem={ cartItem }
 						/>
@@ -43,10 +43,10 @@ const CheckoutOrderSummary = ( { cartItems = [] } ) => {
 	);
 };
 
-CheckoutOrderSummary.propTypes = {
+OrderSummary.propTypes = {
 	cartItems: PropTypes.arrayOf(
 		PropTypes.shape( { key: PropTypes.string.isRequired } )
 	),
 };
 
-export default CheckoutOrderSummary;
+export default OrderSummary;

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -14,7 +14,7 @@ import {
 import PropTypes from 'prop-types';
 import Dinero from 'dinero.js';
 
-const CheckoutOrderSummaryItem = ( { cartItem } ) => {
+const OrderSummaryItem = ( { cartItem } ) => {
 	const {
 		images,
 		low_stock_remaining: lowStockRemaining = null,
@@ -37,9 +37,9 @@ const CheckoutOrderSummaryItem = ( { cartItem } ) => {
 		.getAmount();
 
 	return (
-		<div className="wc-block-order-summary-item">
-			<div className="wc-block-order-summary-item__image">
-				<div className="wc-block-order-summary-item__quantity">
+		<div className="wc-block-components-order-summary-item">
+			<div className="wc-block-components-order-summary-item__image">
+				<div className="wc-block-components-order-summary-item__quantity">
 					<Label
 						label={ quantity }
 						screenReaderLabel={ sprintf(
@@ -51,11 +51,11 @@ const CheckoutOrderSummaryItem = ( { cartItem } ) => {
 				</div>
 				<ProductImage image={ images.length ? images[ 0 ] : {} } />
 			</div>
-			<div className="wc-block-order-summary-item__description">
-				<div className="wc-block-order-summary-item__header">
+			<div className="wc-block-components-order-summary-item__description">
+				<div className="wc-block-components-order-summary-item__header">
 					<ProductName permalink={ permalink } name={ name } />
 					<ProductPrice
-						className="wc-block-order-summary-item__total-price"
+						className="wc-block-components-order-summary-item__total-price"
 						currency={ currency }
 						value={ linePrice }
 					/>
@@ -71,7 +71,7 @@ const CheckoutOrderSummaryItem = ( { cartItem } ) => {
 	);
 };
 
-CheckoutOrderSummaryItem.propTypes = {
+OrderSummaryItem.propTypes = {
 	cartItems: PropTypes.shape( {
 		images: PropTypes.array,
 		low_stock_remaining: PropTypes.number,
@@ -87,4 +87,4 @@ CheckoutOrderSummaryItem.propTypes = {
 	} ),
 };
 
-export default CheckoutOrderSummaryItem;
+export default OrderSummaryItem;

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import {
+	OrderSummary,
 	SubtotalsItem,
 	TotalsFeesItem,
 	TotalsCouponCodeInput,
@@ -17,11 +18,6 @@ import {
 	DISPLAY_CART_PRICES_INCLUDING_TAX,
 } from '@woocommerce/block-settings';
 import { useStoreCartCoupons } from '@woocommerce/base-hooks';
-
-/**
- * Internal dependencies
- */
-import OrderSummary from './order-summary.js';
 
 const CheckoutSidebar = ( {
 	cartCoupons = [],

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -28,16 +28,16 @@
 	}
 }
 
-.wc-block-order-summary {
+.wc-block-components-order-summary {
 	border: 0;
 }
 
-.wc-block-order-summary__content {
+.wc-block-components-order-summary__content {
 	display: table;
 	width: 100%;
 }
 
-.wc-block-order-summary-item {
+.wc-block-components-order-summary-item {
 	display: table-row;
 	width: 100%;
 
@@ -53,13 +53,13 @@
 	}
 }
 
-.wc-block-order-summary-item__image,
-.wc-block-order-summary-item__description {
+.wc-block-components-order-summary-item__image,
+.wc-block-components-order-summary-item__description {
 	display: table-cell;
 	vertical-align: top;
 }
 
-.wc-block-order-summary-item__image {
+.wc-block-components-order-summary-item__image {
 	width: #{$gap-large * 2};
 	padding-top: $gap;
 	padding-bottom: $gap;
@@ -71,7 +71,7 @@
 	}
 }
 
-.wc-block-order-summary-item__quantity {
+.wc-block-components-order-summary-item__quantity {
 	@include font-size(smaller);
 	align-items: center;
 	background: #fff;
@@ -93,7 +93,7 @@
 	z-index: 1;
 }
 
-.wc-block-order-summary-item__description {
+.wc-block-components-order-summary-item__description {
 	padding-left: $gap-large;
 	padding-top: $gap;
 	padding-bottom: $gap;
@@ -106,7 +106,7 @@
 	}
 }
 
-.wc-block-order-summary-item__header {
+.wc-block-components-order-summary-item__header {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-between;

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -70,11 +70,11 @@
 	.wc-block-order-summary-item__quantity {
 		@include font-size(smaller);
 		align-items: center;
-		background: #000;
-		border: 2px solid #fff;
+		background: #fff;
+		border: 2px solid;
 		border-radius: 1em;
-		box-shadow: 0 0 0 2px #000;
-		color: #fff;
+		box-shadow: 0 0 0 2px #fff;
+		color: #000;
 		display: flex;
 		line-height: 1;
 		min-height: 20px;

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -22,97 +22,94 @@
 .wc-block-checkout__sidebar {
 	.wc-block-product-name {
 		color: inherit;
-	}
-
-	.wc-block-order-summary {
-		border: 0;
-	}
-
-	.wc-block-order-summary__content {
-		display: table;
-		width: 100%;
-	}
-
-	.wc-block-order-summary-item {
-		display: table-row;
-		width: 100%;
-
-		> div {
-			border-bottom: 1px solid $core-grey-light-600;
-		}
-
-		&:last-child {
-			> div {
-				border-bottom: none;
-				padding-bottom: 0;
-			}
-		}
-	}
-
-	.wc-block-order-summary-item__image,
-	.wc-block-order-summary-item__description {
-		display: table-cell;
-		vertical-align: top;
-	}
-
-	.wc-block-order-summary-item__image {
-		width: #{$gap-large * 2};
-		padding-top: $gap;
-		padding-bottom: $gap;
-		position: relative;
-
-		> img {
-			width: #{$gap-large * 2};
-			max-width: #{$gap-large * 2};
-		}
-	}
-
-	.wc-block-order-summary-item__quantity {
-		@include font-size(smaller);
-		align-items: center;
-		background: #fff;
-		border: 2px solid;
-		border-radius: 1em;
-		box-shadow: 0 0 0 2px #fff;
-		color: #000;
-		display: flex;
-		line-height: 1;
-		min-height: 20px;
-		padding: 0 0.4em;
-		position: absolute;
-		justify-content: center;
-		min-width: 20px;
-		right: 0;
-		top: $gap;
-		transform: translate(50%, -50%);
-		white-space: nowrap;
-		z-index: 1;
-	}
-
-	.wc-block-order-summary-item__description {
-		padding-left: $gap-large;
-		padding-top: $gap;
-		padding-bottom: $gap;
-		line-height: 1.375;
-
-		p,
-		.wc-block-product-metadata {
-			line-height: 1.375;
-			margin-top: #{ ( $gap-large - $gap ) / 2 };
-		}
-	}
-
-	.wc-block-order-summary-item__header {
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: space-between;
-	}
-
-	.wc-block-product-name {
 		flex-grow: 1;
 		// Required by IE11.
 		flex-basis: 0;
 	}
+}
+
+.wc-block-order-summary {
+	border: 0;
+}
+
+.wc-block-order-summary__content {
+	display: table;
+	width: 100%;
+}
+
+.wc-block-order-summary-item {
+	display: table-row;
+	width: 100%;
+
+	> div {
+		border-bottom: 1px solid $core-grey-light-600;
+	}
+
+	&:last-child {
+		> div {
+			border-bottom: none;
+			padding-bottom: 0;
+		}
+	}
+}
+
+.wc-block-order-summary-item__image,
+.wc-block-order-summary-item__description {
+	display: table-cell;
+	vertical-align: top;
+}
+
+.wc-block-order-summary-item__image {
+	width: #{$gap-large * 2};
+	padding-top: $gap;
+	padding-bottom: $gap;
+	position: relative;
+
+	> img {
+		width: #{$gap-large * 2};
+		max-width: #{$gap-large * 2};
+	}
+}
+
+.wc-block-order-summary-item__quantity {
+	@include font-size(smaller);
+	align-items: center;
+	background: #fff;
+	border: 2px solid;
+	border-radius: 1em;
+	box-shadow: 0 0 0 2px #fff;
+	color: #000;
+	display: flex;
+	line-height: 1;
+	min-height: 20px;
+	padding: 0 0.4em;
+	position: absolute;
+	justify-content: center;
+	min-width: 20px;
+	right: 0;
+	top: $gap;
+	transform: translate(50%, -50%);
+	white-space: nowrap;
+	z-index: 1;
+}
+
+.wc-block-order-summary-item__description {
+	padding-left: $gap-large;
+	padding-top: $gap;
+	padding-bottom: $gap;
+	line-height: 1.375;
+
+	p,
+	.wc-block-product-metadata {
+		line-height: 1.375;
+		margin-top: #{ ( $gap-large - $gap ) / 2 };
+	}
+}
+
+.wc-block-order-summary-item__header {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
 }
 
 .wc-block-component-express-checkout-continue-rule {

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -85,6 +85,7 @@
 		right: 0;
 		top: $gap;
 		transform: translate(50%, -50%);
+		white-space: nowrap;
 		z-index: 1;
 	}
 

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -70,20 +70,22 @@
 	.wc-block-order-summary-item__quantity {
 		@include font-size(smaller);
 		align-items: center;
-		background: #fff;
-		border: 2px solid currentColor;
-		border-radius: 50%;
-		// Use box-shadow to apply an extra border to the quantity.
-		// This distinguishes it from the product image.
-		box-shadow: 0 0 0 2px #fff;
+		background: #000;
+		border: 2px solid #fff;
+		border-radius: 1em;
+		box-shadow: 0 0 0 2px #000;
+		color: #fff;
 		display: flex;
 		line-height: 1;
-		min-height: 22px;
+		min-height: 20px;
+		padding: 0 0.4em;
 		position: absolute;
 		justify-content: center;
-		min-width: 22px;
-		right: -10px;
-		margin: -10px 0 0 0;
+		min-width: 20px;
+		right: 0;
+		top: $gap;
+		transform: translate(50%, -50%);
+		z-index: 1;
 	}
 
 	.wc-block-order-summary-item__description {

--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -2,4 +2,5 @@
 
 This page includes all documentation regarding WooCommerce Blocks and themes.
 
+-   [Cart and Checkout](./cart-and-checkout.md)
 -   [Product grid blocks style update in 2.7.0](./product-grid-270.md)

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -9,7 +9,7 @@ The item quantity badge is the number that appears next to the image in the _Ord
 By default, it uses a combination of black and white borders and shadows so it has enough contrast with themes with light and dark backgrounds. Themes can modify the colors with their own palette with a single CSS selector and four properties. For example:
 
 ```CSS
-.wc-block-order-summary-item__quantity {
+.wc-block-components-order-summary-item__quantity {
 	background: #f9f4ee;
 	border-color: #4b3918;
 	box-shadow: 0 0 0 2px #f9f4ee;

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -1,0 +1,20 @@
+# Cart and Checkout Blocks theming
+
+## Item quantity badge
+
+The item quantity badge is the number that appears next to the image in the _Order summary_ section of the _Checkout_ block sidebar.
+
+<img src="https://user-images.githubusercontent.com/3616980/83862844-c8559500-a722-11ea-9653-2fc8bcd544d2.png" alt="Order summary screenshot" width="234" />
+
+By default, it uses a combination of black and white borders and shadows so it has enough contrast with themes with light and dark backgrounds. Themes can modify the colors with their own palette with a single CSS selector and four properties. For example:
+
+```CSS
+.wc-block-order-summary-item__quantity {
+	background: #f9f4ee;
+	border-color: #4b3918;
+	box-shadow: 0 0 0 2px #f9f4ee;
+	color: #4b3918;
+}
+```
+
+<img src="https://user-images.githubusercontent.com/3616980/83863109-2e421c80-a723-11ea-9bf7-2033a96cf5b2.png" alt="Order summary screenshot with custom styles for the item quantity badge" width="231" />


### PR DESCRIPTION
Fixes #2617.

Small PR updating the item count badge styles in the _Cart_ block.

### Screenshots
| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/83643144-f6ff2e80-a5af-11ea-9df5-8e68ef01dfa3.png) | ![imatge](https://user-images.githubusercontent.com/3616980/83643024-d9ca6000-a5af-11ea-85a3-c98bb1a4e00a.png) |

### How to test the changes in this Pull Request:
Open the _Cart_ block and verify the item count badge matches the new styles.

### Changelog

> The item count badges of the Checkout block have been updated so it looks better in light & dark backgrounds.