### PR TITLE
Fix Product Categories List align attribute

### DIFF
--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -36,6 +36,13 @@ registerBlockType( 'woocommerce/product-categories', {
 	},
 	attributes: {
 		/**
+		 * Alignment of the block.
+		 */
+		align: {
+			type: 'string',
+		},
+
+		/**
 		 * Whether to show the product count in each category.
 		 */
 		hasCount: {

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -43,6 +43,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		return array_merge(
 			parent::get_attributes(),
 			array(
+				'align'          => $this->get_schema_align(),
 				'className'      => $this->get_schema_string(),
 				'hasCount'       => $this->get_schema_boolean( true ),
 				'hasImage'       => $this->get_schema_boolean( false ),

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -85,11 +85,39 @@ class ProductCategories extends AbstractDynamicBlock {
 			}
 		}
 
-		$output  = '<div class="wc-block-product-categories ' . esc_attr( $attributes['className'] ) . ' ' . ( $attributes['isDropdown'] ? 'is-dropdown' : 'is-list' ) . '">';
+		$classes = $this->get_container_classes( $attributes );
+
+		$output  = '<div class="' . esc_attr( $classes ) . '">';
 		$output .= ! empty( $attributes['isDropdown'] ) ? $this->renderDropdown( $categories, $attributes, $uid ) : $this->renderList( $categories, $attributes, $uid );
 		$output .= '</div>';
 
 		return $output;
+	}
+
+	/**
+	 * Get the list of classes to apply to this block.
+	 *
+	 * @param array $attributes Block attributes. Default empty array.
+	 * @return string space-separated list of classes.
+	 */
+	protected function get_container_classes( $attributes = array() ) {
+		$classes = array( 'wc-block-product-categories' );
+
+		if ( isset( $attributes['align'] ) ) {
+			$classes[] = "align{$attributes['align']}";
+		}
+
+		if ( ! empty( $attributes['className'] ) ) {
+			$classes[] = $attributes['className'];
+		}
+
+		if ( $attributes['isDropdown'] ) {
+			$classes[] = 'is-dropdown';
+		} else {
+			$classes[] = 'is-list';
+		}
+
+		return implode( ' ', $classes );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2696.

I added this PR to the 2.8.0 milestone, given that it's not a regression and we are doing biweekly releases, I don't think we need to do a point release for it. cc @nerrad 

### Screenshots

![Peek 2020-06-12 11-45](https://user-images.githubusercontent.com/3616980/84489943-c059a000-aca2-11ea-8660-9218817db8a0.gif)

### How to test the changes in this Pull Request:

1. Add a Product Categories List block to a page.
2. Switch to _Full Width_ align.
3. Verify the block doesn't show an error.
4. If you are using Storefront or another theme with sidebar, make sure the page has the _Full Width_ template.
4. Open the page in the frontend and verify the Product Categories List block is aligned as a full width block.

### Changelog

> Fix an error appearing in the Product Categories List block with _Full Width_ align.
