### PR TITLE
More e2e snapshot instability investigation

### DIFF
--- a/tests/utils/visit-block-page.js
+++ b/tests/utils/visit-block-page.js
@@ -47,7 +47,8 @@ export async function visitBlockPage( title ) {
 	if ( await page.$( '#post-search-input' ) ) {
 		// search for the page.
 		await page.type( '#post-search-input', title );
-		await page.click( '#search-submit', { waitUntil: 'domcontentloaded' } );
+		await page.click( '#search-submit' );
+		await page.waitForNavigation( { waitUntil: 'domcontentloaded' } );
 		const pageLink = await page.$x( `//a[contains(text(), '${ title }')]` );
 		if ( pageLink.length > 0 ) {
 			// clicking the link directly caused racing issues, so I used goto.


### PR DESCRIPTION
#2764 didn't resolve the instability, the test run on master surfaced another fail due to snapshot change.  On debugging I noticed that this line is not resolving an expected result:

```js
const pageLink = await page.$x( `//a[contains(text(), '${ title }')]` );
```

Then I noticed that before this line, there is a call to `await page.click( '#search-submit', { waitFor: 'domcontentloaded' } );`.  However, [according to the documentation](https://devdocs.io/puppeteer/index#pageclickselector-options), `waitFor` is **not** an option for `page.click()`.  It appears convention is to use `page.waitForNavigation` when a click/submit results in a page load (and it _does_ accept a `waitFor` option).

Tests seem to be handling this change okay, so I'm going to merge this change and see if it improves things.