### PR TITLE
 Update base/components classnames 

### DIFF
--- a/assets/js/base/components/block-error-boundary/block-error.js
+++ b/assets/js/base/components/block-error-boundary/block-error.js
@@ -16,21 +16,27 @@ const BlockError = ( {
 	errorMessagePrefix = __( 'Error:', 'woo-gutenberg-products-block' ),
 } ) => {
 	return (
-		<div className="wc-block-error">
+		<div className="wc-block-error wc-block-components-error">
 			{ imageUrl && (
 				<img
-					className="wc-block-error__image"
+					className="wc-block-error__image wc-block-components-error__image"
 					src={ imageUrl }
 					alt=""
 				/>
 			) }
-			<div className="wc-block-error__content">
+			<div className="wc-block-error__content wc-block-components-error__content">
 				{ header && (
-					<p className="wc-block-error__header">{ header }</p>
+					<p className="wc-block-error__header wc-block-components-error__header">
+						{ header }
+					</p>
 				) }
-				{ text && <p className="wc-block-error__text">{ text }</p> }
+				{ text && (
+					<p className="wc-block-error__text wc-block-components-error__text">
+						{ text }
+					</p>
+				) }
 				{ errorMessage && (
-					<p className="wc-block-error__message">
+					<p className="wc-block-error__message wc-block-components-error__message">
 						{ errorMessagePrefix ? errorMessagePrefix + ' ' : '' }
 						{ errorMessage }
 					</p>

--- a/assets/js/base/components/block-error-boundary/style.scss
+++ b/assets/js/base/components/block-error-boundary/style.scss
@@ -1,4 +1,4 @@
-.wc-block-error {
+.wc-block-components-error {
 	display: flex;
 	background-color: #f3f3f4;
 	border-left: 4px solid #6d6d6d;
@@ -8,29 +8,29 @@
 	flex-direction: column;
 }
 
-.wc-block-error__header {
+.wc-block-components-error__header {
 	@include font-size(larger);
 	font-weight: bold;
 	margin: 0;
 }
 
-.wc-block-error__image {
+.wc-block-components-error__image {
 	max-width: 25%;
 }
-.wc-block-error__text {
+.wc-block-components-error__text {
 	margin: 0;
 }
-.wc-block-error__message {
+.wc-block-components-error__message {
 	margin: 1em 0 0 0;
 	font-style: italic;
 }
 
 @include breakpoint( ">480px" ) {
-	.wc-block-error {
+	.wc-block-components-error {
 		flex-direction: row;
 	}
 
-	.wc-block-error__image + .wc-block-error__content {
+	.wc-block-components-error__image + .wc-block-components-error__content {
 		margin-left: $gap-large;
 	}
 }

--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -100,7 +100,7 @@ const AddressForm = ( {
 	id = id || instanceId;
 
 	return (
-		<div id={ id } className="wc-block-address-form">
+		<div id={ id } className="wc-block-components-address-form">
 			{ sortedAddressFields.map( ( field ) => {
 				if ( field.hidden ) {
 					return null;
@@ -175,7 +175,7 @@ const AddressForm = ( {
 					<ValidatedTextInput
 						key={ field.key }
 						id={ `${ id }-${ field.key }` }
-						className={ `wc-block-address-form__${ field.key }` }
+						className={ `wc-block-components-address-form__${ field.key }` }
 						label={
 							field.required ? field.label : field.optionalLabel
 						}

--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -11,16 +11,16 @@ import Title from '@woocommerce/base-components/title';
 import './style.scss';
 
 const StepHeading = ( { title, stepHeadingContent } ) => (
-	<div className="wc-block-checkout-step__heading">
+	<div className="wc-block-components-checkout-step__heading">
 		<Title
 			aria-hidden="true"
-			className="wc-block-checkout-step__title"
+			className="wc-block-components-checkout-step__title"
 			headingLevel="2"
 		>
 			{ title }
 		</Title>
 		{ !! stepHeadingContent && (
-			<span className="wc-block-checkout-step__heading-content">
+			<span className="wc-block-components-checkout-step__heading-content">
 				{ stepHeadingContent }
 			</span>
 		) }
@@ -39,7 +39,10 @@ const FormStep = ( {
 } ) => {
 	return (
 		<fieldset
-			className={ classnames( className, 'wc-block-checkout-step' ) }
+			className={ classnames(
+				className,
+				'wc-block-components-checkout-step'
+			) }
 			id={ id }
 			disabled={ disabled }
 		>
@@ -48,13 +51,13 @@ const FormStep = ( {
 				title={ title }
 				stepHeadingContent={ stepHeadingContent() }
 			/>
-			<div className="wc-block-checkout-step__container">
+			<div className="wc-block-components-checkout-step__container">
 				{ !! description && (
-					<p className="wc-block-checkout-step__description">
+					<p className="wc-block-components-checkout-step__description">
 						{ description }
 					</p>
 				) }
-				<div className="wc-block-checkout-step__content">
+				<div className="wc-block-components-checkout-step__content">
 					{ children }
 				</div>
 			</div>

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -1,8 +1,8 @@
-.wc-block-checkout-form {
+.wc-block-components-checkout-form {
 	counter-reset: checkout-step;
 }
 
-.wc-block-checkout-form fieldset.wc-block-checkout-step {
+.wc-block-components-checkout-form fieldset.wc-block-components-checkout-step {
 	position: relative;
 	border: none;
 	padding: 0 0 0 $gap-larger;
@@ -14,19 +14,19 @@
 	}
 }
 
-.wc-block-checkout-step__container {
+.wc-block-components-checkout-step__container {
 	position: relative;
 }
 
-.wc-block-checkout-step__content {
+.wc-block-components-checkout-step__content {
 	padding-bottom: em($gap-large);
 }
 
-.wc-block-checkout-form fieldset.wc-block-checkout-step:disabled {
+.wc-block-components-checkout-form fieldset.wc-block-components-checkout-step:disabled {
 	opacity: 0.6;
 }
 
-.wc-block-checkout-step__heading {
+.wc-block-components-checkout-step__heading {
 	display: flex;
 	justify-content: space-between;
 	align-content: center;
@@ -35,15 +35,15 @@
 	position: relative;
 }
 
-.wc-block-checkout-step:first-child .wc-block-checkout-step__heading {
+.wc-block-components-checkout-step:first-child .wc-block-components-checkout-step__heading {
 	margin-top: 0;
 }
 
-.wc-block-checkout-step__title {
+.wc-block-components-checkout-step__title {
 	margin: 0 $gap-small 0 0;
 }
 
-.wc-block-checkout-step__heading-content {
+.wc-block-components-checkout-step__heading-content {
 	@include font-size(smaller);
 	color: $gray-80;
 	position: absolute;
@@ -55,14 +55,14 @@
 	}
 }
 
-.wc-block-checkout-step__description {
+.wc-block-components-checkout-step__description {
 	@include font-size(small);
 	line-height: 1.25;
 	color: $gray-60;
 	margin-bottom: $gap;
 }
 
-.wc-block-checkout-step__title::before {
+.wc-block-components-checkout-step__title::before {
 	@include reset-box();
 	background: transparent;
 	counter-increment: checkout-step;
@@ -76,7 +76,7 @@
 	transform: translateX(-50%);
 }
 
-.wc-block-checkout-step__container::after {
+.wc-block-components-checkout-step__container::after {
 	content: "";
 	height: 100%;
 	border-left: 1px solid;
@@ -85,6 +85,6 @@
 	top: 0;
 }
 
-.wc-block-checkout-step:last-child .wc-block-checkout-step__container::after {
+.wc-block-components-checkout-step:last-child .wc-block-components-checkout-step__container::after {
 	content: none;
 }

--- a/assets/js/base/components/cart-checkout/form/index.js
+++ b/assets/js/base/components/cart-checkout/form/index.js
@@ -20,7 +20,10 @@ const CheckoutForm = ( {
 	};
 	return (
 		<form
-			className={ classnames( 'wc-block-checkout-form', className ) }
+			className={ classnames(
+				'wc-block-components-checkout-form',
+				className
+			) }
 			onSubmit={ formOnSubmit }
 		>
 			{ children }

--- a/assets/js/base/components/cart-checkout/form/style.scss
+++ b/assets/js/base/components/cart-checkout/form/style.scss
@@ -1,4 +1,4 @@
-.wc-block-checkout-form {
+.wc-block-components-checkout-form {
 	margin: 0;
 	max-width: 100%;
 }

--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -73,7 +73,7 @@
 	line-height: 1.375;
 
 	p,
-	.wc-block-product-metadata {
+	.wc-block-components-product-metadata {
 		line-height: 1.375;
 		margin-top: #{ ( $gap-large - $gap ) / 2 };
 	}

--- a/assets/js/base/components/cart-checkout/payment-method-icons/index.js
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/index.js
@@ -25,10 +25,15 @@ export const PaymentMethodIcons = ( { icons = [], align = 'center' } ) => {
 		return null;
 	}
 
-	const containerClass = classnames( 'wc-block-cart__payment-method-icons', {
-		'wc-block-cart__payment-method-icons--align-left': align === 'left',
-		'wc-block-cart__payment-method-icons--align-right': align === 'right',
-	} );
+	const containerClass = classnames(
+		'wc-block-components-payment-method-icons',
+		{
+			'wc-block-components-payment-method-icons--align-left':
+				align === 'left',
+			'wc-block-components-payment-method-icons--align-right':
+				align === 'right',
+		}
+	);
 
 	return (
 		<div className={ containerClass }>

--- a/assets/js/base/components/cart-checkout/payment-method-icons/payment-method-icon.js
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/payment-method-icon.js
@@ -4,7 +4,7 @@
  * @param {string} id Icon ID.
  */
 const getIconClassName = ( id ) => {
-	return `wc-blocks-payment-method-icon wc-blocks-payment-method-icon--${ id }`;
+	return `wc-block-components-payment-method-icon wc-block-components-payment-method-icon--${ id }`;
 };
 
 /**

--- a/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
@@ -1,9 +1,9 @@
-.wc-block-cart__payment-method-icons {
+.wc-block-components-payment-method-icons {
 	display: block;
 	text-align: center;
 	margin: 0 0 #{$gap - 2px};
 
-	.wc-blocks-payment-method-icon {
+	.wc-block-components-payment-method-icon {
 		display: inline-block;
 		margin: 0 4px 2px;
 		padding: 0;
@@ -15,7 +15,7 @@
 	&--align-left {
 		text-align: left;
 
-		.wc-blocks-payment-method-icon {
+		.wc-block-components-payment-method-icon {
 			margin-left: 0;
 			margin-right: 8px;
 		}
@@ -24,7 +24,7 @@
 	&--align-right {
 		text-align: right;
 
-		.wc-blocks-payment-method-icon {
+		.wc-block-components-payment-method-icon {
 			margin-right: 0;
 			margin-left: 8px;
 		}
@@ -37,8 +37,8 @@
 
 .is-mobile,
 .is-small {
-	.wc-block-cart__payment-method-icons {
-		.wc-blocks-payment-method-icon {
+	.wc-block-components-payment-method-icons {
+		.wc-block-components-payment-method-icon {
 			height: 16px;
 		}
 	}

--- a/assets/js/base/components/cart-checkout/payment-method-label/index.js
+++ b/assets/js/base/components/cart-checkout/payment-method-label/index.js
@@ -29,8 +29,8 @@ export const PaymentMethodLabel = ( { icon = '', text = '' } ) => {
 	const hasIcon = !! icon;
 	const hasNamedIcon =
 		hasIcon && typeof icon === 'string' && namedIcons[ icon ];
-	const className = classnames( 'wc-block-cart__payment-method-label', {
-		'wc-block-cart__payment-method-label--with-icon': hasIcon,
+	const className = classnames( 'wc-block-components-payment-method-label', {
+		'wc-block-components-payment-method-label--with-icon': hasIcon,
 	} );
 
 	return (

--- a/assets/js/base/components/cart-checkout/payment-method-label/style.scss
+++ b/assets/js/base/components/cart-checkout/payment-method-label/style.scss
@@ -1,4 +1,4 @@
-.wc-block-cart__payment-method-label--with-icon {
+.wc-block-components-payment-method-label--with-icon {
 	display: inline-block;
 	vertical-align: middle;
 	> img,
@@ -10,7 +10,7 @@
 
 .is-mobile,
 .is-small {
-	.wc-block-cart__payment-method-label--with-icon {
+	.wc-block-components-payment-method-label--with-icon {
 		> img,
 		> svg {
 			display: none;

--- a/assets/js/base/components/cart-checkout/product-low-stock-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-low-stock-badge/index.js
@@ -18,7 +18,7 @@ const ProductLowStockBadge = ( { lowStockRemaining } ) => {
 	}
 
 	return (
-		<div className="wc-block-low-stock-badge">
+		<div className="wc-block-components-product-low-stock-badge">
 			{ sprintf(
 				/* translators: %d stock amount (number of items in stock for product) */
 				__( '%d left in stock', 'woo-gutenberg-products-block' ),

--- a/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
@@ -1,4 +1,4 @@
-.wc-block-low-stock-badge {
+.wc-block-components-product-low-stock-badge {
 	@include font-size(smaller);
 	background-color: $white;
 	border-radius: 3px;

--- a/assets/js/base/components/cart-checkout/product-metadata/index.js
+++ b/assets/js/base/components/cart-checkout/product-metadata/index.js
@@ -16,9 +16,9 @@ const ProductMetadata = ( {
 	variation = [],
 } ) => {
 	return (
-		<div className="wc-block-product-metadata">
+		<div className="wc-block-components-product-metadata">
 			<ProductSummary
-				className="wc-block-product-description"
+				className="wc-block-components-product-metadata__description"
 				shortDescription={ shortDescription }
 				fullDescription={ fullDescription }
 			/>

--- a/assets/js/base/components/cart-checkout/product-metadata/index.js
+++ b/assets/js/base/components/cart-checkout/product-metadata/index.js
@@ -22,7 +22,10 @@ const ProductMetadata = ( {
 				shortDescription={ shortDescription }
 				fullDescription={ fullDescription }
 			/>
-			<ProductVariationData variation={ variation } />
+			<ProductVariationData
+				className="wc-block-components-product-metadata__variation-data"
+				variation={ variation }
+			/>
 		</div>
 	);
 };

--- a/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -1,9 +1,9 @@
-.wc-block-product-metadata {
+.wc-block-components-product-metadata {
 	@include font-size(smaller);
 	color: $core-grey-dark-400;
 
-	.wc-block-product-description > p,
-	.wc-block-product-variation-data {
+	.wc-block-components-product-metadata__description > p,
+	.wc-block-components-product-variation-data {
 		margin: 0.25em 0 0 0;
 	}
 }

--- a/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -3,7 +3,7 @@
 	color: $core-grey-dark-400;
 
 	.wc-block-components-product-metadata__description > p,
-	.wc-block-components-product-variation-data {
+	.wc-block-components-product-metadata__variation-data {
 		margin: 0.25em 0 0 0;
 	}
 }

--- a/assets/js/base/components/cart-checkout/product-name/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/index.js
@@ -14,7 +14,7 @@ const ProductName = ( { name, permalink, disabled } ) => {
 		// we use tabIndex -1 to prevent the link from being focused, pointer-events
 		// disabled click events, so we get an almost disabled link.
 		<a
-			className="wc-block-product-name"
+			className="wc-block-components-product-name"
 			href={ permalink }
 			tabIndex={ disabled ? -1 : 0 }
 		>

--- a/assets/js/base/components/cart-checkout/product-name/style.scss
+++ b/assets/js/base/components/cart-checkout/product-name/style.scss
@@ -1,4 +1,4 @@
-.wc-block-product-name {
+.wc-block-components-product-name {
 	@include font-size(regular);
 	@include wrap-break-word();
 	display: block;

--- a/assets/js/base/components/cart-checkout/product-price/index.js
+++ b/assets/js/base/components/cart-checkout/product-price/index.js
@@ -26,7 +26,7 @@ const ProductPrice = ( { className, currency, regularValue, value } ) => {
 					</span>
 					<FormattedMonetaryAmount
 						className={ classNames(
-							'wc-block-product-price--regular',
+							'wc-block-components-product-price--regular',
 							className
 						) }
 						currency={ currency }
@@ -41,9 +41,13 @@ const ProductPrice = ( { className, currency, regularValue, value } ) => {
 				</>
 			) }
 			<FormattedMonetaryAmount
-				className={ classNames( 'wc-block-product-price', className, {
-					'is-discounted': isDiscounted,
-				} ) }
+				className={ classNames(
+					'wc-block-components-product-price',
+					className,
+					{
+						'is-discounted': isDiscounted,
+					}
+				) }
 				currency={ currency }
 				value={ value }
 			/>

--- a/assets/js/base/components/cart-checkout/product-price/style.scss
+++ b/assets/js/base/components/cart-checkout/product-price/style.scss
@@ -1,4 +1,4 @@
-.wc-block-product-price {
+.wc-block-components-product-price {
 	color: $black;
 
 	&.is-discounted {
@@ -6,7 +6,7 @@
 	}
 }
 
-.wc-block-product-price--regular {
+.wc-block-components-product-price--regular {
 	color: $core-grey-dark-400;
 	text-decoration: line-through;
 }

--- a/assets/js/base/components/cart-checkout/product-sale-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/index.js
@@ -25,7 +25,7 @@ const ProductSaleBadge = ( { currency, saleAmount } ) => {
 		return null;
 	}
 	return (
-		<div className="wc-block-components-product-sale-badge">
+		<div className="wc-block-components-sale-badge">
 			{ __experimentalCreateInterpolateElement(
 				/* translators: <price/> will be replaced by the discount amount */
 				__( 'Save <price/>!', 'woo-gutenberg-products-block' ),

--- a/assets/js/base/components/cart-checkout/product-sale-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/index.js
@@ -25,7 +25,7 @@ const ProductSaleBadge = ( { currency, saleAmount } ) => {
 		return null;
 	}
 	return (
-		<div className="wc-block-sale-badge">
+		<div className="wc-block-components-product-sale-badge">
 			{ __experimentalCreateInterpolateElement(
 				/* translators: <price/> will be replaced by the discount amount */
 				__( 'Save <price/>!', 'woo-gutenberg-products-block' ),

--- a/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
@@ -1,4 +1,4 @@
-.wc-block-sale-badge {
+.wc-block-components-product-sale-badge {
 	@include font-size(smaller);
 	background-color: $core-grey-dark-600;
 	border-radius: 2px;

--- a/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
@@ -1,4 +1,4 @@
-.wc-block-components-product-sale-badge {
+.wc-block-components-sale-badge {
 	@include font-size(smaller);
 	background-color: $core-grey-dark-600;
 	border-radius: 2px;

--- a/assets/js/base/components/cart-checkout/product-variation-data/index.js
+++ b/assets/js/base/components/cart-checkout/product-variation-data/index.js
@@ -25,7 +25,7 @@ const ProductVariationData = ( { variation = [] } ) => {
 		.join( ' / ' );
 
 	return (
-		<div className="wc-block-product-variation-data">
+		<div className="wc-block-components-product-variation-data">
 			{ variationsText }
 		</div>
 	);

--- a/assets/js/base/components/cart-checkout/product-variation-data/index.js
+++ b/assets/js/base/components/cart-checkout/product-variation-data/index.js
@@ -3,11 +3,12 @@
  */
 import { decodeEntities } from '@wordpress/html-entities';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Returns a formatted element containing variation details.
  */
-const ProductVariationData = ( { variation = [] } ) => {
+const ProductVariationData = ( { className, variation = [] } ) => {
 	if ( ! variation ) {
 		return null;
 	}
@@ -25,7 +26,12 @@ const ProductVariationData = ( { variation = [] } ) => {
 		.join( ' / ' );
 
 	return (
-		<div className="wc-block-components-product-variation-data">
+		<div
+			className={ classNames(
+				'wc-block-components-product-variation-data',
+				className
+			) }
+		>
 			{ variationsText }
 		</div>
 	);

--- a/assets/js/base/components/cart-checkout/shipping-calculator/address.js
+++ b/assets/js/base/components/cart-checkout/shipping-calculator/address.js
@@ -53,7 +53,7 @@ const ShippingCalculatorAddress = ( {
 	} );
 
 	return (
-		<form className="wc-block-shipping-calculator-address">
+		<form className="wc-block-components-shipping-calculator-address">
 			<AddressForm
 				fields={ addressFields }
 				fieldConfig={ fieldConfig }
@@ -61,7 +61,7 @@ const ShippingCalculatorAddress = ( {
 				values={ address }
 			/>
 			<Button
-				className="wc-block-shipping-calculator-address__button"
+				className="wc-block-components-shipping-calculator-address__button"
 				disabled={ isShallowEqual( address, initialAddress ) }
 				onClick={ ( e ) => {
 					e.preventDefault();

--- a/assets/js/base/components/cart-checkout/shipping-calculator/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-calculator/index.js
@@ -16,7 +16,7 @@ const ShippingCalculator = ( {
 } ) => {
 	const { shippingAddress, setShippingAddress } = useShippingDataContext();
 	return (
-		<div className="wc-block-cart__shipping-calculator">
+		<div className="wc-block-components-shipping-calculator">
 			<ShippingCalculatorAddress
 				address={ shippingAddress }
 				addressFields={ addressFields }

--- a/assets/js/base/components/cart-checkout/shipping-calculator/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-calculator/style.scss
@@ -1,11 +1,11 @@
-.wc-block-shipping-calculator-address {
+.wc-block-components-shipping-calculator-address {
 	margin-bottom: 0;
 }
 
-.wc-block-shipping-calculator-address__button {
+.wc-block-components-shipping-calculator-address__button {
 	width: 100%;
 }
 
-.wc-block-cart__shipping-calculator {
+.wc-block-components-shipping-calculator {
 	padding: em($gap-smaller) 0 em($gap-small);
 }

--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -10,6 +10,11 @@ import {
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
  * Shows a formatted shipping location.
  */
 const ShippingLocation = ( { address } ) => {
@@ -41,7 +46,7 @@ const ShippingLocation = ( { address } ) => {
 
 	return (
 		formattedLocation && (
-			<span className="wc-block-cart__shipping-address">
+			<span className="wc-block-components-shipping-address">
 				{ sprintf(
 					/* Translators: %s location. */
 					__( 'Shipping to %s', 'woo-gutenberg-products-block' ),

--- a/assets/js/base/components/cart-checkout/shipping-location/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-location/style.scss
@@ -1,0 +1,4 @@
+.wc-block-components-shipping-address,
+.wc-block-components-shipping-address button {
+	color: $core-grey-dark-400;
+}

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/package-options.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/package-options.js
@@ -21,7 +21,7 @@ const PackageOptions = ( {
 			<Notice
 				isDismissible={ false }
 				className={ classnames(
-					'wc-block-shipping-rates-control__no-results-notice',
+					'wc-block-components-shipping-rates-control__no-results-notice',
 					'woocommerce-message',
 					'woocommerce-info'
 				) }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
@@ -30,21 +30,21 @@ const Package = ( {
 		<>
 			{ title && (
 				<Title
-					className="wc-block-shipping-rates-control__package-title"
+					className="wc-block-components-shipping-rates-control__package-title"
 					headingLevel="3"
 				>
 					{ title }
 				</Title>
 			) }
 			{ showItems && (
-				<ul className="wc-block-shipping-rates-control__package-items">
+				<ul className="wc-block-components-shipping-rates-control__package-items">
 					{ Object.values( shippingRate.items ).map( ( v ) => {
 						const name = decodeEntities( v.name );
 						const quantity = v.quantity;
 						return (
 							<li
 								key={ name }
-								className="wc-block-shipping-rates-control__package-item"
+								className="wc-block-components-shipping-rates-control__package-item"
 							>
 								<Label
 									label={ `${ name } ×${ quantity }` }
@@ -80,7 +80,7 @@ const Package = ( {
 	if ( collapsible ) {
 		return (
 			<Panel
-				className="wc-block-shipping-rates-control__package"
+				className="wc-block-components-shipping-rates-control__package"
 				hasBorder={ true }
 				initialOpen={ true }
 				title={ header }
@@ -92,7 +92,7 @@ const Package = ( {
 	return (
 		<div
 			className={ classNames(
-				'wc-block-shipping-rates-control__package',
+				'wc-block-components-shipping-rates-control__package',
 				className
 			) }
 		>

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/packages.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/packages.js
@@ -22,7 +22,7 @@ const Packages = ( {
 	);
 	/* eslint-disable camelcase */
 	return (
-		<div className="wc-block-shipping-rates-control">
+		<div className="wc-block-components-shipping-rates-control">
 			{ shippingRates.map( ( { package_id, ...shippingRate } ) => (
 				<Package
 					key={ package_id }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
@@ -1,10 +1,10 @@
-.wc-block-shipping-rates-control__package {
-	.wc-block-shipping-rates-control__package-title {
+.wc-block-components-shipping-rates-control__package {
+	.wc-block-components-shipping-rates-control__package-title {
 		margin: 0;
 	}
 }
 
-.wc-block-shipping-rates-control__package-items {
+.wc-block-components-shipping-rates-control__package-items {
 	@include font-size(small);
 	color: $core-grey-dark-400;
 	display: block;
@@ -13,28 +13,23 @@
 	padding: 0;
 }
 
-.wc-block-shipping-rates-control__package-item {
+.wc-block-components-shipping-rates-control__package-item {
 	@include wrap-break-word();
 	display: inline-block;
 	margin: 0;
 	padding: 0;
 }
 
-.wc-block-shipping-rates-control__package-item:not(:last-child)::after {
+.wc-block-components-shipping-rates-control__package-item:not(:last-child)::after {
 	content: ", ";
 	white-space: pre;
 }
 
-.wc-block-cart__shipping-address,
-.wc-block-cart__shipping-address button {
-	color: $core-grey-dark-400;
-}
-
-.components-notice.wc-block-shipping-rates-control__no-results-notice {
+.components-notice.wc-block-components-shipping-rates-control__no-results-notice {
 	margin-bottom: 0;
 }
 
-.wc-block-shipping-rates-control {
+.wc-block-components-shipping-rates-control {
 	.wc-blocks-components-panel__content {
 		padding-bottom: 0;
 	}

--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/index.js
@@ -39,11 +39,11 @@ const TotalsCouponCodeInput = ( {
 		}
 	}, [ isLoading, couponValue, validationError ] );
 
-	const textInputId = `wc-block-coupon-code__input-${ instanceId }`;
+	const textInputId = `wc-block-components-totals-coupon__input-${ instanceId }`;
 
 	return (
 		<Panel
-			className="wc-block-coupon-code"
+			className="wc-block-components-totals-coupon"
 			hasBorder={ true }
 			initialOpen={ initialOpen }
 			title={
@@ -69,12 +69,12 @@ const TotalsCouponCodeInput = ( {
 				isLoading={ isLoading }
 				showSpinner={ false }
 			>
-				<div className="wc-block-coupon-code__content">
-					<form className="wc-block-coupon-code__form">
+				<div className="wc-block-components-totals-coupon__content">
+					<form className="wc-block-components-totals-coupon__form">
 						<ValidatedTextInput
 							id={ textInputId }
 							errorId="coupon"
-							className="wc-block-coupon-code__input"
+							className="wc-block-components-totals-coupon__input"
 							label={ __(
 								'Enter code',
 								'woo-gutenberg-products-block'
@@ -91,7 +91,7 @@ const TotalsCouponCodeInput = ( {
 							showError={ false }
 						/>
 						<Button
-							className="wc-block-coupon-code__button"
+							className="wc-block-components-totals-coupon__button"
 							disabled={ isLoading || ! couponValue }
 							showSpinner={ isLoading }
 							onClick={ ( e ) => {

--- a/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-coupon-code-input/style.scss
@@ -1,15 +1,15 @@
-.wc-block-coupon-code__form {
+.wc-block-components-totals-coupon__form {
 	display: flex;
 	margin-bottom: 0;
 	width: 100%;
 
-	.wc-block-coupon-code__input {
+	.wc-block-components-totals-coupon__input {
 		margin-bottom: 0;
 		margin-top: 0;
 		flex-grow: 1;
 	}
 
-	.wc-block-coupon-code__button {
+	.wc-block-components-totals-coupon__button {
 		height: 48px;
 		flex-shrink: 0;
 		margin-left: $gap-smaller;
@@ -19,11 +19,11 @@
 	}
 }
 
-.wc-block-coupon-code__content {
+.wc-block-components-totals-coupon__content {
 	flex-direction: column;
 	position: relative;
 
-	.wc-block-form-input-validation-error {
+	.wc-block-components-validation-error {
 		margin-top: $gap-smaller;
 		position: relative;
 		width: 100%;

--- a/assets/js/base/components/cart-checkout/totals/totals-discount-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-discount-item/index.js
@@ -11,6 +11,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import TotalsItem from '../totals-item';
+import './style.scss';
 
 const TotalsDiscountItem = ( {
 	cartCoupons = [],
@@ -36,6 +37,7 @@ const TotalsDiscountItem = ( {
 
 	return (
 		<TotalsItem
+			className="wc-block-components-totals-discount"
 			currency={ currency }
 			description={
 				cartCoupons.length !== 0 && (
@@ -47,11 +49,11 @@ const TotalsDiscountItem = ( {
 						isLoading={ isRemovingCoupon }
 						showSpinner={ false }
 					>
-						<ul className="wc-block-cart-coupon-list">
+						<ul className="wc-block-components-totals-discount__coupon-list">
 							{ cartCoupons.map( ( cartCoupon ) => (
 								<Chip
 									key={ 'coupon-' + cartCoupon.code }
-									className="wc-block-cart-coupon-list__item"
+									className="wc-block-components-totals-discount__coupon-list-item"
 									text={ cartCoupon.code }
 									screenReaderText={ sprintf(
 										/* Translators: %s Coupon code. */

--- a/assets/js/base/components/cart-checkout/totals/totals-discount-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-discount-item/style.scss
@@ -1,0 +1,5 @@
+.wc-block-components-totals-discount__coupon-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}

--- a/assets/js/base/components/cart-checkout/totals/totals-fees-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-fees-item/index.js
@@ -27,6 +27,7 @@ const TotalsFeesItem = ( { currency, values } ) => {
 
 	return (
 		<TotalsItem
+			className="wc-block-components-totals-fees"
 			currency={ currency }
 			label={ __( 'Fees', 'woo-gutenberg-products-block' ) }
 			value={

--- a/assets/js/base/components/cart-checkout/totals/totals-footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-footer-item/index.js
@@ -18,13 +18,13 @@ const TotalsFooterItem = ( { currency, values } ) => {
 
 	return (
 		<TotalsItem
-			className="wc-block-totals-footer-item"
+			className="wc-block-components-totals-footer-item"
 			currency={ currency }
 			label={ __( 'Total', 'woo-gutenberg-products-block' ) }
 			value={ parseInt( totalPrice, 10 ) }
 			description={
 				DISPLAY_CART_PRICES_INCLUDING_TAX && (
-					<p className="wc-block-totals-footer-item-tax">
+					<p className="wc-block-components-totals-footer-item-tax">
 						{ __experimentalCreateInterpolateElement(
 							__(
 								'Including <TaxAmount/> in taxes',
@@ -33,7 +33,7 @@ const TotalsFooterItem = ( { currency, values } ) => {
 							{
 								TaxAmount: (
 									<FormattedMonetaryAmount
-										className="wc-block-totals-footer-item-tax-value"
+										className="wc-block-components-totals-footer-item-tax-value"
 										currency={ currency }
 										displayType="text"
 										value={ parseInt( totalTax, 10 ) }

--- a/assets/js/base/components/cart-checkout/totals/totals-footer-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-footer-item/style.scss
@@ -1,15 +1,15 @@
-.wc-block-totals-footer-item {
-	.wc-block-totals-table-item__value,
-	.wc-block-totals-table-item__label {
+.wc-block-components-totals-footer-item {
+	.wc-block-components-totals-item__value,
+	.wc-block-components-totals-item__label {
 		@include font-size(large);
 		color: #000;
 	}
 
-	.wc-block-totals-table-item__label {
+	.wc-block-components-totals-item__label {
 		font-weight: normal;
 	}
 
-	.wc-block-totals-footer-item-tax {
+	.wc-block-components-totals-footer-item-tax {
 		margin-bottom: 0;
 	}
 }

--- a/assets/js/base/components/cart-checkout/totals/totals-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-item/index.js
@@ -14,22 +14,27 @@ import './style.scss';
 const TotalsItem = ( { className, currency, label, value, description } ) => {
 	return (
 		<div
-			className={ classnames( 'wc-block-totals-table-item', className ) }
+			className={ classnames(
+				'wc-block-components-totals-item',
+				className
+			) }
 		>
-			<span className="wc-block-totals-table-item__label">{ label }</span>
+			<span className="wc-block-components-totals-item__label">
+				{ label }
+			</span>
 			{ isValidElement( value ) ? (
-				<div className="wc-block-totals-table-item__value">
+				<div className="wc-block-components-totals-item__value">
 					{ value }
 				</div>
 			) : (
 				<FormattedMonetaryAmount
-					className="wc-block-totals-table-item__value"
+					className="wc-block-components-totals-item__value"
 					currency={ currency }
 					displayType="text"
 					value={ value }
 				/>
 			) }
-			<div className="wc-block-totals-table-item__description">
+			<div className="wc-block-components-totals-item__description">
 				{ description }
 			</div>
 		</div>

--- a/assets/js/base/components/cart-checkout/totals/totals-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-item/style.scss
@@ -1,20 +1,20 @@
-.wc-block-totals-table-item {
+.wc-block-components-totals-item {
 	display: flex;
 	flex-wrap: wrap;
 	padding: em($gap-small) 0;
 	width: 100%;
 }
 
-.wc-block-totals-table-item__label {
+.wc-block-components-totals-item__label {
 	flex-grow: 1;
 	font-weight: bold;
 }
 
-.wc-block-totals-table-item__value {
+.wc-block-components-totals-item__value {
 	white-space: nowrap;
 }
 
-.wc-block-totals-table-item__description {
+.wc-block-components-totals-item__description {
 	@include font-size(small);
 	width: 100%;
 }

--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/index.js
@@ -50,12 +50,12 @@ const TotalsShippingItem = ( {
 		return (
 			<>
 				<TotalsItem
-					className="wc-block-shipping-totals"
+					className="wc-block-components-totals-shipping"
 					label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
 					value={
 						showCalculator ? (
 							<button
-								className="wc-block-shipping-totals__change-address-button"
+								className="wc-block-components-totals-shipping__change-address-button"
 								onClick={ () => {
 									setIsShippingCalculatorOpen(
 										! isShippingCalculatorOpen
@@ -89,7 +89,7 @@ const TotalsShippingItem = ( {
 	}
 
 	return (
-		<div className="wc-block-shipping-totals">
+		<div className="wc-block-components-totals-shipping">
 			<TotalsItem
 				label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
 				value={ totalShippingValue ? totalShippingValue : '' }
@@ -98,7 +98,7 @@ const TotalsShippingItem = ( {
 						<ShippingLocation address={ shippingAddress } />{ ' ' }
 						{ showCalculator && (
 							<button
-								className="wc-block-shipping-totals__change-address-button"
+								className="wc-block-components-totals-shipping__change-address-button"
 								onClick={ () => {
 									setIsShippingCalculatorOpen(
 										! isShippingCalculatorOpen

--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/shipping-rate-selector.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/shipping-rate-selector.js
@@ -30,7 +30,7 @@ const ShippingRateSelector = ( {
 	shippingRatesLoading,
 } ) => {
 	return (
-		<fieldset className="wc-block-shipping-totals__fieldset">
+		<fieldset className="wc-block-components-totals-shipping__fieldset">
 			<legend className="screen-reader-text">
 				{ hasRates
 					? __( 'Shipping options', 'woo-gutenberg-products-block' )
@@ -40,7 +40,7 @@ const ShippingRateSelector = ( {
 					  ) }
 			</legend>
 			<ShippingRatesControl
-				className="wc-block-shipping-totals__options"
+				className="wc-block-components-totals-shipping__options"
 				collapsibleWhenMultiple={ true }
 				noResultsMessage={ __(
 					'No shipping options were found.',

--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/style.scss
@@ -1,34 +1,34 @@
-.wc-block-shipping-totals {
+.wc-block-components-totals-shipping {
 	// Added extra label for specificity.
-	fieldset.wc-block-shipping-totals__fieldset {
+	fieldset.wc-block-components-totals-shipping__fieldset {
 		background-color: transparent;
 		margin: 0;
 		padding: 0;
 		border: 0;
 	}
 
-	.wc-block-shipping-totals__options {
-		.wc-block-radio-control__label,
-		.wc-block-radio-control__description,
-		.wc-block-radio-control__secondary-label,
-		.wc-block-radio-control__secondary-description {
+	.wc-block-components-totals-shipping__options {
+		.wc-block-components-radio-control__label,
+		.wc-block-components-radio-control__description,
+		.wc-block-components-radio-control__secondary-label,
+		.wc-block-components-radio-control__secondary-description {
 			flex-basis: 100%;
 			text-align: left;
 		}
 	}
 
-	.wc-block-radio-control__option,
-	.wc-block-radio-control__option-layout {
+	.wc-block-components-radio-control__option,
+	.wc-block-components-radio-control__option-layout {
 		&:last-child {
 			border-bottom: none;
 		}
 	}
 
-	.wc-block-shipping-rates-control__no-results-notice {
+	.wc-block-components-shipping-rates-control__no-results-notice {
 		margin-bottom: em($gap-small);
 	}
 
-	.wc-block-shipping-totals__change-address-button {
+	.wc-block-components-totals-shipping__change-address-button {
 		@include link-button();
 
 		&:hover,

--- a/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
@@ -23,6 +23,7 @@ const TotalsTaxesItem = ( { currency, values } ) => {
 	if ( ! DISPLAY_ITEMIZED_TAXES ) {
 		return (
 			<TotalsItem
+				className="wc-block-components-totals-taxes"
 				currency={ currency }
 				label={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
 				value={ parseInt( totalTax, 10 ) }
@@ -35,6 +36,7 @@ const TotalsTaxesItem = ( { currency, values } ) => {
 			{ taxLines.map( ( { name, price }, i ) => (
 				<TotalsItem
 					key={ `tax-line-${ i }` }
+					className="wc-block-components-totals-taxes"
 					currency={ currency }
 					label={ name }
 					value={ parseInt( price, 10 ) }

--- a/assets/js/base/components/checkbox-control/index.js
+++ b/assets/js/base/components/checkbox-control/index.js
@@ -25,17 +25,22 @@ const CheckboxControl = ( {
 
 	return (
 		<label
-			className={ classNames( 'wc-block-checkbox', className ) }
+			className={ classNames(
+				'wc-block-components-checkbox',
+				className
+			) }
 			htmlFor={ checkboxId }
 		>
 			<input
 				id={ checkboxId }
-				className="wc-block-checkbox__input"
+				className="wc-block-components-checkbox__input"
 				type="checkbox"
 				onChange={ ( event ) => onChange( event.target.checked ) }
 				{ ...rest }
 			/>
-			<span className="wc-block-checkbox__label">{ label }</span>
+			<span className="wc-block-components-checkbox__label">
+				{ label }
+			</span>
 		</label>
 	);
 };

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -1,9 +1,9 @@
-.wc-block-checkbox {
+.wc-block-components-checkbox {
 	@include reset-typography();
 	display: block;
 	position: relative;
 
-	.wc-block-checkbox__input[type="checkbox"] {
+	.wc-block-components-checkbox__input[type="checkbox"] {
 		appearance: none;
 		border: 1px solid currentColor;
 		height: 1rem;
@@ -34,7 +34,7 @@
 		}
 	}
 
-	.wc-block-checkbox__input[type="checkbox"] + .wc-block-checkbox__label {
+	.wc-block-components-checkbox__input[type="checkbox"] + .wc-block-components-checkbox__label {
 		padding-left: $gap-smaller;
 		vertical-align: middle;
 	}

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -142,6 +142,7 @@ const CheckboxList = ( {
 
 	const classes = classNames(
 		'wc-block-checkbox-list',
+		'wc-block-components-checkbox-list',
 		{
 			'is-loading': isLoading,
 		},

--- a/assets/js/base/components/checkbox-list/style.scss
+++ b/assets/js/base/components/checkbox-list/style.scss
@@ -1,5 +1,5 @@
-.editor-styles-wrapper .wc-block-checkbox-list,
-.wc-block-checkbox-list {
+.editor-styles-wrapper .wc-block-components-checkbox-list,
+.wc-block-components-checkbox-list {
 	margin: 0;
 	padding: 0;
 	list-style: none outside;

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -32,7 +32,12 @@ const CountryInput = ( {
 	} ) );
 
 	return (
-		<div className={ classnames( className, 'wc-block-country-input' ) }>
+		<div
+			className={ classnames(
+				className,
+				'wc-block-components-country-input'
+			) }
+		>
 			<ValidatedSelect
 				id={ id }
 				label={ label }

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -33,10 +33,15 @@ const DropdownSelector = ( {
 } ) => {
 	const inputRef = useRef( null );
 
-	const classes = classNames( className, 'wc-block-dropdown-selector', {
-		'is-disabled': isDisabled,
-		'is-loading': isLoading,
-	} );
+	const classes = classNames(
+		className,
+		'wc-block-dropdown-selector',
+		'wc-block-components-dropdown-selector',
+		{
+			'is-disabled': isDisabled,
+			'is-loading': isLoading,
+		}
+	);
 
 	/**
 	 * State reducer for the downshift component.

--- a/assets/js/base/components/dropdown-selector/input-wrapper.js
+++ b/assets/js/base/components/dropdown-selector/input-wrapper.js
@@ -2,7 +2,7 @@ const DropdownSelectorInputWrapper = ( { children, onClick } ) => {
 	return (
 		/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 		<div
-			className="wc-block-dropdown-selector__input-wrapper"
+			className="wc-block-dropdown-selector__input-wrapper wc-block-components-dropdown-selector__input-wrapper"
 			onClick={ onClick }
 		>
 			{ children }

--- a/assets/js/base/components/dropdown-selector/input.js
+++ b/assets/js/base/components/dropdown-selector/input.js
@@ -13,7 +13,8 @@ const DropdownSelectorInput = ( {
 		<input
 			{ ...getInputProps( {
 				ref: inputRef,
-				className: 'wc-block-dropdown-selector__input',
+				className:
+					'wc-block-dropdown-selector__input wc-block-components-dropdown-selector__input',
 				disabled: isDisabled,
 				onFocus,
 				onKeyDown( e ) {

--- a/assets/js/base/components/dropdown-selector/menu.js
+++ b/assets/js/base/components/dropdown-selector/menu.js
@@ -14,7 +14,8 @@ const DropdownSelectorMenu = ( {
 	return (
 		<ul
 			{ ...getMenuProps( {
-				className: 'wc-block-dropdown-selector__list',
+				className:
+					'wc-block-dropdown-selector__list wc-block-components-dropdown-selector__list',
 			} ) }
 		>
 			{ options.map( ( option, index ) => {
@@ -26,6 +27,7 @@ const DropdownSelectorMenu = ( {
 							key: option.value,
 							className: classNames(
 								'wc-block-dropdown-selector__list-item',
+								'wc-block-components-dropdown-selector__list-item',
 								{
 									'is-selected': selected,
 									'is-highlighted':

--- a/assets/js/base/components/dropdown-selector/selected-chip.js
+++ b/assets/js/base/components/dropdown-selector/selected-chip.js
@@ -6,7 +6,7 @@ import { __, sprintf } from '@wordpress/i18n';
 const DropdownSelectorSelectedChip = ( { onRemoveItem, option } ) => {
 	return (
 		<button
-			className="wc-block-dropdown-selector__selected-chip"
+			className="wc-block-dropdown-selector__selected-chip wc-block-components-dropdown-selector__selected-chip"
 			onClick={ () => {
 				onRemoveItem( option.value );
 			} }
@@ -20,10 +20,10 @@ const DropdownSelectorSelectedChip = ( { onRemoveItem, option } ) => {
 				option.name
 			) }
 		>
-			<span className="wc-block-dropdown-selector__selected-chip__label">
+			<span className="wc-block-dropdown-selector__selected-chip__label wc-block-components-dropdown-selector__selected-chip__label">
 				{ option.label }
 			</span>
-			<span className="wc-block-dropdown-selector__selected-chip__remove">
+			<span className="wc-block-dropdown-selector__selected-chip__remove wc-block-components-dropdown-selector__selected-chip__remove">
 				𝘅
 			</span>
 		</button>

--- a/assets/js/base/components/dropdown-selector/selected-value.js
+++ b/assets/js/base/components/dropdown-selector/selected-value.js
@@ -12,10 +12,10 @@ const DropdownSelectorSelectedValue = ( { onClick, onRemoveItem, option } ) => {
 	}, [ labelRef ] );
 
 	return (
-		<div className="wc-block-dropdown-selector__selected-value">
+		<div className="wc-block-dropdown-selector__selected-value wc-block-components-dropdown-selector__selected-value">
 			<button
 				ref={ labelRef }
-				className="wc-block-dropdown-selector__selected-value__label"
+				className="wc-block-dropdown-selector__selected-value__label wc-block-components-dropdown-selector__selected-value__label"
 				onClick={ ( e ) => {
 					e.stopPropagation();
 					onClick( option.value );
@@ -32,7 +32,7 @@ const DropdownSelectorSelectedValue = ( { onClick, onRemoveItem, option } ) => {
 				{ option.label }
 			</button>
 			<button
-				className="wc-block-dropdown-selector__selected-value__remove"
+				className="wc-block-dropdown-selector__selected-value__remove wc-block-components-dropdown-selector__selected-value__remove"
 				onClick={ () => {
 					onRemoveItem( option.value );
 				} }

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -1,10 +1,10 @@
-.wc-block-dropdown-selector {
+.wc-block-components-dropdown-selector {
 	max-width: 300px;
 	position: relative;
 	width: 100%;
 }
 
-.wc-block-dropdown-selector__input-wrapper {
+.wc-block-components-dropdown-selector__input-wrapper {
 	align-items: center;
 	border: 1px solid #9f9f9f;
 	border-radius: 4px;
@@ -18,14 +18,14 @@
 	}
 }
 
-.wc-block-dropdown-selector__placeholder {
+.wc-block-components-dropdown-selector__placeholder {
 	@include font-size(small);
 	height: 1.8em;
 	margin: 0 $gap-smallest;
 	white-space: nowrap;
 }
 
-.wc-block-dropdown-selector__input {
+.wc-block-components-dropdown-selector__input {
 	@include font-size(small);
 	height: 1.8em;
 	min-width: 0;
@@ -62,8 +62,8 @@
 }
 
 // Visually hide the input
-.is-single .wc-block-dropdown-selector__input:first-child,
-.is-multiple .wc-block-dropdown-selector__input {
+.is-single .wc-block-components-dropdown-selector__input:first-child,
+.is-multiple .wc-block-components-dropdown-selector__input {
 	background: transparent;
 	border: 0;
 
@@ -74,11 +74,11 @@
 	}
 }
 
-.wc-block-dropdown-selector {
+.wc-block-components-dropdown-selector {
 	// Reset <button> styles
-	.wc-block-dropdown-selector__selected-chip,
-	.wc-block-dropdown-selector__selected-value__label,
-	.wc-block-dropdown-selector__selected-value__remove {
+	.wc-block-components-dropdown-selector__selected-chip,
+	.wc-block-components-dropdown-selector__selected-value__label,
+	.wc-block-components-dropdown-selector__selected-value__remove {
 		background-color: transparent;
 		border: 0;
 		color: inherit;
@@ -94,7 +94,7 @@
 		}
 	}
 
-	.wc-block-dropdown-selector__selected-value {
+	.wc-block-components-dropdown-selector__selected-value {
 		align-items: center;
 		color: $core-grey-dark-600;
 		display: inline-flex;
@@ -103,7 +103,7 @@
 		width: 100%;
 	}
 
-	.wc-block-dropdown-selector__selected-chip {
+	.wc-block-components-dropdown-selector__selected-chip {
 		align-items: center;
 		background-color: $core-grey-light-600;
 		border: 1px solid #9f9f9f;
@@ -124,16 +124,16 @@
 		}
 	}
 
-	.wc-block-dropdown-selector__selected-value__label,
-	.wc-block-dropdown-selector__selected-chip__label {
+	.wc-block-components-dropdown-selector__selected-value__label,
+	.wc-block-components-dropdown-selector__selected-chip__label {
 		@include font-size(small);
 		flex-grow: 1;
 		padding: 0;
 		text-align: left;
 	}
 
-	.wc-block-dropdown-selector__selected-value__remove,
-	.wc-block-dropdown-selector__selected-chip__remove {
+	.wc-block-components-dropdown-selector__selected-value__remove,
+	.wc-block-components-dropdown-selector__selected-chip__remove {
 		background-color: transparent;
 		border: 0;
 		display: inline-block;
@@ -142,7 +142,7 @@
 	}
 }
 
-.wc-block-dropdown-selector__list {
+.wc-block-components-dropdown-selector__list {
 	background-color: #fff;
 	margin: -1px 0 0;
 	padding: 0;
@@ -159,7 +159,7 @@
 	}
 }
 
-.wc-block-dropdown-selector__list-item {
+.wc-block-components-dropdown-selector__list-item {
 	@include font-size(small);
 	color: $core-grey-dark-600;
 	cursor: default;

--- a/assets/js/base/components/filter-submit-button/index.js
+++ b/assets/js/base/components/filter-submit-button/index.js
@@ -24,6 +24,7 @@ const FilterSubmitButton = ( {
 			type="submit"
 			className={ classNames(
 				'wc-block-filter-submit-button',
+				'wc-block-components-filter-submit-button',
 				className
 			) }
 			disabled={ disabled }

--- a/assets/js/base/components/filter-submit-button/style.scss
+++ b/assets/js/base/components/filter-submit-button/style.scss
@@ -1,4 +1,4 @@
-.wc-block-filter-submit-button {
+.wc-block-components-filter-submit-button {
 	display: block;
 	margin-left: auto;
 	white-space: nowrap;

--- a/assets/js/base/components/load-more-button/index.js
+++ b/assets/js/base/components/load-more-button/index.js
@@ -12,7 +12,7 @@ import './style.scss';
 
 export const LoadMoreButton = ( { onClick, label, screenReaderLabel } ) => {
 	return (
-		<div className="wp-block-button wc-block-load-more">
+		<div className="wp-block-button wc-block-components-load-more">
 			<button className="wp-block-button__link" onClick={ onClick }>
 				<Label
 					label={ label }

--- a/assets/js/base/components/load-more-button/index.js
+++ b/assets/js/base/components/load-more-button/index.js
@@ -12,7 +12,7 @@ import './style.scss';
 
 export const LoadMoreButton = ( { onClick, label, screenReaderLabel } ) => {
 	return (
-		<div className="wp-block-button wc-block-components-load-more">
+		<div className="wp-block-button wc-block-load-more wc-block-components-load-more">
 			<button className="wp-block-button__link" onClick={ onClick }>
 				<Label
 					label={ label }

--- a/assets/js/base/components/load-more-button/style.scss
+++ b/assets/js/base/components/load-more-button/style.scss
@@ -1,4 +1,4 @@
-.wc-block-load-more {
+.wc-block-components-load-more {
 	text-align: center;
 	width: 100%;
 }

--- a/assets/js/base/components/loading-mask/index.js
+++ b/assets/js/base/components/loading-mask/index.js
@@ -24,10 +24,15 @@ const LoadingMask = ( {
 	}
 
 	return (
-		<div className={ classNames( className, 'wc-block-loading-mask' ) }>
+		<div
+			className={ classNames(
+				className,
+				'wc-block-components-loading-mask'
+			) }
+		>
 			{ showSpinner && <Spinner /> }
 			<div
-				className="wc-blocks-loading-mask__children"
+				className="wc-block-components-loading-mask__children"
 				aria-hidden={ true }
 			>
 				{ children }

--- a/assets/js/base/components/loading-mask/style.scss
+++ b/assets/js/base/components/loading-mask/style.scss
@@ -1,4 +1,4 @@
-.wc-block-loading-mask {
+.wc-block-components-load-more {
 	position: relative;
 	min-height: 18px + $gap;
 
@@ -11,6 +11,6 @@
 	}
 }
 
-.wc-blocks-loading-mask__children {
+.wc-block-components-loading-mask__children {
 	opacity: 0.5;
 }

--- a/assets/js/base/components/loading-mask/style.scss
+++ b/assets/js/base/components/loading-mask/style.scss
@@ -1,4 +1,4 @@
-.wc-block-components-load-more {
+.wc-block-components-loading-mask {
 	position: relative;
 	min-height: 18px + $gap;
 

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -49,7 +49,7 @@ const Pagination = ( {
 	}
 
 	return (
-		<div className="wc-block-pagination">
+		<div className="wc-block-pagination wc-block-components-pagination">
 			<Label
 				screenReaderLabel={ __(
 					'Navigate to another page',
@@ -58,7 +58,7 @@ const Pagination = ( {
 			/>
 			{ displayNextAndPreviousArrows && (
 				<button
-					className="wc-block-pagination-page"
+					className="wc-block-pagination-page wc-block-components-pagination__page"
 					onClick={ () => onPageChange( currentPage - 1 ) }
 					title={ __(
 						'Previous page',
@@ -77,9 +77,16 @@ const Pagination = ( {
 			) }
 			{ showFirstPage && (
 				<button
-					className={ classNames( 'wc-block-pagination-page', {
-						'wc-block-pagination-page--active': currentPage === 1,
-					} ) }
+					className={ classNames(
+						'wc-block-pagination-page',
+						'wc-block-components-pagination__page',
+						{
+							'wc-block-pagination-page--active':
+								currentPage === 1,
+							'wc-block-components-pagination__page--active':
+								currentPage === 1,
+						}
+					) }
 					onClick={ () => onPageChange( 1 ) }
 					disabled={ currentPage === 1 }
 				>
@@ -95,7 +102,7 @@ const Pagination = ( {
 			) }
 			{ showFirstPageEllipsis && (
 				<span
-					className="wc-block-pagination-ellipsis"
+					className="wc-block-pagination-ellipsis wc-block-components-pagination__ellipsis"
 					aria-hidden="true"
 				>
 					{ __( '…', 'woo-gutenberg-products-block' ) }
@@ -105,10 +112,16 @@ const Pagination = ( {
 				return (
 					<button
 						key={ page }
-						className={ classNames( 'wc-block-pagination-page', {
-							'wc-block-pagination-page--active':
-								currentPage === page,
-						} ) }
+						className={ classNames(
+							'wc-block-pagination-page',
+							'wc-block-components-pagination__page',
+							{
+								'wc-block-pagination-page--active':
+									currentPage === page,
+								'wc-block-components-pagination__page--active':
+									currentPage === page,
+							}
+						) }
 						onClick={
 							currentPage === page
 								? null
@@ -129,7 +142,7 @@ const Pagination = ( {
 			} ) }
 			{ showLastPageEllipsis && (
 				<span
-					className="wc-block-pagination-ellipsis"
+					className="wc-block-pagination-ellipsis wc-block-components-pagination__ellipsis"
 					aria-hidden="true"
 				>
 					{ __( '…', 'woo-gutenberg-products-block' ) }
@@ -137,10 +150,16 @@ const Pagination = ( {
 			) }
 			{ showLastPage && (
 				<button
-					className={ classNames( 'wc-block-pagination-page', {
-						'wc-block-pagination-page--active':
-							currentPage === totalPages,
-					} ) }
+					className={ classNames(
+						'wc-block-pagination-page',
+						'wc-block-components-pagination__page',
+						{
+							'wc-block-pagination-page--active':
+								currentPage === totalPages,
+							'wc-block-components-pagination__page--active':
+								currentPage === totalPages,
+						}
+					) }
 					onClick={ () => onPageChange( totalPages ) }
 					disabled={ currentPage === totalPages }
 				>
@@ -156,7 +175,7 @@ const Pagination = ( {
 			) }
 			{ displayNextAndPreviousArrows && (
 				<button
-					className="wc-block-pagination-page"
+					className="wc-block-pagination-page wc-block-components-pagination__page"
 					onClick={ () => onPageChange( currentPage + 1 ) }
 					title={ __( 'Next page', 'woo-gutenberg-products-block' ) }
 					disabled={ currentPage >= totalPages }

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -1,16 +1,16 @@
-.wc-block-pagination {
+.wc-block-components-pagination {
 	margin: 0 auto $gap;
 }
 
-.wc-block-pagination-page,
-.wc-block-pagination-ellipsis {
+.wc-block-components-pagination__page,
+.wc-block-components-pagination__ellipsis {
 	@include font-size(regular);
 	color: #333;
 	display: inline-block;
 	font-weight: normal;
 }
 
-.wc-block-pagination-page {
+.wc-block-components-pagination__page {
 	border-color: transparent;
 	padding: 0.3em 0.6em;
 	min-width: 2.2em;
@@ -29,7 +29,7 @@
 	}
 }
 
-.wc-block-pagination-ellipsis {
+.wc-block-components-pagination__ellipsis {
 	padding: 0.3em;
 
 	@include breakpoint( "<782px" ) {
@@ -37,7 +37,7 @@
 	}
 }
 
-.wc-block-pagination-page--active[disabled] {
+.wc-block-components-pagination__page--active[disabled] {
 	color: #333;
 	font-weight: bold;
 	opacity: 1 !important;

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -98,7 +98,7 @@ const PaymentMethods = () => {
 					} ) }
 					{ customerId > 0 && supports.savePaymentInfo && (
 						<CheckboxControl
-							className="wc-block-checkout__save-card-info"
+							className="wc-block-components-checkout-payment-methods__save-card-info"
 							label={ __(
 								'Save payment information to my account for future purchases.',
 								'woo-gutenberg-products-block'

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -98,7 +98,7 @@ const PaymentMethods = () => {
 					} ) }
 					{ customerId > 0 && supports.savePaymentInfo && (
 						<CheckboxControl
-							className="wc-block-components-checkout-payment-methods__save-card-info"
+							className="wc-block-components-payment-methods__save-card-info"
 							label={ __(
 								'Save payment information to my account for future purchases.',
 								'woo-gutenberg-products-block'

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -125,7 +125,7 @@
 				transform: translateY(#{$gap-smallest}) scale(0.75);
 			}
 		}
-		& + .wc-block-form-input-validation-error {
+		& + .wc-block-components-validation-error {
 			position: static;
 			margin-top: -$gap-large;
 		}
@@ -157,7 +157,7 @@
 .is-large {
 	.wc-card-expiry-element,
 	.wc-card-cvc-element {
-		.wc-block-form-input-validation-error > p {
+		.wc-block-components-validation-error > p {
 			line-height: 16px;
 			padding-top: 4px;
 		}
@@ -168,7 +168,7 @@
 .is-small {
 	.wc-card-expiry-element,
 	.wc-card-cvc-element {
-		.wc-block-form-input-validation-error > p {
+		.wc-block-components-validation-error > p {
 			min-height: 28px;
 		}
 	}

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -222,8 +222,12 @@ const PriceSlider = ( {
 
 	const classes = classnames(
 		'wc-block-price-filter',
+		'wc-block-components-price-slider',
 		showInputFields && 'wc-block-price-filter--has-input-fields',
+		showInputFields && 'wc-block-components-price-slider--has-input-fields',
 		showFilterButton && 'wc-block-price-filter--has-filter-button',
+		showFilterButton &&
+			'wc-block-components-price-slider--has-filter-button',
 		isLoading && 'is-loading',
 		! hasValidConstraints && 'is-disabled'
 	);
@@ -236,19 +240,19 @@ const PriceSlider = ( {
 	return (
 		<div className={ classes }>
 			<div
-				className="wc-block-price-filter__range-input-wrapper wc-block-components-price-filter__range-input-wrapper"
+				className="wc-block-price-filter__range-input-wrapper wc-block-components-price-slider__range-input-wrapper"
 				onMouseMove={ findClosestRange }
 				onFocus={ findClosestRange }
 			>
 				{ hasValidConstraints && (
 					<div aria-hidden={ showInputFields }>
 						<div
-							className="wc-block-price-filter__range-input-progress wc-block-components-price-filter__range-input-progress"
+							className="wc-block-price-filter__range-input-progress wc-block-components-price-slider__range-input-progress"
 							style={ progressStyles }
 						/>
 						<input
 							type="range"
-							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--min wc-block-components-price-filter__range-input wc-block-components-price-filter__range-input--min"
+							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--min wc-block-components-price-slider__range-input wc-block-components-price-slider__range-input--min"
 							aria-label={ __(
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
@@ -268,7 +272,7 @@ const PriceSlider = ( {
 						/>
 						<input
 							type="range"
-							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--max wc-block-components-price-filter__range-input wc-block-components-price-filter__range-input--max"
+							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--max wc-block-components-price-slider__range-input wc-block-components-price-slider__range-input--max"
 							aria-label={ __(
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
@@ -295,7 +299,7 @@ const PriceSlider = ( {
 						<FormattedMonetaryAmount
 							currency={ currency }
 							displayType="input"
-							className="wc-block-price-filter__amount wc-block-price-filter__amount--min wc-block-form-text-input wc-block-components-price-filter__amount wc-block-components-price-filter__amount--min"
+							className="wc-block-price-filter__amount wc-block-price-filter__amount--min wc-block-form-text-input wc-block-components-price-slider__amount wc-block-components-price-slider__amount--min"
 							aria-label={ __(
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
@@ -313,7 +317,7 @@ const PriceSlider = ( {
 						<FormattedMonetaryAmount
 							currency={ currency }
 							displayType="input"
-							className="wc-block-price-filter__amount wc-block-price-filter__amount--max wc-block-form-text-input wc-block-components-price-filter__amount wc-block-components-price-filter__amount--max"
+							className="wc-block-price-filter__amount wc-block-price-filter__amount--max wc-block-form-text-input wc-block-components-price-slider__amount wc-block-components-price-slider__amount--max"
 							aria-label={ __(
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
@@ -334,7 +338,7 @@ const PriceSlider = ( {
 					! isLoading &&
 					Number.isFinite( minPrice ) &&
 					Number.isFinite( maxPrice ) && (
-						<div className="wc-block-price-filter__range-text wc-block-components-price-filter__range-text">
+						<div className="wc-block-price-filter__range-text wc-block-components-price-slider__range-text">
 							{ __( 'Price', 'woo-gutenberg-products-block' ) }
 							: &nbsp;
 							<FormattedMonetaryAmount
@@ -352,7 +356,7 @@ const PriceSlider = ( {
 					) }
 				{ showFilterButton && (
 					<FilterSubmitButton
-						className="wc-block-price-filter__button wc-block-components-price-filter__button"
+						className="wc-block-price-filter__button wc-block-components-price-slider__button"
 						disabled={ isLoading || ! hasValidConstraints }
 						onClick={ onSubmit }
 						screenReaderLabel={ __(

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -236,19 +236,19 @@ const PriceSlider = ( {
 	return (
 		<div className={ classes }>
 			<div
-				className="wc-block-price-filter__range-input-wrapper"
+				className="wc-block-price-filter__range-input-wrapper wc-block-components-price-filter__range-input-wrapper"
 				onMouseMove={ findClosestRange }
 				onFocus={ findClosestRange }
 			>
 				{ hasValidConstraints && (
 					<div aria-hidden={ showInputFields }>
 						<div
-							className="wc-block-price-filter__range-input-progress"
+							className="wc-block-price-filter__range-input-progress wc-block-components-price-filter__range-input-progress"
 							style={ progressStyles }
 						/>
 						<input
 							type="range"
-							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--min"
+							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--min wc-block-components-price-filter__range-input wc-block-components-price-filter__range-input--min"
 							aria-label={ __(
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
@@ -268,7 +268,7 @@ const PriceSlider = ( {
 						/>
 						<input
 							type="range"
-							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--max"
+							className="wc-block-price-filter__range-input wc-block-price-filter__range-input--max wc-block-components-price-filter__range-input wc-block-components-price-filter__range-input--max"
 							aria-label={ __(
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
@@ -295,7 +295,7 @@ const PriceSlider = ( {
 						<FormattedMonetaryAmount
 							currency={ currency }
 							displayType="input"
-							className="wc-block-price-filter__amount wc-block-price-filter__amount--min wc-block-form-text-input"
+							className="wc-block-price-filter__amount wc-block-price-filter__amount--min wc-block-form-text-input wc-block-components-price-filter__amount wc-block-components-price-filter__amount--min"
 							aria-label={ __(
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
@@ -313,7 +313,7 @@ const PriceSlider = ( {
 						<FormattedMonetaryAmount
 							currency={ currency }
 							displayType="input"
-							className="wc-block-price-filter__amount wc-block-price-filter__amount--max wc-block-form-text-input"
+							className="wc-block-price-filter__amount wc-block-price-filter__amount--max wc-block-form-text-input wc-block-components-price-filter__amount wc-block-components-price-filter__amount--max"
 							aria-label={ __(
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
@@ -334,7 +334,7 @@ const PriceSlider = ( {
 					! isLoading &&
 					Number.isFinite( minPrice ) &&
 					Number.isFinite( maxPrice ) && (
-						<div className="wc-block-price-filter__range-text">
+						<div className="wc-block-price-filter__range-text wc-block-components-price-filter__range-text">
 							{ __( 'Price', 'woo-gutenberg-products-block' ) }
 							: &nbsp;
 							<FormattedMonetaryAmount
@@ -352,7 +352,7 @@ const PriceSlider = ( {
 					) }
 				{ showFilterButton && (
 					<FilterSubmitButton
-						className="wc-block-price-filter__button"
+						className="wc-block-price-filter__button wc-block-components-price-filter__button"
 						disabled={ isLoading || ! hasValidConstraints }
 						onClick={ onSubmit }
 						screenReaderLabel={ __(

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -293,7 +293,7 @@ const PriceSlider = ( {
 					</div>
 				) }
 			</div>
-			<div className="wc-block-price-filter__controls">
+			<div className="wc-block-price-filter__controls wc-block-components-price-slider__controls">
 				{ showInputFields && (
 					<Fragment>
 						<FormattedMonetaryAmount

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -46,10 +46,10 @@
 	appearance: none;
 }
 
-.wc-block-price-filter {
+.wc-block-components-price-filter {
 	margin-bottom: $gap-large;
 
-	.wc-block-price-filter__range-input-wrapper {
+	.wc-block-components-price-filter__range-input-wrapper {
 		@include reset;
 		height: 9px;
 		clear: both;
@@ -58,7 +58,7 @@
 		background: #e1e1e1;
 		margin: 15px 0;
 
-		.wc-block-price-filter__range-input-progress {
+		.wc-block-components-price-filter__range-input-progress {
 			height: 9px;
 			width: 100%;
 			position: absolute;
@@ -71,35 +71,35 @@
 		}
 	}
 
-	.wc-block-price-filter__controls {
+	.wc-block-components-price-filter__controls {
 		display: flex;
 
-		.wc-block-price-filter__amount {
+		.wc-block-components-price-filter__amount {
 			margin: 0;
 			border-radius: 4px;
 			width: auto;
 			max-width: 100px;
 			min-width: 0;
 
-			&.wc-block-price-filter__amount--min {
+			&.wc-block-components-price-filter__amount--min {
 				margin-right: 10px;
 			}
-			&.wc-block-price-filter__amount--max {
+			&.wc-block-components-price-filter__amount--max {
 				margin-left: auto;
 			}
 		}
 	}
-	&.wc-block-price-filter--has-filter-button {
-		.wc-block-price-filter__controls {
+	&.wc-block-components-price-filter--has-filter-button {
+		.wc-block-components-price-filter__controls {
 			justify-content: flex-end;
 
-			.wc-block-price-filter__amount.wc-block-price-filter__amount--max {
+			.wc-block-components-price-filter__amount.wc-block-components-price-filter__amount--max {
 				margin-left: 0;
 				margin-right: 10px;
 			}
 		}
 	}
-	.wc-block-price-filter__range-input {
+	.wc-block-components-price-filter__range-input {
 		@include reset;
 		width: 100%;
 		height: 0;
@@ -148,7 +148,7 @@
 			}
 		}
 
-		&.wc-block-price-filter__range-input--min {
+		&.wc-block-components-price-filter__range-input--min {
 			z-index: 21;
 
 			&::-webkit-slider-thumb {
@@ -164,7 +164,7 @@
 			}
 		}
 
-		&.wc-block-price-filter__range-input--max {
+		&.wc-block-components-price-filter__range-input--max {
 			z-index: 20;
 
 			&::-webkit-slider-thumb {
@@ -183,25 +183,25 @@
 
 	&.is-loading,
 	&.is-disabled {
-		.wc-block-price-filter__range-input-wrapper,
-		.wc-block-price-filter__amount,
-		.wc-block-price-filter__button {
+		.wc-block-components-price-filter__range-input-wrapper,
+		.wc-block-components-price-filter__amount,
+		.wc-block-components-price-filter__button {
 			@include placeholder();
 			box-shadow: none;
 		}
 	}
 
 	&.is-disabled:not(.is-loading) {
-		.wc-block-price-filter__range-input-wrapper,
-		.wc-block-price-filter__amount,
-		.wc-block-price-filter__button {
+		.wc-block-components-price-filter__range-input-wrapper,
+		.wc-block-components-price-filter__amount,
+		.wc-block-components-price-filter__button {
 			animation: none;
 		}
 	}
 }
 
 .rtl {
-	.wc-block-price-filter .wc-block-price-filter__range-input-wrapper .wc-block-price-filter__range-input-progress {
+	.wc-block-components-price-filter .wc-block-components-price-filter__range-input-wrapper .wc-block-components-price-filter__range-input-progress {
 		--track-background: linear-gradient(to left, transparent var(--low), var(--range-color) 0, var(--range-color) var(--high), transparent 0) no-repeat 0 100% / 100% 100%;
 		--range-color: #a8739d;
 		background: var(--track-background);
@@ -209,20 +209,20 @@
 }
 
 @mixin ie {
-	.wc-block-price-filter {
-		.wc-block-price-filter__range-input-wrapper {
+	.wc-block-components-price-filter {
+		.wc-block-components-price-filter__range-input-wrapper {
 			background: transparent;
 			box-shadow: none;
 			height: 24px;
 
-			.wc-block-price-filter__range-input-progress {
+			.wc-block-components-price-filter__range-input-progress {
 				background: #a8739d;
 				box-shadow: 0 0 0 1px inset #95588a;
 				width: 100%;
 				top: 7px;
 			}
 		}
-		.wc-block-price-filter__range-input {
+		.wc-block-components-price-filter__range-input {
 			height: 24px;
 			pointer-events: auto;
 			position: absolute;
@@ -255,7 +255,7 @@
 				pointer-events: auto;
 			}
 		}
-		.wc-block-price-filter__range-input--max {
+		.wc-block-components-price-filter__range-input--max {
 			&::-ms-fill-upper {
 				background: #e1e1e1;
 				box-shadow: 0 0 0 1px inset #b8b8b8;
@@ -267,14 +267,14 @@
 
 		&.is-loading,
 		&.is-disabled {
-			.wc-block-price-filter__range-input-wrapper {
+			.wc-block-components-price-filter__range-input-wrapper {
 				@include placeholder();
 				box-shadow: none;
 			}
 		}
 
 		&.is-disabled:not(.is-loading) {
-			.wc-block-price-filter__range-input-wrapper {
+			.wc-block-components-price-filter__range-input-wrapper {
 				animation: none;
 			}
 		}

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -46,10 +46,10 @@
 	appearance: none;
 }
 
-.wc-block-components-price-filter {
+.wc-block-components-price-slider {
 	margin-bottom: $gap-large;
 
-	.wc-block-components-price-filter__range-input-wrapper {
+	.wc-block-components-price-slider__range-input-wrapper {
 		@include reset;
 		height: 9px;
 		clear: both;
@@ -58,7 +58,7 @@
 		background: #e1e1e1;
 		margin: 15px 0;
 
-		.wc-block-components-price-filter__range-input-progress {
+		.wc-block-components-price-slider__range-input-progress {
 			height: 9px;
 			width: 100%;
 			position: absolute;
@@ -71,35 +71,35 @@
 		}
 	}
 
-	.wc-block-components-price-filter__controls {
+	.wc-block-components-price-slider__controls {
 		display: flex;
 
-		.wc-block-components-price-filter__amount {
+		.wc-block-components-price-slider__amount {
 			margin: 0;
 			border-radius: 4px;
 			width: auto;
 			max-width: 100px;
 			min-width: 0;
 
-			&.wc-block-components-price-filter__amount--min {
+			&.wc-block-components-price-slider__amount--min {
 				margin-right: 10px;
 			}
-			&.wc-block-components-price-filter__amount--max {
+			&.wc-block-components-price-slider__amount--max {
 				margin-left: auto;
 			}
 		}
 	}
-	&.wc-block-components-price-filter--has-filter-button {
-		.wc-block-components-price-filter__controls {
+	&.wc-block-components-price-slider--has-filter-button {
+		.wc-block-components-price-slider__controls {
 			justify-content: flex-end;
 
-			.wc-block-components-price-filter__amount.wc-block-components-price-filter__amount--max {
+			.wc-block-components-price-slider__amount.wc-block-components-price-slider__amount--max {
 				margin-left: 0;
 				margin-right: 10px;
 			}
 		}
 	}
-	.wc-block-components-price-filter__range-input {
+	.wc-block-components-price-slider__range-input {
 		@include reset;
 		width: 100%;
 		height: 0;
@@ -148,7 +148,7 @@
 			}
 		}
 
-		&.wc-block-components-price-filter__range-input--min {
+		&.wc-block-components-price-slider__range-input--min {
 			z-index: 21;
 
 			&::-webkit-slider-thumb {
@@ -164,7 +164,7 @@
 			}
 		}
 
-		&.wc-block-components-price-filter__range-input--max {
+		&.wc-block-components-price-slider__range-input--max {
 			z-index: 20;
 
 			&::-webkit-slider-thumb {
@@ -183,25 +183,25 @@
 
 	&.is-loading,
 	&.is-disabled {
-		.wc-block-components-price-filter__range-input-wrapper,
-		.wc-block-components-price-filter__amount,
-		.wc-block-components-price-filter__button {
+		.wc-block-components-price-slider__range-input-wrapper,
+		.wc-block-components-price-slider__amount,
+		.wc-block-components-price-slider__button {
 			@include placeholder();
 			box-shadow: none;
 		}
 	}
 
 	&.is-disabled:not(.is-loading) {
-		.wc-block-components-price-filter__range-input-wrapper,
-		.wc-block-components-price-filter__amount,
-		.wc-block-components-price-filter__button {
+		.wc-block-components-price-slider__range-input-wrapper,
+		.wc-block-components-price-slider__amount,
+		.wc-block-components-price-slider__button {
 			animation: none;
 		}
 	}
 }
 
 .rtl {
-	.wc-block-components-price-filter .wc-block-components-price-filter__range-input-wrapper .wc-block-components-price-filter__range-input-progress {
+	.wc-block-components-price-slider .wc-block-components-price-slider__range-input-wrapper .wc-block-components-price-slider__range-input-progress {
 		--track-background: linear-gradient(to left, transparent var(--low), var(--range-color) 0, var(--range-color) var(--high), transparent 0) no-repeat 0 100% / 100% 100%;
 		--range-color: #a8739d;
 		background: var(--track-background);
@@ -209,20 +209,20 @@
 }
 
 @mixin ie {
-	.wc-block-components-price-filter {
-		.wc-block-components-price-filter__range-input-wrapper {
+	.wc-block-components-price-slider {
+		.wc-block-components-price-slider__range-input-wrapper {
 			background: transparent;
 			box-shadow: none;
 			height: 24px;
 
-			.wc-block-components-price-filter__range-input-progress {
+			.wc-block-components-price-slider__range-input-progress {
 				background: #a8739d;
 				box-shadow: 0 0 0 1px inset #95588a;
 				width: 100%;
 				top: 7px;
 			}
 		}
-		.wc-block-components-price-filter__range-input {
+		.wc-block-components-price-slider__range-input {
 			height: 24px;
 			pointer-events: auto;
 			position: absolute;
@@ -255,7 +255,7 @@
 				pointer-events: auto;
 			}
 		}
-		.wc-block-components-price-filter__range-input--max {
+		.wc-block-components-price-slider__range-input--max {
 			&::-ms-fill-upper {
 				background: #e1e1e1;
 				box-shadow: 0 0 0 1px inset #b8b8b8;
@@ -267,14 +267,14 @@
 
 		&.is-loading,
 		&.is-disabled {
-			.wc-block-components-price-filter__range-input-wrapper {
+			.wc-block-components-price-slider__range-input-wrapper {
 				@include placeholder();
 				box-shadow: none;
 			}
 		}
 
 		&.is-disabled:not(.is-loading) {
-			.wc-block-components-price-filter__range-input-wrapper {
+			.wc-block-components-price-slider__range-input-wrapper {
 				animation: none;
 			}
 		}

--- a/assets/js/base/components/quantity-selector/index.js
+++ b/assets/js/base/components/quantity-selector/index.js
@@ -22,7 +22,10 @@ const QuantitySelector = ( {
 	itemName = '',
 	disabled,
 } ) => {
-	const classes = classNames( 'wc-block-quantity-selector', className );
+	const classes = classNames(
+		'wc-block-components-quantity-selector',
+		className
+	);
 
 	const hasMaximum = typeof maximum !== 'undefined';
 	const canDecrease = quantity > minimum;
@@ -60,7 +63,7 @@ const QuantitySelector = ( {
 	return (
 		<div className={ classes }>
 			<input
-				className="wc-block-quantity-selector__input"
+				className="wc-block-components-quantity-selector__input"
 				disabled={ disabled }
 				type="number"
 				step="1"
@@ -94,7 +97,7 @@ const QuantitySelector = ( {
 					'Reduce quantity',
 					'woo-gutenberg-products-block'
 				) }
-				className="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus"
+				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
 				disabled={ disabled || ! canDecrease }
 				onClick={ () => {
 					const newQuantity = quantity - 1;
@@ -119,7 +122,7 @@ const QuantitySelector = ( {
 					'woo-gutenberg-products-block'
 				) }
 				disabled={ disabled || ! canIncrease }
-				className="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus"
+				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
 				onClick={ () => {
 					const newQuantity = quantity + 1;
 					onChange( newQuantity );

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -10,7 +10,7 @@
 	}
 }
 
-.wc-block-quantity-selector {
+.wc-block-components-quantity-selector {
 	display: flex;
 	min-width: 100px;
 	border: 1px solid $core-grey-light-600;
@@ -18,7 +18,7 @@
 	border-radius: 4px;
 
 	// Extra label for specificity needed in the editor.
-	input.wc-block-quantity-selector__input {
+	input.wc-block-components-quantity-selector__input {
 		@include font-size(regular);
 		order: 2;
 		min-width: 40px;
@@ -47,7 +47,7 @@
 		-webkit-appearance: none;
 		margin: 0;
 	}
-	.wc-block-quantity-selector__button {
+	.wc-block-components-quantity-selector__button {
 		@include reset-button;
 		@include font-size(regular);
 		min-width: 30px;
@@ -67,10 +67,10 @@
 			@include reset-button;
 		}
 	}
-	.wc-block-quantity-selector__button--minus {
+	.wc-block-components-quantity-selector__button--minus {
 		order: 1;
 	}
-	.wc-block-quantity-selector__button--plus {
+	.wc-block-components-quantity-selector__button--plus {
 		order: 3;
 	}
 }

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -1,5 +1,5 @@
 @mixin radio-control-styles {
-	.wc-block-radio-control__option {
+	.wc-block-components-radio-control__option {
 		@include reset-typography();
 		border-bottom: 1px solid $core-grey-light-600;
 		display: block;
@@ -7,40 +7,40 @@
 		position: relative;
 	}
 
-	.wc-block-radio-control__option-layout {
+	.wc-block-components-radio-control__option-layout {
 		display: table;
 		width: 100%;
 		border-bottom: 1px solid $core-grey-light-600;
 		padding-bottom: $gap-small;
 	}
 
-	.wc-block-radio-control__option .wc-block-radio-control__option-layout {
+	.wc-block-components-radio-control__option .wc-block-components-radio-control__option-layout {
 		border-bottom: 0;
 	}
 
-	.wc-block-radio-control__input {
+	.wc-block-components-radio-control__input {
 		left: $gap-large;
 		position: absolute;
 		top: $gap-small;
 	}
 
-	.wc-block-radio-control__label-group,
-	.wc-block-radio-control__description-group {
+	.wc-block-components-radio-control__label-group,
+	.wc-block-components-radio-control__description-group {
 		display: table-row;
 
 		> span {
 			display: table-cell;
 		}
 
-		.wc-block-radio-control__secondary-label,
-		.wc-block-radio-control__secondary-description {
+		.wc-block-components-radio-control__secondary-label,
+		.wc-block-components-radio-control__secondary-description {
 			text-align: right;
 			min-width: 50%;
 		}
 	}
 
-	.wc-block-radio-control__label,
-	.wc-block-radio-control__secondary-label {
+	.wc-block-components-radio-control__label,
+	.wc-block-components-radio-control__secondary-label {
 		line-height: 20px;
 		// Currently, max() CSS function calls need to be wrapped with unquote.
 		// See: https://github.com/sass/sass/issues/2378#issuecomment-367490840
@@ -48,8 +48,8 @@
 		color: $core-grey-dark-600;
 	}
 
-	.wc-block-radio-control__description,
-	.wc-block-radio-control__secondary-description {
+	.wc-block-components-radio-control__description,
+	.wc-block-components-radio-control__secondary-description {
 		@include font-size(small);
 		line-height: 20px;
 		color: $core-grey-dark-400;
@@ -58,8 +58,8 @@
 
 @mixin radio-control-input-styles {
 	// Extra class for specificity.
-	.wc-block-radio-control {
-		.wc-block-radio-control__input {
+	.wc-block-components-radio-control {
+		.wc-block-components-radio-control__input {
 			appearance: none;
 			background: #fff;
 			border: 2px solid currentColor;
@@ -88,7 +88,7 @@
 		}
 
 		@include breakpoint( ">782px" ) {
-			.wc-block-radio-control__input {
+			.wc-block-components-radio-control__input {
 				height: 1rem;
 				margin-top: 2px;
 				min-height: 16px;

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -24,7 +24,10 @@ const RadioControl = ( {
 	return (
 		options.length && (
 			<div
-				className={ classnames( 'wc-block-radio-control', className ) }
+				className={ classnames(
+					'wc-block-components-radio-control',
+					className
+				) }
 			>
 				{ options.map( ( option ) => (
 					<RadioControlOption

--- a/assets/js/base/components/radio-control/option-layout.js
+++ b/assets/js/base/components/radio-control/option-layout.js
@@ -6,12 +6,12 @@ const OptionLayout = ( {
 	id,
 } ) => {
 	return (
-		<div className="wc-block-radio-control__option-layout">
-			<div className="wc-block-radio-control__label-group">
+		<div className="wc-block-components-radio-control__option-layout">
+			<div className="wc-block-components-radio-control__label-group">
 				{ label && (
 					<span
 						id={ id ? `${ id }__label` : null }
-						className="wc-block-radio-control__label"
+						className="wc-block-components-radio-control__label"
 					>
 						{ label }
 					</span>
@@ -19,17 +19,17 @@ const OptionLayout = ( {
 				{ secondaryLabel && (
 					<span
 						id={ id ? `${ id }__secondary-label` : null }
-						className="wc-block-radio-control__secondary-label"
+						className="wc-block-components-radio-control__secondary-label"
 					>
 						{ secondaryLabel }
 					</span>
 				) }
 			</div>
-			<div className="wc-block-radio-control__description-group">
+			<div className="wc-block-components-radio-control__description-group">
 				{ description && (
 					<span
 						id={ id ? `${ id }__description` : null }
-						className="wc-block-radio-control__description"
+						className="wc-block-components-radio-control__description"
 					>
 						{ description }
 					</span>
@@ -37,7 +37,7 @@ const OptionLayout = ( {
 				{ secondaryDescription && (
 					<span
 						id={ id ? `${ id }__secondary-description` : null }
-						className="wc-block-radio-control__secondary-description"
+						className="wc-block-components-radio-control__secondary-description"
 					>
 						{ secondaryDescription }
 					</span>

--- a/assets/js/base/components/radio-control/option.js
+++ b/assets/js/base/components/radio-control/option.js
@@ -20,12 +20,12 @@ const Option = ( { checked, name, onChange, option } ) => {
 
 	return (
 		<label
-			className="wc-block-radio-control__option"
+			className="wc-block-components-radio-control__option"
 			htmlFor={ `${ name }-${ value }` }
 		>
 			<input
 				id={ `${ name }-${ value }` }
-				className="wc-block-radio-control__input"
+				className="wc-block-components-radio-control__input"
 				type="radio"
 				name={ name }
 				value={ value }

--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -117,7 +117,7 @@ function getReviewDate( review ) {
 	} = review;
 	return (
 		<time
-			className="wc-block-review-list-item__published-date wc-block--components-review-list-item__published-date"
+			className="wc-block-review-list-item__published-date wc-block-components-review-list-item__published-date"
 			dateTime={ dateCreated }
 		>
 			{ formattedDateCreated }
@@ -131,9 +131,9 @@ function getReviewRating( review ) {
 		width: ( rating / 5 ) * 100 + '%' /* stylelint-disable-line */,
 	};
 	return (
-		<div className="wc-block-review-list-item__rating wc-block-components--review-list-item__rating">
+		<div className="wc-block-review-list-item__rating wc-block-components-review-list-item__rating">
 			<div
-				className="wc-block-review-list-item__rating__stars wc-block-components--review-list-item__rating__stars"
+				className="wc-block-review-list-item__rating__stars wc-block-components-review-list-item__rating__stars"
 				role="img"
 			>
 				<span style={ starStyle }>

--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -15,7 +15,7 @@ function getReviewImage( review, imageType, isLoading ) {
 	if ( isLoading || ! review ) {
 		return (
 			<div
-				className="wc-block-review-list-item__image"
+				className="wc-block-review-list-item__image wc-block-components-review-list-item__image"
 				width="48"
 				height="48"
 			/>
@@ -23,13 +23,13 @@ function getReviewImage( review, imageType, isLoading ) {
 	}
 
 	return (
-		<div className="wc-block-review-list-item__image">
+		<div className="wc-block-review-list-item__image wc-block-components-review-list-item__image">
 			{ imageType === 'product' ? (
 				<img
 					aria-hidden="true"
 					alt={ review.product_image?.alt || '' }
 					src={ review.product_image?.src || '' }
-					className="wc-block-review-list-item__image"
+					className="wc-block-review-list-item__image wc-block-components-review-list-item__image"
 					width="48"
 					height="48"
 				/>
@@ -39,14 +39,14 @@ function getReviewImage( review, imageType, isLoading ) {
 					alt=""
 					src={ review.reviewer_avatar_urls[ '48' ] || '' }
 					srcSet={ review.reviewer_avatar_urls[ '96' ] + ' 2x' }
-					className="wc-block-review-list-item__image"
+					className="wc-block-review-list-item__image wc-block-components-review-list-item__image"
 					width="48"
 					height="48"
 				/>
 			) }
 			{ review.verified && (
 				<div
-					className="wc-block-review-list-item__verified"
+					className="wc-block-review-list-item__verified wc-block-components-review-list-item__verified"
 					title={ __(
 						'Verified buyer',
 						'woo-gutenberg-products-block'
@@ -71,7 +71,7 @@ function getReviewContent( review ) {
 				'Hide full review',
 				'woo-gutenberg-products-block'
 			) }
-			className="wc-block-review-list-item__text"
+			className="wc-block-review-list-item__text wc-block-components-review-list-item__text"
 		>
 			<div
 				dangerouslySetInnerHTML={ {
@@ -87,7 +87,7 @@ function getReviewContent( review ) {
 
 function getReviewProductName( review ) {
 	return (
-		<div className="wc-block-review-list-item__product">
+		<div className="wc-block-review-list-item__product wc-block-components-review-list-item__product">
 			<a
 				href={ review.product_permalink }
 				dangerouslySetInnerHTML={ {
@@ -104,7 +104,9 @@ function getReviewProductName( review ) {
 function getReviewerName( review ) {
 	const { reviewer = '' } = review;
 	return (
-		<div className="wc-block-review-list-item__author">{ reviewer }</div>
+		<div className="wc-block-review-list-item__author wc-block-components-review-list-item__author">
+			{ reviewer }
+		</div>
 	);
 }
 
@@ -115,7 +117,7 @@ function getReviewDate( review ) {
 	} = review;
 	return (
 		<time
-			className="wc-block-review-list-item__published-date"
+			className="wc-block-review-list-item__published-date wc-block--components-review-list-item__published-date"
 			dateTime={ dateCreated }
 		>
 			{ formattedDateCreated }
@@ -129,9 +131,9 @@ function getReviewRating( review ) {
 		width: ( rating / 5 ) * 100 + '%' /* stylelint-disable-line */,
 	};
 	return (
-		<div className="wc-block-review-list-item__rating">
+		<div className="wc-block-review-list-item__rating wc-block-components--review-list-item__rating">
 			<div
-				className="wc-block-review-list-item__rating__stars"
+				className="wc-block-review-list-item__rating__stars wc-block-components--review-list-item__rating__stars"
 				role="img"
 			>
 				<span style={ starStyle }>
@@ -164,9 +166,13 @@ const ReviewListItem = ( { attributes, review = {} } ) => {
 
 	return (
 		<li
-			className={ classNames( 'wc-block-review-list-item__item', {
-				'is-loading': isLoading,
-			} ) }
+			className={ classNames(
+				'wc-block-review-list-item__item',
+				'wc-block-components-review-list-item__item',
+				{
+					'is-loading': isLoading,
+				}
+			) }
 			aria-hidden={ isLoading }
 		>
 			{ ( showProductName ||
@@ -174,14 +180,14 @@ const ReviewListItem = ( { attributes, review = {} } ) => {
 				showReviewerName ||
 				showReviewImage ||
 				showReviewRating ) && (
-				<div className="wc-block-review-list-item__info">
+				<div className="wc-block-review-list-item__info wc-block-components-review-list-item__info">
 					{ showReviewImage &&
 						getReviewImage( review, imageType, isLoading ) }
 					{ ( showProductName ||
 						showReviewerName ||
 						showReviewRating ||
 						showReviewDate ) && (
-						<div className="wc-block-review-list-item__meta">
+						<div className="wc-block-review-list-item__meta wc-block-components-review-list-item__meta">
 							{ showReviewRating && getReviewRating( review ) }
 							{ showProductName &&
 								getReviewProductName( review ) }

--- a/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/assets/js/base/components/reviews/review-list-item/style.scss
@@ -1,34 +1,34 @@
 .is-loading {
-	.wc-block-review-list-item__text {
+	.wc-block-components-review-list-item__text {
 		@include placeholder();
 		display: block;
 		width: 60%;
 	}
 
-	.wc-block-review-list-item__info {
-		.wc-block-review-list-item__image {
+	.wc-block-components-review-list-item__info {
+		.wc-block-components-review-list-item__image {
 			@include placeholder();
 		}
 
-		.wc-block-review-list-item__meta {
-			.wc-block-review-list-item__author {
+		.wc-block-components-review-list-item__meta {
+			.wc-block-components-review-list-item__author {
 				@include placeholder();
 				@include font-size(regular);
 				width: 80px;
 			}
 
-			.wc-block-review-list-item__product {
+			.wc-block-components-review-list-item__product {
 				display: none;
 			}
 
-			.wc-block-review-list-item__rating {
-				.wc-block-review-list-item__rating__stars > span {
+			.wc-block-components-review-list-item__rating {
+				.wc-block-components-review-list-item__rating__stars > span {
 					display: none;
 				}
 			}
 		}
 
-		.wc-block-review-list-item__published-date {
+		.wc-block-components-review-list-item__published-date {
 			@include placeholder();
 			height: 1em;
 			width: 120px;
@@ -36,33 +36,33 @@
 	}
 }
 
-.editor-styles-wrapper .wc-block-review-list-item__item,
-.wc-block-review-list-item__item {
+.editor-styles-wrapper .wc-block-components-review-list-item__item,
+.wc-block-components-review-list-item__item {
 	margin: 0 0 $gap-large * 2;
 	list-style: none;
 }
 
-.wc-block-review-list-item__info {
+.wc-block-components-review-list-item__info {
 	display: grid;
 	grid-template-columns: 1fr;
 	margin-bottom: $gap-large;
 }
 
-.wc-block-review-list-item__meta {
+.wc-block-components-review-list-item__meta {
 	grid-column: 1;
 	grid-row: 1;
 }
 
 .has-image {
-	.wc-block-review-list-item__info {
+	.wc-block-components-review-list-item__info {
 		grid-template-columns: #{48px + $gap} 1fr;
 	}
-	.wc-block-review-list-item__meta {
+	.wc-block-components-review-list-item__meta {
 		grid-column: 2;
 	}
 }
 
-.wc-block-review-list-item__image {
+.wc-block-components-review-list-item__image {
 	height: 48px;
 	grid-column: 1;
 	grid-row: 1 / 3;
@@ -76,7 +76,7 @@
 	}
 }
 
-.wc-block-review-list-item__verified {
+.wc-block-components-review-list-item__verified {
 	width: 21px;
 	height: 21px;
 	text-indent: 21px;
@@ -96,7 +96,7 @@
 	}
 }
 
-.wc-block-review-list-item__meta {
+.wc-block-components-review-list-item__meta {
 	display: flex;
 	align-items: center;
 	flex-flow: row wrap;
@@ -109,32 +109,32 @@
 	}
 }
 
-.wc-block-review-list-item__product {
+.wc-block-components-review-list-item__product {
 	display: block;
 	font-weight: bold;
 	order: 1;
 	margin-right: $gap/2;
 }
 
-.wc-block-review-list-item__author {
+.wc-block-components-review-list-item__author {
 	display: block;
 	font-weight: bold;
 	order: 1;
 	margin-right: $gap/2;
 }
 
-.wc-block-review-list-item__product + .wc-block-review-list-item__author {
+.wc-block-components-review-list-item__product + .wc-block-components-review-list-item__author {
 	font-weight: normal;
 	color: #808080;
 	order: 4;
 }
 
-.wc-block-review-list-item__published-date {
+.wc-block-components-review-list-item__published-date {
 	color: #808080;
 	order: 5;
 }
 
-.wc-block-review-list-item__author + .wc-block-review-list-item__published-date {
+.wc-block-components-review-list-item__author + .wc-block-components-review-list-item__published-date {
 	&::before {
 		content: "";
 		display: inline-block;
@@ -145,17 +145,17 @@
 	}
 }
 
-.wc-block-review-list-item__author:first-child + .wc-block-review-list-item__published-date,
-.wc-block-review-list-item__rating + .wc-block-review-list-item__author + .wc-block-review-list-item__published-date {
+.wc-block-components-review-list-item__author:first-child + .wc-block-components-review-list-item__published-date,
+.wc-block-components-review-list-item__rating + .wc-block-components-review-list-item__author + .wc-block-components-review-list-item__published-date {
 	&::before {
 		display: none;
 	}
 }
 
-.wc-block-review-list-item__rating {
+.wc-block-components-review-list-item__rating {
 	order: 2;
 
-	> .wc-block-review-list-item__rating__stars {
+	> .wc-block-components-review-list-item__rating__stars {
 		@include font-size(regular);
 		display: inline-block;
 		top: 0;
@@ -169,7 +169,7 @@
 		vertical-align: top;
 	}
 
-	> .wc-block-review-list-item__rating__stars::before {
+	> .wc-block-components-review-list-item__rating__stars::before {
 		content: "\53\53\53\53\53";
 		opacity: 0.25;
 		float: left;
@@ -178,7 +178,7 @@
 		position: absolute;
 	}
 
-	> .wc-block-review-list-item__rating__stars span {
+	> .wc-block-components-review-list-item__rating__stars span {
 		overflow: hidden;
 		float: left;
 		top: 0;
@@ -187,7 +187,7 @@
 		padding-top: 1.5em;
 	}
 
-	> .wc-block-review-list-item__rating__stars span::before {
+	> .wc-block-components-review-list-item__rating__stars span::before {
 		content: "\53\53\53\53\53";
 		top: 0;
 		position: absolute;

--- a/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/assets/js/base/components/reviews/review-list-item/style.scss
@@ -1,6 +1,7 @@
 .is-loading {
 	.wc-block-components-review-list-item__text {
 		@include placeholder();
+		@include force-content();
 		display: block;
 		width: 60%;
 	}
@@ -8,12 +9,14 @@
 	.wc-block-components-review-list-item__info {
 		.wc-block-components-review-list-item__image {
 			@include placeholder();
+			@include force-content();
 		}
 
 		.wc-block-components-review-list-item__meta {
 			.wc-block-components-review-list-item__author {
 				@include placeholder();
 				@include font-size(regular);
+				@include force-content();
 				width: 80px;
 			}
 
@@ -30,6 +33,7 @@
 
 		.wc-block-components-review-list-item__published-date {
 			@include placeholder();
+			@include force-content();
 			height: 1em;
 			width: 120px;
 		}

--- a/assets/js/base/components/reviews/review-list/index.js
+++ b/assets/js/base/components/reviews/review-list/index.js
@@ -26,7 +26,7 @@ const ReviewList = ( { attributes, reviews } ) => {
 	};
 
 	return (
-		<ul className="wc-block-review-list">
+		<ul className="wc-block-review-list wc-block-components-review-list">
 			{ reviews.length === 0 ? (
 				<ReviewListItem attributes={ attrs } />
 			) : (

--- a/assets/js/base/components/reviews/review-list/style.scss
+++ b/assets/js/base/components/reviews/review-list/style.scss
@@ -1,4 +1,4 @@
-.wc-block-review-list,
-.editor-styles .wc-block-review-list {
+.wc-block-components-review-list,
+.editor-styles .wc-block-components-review-list {
 	margin: 0;
 }

--- a/assets/js/base/components/select/index.js
+++ b/assets/js/base/components/select/index.js
@@ -22,7 +22,7 @@ const Select = ( {
 	return (
 		<div
 			id={ id }
-			className={ classnames( 'wc-block-select', className, {
+			className={ classnames( 'wc-block-components-select', className, {
 				'is-active': value,
 			} ) }
 		>

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,4 +1,4 @@
-.wc-block-select {
+.wc-block-components-select {
 	height: 3em;
 	position: relative;
 	margin-bottom: em($gap-large);

--- a/assets/js/base/components/sidebar-layout/main.js
+++ b/assets/js/base/components/sidebar-layout/main.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 
 const Main = ( { children, className } ) => {
 	return (
-		<div className={ classNames( 'wc-block-main', className ) }>
+		<div className={ classNames( 'wc-block-components-main', className ) }>
 			{ children }
 		</div>
 	);

--- a/assets/js/base/components/sidebar-layout/sidebar-layout.js
+++ b/assets/js/base/components/sidebar-layout/sidebar-layout.js
@@ -13,7 +13,10 @@ import './style.scss';
 const SidebarLayout = ( { children, className } ) => {
 	return (
 		<ContainerWidthContextProvider
-			className={ classNames( 'wc-block-sidebar-layout', className ) }
+			className={ classNames(
+				'wc-block-components-sidebar-layout',
+				className
+			) }
 		>
 			{ children }
 		</ContainerWidthContextProvider>

--- a/assets/js/base/components/sidebar-layout/sidebar.js
+++ b/assets/js/base/components/sidebar-layout/sidebar.js
@@ -6,7 +6,9 @@ import PropTypes from 'prop-types';
 
 const Sidebar = ( { children, className } ) => {
 	return (
-		<div className={ classNames( 'wc-block-sidebar', className ) }>
+		<div
+			className={ classNames( 'wc-block-components-sidebar', className ) }
+		>
 			{ children }
 		</div>
 	);

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -1,17 +1,17 @@
-.wc-block-sidebar-layout {
+.wc-block-components-sidebar-layout {
 	display: flex;
 	flex-wrap: wrap;
 	margin: 0 auto $gap;
 	position: relative;
 
-	.wc-block-main {
+	.wc-block-components-main {
 		margin: 0;
 		padding-right: percentage($gap-largest / 1060px); // ~1060px is the default width of the content area in Storefront.
 		width: 65%;
 	}
 }
 
-.wc-block-sidebar {
+.wc-block-components-sidebar {
 	margin: 0;
 	padding-left: percentage($gap-large / 1060px);
 	width: 35%;
@@ -27,15 +27,15 @@
 .is-medium,
 .is-small,
 .is-mobile {
-	&.wc-block-sidebar-layout {
+	&.wc-block-components-sidebar-layout {
 		flex-direction: column;
 		margin: 0 auto $gap;
 
-		.wc-block-main {
+		.wc-block-components-main {
 			padding: 0;
 			width: 100%;
 		}
-		.wc-block-sidebar {
+		.wc-block-components-sidebar {
 			padding: 0;
 			width: 100%;
 		}
@@ -43,8 +43,8 @@
 }
 
 .is-large {
-	.wc-block-sidebar {
-		.wc-block-totals-table-item,
+	.wc-block-components-sidebar {
+		.wc-block-components-totals-item,
 		.wc-blocks-components-panel {
 			padding-left: $gap;
 			padding-right: $gap;
@@ -54,7 +54,7 @@
 
 // For Twenty Twenty we need to increase specificity a bit more.
 .theme-twentytwenty {
-	.wc-block-sidebar .wc-blocks-components-panel > h2 {
+	.wc-block-components-sidebar .wc-blocks-components-panel > h2 {
 		@include font-size(large);
 		@include reset-box();
 	}

--- a/assets/js/base/components/store-notices-container/snackbar-notices.js
+++ b/assets/js/base/components/store-notices-container/snackbar-notices.js
@@ -18,7 +18,7 @@ const NoticesContainer = () => {
 	return (
 		<SnackbarList
 			notices={ snackbarNotices }
-			className={ 'wc-block-notices__snackbar' }
+			className={ 'wc-block-components-notices__snackbar' }
 			onRemove={ removeNotice }
 		/>
 	);

--- a/assets/js/base/components/store-notices-container/style.scss
+++ b/assets/js/base/components/store-notices-container/style.scss
@@ -25,7 +25,7 @@
 	}
 }
 
-.wc-block-notices__snackbar {
+.wc-block-components-notices__snackbar {
 	position: fixed;
 	bottom: 20px;
 	left: 16px;

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -38,10 +38,10 @@
 					margin: 0.2em 0 -0.2em;
 				}
 
-				.wc-block-cart__payment-method-icons {
+				.wc-block-components-payment-method-icons {
 					margin: 0.2em 0 -0.2em;
 
-					.wc-blocks-payment-method-icon {
+					.wc-block-components-payment-method-icon {
 						height: 1.2em;
 						vertical-align: middle;
 					}

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -37,9 +37,13 @@ const TextInput = forwardRef(
 
 		return (
 			<div
-				className={ classnames( 'wc-block-text-input', className, {
-					'is-active': isActive || value,
-				} ) }
+				className={ classnames(
+					'wc-block-components-text-input',
+					className,
+					{
+						'is-active': isActive || value,
+					}
+				) }
 			>
 				<input
 					type={ type }
@@ -76,7 +80,7 @@ const TextInput = forwardRef(
 				{ !! help && (
 					<p
 						id={ id + '__help' }
-						className="wc-block-text-input__help"
+						className="wc-block-components-text-input__help"
 					>
 						{ help }
 					</p>

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -1,4 +1,4 @@
-.wc-block-text-input {
+.wc-block-components-text-input {
 	position: relative;
 	margin-bottom: em($gap-large);
 	white-space: nowrap;

--- a/assets/js/base/components/title/index.js
+++ b/assets/js/base/components/title/index.js
@@ -14,7 +14,7 @@ import './style.scss';
  */
 const Title = ( { children, className, headingLevel, ...props } ) => {
 	const buttonClassName = classNames(
-		'wc-block-component__title',
+		'wc-block-components-title',
 		className
 	);
 	const TagName = `h${ headingLevel }`;

--- a/assets/js/base/components/title/style.scss
+++ b/assets/js/base/components/title/style.scss
@@ -1,12 +1,12 @@
 // Extra class for specificity to overwrite editor styles.
-.wc-block-component__title.wc-block-component__title {
+.wc-block-components-title.wc-block-components-title {
 	@include reset-box();
 	@include font-size(large);
 }
 
 // For Twenty Twenty we need to increase specificity a bit more.
 .theme-twentytwenty {
-	.wc-block-component__title.wc-block-component__title {
+	.wc-block-components-title.wc-block-components-title {
 		@include reset-box();
 		@include font-size(large);
 	}

--- a/assets/js/base/components/validation/style.scss
+++ b/assets/js/base/components/validation/style.scss
@@ -1,4 +1,4 @@
-.wc-block-form-input-validation-error {
+.wc-block-components-validation-error {
 	@include font-size(smaller);
 	color: $error-red;
 	max-width: 100%;
@@ -16,6 +16,6 @@
 	}
 }
 
-.wc-block-select + .wc-block-form-input-validation-error {
+.wc-block-components-select + .wc-block-components-validation-error {
 	margin-bottom: $gap-large;
 }

--- a/assets/js/base/components/validation/validation-input-error.js
+++ b/assets/js/base/components/validation/validation-input-error.js
@@ -25,7 +25,7 @@ export const ValidationInputError = ( {
 	}
 
 	return (
-		<div className="wc-block-form-input-validation-error" role="alert">
+		<div className="wc-block-components-validation-error" role="alert">
 			<p id={ getValidationErrorId( elementId ) }>{ errorMessage }</p>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,11 +1,11 @@
 .wc-block-cart {
 	color: $core-grey-dark-600;
 
-	.wc-block-cart__shipping-calculator {
+	.wc-block-components-shipping-calculator {
 		white-space: nowrap;
 	}
 
-	.wc-block-product-name {
+	.wc-block-components-product-name {
 		color: inherit;
 	}
 }
@@ -90,8 +90,8 @@ table.wc-block-cart-items {
 			text-align: right;
 			line-height: 1.25;
 
-			.wc-block-product-price,
-			.wc-block-product-price--regular {
+			.wc-block-components-product-price,
+			.wc-block-components-product-price--regular {
 				display: block;
 			}
 		}
@@ -121,7 +121,7 @@ table.wc-block-cart-items {
 			.wc-block-cart-item__price,
 			.wc-block-cart-item__product-metadata,
 			.wc-block-cart-item__image > *,
-			.wc-block-quantity-selector {
+			.wc-block-components-quantity-selector {
 				@include placeholder();
 			}
 			.wc-block-cart-item__product-name {
@@ -159,10 +159,10 @@ table.wc-block-cart-items {
 		min-height: 460px;
 	}
 }
-.wc-block-sidebar-layout.wc-block-cart--skeleton {
+.wc-block-components-sidebar-layout.wc-block-cart--skeleton {
 	display: none;
 }
-.is-loading + .wc-block-sidebar-layout.wc-block-cart--skeleton {
+.is-loading + .wc-block-components-sidebar-layout.wc-block-cart--skeleton {
 	display: flex;
 }
 
@@ -170,7 +170,7 @@ table.wc-block-cart-items {
 .is-small,
 .is-mobile {
 	&.wc-block-cart {
-		.wc-block-sidebar {
+		.wc-block-components-sidebar {
 			.wc-block-cart__totals-title {
 				display: none;
 			}
@@ -225,11 +225,11 @@ table.wc-block-cart-items {
 				grid-row-start: 2;
 				align-self: center;
 
-				.wc-block-formatted-money-amount {
+				.wc-block-components-formatted-money-amount {
 					display: inline-block;
 				}
 
-				.wc-block-sale-badge {
+				.wc-block-components-product-sale-badge {
 					display: none;
 				}
 			}
@@ -255,27 +255,21 @@ table.wc-block-cart-items {
 }
 
 .is-large.wc-block-cart {
-	.wc-block-radio-control__option {
+	.wc-block-components-radio-control__option {
 		padding-left: $gap-large;
 	}
 
-	.wc-block-radio-control__input {
+	.wc-block-components-radio-control__input {
 		left: 0;
 	}
 
-	.wc-block-sidebar {
+	.wc-block-components-sidebar {
 		> .wc-block-cart__totals-title,
-		.wc-block-cart__shipping-calculator,
-		.wc-block-shipping-rates-control__package:not(.wc-blocks-components-panel),
+		.wc-block-components-shipping-calculator,
+		.wc-block-components-shipping-rates-control__package:not(.wc-blocks-components-panel),
 		> .wc-block-cart__submit-container {
 			padding-left: $gap;
 			padding-right: $gap;
 		}
 	}
-}
-
-.wc-block-cart-coupon-list {
-	list-style: none;
-	margin: 0;
-	padding: 0;
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -229,7 +229,7 @@ table.wc-block-cart-items {
 					display: inline-block;
 				}
 
-				.wc-block-components-product-sale-badge {
+				.wc-block-components-sale-badge {
 					display: none;
 				}
 			}

--- a/assets/js/blocks/cart-checkout/checkout/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/editor.scss
@@ -1,5 +1,5 @@
 .editor-styles-wrapper {
-	.wp-block h4.wc-block-checkout-step__title {
+	.wp-block h4.wc-block-components-checkout-step__title {
 		@include font-size(regular);
 		line-height: 24px;
 		margin: 0 $gap-small 0 0;

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -8,13 +8,13 @@
 }
 
 .wc-block-checkout__shipping-option {
-	.wc-block-shipping-rates-control__package:not(:first-of-type) {
+	.wc-block-components-shipping-rates-control__package:not(:first-of-type) {
 		margin-top: $gap-larger;
 	}
 }
 
 .wc-block-checkout__sidebar {
-	.wc-block-product-name {
+	.wc-block-components-product-name {
 		color: inherit;
 		padding-right: $gap-small;
 		flex-grow: 1;
@@ -84,8 +84,8 @@
 		@include force-content();
 		width: 150px;
 	}
-	.wc-block-checkout-form {
-		.wc-block-checkout-step__title {
+	.wc-block-components-checkout-form {
+		.wc-block-components-checkout-step__title {
 			@include placeholder();
 			@include force-content();
 			display: block;
@@ -100,17 +100,17 @@
 				width: 1.5em;
 			}
 		}
-		.wc-block-checkout-step__container::after {
+		.wc-block-components-checkout-step__container::after {
 			@include placeholder();
 		}
-		.wc-block-checkout-step__content > span {
+		.wc-block-components-checkout-step__content > span {
 			@include placeholder();
 			@include force-content();
 			display: block;
 			min-height: 100px;
 		}
-		.wc-block-checkout-step::before,
-		.wc-block-checkout-step::after {
+		.wc-block-components-checkout-step::before,
+		.wc-block-components-checkout-step::after {
 			@include placeholder();
 		}
 	}
@@ -120,10 +120,10 @@
 		min-height: 460px;
 	}
 }
-.wc-block-sidebar-layout.wc-block-checkout--skeleton {
+.wc-block-components-sidebar-layout.wc-block-checkout--skeleton {
 	display: none;
 }
-.is-loading + .wc-block-sidebar-layout.wc-block-checkout--skeleton {
+.is-loading + .wc-block-components-sidebar-layout.wc-block-checkout--skeleton {
 	display: flex;
 }
 
@@ -193,16 +193,16 @@
 				display: block;
 			}
 
-			.wc-block-text-input,
-			.wc-block-country-input,
-			.wc-block-select {
+			.wc-block-components-text-input,
+			.wc-block-components-country-input,
+			.wc-block-components-select {
 				float: left;
 				margin-left: #{$gap-small / 2};
 				margin-right: #{$gap-small / 2};
 				position: relative;
 				width: calc(50% - #{$gap-small});
 
-				.wc-block-select {
+				.wc-block-components-select {
 					float: none;
 					width: 100%;
 					margin-left: 0;
@@ -210,13 +210,13 @@
 				}
 			}
 
-			.wc-block-address-form__company,
-			.wc-block-address-form__address_1,
-			.wc-block-address-form__address_2 {
+			.wc-block-components-address-form__company,
+			.wc-block-components-address-form__address_1,
+			.wc-block-components-address-form__address_2 {
 				width: calc(100% - #{$gap-small});
 			}
 
-			.wc-block-checkbox {
+			.wc-block-components-checkbox {
 				clear: both;
 			}
 		}
@@ -229,7 +229,7 @@
 	}
 
 	.wc-block-checkout__shipping-option {
-		.wc-block-radio-control__input {
+		.wc-block-components-radio-control__input {
 			margin-left: -8px;
 		}
 	}

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -183,7 +183,7 @@
 .is-large {
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {
-		.wc-block-address-form {
+		.wc-block-components-address-form {
 			margin-left: #{-$gap-small / 2};
 			margin-right: #{-$gap-small / 2};
 

--- a/assets/js/components/block-title/editor.scss
+++ b/assets/js/components/block-title/editor.scss
@@ -1,6 +1,6 @@
 // Ensure textarea bg color is transparent for block titles.
 // Some themes (e.g. Twenty Twenty) set a non-white background for the editor, and Gutenberg sets white background for text inputs, creating this issue.
 // https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1204
-.wc-block-components-title {
+.wc-block-editor-components-title {
 	background-color: transparent;
 }

--- a/assets/js/components/block-title/index.js
+++ b/assets/js/components/block-title/index.js
@@ -16,7 +16,7 @@ const BlockTitle = ( { className, headingLevel, onChange, heading } ) => {
 		<TagName>
 			<PlainText
 				className={ classnames(
-					'wc-block-components-title',
+					'wc-block-editor-components-title',
 					className
 				) }
 				value={ heading }

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -25,12 +25,12 @@ All class names assigned to an element must be prefixed. We use different prefix
 
 As a rule of thumb, this is the relation between location in the source tree and class name used:
 
-| Location in the tree | Class names used | Can be styled by themes?
-| --- | --- | :---: |
-| assets/js/atomic/blocks | `.wc-block-components-` | ✓ |
-| assets/js/base/components | `.wc-block-components-` | ✓ |
-| assets/js/blocks | Frontend: `.wc-block-`<br>Editor: `.wc-block-editor-` | ✓<br>✘ |
-| assets/js/components |  `.wc-block-editor-components-` | ✘ |
+| Location in the tree      | Class names used                                      | Can be styled by themes? |
+| ------------------------- | ----------------------------------------------------- | :----------------------: |
+| assets/js/atomic/blocks   | `.wc-block-components-`                               |            ✓             |
+| assets/js/base/components | `.wc-block-components-`                               |            ✓             |
+| assets/js/blocks          | Frontend: `.wc-block-`<br>Editor: `.wc-block-editor-` |          ✓<br>✘          |
+| assets/js/components      | `.wc-block-editor-components-`                        |            ✘             |
 
 After the prefix, class names are built using BEM:
 
@@ -126,7 +126,7 @@ input[type="radio"]:checked { // specificity 0, 2, 1
 And these are the styles of the block:
 
 ```
-.wc-block-radio-control__input { // specificity 0, 1, 0
+.wc-block-components-radio-control__input { // specificity 0, 1, 0
 	background: #fff;
 }
 ```
@@ -139,8 +139,8 @@ As you can see, the styles coming from the themes have higher specificity, so ou
    For example:
 
 ```
-.wc-block-radio-control {
-	.wc-block-radio-control__input { // specificity 0, 2, 0, we win theme A!
+.wc-block-components-radio-control {
+	.wc-block-components-radio-control__input { // specificity 0, 2, 0, we win theme A!
 		background: #fff;
 	}
 }
@@ -149,9 +149,9 @@ As you can see, the styles coming from the themes have higher specificity, so ou
 4. Try adding an extra css class (or tag selector) to increase specificity. When doing so, add a comment explaining it.
 
 ```
-.wc-block-radio-control {
+.wc-block-components-radio-control {
 	// Extra class for specificity.
-	.wc-block-radio-control__option .wc-block-radio-control__input { // specificity 0, 3, 0, we win theme B!
+	.wc-block-components-radio-control__option .wc-block-components-radio-control__input { // specificity 0, 3, 0, we win theme B!
 		background: #fff;
 	}
 }

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -56,7 +56,7 @@ In most cases, it should be safe to do a search & replace in the stylesheet repl
 
 ## Deprecated classes
 
-Some classes that were introduced in previous versions or that have shipped in WooCommerce Core, have not been removed but are deprecated. Those classes will not be removed until the next major version but all themes are encouraged to update to the new ones:
+Some classes that were introduced in previous versions or that have shipped in WooCommerce Core, have not been removed but are deprecated. Those classes will not be removed until the next major version but all themes are encouraged to update to the new ones as soon as possible:
 
 | Deprecated                        | New class name                               |
 | --------------------------------- | -------------------------------------------- |

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -6,44 +6,44 @@ In WC Blocks 2.8.0, some class names were updated in order to simplify them, fix
 
 Some classes that were introduced in 2.6.0 and 2.7.0 and didn't ship in WooCommerce Core have been replaced by new ones. They can be found in this table:
 
-| Removed                                | New class name                                                 |
-| -------------------------------------- | -------------------------------------------------------------- |
-| `wc-block-address-form`                | `wc-block-components-address-form`                             |
-| `wc-block-checkout-form`               | `wc-block-components-checkout-form`                            |
-| `wc-block-checkout-step`               | `wc-block-components-checkout-step`                            |
-| `wc-block-cart__payment-method-icons`  | `wc-block-components-payment-method-icons`                     |
-| `wc-blocks-payment-method-icon`        | `wc-block-components-payment-method-icon`                      |
-| `wc-block-cart__payment-method-label`  | `wc-block-components-payment-method-label`                     |
-| `wc-block-low-stock-badge`             | `wc-block-components-product-low-stock-badge`                  |
-| `wc-block-product-metadata`            | `wc-block-components-product-metadata`                         |
-| `wc-block-product-name`                | `wc-block-components-product-name`                             |
-| `wc-block-product-price`               | `wc-block-components-product-price`                            |
-| `wc-block-sale-badge`                  | `wc-block-components-sale-badge`                               |
-| `wc-block-product-variation-data`      | `wc-block-components-product-variation-data`                   |
-| `wc-block-cart__shipping-calculator`   | `wc-block-components-shipping-calculator`                      |
-| `wc-block-shipping-calculator`         | `wc-block-components-shipping-calculator`                      |
-| `wc-block-cart__shipping-address`      | `wc-block-components-shipping-address`                         |
-| `wc-block-shipping-rates-control`      | `wc-block-components-shipping-rates-control`                   |
-| `wc-block-coupon-code`                 | `wc-block-components-totals-coupon`                            |
-| `wc-block-cart-coupon-list`            | `wc-block-components-totals-discount__coupon-list`             |
-| `wc-block-totals-footer-item`          | `wc-block-components-totals-footer-item`                       |
-| `wc-block-totals-table-item`           | `wc-block-components-totals-item`                              |
-| `wc-block-shipping-totals`             | `wc-block-components-totals-shipping`                          |
-| `wc-block-checkbox`                    | `wc-block-components-checkbox`                                 |
-| `wc-block-country-input`               | `wc-block-components-country-input`                            |
-| `wc-block-loading-mask`                | `wc-block-components-loading-mask`                             |
-| `wc-blocks-loading-mask__children`     | `wc-block-components-loading-mask__children`                   |
-| `wc-block-quantity-selector`           | `wc-block-components-quantity-selector`                        |
-| `wc-block-radio-control`               | `wc-block-components-radio-control`                            |
-| `wc-block-select`                      | `wc-block-components-select`                                   |
-| `wc-block-main`                        | `wc-block-components-main`                                     |
-| `wc-block-sidebar-layout`              | `wc-block-components-sidebar-layout`                           |
-| `wc-block-sidebar`                     | `wc-block-components-sidebar`                                  |
-| `wc-block-notices__snackbar`           | `wc-block-components-notices__snackbar`                        |
-| `wc-block-text-input`                  | `wc-block-components-text-input`                               |
-| `wc-block-component__title`            | `wc-block-components-title`                                    |
-| `wc-block-form-input-validation-error` | `wc-block-components-validation-error`                         |
-| `wc-block-checkout__save-card-info`    | `wc-block-components-checkout-payment-methods__save-card-info` |
+| Removed                                | New class name                                        |
+| -------------------------------------- | ----------------------------------------------------- |
+| `wc-block-address-form`                | `wc-block-components-address-form`                    |
+| `wc-block-checkout-form`               | `wc-block-components-checkout-form`                   |
+| `wc-block-checkout-step`               | `wc-block-components-checkout-step`                   |
+| `wc-block-cart__payment-method-icons`  | `wc-block-components-payment-method-icons`            |
+| `wc-blocks-payment-method-icon`        | `wc-block-components-payment-method-icon`             |
+| `wc-block-cart__payment-method-label`  | `wc-block-components-payment-method-label`            |
+| `wc-block-low-stock-badge`             | `wc-block-components-product-low-stock-badge`         |
+| `wc-block-product-metadata`            | `wc-block-components-product-metadata`                |
+| `wc-block-product-name`                | `wc-block-components-product-name`                    |
+| `wc-block-product-price`               | `wc-block-components-product-price`                   |
+| `wc-block-sale-badge`                  | `wc-block-components-sale-badge`                      |
+| `wc-block-product-variation-data`      | `wc-block-components-product-variation-data`          |
+| `wc-block-cart__shipping-calculator`   | `wc-block-components-shipping-calculator`             |
+| `wc-block-shipping-calculator`         | `wc-block-components-shipping-calculator`             |
+| `wc-block-cart__shipping-address`      | `wc-block-components-shipping-address`                |
+| `wc-block-shipping-rates-control`      | `wc-block-components-shipping-rates-control`          |
+| `wc-block-coupon-code`                 | `wc-block-components-totals-coupon`                   |
+| `wc-block-cart-coupon-list`            | `wc-block-components-totals-discount__coupon-list`    |
+| `wc-block-totals-footer-item`          | `wc-block-components-totals-footer-item`              |
+| `wc-block-totals-table-item`           | `wc-block-components-totals-item`                     |
+| `wc-block-shipping-totals`             | `wc-block-components-totals-shipping`                 |
+| `wc-block-checkbox`                    | `wc-block-components-checkbox`                        |
+| `wc-block-country-input`               | `wc-block-components-country-input`                   |
+| `wc-block-loading-mask`                | `wc-block-components-loading-mask`                    |
+| `wc-blocks-loading-mask__children`     | `wc-block-components-loading-mask__children`          |
+| `wc-block-quantity-selector`           | `wc-block-components-quantity-selector`               |
+| `wc-block-radio-control`               | `wc-block-components-radio-control`                   |
+| `wc-block-select`                      | `wc-block-components-select`                          |
+| `wc-block-main`                        | `wc-block-components-main`                            |
+| `wc-block-sidebar-layout`              | `wc-block-components-sidebar-layout`                  |
+| `wc-block-sidebar`                     | `wc-block-components-sidebar`                         |
+| `wc-block-notices__snackbar`           | `wc-block-components-notices__snackbar`               |
+| `wc-block-text-input`                  | `wc-block-components-text-input`                      |
+| `wc-block-component__title`            | `wc-block-components-title`                           |
+| `wc-block-form-input-validation-error` | `wc-block-components-validation-error`                |
+| `wc-block-checkout__save-card-info`    | `wc-block-components-payment-methods__save-card-info` |
 
 **Note:** if not listed, all items in the table above include derived classes.
 

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -6,14 +6,76 @@ In WC Blocks 2.8.0, some class names were updated in order to simplify them, fix
 
 Some classes that were introduced in 2.6.0 and 2.7.0 and didn't ship in WooCommerce Core have been replaced by new ones. They can be found in this table:
 
-| Removed | New class name |
-| --- | --- |
+| Removed                                | New class name                                                 |
+| -------------------------------------- | -------------------------------------------------------------- |
+| `wc-block-address-form`                | `wc-block-components-address-form`                             |
+| `wc-block-checkout-form`               | `wc-block-components-checkout-form`                            |
+| `wc-block-checkout-step`               | `wc-block-components-checkout-step`                            |
+| `wc-block-cart__payment-method-icons`  | `wc-block-components-payment-method-icons`                     |
+| `wc-blocks-payment-method-icon`        | `wc-block-components-payment-method-icon`                      |
+| `wc-block-cart__payment-method-label`  | `wc-block-components-payment-method-label`                     |
+| `wc-block-low-stock-badge`             | `wc-block-components-product-low-stock-badge`                  |
+| `wc-block-product-metadata`            | `wc-block-components-product-metadata`                         |
+| `wc-block-product-name`                | `wc-block-components-product-name`                             |
+| `wc-block-product-price`               | `wc-block-components-product-price`                            |
+| `wc-block-sale-badge`                  | `wc-block-components-product-sale-badge`                       |
+| `wc-block-product-variation-data`      | `wc-block-components-product-variation-data`                   |
+| `wc-block-cart__shipping-calculator`   | `wc-block-components-shipping-calculator`                      |
+| `wc-block-shipping-calculator`         | `wc-block-components-shipping-calculator`                      |
+| `wc-block-cart__shipping-address`      | `wc-block-components-shipping-address`                         |
+| `wc-block-shipping-rates-control`      | `wc-block-components-shipping-rates-control`                   |
+| `wc-block-coupon-code`                 | `wc-block-components-totals-coupon`                            |
+| `wc-block-cart-coupon-list`            | `wc-block-components-totals-discount__coupon-list`             |
+| `wc-block-totals-footer-item`          | `wc-block-components-totals-footer-item`                       |
+| `wc-block-totals-table-item`           | `wc-block-components-totals-item`                              |
+| `wc-block-shipping-totals`             | `wc-block-components-totals-shipping`                          |
+| `wc-block-checkbox`                    | `wc-block-components-checkbox`                                 |
+| `wc-block-country-input`               | `wc-block-components-country-input`                            |
+| `wc-block-loading-mask`                | `wc-block-components-loading-mask`                             |
+| `wc-blocks-loading-mask__children`     | `wc-block-components-loading-mask__children`                   |
+| `wc-block-quantity-selector`           | `wc-block-components-quantity-selector`                        |
+| `wc-block-radio-control`               | `wc-block-components-radio-control`                            |
+| `wc-block-select`                      | `wc-block-components-select`                                   |
+| `wc-block-main`                        | `wc-block-components-main`                                     |
+| `wc-block-sidebar-layout`              | `wc-block-components-sidebar-layout`                           |
+| `wc-block-sidebar`                     | `wc-block-components-sidebar`                                  |
+| `wc-block-notices__snackbar`           | `wc-block-components-notices__snackbar`                        |
+| `wc-block-text-input`                  | `wc-block-components-text-input`                               |
+| `wc-block-component__title`            | `wc-block-components-title`                                    |
+| `wc-block-form-input-validation-error` | `wc-block-components-validation-error`                         |
+| `wc-block-checkout__save-card-info`    | `wc-block-components-checkout-payment-methods__save-card-info` |
+
+-   **Note:** if not listed, all items in the table above include derived classes.
+    : For example: given that `wc-block-address-form` changed to `wc-block-components-address-form`
+    : `wc-block-address-form__company` also changed to `wc-block-components-address-form__company`
+    : `wc-block-address-form__address_1` also changed to `wc-block-components-address-form__address_1`
+    : ...
+
+In most cases, it should be safe to do a search & replace in the stylesheet replacing the removed class names with the new ones.
 
 ## Deprecated classes
 
 Some classes that were introduced in previous versions or that have shipped in WooCommerce Core, have not been removed but are deprecated. Those classes will not be removed yet but all themes are encouraged to update to the new ones:
 
-| Deprecated | New class name |
-| --- | --- |
-| `wc-block-product-sort-select` | `wc-block-components-product-sort-select` |
+| Deprecated                        | New class name                               |
+| --------------------------------- | -------------------------------------------- |
+| `wc-block-error`                  | `wc-block-components-error`                  |
+| `wc-block-product-sort-select`    | `wc-block-components-product-sort-select`    |
 | `wc-block-formatted-money-amount` | `wc-block-components-formatted-money-amount` |
+| `wc-block-checkbox-list`          | `wc-block-components-checkbox-list`          |
+| `wc-block-dropdown-selector`      | `wc-block-components-dropdown-selector`      |
+| `wc-block-filter-submit-button`   | `wc-block-components-filter-submit-button`   |
+| `wc-block-load-more`              | `wc-block-components-load-more`              |
+| `wc-block-pagination`             | `wc-block-components-pagination`             |
+| `wc-block-pagination-page`        | `wc-block-components-pagination__page`       |
+| `wc-block-pagination-ellipsis`    | `wc-block-components-pagination__ellipsis`   |
+| `wc-block-review-list`            | `wc-block-components-review-list`            |
+| `wc-block-review-sort-select`     | `wc-block-components-review-sort-select`     |
+| `wc-block-price-filter`           | `wc-block-components-price-filter`           |
+| `wc-block-form-text-input`        | `wc-block-components-price-filter__amount`   |
+
+-   **Note:** if not listed, all items in the table above include derived classes.
+    : For example: given that `wc-block-error` changed to `wc-block-components-error`
+    : `wc-block-error__company` also changed to `wc-block-components-error__content`
+    : `wc-block-error__address_1` also changed to `wc-block-components-error__image`
+    : ...

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -56,7 +56,7 @@ In most cases, it should be safe to do a search & replace in the stylesheet repl
 
 ## Deprecated classes
 
-Some classes that were introduced in previous versions or that have shipped in WooCommerce Core, have not been removed but are deprecated. Those classes will not be removed yet but all themes are encouraged to update to the new ones:
+Some classes that were introduced in previous versions or that have shipped in WooCommerce Core, have not been removed but are deprecated. Those classes will not be removed until the next major version but all themes are encouraged to update to the new ones:
 
 | Deprecated                        | New class name                               |
 | --------------------------------- | -------------------------------------------- |

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -45,11 +45,12 @@ Some classes that were introduced in 2.6.0 and 2.7.0 and didn't ship in WooComme
 | `wc-block-form-input-validation-error` | `wc-block-components-validation-error`                         |
 | `wc-block-checkout__save-card-info`    | `wc-block-components-checkout-payment-methods__save-card-info` |
 
--   **Note:** if not listed, all items in the table above include derived classes.
-    : For example: given that `wc-block-address-form` changed to `wc-block-components-address-form`
-    : `wc-block-address-form__company` also changed to `wc-block-components-address-form__company`
-    : `wc-block-address-form__address_1` also changed to `wc-block-components-address-form__address_1`
-    : ...
+**Note:** if not listed, all items in the table above include derived classes.
+
+-   For example: given that `wc-block-address-form` changed to `wc-block-components-address-form`
+    -   `wc-block-address-form__company` also changed to `wc-block-components-address-form__company`
+    -   `wc-block-address-form__address_1` also changed to `wc-block-components-address-form__address_1`
+    -   ...
 
 In most cases, it should be safe to do a search & replace in the stylesheet replacing the removed class names with the new ones.
 
@@ -74,8 +75,9 @@ Some classes that were introduced in previous versions or that have shipped in W
 | `wc-block-price-filter`           | `wc-block-components-price-slider`           |
 | `wc-block-form-text-input`        | `wc-block-components-price-slider__amount`   |
 
--   **Note:** if not listed, all items in the table above include derived classes.
-    : For example: given that `wc-block-error` changed to `wc-block-components-error`
-    : `wc-block-error__company` also changed to `wc-block-components-error__content`
-    : `wc-block-error__address_1` also changed to `wc-block-components-error__image`
-    : ...
+**Note:** if not listed, all items in the table above include derived classes.
+
+-   For example: given that `wc-block-error` changed to `wc-block-components-error`
+    -   `wc-block-error__company` also changed to `wc-block-components-error__content`
+    -   `wc-block-error__address_1` also changed to `wc-block-components-error__image`
+    -   ...

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -71,8 +71,8 @@ Some classes that were introduced in previous versions or that have shipped in W
 | `wc-block-pagination-ellipsis`    | `wc-block-components-pagination__ellipsis`   |
 | `wc-block-review-list`            | `wc-block-components-review-list`            |
 | `wc-block-review-sort-select`     | `wc-block-components-review-sort-select`     |
-| `wc-block-price-filter`           | `wc-block-components-price-filter`           |
-| `wc-block-form-text-input`        | `wc-block-components-price-filter__amount`   |
+| `wc-block-price-filter`           | `wc-block-components-price-slider`           |
+| `wc-block-form-text-input`        | `wc-block-components-price-slider__amount`   |
 
 -   **Note:** if not listed, all items in the table above include derived classes.
     : For example: given that `wc-block-error` changed to `wc-block-components-error`

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -18,7 +18,7 @@ Some classes that were introduced in 2.6.0 and 2.7.0 and didn't ship in WooComme
 | `wc-block-product-metadata`            | `wc-block-components-product-metadata`                         |
 | `wc-block-product-name`                | `wc-block-components-product-name`                             |
 | `wc-block-product-price`               | `wc-block-components-product-price`                            |
-| `wc-block-sale-badge`                  | `wc-block-components-product-sale-badge`                       |
+| `wc-block-sale-badge`                  | `wc-block-components-sale-badge`                               |
 | `wc-block-product-variation-data`      | `wc-block-components-product-variation-data`                   |
 | `wc-block-cart__shipping-calculator`   | `wc-block-components-shipping-calculator`                      |
 | `wc-block-shipping-calculator`         | `wc-block-components-shipping-calculator`                      |

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -130,8 +130,8 @@ class Cart extends AbstractBlock {
 	 */
 	protected function get_skeleton() {
 		return '
-			<div class="wc-block-skeleton wc-block-sidebar-layout wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton hidden" aria-hidden="true">
-				<div class="wc-block-main wc-block-cart__main">
+			<div class="wc-block-skeleton wc-block-components-sidebar-layout wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton hidden" aria-hidden="true">
+				<div class="wc-block-components-main wc-block-cart__main">
 					<h2><span></span></h2>
 					<table class="wc-block-cart-items">
 						<thead>
@@ -152,10 +152,10 @@ class Cart extends AbstractBlock {
 									<div class="wc-block-cart-item__product-metadata"></div>
 								</td>
 								<td class="wc-block-cart-item__quantity">
-								<div class="wc-block-quantity-selector">
-									<input class="wc-block-quantity-selector__input" type="number" step="1" min="0" value="1" />
-									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus">－</button>
-									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus">＋</button>
+								<div class="wc-block-components-quantity-selector">
+									<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
+									<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
+									<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
 								</div>
 								</td>
 								<td class="wc-block-cart-item__total">
@@ -171,10 +171,10 @@ class Cart extends AbstractBlock {
 									<div class="wc-block-cart-item__product-metadata">&nbsp;</div>
 								</td>
 								<td class="wc-block-cart-item__quantity">
-								<div class="wc-block-quantity-selector">
-									<input class="wc-block-quantity-selector__input" type="number" step="1" min="0" value="1" />
-									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus">－</button>
-									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus">＋</button>
+								<div class="wc-block-components-quantity-selector">
+									<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
+									<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
+									<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
 								</div>
 								</td>
 								<td class="wc-block-cart-item__total">
@@ -190,10 +190,10 @@ class Cart extends AbstractBlock {
 									<div class="wc-block-cart-item__product-metadata"></div>
 								</td>
 								<td class="wc-block-cart-item__quantity">
-								<div class="wc-block-quantity-selector">
-									<input class="wc-block-quantity-selector__input" type="number" step="1" min="0" value="1" />
-									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--minus">－</button>
-									<button class="wc-block-quantity-selector__button wc-block-quantity-selector__button--plus">＋</button>
+								<div class="wc-block-components-quantity-selector">
+									<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
+									<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
+									<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
 								</div>
 								</td>
 								<td class="wc-block-cart-item__total">
@@ -203,7 +203,7 @@ class Cart extends AbstractBlock {
 						</tbody>
 					</table>
 				</div>
-				<div class="wc-block-sidebar wc-block-cart__sidebar">
+				<div class="wc-block-components-sidebar wc-block-cart__sidebar">
 					<div class="components-card"></div>
 				</div>
 			</div>

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -170,57 +170,57 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function get_skeleton() {
 		return '
-			<div class="wc-block-skeleton wc-block-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton hidden" aria-hidden="true">
-				<div class="wc-block-main wc-block-checkout__main">
+			<div class="wc-block-skeleton wc-block-components-sidebar-layout wc-block-checkout wc-block-checkout--is-loading wc-block-checkout--skeleton hidden" aria-hidden="true">
+				<div class="wc-block-components-main wc-block-checkout__main">
 					<div class="wc-block-components-express-checkout"></div>
 					<div class="wc-block-components-express-checkout-continue-rule"><span></span></div>
-					<form class="wc-block-checkout-form">
-						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<div class="wc-block-checkout-step__heading">
-								<div class="wc-block-checkout-step__title"></div>
+					<form class="wc-block-components-checkout-form">
+						<fieldset class="wc-block-checkout__contact-fields wc-block-components-checkout-step">
+							<div class="wc-block-components-checkout-step__heading">
+								<div class="wc-block-components-checkout-step__title"></div>
 							</div>
-							<div class="wc-block-checkout-step__container">
-								<div class="wc-block-checkout-step__content">
+							<div class="wc-block-components-checkout-step__container">
+								<div class="wc-block-components-checkout-step__content">
 									<span></span>
 								</div>
 							</div>
 						</fieldset>
-						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<div class="wc-block-checkout-step__heading">
-								<div class="wc-block-checkout-step__title"></div>
+						<fieldset class="wc-block-checkout__contact-fields wc-block-components-checkout-step">
+							<div class="wc-block-components-checkout-step__heading">
+								<div class="wc-block-components-checkout-step__title"></div>
 							</div>
-							<div class="wc-block-checkout-step__container">
-								<div class="wc-block-checkout-step__content">
+							<div class="wc-block-components-checkout-step__container">
+								<div class="wc-block-components-checkout-step__content">
 									<span></span>
 								</div>
 							</div>
 						</fieldset>
-						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<div class="wc-block-checkout-step__heading">
-								<div class="wc-block-checkout-step__title"></div>
+						<fieldset class="wc-block-checkout__contact-fields wc-block-components-checkout-step">
+							<div class="wc-block-components-checkout-step__heading">
+								<div class="wc-block-components-checkout-step__title"></div>
 							</div>
-							<div class="wc-block-checkout-step__container">
-								<div class="wc-block-checkout-step__content">
+							<div class="wc-block-components-checkout-step__container">
+								<div class="wc-block-components-checkout-step__content">
 									<span></span>
 								</div>
 							</div>
 						</fieldset>
-						<fieldset class="wc-block-checkout__contact-fields wc-block-checkout-step">
-							<div class="wc-block-checkout-step__heading">
-								<div class="wc-block-checkout-step__title"></div>
+						<fieldset class="wc-block-checkout__contact-fields wc-block-components-checkout-step">
+							<div class="wc-block-components-checkout-step__heading">
+								<div class="wc-block-components-checkout-step__title"></div>
 							</div>
-							<div class="wc-block-checkout-step__container">
-								<div class="wc-block-checkout-step__content">
+							<div class="wc-block-components-checkout-step__container">
+								<div class="wc-block-components-checkout-step__content">
 									<span></span>
 								</div>
 							</div>
 						</fieldset>
 					</form>
 				</div>
-				<div class="wc-block-sidebar wc-block-checkout__sidebar">
+				<div class="wc-block-components-sidebar wc-block-checkout__sidebar">
 					<div class="components-card"></div>
 				</div>
-				<div class="wc-block-main wc-block-checkout__main-totals">
+				<div class="wc-block-components-main wc-block-checkout__main-totals">
 					<div class="wc-block-checkout__actions">
 						<button class="components-button button wc-block-button wc-block-components-checkout-place-order-button">&nbsp;</button>
 					</div>


### PR DESCRIPTION
Part of #2457.
Fixes #1455.

Updates the class names of all components inside `base/components` to follow the guidelines. It applies the deprecation policy from https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2457#issuecomment-642032512:
* if a class name was released with WC Core, we list it in the docs as 'deprecated' but don't remove it, in parallel we add the new one so themes can start using the correct ones
* if a class names was not released with WC Core, we simply replace it with the new one and document the change

### How to test the changes in this Pull Request:

I think the only way to test is checking each single block from the list below to verify there are no visual regressions:

- All Reviews, Reviews by Product, Reviews by Category.
- All Products, Filter by Price, Filter by Attribute and Active Filters.
- Cart and Checkout.

If I'm not wrong, these are the only blocks that use components from `base/components`.

I added the `skip-changelog` label because #2691 already has the changelog entry relative to this change.