### PR TITLE
add basic docs for running e2e tests

### DIFF
--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -51,3 +51,4 @@ When you're done, you may want to shut down the test environment:
 
 - `npm run wp-env stop` to stop the test environment
 
+**Note:** There are a number of other `wp-env` commands that would be useful to know. You can see them [here](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).

--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -51,4 +51,4 @@ When you're done, you may want to shut down the test environment:
 
 - `npm run wp-env stop` to stop the test environment
 
-**Note:** There are a number of other useful `wp-env` commands. You find out more [in wp-env docs](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).
+**Note:** There are a number of other useful `wp-env` commands. You can find out more in the [wp-env docs](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).

--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -4,9 +4,18 @@ Tests for JavaScript in the Blocks plugin are powered by [Jest](https://jestjs.i
 
 The Blocks plugin follows the same patterns as Gutenberg, therefore for instructions on writing tests you can [refer to this page in the Gutenberg Handbook](https://developer.wordpress.org/block-editor/contributors/develop/testing-overview/).
 
-## Running Tests
+We have two kinds of JavaScript tests:
 
-Assuming you've already followed the [Getting Started Guide](getting-started.md) on setting up node and other dependencies, tests are ran from the command line using the following command:
+- JavaScript unit tests - test APIs, hooks, library functionality that we use to build blocks or expose to plugin authors.
+- End-to-end (e2e) tests - test blocks from the user interface. 
+
+These tests are all run automatically on open PRs by Travis CI.
+
+## How to run JavaScript unit tests
+
+Unit tests are implemented near the code they test, in `*.test.js` files.
+
+Assuming you've already followed the [Getting Started Guide](getting-started.md) on setting up node and other dependencies, unit tests are ran from the command line using the following command:
 
 ```
 $ npm run test
@@ -18,3 +27,25 @@ Additionally,
 
 -   `test:update` updates the snapshot tests for components, used if you change a component that has tests attached.
 -   `test:watch` keeps watch of files and automatically re-runs tests when things change.
+
+## How to run end-to-end tests
+
+End-to-end tests are implemented in `tests/e2e-tests/specs/`.
+
+Since these drive the user interface, they need to run against a test environment - i.e. a web server running WordPress, Woo and blocks plugin, with a known state/configuration). 
+
+To set up to run e2e tests:
+
+- `npm run build:e2e-test` to build container images used for e2e
+- `npm run wp-env start` to start the test environment
+
+Then, to run the tests:
+
+- `npm run test:e2e` 
+
+When you're iterating on a new test you'll run this repeatedly until your test is just right.
+
+When you're done, you may want to shut down the test environment:
+
+- `npm run wp-env stop` to stop the test environment
+

--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -11,11 +11,13 @@ We have two kinds of JavaScript tests:
 
 These tests are all run automatically on open PRs by Travis CI.
 
+All the following tests require that the dependencies are installed (`npm install` `composer install`). Ensure you've followed the [Getting Started Guide](getting-started.md) to set up node and other dependencies before running any tests.
+
 ## How to run JavaScript unit tests
 
 Unit tests are implemented near the code they test, in `*.test.js` files.
 
-Assuming you've already followed the [Getting Started Guide](getting-started.md) on setting up node and other dependencies, unit tests are ran from the command line using the following command:
+Use the following command to run the unit tests:
 
 ```
 $ npm run test
@@ -43,7 +45,7 @@ Then, to run the tests:
 
 - `npm run test:e2e` 
 
-When you're iterating on a new test you'll run this repeatedly until your test is just right.
+When you're iterating on a new test you'll often run this repeatedly, as you develop, until your test is just right.
 
 When you're done, you may want to shut down the test environment:
 

--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -34,7 +34,7 @@ Additionally,
 
 End-to-end tests are implemented in `tests/e2e-tests/specs/`.
 
-Since these drive the user interface, they need to run against a test environment - i.e. a web server running WordPress, Woo and blocks plugin, with a known state/configuration). 
+Since these drive the user interface, they need to run against a test environment - i.e. a web server running WordPress, Woo and blocks plugin, with a known state/configuration. 
 
 To set up to run e2e tests:
 
@@ -51,4 +51,4 @@ When you're done, you may want to shut down the test environment:
 
 - `npm run wp-env stop` to stop the test environment
 
-**Note:** There are a number of other `wp-env` commands that would be useful to know. You can see them [here](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).
+**Note:** There are a number of other useful `wp-env` commands. You find out more [in wp-env docs](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).


### PR DESCRIPTION
Related #2718

Super basic docs for how to run our e2e tests, and clarifying the two kinds of "JavaScript tests" that we have.

### How to test the changes in this Pull Request:

- Read through the doc changes.
- Is it helpful, does it make sense?
- If you were a totally overwhelmed newbie in the team, would this help you run the e2e tests?