### PR TITLE
Use IE11 friendly code for Dashicon component replacement.

### DIFF
--- a/assets/js/module_replacements/dashicon.js
+++ b/assets/js/module_replacements/dashicon.js
@@ -7,9 +7,16 @@ import {
 } from '@woocommerce/icons';
 import { createElement } from '@wordpress/element';
 
-export default ( { icon, size = 20, className, ...extraProps } ) => {
-	let Icon = () => null;
-	switch ( icon ) {
+// Note: Aside from import/export, everything in this file must be IE11 friendly
+// because currently it does not go through babel transpiling. It is injected
+// as a replacement for the `@wordpress/component/dashicon` component via
+// the Webpack NormalModuleReplacementPlugin plugin.
+
+export default function( props ) {
+	let Icon = function() {
+		return null;
+	};
+	switch ( props.icon ) {
 		case 'arrow-down-alt2':
 			Icon = ArrowDownIcon;
 			break;
@@ -17,7 +24,8 @@ export default ( { icon, size = 20, className, ...extraProps } ) => {
 			Icon = DismissIcon;
 			break;
 	}
-	// can't use JSX here because the Webpack NormalModuleReplacementPlugin
-	// is unable to parse JSX at that point in the build.
-	return createElement( Icon, { size, className, ...extraProps } );
-};
+	return createElement( Icon, {
+		size: props.size || 20,
+		className: props.className,
+	} );
+}


### PR DESCRIPTION
Fixes: #2703 

In #2664 I implemented some code that would swap out the `@woocommerce/components/Dashicon` component with a patched fix to reduce our bundle sizes. However, I didn't realize in the process this broke things for IE11 (any frontend client side code importing from `@wordpress/components` directly - All Products, Filter Blocks, Cart and Checkout etc).

When the `NormalModuleReplacementPlugin` is used in webpack, the code replacing modules is not transpiled through babel (at least from what I can see). Ideally, we'd figure out how to fix that (and I did take a bit of time to try unsuccessfully) but the simpler fix for now is to just use IE11 friendly code in the script.

@Aljullu, ordinarily I wouldn't consider this patch release worthy and would just wait until our next scheduled release, but because the 2.7 branch is going in WC core and 2.8.0 would be past the code freeze date, I think it's better to get this into 2.7.1 so there are no regressions for users of the All Products or Filter blocks on IE11 (even though I think the IE11 experience is super poor!). 

## To test

This affects All Products, Filter Blocks and Cart and Checkout blocks.

- Verify nothing is broken in up to date browsers (Firefox, Safari, Chrome). Simply loading the blocks should suffice. You can repeat the checks in #2664.
- Verify IE11 no longer has errors for any of the blocks.

There also should be no significant change in bundlesize (which the GitHub action should report on in this pull).