### PR TITLE
Reorder internal/external dependencies

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -1,4 +1,21 @@
 /**
+ * External dependencies
+ */
+import {
+	createContext,
+	useContext,
+	useState,
+	useReducer,
+	useCallback,
+	useEffect,
+	useRef,
+	useMemo,
+} from '@wordpress/element';
+import { getSetting } from '@woocommerce/settings';
+import { useStoreNotices, useEmitResponse } from '@woocommerce/base-hooks';
+import { useEditorContext } from '@woocommerce/base-context';
+
+/**
  * Internal dependencies
  */
 import {
@@ -30,23 +47,6 @@ import {
 	reducer as emitReducer,
 } from './event-emit';
 import { useValidationContext } from '../validation';
-
-/**
- * External dependencies
- */
-import {
-	createContext,
-	useContext,
-	useState,
-	useReducer,
-	useCallback,
-	useEffect,
-	useRef,
-	useMemo,
-} from '@wordpress/element';
-import { getSetting } from '@woocommerce/settings';
-import { useStoreNotices, useEmitResponse } from '@woocommerce/base-hooks';
-import { useEditorContext } from '@woocommerce/base-context';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').PaymentMethodDataContext} PaymentMethodDataContext

--- a/assets/js/data/query-state/test/selectors.js
+++ b/assets/js/data/query-state/test/selectors.js
@@ -1,12 +1,12 @@
 /**
- * Internal dependencies
- */
-import { getValueForQueryKey, getValueForQueryContext } from '../selectors';
-
-/**
  * External dependencies
  */
 import deepFreeze from 'deep-freeze';
+
+/**
+ * Internal dependencies
+ */
+import { getValueForQueryKey, getValueForQueryContext } from '../selectors';
 
 const testState = deepFreeze( {
 	contexta: JSON.stringify( {

--- a/assets/js/data/schema/test/reducers.js
+++ b/assets/js/data/schema/test/reducers.js
@@ -1,13 +1,13 @@
 /**
+ * External dependencies
+ */
+import deepFreeze from 'deep-freeze';
+
+/**
  * Internal dependencies
  */
 import { receiveRoutes } from '../reducers';
 import { ACTION_TYPES as types } from '../action-types';
-
-/**
- * External dependencies
- */
-import deepFreeze from 'deep-freeze';
 
 describe( 'receiveRoutes', () => {
 	it( 'returns original state when action type is not a match', () => {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -1,16 +1,16 @@
 /**
+ * External dependencies
+ */
+import { Elements, useStripe } from '@stripe/react-stripe-js';
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 import { getStripeServerData } from '../stripe-utils';
 import { useCheckoutSubscriptions } from './use-checkout-subscriptions';
 import { InlineCard, CardElements } from './elements';
-
-/**
- * External dependencies
- */
-import { Elements, useStripe } from '@stripe/react-stripe-js';
-import { useState } from '@wordpress/element';
 
 /**
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/payment-request-express.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/payment-request-express.js
@@ -1,14 +1,14 @@
 /**
+ * External dependencies
+ */
+import { Elements, PaymentRequestButtonElement } from '@stripe/react-stripe-js';
+
+/**
  * Internal dependencies
  */
 import { getStripeServerData } from '../stripe-utils';
 import { useInitialization } from './use-initialization';
 import { useCheckoutSubscriptions } from './use-checkout-subscriptions';
-
-/**
- * External dependencies
- */
-import { Elements, PaymentRequestButtonElement } from '@stripe/react-stripe-js';
 
 /**
  * @typedef {import('../stripe-utils/type-defs').Stripe} Stripe

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -1,14 +1,14 @@
 /**
- * Internal dependencies
- */
-import { normalizeLineItems } from './normalize';
-import { errorTypes, errorCodes } from './constants';
-
-/**
  * External dependencies
  */
 import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { normalizeLineItems } from './normalize';
+import { errorTypes, errorCodes } from './constants';
 
 /**
  * @typedef {import('./type-defs').StripeServerData} StripeServerData

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -1,12 +1,12 @@
 /**
- * Internal dependencies
- */
-import { getSetting } from './get-setting';
-
-/**
  * External dependencies
  */
 import compareVersions from 'compare-versions';
+
+/**
+ * Internal dependencies
+ */
+import { getSetting } from './get-setting';
 
 export * from './default-constants';
 export { setSetting } from './set-setting';


### PR DESCRIPTION
Part of #2052 

This just reorders external dependencies to be defined before internal dependencies. Found using regex.

Not much to test; just a successful build as no other changes were made.