### PR TITLE
Rename wc-single-product script name

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -85,7 +85,7 @@ class Assets {
 		self::register_script( 'wc-cart-block', plugins_url( self::get_block_asset_build_path( 'cart' ), __DIR__ ), $block_dependencies );
 
 		if ( 'experimental' === WOOCOMMERCE_BLOCKS_PHASE ) {
-			self::register_script( 'wc-single-product', plugins_url( self::get_block_asset_build_path( 'single-product' ), __DIR__ ), $block_dependencies );
+			self::register_script( 'wc-single-product-block', plugins_url( self::get_block_asset_build_path( 'single-product' ), __DIR__ ), $block_dependencies );
 		}
 	}
 

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -30,7 +30,7 @@ class SingleProduct extends AbstractBlock {
 			$this->namespace . '/' . $this->block_name,
 			array(
 				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
+				'editor_script'   => 'wc-' . $this->block_name . '-block',
 				'editor_style'    => 'wc-block-editor',
 				'style'           => [ 'wc-block-style', 'wc-block-vendors-style' ],
 				'script'          => 'wc-' . $this->block_name . '-frontend',


### PR DESCRIPTION
Fixes #2646.

WC Core has a script named `wc-single-product` that is used for the Single Product page image. We were naming the Single Product block script with the same name, so there was a conflict. This PR renames our script to `wc-single-product-block`.

### How to test the changes in this Pull Request:

1. Go to a product's page.
2. Verify the images load as usual.
3. Verify there are no regressions in the single product block.