### PR TITLE
Release: 2.7.0

### DIFF
--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -1,3 +1,5 @@
+[![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
+
 ## Testing notes and ZIP for testing
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4747000/woocommerce-gutenberg-products-block.zip)

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -1,0 +1,97 @@
+## Testing notes and ZIP for testing
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4747000/woocommerce-gutenberg-products-block.zip)
+
+### Cart and Checkout styles
+
+- Create pages with the Cart and Checkout blocks.
+- Check the styles of both pages and verify:
+	- The Cart and Checkout headings match the styles inherited from the theme (#2597)
+	- In Checkout, step progress indicators match the heading style and they don't have a background circle (#2649).<br>
+![Checkout heading styles](https://user-images.githubusercontent.com/3616980/84032118-1e327300-a997-11ea-8c06-363ac2bd78b3.png)
+	- In Checkout, the item quantity badges are visible with dark backgrounds (with Storefront, you can change the background color in Appearance > Customize > Background) (#2619).<br>
+![Item quantity badges](https://user-images.githubusercontent.com/3616980/84031988-ed523e00-a996-11ea-8545-339111e31f5f.png)
+		- Try adding the code snippet from the [Cart and Checkout theming](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/docs/theming/cart-and-checkout.md#item-quantity-badge) docs (you can do it via a child theme or directly in the browser devtools) and verify the item quantity badge styles update accordingly.
+	- In general, verify there were no regressions introduced after 2.6.0.
+- The Cart block title should be `Your cart (X items)` (#2615).<br>
+![Cart block title](https://user-images.githubusercontent.com/3616980/84032294-66ea2c00-a997-11ea-8d6d-929668cb702b.png)
+- Introduce an invalid credit card number and verify there is enough padding around the validation errors (#2662).<br>
+![Credit card validation errors](https://user-images.githubusercontent.com/3616980/84011799-f0d5cd00-a976-11ea-8cb2-a7e7ef38b0b0.png)
+- In the editor, add the Cart block and verify the headings have the proper font size and there is margin between the `Proceed to Checkout` button and the credit card icons -- to get the icons, you need to install the Stripe payment gateway (#2486).
+
+| 2.6.0 | 2.7.0 |
+| --- | --- |
+| ![Cart in editor in 2.6.0](https://user-images.githubusercontent.com/3616980/81926566-71a4e180-95e2-11ea-8c43-7a5064831e5b.png) | ![Cart in editor in 2.7.0](https://user-images.githubusercontent.com/3616980/81926959-24753f80-95e3-11ea-8cd4-6374ff3870ce.png) |
+
+#### Specific themes
+- [Hello theme](https://elementor.com/hello-theme/):
+	- Verify the text inside the selects is visible on hover (#2647).<br>
+![Select in Hello theme](https://user-images.githubusercontent.com/3616980/84032650-f4c61700-a997-11ea-969d-6427d1e221bb.png)
+- Twenty Twenty:
+	- Add the All Products block and the Hand-picked Products block in a page and verify (#2573):
+		- That with the All Products block you can add the On Sale badge and it's correctly aligned in the editor and the frontend (before, it was always shown on top of the image).<br>
+![All Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013870-fef22800-a01d-11ea-8ea8-21229285d10a.png)
+		- The Hand-picked Products block discounted prices are not underlined.<br>
+![Hand-picked Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013599-8e4b0b80-a01d-11ea-88ab-a1537110c4e2.png)
+	- Go to the Checkout block and verify font sizes look correct (they are inherited from the theme) (#2533).
+
+### Cart and Checkout error flow (#2655)
+
+#### Scenario One: initial report fixed
+
+1. On Checkout introduce an invalid card number `4000 0000 0000 0002`.
+2. Try to place the order and notice the error `The card was declined`.
+3. Replace the credit card number with a valid one (`4242 4242 4242 4242`).
+4. Try to place the order again and verify the process works.
+
+#### Scenario Two: Trying to break via validation errors.
+
+You'll need to be logged in with a user that has saved payment methods.
+
+1. On checkout, select CC payment method and then select a saved payment method again.
+2. Leave one of the required fields empty.
+3. Submit the checkout which should cause a validation error on the field.
+4. Fix the validation error
+5. Submit again and checkout should complete using the selected saved payment method.
+
+#### Scenario Three: Variation of trying to break via validation errors.
+
+1. On checkout, select CC payment method.
+2. Fill out cc number that will trigger declined card (`4000 0000 0000 0002`).
+3. After server response (with error), clear a required field.
+4. Select saved payment method.
+5. Submit the checkout -> this should produce a validation error.
+6. Fix the field.
+7. Submit the checkout and this should result in the purchase completing successfully.
+
+#### Scenario Four: Payment with Cheque after failed CC.
+
+1. On Checkout, select CC payment method.
+2. Fill out cc number that will trigger declined card (`4000 0000 0000 0002`).
+3. After server response (with error), select cheque payment method.
+4. Submit the checkout and this should result in the purchase completing successfully for the cheque payment method.
+
+### No shipping methods placeholder when they are all disabled (#2543)
+1. Disable all shipping methods from your store.
+2. Edit a page with the _Checkout_ block and verify the 'no shipping methods' placeholder appears.
+
+### Feature flags (#2591)
+* Verify you can't add the Single Product block.
+
+### Single Product page regression (#2648)
+* Go to a product page.
+* Verify you can see the product images as usual.<br>
+![Single Product page](https://user-images.githubusercontent.com/3616980/84032892-4f5f7300-a998-11ea-9f2d-f2d0e57860c9.png)
+
+#### Product grid inconsistencies (#2428)
+- Update a product so it has a very small image (100px or less).
+- Add the All Products block and a PHP-based product grids block (Hand-picked products, for example) and verify:
+	- Both of them have the same styles for prices.
+	- Both of them scale up the small image.
+_Handpicked products on top, All Products below:_<br>
+![Product grid blocks by default](https://user-images.githubusercontent.com/3616980/83166453-3d1b4480-a10f-11ea-813f-2515b26dedac.png)
+- Add the [code snippets](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/docs/theming/product-grid-270.md#product-grid-blocks-style-update-in-270) from the theming docs to undo the changes and verify:
+	- Hand-picked products block doesn't scale up the image anymore.
+	- All Products block shows discounted prices in two lines.
+_Handpicked products on top, All Products below:_<br>
+![Product grid blocks with the code snippets applied](https://user-images.githubusercontent.com/3616980/83164436-828a4280-a10c-11ea-81c1-b9a62cdf52b5.png)

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -74,6 +74,7 @@ You'll need to be logged in with a user that has saved payment methods.
 4. Submit the checkout and this should result in the purchase completing successfully for the cheque payment method.
 
 ### No shipping methods placeholder when they are all disabled (#2543)
+_(Requires at least WooCommerce 4.3)_
 1. Disable all shipping methods from your store.
 2. Edit a page with the _Checkout_ block and verify the 'no shipping methods' placeholder appears.
 

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -2,3 +2,4 @@ Every release includes specific testing instructions for features and bug fixes 
 
 - [2.6.0](./260.md)
     - [2.6.1](./261.md)
+- [2.7.0](./270.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "2.7.0-dev",
+	"version": "2.7.0",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - enhancement: The Cart block titles have been merged into one. [#2615](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2615)
 - enhancement: The item count badges of the Checkout block have been updated so it looks better in light & dark backgrounds. [#2619](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2619)
 - enhancement: Checkout step progress indicator design has been updated to match the theme headings style. [#2649](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2649)
+- performance: Reduce bundlesize of blocks using @wordpress/components directly. [#2664](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2664)
 
 = 2.6.1 - 2020-06-01 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,19 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 2.7.0 - 2020-06-08 =
+- bug: Fix bug in Checkout block preventing a retry of credit card payment when first credit card used fails and a new one is tried. [#2655](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2655)
+- bug: Avoid some theme style properties leaking into the Cart and Checkout select controls. [#2647](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2647)
+- bug: Fixes to the product grid blocks in Twenty Twenty: discounted prices are no longer underlined and the On Sale badge is correctly positioned in the All Products block. [#2573](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2573)
+- bug: Improved alignment of credit card validation error messages. [#2662](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2662)
+- bug: Show the 'No shipping methods' placeholder in the editor with the _Checkout_ block if there are shipping methods but all of them are disabled. [#2543](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2543)
+- enhancement: Filter block font sizes have been adjusted to be in line with other blocks. [#2594](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2594)
+- enhancement: The All Products block and the other product grid blocks now share more styles and the markup is more similar (see release post or docs to learn how to undo this change). [#2428](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2428) [DN]
+- enhancement: The Cart and Checkout blocks now use the heading styles provided by the theme. [#2597](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2597)
+- enhancement: The Cart block titles have been merged into one. [#2615](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2615)
+- enhancement: The item count badges of the Checkout block have been updated so it looks better in light & dark backgrounds. [#2619](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2619)
+- enhancement: Checkout step progress indicator design has been updated to match the theme headings style. [#2649](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2649)
+
 = 2.6.1 - 2020-06-01 =
 
 - fix: Updated the wc_reserved_stock table for compatibility with versions of MySql < 5.6.5. [#2590](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2590)

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
-= 2.7.0 - 2020-06-08 =
+= 2.7.0 - 2020-06-09 =
 - bug: Fix bug in Checkout block preventing a retry of credit card payment when first credit card used fails and a new one is tried. [#2655](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2655)
 - bug: Avoid some theme style properties leaking into the Cart and Checkout select controls. [#2647](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2647)
 - bug: Fixes to the product grid blocks in Twenty Twenty: discounted prices are no longer underlined and the On Sale badge is correctly positioned in the All Products block. [#2573](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2573)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 2.6.0
+Stable tag: 2.7.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -101,7 +101,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '2.6.0';
+					$version = '2.7.0';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.7.0-dev
+ * Version: 2.7.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This is the release pull request for 2.7.0 of the WooCommerce Blocks plugin.

## Communication

This release introduces:

> Improvements and fixes to the Cart and Checkout blocks including better theme compatibility and a fix to an issue that was blocking users from placing an order after fixing an invalid cart number previously introduced.
> 
> This release also includes style improvements to product grid blocks and some styling fixes specifically targeting the Twenty Twenty theme.
> 
> Under the hood, there has been development related to the Single Product block and we introduced a feature gating system. Those two items should be transparent for the users so they are excluded from the changelog and the release post.

You can read the [full changelog](https://github.com/woocommerce/woocommerce-gutenberg-products-block/compare/release/2.7?expand=1#diff-eb6b6c90251ab33cee784713c451e6d8L121).

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

**Release announcement:**

* "_[WooCommerce Blocks 2.7 release notes](https://woocommerce.wordpress.com/2020/06/09/woocommerce-blocks-2-7-release-notes/)_"

**Developer Notes** - The following issues require developer notes in the release post:

* #2428: a line is included in the release post which links to the [docs in the theming section](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/docs/theming/product-grid-270.md).

**Relevant developer documentation:**

* We started a [Cart and Checkout Blocks theming](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/docs/theming/cart-and-checkout.md) page in the docs. Currently it only includes documentation on how to style the 'item quantity badge', but the plan is to expand it in future releases.

* [x] The release includes a changelog entry in the readme.txt? [Click here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/compare/release/2.7?expand=1#diff-eb6b6c90251ab33cee784713c451e6d8L121).

## Quality

* [ ] Changes in this release are covered by Automated Tests.
    * Most changes included in this release are either behing a feature flag or are style fixes which are restricted to CSS or small markup refactors, so they are not covered by tests.

* This release has been tested on the following platforms:
    * [x] mobile
    * [x] desktop

* [ ] This release affects public facing REST APIs.
    * It doesn't.

* [ ] This release impacts **other extensions** or **backward compatibility**.
    * [ ] The release changes the signature of public methods or functions
        * No, it doesn't.
    * [ ] The release affects filters or action hooks.
        * No, it doesn't.

* [x] Link to **testing instructions** for this release: [See them in the docs](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/release/2.7/docs/testing/releases/270.md).

* [ ] The release has a negative performance impact on sites.
    * We hadn't noticed any performance regression with the changes included in this release.

* [x] The release has positive performance impact on sites. If checked, please document these improvements here.
	* #2577 moved the preview images out of JS, heavily reducing the size of several block scripts.
	* #2664 made it so dashicons imports are ignored, giving huge bundle size gains.
	* Some other PRs brought some other positive gains like #2587 and #2597.
