### PR TITLE
allow payment methods to disable based on shipping (API change)

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -107,10 +107,7 @@ const reducer = (
 		case SET_REGISTERED_PAYMENT_METHODS:
 			return {
 				...state,
-				paymentMethods: {
-					...state.paymentMethods,
-					...paymentMethods,
-				},
+				paymentMethods,
 			};
 		case SET_REGISTERED_EXPRESS_PAYMENT_METHODS:
 			return {

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -11,7 +11,7 @@ import {
 	useEditorContext,
 	useShippingDataContext,
 } from '@woocommerce/base-context';
-import { useStoreCart } from '@woocommerce/base-hooks';
+import { useStoreCart, useShallowEqual } from '@woocommerce/base-hooks';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 
 /**
@@ -54,10 +54,8 @@ const usePaymentMethodRegistration = (
 ) => {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 	const { isEditor } = useEditorContext();
-	const {
-		selectedRates: selectedShippingMethods,
-		shippingAddress,
-	} = useShippingDataContext();
+	const { selectedRates, shippingAddress } = useShippingDataContext();
+	const selectedShippingMethods = useShallowEqual( selectedRates );
 	const { cartTotals, cartNeedsShipping } = useStoreCart();
 	const canPayArgument = useRef( {
 		cartTotals,

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -54,12 +54,16 @@ const usePaymentMethodRegistration = (
 ) => {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 	const { isEditor } = useEditorContext();
-	const { shippingAddress } = useShippingDataContext();
+	const {
+		selectedRates: selectedShippingMethods,
+		shippingAddress,
+	} = useShippingDataContext();
 	const { cartTotals, cartNeedsShipping } = useStoreCart();
 	const canPayArgument = useRef( {
 		cartTotals,
 		cartNeedsShipping,
 		shippingAddress,
+		selectedShippingMethods,
 	} );
 
 	useEffect( () => {
@@ -67,51 +71,64 @@ const usePaymentMethodRegistration = (
 			cartTotals,
 			cartNeedsShipping,
 			shippingAddress,
+			selectedShippingMethods,
 		};
-	}, [ cartTotals, cartNeedsShipping, shippingAddress ] );
+	}, [
+		cartTotals,
+		cartNeedsShipping,
+		shippingAddress,
+		selectedShippingMethods,
+	] );
 
-	const resolveCanMakePayments = useCallback( async () => {
-		let initializedPaymentMethods = {},
-			canPay;
-		const setInitializedPaymentMethods = ( paymentMethod ) => {
-			initializedPaymentMethods = {
-				...initializedPaymentMethods,
+	const refreshCanMakePayments = useCallback( async () => {
+		let availablePaymentMethods = {};
+		const addAvailablePaymentMethod = ( paymentMethod ) => {
+			availablePaymentMethods = {
+				...availablePaymentMethods,
 				[ paymentMethod.name ]: paymentMethod,
 			};
 		};
 		for ( const paymentMethodName in registeredPaymentMethods ) {
-			const current = registeredPaymentMethods[ paymentMethodName ];
+			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
 
+			// In editor, shortcut so all payment methods show as available.
 			if ( isEditor ) {
-				setInitializedPaymentMethods( current );
+				addAvailablePaymentMethod( paymentMethod );
 				continue;
 			}
 
+			// In front end, ask payment method if it should be available.
 			try {
-				canPay = await Promise.resolve(
-					current.canMakePayment( canPayArgument.current )
+				const canPay = await Promise.resolve(
+					paymentMethod.canMakePayment( canPayArgument.current )
 				);
 				if ( canPay ) {
 					if ( canPay.error ) {
 						throw new Error( canPay.error.message );
 					}
-					setInitializedPaymentMethods( current );
+					addAvailablePaymentMethod( paymentMethod );
 				}
 			} catch ( e ) {
+				// If user is admin, show payment `canMakePayment` errors as a notice.
 				handleRegistrationError( e );
 			}
 		}
-		// all payment methods have been initialized so dispatch and set
-		dispatcher( initializedPaymentMethods );
+
+		// Re-dispatch available payment methods to store.
+		dispatcher( availablePaymentMethods );
+
+		// Note: some payment methods use the `canMakePayment` callback to initialize / setup.
+		// Example: Stripe CC, Stripe Payment Request.
+		// That's why we track "is initialised" state here.
 		setIsInitialized( true );
 	}, [ dispatcher, isEditor, registeredPaymentMethods ] );
 
-	// if not initialized invoke the callback to kick off resolving the payments.
+	// Determine which payment methods are available initially and whenever
+	// shipping methods change.
+	// Some payment methods (e.g. COD) can be disabled for specific shipping methods.
 	useEffect( () => {
-		if ( ! isInitialized ) {
-			resolveCanMakePayments();
-		}
-	}, [ resolveCanMakePayments, isInitialized ] );
+		refreshCanMakePayments();
+	}, [ refreshCanMakePayments, selectedShippingMethods ] );
 
 	return isInitialized;
 };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -16,30 +16,47 @@ const ApplePayPreview = () => <img src={ applePayImage } alt="" />;
 const canPayStripePromise = loadStripe();
 const componentStripePromise = loadStripe();
 
+let apiInitialized = false,
+	canPay = false;
+
+// Initialise stripe API client and determine if payment method can be used
+// in current environment (e.g. geo + shopper has payment settings configured).
+function paymentRequestAvailable( currencyCode ) {
+	// If we've already initialised, return the cached results.
+	if ( apiInitialized ) {
+		return canPay;
+	}
+
+	return canPayStripePromise.then( ( stripe ) => {
+		if ( stripe === null ) {
+			return false;
+		}
+		// Do a test payment to confirm if payment method is available.
+		const paymentRequest = stripe.paymentRequest( {
+			total: {
+				label: 'Test total',
+				amount: 1000,
+			},
+			country: getSetting( 'baseLocation', {} )?.country,
+			currency: currencyCode,
+		} );
+		return paymentRequest.canMakePayment().then( ( result ) => {
+			canPay = !! result;
+			apiInitialized = true;
+			return canPay;
+		} );
+	} );
+}
+
 const PaymentRequestPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
 	content: <PaymentRequestExpress stripe={ componentStripePromise } />,
 	edit: <ApplePayPreview />,
 	canMakePayment: ( cartData ) =>
-		canPayStripePromise.then( ( stripe ) => {
-			if ( stripe === null ) {
-				return false;
-			}
-			// do a test payment request to check if payment request payment can be
-			// done.
-			const paymentRequest = stripe.paymentRequest( {
-				total: {
-					label: 'Test total',
-					amount: 1000,
-				},
-				country: getSetting( 'baseLocation', {} )?.country,
-				// eslint-disable-next-line camelcase
-				currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
-			} );
-			return paymentRequest
-				.canMakePayment()
-				.then( ( result ) => !! result );
-		} ),
+		paymentRequestAvailable(
+			// eslint-disable-next-line camelcase
+			cartData?.cartTotals?.currency_code?.toLowerCase()
+		),
 	paymentMethodId: 'stripe',
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -16,20 +16,21 @@ const ApplePayPreview = () => <img src={ applePayImage } alt="" />;
 const canPayStripePromise = loadStripe();
 const componentStripePromise = loadStripe();
 
-let apiInitialized = false,
+let isStripeInitialized = false,
 	canPay = false;
 
 // Initialise stripe API client and determine if payment method can be used
 // in current environment (e.g. geo + shopper has payment settings configured).
 function paymentRequestAvailable( currencyCode ) {
 	// If we've already initialised, return the cached results.
-	if ( apiInitialized ) {
+	if ( isStripeInitialized ) {
 		return canPay;
 	}
 
 	return canPayStripePromise.then( ( stripe ) => {
 		if ( stripe === null ) {
-			return false;
+			isStripeInitialized = true;
+			return canPay;
 		}
 		// Do a test payment to confirm if payment method is available.
 		const paymentRequest = stripe.paymentRequest( {
@@ -42,7 +43,7 @@ function paymentRequestAvailable( currencyCode ) {
 		} );
 		return paymentRequest.canMakePayment().then( ( result ) => {
 			canPay = !! result;
-			apiInitialized = true;
+			isStripeInitialized = true;
 			return canPay;
 		} );
 	} );


### PR DESCRIPTION
Fixes #2838

This PR changes the payment methods registration hook so that it calls `canMakePayment` on each payment method whenever shopper changes shipping. 

The goal here is to better support payment methods that need to disable (hide/show) dependent on the selected shipping rate, or potentially other factors in future. See #2838 and #2831 for more info - `Cash on Delivery` needs this capability.

This is quite different from the previous usage/expectations of the API, so will need careful testing.

### How to test the changes in this Pull Request:
The change to the API can't be directly tested, as none of the current payment methods use the feature.

So please test all supported payment methods and flows. I've tested all but `Stripe Payment Request` (Apple / Chrome Pay) as it's not available for me.

To test the new feature, you can hack an existing payment method `canMakePayment` callback and add the new `selectedShippingMethods` parameter. 

- `canMakePayment` should be called whenever shipping method changes.
- The selected shipping method(s) should be passed to `canMakePayment`.

### Some other context / notes
As far as I understand, `canMakePayment` has two purposes:

1. Determine if a payment method should be available (i.e. presented to user in checkout).
2. Initialise (set up) the payment method.

In my view, (1) is the primary purpose, and (2) could be considered a side effect. Stripe (CC and Payment Request) are the only methods that use the "initialisation" feature right now. In any case, this is how the API works currently so we need to take care making this change.

I hope that the expensive, async init for Stripe in `canMakePayment` is effectively cached, so on subsequent calls the promise returns immediately. If not, we may need to add memoization or other caching.

Other thoughts we might want to follow up:

- We could make `canMakePayment` interface simpler:
   - default to true if payment method does nothing
   - allow a boolean value with no callback
- There's some code in `usePaymentMethodRegistration()` which catches initialization errors and shows a notice to admins. I think this is primarily there for Stripe integration, and is not really general purpose. We could consider moving this out so each payment method extension handles its own init, if needed, so that `canMakePayment` is focused specifically on availability (which could depend on successful init where appropriate!). 

### Changelog

> Add suggested changelog entry here. TBC TBC
