### PR TITLE
Remove text color from Cart and Checkout blocks

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -122,6 +122,27 @@ $fontSizes: (
 	-ms-word-break: break-all;
 }
 
+// Shows a border with the current color and a custom opacity. That can't be achieved
+// with normal border because `currentColor` doesn't allow tweaking the opacity, and
+// setting the opacity of the entire element would change the children's opacity too.
+@mixin with-translucent-border($border-width: 1px, $opacity: 0.3) {
+	position: relative;
+
+	&::after {
+		border-style: solid;
+		border-width: $border-width;
+		bottom: 0;
+		content: "";
+		display: block;
+		left: 0;
+		opacity: $opacity;
+		pointer-events: none;
+		position: absolute;
+		right: 0;
+		top: 0;
+	}
+}
+
 // Converts a px unit to em.
 @function em($size, $base: 16px) {
 	@return $size / $base * 1em;

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -45,20 +45,18 @@
 
 .wc-block-components-checkout-step__heading-content {
 	@include font-size(smaller);
-	color: $gray-80;
 	position: absolute;
 	right: 0;
 
 	a {
 		font-weight: bold;
-		color: $gray-80;
+		color: inherit;
 	}
 }
 
 .wc-block-components-checkout-step__description {
 	@include font-size(small);
 	line-height: 1.25;
-	color: $gray-60;
 	margin-bottom: $gap;
 }
 
@@ -80,6 +78,7 @@
 	content: "";
 	height: 100%;
 	border-left: 1px solid;
+	opacity: 0.3;
 	position: absolute;
 	left: -$gap-larger/2;
 	top: 0;

--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -11,17 +11,18 @@
 }
 
 .wc-block-components-order-summary-item {
+	@include with-translucent-border(0 0 1px);
 	display: table-row;
+	padding-bottom: 1px;
 	width: 100%;
-
-	> div {
-		border-bottom: 1px solid $core-grey-light-600;
-	}
 
 	&:last-child {
 		> div {
-			border-bottom: none;
 			padding-bottom: 0;
+		}
+
+		&::after {
+			display: none;
 		}
 	}
 }

--- a/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-low-stock-badge/style.scss
@@ -1,11 +1,10 @@
 .wc-block-components-product-low-stock-badge {
 	@include font-size(smaller);
-	background-color: $white;
-	border-radius: 3px;
-	border: 1px solid $black;
+	border-radius: 2px;
+	border: 1px solid;
 	display: inline-block;
-	color: $black;
-	padding: 0 1em;
+	font-weight: 600;
+	padding: 0 0.66em;
 	text-transform: uppercase;
 	white-space: nowrap;
 }

