### PR TITLE
Avoid some theme style properties leaking into the Cart and Checkout select controls

### DIFF
--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -39,27 +39,26 @@
 	}
 
 	.components-custom-select-control__button {
-		@include font-size(regular);
-		background-color: #fff;
-		box-shadow: none;
-		color: $input-text-active;
-		font-family: inherit;
-		font-weight: normal;
-		height: 3em;
-		letter-spacing: inherit;
-		line-height: 1;
-		overflow: hidden;
-		padding: em($gap-large) $gap em($gap-smallest);
-		text-overflow: ellipsis;
-		text-transform: none;
-		white-space: nowrap;
-		width: 100%;
-
+		&,
 		&:hover,
 		&:focus,
 		&:active {
+			@include font-size(regular);
 			background-color: #fff;
-			text-decoration: none;
+			box-shadow: none;
+			color: $input-text-active;
+			font-family: inherit;
+			font-weight: normal;
+			height: 3em;
+			letter-spacing: inherit;
+			line-height: 1;
+			overflow: hidden;
+			padding: em($gap-large) $gap em($gap-smallest);
+			text-align: left;
+			text-overflow: ellipsis;
+			text-transform: none;
+			white-space: nowrap;
+			width: 100%;
 		}
 	}
 


### PR DESCRIPTION
Some themes are adding styles to hovered buttons that don't make sense in our Select component (ie: [Hello theme](https://elementor.com/hello-theme/) sets the button text color to white when hovered, making the text invisible). This PR explicitly defines all select styles for the different states, making it harder for themes to break the select component.

It also forces the text to be left-aligned.

### Screenshots

Screenshot of the issue:
![Peek 2020-06-05 10-49](https://user-images.githubusercontent.com/3616980/83856703-419cba00-a71a-11ea-971b-3651c39a15b2.gif)

### How to test the changes in this Pull Request:

1. In Storefront (and, optionally, other themes), make sure there are no regressions with selects in _Cart_ & _Checkout_ address forms.
2. Install the [Hello theme](https://elementor.com/hello-theme/) from Elementor and make sure text in selects is visible when hovered and is left aligned.

### Changelog

> Avoid some theme style properties leaking into the Cart and Checkout select controls.