### PR TITLE
Release: 2.8.0

### DIFF
--- a/docs/testing/releases/260.md
+++ b/docs/testing/releases/260.md
@@ -1,6 +1,6 @@
 [![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
 
-## Testing Notes and ZIP for testing
+## Testing notes and ZIP for release 2.6.0
 
 **Zip File for testing:**
 [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/archive/v2.6.0.zip)

--- a/docs/testing/releases/261.md
+++ b/docs/testing/releases/261.md
@@ -1,7 +1,9 @@
 Release build zip:
 [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/archive/v2.6.1.zip)
 
-## To test:
+## Testing notes and ZIP for release 2.6.1
+
+### To test:
 
 1. View your stock table (`wc_reserved_stock`) in the database
 2. Go to checkout with some items in the cart

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -1,6 +1,6 @@
 [![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
 
-## Testing notes and ZIP for testing
+## Testing notes and ZIP for release 2.7.0
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4747000/woocommerce-gutenberg-products-block.zip)
 

--- a/docs/testing/releases/271.md
+++ b/docs/testing/releases/271.md
@@ -1,6 +1,6 @@
 [![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
 
-## Testing notes and ZIP for testing
+## Testing notes and ZIP for release 2.7.1
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4785662/woocommerce-gutenberg-products-block.zip)
 

--- a/docs/testing/releases/280.md
+++ b/docs/testing/releases/280.md
@@ -1,0 +1,84 @@
+[![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
+
+## Testing notes and ZIP for release 2.8.0
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4826924/woocommerce-gutenberg-products-block.zip)
+
+### Cart & Checkout <!-- heading -->
+
+#### Tax display in shipping methods <!-- heading -->
+
+- [ ] Go to _WooCommerce_ > _Settings_ > _Tax_ > _Tax options_ and set _Display prices during cart and checkout_ to _Including tax_:
+![imatge](https://user-images.githubusercontent.com/3616980/83771631-c5a36300-a682-11ea-9a42-dfa71a1e6641.png)
+- [ ] Set a flat rate shipping method with cost 5:
+![imatge](https://user-images.githubusercontent.com/3616980/83772266-7d387500-a683-11ea-8105-17e47ee68487.png)
+- [ ] Set default tax rates to 10%:
+![imatge](https://user-images.githubusercontent.com/3616980/83772343-90e3db80-a683-11ea-976e-e20b530e8707.png)
+- [ ] Now, as a customer, add a product that needs shipping to your cart and visit the _Cart_ page (with the block).
+- [ ] Go to the Checkout page and verify shipping method prices also appear with taxes [#2748](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2748).
+
+#### Accessibility <!-- heading -->
+
+- [ ] With a screen reader navigate the Cart block and verify when the Change address button is focused, it correctly announces whether it's expanded or not [#2603](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2603).
+
+#### Styling <!-- heading -->
+
+- [ ] Change to a theme with a background color different from white or in the customizer change Storefront's background color to another one.
+- Visit the Checkout page and verify that  <!-- heading -->
+- [ ] The `Express checkout` title doesn't have a background color different from the rest of the page and has left and right padding (so it doesn't collide with the border).
+- [ ] The `Express checkout` and `Order summary` titles are aligned.
+- [ ] The `Express checkout` box border is 1px wide, like in the [new designs](https://user-images.githubusercontent.com/3616980/83534129-c0161380-a4f0-11ea-985f-851b40d2e92b.png).
+
+- [ ] Disable all shipping methods but one.
+- [ ] Go to the Cart page and verify there is no double-border between the shipping method and the _Coupon Code_ panel (the border should be 1px instead of 2px as it was before).
+
+![imatge](https://user-images.githubusercontent.com/3616980/84389951-25f05280-abf7-11ea-90d5-27d182982e43.png)
+
+- [ ] Create a product with a long name.
+- [ ] Go to the Checkout page and resize the window to trigger different sizes.
+- [ ] Verify there is always spacing between the product name and the price in the _Order summary_ panel.
+![imatge](https://user-images.githubusercontent.com/3616980/84388946-ad3cc680-abf5-11ea-94cf-2f4c30f5e40e.png)
+
+- [ ] Still in the Checkout page, verify the _Order summary_ panel doesn't have top and bottom borders.
+
+![imatge](https://user-images.githubusercontent.com/3616980/84389065-d2313980-abf5-11ea-9215-1356919d29ed.png)
+
+- [ ] Make sure you don't have any express payment method enabled.
+- [ ] Go to the Checkout page.
+- [ ] Verify the step 1 title and the sidebar title are aligned.
+
+![imatge](https://user-images.githubusercontent.com/3616980/84397770-5dfb9380-abff-11ea-8ca4-12cd393cd8b1.png)
+
+- [ ] Add the Checkout block to a page or post and, in the editor, verify there is no spacing between the product description and the product variations in the _Order summary_.
+
+![imatge](https://user-images.githubusercontent.com/3616980/84389163-f2f98f00-abf5-11ea-9f77-63032fee21f6.png)
+
+- [ ] Disable all shipping options from your store.
+- [ ] Go to the Cart block.
+- [ ] Verify there is margin below the 'no shipping options' notice.
+
+![imatge](https://user-images.githubusercontent.com/3616980/84391799-be87d200-abf9-11ea-9d50-dd6e8b11cf5b.png)
+
+- [ ] With Storefront, go to Appearance > Customize and change the typography color.
+- [ ] Verify the color is applied to the Cart and Checkout text and borders.
+- [ ] Test other themes to verify there are no regressions.
+
+
+### Product Categories List <!-- heading -->
+
+#### Fix Product Categories List breaking when changing align attribute. <!-- heading -->
+
+- [ ] Add a Product Categories List block to a page.
+- [ ] Switch to _Full Width_ align.
+- [ ] Verify the block doesn't show an error.
+- [ ] If you are using Storefront or another theme with sidebar, make sure the page has the _Full Width_ template.
+- [ ] Open the page in the frontend and verify the Product Categories List block is aligned as a full width block.
+
+### Miscellaneous <!-- heading -->
+
+- [ ] Go to Appearance > Customize > WooCommerce > Product images and change the cropping options.
+- [ ] Test the Cart, Checkout and Review blocks (for Review blocks, you might need to change its attributes so it shows the product image instead of the customer image) and verify they show the cropped image.
+- [ ] Edit an old All Products block and verify the block didn't invalidate.
+- [ ] Edit it and select the Product image inner block. There, toggle the _Image sizing_ attribute.
+- [ ] Verify when _Cropped_ is selected, the cropped image is displayed.
+- [ ] Repeat the process with the Product block.

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -4,3 +4,4 @@ Every release includes specific testing instructions for features and bug fixes 
     - [2.6.1](./261.md)
 - [2.7.0](./270.md)
     - [2.7.1](./271.md)
+- [2.8.0](./280.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "2.8.0-dev",
+	"version": "2.8.0",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 2.7.0
+Stable tag: 2.8.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,17 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 2.8.0 - 2020-06-23 =
+- bug: Cart and Checkout blocks display shipping methods with tax rates if that's how it's set in the settings. [#2748](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2748)
+- bug: Fix an error appearing in the Product Categories List block with _Full Width_ align. [#2700](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2700)
+- enhancement: Added aria-expanded attribute to Change address button in the Cart block [#2603](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2603)
+- enhancement: Fix updating the `wc_reserve_stock` stock_quantity value after making changes to the cart inbetween checkouts. [#2747](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2747)
+- enhancement: Remove background color from Express checkout title. [#2704](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2704)
+- enhancement: Several style enhancements to the Cart and Checkout blocks sidebar. [#2694](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2694)
+- enhancement: The Cart and Checkout blocks now use the font colors provided by the theme. [#2745](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2745)
+- enhancement: Update some class names to match the new guidelines. [Check the docs](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/theming/README.md) in order to see which class names have been updated. [#2691](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2691) [DN]
+- enhancement: Blocks now respect the product image cropping settings. For the All Products block, the user can switch between the cropped thumbnail and the full size image. [#2755](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2755)
+
 = 2.7.1 - 2020-06-16 =
 - bug: Use IE11 friendly code for Dashicon component replacement. [#2708](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2708)
 - bug: Fix PHP warnings produced by StoreAPI endpoints when variations have no prices. [#2722](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2722)

--- a/src/Package.php
+++ b/src/Package.php
@@ -101,7 +101,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '2.7.0';
+					$version = '2.8.0';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.8.0-dev
+ * Version: 2.8.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This is the release pull request for 2.8.0 of the WooCommerce Blocks plugin.

## Communication

<!--
  This section is for any notes related to communicating the release.
  Please include any extra details with each item as needed.
-->

This release introduces:

> This release introduces several updates to Cart and Checkout styles to work better with other themes out of the box, it also fixes an issue with the stock reserve table, and introduce cropped images in All Products, Cart & Checkout, and Reviews blocks.

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

<!--
In this section you are highlighting all the public facing documentation that is related to the
release. Feel free to remove anything that doesn't apply for this release.
-->

**Release announcement:** <!-- Link to release announcement post on developer.woocommerce.com (published after release) -->

**Developer Notes** - The following issues require developer notes in the release post:
This PR needs a dev note in the release post
https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2691

<!--
Issues or pulls needing a developer note are labelled with `status: needs-dev-note`. Review
those and list here as checklist items. You can have different engineers write the notes
(usually the engineer that did the changes) if needed, but they should be summarized and included in the release post.
-->


**Relevant developer documentation:** <!-- Link(s) to any developer documentation related to the release -->
[Class names update in 2.8.0](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/theming/class-names-update-280.md)


* [x] The release includes a changelog entry in the readme.txt?


## Quality

* [x] Changes in this release are covered by Automated Tests.
Those changes are not covered by any tests we have because they mostly target styling features.

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [ ] This release impacts **other extensions** or **backward compatibility**.
    * [ ] The release changes the signature of public methods or functions
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)
    * [ ] The release affects filters or action hooks.
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)

* [ ] Link to **testing instructions** for this release: [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/6378e908b45b8065b4cc0a16bfc2d7692a12737a/docs/testing/releases/280.md)

* [x] The release has a negative performance impact on sites.
We have a small bundle increase in some of our files

| Bundle                               | Release 2 7 | Release 2 8 | Diff   |
| ------------------------------------ | ----------- | ----------- | ------ |
| `./build/all-products.js`            | 20.34KB     | 24.4KB      | 4.06KB |
| `./build/single-product.js`          | 14.67KB     | 17.9KB      | 3.23KB |
| `./build/all-products-frontend.js`   | 37.61KB     | 40.35KB     | 2.75KB |
| `./build/single-product-frontend.js` | 40.36KB     | 43.11KB     | 2.74KB |
| `./build/vendors.js`                 | 404.93KB    | 405.99KB    | 1.06KB |