--- a/assets/js/base/components/cart-checkout/product-metadata/style.scss
+++ b/assets/js/base/components/cart-checkout/product-metadata/style.scss
@@ -1,6 +1,5 @@
 .wc-block-components-product-metadata {
 	@include font-size(smaller);
-	color: $core-grey-dark-400;
 
 	.wc-block-components-product-metadata__description > p,
 	.wc-block-components-product-metadata__variation-data {

--- a/assets/js/base/components/cart-checkout/product-price/index.js
+++ b/assets/js/base/components/cart-checkout/product-price/index.js
@@ -14,35 +14,51 @@ import './style.scss';
 const ProductPrice = ( { className, currency, regularValue, value } ) => {
 	const isDiscounted =
 		Number.isFinite( regularValue ) && regularValue !== value;
-	return (
-		<>
-			{ isDiscounted && (
-				<>
-					<span className="screen-reader-text">
-						{ __(
-							'Previous price:',
-							'woo-gutenberg-products-block'
-						) }
-					</span>
+
+	if ( isDiscounted ) {
+		return (
+			<span className="price wc-block-components-product-price">
+				<span className="screen-reader-text">
+					{ __( 'Previous price:', 'woo-gutenberg-products-block' ) }
+				</span>
+				<del>
 					<FormattedMonetaryAmount
 						className={ classNames(
-							'wc-block-components-product-price--regular',
+							'wc-block-components-product-price__regular',
 							className
 						) }
 						currency={ currency }
 						value={ regularValue }
 					/>
-					<span className="screen-reader-text">
-						{ __(
-							'Discounted price:',
-							'woo-gutenberg-products-block'
+				</del>
+				<span className="screen-reader-text">
+					{ __(
+						'Discounted price:',
+						'woo-gutenberg-products-block'
+					) }
+				</span>
+				<ins>
+					<FormattedMonetaryAmount
+						className={ classNames(
+							'wc-block-components-product-price__value',
+							className,
+							{
+								'is-discounted': isDiscounted,
+							}
 						) }
-					</span>
-				</>
-			) }
+						currency={ currency }
+						value={ value }
+					/>
+				</ins>
+			</span>
+		);
+	}
+
+	return (
+		<span className="price wc-block-components-product-price">
 			<FormattedMonetaryAmount
 				className={ classNames(
-					'wc-block-components-product-price',
+					'wc-block-components-product-price__value',
 					className,
 					{
 						'is-discounted': isDiscounted,
@@ -51,7 +67,7 @@ const ProductPrice = ( { className, currency, regularValue, value } ) => {
 				currency={ currency }
 				value={ value }
 			/>
-		</>
+		</span>
 	);
 };
 

--- a/assets/js/base/components/cart-checkout/product-price/style.scss
+++ b/assets/js/base/components/cart-checkout/product-price/style.scss
@@ -1,12 +1,5 @@
-.wc-block-components-product-price {
-	color: $black;
-
+.wc-block-components-product-price__value {
 	&.is-discounted {
 		margin-left: 0.5em;
 	}
-}
-
-.wc-block-components-product-price--regular {
-	color: $core-grey-dark-400;
-	text-decoration: line-through;
 }

--- a/assets/js/base/components/cart-checkout/product-sale-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/index.js
@@ -28,7 +28,7 @@ const ProductSaleBadge = ( { currency, saleAmount } ) => {
 		<div className="wc-block-components-sale-badge">
 			{ __experimentalCreateInterpolateElement(
 				/* translators: <price/> will be replaced by the discount amount */
-				__( 'Save <price/>!', 'woo-gutenberg-products-block' ),
+				__( 'Save <price/>', 'woo-gutenberg-products-block' ),
 				{
 					price: (
 						<FormattedMonetaryAmount

--- a/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/style.scss
@@ -1,11 +1,9 @@
 .wc-block-components-sale-badge {
 	@include font-size(smaller);
-	background-color: $core-grey-dark-600;
 	border-radius: 2px;
-	color: $white;
+	border: 1px solid;
 	display: inline-block;
 	font-weight: 600;
-	letter-spacing: 0.0833em; // 1px/12px
 	padding: 0 0.66em;
 	text-transform: uppercase;
 	white-space: nowrap;

--- a/assets/js/base/components/cart-checkout/return-to-cart-button/style.scss
+++ b/assets/js/base/components/cart-checkout/return-to-cart-button/style.scss
@@ -1,6 +1,6 @@
 .wc-block-components-checkout-return-to-cart-button {
 	box-shadow: none;
-	color: $gray-60;
+	color: inherit;
 	padding-left: calc(24px + 0.25em);
 	position: relative;
 	text-decoration: none;

--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -10,11 +10,6 @@ import {
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
- * Internal dependencies
- */
-import './style.scss';
-
-/**
  * Shows a formatted shipping location.
  */
 const ShippingLocation = ( { address } ) => {

--- a/assets/js/base/components/cart-checkout/shipping-location/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-location/style.scss
@@ -1,4 +1,0 @@
-.wc-block-components-shipping-address,
-.wc-block-components-shipping-address button {
-	color: $core-grey-dark-400;
-}

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
@@ -6,7 +6,6 @@
 
 .wc-block-components-shipping-rates-control__package-items {
 	@include font-size(small);
-	color: $core-grey-dark-400;
 	display: block;
 	list-style: none;
 	margin: 0;

--- a/assets/js/base/components/cart-checkout/totals/totals-footer-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-footer-item/style.scss
@@ -2,7 +2,6 @@
 	.wc-block-components-totals-item__value,
 	.wc-block-components-totals-item__label {
 		@include font-size(large);
-		color: #000;
 	}
 
 	.wc-block-components-totals-item__label {

--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/style.scss
@@ -19,8 +19,8 @@
 
 	.wc-block-components-radio-control__option,
 	.wc-block-components-radio-control__option-layout {
-		&:last-child {
-			border-bottom: none;
+		&:last-child::after {
+			display: none;
 		}
 	}
 
@@ -36,5 +36,9 @@
 		&:active {
 			opacity: 0.8;
 		}
+	}
+
+	.wc-blocks-components-panel:last-child::after {
+		border-bottom-width: 0;
 	}
 }

--- a/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-taxes-item/index.js
@@ -12,6 +12,7 @@ import {
  * Internal dependencies
  */
 import TotalsItem from '../totals-item';
+import './style.scss';
 
 const TotalsTaxesItem = ( { currency, values } ) => {
 	const { total_tax: totalTax, tax_lines: taxLines } = values;

--- a/assets/js/base/components/cart-checkout/totals/totals-taxes-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/totals-taxes-item/style.scss
@@ -1,0 +1,3 @@
+.wc-block-components-totals-taxes {
+	@include with-translucent-border(1px 0 0);
+}

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -1,7 +1,9 @@
 .wc-blocks-components-panel.has-border {
-	border-top: 1px solid $core-grey-light-600;
-	border-bottom: 1px solid $core-grey-light-600;
-	margin-bottom: -1px;
+	@include with-translucent-border( 1px 0 );
+
+	+ .wc-blocks-components-panel.has-border::after {
+		border-top-width: 0;
+	}
 }
 
 .wc-blocks-components-panel__button {
@@ -26,6 +28,7 @@
 	}
 
 	> .wc-blocks-components-panel__button-icon {
+		fill: currentColor;
 		position: absolute;
 		right: 0;
 		top: 50%;
@@ -36,6 +39,7 @@
 
 .wc-blocks-components-panel__content {
 	padding-bottom: em($gap);
+	overflow: auto;
 }
 
 .theme-twentytwenty .wc-blocks-components-panel__button {

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -1,4 +1,5 @@
 $border-width: 1px;
+$border-radius: 5px;
 
 .wc-block-components-express-checkout {
 	margin: auto;
@@ -10,30 +11,32 @@ $border-width: 1px;
 		left: 0;
 		position: absolute;
 		right: 0;
-		top: 0;
+		top: -$border-radius;
 		vertical-align: middle;
 
 		// Pseudo-elements used to show the border before and after the title.
 		&::before {
-			border: $border-width solid transparent;
-			border-left-color: currentColor;
-			border-top-color: currentColor;
-			border-radius: 5px 0 0 0;
+			border-left: $border-width solid currentColor;
+			border-top: $border-width solid currentColor;
+			border-radius: $border-radius 0 0 0;
 			content: "";
 			display: block;
+			height: $border-radius - $border-width;
 			margin-right: $gap-small;
+			opacity: 0.3;
 			pointer-events: none;
 			width: #{$gap-larger - $gap-small - $border-width * 2};
 		}
 
 		&::after {
-			border: $border-width solid transparent;
-			border-right-color: currentColor;
-			border-top-color: currentColor;
-			border-radius: 0 5px 0 0;
+			border-right: $border-width solid currentColor;
+			border-top: $border-width solid currentColor;
+			border-radius: 0 $border-radius 0 0;
 			content: "";
 			display: block;
+			height: $border-radius - $border-width;
 			margin-left: $gap-small;
+			opacity: 0.3;
 			pointer-events: none;
 			flex-grow: 1;
 		}
@@ -45,11 +48,13 @@ $border-width: 1px;
 	}
 
 	.wc-block-components-express-checkout__content {
-		border: $border-width solid currentColor;
-		border-top-width: 0;
-		border-radius: 5px;
-		margin-top: 0.75em;
+		@include with-translucent-border(0 $border-width $border-width);
+		margin-top: calc(0.75em + #{$border-radius});
 		padding: em($gap-large) #{$gap-larger - $border-width} em($gap) #{$gap-larger - $border-width};
+
+		&::after {
+			border-radius: 0 0 $border-radius $border-radius;
+		}
 
 		> p {
 			margin-bottom: em($gap);

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -1,21 +1,22 @@
 @mixin radio-control-styles {
 	.wc-block-components-radio-control__option {
 		@include reset-typography();
-		border-bottom: 1px solid $core-grey-light-600;
+		@include with-translucent-border(0 0 1px);
 		display: block;
 		padding: $gap-small $gap-small 0 #{$gap-larger * 2};
-		position: relative;
 	}
 
 	.wc-block-components-radio-control__option-layout {
+		@include with-translucent-border(0 0 1px);
 		display: table;
 		width: 100%;
-		border-bottom: 1px solid $core-grey-light-600;
 		padding-bottom: $gap-small;
 	}
 
 	.wc-block-components-radio-control__option .wc-block-components-radio-control__option-layout {
-		border-bottom: 0;
+		&::after {
+			display: none;
+		}
 	}
 
 	.wc-block-components-radio-control__input {
@@ -45,14 +46,12 @@
 		// Currently, max() CSS function calls need to be wrapped with unquote.
 		// See: https://github.com/sass/sass/issues/2378#issuecomment-367490840
 		line-height: unquote("max(1rem, 20px)");
-		color: $core-grey-dark-600;
 	}
 
 	.wc-block-components-radio-control__description,
 	.wc-block-components-radio-control__secondary-description {
 		@include font-size(small);
 		line-height: 20px;
-		color: $core-grey-dark-400;
 	}
 }
 

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -9,20 +9,19 @@
 			flex: auto;
 			background: transparent;
 			padding: $gap-small $gap;
-			color: $black;
+			color: inherit;
 			outline-offset: -1px;
 			text-align: center;
 			transition: box-shadow 0.1s linear;
-			box-shadow: inset 0 -2px $core-grey-light-600;
+			box-shadow: inset 0 -1px currentColor;
 			&.is-active {
-				box-shadow: inset 0 -3px $black;
+				box-shadow: inset 0 -3px currentColor;
 				font-weight: 600;
 				position: relative;
 			}
 			&:focus {
-				color: $black;
 				outline-offset: -1px;
-				outline: 1px dotted $gray-60;
+				outline: 1px dotted currentColor;
 			}
 			.wc-block-components-tabs__item-content {
 				@include font-size(regular);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -1,6 +1,4 @@
 .wc-block-cart {
-	color: $core-grey-dark-600;
-
 	.wc-block-components-shipping-calculator {
 		white-space: nowrap;
 	}
@@ -24,18 +22,14 @@ table.wc-block-cart-items td {
 table.wc-block-cart-items {
 	table-layout: fixed;
 	width: 100%;
-	border-bottom: 1px solid $core-grey-light-600;
 
 	th {
 		padding: 0.25rem $gap 0.25rem 0;
 		white-space: nowrap;
-		border-collapse: collapse;
 	}
 	td {
-		border-top: 1px solid $core-grey-light-600;
 		padding: $gap $gap $gap 0;
 		vertical-align: top;
-		border-collapse: collapse;
 	}
 	th:last-child,
 	td:last-child {
@@ -70,14 +64,12 @@ table.wc-block-cart-items {
 				@include link-button;
 				@include font-size(smaller);
 
-				color: $core-grey-dark-400;
 				text-transform: none;
 				white-space: nowrap;
 			}
 			.wc-block-cart-item__remove-icon {
 				@include link-button;
 
-				color: $core-grey-dark-400;
 				fill: currentColor;
 				position: absolute;
 				top: $gap;
@@ -90,8 +82,8 @@ table.wc-block-cart-items {
 			text-align: right;
 			line-height: 1.25;
 
-			.wc-block-components-product-price,
-			.wc-block-components-product-price--regular {
+			.wc-block-components-product-price__regular,
+			.wc-block-components-product-price__value {
 				display: block;
 			}
 		}
@@ -179,7 +171,6 @@ table.wc-block-cart-items {
 	table.wc-block-cart-items {
 		td {
 			padding: 0;
-			border: 0;
 		}
 		.wc-block-cart-items__header {
 			display: none;
@@ -188,11 +179,10 @@ table.wc-block-cart-items {
 			display: none;
 		}
 		.wc-block-cart-items__row {
+			@include with-translucent-border(0 0 1px);
 			display: grid;
 			grid-template-columns: 80px 132px;
-			border-top: 1px solid $core-grey-light-600;
 			padding: $gap 0;
-			position: relative;
 
 			.wc-block-cart-item__image {
 				grid-column-start: 1;
@@ -255,6 +245,15 @@ table.wc-block-cart-items {
 }
 
 .is-large.wc-block-cart {
+	.wc-block-cart-items {
+		@include with-translucent-border(0 0 1px);
+
+		td {
+			@include with-translucent-border(1px 0 0);
+			padding: $gap $gap $gap 0;
+			vertical-align: top;
+		}
+	}
 	.wc-block-components-radio-control__option {
 		padding-left: $gap-large;
 	}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -23,18 +23,6 @@ table.wc-block-cart-items {
 	table-layout: fixed;
 	width: 100%;
 
-	th {
-		padding: 0.25rem $gap 0.25rem 0;
-		white-space: nowrap;
-	}
-	td {
-		padding: $gap $gap $gap 0;
-		vertical-align: top;
-	}
-	th:last-child,
-	td:last-child {
-		padding-right: 0;
-	}
 	.wc-block-cart-items__header {
 		@include font-size(smaller);
 		text-transform: uppercase;
@@ -248,10 +236,18 @@ table.wc-block-cart-items {
 	.wc-block-cart-items {
 		@include with-translucent-border(0 0 1px);
 
+		th {
+			padding: 0.25rem $gap 0.25rem 0;
+			white-space: nowrap;
+		}
 		td {
 			@include with-translucent-border(1px 0 0);
 			padding: $gap $gap $gap 0;
 			vertical-align: top;
+		}
+		th:last-child,
+		td:last-child {
+			padding-right: 0;
 		}
 	}
 	.wc-block-components-radio-control__option {

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -40,7 +40,8 @@
 	&::after {
 		content: " ";
 		flex: 1;
-		border-bottom: 1px solid $core-grey-light-600;
+		border-bottom: 1px solid;
+		opacity: 0.3;
 	}
 }
 
@@ -79,7 +80,7 @@
 	.wc-block-components-express-checkout {
 		min-height: 150px;
 	}
-	.wc-block-components-express-checkout-continue-rule span {
+	.wc-block-components-express-checkout-continue-rule > span {
 		@include placeholder();
 		@include force-content();
 		width: 150px;

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -18,6 +18,7 @@ Some classes that were introduced in 2.6.0 and 2.7.0 and didn't ship in WooComme
 | `wc-block-product-metadata`            | `wc-block-components-product-metadata`                |
 | `wc-block-product-name`                | `wc-block-components-product-name`                    |
 | `wc-block-product-price`               | `wc-block-components-product-price`                   |
+| `wc-block-product-price--regular`      | `wc-block-components-product-price__regular`          |
 | `wc-block-sale-badge`                  | `wc-block-components-sale-badge`                      |
 | `wc-block-product-variation-data`      | `wc-block-components-product-variation-data`          |
 | `wc-block-cart__shipping-calculator`   | `wc-block-components-shipping-calculator`             |


### PR DESCRIPTION
Fixes #2459.
Fixes #2540.

A couple of notes:
* According to the designs, borders are not fully opaque. There wasn't an easy way to use `currentColor` for borders and at the same time reduce its opacity without reducing the children elements opacity too. The best solution I could find was to render a pseudoelement responsible for displaying the borders and reduce the opacity there. I created a SCSS mixin to avoid duplicating the code in several elements.
* Removing colors meant that discounted prices were no longer light gray. To solve that, I wrapped the ProductPrice component with the legacy `price` class so we would inherit theme styles.

### Screenshots

_Storefront (default):_
![imatge](https://user-images.githubusercontent.com/3616980/84988455-4f066b00-b142-11ea-98c2-7b602b3aa3f2.png)

_Storefront with different colors:_
![imatge](https://user-images.githubusercontent.com/3616980/84988595-8e34bc00-b142-11ea-9462-f445c313e0c0.png)

_Bistro:_
![imatge](https://user-images.githubusercontent.com/3616980/84988676-b3c1c580-b142-11ea-8e00-b582db243748.png)

### How to test the changes in this Pull Request:

1. With Storefront, go to Appearance > Customize and change the typography color.
2. Verify the color is applied to the Cart and Checkout text and borders.
3. Test other themes to verify there are no regressions.

### Changelog

> The Cart and Checkout blocks now use the font colors provided by the theme.