### PR TITLE
Ignore dashicons imports

### DIFF
--- a/assets/js/icons/index.js
+++ b/assets/js/icons/index.js
@@ -1,6 +1,7 @@
 export { default as Icon } from './icon';
 
 export { default as arrowBack } from './library/arrow-back';
+export { default as arrowDownAlt2 } from './library/arrow-down-alt2';
 export { default as bank } from './library/bank';
 export { default as barcode } from './library/barcode';
 export { default as bill } from './library/bill';
@@ -20,6 +21,7 @@ export { default as grid } from './library/grid';
 export { default as image } from './library/image';
 export { default as list } from './library/list';
 export { default as more } from './library/more';
+export { default as noAlt } from './library/no-alt';
 export { default as notes } from './library/notes';
 export { default as notice } from './library/notice';
 export { default as radioSelected } from './library/radio-selected';

--- a/assets/js/icons/library/arrow-down-alt2.js
+++ b/assets/js/icons/library/arrow-down-alt2.js
@@ -2,11 +2,14 @@
  * External dependencies
  */
 import { SVG } from 'wordpress-components';
+import classnames from 'classnames';
 
 const arrowDownAlt2 = ( { className, size, ...extraProps } ) => {
-	const iconClass = [ 'dashicon', 'dashicons-arrow-down-alt2', className ]
-		.filter( Boolean )
-		.join( ' ' );
+	const iconClass = classnames(
+		'dashicon',
+		'dashicons-arrow-down-alt2',
+		className
+	);
 	return (
 		<SVG
 			xmlns="http://www.w3.org/2000/svg"

--- a/assets/js/icons/library/arrow-down-alt2.js
+++ b/assets/js/icons/library/arrow-down-alt2.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const arrowDownAlt2 = ( { className, size, ...extraProps } ) => {
+	const iconClass = [ 'dashicon', 'dashicons-arrow-down-alt2', className ]
+		.filter( Boolean )
+		.join( ' ' );
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			className={ iconClass }
+			width={ size }
+			height={ size }
+			{ ...extraProps }
+		>
+			<path d="M5 6l5 5 5-5 2 1-7 7-7-7z" />
+		</SVG>
+	);
+};
+
+export default arrowDownAlt2;

--- a/assets/js/icons/library/no-alt.js
+++ b/assets/js/icons/library/no-alt.js
@@ -2,11 +2,13 @@
  * External dependencies
  */
 import { SVG } from 'wordpress-components';
-
+import classnames from 'classnames';
 const noAlt = ( { className, size, ...extraProps } ) => {
-	const iconClass = [ 'dashicon', 'dashicons-arrow-down-alt2', className ]
-		.filter( Boolean )
-		.join( ' ' );
+	const iconClass = classnames(
+		'dashicon',
+		'dashicons-arrow-down-alt2',
+		className
+	);
 	return (
 		<SVG
 			xmlns="http://www.w3.org/2000/svg"

--- a/assets/js/icons/library/no-alt.js
+++ b/assets/js/icons/library/no-alt.js
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const noAlt = ( { className, size, ...extraProps } ) => {
+	const iconClass = [ 'dashicon', 'dashicons-arrow-down-alt2', className ]
+		.filter( Boolean )
+		.join( ' ' );
+	return (
+		<SVG
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 20 20"
+			className={ iconClass }
+			width={ size }
+			height={ size }
+			{ ...extraProps }
+		>
+			<path d="M14.95 6.46L11.41 10l3.54 3.54-1.41 1.41L10 11.42l-3.53 3.53-1.42-1.42L8.58 10 5.05 6.47l1.42-1.42L10 8.58l3.54-3.53z" />
+		</SVG>
+	);
+};
+
+export default noAlt;

--- a/assets/js/module_replacements/dashicon.js
+++ b/assets/js/module_replacements/dashicon.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import {
+	arrowDownAlt2 as ArrowDownIcon,
+	noAlt as DismissIcon,
+} from '@woocommerce/icons';
+import { createElement } from '@wordpress/element';
+
+export default ( { icon, size = 20, className, ...extraProps } ) => {
+	let Icon = () => null;
+	switch ( icon ) {
+		case 'arrow-down-alt2':
+			Icon = ArrowDownIcon;
+			break;
+		case 'no-alt':
+			Icon = DismissIcon;
+			break;
+	}
+	// can't use JSX here because the Webpack NormalModuleReplacementPlugin
+	// is unable to parse JSX at that point in the build.
+	return createElement( Icon, { size, className, ...extraProps } );
+};

--- a/bin/module_replacements/dashicon.js
+++ b/bin/module_replacements/dashicon.js
@@ -1,0 +1,1 @@
+export default () => null;

--- a/bin/module_replacements/dashicon.js
+++ b/bin/module_replacements/dashicon.js
@@ -1,1 +1,0 @@
-export default () => null;

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -12,7 +12,7 @@ const chalk = require( 'chalk' );
 const { omit } = require( 'lodash' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
-const dashIconReplacmentModule = path.resolve(
+const dashIconReplacementModule = path.resolve(
 	__dirname,
 	'../assets/js/module_replacements/dashicon.js'
 );
@@ -367,7 +367,7 @@ const getMainConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				( result ) => ( result.resource = dashIconReplacmentModule )
+				( result ) => ( result.resource = dashIconReplacementModule )
 			),
 		],
 		resolve,
@@ -466,7 +466,7 @@ const getFrontConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				( result ) => ( result.resource = dashIconReplacmentModule )
+				( result ) => ( result.resource = dashIconReplacementModule )
 			),
 		],
 		resolve,
@@ -602,7 +602,7 @@ const getPaymentMethodsExtensionConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				( result ) => ( result.resource = dashIconReplacmentModule )
+				( result ) => ( result.resource = dashIconReplacementModule )
 			),
 		],
 		resolve,

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -12,8 +12,6 @@ const chalk = require( 'chalk' );
 const { omit } = require( 'lodash' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
-const dashiconsNoop = {};
-
 function findModuleMatch( module, match ) {
 	if ( module.request && match.test( module.request ) ) {
 		return true;
@@ -364,7 +362,11 @@ const getMainConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				() => dashiconsNoop
+				( result ) =>
+					( result.resource = path.resolve(
+						__dirname,
+						'../bin/module_replacements/dashicon.js'
+					) )
 			),
 		],
 		resolve,
@@ -463,7 +465,11 @@ const getFrontConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				() => dashiconsNoop
+				( result ) =>
+					( result.resource = path.resolve(
+						__dirname,
+						'../bin/module_replacements/dashicon.js'
+					) )
 			),
 		],
 		resolve,
