### PR TITLE
Update automattic/jetpack-autoloader to 2.0 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	"minimum-stability": "dev",
 	"require": {
 		"composer/installers": "1.7.0",
-		"automattic/jetpack-autoloader": "^1.6.0"
+		"automattic/jetpack-autoloader": "^2.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "6.5.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b5167f2ba67ad97db15fb893f700291",
+    "content-hash": "c2fcf5512c74c4ffa8e05953eb92c3a5",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.6.0",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "3bcbe1ae19febd6beeb181cf11af0bf0b7abe7e7"
+                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/3bcbe1ae19febd6beeb181cf11af0bf0b7abe7e7",
-                "reference": "3bcbe1ae19febd6beeb181cf11af0bf0b7abe7e7",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/4502da4b2443fc1b61389cacc94c34876aca2b3d",
+                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1"
+                "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-03-26T07:57:53+00:00"
+            "time": "2020-07-09T13:18:38+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2837 

<!-- Don't forget to update the title with something descriptive. -->

This updates `automattic/jetpack-autoloader` to the 2.0 branch of the package. This is keeping in line with a similar update happening in WooCommerce core and other ecosystem dependencies being included in WC Core as dependencies.

## Testing

Any issues should surface immediately when testing.

- Run `composer install` to ensure your composer packages are updated and you generate the new autoloader.
- Smoke test anywhere blocks are (if there's an issue there should be a fatal pop up fairly quickly for unfound files).
- Verify experimental blocks are available (single product).
- Verify Cart and Checkout is available and works for a purchase (any payment method is sufficient).


### Changelog

> Updated the `automattic/jetpack-autoloader` package to the 2.0 branch.
