### PR TITLE
Auto-merge renovate dependency updates (except major versions)

### DIFF
--- a/docs/releases/handling-releases.md
+++ b/docs/releases/handling-releases.md
@@ -28,6 +28,7 @@ _Outcome_: **You are equipped to ship a release!**
 -   Ensure all issues/PRs intended for this release are merged, closed and linked to release.
 -   All PRs should have changelog entry, or `skip-changelog` tag.
 -   Check with the team to confirm any outstanding or in progress work.
+-   Review recent [dependency updates](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pulls?q=is%3Apr+is%3Aclosed+author%3Aapp%2Frenovate) to be included in this release, and ensure they have been adequately tested. 
 
 Note: changelog should be formatted like this in PR description. Note the preceding `>` - this is required by changelog script.
 

--- a/docs/releases/handling-releases.md
+++ b/docs/releases/handling-releases.md
@@ -50,7 +50,7 @@ _Outcome_: **Team is aware of release and in agreement about what fixes & featur
 
 Using the [release pull request template](../../.github/release_pull_request_template.md), create a pull request for the release branch you just created. This pull request will have changes merged to the min branch, but might not be a straight merge if it contains cherry-picked commits. The pull request also contains the checklist to go over as a part of the release along with being a place to contain all planning/communication around the release. The checklist should be completed and the pull request has an approved review from at least one team member before you do the Github deploy or release the plugin to WordPress.org.
 
-### Patch releases against latest main branch
+##### Patch releases against latest main branch
 
 If it's determined a patch release will include the latest main branch:
 
@@ -59,7 +59,7 @@ If it's determined a patch release will include the latest main branch:
 - Move all closed issues and pulls from the current release milestone into the patch release milestone.
 - Push the release branch to origin (so changes are in GitHub repo).
 
-### Patch releases with cherry-picking.
+##### Patch releases with cherry-picking.
 
 This is for releases where just fixes specific to the branch are released and not the latest changes in `main`.
 
@@ -73,7 +73,7 @@ This is for releases where just fixes specific to the branch are released and no
 -   Push the release branch to origin (so changes are in GitHub repo).
 -   Label the PR: `status: cherry-picked 🍒`.
 
-### Minor/Major releases
+##### Minor/Major releases
 
 - Ensure your local checkout is updated to the tip of the release branch.
 

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
 	"extends": [ "config:base" ],
 	"lockFileMaintenance": { "enabled": true },
 	"ignoreDeps": [ "husky" ],
+	"schedule": [ "before 3am on wednesday" ],
 	"composer": {
 		"enabled": false
 	},

--- a/renovate.json
+++ b/renovate.json
@@ -6,11 +6,15 @@
 	"composer": {
 		"enabled": false
 	},
-  "labels": ["type: dependencies", "skip-changelog"],
+	"labels": ["type: dependencies", "skip-changelog"],
 	"packageRules": [
 		{
 			"packageNames": [ "automattic/jetpack-autoloader" ],
 			"rangeStrategy": "bump"
-		}
-	]
+		},
+    {
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
 	"extends": [ "config:base" ],
 	"lockFileMaintenance": { "enabled": true },
 	"ignoreDeps": [ "husky" ],
-	"schedule": [ "before 3am on wednesday" ],
 	"composer": {
 		"enabled": false
 	},

--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,9 @@
 			"packageNames": [ "automattic/jetpack-autoloader" ],
 			"rangeStrategy": "bump"
 		},
-    {
-      "updateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    }
-  ]	]
+		{
+			"updateTypes": ["minor", "patch", "pin", "digest"],
+			"automerge": true
+		}
+	]
 }


### PR DESCRIPTION
Fixes #2625

Enables automerge for all updates except major, using the approach from [renovate docs](https://docs.renovatebot.com/configuration-options/#automerge).

I also removed our [schedule config](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/598), as there's no need to defer automerges to a particular part of the week. We can roll this back if people prefer a schedule. It's possible that dependency updates could cause issues when we're in the middle of a release. cc @Aljullu @mikejolley for thoughts on this.

This is the expected behaviour for this config, I think we have to merge to confirm this (!):

- PRs will be generated for major updates, as before. We'll need to manually test, review and merge these.
- All other updates will be automerged immediately.

Regarding process, here's what I'm thinking:

- For major updates, let's stick with the current auto-round-robin review approach. The assigned reviewer can reassign or ping others if needed.
- I've added a new step to the release process to note any updates and ensure they've been tested/reviewed. 


