### PR TITLE
Fix missing scoped variable in closure and missing schema definitions.

### DIFF
--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -82,7 +82,6 @@ class ProductCollectionData extends AbstractRoute {
 			}
 
 			$data['attribute_counts'] = [];
-
 			// Or type queries need special handling because the attribute, if set, needs removing from the query first otherwise counts would not be correct.
 			if ( $taxonomy__or_queries ) {
 				foreach ( $taxonomy__or_queries as $taxonomy ) {
@@ -92,7 +91,7 @@ class ProductCollectionData extends AbstractRoute {
 					if ( ! empty( $filter_attributes ) ) {
 						$filter_attributes = array_filter(
 							$filter_attributes,
-							function( $query ) {
+							function( $query ) use ( $taxonomy ) {
 								return $query['attribute'] !== $taxonomy;
 							}
 						);

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -335,11 +335,17 @@ class Products extends AbstractRoute {
 					'term_id'   => array(
 						'description'       => __( 'List of attribute term IDs.', 'woo-gutenberg-products-block' ),
 						'type'              => 'array',
+						'items'             => [
+							'type' => 'integer',
+						],
 						'sanitize_callback' => 'wp_parse_id_list',
 					),
 					'slug'      => array(
 						'description'       => __( 'List of attribute slug(s). If a term ID is provided, this will be ignored.', 'woo-gutenberg-products-block' ),
 						'type'              => 'array',
+						'items'             => [
+							'type' => 'string',
+						],
 						'sanitize_callback' => 'wp_parse_slug_list',
 					),
 					'operator'  => array(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes: #2717

Fixes notices coming from missing scoped variable in closure and from incorrect schema definitions for array values.

<!-- Don't forget to update the title with something descriptive. -->

## To Test

See #2717 for reproducing steps. There should no longer be those notices appear in PHP error logs and also verify that filtering still works as expected.
