### PR TITLE
Sort states and countries correctly using `deep_sort_with_accents`

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -78,15 +78,12 @@ class Cart extends AbstractBlock {
 			AssetDataRegistry::class
 		);
 
-		$block_data = [
-			'shippingCountries' => [ WC()->countries, 'get_shipping_countries' ],
-			'shippingStates'    => [ WC()->countries, 'get_shipping_country_states' ],
-		];
+		if ( ! $data_registry->exists( 'shippingCountries' ) ) {
+			$data_registry->add( 'shippingCountries', $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() ) );
+		}
 
-		foreach ( $block_data as $key => $callback ) {
-			if ( ! $data_registry->exists( $key ) ) {
-				$data_registry->add( $key, call_user_func( $callback ) );
-			}
+		if ( ! $data_registry->exists( 'shippingStates' ) ) {
+			$data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
 		}
 
 		$permalink = ! empty( $attributes['checkoutPageId'] ) ? get_permalink( $attributes['checkoutPageId'] ) : false;
@@ -101,6 +98,27 @@ class Cart extends AbstractBlock {
 		}
 
 		do_action( 'woocommerce_blocks_cart_enqueue_data' );
+	}
+
+	/**
+	 * Removes accents from an array of values, sorts by the values, then returns the original array values sorted.
+	 *
+	 * @param array $array Array of values to sort.
+	 * @return array Sorted array.
+	 */
+	protected function deep_sort_with_accents( $array ) {
+		if ( ! is_array( $array ) ) {
+			return $array;
+		}
+
+		if ( is_array( reset( $array ) ) ) {
+			return array_map( [ $this, 'deep_sort_with_accents' ], $array );
+		}
+
+		$array_without_accents = array_map( 'remove_accents', $array );
+		asort( $array_without_accents );
+
+		return array_replace( $array_without_accents, $array );
 	}
 
 	/**

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -107,7 +107,7 @@ class Cart extends AbstractBlock {
 	 * @return array Sorted array.
 	 */
 	protected function deep_sort_with_accents( $array ) {
-		if ( ! is_array( $array ) ) {
+		if ( ! is_array( $array ) || empty( $array ) ) {
 			return $array;
 		}
 
@@ -115,9 +115,8 @@ class Cart extends AbstractBlock {
 			return array_map( [ $this, 'deep_sort_with_accents' ], $array );
 		}
 
-		$array_without_accents = array_map( 'remove_accents', $array );
+		$array_without_accents = array_map( 'remove_accents', array_map( 'wc_strtolower', array_map( 'html_entity_decode', $array ) ) );
 		asort( $array_without_accents );
-
 		return array_replace( $array_without_accents, $array );
 	}
 

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -131,7 +131,7 @@ class Checkout extends AbstractBlock {
 	 * @return array Sorted array.
 	 */
 	protected function deep_sort_with_accents( $array ) {
-		if ( ! is_array( $array ) ) {
+		if ( ! is_array( $array ) || empty( $array ) ) {
 			return $array;
 		}
 
@@ -139,9 +139,8 @@ class Checkout extends AbstractBlock {
 			return array_map( [ $this, 'deep_sort_with_accents' ], $array );
 		}
 
-		$array_without_accents = array_map( 'remove_accents', $array );
+		$array_without_accents = array_map( 'remove_accents', array_map( 'wc_strtolower', array_map( 'html_entity_decode', $array ) ) );
 		asort( $array_without_accents );
-
 		return array_replace( $array_without_accents, $array );
 	}
 

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -84,17 +84,20 @@ class Checkout extends AbstractBlock {
 			AssetDataRegistry::class
 		);
 
-		$block_data = [
-			'allowedCountries'  => [ WC()->countries, 'get_allowed_countries' ],
-			'shippingCountries' => [ WC()->countries, 'get_shipping_countries' ],
-			'allowedStates'     => [ WC()->countries, 'get_allowed_country_states' ],
-			'shippingStates'    => [ WC()->countries, 'get_shipping_country_states' ],
-		];
+		if ( ! $data_registry->exists( 'allowedCountries' ) ) {
+			$data_registry->add( 'allowedCountries', $this->deep_sort_with_accents( WC()->countries->get_allowed_countries() ) );
+		}
 
-		foreach ( $block_data as $key => $callback ) {
-			if ( ! $data_registry->exists( $key ) ) {
-				$data_registry->add( $key, call_user_func( $callback ) );
-			}
+		if ( ! $data_registry->exists( 'allowedStates' ) ) {
+			$data_registry->add( 'allowedStates', $this->deep_sort_with_accents( WC()->countries->get_allowed_country_states() ) );
+		}
+
+		if ( ! $data_registry->exists( 'shippingCountries' ) ) {
+			$data_registry->add( 'shippingCountries', $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() ) );
+		}
+
+		if ( ! $data_registry->exists( 'shippingStates' ) ) {
+			$data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
 		}
 
 		$permalink = ! empty( $attributes['cartPageId'] ) ? get_permalink( $attributes['cartPageId'] ) : false;
@@ -119,6 +122,27 @@ class Checkout extends AbstractBlock {
 		}
 
 		do_action( 'woocommerce_blocks_checkout_enqueue_data' );
+	}
+
+	/**
+	 * Removes accents from an array of values, sorts by the values, then returns the original array values sorted.
+	 *
+	 * @param array $array Array of values to sort.
+	 * @return array Sorted array.
+	 */
+	protected function deep_sort_with_accents( $array ) {
+		if ( ! is_array( $array ) ) {
+			return $array;
+		}
+
+		if ( is_array( reset( $array ) ) ) {
+			return array_map( [ $this, 'deep_sort_with_accents' ], $array );
+		}
+
+		$array_without_accents = array_map( 'remove_accents', $array );
+		asort( $array_without_accents );
+
+		return array_replace( $array_without_accents, $array );
 	}
 
 	/**


### PR DESCRIPTION
Fixes state sorting by removing accents before performing the sort.

Alternative fix for https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1903

Closes #1903 
Fixes #1902

### How to test the changes in this Pull Request:

1. Switch to Catalan.
2. Dashboard > Updates > Download translation packs
3. Go to Block Checkout
4. Select Espanya
5. View state dropdown. Verify Illes Balears is correctly sorted after Huelva.

### Changelog

> Correctly sort states after translation on Block Checkout.
