### PR TITLE
optionally render product description in best-sellers block

### DIFF
--- a/assets/js/components/grid-content-control/index.js
+++ b/assets/js/components/grid-content-control/index.js
@@ -11,6 +11,8 @@ import { ToggleControl } from '@wordpress/components';
  */
 const GridContentControl = ( { onChange, settings } ) => {
 	const { button, price, rating, title } = settings;
+	const description = settings?.description ?? false;
+
 	return (
 		<Fragment>
 			<ToggleControl
@@ -63,6 +65,27 @@ const GridContentControl = ( { onChange, settings } ) => {
 			/>
 			<ToggleControl
 				label={ __(
+					'Short description',
+					'woo-gutenberg-products-block'
+				) }
+				help={
+					description
+						? __(
+								'Product description is visible.',
+								'woo-gutenberg-products-block'
+						  )
+						: __(
+								'Product description is hidden.',
+								'woo-gutenberg-products-block'
+						  )
+				}
+				checked={ description }
+				onChange={ () =>
+					onChange( { ...settings, description: ! description } )
+				}
+			/>
+			<ToggleControl
+				label={ __(
 					'Add to Cart button',
 					'woo-gutenberg-products-block'
 				) }
@@ -93,6 +116,7 @@ GridContentControl.propTypes = {
 		price: PropTypes.bool.isRequired,
 		rating: PropTypes.bool.isRequired,
 		title: PropTypes.bool.isRequired,
+		description: PropTypes.bool,
 	} ).isRequired,
 	/**
 	 * Callback to update the layout settings.

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -91,10 +91,11 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'title'  => $this->get_schema_boolean( true ),
-				'price'  => $this->get_schema_boolean( true ),
-				'rating' => $this->get_schema_boolean( true ),
-				'button' => $this->get_schema_boolean( true ),
+				'title'       => $this->get_schema_boolean( true ),
+				'price'       => $this->get_schema_boolean( true ),
+				'rating'      => $this->get_schema_boolean( true ),
+				'button'      => $this->get_schema_boolean( true ),
+				'description' => $this->get_schema_boolean( true ),
 			),
 		);
 	}
@@ -324,13 +325,14 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		}
 
 		$data = (object) array(
-			'permalink' => esc_url( $product->get_permalink() ),
-			'image'     => $this->get_image_html( $product ),
-			'title'     => $this->get_title_html( $product ),
-			'rating'    => $this->get_rating_html( $product ),
-			'price'     => $this->get_price_html( $product ),
-			'badge'     => $this->get_sale_badge_html( $product ),
-			'button'    => $this->get_button_html( $product ),
+			'permalink'   => esc_url( $product->get_permalink() ),
+			'image'       => $this->get_image_html( $product ),
+			'title'       => $this->get_title_html( $product ),
+			'rating'      => $this->get_rating_html( $product ),
+			'price'       => $this->get_price_html( $product ),
+			'badge'       => $this->get_sale_badge_html( $product ),
+			'description' => $this->get_description( $product ),
+			'button'      => $this->get_button_html( $product ),
 		);
 
 		return apply_filters(
@@ -343,6 +345,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 				{$data->badge}
 				{$data->price}
 				{$data->rating}
+				{$data->description}
 				{$data->button}
 			</li>",
 			$data,
@@ -444,6 +447,22 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			return '';
 		}
 		return '<div class="wp-block-button wc-block-grid__product-add-to-cart">' . $this->get_add_to_cart( $product ) . '</div>';
+	}
+
+
+	/**
+	 * Render product description.
+	 *
+	 * @param \WC_Product $product Product.
+	 * @return string Rendered description markup.
+	 */
+	protected function get_description( $product ) {
+		if ( empty( $this->attributes['contentVisibility']['description'] ) ) {
+			return '';
+		}
+		$short_description = apply_filters( 'woocommerce_short_description', $product->get_short_description() ? $product->get_short_description() : wc_trim_string( $product->get_description(), 400 ) );
+
+		return '<div class="wc-block-grid__product-description">' . $short_description . '</div>';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1286

This adds a new option to the Best Sellers block for displaying the short description text. This defaults to hidden, consistent with previous behaviour.

This is somewhat similar to the forthcoming behaviour for customising the content displayed in the [(single) Product block](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2379). In that block, there are element blocks that can be selected and moved around for things like price, title, description, and these are implement as react components and rendered on the front end. The existing "product grid" blocks are implemented using PHP and rendered on the server. 

In this PR, I've added support to the PHP server-side render (SSR) code for the description field (just for `Best Sellers` to start). I'm keen for feedback about whether we should continue and implement this across all these SSR grid blocks, or whether we should hold off in anticipation of using react/front-end render for these blocks too. cc @nerrad @mikejolley for thoughts on this. 

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="933" alt="Screen Shot 2020-06-19 at 3 53 46 PM" src="https://user-images.githubusercontent.com/4167300/85095298-14392b80-b245-11ea-9d3d-ce84b5842a95.png">

<img width="1236" alt="Screen Shot 2020-06-19 at 3 54 13 PM" src="https://user-images.githubusercontent.com/4167300/85095318-21561a80-b245-11ea-9c44-6fc701cf7400.png">

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.
