### PR TITLE
Update Checkout step progress indicator design

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -48,12 +48,16 @@ const FormStep = ( {
 				title={ title }
 				stepHeadingContent={ stepHeadingContent() }
 			/>
-			{ !! description && (
-				<p className="wc-block-checkout-step__description">
-					{ description }
-				</p>
-			) }
-			<div className="wc-block-checkout-step__content">{ children }</div>
+			<div className="wc-block-checkout-step__container">
+				{ !! description && (
+					<p className="wc-block-checkout-step__description">
+						{ description }
+					</p>
+				) }
+				<div className="wc-block-checkout-step__content">
+					{ children }
+				</div>
+			</div>
 		</fieldset>
 	);
 };

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -1,6 +1,3 @@
-$circle-size: 24px;
-$line-offset-from-circle-size: 8px;
-
 .wc-block-checkout-form {
 	counter-reset: checkout-step;
 }
@@ -8,13 +5,21 @@ $line-offset-from-circle-size: 8px;
 .wc-block-checkout-form fieldset.wc-block-checkout-step {
 	position: relative;
 	border: none;
-	padding: 0 0 $gap-larger $gap-larger;
+	padding: 0 0 0 $gap-larger;
 	background: none;
 	margin: 0;
 
 	.is-large & {
 		padding-right: $gap-large;
 	}
+}
+
+.wc-block-checkout-step__container {
+	position: relative;
+}
+
+.wc-block-checkout-step__content {
+	padding-bottom: $gap-larger;
 }
 
 .wc-block-checkout-form fieldset.wc-block-checkout-step:disabled {
@@ -28,11 +33,11 @@ $line-offset-from-circle-size: 8px;
 	flex-wrap: wrap;
 	margin-bottom: $gap-smaller;
 	position: relative;
+}
 
-	.wc-block-checkout-step__title {
-		line-height: 1.5;
-		margin: 0 $gap-small 0 0;
-	}
+.wc-block-checkout-step__title {
+	line-height: 1.5;
+	margin: 0 $gap-small 0 0;
 }
 
 .wc-block-checkout-step__heading-content {
@@ -54,37 +59,29 @@ $line-offset-from-circle-size: 8px;
 	margin-bottom: $gap;
 }
 
-.wc-block-checkout-step::before {
-	@include font-size(small);
+.wc-block-checkout-step__title::before {
+	@include reset-box();
+	background: transparent;
 	counter-increment: checkout-step;
-	content: counter(checkout-step);
-	content: counter(checkout-step) / "";
+	content: "\00a0" counter(checkout-step) ".";
+	content: "\00a0" counter(checkout-step) "." / "";
 	position: absolute;
-	width: $circle-size;
-	height: $circle-size;
-	left: 0;
+	width: $gap-larger;
+	left: -$gap-larger/2;
 	top: 0;
-	background: $gray-20;
-	color: $white;
-	line-height: $circle-size;
 	text-align: center;
-	border-radius: $circle-size / 2;
-	box-sizing: content-box;
+	transform: translateX(-50%);
 }
 
-// because themes can register different background colors, we can't always
-// relay on using white border to offest the step left line,
-.wc-block-checkout-step::after {
+.wc-block-checkout-step__container::after {
 	content: "";
-	// 1 Circle size + offset of the first circle and next circle.
-	height: calc(100% - #{$circle-size + $line-offset-from-circle-size * 2});
-	width: 1px;
-	background-color: $gray-10;
+	height: calc(100% - #{$gap-smaller});
+	border-left: 1px solid;
 	position: absolute;
-	left: $circle-size/2;
-	top: $circle-size + $line-offset-from-circle-size;
+	left: -$gap-larger/2;
+	top: 0;
 }
 
-.wc-block-checkout-step:last-child::after {
+.wc-block-checkout-step:last-child .wc-block-checkout-step__container::after {
 	content: none;
 }

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -174,7 +174,25 @@
 		width: 150px;
 	}
 	.wc-block-checkout-form {
-		fieldset span {
+		.wc-block-checkout-step__title {
+			@include placeholder();
+			@include force-content();
+			display: block;
+			width: 10em;
+
+			&::before {
+				@include placeholder();
+				@include force-content();
+				border-radius: 50%;
+				display: block;
+				height: 100%;
+				width: 1.5em;
+			}
+		}
+		.wc-block-checkout-step__container::after {
+			@include placeholder();
+		}
+		.wc-block-checkout-step__content > span {
 			@include placeholder();
 			@include force-content();
 			display: block;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -176,16 +176,44 @@ class Checkout extends AbstractBlock {
 					<div class="wc-block-components-express-checkout-continue-rule"><span></span></div>
 					<form class="wc-block-checkout-form">
 						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<span></span>
+							<div class="wc-block-checkout-step__heading">
+								<div class="wc-block-checkout-step__title"></div>
+							</div>
+							<div class="wc-block-checkout-step__container">
+								<div class="wc-block-checkout-step__content">
+									<span></span>
+								</div>
+							</div>
 						</fieldset>
 						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<span></span>
+							<div class="wc-block-checkout-step__heading">
+								<div class="wc-block-checkout-step__title"></div>
+							</div>
+							<div class="wc-block-checkout-step__container">
+								<div class="wc-block-checkout-step__content">
+									<span></span>
+								</div>
+							</div>
 						</fieldset>
 						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<span></span>
+							<div class="wc-block-checkout-step__heading">
+								<div class="wc-block-checkout-step__title"></div>
+							</div>
+							<div class="wc-block-checkout-step__container">
+								<div class="wc-block-checkout-step__content">
+									<span></span>
+								</div>
+							</div>
 						</fieldset>
 						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<span></span>
+							<div class="wc-block-checkout-step__heading">
+								<div class="wc-block-checkout-step__title"></div>
+							</div>
+							<div class="wc-block-checkout-step__container">
+								<div class="wc-block-checkout-step__content">
+									<span></span>
+								</div>
+							</div>
 						</fieldset>
 					</form>
 				</div>


### PR DESCRIPTION
Fixes #2618.

### Screenshots
_Storefront:_
![imatge](https://user-images.githubusercontent.com/3616980/83887700-1b424300-a749-11ea-9ee7-08d407b16075.png)

_Twenty Twenty:_
![imatge](https://user-images.githubusercontent.com/3616980/83887763-2f864000-a749-11ea-8eea-a90b745b62ab.png)

_Bistro:_
![imatge](https://user-images.githubusercontent.com/3616980/83887862-53498600-a749-11ea-8252-dad6c1671a6d.png)

### How to test the changes in this Pull Request:

1. Load the _Checkout_ block and verify step title numbers have the new styles.
2. Check with different themes to verify it looks good in all of them.
3. Verify the skeleton displayed while loading looks ok as well.

### Changelog

> Checkout step progress indicator design has been updated to match the theme headings style.