### PR TITLE
Fix instability with snapshot tests

### DIFF
--- a/tests/utils/visit-block-page.js
+++ b/tests/utils/visit-block-page.js
@@ -49,7 +49,7 @@ export async function visitBlockPage( title ) {
 		await page.type( '#post-search-input', title );
 		await page.click( '#search-submit', { waitUntil: 'domcontentloaded' } );
 		const pageLink = await page.$x( `//a[contains(text(), '${ title }')]` );
-		if ( ( await pageLink.length ) > 0 ) {
+		if ( pageLink.length > 0 ) {
 			// clicking the link directly caused racing issues, so I used goto.
 			link = await page.evaluate(
 				( a ) => a.getAttribute( 'href' ),


### PR DESCRIPTION
Fixes: #2741 

After some investigation/debugging on why the snapshot test for the Product Search block was unstable (intermittently fails on any e2e job on travis), I determined the following:

I did the following in my debugging:

- verified pages were getting created from fixtures okay on travis
- verified that the created test page link would get found via the [xPath selector](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/72aca6d765ee70e0bcaf5474ff0a65449d2415d1/tests/utils/visit-block-page.js#L51)
- console.logging the derived link after [this condition](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/72aca6d765ee70e0bcaf5474ff0a65449d2415d1/tests/utils/visit-block-page.js#L52-L58) revealed that it was an empty string when the snapshot failed (which meant the page was getting recreated).

So it had to be either the condition itself (unnecessary await), or the evaluate expression inside that condition. The `await` is definitely unnecessary so I removed that and subsequent repeated test runs seemed to all pass without fails. If travis passes one more time after I convert this pull from draft then I'll merge it. Hopefully that will resolve things for good.

Note: I suspect the expression `( await pageLink.length ) > 0` was what was randomly causing the fails due to potential timing issues because `await` wraps a non-promise in a Promise and resolves. But honestly I don't really know 😄 .