### PR TITLE
Remove background color from Express Checkout title

### DIFF
--- a/assets/js/base/components/payment-methods/express-checkout.js
+++ b/assets/js/base/components/payment-methods/express-checkout.js
@@ -16,12 +16,17 @@ const ExpressCheckoutContainer = ( { children } ) => {
 	return (
 		<>
 			<div className="wc-block-components-express-checkout">
-				<Title
-					className="wc-block-components-express-checkout__title"
-					headingLevel="2"
-				>
-					{ __( 'Express checkout', 'woo-gutenberg-products-block' ) }
-				</Title>
+				<div className="wc-block-components-express-checkout__title-container">
+					<Title
+						className="wc-block-components-express-checkout__title"
+						headingLevel="2"
+					>
+						{ __(
+							'Express checkout',
+							'woo-gutenberg-products-block'
+						) }
+					</Title>
+				</div>
 				<div className="wc-block-components-express-checkout__content">
 					<StoreNoticesProvider context="wc/express-payment-area">
 						{ children }

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -20,6 +20,7 @@ $border-width: 1px;
 			border-radius: 5px 0 0 0;
 			content: "";
 			display: block;
+			margin-right: $gap-small;
 			pointer-events: none;
 			width: #{$gap-larger - $gap-small - $border-width * 2};
 		}
@@ -31,6 +32,7 @@ $border-width: 1px;
 			border-radius: 0 5px 0 0;
 			content: "";
 			display: block;
+			margin-left: $gap-small;
 			pointer-events: none;
 			flex-grow: 1;
 		}
@@ -38,8 +40,6 @@ $border-width: 1px;
 
 	.wc-block-components-express-checkout__title {
 		flex-grow: 0;
-		padding-left: $gap-small;
-		padding-right: $gap-small;
 		transform: translateY(-50%);
 	}
 

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -13,6 +13,7 @@ $border-width: 1px;
 		top: 0;
 		vertical-align: middle;
 
+		// Pseudo-elements used to show the border before and after the title.
 		&::before {
 			border: $border-width solid transparent;
 			border-left-color: currentColor;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -1,25 +1,58 @@
+$border-width: 1px;
+
 .wc-block-components-express-checkout {
 	margin: auto;
-	border: 2px solid $black;
-	border-radius: 5px;
-	padding: 8px;
 	position: relative;
 
+	.wc-block-components-express-checkout__title-container {
+		display: flex;
+		flex-direction: row;
+		left: 0;
+		position: absolute;
+		right: 0;
+		top: 0;
+		vertical-align: middle;
+
+		&::before {
+			border: $border-width solid transparent;
+			border-left-color: currentColor;
+			border-top-color: currentColor;
+			border-radius: 5px 0 0 0;
+			content: "";
+			display: block;
+			pointer-events: none;
+			width: #{$gap-larger - $gap-small - $border-width * 2};
+		}
+
+		&::after {
+			border: $border-width solid transparent;
+			border-right-color: currentColor;
+			border-top-color: currentColor;
+			border-radius: 0 5px 0 0;
+			content: "";
+			display: block;
+			pointer-events: none;
+			flex-grow: 1;
+		}
+	}
+
 	.wc-block-components-express-checkout__title {
-		background-color: $white;
+		flex-grow: 0;
 		padding-left: $gap-small;
 		padding-right: $gap-small;
-		margin-left: $gap-small;
-		display: inline-block;
-		vertical-align: middle;
 		transform: translateY(-50%);
-		position: absolute;
-		top: 0;
-		margin-top: -2px; // Same as container border width.
 	}
 
 	.wc-block-components-express-checkout__content {
-		padding: $gap $gap-large 0;
+		border: $border-width solid currentColor;
+		border-top-width: 0;
+		border-radius: 5px;
+		margin-top: 0.75em;
+		padding: em($gap-large) #{$gap-larger - $border-width} em($gap) #{$gap-larger - $border-width};
+
+		> p {
+			margin-bottom: em($gap);
+		}
 	}
 
 	.wc-block-components-express-checkout-payment-event-buttons {
@@ -29,10 +62,11 @@
 		flex-wrap: wrap;
 		width: 100%;
 		padding: 0;
-		margin: 0 0 $gap;
+		margin: 0;
 		overflow: hidden;
 		> li {
 			display: inline-block;
+			margin: 0;
 			width: 50%;
 			> img {
 				width: 100%;
@@ -214,11 +248,16 @@
 	}
 }
 
+.theme-twentynineteen {
+	.wc-block-components-express-checkout__title::before {
+		display: none;
+	}
+}
+
 // For Twenty Twenty we need to increase specificity of the title.
 .theme-twentytwenty {
 	.wc-block-components-express-checkout .wc-block-components-express-checkout__title {
 		padding-left: $gap-small;
 		padding-right: $gap-small;
-		margin-left: $gap-small;
 	}
 }


### PR DESCRIPTION
Fixes #2659.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/84501753-5992b180-acb7-11ea-983d-17292bc8b8a9.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/84501704-3f58d380-acb7-11ea-9624-789b350fb8aa.png)

### How to test the changes in this Pull Request:

1. Change to a theme with a background color different from white or in the customizer change Storefront's background color to another one.
2. Visit the Checkout page and verify that:
  * The `Express checkout` title doesn't have a background color different from the rest of the page and has left and right padding (so it doesn't collide with the border).
  * The `Express checkout` and `Order summary` titles are aligned.
  * The `Express checkout` box border is 1px wide, like in the [new designs](https://user-images.githubusercontent.com/3616980/83534129-c0161380-a4f0-11ea-985f-851b40d2e92b.png).

### Changelog

> Remove background color from Express Checkout title.