### PR TITLE
Fix undefined index notice for query_type on the product collection data endpoint.

### DIFF
--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -74,10 +74,12 @@ class ProductCollectionData extends AbstractRoute {
 			$taxonomy__and_queries = [];
 
 			foreach ( $request['calculate_attribute_counts'] as $attributes_to_count ) {
-				if ( empty( $attributes_to_count['query_type'] ) || 'or' === $attributes_to_count['query_type'] ) {
-					$taxonomy__or_queries[] = $attributes_to_count['taxonomy'];
-				} else {
-					$taxonomy__and_queries[] = $attributes_to_count['taxonomy'];
+				if ( ! empty( $attributes_to_count['taxonomy'] ) ) {
+					if ( empty( $attributes_to_count['query_type'] ) || 'or' === $attributes_to_count['query_type'] ) {
+						$taxonomy__or_queries[] = $attributes_to_count['taxonomy'];
+					} else {
+						$taxonomy__and_queries[] = $attributes_to_count['taxonomy'];
+					}
 				}
 			}
 

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -74,7 +74,7 @@ class ProductCollectionData extends AbstractRoute {
 			$taxonomy__and_queries = [];
 
 			foreach ( $request['calculate_attribute_counts'] as $attributes_to_count ) {
-				if ( 'or' === $attributes_to_count['query_type'] ) {
+				if ( empty( $attributes_to_count['query_type'] ) || 'or' === $attributes_to_count['query_type'] ) {
 					$taxonomy__or_queries[] = $attributes_to_count['taxonomy'];
 				} else {
 					$taxonomy__and_queries[] = $attributes_to_count['taxonomy'];


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes: #2715

<!-- Don't forget to update the title with something descriptive. -->

Besides fixing the cause of the notice by including `'or'` as the default value for `query_type` if it's not defined on the request, I did do some investigation into why this is happening to begin with from the client request. I couldn't find the cause after a timeboxed amount so I'm fine with using his fix for now (especially since it accounts for possible missing value by _any_ client making the request).

I also added some additional defensive checks for the `taxonomy` index as well as it's possible that a client might send a request missing that key.

## To Test

This impacts the Attribute Filter block for the All Products block. Testing should ensure that the filters work as expected for the All Products block and while testing, verify that the reported notice in #2715 no longer appears in PHP error logs.
