### PR TITLE
Update minimum required versions in readme.txt to align them with readme.md

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -44,8 +44,8 @@ Use this plugin if you want access to the bleeding edge of available blocks for 
 
 = Minimum Requirements =
 
-* WordPress 5.0
-* WooCommerce 3.7 or greater
+* WordPress 5.2 or greater
+* WooCommerce 4.0 or greater
 * PHP version 5.6 or greater (PHP 7.2 or greater is recommended)
 * MySQL version 5.0 or greater (MySQL 5.6 or greater is recommended)
 


### PR DESCRIPTION
Aligns the required versions between readme.txt and [readme.md](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/README.md#installing-the-development-version).