### PR TITLE
Fix retrying after failed payment processed server side.

### DIFF
--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -45,6 +45,7 @@ const getCcOrEcheckPaymentMethodOption = (
 			setPaymentStatus().success( {
 				payment_method: method.gateway,
 				[ savedTokenKey ]: token,
+				isSavedToken: true,
 			} );
 		},
 	};
@@ -77,6 +78,7 @@ const getDefaultPaymentMethodOptions = (
 			setPaymentStatus().success( {
 				payment_method: method.gateway,
 				[ savedTokenKey ]: token,
+				isSavedToken: true,
 			} );
 		},
 	};

--- a/assets/js/base/context/cart-checkout/payment-methods/constants.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/constants.js
@@ -35,6 +35,7 @@ export const DEFAULT_PAYMENT_DATA = {
 		// wants to pass along for payment
 		// processing server side.
 	},
+	hasSavedToken: false,
 	errorMessage: '',
 	paymentMethods: {},
 	expressPaymentMethods: {},

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -276,6 +276,23 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		}
 	}, [ checkoutIsIdle, currentStatus.isSuccessful ] );
 
+	// if checkout has an error and payment is not being made with a saved token
+	// and payment status is success, then let's sync payment status back to
+	// pristine.
+	useEffect( () => {
+		if (
+			checkoutHasError &&
+			currentStatus.isSuccessful &&
+			! paymentData.hasSavedToken
+		) {
+			dispatch( statusOnly( PRISTINE ) );
+		}
+	}, [
+		checkoutHasError,
+		currentStatus.isSuccessful,
+		paymentData.hasSavedToken,
+	] );
+
 	// set initial active payment method if it's undefined.
 	useEffect( () => {
 		const paymentMethodKeys = Object.keys( paymentData.paymentMethods );

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -15,6 +15,12 @@ const {
 	SET_SHOULD_SAVE_PAYMENT_METHOD,
 } = ACTION_TYPES;
 
+const hasSavedPaymentToken = ( paymentMethodData ) => {
+	return !! (
+		typeof paymentMethodData === 'object' && paymentMethodData.isSavedToken
+	);
+};
+
 /**
  * Reducer for payment data state
  *
@@ -64,6 +70,9 @@ const reducer = (
 						currentStatus: SUCCESS,
 						paymentMethodData:
 							paymentMethodData || state.paymentMethodData,
+						hasSavedToken: hasSavedPaymentToken(
+							paymentMethodData
+						),
 				  }
 				: state;
 		case PROCESSING:


### PR DESCRIPTION
Fixes: #2638

For reference, see the original report in #2638. Essentially what was happening:

-  The payment status was not updating for a selected payment method (when it's not a saved token selected) after the server processing returns an error.
-  This in turn meant the `onPaymentProcessing` event would not fire again on an attempt of a new credit card number right away.
-  This in turn meant that, in the case of Stripe, a new source was not created (from the new CC details) and when submitted, the server was processing the same _previous_ credit card entered.

The fix involved:

- Add a new state property in the payment method data context for the payment method data slice that tracks whether a saved token is selected (true) or not (false).
- Update the `SavedPaymentMethodOptions` component so that it will set this state when a saved payment method token is selected.
- Add an effect hook to the payment method data context to update the payment status to pristine given the right condition of the checkout status, the payment status, and whether a saved payment token was selected or not.

## To Test

This impacts:

- saved payment method token payments
- payment methods
- Express payments (not directly).

So to test, you need to verify that all payment methods type purchases work. Also as an extra verification, here are various test steps to try:

### Scenario One: initial report fixed

Follow the steps reported in #2638 and ensure that it is fixed.

### Scenario Two: Trying to break via validation errors.

You'll need to be logged in with a user that has saved payment methods.

1. On checkout, select CC payment method and then select a saved payment method again.
2. Leave one of the required fields empty.
3. Submit the checkout which should cause a validation error on the field.
4. Fix the validation error
5. Submit again and checkout should complete using the selected saved payment method.

### Scenario Three: Variation of trying to break via validation errors.

1. On checkout, select CC payment method.
2. Fill out cc number that will trigger declined card (`4000 0000 0000 0002`).
3. After server response (with error), clear a required field.
4. Select saved payment method.
5. Submit the checkout -> this should produce a validation error.
6. Fix the field.
7. Submit the checkout and this should result in the purchase completing successfully.

### Scenario Four: Payment with Cheque after failed CC.

1. On Checkout, select CC payment method.
2. Fill out cc number that will trigger declined card (`4000 0000 0000 0002`).
3. After server response (with error), select cheque payment method.
4. Submit the checkout and this should result in the purchase completing successfully for the cheque payment method.

### Changelog

> bug: Fix bug in Checkout block preventing a retry of credit card payment when first credit card used fails and a new one is tried. 