### PR TITLE
Release: 2.9.0

### DIFF
--- a/docs/testing/releases/290.md
+++ b/docs/testing/releases/290.md
@@ -6,10 +6,10 @@ Zip file for testing: tbc
 ## Correctly sort translated state and country drop-down menus in Checkout block. #2779
 In some languages, the `State` and `Country` drop-down menus in the checkout block were sorted incorrectly. They should now be alphabetically sorted in all circumstances.
 
-1. Edit the `Checkout` page, add the `Checkout` block, and save changes.
+1. Edit the `Checkout` page, remove the `[checkout]`  shortcode, add the `Checkout` block, and save changes.
 1. Go to `Dashboard > Settings > General`, select `Català` from `Site Language`, click `Save Changes`.
 1. Update language packs: `Dashboard > Updates > Download translation packs`.
 1. View the front end of your site and add a product to the cart. Navigate to checkout page.
 1. In checkout, select `Espanya` (Spain) from `País / Regió` (country) dropdown.
 1. Click `Província` (state) dropdown and confirm that the menu items are alphabetically sorted.
-1. 
+

--- a/docs/testing/releases/290.md
+++ b/docs/testing/releases/290.md
@@ -1,0 +1,15 @@
+## Testing notes and ZIP for release 2.9.0
+
+Zip file for testing: tbc
+
+### Testing notes
+## Correctly sort translated state and country drop-down menus in Checkout block. #2779
+In some languages, the `State` and `Country` drop-down menus in the checkout block were sorted incorrectly. They should now be alphabetically sorted in all circumstances.
+
+1. Edit the `Checkout` page, add the `Checkout` block, and save changes.
+1. Go to `Dashboard > Settings > General`, select `Català` from `Site Language`, click `Save Changes`.
+1. Update language packs: `Dashboard > Updates > Download translation packs`.
+1. View the front end of your site and add a product to the cart. Navigate to checkout page.
+1. In checkout, select `Espanya` (Spain) from `País / Regió` (country) dropdown.
+1. Click `Província` (state) dropdown and confirm that the menu items are alphabetically sorted.
+1. 

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -5,3 +5,4 @@ Every release includes specific testing instructions for features and bug fixes 
 - [2.7.0](./270.md)
     - [2.7.1](./271.md)
 - [2.8.0](./280.md)
+- [2.9.0](./290.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/block-library",
-	"version": "2.8.0-dev",
+	"version": "2.9.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/block-library",
-	"version": "2.9.0-dev",
+	"version": "2.9.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "2.9.0-dev",
+	"version": "2.9.0",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -88,7 +88,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 = 2.9.0 - 2020-07-07 =
 - bug: Correctly sort translated state and country drop-down menus in Checkout block. [#2779](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2779) 
 - dev: Add storybook story for icon library. [#2787](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2787) 
-- dev: Add custom jest matcher `toRenderBlock`, used for confirming blocks are available in the editor in e2e tests.. [#2780](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2780) 
+- dev: Add custom jest matcher `toRenderBlock`, used for confirming blocks are available in the editor in e2e tests. [#2780](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2780) 
 - dev: Use consistent Button component in Cart & Checkout blocks. [#2781](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2781) 
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -86,9 +86,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 == Changelog ==
 
 = 2.9.0 - 2020-07-07 =
-- bug: Add storybook story for icon library [#2787](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2787) 
-- dev: Add custom jest e2e matcher [#2780](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2780) 
-- dev: Correctly sort states after translation on Block Checkout. [#2779](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2779) 
+- bug: Add storybook story for icon library. [#2787](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2787) 
+- dev: Add custom jest matcher `toRenderBlock`, used for confirming blocks are available in the editor in e2e tests.. [#2780](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2780) 
+- dev: Correctly sort translated state and country drop-down menus in Checkout block. [#2779](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2779) 
 - dev: Use consistent Button component in Cart & Checkout blocks. [#2781](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2781) 
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 2.9.0-dev
+Stable tag: 2.9.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,13 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 2.9.0 - 2020-07-07 =
+- bug: Add storybook story for icon library [#2787](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2787) 
+- dev: Add custom jest e2e matcher [#2780](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2780) 
+- dev: Correctly sort states after translation on Block Checkout. [#2779](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2779) 
+- dev: Use consistent Button component in Cart & Checkout blocks. [#2781](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2781) 
+
+
 = 2.8.0 - 2020-06-23 =
 - bug: Cart and Checkout blocks display shipping methods with tax rates if that's how it's set in the settings. [#2748](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2748)
 - bug: Fix an error appearing in the Product Categories List block with _Full Width_ align. [#2700](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2700)

--- a/readme.txt
+++ b/readme.txt
@@ -86,9 +86,9 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 == Changelog ==
 
 = 2.9.0 - 2020-07-07 =
-- bug: Add storybook story for icon library. [#2787](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2787) 
+- bug: Correctly sort translated state and country drop-down menus in Checkout block. [#2779](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2779) 
+- dev: Add storybook story for icon library. [#2787](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2787) 
 - dev: Add custom jest matcher `toRenderBlock`, used for confirming blocks are available in the editor in e2e tests.. [#2780](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2780) 
-- dev: Correctly sort translated state and country drop-down menus in Checkout block. [#2779](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2779) 
 - dev: Use consistent Button component in Cart & Checkout blocks. [#2781](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2781) 
 
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -101,7 +101,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '2.9.0-dev';
+					$version = '2.9.0';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 2.8.0
+ * Version: 2.9.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This is the release pull request for 2.9.0 of the WooCommerce Blocks plugin.

## Communication

This is a small bug-fix release with no new features.

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release.

<!--
In this section you are highlighting all the public facing documentation that is related to the
release. Feel free to remove anything that doesn't apply for this release.
-->

**Release announcement:** <!-- Link to release announcement post on developer.woocommerce.com (published after release) --> tbc

* [x] The release includes a changelog entry in readme.txt

## Quality

<!--
  This section is for any notes related to quality around the release.
  Please include any extra details with each item as needed. This can include notes about
  why something isn't checked or expanding info on your response to an item.
-->

* [ ] Changes in this release are covered by Automated Tests.
     <!--
      This section is for confirming that the release changeset is covered by automated tests. If not,
      please leave some details on why not and any relevant information indicating confidence without
      those tests.
      -->
     * [ ] Unit tests
     * [ ] E2E tests
     * [ ] for each supported WordPress and WooCommerce core versions.
     * **No additional test coverage for the bug fixes in this release.** Not necessary as these are all minor bug fixes.
     

* [ ] This release has been tested on the following platforms:
     * [ ] mobile
     * [ ] desktop

* [ ] This release affects public facing REST APIs.
    * **No changes to published REST APIs.**
    * [ ] It conforms to REST API versioning policy.

* [ ] This release impacts **other extensions** or **backward compatibility**.
    * **No changes to extension interfaces/APIs.**
    * [ ] The release changes the signature of public methods or functions
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)
    * [ ] The release affects filters or action hooks.
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)

* [ ] Link to **testing instructions** for this release: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/a58a399a01c36bfa856a38577094b1e8432d8cb1/docs/testing/releases/290.md

* No change to performance impact on sites (positive/negative).

## Additional Notes
