### PR TITLE
Add expected folder for testing instructions to the release PR template

### DIFF
--- a/.github/release_pull_request_template.md
+++ b/.github/release_pull_request_template.md
@@ -72,7 +72,7 @@ those and list here as checklist items. You can have different engineers write t
     * [ ] The release affects filters or action hooks.
         * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)
 
-* [ ] Link to **testing instructions** for this release: <!-- Enter a link to the testing instructions here -->
+* [ ] Link to **testing instructions** for this release: <!-- Enter a link to the testing instructions here, ideally in /docs/testing/releases -->
 
 * [ ] The release has a negative performance impact on sites.
     * [ ] There are new assets (JavaScript or CSS bundles)

--- a/docs/releases/readme.md
+++ b/docs/releases/readme.md
@@ -90,6 +90,7 @@ _Outcome_: **Release branch has all relevant changes merged & pushed and there i
 -   Make any other changes to readme as needed - e.g. support versions changing, new blocks.
 -   Push readme changes to release branch on origin repo.
     -   Note: you can push your readme changes directly to branch – no need for a PR & review process.
+-   Create testing notes for the release (you might be able to copy some from the pulls included in the release). Add the notes to [`docs/testing/releases`](../testing/releases/) (and update the [README.md index](../testing/releases/README.md) there)
 
 _Outcome_: **Release branch has `readme.txt` is updated with release details.**
 
@@ -108,7 +109,7 @@ _Outcome_: **Release branch has `readme.txt` is updated with release details.**
     -   Test to confirm new features/fixes are working correctly.
     -   Smoke test – test a cross section of core functionality.
     -   Tests performed should be recorded and listed in the release pull request.
--   Ask a team member to review the changes in the release pull request and for anyone who has done testing that they approve the pull request. **Remember release pull requests are just used for tracking the release and are not merged into master**.
+-   Ask a team member to review the changes in the release pull request and for anyone who has done testing that they approve the pull request.
 
 _Outcome_: **Confident that source code is ready for release: intended fixes are working correctly, no release blockers or build issues.**
 


### PR DESCRIPTION
When releasing 2.7.0, I missed that it was expected that testing instructions were pushed to `/docs/testing/releases` (thanks @nerrad for the heads-up).

This PR adds this info to the release PR template.