### PR TITLE
Fix notices on variations without prices

### DIFF
--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -240,7 +240,7 @@ abstract class AbstractSchema {
 	protected function prepare_money_response( $amount, $decimals = 2, $rounding_mode = PHP_ROUND_HALF_UP ) {
 		return (string) intval(
 			round(
-				wc_format_decimal( $amount ) * ( 10 ** $decimals ),
+				( (float) wc_format_decimal( $amount ) ) * ( 10 ** $decimals ),
 				0,
 				absint( $rounding_mode )
 			)

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -431,7 +431,7 @@ class ProductSchema extends AbstractSchema {
 		if ( $product->is_type( 'variable' ) ) {
 			$prices = $product->get_variation_prices( true );
 
-			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
+			if ( ! empty( $prices['price'] ) && ( min( $prices['price'] ) !== max( $prices['price'] ) ) ) {
 				return (object) [
 					'min_amount' => $this->prepare_money_response( min( $prices['price'] ), wc_get_price_decimals() ),
 					'max_amount' => $this->prepare_money_response( max( $prices['price'] ), wc_get_price_decimals() ),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes: #2714
Fixes: #2578

This fixes a couple notices that appear when there are variations without prices. Later PHP versions are more strict on:

- Doing calculations on non-numeric values.
- Passing in empty arrays to `min` or `max`

### How to test the changes in this Pull Request:

See the reproducing steps in #2714 

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix PHP warnings produced by StoreAPI endpoints when variations have no prices.
