### PR TITLE
Deregister core cart/checkout scripts and styles when rendering the blocks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
 		context: true,
 		jestPuppeteer: true,
 		fetchMock: true,
+		jQuery: 'readonly',
 	},
 	plugins: [ 'jest', 'woocommerce' ],
 	rules: {

--- a/assets/js/base/utils/legacy-events.js
+++ b/assets/js/base/utils/legacy-events.js
@@ -45,6 +45,10 @@ export const translateJQueryEventToNative = (
 	cancelable = false
 ) => {
 	// @ts-ignore -- jQuery is window global
+	if ( typeof jQuery !== 'function' ) {
+		return;
+	}
+	// @ts-ignore -- jQuery is window global
 	jQuery( document ).on( jQueryEventName, () => {
 		dispatchEvent( nativeEventName, bubbles, cancelable );
 	} );

--- a/assets/js/base/utils/legacy-events.js
+++ b/assets/js/base/utils/legacy-events.js
@@ -37,6 +37,9 @@ export const triggerFragmentRefresh = () => {
  * @param {string}  nativeEventName Name of the native event to dispatch.
  * @param {boolean} bubbles         Whether the event bubbles.
  * @param {boolean} cancelable      Whether the event is cancelable.
+ *
+ * @returns {Function} Function to remove the jQuery event handler. Ideally it
+ * should be used when the component is unmounted.
  */
 export const translateJQueryEventToNative = (
 	jQueryEventName,
@@ -46,10 +49,15 @@ export const translateJQueryEventToNative = (
 ) => {
 	// @ts-ignore -- jQuery is window global
 	if ( typeof jQuery !== 'function' ) {
-		return;
+		return () => void null;
 	}
-	// @ts-ignore -- jQuery is window global
-	jQuery( document ).on( jQueryEventName, () => {
+
+	const eventDispatcher = () => {
 		dispatchEvent( nativeEventName, bubbles, cancelable );
-	} );
+	};
+
+	// @ts-ignore -- jQuery is window global
+	jQuery( document ).on( jQueryEventName, eventDispatcher );
+	// @ts-ignore -- jQuery is window global
+	return () => jQuery( document ).off( jQueryEventName, eventDispatcher );
 };

--- a/assets/js/base/utils/legacy-events.js
+++ b/assets/js/base/utils/legacy-events.js
@@ -44,7 +44,7 @@ export const translateJQueryEventToNative = (
 	bubbles = false,
 	cancelable = false
 ) => {
-	// @ts-ignore jQuery is window global
+	// @ts-ignore -- jQuery is window global
 	jQuery( document ).on( jQueryEventName, () => {
 		dispatchEvent( nativeEventName, bubbles, cancelable );
 	} );

--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -20,31 +20,40 @@ import FullCart from './full-cart';
 
 // Make it so we can read jQuery events triggered by WC Core elements.
 translateJQueryEventToNative( 'added_to_cart', 'wc-blocks_added_to_cart' );
+translateJQueryEventToNative(
+	'removed_from_cart',
+	'wc-blocks_removed_from_cart'
+);
 
 const Block = ( { emptyCart, attributes, scrollToTop } ) => {
 	const { cartItems, cartIsLoading } = useStoreCart();
 
 	useEffect( () => {
 		const invalidateCartData = () => {
-			if ( cartItems.length === 0 ) {
-				dispatch( storeKey ).invalidateResolutionForStore();
-				scrollToTop();
-			}
+			dispatch( storeKey ).invalidateResolutionForStore();
+			scrollToTop();
 		};
 
 		document.body.addEventListener(
 			'wc-blocks_added_to_cart',
 			invalidateCartData
 		);
+		document.body.addEventListener(
+			'wc-blocks_removed_from_cart',
+			invalidateCartData
+		);
 
-		// returned function will be called on component unmount
 		return () => {
 			document.body.removeEventListener(
 				'wc-blocks_added_to_cart',
 				invalidateCartData
 			);
+			document.body.removeEventListener(
+				'wc-blocks_removed_from_cart',
+				invalidateCartData
+			);
 		};
-	}, [ cartItems.length ] );
+	}, [ cartItems.length, scrollToTop ] );
 
 	return (
 		<>

--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -1,21 +1,48 @@
 /**
  * External dependencies
  */
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { dispatch } from '@wordpress/data';
 import { useStoreCart } from '@woocommerce/base-hooks';
-import { RawHTML } from '@wordpress/element';
+import { useEffect, RawHTML } from '@wordpress/element';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
 import {
 	ValidationContextProvider,
 	CartProvider,
 } from '@woocommerce/base-context';
+import { translateJQueryEventToNative } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
  */
 import FullCart from './full-cart';
 
+// Make it so we can read jQuery events triggered by WC Core elements.
+translateJQueryEventToNative( 'added_to_cart', 'wc-blocks_added_to_cart' );
+
 const Block = ( { emptyCart, attributes } ) => {
 	const { cartItems, cartIsLoading } = useStoreCart();
+
+	useEffect( () => {
+		const invalidateCartData = () => {
+			if ( cartItems.length === 0 ) {
+				dispatch( storeKey ).invalidateResolutionForStore();
+			}
+		};
+
+		document.body.addEventListener(
+			'wc-blocks_added_to_cart',
+			invalidateCartData
+		);
+
+		// returned function will be called on component unmount
+		return () => {
+			document.body.removeEventListener(
+				'wc-blocks_added_to_cart',
+				invalidateCartData
+			);
+		};
+	}, [ cartItems.length ] );
 
 	return (
 		<>

--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -18,13 +18,6 @@ import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
  */
 import FullCart from './full-cart';
 
-// Make it so we can read jQuery events triggered by WC Core elements.
-translateJQueryEventToNative( 'added_to_cart', 'wc-blocks_added_to_cart' );
-translateJQueryEventToNative(
-	'removed_from_cart',
-	'wc-blocks_removed_from_cart'
-);
-
 const Block = ( { emptyCart, attributes, scrollToTop } ) => {
 	const { cartItems, cartIsLoading } = useStoreCart();
 
@@ -33,6 +26,16 @@ const Block = ( { emptyCart, attributes, scrollToTop } ) => {
 			dispatch( storeKey ).invalidateResolutionForStore();
 			scrollToTop();
 		};
+
+		// Make it so we can read jQuery events triggered by WC Core elements.
+		const removeJQueryAddedToCartEvent = translateJQueryEventToNative(
+			'added_to_cart',
+			'wc-blocks_added_to_cart'
+		);
+		const removeJQueryRemovedFromCartEvent = translateJQueryEventToNative(
+			'removed_from_cart',
+			'wc-blocks_removed_from_cart'
+		);
 
 		document.body.addEventListener(
 			'wc-blocks_added_to_cart',
@@ -44,6 +47,9 @@ const Block = ( { emptyCart, attributes, scrollToTop } ) => {
 		);
 
 		return () => {
+			removeJQueryAddedToCartEvent();
+			removeJQueryRemovedFromCartEvent();
+
 			document.body.removeEventListener(
 				'wc-blocks_added_to_cart',
 				invalidateCartData

--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -53,7 +53,7 @@ const Block = ( { emptyCart, attributes, scrollToTop } ) => {
 				invalidateCartData
 			);
 		};
-	}, [ cartItems.length, scrollToTop ] );
+	}, [ scrollToTop ] );
 
 	return (
 		<>

--- a/assets/js/blocks/cart-checkout/cart/block.js
+++ b/assets/js/blocks/cart-checkout/cart/block.js
@@ -11,6 +11,7 @@ import {
 	CartProvider,
 } from '@woocommerce/base-context';
 import { translateJQueryEventToNative } from '@woocommerce/base-utils';
+import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 
 /**
  * Internal dependencies
@@ -20,13 +21,14 @@ import FullCart from './full-cart';
 // Make it so we can read jQuery events triggered by WC Core elements.
 translateJQueryEventToNative( 'added_to_cart', 'wc-blocks_added_to_cart' );
 
-const Block = ( { emptyCart, attributes } ) => {
+const Block = ( { emptyCart, attributes, scrollToTop } ) => {
 	const { cartItems, cartIsLoading } = useStoreCart();
 
 	useEffect( () => {
 		const invalidateCartData = () => {
 			if ( cartItems.length === 0 ) {
 				dispatch( storeKey ).invalidateResolutionForStore();
+				scrollToTop();
 			}
 		};
 
@@ -61,4 +63,4 @@ const Block = ( { emptyCart, attributes } ) => {
 	);
 };
 
-export default Block;
+export default withScrollToTop( Block );

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -63,6 +63,12 @@ class Cart extends AbstractBlock {
 			}
 		);
 
+		// Deregister core cart scripts and styles.
+		wp_deregister_script( 'wc-cart' );
+		wp_deregister_script( 'wc-password-strength-meter' );
+		wp_deregister_script( 'selectWoo' );
+		wp_deregister_style( 'select2' );
+
 		return $this->inject_html_data_attributes( $content . $this->get_skeleton(), $block_attributes );
 	}
 

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -60,6 +60,12 @@ class Checkout extends AbstractBlock {
 		$this->enqueue_assets( $block_attributes );
 		do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' );
 
+		// Deregister core checkout scripts and styles.
+		wp_deregister_script( 'wc-checkout' );
+		wp_deregister_script( 'wc-password-strength-meter' );
+		wp_deregister_script( 'selectWoo' );
+		wp_deregister_style( 'select2' );
+
 		return $this->inject_html_data_attributes( $content . $this->get_skeleton(), $block_attributes );
 	}
 

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -32,6 +32,7 @@ global.wcSettings = {
 
 global.jQuery = () => ( {
 	on: () => void null,
+	off: () => void null,
 } );
 
 const wordPressPackages = [

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -30,6 +30,10 @@ global.wcSettings = {
 	},
 };
 
+global.jQuery = () => ( {
+	on: () => void null,
+} );
+
 const wordPressPackages = [
 	'blocks',
 	'components',


### PR DESCRIPTION
Fixes #2239 

This PR deregisters the scripts and styles used by cart and checkout shortcodes when rendering the blocks. I took the list of scripts/styles to deregister from these lines in Core:

https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-frontend-scripts.php#L363-L377

It looks like we were relying on some logic from `cart.js` to redirect the empty cart to the full cart when a product was added. I needed to rewrite that logic in the block. In order to do that, I needed to subscribe to a jQuery event since that's what's used in Core. I added a translation layer to convert jQuery events to JS native events. While not ideal, that's the best solution I could find given the current situation where core uses jQuery.

### How to test the changes in this Pull Request:

**Test Empty cart redirects to the Full cart when a product is added:**

1. Go to the cart page without having any product in the cart. Add one from the Block below and verify you are redirected to the `full cart` view.
1. Repeat the step above but before doing that, edit the empty cart template and replace the Newest products block with a shortcode (ie: `[products limit="3" columns="3" visibility="featured" ]`).

Note: It's not possible to test this flow with the All Products block because of #2836.

**Test there are no regressions in the purchase flow:**

1. Do a purchase from start to end with the blocks and verify everything works and the confirmation page appears after payment.
1. Do a purchase with the shortcodes and verify there are no regressions: functionality should work as usual and styles should be loaded.

### Changelog

> Don't load shortcode Cart and Checkout scripts when using the blocks.