### PR TITLE
Release: 2.7.1

### DIFF
--- a/assets/js/module_replacements/dashicon.js
+++ b/assets/js/module_replacements/dashicon.js
@@ -7,9 +7,16 @@ import {
 } from '@woocommerce/icons';
 import { createElement } from '@wordpress/element';
 
-export default ( { icon, size = 20, className, ...extraProps } ) => {
-	let Icon = () => null;
-	switch ( icon ) {
+// Note: Aside from import/export, everything in this file must be IE11 friendly
+// because currently it does not go through babel transpiling. It is injected
+// as a replacement for the `@wordpress/component/dashicon` component via
+// the Webpack NormalModuleReplacementPlugin plugin.
+
+export default function( props ) {
+	let Icon = function() {
+		return null;
+	};
+	switch ( props.icon ) {
 		case 'arrow-down-alt2':
 			Icon = ArrowDownIcon;
 			break;
@@ -17,7 +24,8 @@ export default ( { icon, size = 20, className, ...extraProps } ) => {
 			Icon = DismissIcon;
 			break;
 	}
-	// can't use JSX here because the Webpack NormalModuleReplacementPlugin
-	// is unable to parse JSX at that point in the build.
-	return createElement( Icon, { size, className, ...extraProps } );
-};
+	return createElement( Icon, {
+		size: props.size || 20,
+		className: props.className,
+	} );
+}

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -1,3 +1,5 @@
+[![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
+
 ## Testing notes and ZIP for testing
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4747000/woocommerce-gutenberg-products-block.zip)

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -1,0 +1,97 @@
+## Testing notes and ZIP for testing
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4747000/woocommerce-gutenberg-products-block.zip)
+
+### Cart and Checkout styles
+
+- Create pages with the Cart and Checkout blocks.
+- Check the styles of both pages and verify:
+	- The Cart and Checkout headings match the styles inherited from the theme (#2597)
+	- In Checkout, step progress indicators match the heading style and they don't have a background circle (#2649).<br>
+![Checkout heading styles](https://user-images.githubusercontent.com/3616980/84032118-1e327300-a997-11ea-8c06-363ac2bd78b3.png)
+	- In Checkout, the item quantity badges are visible with dark backgrounds (with Storefront, you can change the background color in Appearance > Customize > Background) (#2619).<br>
+![Item quantity badges](https://user-images.githubusercontent.com/3616980/84031988-ed523e00-a996-11ea-8545-339111e31f5f.png)
+		- Try adding the code snippet from the [Cart and Checkout theming](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/docs/theming/cart-and-checkout.md#item-quantity-badge) docs (you can do it via a child theme or directly in the browser devtools) and verify the item quantity badge styles update accordingly.
+	- In general, verify there were no regressions introduced after 2.6.0.
+- The Cart block title should be `Your cart (X items)` (#2615).<br>
+![Cart block title](https://user-images.githubusercontent.com/3616980/84032294-66ea2c00-a997-11ea-8d6d-929668cb702b.png)
+- Introduce an invalid credit card number and verify there is enough padding around the validation errors (#2662).<br>
+![Credit card validation errors](https://user-images.githubusercontent.com/3616980/84011799-f0d5cd00-a976-11ea-8cb2-a7e7ef38b0b0.png)
+- In the editor, add the Cart block and verify the headings have the proper font size and there is margin between the `Proceed to Checkout` button and the credit card icons -- to get the icons, you need to install the Stripe payment gateway (#2486).
+
+| 2.6.0 | 2.7.0 |
+| --- | --- |
+| ![Cart in editor in 2.6.0](https://user-images.githubusercontent.com/3616980/81926566-71a4e180-95e2-11ea-8c43-7a5064831e5b.png) | ![Cart in editor in 2.7.0](https://user-images.githubusercontent.com/3616980/81926959-24753f80-95e3-11ea-8cd4-6374ff3870ce.png) |
+
+#### Specific themes
+- [Hello theme](https://elementor.com/hello-theme/):
+	- Verify the text inside the selects is visible on hover (#2647).<br>
+![Select in Hello theme](https://user-images.githubusercontent.com/3616980/84032650-f4c61700-a997-11ea-969d-6427d1e221bb.png)
+- Twenty Twenty:
+	- Add the All Products block and the Hand-picked Products block in a page and verify (#2573):
+		- That with the All Products block you can add the On Sale badge and it's correctly aligned in the editor and the frontend (before, it was always shown on top of the image).<br>
+![All Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013870-fef22800-a01d-11ea-8ea8-21229285d10a.png)
+		- The Hand-picked Products block discounted prices are not underlined.<br>
+![Hand-picked Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013599-8e4b0b80-a01d-11ea-88ab-a1537110c4e2.png)
+	- Go to the Checkout block and verify font sizes look correct (they are inherited from the theme) (#2533).
+
+### Cart and Checkout error flow (#2655)
+
+#### Scenario One: initial report fixed
+
+1. On Checkout introduce an invalid card number `4000 0000 0000 0002`.
+2. Try to place the order and notice the error `The card was declined`.
+3. Replace the credit card number with a valid one (`4242 4242 4242 4242`).
+4. Try to place the order again and verify the process works.
+
+#### Scenario Two: Trying to break via validation errors.
+
+You'll need to be logged in with a user that has saved payment methods.
+
+1. On checkout, select CC payment method and then select a saved payment method again.
+2. Leave one of the required fields empty.
+3. Submit the checkout which should cause a validation error on the field.
+4. Fix the validation error
+5. Submit again and checkout should complete using the selected saved payment method.
+
+#### Scenario Three: Variation of trying to break via validation errors.
+
+1. On checkout, select CC payment method.
+2. Fill out cc number that will trigger declined card (`4000 0000 0000 0002`).
+3. After server response (with error), clear a required field.
+4. Select saved payment method.
+5. Submit the checkout -> this should produce a validation error.
+6. Fix the field.
+7. Submit the checkout and this should result in the purchase completing successfully.
+
+#### Scenario Four: Payment with Cheque after failed CC.
+
+1. On Checkout, select CC payment method.
+2. Fill out cc number that will trigger declined card (`4000 0000 0000 0002`).
+3. After server response (with error), select cheque payment method.
+4. Submit the checkout and this should result in the purchase completing successfully for the cheque payment method.
+
+### No shipping methods placeholder when they are all disabled (#2543)
+1. Disable all shipping methods from your store.
+2. Edit a page with the _Checkout_ block and verify the 'no shipping methods' placeholder appears.
+
+### Feature flags (#2591)
+* Verify you can't add the Single Product block.
+
+### Single Product page regression (#2648)
+* Go to a product page.
+* Verify you can see the product images as usual.<br>
+![Single Product page](https://user-images.githubusercontent.com/3616980/84032892-4f5f7300-a998-11ea-9f2d-f2d0e57860c9.png)
+
+#### Product grid inconsistencies (#2428)
+- Update a product so it has a very small image (100px or less).
+- Add the All Products block and a PHP-based product grids block (Hand-picked products, for example) and verify:
+	- Both of them have the same styles for prices.
+	- Both of them scale up the small image.
+_Handpicked products on top, All Products below:_<br>
+![Product grid blocks by default](https://user-images.githubusercontent.com/3616980/83166453-3d1b4480-a10f-11ea-813f-2515b26dedac.png)
+- Add the [code snippets](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/docs/theming/product-grid-270.md#product-grid-blocks-style-update-in-270) from the theming docs to undo the changes and verify:
+	- Hand-picked products block doesn't scale up the image anymore.
+	- All Products block shows discounted prices in two lines.
+_Handpicked products on top, All Products below:_<br>
+![Product grid blocks with the code snippets applied](https://user-images.githubusercontent.com/3616980/83164436-828a4280-a10c-11ea-81c1-b9a62cdf52b5.png)

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -74,6 +74,7 @@ You'll need to be logged in with a user that has saved payment methods.
 4. Submit the checkout and this should result in the purchase completing successfully for the cheque payment method.
 
 ### No shipping methods placeholder when they are all disabled (#2543)
+_(Requires at least WooCommerce 4.3)_
 1. Disable all shipping methods from your store.
 2. Edit a page with the _Checkout_ block and verify the 'no shipping methods' placeholder appears.
 

--- a/docs/testing/releases/271.md
+++ b/docs/testing/releases/271.md
@@ -1,0 +1,20 @@
+[![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
+
+## Testing notes and ZIP for testing
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4785662/woocommerce-gutenberg-products-block.zip)
+
+### All Products, Cart and Checkout in IE11
+
+-   With IE11, create a page with the All Products block.
+-   Verify you can add the block without problems in the editor.
+-   Visit the page in the frontend, and verify the block works as expected and no JS errors are shown in the devtools console.
+-   Repeat the process above with the Cart and Checkout blocks.
+
+### PHP notices
+
+-   Create a new product. For its type chose 'Variable Product', create one attribute and two variations. Leave both variations price to 0.
+-   Create a new page with the All Products, Filter by Price and Filter by Attributes blocks.
+-   Save the page and visit it in the frontend.
+-   Using the Filter by Attributes block, filter the products by a specific attribute, making sure the Variable Product you created gets visible at some point.
+-   Go to the PHP logs of your site and verify there isn't any PHP warning in the logs related to the steps described above.

--- a/docs/testing/releases/271.md
+++ b/docs/testing/releases/271.md
@@ -6,15 +6,15 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### All Products, Cart and Checkout in IE11
 
--   With IE11, create a page with the All Products block.
--   Verify you can add the block without problems in the editor.
--   Visit the page in the frontend, and verify the block works as expected and no JS errors are shown in the devtools console.
--   Repeat the process above with the Cart and Checkout blocks.
+* [ ]   With IE11, create a page with the All Products block.
+* [ ]   Verify you can add the block without problems in the editor.
+* [ ]   Visit the page in the frontend, and verify the block works as expected and no JS errors are shown in the devtools console.
+* [ ]   Repeat the process above with the Cart and Checkout blocks.
 
 ### PHP notices
 
--   Create a new product. For its type chose 'Variable Product', create one attribute and two variations. Leave both variations price to 0.
--   Create a new page with the All Products, Filter by Price and Filter by Attributes blocks.
--   Save the page and visit it in the frontend.
--   Using the Filter by Attributes block, filter the products by a specific attribute, making sure the Variable Product you created gets visible at some point.
--   Go to the PHP logs of your site and verify there isn't any PHP warning in the logs related to the steps described above.
+* [ ]   Create a new product. For its type chose 'Variable Product', create one attribute and two variations. Leave both variations price to 0.
+* [ ]   Create a new page with the All Products, Filter by Price and Filter by Attributes blocks.
+* [ ]   Save the page and visit it in the frontend.
+* [ ]   Using the Filter by Attributes block, filter the products by a specific attribute, making sure the Variable Product you created gets visible at some point.
+* [ ]   Go to the PHP logs of your site and verify there isn't any PHP warning in the logs related to the steps described above.

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -3,3 +3,4 @@ Every release includes specific testing instructions for features and bug fixes 
 - [2.6.0](./260.md)
     - [2.6.1](./261.md)
 - [2.7.0](./270.md)
+    - [2.7.1](./271.md)

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -2,3 +2,4 @@ Every release includes specific testing instructions for features and bug fixes 
 
 - [2.6.0](./260.md)
     - [2.6.1](./261.md)
+- [2.7.0](./270.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/block-library",
-	"version": "2.7.0-dev",
+	"version": "2.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "2.7.0-dev",
+	"version": "2.7.0",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "2.7.0",
+	"version": "2.7.1",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - enhancement: The Cart block titles have been merged into one. [#2615](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2615)
 - enhancement: The item count badges of the Checkout block have been updated so it looks better in light & dark backgrounds. [#2619](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2619)
 - enhancement: Checkout step progress indicator design has been updated to match the theme headings style. [#2649](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2649)
+- performance: Reduce bundlesize of blocks using @wordpress/components directly. [#2664](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2664)
 
 = 2.6.1 - 2020-06-01 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,19 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 2.7.0 - 2020-06-08 =
+- bug: Fix bug in Checkout block preventing a retry of credit card payment when first credit card used fails and a new one is tried. [#2655](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2655)
+- bug: Avoid some theme style properties leaking into the Cart and Checkout select controls. [#2647](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2647)
+- bug: Fixes to the product grid blocks in Twenty Twenty: discounted prices are no longer underlined and the On Sale badge is correctly positioned in the All Products block. [#2573](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2573)
+- bug: Improved alignment of credit card validation error messages. [#2662](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2662)
+- bug: Show the 'No shipping methods' placeholder in the editor with the _Checkout_ block if there are shipping methods but all of them are disabled. [#2543](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2543)
+- enhancement: Filter block font sizes have been adjusted to be in line with other blocks. [#2594](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2594)
+- enhancement: The All Products block and the other product grid blocks now share more styles and the markup is more similar (see release post or docs to learn how to undo this change). [#2428](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2428) [DN]
+- enhancement: The Cart and Checkout blocks now use the heading styles provided by the theme. [#2597](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2597)
+- enhancement: The Cart block titles have been merged into one. [#2615](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2615)
+- enhancement: The item count badges of the Checkout block have been updated so it looks better in light & dark backgrounds. [#2619](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2619)
+- enhancement: Checkout step progress indicator design has been updated to match the theme headings style. [#2649](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2649)
+
 = 2.6.1 - 2020-06-01 =
 
 - fix: Updated the wc_reserved_stock table for compatibility with versions of MySql < 5.6.5. [#2590](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2590)

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,12 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 2.7.1 - 2020-06-16 =
+- bug: Use IE11 friendly code for Dashicon component replacement. [#2708](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2708) 
+- bug: Fix PHP warnings produced by StoreAPI endpoints when variations have no prices. [#2722](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2722) 
+- bug: Fix missing scoped variable in closure and missing schema definitions. [#2724](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2724) 
+- bug: Fix undefined index notice for query_type on the product collection data endpoint. [#2723](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2723)
+
 = 2.7.0 - 2020-06-09 =
 - bug: Fix bug in Checkout block preventing a retry of credit card payment when first credit card used fails and a new one is tried. [#2655](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2655)
 - bug: Avoid some theme style properties leaking into the Cart and Checkout select controls. [#2647](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2647)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 2.7.0
+Stable tag: 2.7.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,7 +120,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
-= 2.7.0 - 2020-06-08 =
+= 2.7.0 - 2020-06-09 =
 - bug: Fix bug in Checkout block preventing a retry of credit card payment when first credit card used fails and a new one is tried. [#2655](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2655)
 - bug: Avoid some theme style properties leaking into the Cart and Checkout select controls. [#2647](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2647)
 - bug: Fixes to the product grid blocks in Twenty Twenty: discounted prices are no longer underlined and the On Sale badge is correctly positioned in the All Products block. [#2573](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2573)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 2.6.0
+Stable tag: 2.7.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -101,7 +101,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '2.7.0';
+					$version = '2.7.1';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/src/Package.php
+++ b/src/Package.php
@@ -101,7 +101,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '2.6.0';
+					$version = '2.7.0';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -74,10 +74,12 @@ class ProductCollectionData extends AbstractRoute {
 			$taxonomy__and_queries = [];
 
 			foreach ( $request['calculate_attribute_counts'] as $attributes_to_count ) {
-				if ( 'or' === $attributes_to_count['query_type'] ) {
-					$taxonomy__or_queries[] = $attributes_to_count['taxonomy'];
-				} else {
-					$taxonomy__and_queries[] = $attributes_to_count['taxonomy'];
+				if ( ! empty( $attributes_to_count['taxonomy'] ) ) {
+					if ( empty( $attributes_to_count['query_type'] ) || 'or' === $attributes_to_count['query_type'] ) {
+						$taxonomy__or_queries[] = $attributes_to_count['taxonomy'];
+					} else {
+						$taxonomy__and_queries[] = $attributes_to_count['taxonomy'];
+					}
 				}
 			}
 

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -84,7 +84,6 @@ class ProductCollectionData extends AbstractRoute {
 			}
 
 			$data['attribute_counts'] = [];
-
 			// Or type queries need special handling because the attribute, if set, needs removing from the query first otherwise counts would not be correct.
 			if ( $taxonomy__or_queries ) {
 				foreach ( $taxonomy__or_queries as $taxonomy ) {
@@ -94,7 +93,7 @@ class ProductCollectionData extends AbstractRoute {
 					if ( ! empty( $filter_attributes ) ) {
 						$filter_attributes = array_filter(
 							$filter_attributes,
-							function( $query ) {
+							function( $query ) use ( $taxonomy ) {
 								return $query['attribute'] !== $taxonomy;
 							}
 						);

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -335,11 +335,17 @@ class Products extends AbstractRoute {
 					'term_id'   => array(
 						'description'       => __( 'List of attribute term IDs.', 'woo-gutenberg-products-block' ),
 						'type'              => 'array',
+						'items'             => [
+							'type' => 'integer',
+						],
 						'sanitize_callback' => 'wp_parse_id_list',
 					),
 					'slug'      => array(
 						'description'       => __( 'List of attribute slug(s). If a term ID is provided, this will be ignored.', 'woo-gutenberg-products-block' ),
 						'type'              => 'array',
+						'items'             => [
+							'type' => 'string',
+						],
 						'sanitize_callback' => 'wp_parse_slug_list',
 					),
 					'operator'  => array(

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -240,7 +240,7 @@ abstract class AbstractSchema {
 	protected function prepare_money_response( $amount, $decimals = 2, $rounding_mode = PHP_ROUND_HALF_UP ) {
 		return (string) intval(
 			round(
-				wc_format_decimal( $amount ) * ( 10 ** $decimals ),
+				( (float) wc_format_decimal( $amount ) ) * ( 10 ** $decimals ),
 				0,
 				absint( $rounding_mode )
 			)

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -354,7 +354,7 @@ class ProductSchema extends AbstractSchema {
 		if ( $product->is_type( 'variable' ) ) {
 			$prices = $product->get_variation_prices( true );
 
-			if ( min( $prices['price'] ) !== max( $prices['price'] ) ) {
+			if ( ! empty( $prices['price'] ) && ( min( $prices['price'] ) !== max( $prices['price'] ) ) ) {
 				return (object) [
 					'min_amount' => $this->prepare_money_response( min( $prices['price'] ), wc_get_price_decimals() ),
 					'max_amount' => $this->prepare_money_response( max( $prices['price'] ), wc_get_price_decimals() ),

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.7.0
+ * Version: 2.7.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.7.0-dev
+ * Version: 2.7.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This is the release pull request for 2.7.1 of the WooCommerce Blocks plugin.

## Communication

This release introduces:

* Update to Dashicons replacement code to make it IE11 friendly.
* Fixes to avoid several PHP notices.

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

**Release announcement:** _It's a small point release, so we will not do a release announcement._

**Developer Notes:** _N/A_

**Relevant developer documentation:** _N/A_

**Happiness Engineer:** _N/A_

* [x] The release includes a changelog entry in the readme.txt?

## Quality

* [ ] Changes in this release are covered by Automated Tests.
_The fixes included in this release are specific to IE11 and PHP warnings that were missed before releasing 2.7.0. There aren't specific tests added for them._

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [x] Link to **testing instructions** for this release:
https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/release/2.7/docs/testing/releases/271.md