### PR TITLE
Update dependency rules to enforce order and `WooCommerce dependencies`

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -3,6 +3,10 @@
  */
 import { getCategories, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * WooCommerce dependencies
+ */
 import { woo as Icon } from '@woocommerce/icons';
 
 /**
@@ -15,7 +19,7 @@ import './filters/get-block-attributes';
 
 setCategories( [
 	...getCategories().filter( ( { slug } ) => slug !== 'woocommerce' ),
-	// Add a WooCommerce block category
+	// Add a WooCommerce block category.
 	{
 		slug: 'woocommerce',
 		title: __( 'WooCommerce', 'woo-gutenberg-products-block' ),

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"lint:ci": "npm run lint:js && npm run lint:css",
 		"lint:css": "stylelint 'assets/**/*.scss'",
 		"lint:css-fix": "stylelint 'assets/**/*.scss' --fix",
-		"lint:js": "wp-scripts lint-js",
+		"lint:js": "wp-scripts lint-js -f codeframe",
 		"lint:js-fix": "eslint assets/js --ext=js,jsx --fix",
 		"lint:php": "composer run-script phpcs ./src",
 		"package-plugin": "./bin/build-plugin-zip.sh",
@@ -186,11 +186,11 @@
 	},
 	"lint-staged": {
 		"*.scss": [
-			"npm run lint:css"
+			"npm run lint:css -s"
 		],
 		"*.js": [
 			"prettier --write",
-			"npm run lint:js"
+			"npm run lint:js -s"
 		],
 		"*.php": [
 			"php -d display_errors=1 -l",


### PR DESCRIPTION
This PR probably needs some debate due to the `WooCommerce` rule, but giving you the option :) 

- Uses codeframe formatter to improve output of linting errors
- Adds a linting rule to ensure the order of dependencies is External, WooCommerce, Internal.
- Adds a linting rule to enforce `@woocommerce` dependencies under their own section

I've updated one file to check the rules pass.

![GitHub Desktop 2020-06-24 11-22-52](https://user-images.githubusercontent.com/90977/85541984-85475d00-b610-11ea-99a0-9917295bcfca.png)

Closes #2052

Note: WooCommerce admin uses this structure in it's dependencies too.