### PR TITLE
Update reserved stock when a row already exists

### DIFF
--- a/src/StoreApi/Utilities/ReserveStock.php
+++ b/src/StoreApi/Utilities/ReserveStock.php
@@ -165,7 +165,7 @@ final class ReserveStock {
 				INSERT INTO {$wpdb->wc_reserved_stock} ( `order_id`, `product_id`, `stock_quantity`, `timestamp`, `expires` )
 				SELECT %d, %d, %d, NOW(), ( NOW() + INTERVAL %d MINUTE ) FROM DUAL
 				WHERE ( $query_for_stock FOR UPDATE ) - ( $query_for_reserved_stock FOR UPDATE ) >= %d
-				ON DUPLICATE KEY UPDATE `expires` = VALUES( `expires` )
+				ON DUPLICATE KEY UPDATE `expires` = VALUES( `expires` ), `stock_quantity` = VALUES( `stock_quantity` )
 				",
 				$order->get_id(),
 				$product_id,


### PR DESCRIPTION
When the `wc_reserve_stock` table is updated and there is a duplicate row, it was only updating the `expires` column. It needs to also update the `stock_quantity` so changes to the cart are respected.

Fixes #2746

### How to test the changes in this Pull Request:

1. Add a stock managed product to the cart and go to the Block Checkout, qty 1.
2. See the `wc_reserve_stock` table has a row with stock reserved.
3. Go back to the cart and increase the qty of the item in your cart.
4. Go back to the Block Checkout.
5. Confirm the row in `wc_reserve_stock` now has the new qty.

### Changelog

> Fix updating the `wc_reserve_stock` stock_quantity value after making changes to the cart inbetween checkouts.
