### PR TITLE
Fix credit card validation errors alignment

### DIFF
--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -163,6 +163,16 @@
 	}
 }
 
+.is-mobile,
+.is-small {
+	.wc-card-expiry-element,
+	.wc-card-cvc-element {
+		.wc-block-form-input-validation-error > p {
+			min-height: 28px;
+		}
+	}
+}
+
 .wc-blocks-credit-card-images {
 	padding-top: $gap-small;
 	display: flex;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -54,7 +54,7 @@
 
 .wc-block-gateway-container {
 	position: relative;
-	margin-bottom: $gap;
+	margin-bottom: em($gap-large);
 	white-space: nowrap;
 
 	&.wc-card-number-element {

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -150,6 +150,19 @@
 	}
 }
 
+// These elements have available space below, so we can display errors with a
+// larger line height.
+.is-medium,
+.is-large {
+	.wc-card-expiry-element,
+	.wc-card-cvc-element {
+		.wc-block-form-input-validation-error > p {
+			line-height: 16px;
+			padding-top: 4px;
+		}
+	}
+}
+
 .wc-blocks-credit-card-images {
 	padding-top: $gap-small;
 	display: flex;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -80,6 +80,7 @@
 		box-sizing: border-box;
 		height: 3em;
 		color: $input-text-active;
+		cursor: text;
 
 		&:focus {
 			background-color: #fff;
@@ -105,6 +106,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: calc(100% - #{2 * $gap});
+		cursor: text;
 
 		@media screen and (prefers-reduced-motion: reduce) {
 			transition: none;

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -18,6 +18,7 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		max-width: calc(100% - #{2 * $gap});
+		cursor: text;
 
 		@media screen and (prefers-reduced-motion: reduce) {
 			transition: none;


### PR DESCRIPTION
Fixes #2650.

I also took the chance to change the text input cursor to `text`, so it follows better the behavior of native input fields.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/84010872-8c663e00-a975-11ea-8820-53c8388e7849.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/84011799-f0d5cd00-a976-11ea-8cb2-a7e7ef38b0b0.png)

### How to test the changes in this Pull Request:

1. In the _Checkout_ block, verify the cursor in input fields is `text` (see the `CVV/CVC` field in the screenshots above to see the difference).
2. Introduce some invalid numbers in the credit card input fields and verify the error messages are properly aligned.

### Changelog

> Improved alignment of credit card validation error messages.