### PR TITLE
Update WC tested version to 4.2

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -10,7 +10,7 @@
  * Requires at least: 5.2
  * Requires PHP: 5.6
  * WC requires at least: 4.0
- * WC tested up to: 4.0
+ * WC tested up to: 4.2
  *
  * @package WooCommerce\Blocks
  * @internal This file is only used when running the REST API as a feature plugin.


### PR DESCRIPTION
This might not be needed in the future (see https://github.com/woocommerce/woocommerce/pull/26685), but for now, we need to update the WooCommerce tested version.