### PR TITLE
Support bank transfer (BACS) payment method in checkout block

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/bacs/constants.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/constants.js
@@ -1,0 +1,1 @@
+export const PAYMENT_METHOD_NAME = 'bacs';

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -3,17 +3,20 @@
  */
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
+const settings = getSetting( 'bacs_data', {} );
 const defaultLabel = __(
 	'Direct bank transfer',
 	'woo-gutenberg-products-block'
 );
-const label = defaultLabel;
+const label = decodeEntities( settings.title ) || defaultLabel;
 
 /**
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
@@ -23,7 +26,7 @@ const label = defaultLabel;
  * Content component
  */
 const Content = () => {
-	return <div>Bank tranfer stuff</div>;
+	return <div>{ decodeEntities( settings.description || '' ) }</div>;
 };
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { registerPaymentMethod } from '@woocommerce/blocks-registry';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PAYMENT_METHOD_NAME } from './constants';
+
+const defaultLabel = __(
+	'Direct bank transfer',
+	'woo-gutenberg-products-block'
+);
+const label = defaultLabel;
+
+/**
+ * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').RegisteredPaymentMethodProps} RegisteredPaymentMethodProps
+ */
+
+/**
+ * Content component
+ */
+const Content = () => {
+	return <div>Bank tranfer stuff</div>;
+};
+
+/**
+ * Label component
+ *
+ * @param {*} props Props from payment API.
+ */
+const Label = ( props ) => {
+	const { PaymentMethodLabel } = props.components;
+	return <PaymentMethodLabel text={ label } />;
+};
+
+/**
+ * Bank transfer (BACS) payment method config object.
+ */
+const bankTransferPaymentMethod = {
+	name: PAYMENT_METHOD_NAME,
+	label: <Label />,
+	content: <Content />,
+	edit: <Content />,
+	icons: null,
+	canMakePayment: () => true,
+	ariaLabel: label,
+};
+
+registerPaymentMethod( ( Config ) => new Config( bankTransferPaymentMethod ) );

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -76,6 +76,8 @@ const stable = {
 			'./assets/js/payment-method-extensions/payment-methods/cheque/index.js',
 		'wc-payment-method-paypal':
 			'./assets/js/payment-method-extensions/payment-methods/paypal/index.js',
+		'wc-payment-method-bacs':
+			'./assets/js/payment-method-extensions/payment-methods/bacs/index.js',
 	},
 };
 

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -20,6 +20,7 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Stripe;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Cheque;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\PayPal;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\BankTransfer;
 
 /**
  * Takes care of bootstrapping the plugin.
@@ -218,6 +219,13 @@ class Bootstrap {
 			function( Container $container ) {
 				$asset_api = $container->get( AssetApi::class );
 				return new PayPal( $asset_api );
+			}
+		);
+		$this->container->register(
+			BankTransfer::class,
+			function( Container $container ) {
+				$asset_api = $container->get( AssetApi::class );
+				return new BankTransfer( $asset_api );
 			}
 		);
 	}

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\NoticeHandler;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Stripe;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\Cheque;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\PayPal;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\BankTransfer;
 
 /**
  *  The Api class provides an interface to payment method registration.
@@ -104,6 +105,9 @@ class Api {
 		);
 		$payment_method_registry->register(
 			Package::container()->get( PayPal::class )
+		);
+		$payment_method_registry->register(
+			Package::container()->get( BankTransfer::class )
 		);
 	}
 

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Bank Transfer (BACS) (core) gateway implementation.
+ *
+ * @package WooCommerce/Blocks
+ * @since 2.10.0
+ */
+
+namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
+
+use Automattic\WooCommerce\Blocks\Assets\Api;
+
+/**
+ * Bank Transfer (BACS) payment method integration
+ *
+ * @since 2.10.0
+ */
+final class BankTransfer extends AbstractPaymentMethodType {
+	/**
+	 * Payment method name/id/slug (matches id in WC_Gateway_BACS in core).
+	 *
+	 * @var string
+	 */
+	protected $name = 'bacs';
+
+	/**
+	 * An instance of the Asset Api
+	 *
+	 * @var Api
+	 */
+	private $asset_api;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Api $asset_api An instance of Api.
+	 */
+	public function __construct( Api $asset_api ) {
+		$this->asset_api = $asset_api;
+	}
+
+	/**
+	 * Initializes the payment method type.
+	 */
+	public function initialize() {
+		$this->settings = get_option( 'woocommerce_bacs_settings', [] );
+	}
+
+	/**
+	 * Returns if this payment method should be active. If false, the scripts will not be enqueued.
+	 *
+	 * @return boolean
+	 */
+	public function is_active() {
+		return true;
+	}
+
+	/**
+	 * Returns an array of scripts/handles to be registered for this payment method.
+	 *
+	 * @return array
+	 */
+	public function get_payment_method_script_handles() {
+		$this->asset_api->register_script(
+			'wc-payment-method-bacs',
+			'build/wc-payment-method-bacs.js'
+		);
+		return [ 'wc-payment-method-bacs' ];
+	}
+
+	/**
+	 * Returns an array of key=>value pairs of data made available to the payment methods script.
+	 *
+	 * @return array
+	 */
+	public function get_payment_method_data() {
+		return [];
+	}
+}

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -52,7 +52,7 @@ final class BankTransfer extends AbstractPaymentMethodType {
 	 * @return boolean
 	 */
 	public function is_active() {
-		return true;
+		return ! empty( $this->settings['enabled'] ) && 'yes' === $this->settings['enabled'];
 	}
 
 	/**

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -74,6 +74,9 @@ final class BankTransfer extends AbstractPaymentMethodType {
 	 * @return array
 	 */
 	public function get_payment_method_data() {
-		return [];
+		return [
+			'title'       => isset( $this->settings['title'] ) ? $this->settings['title'] : '',
+			'description' => isset( $this->settings['description'] ) ? $this->settings['description'] : '',
+		];
 	}
 }


### PR DESCRIPTION
Fixes #2820

Adds PHP + JS code to register [core BACS payment method](https://docs.woocommerce.com/document/bacs/) with checkout block.

### Screenshots

<img width="595" alt="Screen Shot 2020-07-07 at 3 05 08 PM" src="https://user-images.githubusercontent.com/4167300/86698265-43cc9e00-c063-11ea-839a-aa21a1aea57f.png">

Note - currently no icon. I figure we can handle this as follow up cc @LevinMedia (and @mikejolley who did a fine cheque logo).

Note 2 - with 3 payment methods, the tabs wrap onto new line. We can handle this as follow up also #2628 :)

### How to test the changes in this Pull Request:
1. Get this branch going (`composer install` - new PHP, `npm start`- new JS) and add the checkout block to a page.
2. Visit `WooCommerce > Settings > Payments` and activate & configure bank transfer.
3. On front end, add stuff to cart and proceed to checkout.
3. Select bank transfer payment and complete order.

Confirm that bank details/instructions are displayed in appropriate places (checkout, order received, order emails) and order can be fulfilled as per normal flow for BACS/"manual"/offline payment orders.

Confirm that other payment methods still work correctly.

### Changelog

> Add support for the Bank Transfer (BACS) payment method in the Checkout block. 
