### PR TITLE
Document Cart & Checkout button styles

### DIFF
--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -15,6 +15,18 @@
 	text-transform: none;
 	position: relative;
 
+	&:hover,
+	&:focus,
+	&:active {
+		background-color: $black;
+		color: $white;
+	}
+
+	&:disabled {
+		background-color: transparentize($black, 0.3);
+		color: $white;
+	}
+
 	.wc-block-components-button__text {
 		display: block;
 

--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -2,6 +2,7 @@
 	@include reset-typography();
 	align-items: center;
 	background-color: $black;
+	border: 0;
 	color: $white;
 	display: inline-flex;
 	font-weight: bold;

--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -14,14 +14,6 @@
 	text-transform: none;
 	position: relative;
 
-	&:disabled,
-	&:hover,
-	&:focus,
-	&:active {
-		background-color: $black;
-		color: $white;
-	}
-
 	.wc-block-components-button__text {
 		display: block;
 

--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -2,7 +2,6 @@
 	@include reset-typography();
 	align-items: center;
 	background-color: $black;
-	border: 0;
 	color: $white;
 	display: inline-flex;
 	font-weight: bold;
@@ -15,15 +14,11 @@
 	text-transform: none;
 	position: relative;
 
+	&:disabled,
 	&:hover,
 	&:focus,
 	&:active {
 		background-color: $black;
-		color: $white;
-	}
-
-	&:disabled {
-		background-color: transparentize($black, 0.3);
 		color: $white;
 	}
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -220,12 +220,22 @@ table.wc-block-cart-items {
 	.wc-block-cart__submit-container {
 		background: $white;
 		bottom: 0;
-		box-shadow: 0 -10px 20px 10px transparentize($core-grey-light-700, 0.5);
 		left: 0;
 		padding: $gap;
 		position: fixed;
 		width: 100%;
 		z-index: 9999;
+
+		&::before {
+			box-shadow: 0 -10px 20px 10px currentColor;
+			color: transparentize($core-grey-light-700, 0.5);
+			content: "";
+			height: 100%;
+			left: 0;
+			position: absolute;
+			right: 0;
+			top: 0;
+		}
 	}
 	.wc-block-cart__submit-container-push {
 		height: 100px;

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -47,7 +47,7 @@ alternatively, themes can override the `box-shadow` property completely:
 
 ```CSS
 .wc-block-cart__submit-container::before {
-	box-shadow: 0 -10px 20px 10px rgba(214,209,203,0.5);
+	box-shadow: 0 -10px 20px 10px rgba(214, 209, 203, 0.5);
 }
 ```
 

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -10,7 +10,7 @@ By default, it uses a combination of black and white borders and shadows so it h
 
 ```CSS
 .wc-block-components-order-summary-item__quantity {
-	background: #f9f4ee;
+	background-color: #f9f4ee;
 	border-color: #4b3918;
 	box-shadow: 0 0 0 2px #f9f4ee;
 	color: #4b3918;

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -43,7 +43,7 @@ Take into consideration the container has a top box shadow that might not play w
 }
 ```
 
-alternatively, themes can override the `box-shadow` property completely:
+Alternatively, themes can override the `box-shadow` property completely:
 
 ```CSS
 .wc-block-cart__submit-container::before {

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -12,8 +12,9 @@ Themes can still style them to match theme colors or styles as follows:
 .wc-block-components-button {
 	background-color: #d5502f;
 	color: #fff;
-	/* You can add more rules to modify the border, shadow, etc. */
+	/* More rules can be added to modify the border, shadow, etc. */
 }
+/* It might be needed to modify the hover, focus, active and disabled states too */
 ```
 
 <img src="https://user-images.githubusercontent.com/3616980/86381505-b6b5cd80-bc8d-11ea-8ceb-cfbe84b411d4.png" alt="Button screenshot with custom styles" width="239" />
@@ -34,7 +35,7 @@ By default, the container has a white background so it plays well with the butto
 }
 ```
 
-Take into consideration the container has a top box shadow that might not play well with some dark background colors. If needed, it can be modified directly setting the `color` property (internally, shadow color uses `currentColor`, so it honored the `color` property):
+Take into consideration the container has a top box shadow that might not play well with some dark background colors. If needed, it can be modified directly setting the `color` property (internally, shadow color uses `currentColor`, so it honors the `color` property):
 
 ```CSS
 .wc-block-cart__submit-container::before {

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -1,5 +1,57 @@
 # Cart and Checkout Blocks theming
 
+## Buttons
+
+WC Blocks introduces the button component, it differs from a generic `button` in that it has some default styles to make it correctly fit in the Blocks design.
+
+<img src="https://user-images.githubusercontent.com/3616980/86381945-e6fd6c00-bc8d-11ea-8811-7e546bea69b9.png" alt="Button screenshot" width="242" />
+
+Themes can still style them to match theme colors or styles as follows:
+
+```CSS
+.wc-block-components-button {
+	background-color: #d5502f;
+	color: #fff;
+	/* You can add more rules to modify the border, shadow, etc. */
+}
+```
+
+<img src="https://user-images.githubusercontent.com/3616980/86381505-b6b5cd80-bc8d-11ea-8ceb-cfbe84b411d4.png" alt="Button screenshot with custom styles" width="239" />
+
+Notice the button component doesn't have the `.button` class name. So themes that wrote some styles for buttons might want to apply some (or all) of those styles to the button component as well.
+
+## Mobile submit container
+
+In small viewports, the Cart block displays the _Proceed to Checkout_ button inside a container fixed at the bottom of the screen.
+
+<img src="https://user-images.githubusercontent.com/3616980/86382876-393e8d00-bc8e-11ea-8d0b-e4e347ea4773.png" alt="Submit container screenshot" width="466" />
+
+By default, the container has a white background so it plays well with the button component default colors. Themes that want to apply the same background color as the rest of the page can do it with the following code snippet:
+
+```CSS
+.wc-block-cart__submit-container {
+	background-color: #f9f4ee;
+}
+```
+
+Take into consideration the container has a top box shadow that might not play well with some dark background colors. If needed, it can be modified directly setting the `color` property (internally, shadow color uses `currentColor`, so it honored the `color` property):
+
+```CSS
+.wc-block-cart__submit-container::before {
+	color: rgba(214, 209, 203, 0.5);
+}
+```
+
+alternatively, themes can override the `box-shadow` property completely:
+
+```CSS
+.wc-block-cart__submit-container::before {
+	box-shadow: 0 -10px 20px 10px rgba(214,209,203,0.5);
+}
+```
+
+<img src="https://user-images.githubusercontent.com/3616980/86382693-27f58080-bc8e-11ea-894e-de378af3e2bb.png" alt="Submit container screenshot with custom styles" width="462" />
+
 ## Item quantity badge
 
 The item quantity badge is the number that appears next to the image in the _Order summary_ section of the _Checkout_ block sidebar.


### PR DESCRIPTION
Fixes #2761.

This PR adds docs for themes to style the `Button` component and the Cart block submit container element.

It also has a small tweak in `.wc-block-cart__submit-container`: it makes it so the box shadow is added by a pseudo element. This allows using the `currentColor` value for the shadow color. This way, themes can change the box shadow color without the need to rewrite the entire `box-shadow` property.

### Screenshots

_(there shouldn't be any visual change)_

### How to test the changes in this Pull Request:

1. Do some smoke testing in the Cart & Checkout blocks and verify there are no regressions.