### PR TITLE
Add custom jest e2e matcher

### DIFF
--- a/tests/e2e-tests/config/custom-matchers/index.js
+++ b/tests/e2e-tests/config/custom-matchers/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './to-render-block.js';

--- a/tests/e2e-tests/config/custom-matchers/to-render-block.js
+++ b/tests/e2e-tests/config/custom-matchers/to-render-block.js
@@ -1,0 +1,55 @@
+expect.extend( {
+	async toRenderBlock( page, block = {} ) {
+		const gutenbergNotFoundError = ( await page.content() ).match(
+			/Your site doesn’t include support for/gi
+		);
+		if ( gutenbergNotFoundError !== null ) {
+			return {
+				message: () =>
+					`the ${ block.name ||
+						'block' } is not registered and not loading in the editor.`,
+				pass: false,
+			};
+		}
+
+		const gutenbergValidationError = ( await page.content() ).match(
+			/This block contains unexpected or invalid content/gi
+		);
+		if ( gutenbergValidationError !== null ) {
+			return {
+				message: () =>
+					`the ${ block.name ||
+						'block' } had a validation error while trying to render.`,
+				pass: false,
+			};
+		}
+
+		const errorBoundary = ( await page.content() ).match(
+			/There was an error whilst rendering/gi
+		);
+		if ( errorBoundary !== null ) {
+			return {
+				message: () =>
+					`the ${ block.name ||
+						'block' } had a js error that was caught by our errorBoundary.`,
+				pass: false,
+			};
+		}
+
+		const blockElement = await page.$( block.class );
+		if ( blockElement === null ) {
+			return {
+				message: () =>
+					`the ${ block.name || 'block' } with classname \`${
+						block.class
+					}\` did not render.`,
+				pass: false,
+			};
+		}
+
+		return {
+			message: () => `expected block to render without breaking.`,
+			pass: true,
+		};
+	},
+} );

--- a/tests/e2e-tests/config/jest.config.js
+++ b/tests/e2e-tests/config/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
 	// A list of paths to modules that run some code to configure or set up the testing framework
 	// before each test
 	setupFilesAfterEnv: [
+		'<rootDir>/tests/e2e-tests/config/custom-matchers/index.js',
 		'<rootDir>/tests/e2e-tests/config/jest.setup.js',
 		'expect-puppeteer',
 	],

--- a/tests/e2e-tests/specs/backend/all-products.test.js
+++ b/tests/e2e-tests/specs/backend/all-products.test.js
@@ -34,25 +34,6 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'renders without crashing', async () => {
-		// Gutenberg error
-		expect(
-			( await page.content() ).match(
-				/Your site doesn’t include support for/gi
-			)
-		).toBeNull();
-		// Our ErrorBoundary
-		expect(
-			( await page.content() ).match(
-				/There was an error whilst rendering/gi
-			)
-		).toBeNull();
-		// Validation Error
-		expect(
-			( await page.content() ).match(
-				/This block contains unexpected or invalid content/gi
-			)
-		).toBeNull();
-
-		await expect( page ).toMatchElement( block.class );
+		await expect( page ).toRenderBlock( block );
 	} );
 } );

--- a/tests/e2e-tests/specs/backend/cart.test.js
+++ b/tests/e2e-tests/specs/backend/cart.test.js
@@ -31,25 +31,6 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'renders without crashing', async () => {
-		// Gutenberg error
-		expect(
-			( await page.content() ).match(
-				/Your site doesn’t include support for/gi
-			)
-		).toBeNull();
-		// Our ErrorBoundary
-		expect(
-			( await page.content() ).match(
-				/There was an error whilst rendering/gi
-			)
-		).toBeNull();
-		// Validation Error
-		expect(
-			( await page.content() ).match(
-				/This block contains unexpected or invalid content/gi
-			)
-		).toBeNull();
-
-		await expect( page ).toMatchElement( block.class );
+		await expect( page ).toRenderBlock( block );
 	} );
 } );

--- a/tests/e2e-tests/specs/backend/checkout.test.js
+++ b/tests/e2e-tests/specs/backend/checkout.test.js
@@ -31,25 +31,6 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'renders without crashing', async () => {
-		// Gutenberg error
-		expect(
-			( await page.content() ).match(
-				/Your site doesn’t include support for/gi
-			)
-		).toBeNull();
-		// Our ErrorBoundary
-		expect(
-			( await page.content() ).match(
-				/There was an error whilst rendering/gi
-			)
-		).toBeNull();
-		// Validation Error
-		expect(
-			( await page.content() ).match(
-				/This block contains unexpected or invalid content/gi
-			)
-		).toBeNull();
-
-		await expect( page ).toMatchElement( block.class );
+		await expect( page ).toRenderBlock( block );
 	} );
 } );

--- a/tests/e2e-tests/specs/backend/product-search.test.js
+++ b/tests/e2e-tests/specs/backend/product-search.test.js
@@ -22,26 +22,7 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'renders without crashing', async () => {
-		// Gutenberg error
-		expect(
-			( await page.content() ).match(
-				/Your site doesn’t include support for/gi
-			)
-		).toBeNull();
-		// Our ErrorBoundary
-		expect(
-			( await page.content() ).match(
-				/There was an error whilst rendering/gi
-			)
-		).toBeNull();
-		// Validation Error
-		expect(
-			( await page.content() ).match(
-				/This block contains unexpected or invalid content/gi
-			)
-		).toBeNull();
-
-		await expect( page ).toMatchElement( block.class );
+		await expect( page ).toRenderBlock( block );
 	} );
 
 	it( 'can toggle field label', async () => {

--- a/tests/e2e-tests/specs/backend/single-product.test.js
+++ b/tests/e2e-tests/specs/backend/single-product.test.js
@@ -36,25 +36,6 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'renders without crashing', async () => {
-		// Gutenberg error
-		expect(
-			( await page.content() ).match(
-				/Your site doesn’t include support for/gi
-			)
-		).toBeNull();
-		// Our ErrorBoundary
-		expect(
-			( await page.content() ).match(
-				/There was an error whilst rendering/gi
-			)
-		).toBeNull();
-		// Validation Error
-		expect(
-			( await page.content() ).match(
-				/This block contains unexpected or invalid content/gi
-			)
-		).toBeNull();
-
-		await expect( page ).toMatchElement( block.class );
+		await expect( page ).toRenderBlock( block );
 	} );
 } );


### PR DESCRIPTION
This PR adds a custom matcher to jest for us to use in E2E tests `toRenderBlock` it checks if the page has any broken blocks in it, either due to not being registered, validation issues, or js error (caught by our block boundary), it also checks if the blocks exist, since the rest can all pass with no block.

The matcher is async so you will need to append `await` for it to work.

closes #2709 

### How to use

```
await expect( page ).toRenderBlock( {
	name: 'Single Product',
	class: '.wc-block-single-product'
} );
```
Or if you follow the new process of writing tests, it should be like this

```
await expect( page ).toRenderBlock( block );
```