### PR TITLE
Cart & Checkout: show shipping method prices with taxes when required

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/shipping-rate-selector.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/shipping-rate-selector.js
@@ -6,23 +6,31 @@ import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-mone
 import { decodeEntities } from '@wordpress/html-entities';
 import { getCurrencyFromPriceResponse } from '@woocommerce/base-utils';
 import { ShippingRatesControl } from '@woocommerce/base-components/cart-checkout';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 
-const renderShippingRatesControlOption = ( option ) => ( {
-	label: decodeEntities( option.name ),
-	value: option.rate_id,
-	description: (
-		<>
-			{ option.price && (
-				<FormattedMonetaryAmount
-					currency={ getCurrencyFromPriceResponse( option ) }
-					value={ option.price }
-				/>
-			) }
-			{ option.price && option.delivery_time ? ' — ' : null }
-			{ decodeEntities( option.delivery_time ) }
-		</>
-	),
-} );
+const renderShippingRatesControlOption = ( option ) => {
+	const priceWithTaxes = DISPLAY_CART_PRICES_INCLUDING_TAX
+		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
+		: parseInt( option.price, 10 );
+	return {
+		label: decodeEntities( option.name ),
+		value: option.rate_id,
+		description: (
+			<>
+				{ Number.isFinite( priceWithTaxes ) && (
+					<FormattedMonetaryAmount
+						currency={ getCurrencyFromPriceResponse( option ) }
+						value={ priceWithTaxes }
+					/>
+				) }
+				{ Number.isFinite( priceWithTaxes ) && option.delivery_time
+					? ' — '
+					: null }
+				{ decodeEntities( option.delivery_time ) }
+			</>
+		),
+	};
+};
 
 const ShippingRateSelector = ( {
 	hasRates,

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -49,6 +49,7 @@ import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 import {
 	CHECKOUT_SHOW_LOGIN_REMINDER,
 	CHECKOUT_ALLOWS_GUEST,
+	DISPLAY_CART_PRICES_INCLUDING_TAX,
 } from '@woocommerce/block-settings';
 
 /**
@@ -78,18 +79,23 @@ const Block = ( props ) => {
  *
  * @param {Object} option Shipping Rate.
  */
-const renderShippingRatesControlOption = ( option ) => ( {
-	label: decodeEntities( option.name ),
-	value: option.rate_id,
-	description: decodeEntities( option.description ),
-	secondaryLabel: (
-		<FormattedMonetaryAmount
-			currency={ getCurrencyFromPriceResponse( option ) }
-			value={ option.price }
-		/>
-	),
-	secondaryDescription: decodeEntities( option.delivery_time ),
-} );
+const renderShippingRatesControlOption = ( option ) => {
+	const priceWithTaxes = DISPLAY_CART_PRICES_INCLUDING_TAX
+		? parseInt( option.price, 10 ) + parseInt( option.taxes, 10 )
+		: parseInt( option.price, 10 );
+	return {
+		label: decodeEntities( option.name ),
+		value: option.rate_id,
+		description: decodeEntities( option.description ),
+		secondaryLabel: (
+			<FormattedMonetaryAmount
+				currency={ getCurrencyFromPriceResponse( option ) }
+				value={ priceWithTaxes }
+			/>
+		),
+		secondaryDescription: decodeEntities( option.delivery_time ),
+	};
+};
 
 /**
  * Main Checkout Component.

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -165,6 +165,12 @@ class CartShippingRateSchema extends AbstractSchema {
 					'context'     => [ 'view', 'edit' ],
 					'readonly'    => true,
 				],
+				'taxes'         => [
+					'description' => __( 'Taxes applied to this shipping rate using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
 				'method_id'     => [
 					'description' => __( 'ID of the shipping method that provided the rate.', 'woo-gutenberg-products-block' ),
 					'type'        => 'string',
@@ -299,6 +305,7 @@ class CartShippingRateSchema extends AbstractSchema {
 				'description'   => $this->prepare_html_response( $this->get_rate_prop( $rate, 'description' ) ),
 				'delivery_time' => $this->prepare_html_response( $this->get_rate_prop( $rate, 'delivery_time' ) ),
 				'price'         => $this->prepare_money_response( $this->get_rate_prop( $rate, 'cost' ), wc_get_price_decimals() ),
+				'taxes'         => $this->prepare_money_response( array_sum( $this->get_rate_prop( $rate, 'taxes' ) ), wc_get_price_decimals() ),
 				'instance_id'   => $this->get_rate_prop( $rate, 'instance_id' ),
 				'method_id'     => $this->get_rate_prop( $rate, 'method_id' ),
 				'meta_data'     => $this->get_rate_meta_data( $rate ),


### PR DESCRIPTION
Fixes #2626.

### How to test the changes in this Pull Request:
1. Go to _WooCommerce_ > _Settings_ > _Tax_ > _Tax options_ and set _Display prices during cart and checkout_ to _Including tax_:
![imatge](https://user-images.githubusercontent.com/3616980/83771631-c5a36300-a682-11ea-9a42-dfa71a1e6641.png)
2. Set a flat rate shipping method with cost 5:
![imatge](https://user-images.githubusercontent.com/3616980/83772266-7d387500-a683-11ea-8105-17e47ee68487.png)
3. Set default tax rates to 10%:
![imatge](https://user-images.githubusercontent.com/3616980/83772343-90e3db80-a683-11ea-976e-e20b530e8707.png)
4. Now, as a customer, add a product that needs shipping to your cart and visit the _Cart_ page (with the block).
5. Verify the shipping method options show the prices with taxes.

| `main` | This branch |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/85031775-5dbf4300-b17f-11ea-9b3c-19715c3e569c.png) | ![imatge](https://user-images.githubusercontent.com/3616980/85031660-3bc5c080-b17f-11ea-8517-7c93c0076645.png) |

6. Go to the Checkout page and verify shipping method prices also appear with taxes.

### Changelog

> Cart and Checkout blocks display shipping methods with tax rates if that's how it's set in the settings.