@@ -599,7 +605,11 @@ const getPaymentMethodsExtensionConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				() => dashiconsNoop
+				( result ) =>
+					( result.resource = path.resolve(
+						__dirname,
+						'../bin/module_replacements/dashicon.js'
+					) )
 			),
 		],
 		resolve,

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -6,10 +6,13 @@ const MergeExtractFilesPlugin = require( './merge-extract-files-webpack-plugin' 
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
 const ProgressBarPlugin = require( 'progress-bar-webpack-plugin' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const { NormalModuleReplacementPlugin } = require( 'webpack' );
 const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const chalk = require( 'chalk' );
 const { omit } = require( 'lodash' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
+
+const dashiconsNoop = {};
 
 function findModuleMatch( module, match ) {
 	if ( module.request && match.test( module.request ) ) {
@@ -359,6 +362,10 @@ const getMainConfig = ( options = {} ) => {
 				requestToExternal,
 				requestToHandle,
 			} ),
+			new NormalModuleReplacementPlugin(
+				/dashicon/,
+				() => dashiconsNoop
+			),
 		],
 		resolve,
 	};
@@ -454,6 +461,10 @@ const getFrontConfig = ( options = {} ) => {
 				requestToExternal,
 				requestToHandle,
 			} ),
+			new NormalModuleReplacementPlugin(
+				/dashicon/,
+				() => dashiconsNoop
+			),
 		],
 		resolve,
 	};
@@ -586,6 +597,10 @@ const getPaymentMethodsExtensionConfig = ( options = {} ) => {
 				requestToExternal,
 				requestToHandle,
 			} ),
+			new NormalModuleReplacementPlugin(
+				/dashicon/,
+				() => dashiconsNoop
+			),
 		],
 		resolve,
 	};

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -12,6 +12,11 @@ const chalk = require( 'chalk' );
 const { omit } = require( 'lodash' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
+const dashIconReplacmentModule = path.resolve(
+	__dirname,
+	'../assets/js/module_replacements/dashicon.js'
+);
+
 function findModuleMatch( module, match ) {
 	if ( module.request && match.test( module.request ) ) {
 		return true;
@@ -362,11 +367,7 @@ const getMainConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				( result ) =>
-					( result.resource = path.resolve(
-						__dirname,
-						'../bin/module_replacements/dashicon.js'
-					) )
+				( result ) => ( result.resource = dashIconReplacmentModule )
 			),
 		],
 		resolve,
@@ -465,11 +466,7 @@ const getFrontConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				( result ) =>
-					( result.resource = path.resolve(
-						__dirname,
-						'../bin/module_replacements/dashicon.js'
-					) )
+				( result ) => ( result.resource = dashIconReplacmentModule )
 			),
 		],
 		resolve,
@@ -605,11 +602,7 @@ const getPaymentMethodsExtensionConfig = ( options = {} ) => {
 			} ),
 			new NormalModuleReplacementPlugin(
 				/dashicon/,
-				( result ) =>
-					( result.resource = path.resolve(
-						__dirname,
-						'../bin/module_replacements/dashicon.js'
-					) )
+				( result ) => ( result.resource = dashIconReplacmentModule )
 			),
 		],
 		resolve,


### PR DESCRIPTION
Fixes: #2280

As a part of using Notice components from `@wordpress/components` directly for our new notices system, the `dashicon` package ended up getting pulled in for anything using notices. This resulted in an increase of **~85kb** (unminified) for all builds!

While dashicons are removed in later iterations of `@wordpress/components`, we're [unable to bump up our dependencies yet](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2140) because of issues with non-available packages in the versions of WP we support.

While we do have some components using dashicons (from the package version we use) the solution is to use the `webpack.NormalModuleReplacementPlugin` to replace any `dashicons` imports with a custom version that eliminates the excessive size.

## To test

This impacts anything loading our notices components. While this includes the new Product Block, because this is blocking 2.7.0, testing should primarily focus on:

- All Products
- Cart and Checkout.

Essentially testing involves:

- ensuring the frontend and editor views load without console errors.
- ensuring notices work as expected. I tested using coupons and also submitting the checkout with a empty required field (to trigger the error notice). Make sure the "dismiss x" icon shows up on the notice
- ensure the little down arrow on select dropdowns (in the checkout) show up correctly