### PR TITLE
Remove dashicon classes

### DIFF
--- a/assets/js/base/components/chip/removable-chip.js
+++ b/assets/js/base/components/chip/removable-chip.js
@@ -72,7 +72,11 @@ const RemovableChip = ( {
 				className="wc-block-components-chip__remove"
 				{ ...removeProps }
 			>
-				<Icon srcElement={ noAlt } size={ 16 } />
+				<Icon
+					className="wc-block-components-chip__remove-icon"
+					srcElement={ noAlt }
+					size={ 16 }
+				/>
 			</RemoveElement>
 		</Chip>
 	);

--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -44,10 +44,10 @@
 		border: 0;
 		appearance: none;
 		padding: 0;
+	}
 
-		> .dashicon {
-			vertical-align: middle;
-		}
+	.wc-block-components-chip__remove-icon {
+		vertical-align: middle;
 	}
 }
 

--- a/assets/js/base/components/chip/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/chip/test/__snapshots__/index.js.snap
@@ -107,7 +107,7 @@ exports[`RemovableChip should render custom aria label 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="dashicon dashicons-arrow-down-alt2"
+      className="wc-block-components-chip__remove-icon"
       focusable="false"
       height={16}
       role="img"
@@ -149,7 +149,7 @@ exports[`RemovableChip should render default aria label if text is a node 1`] = 
   >
     <svg
       aria-hidden="true"
-      className="dashicon dashicons-arrow-down-alt2"
+      className="wc-block-components-chip__remove-icon"
       focusable="false"
       height={16}
       role="img"
@@ -189,7 +189,7 @@ exports[`RemovableChip should render screen reader text aria label 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="dashicon dashicons-arrow-down-alt2"
+      className="wc-block-components-chip__remove-icon"
       focusable="false"
       height={16}
       role="img"
@@ -224,7 +224,7 @@ exports[`RemovableChip should render text and the remove button 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="dashicon dashicons-arrow-down-alt2"
+      className="wc-block-components-chip__remove-icon"
       focusable="false"
       height={16}
       role="img"
@@ -259,7 +259,7 @@ exports[`RemovableChip should render with disabled remove button 1`] = `
   >
     <svg
       aria-hidden="true"
-      className="dashicon dashicons-arrow-down-alt2"
+      className="wc-block-components-chip__remove-icon"
       focusable="false"
       height={16}
       role="img"
@@ -295,7 +295,7 @@ exports[`RemovableChip with removeOnAnyClick should be a button when removeOnAny
   >
     <svg
       aria-hidden="true"
-      className="dashicon dashicons-arrow-down-alt2"
+      className="wc-block-components-chip__remove-icon"
       focusable="false"
       height={16}
       role="img"

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -123,7 +123,7 @@ $dropdown-selector-line-height: 18/14;
 		line-height: 1;
 		padding: 0 0 0 0.3em;
 
-		> .dashicon {
+		> svg {
 			display: block;
 		}
 	}

--- a/assets/js/icons/library/arrow-down-alt2.js
+++ b/assets/js/icons/library/arrow-down-alt2.js
@@ -2,19 +2,13 @@
  * External dependencies
  */
 import { SVG } from 'wordpress-components';
-import classnames from 'classnames';
 
 const Component = ( { className, size = 20, ...extraProps } ) => {
-	const iconClass = classnames(
-		'dashicon',
-		'dashicons-arrow-down-alt2',
-		className
-	);
 	return (
 		<SVG
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 20 20"
-			className={ iconClass }
+			className={ className }
 			width={ size }
 			height={ size }
 			{ ...extraProps }

--- a/assets/js/icons/library/no-alt.js
+++ b/assets/js/icons/library/no-alt.js
@@ -2,19 +2,13 @@
  * External dependencies
  */
 import { SVG } from 'wordpress-components';
-import classnames from 'classnames';
 
 const Component = ( { className, size, ...extraProps } ) => {
-	const iconClass = classnames(
-		'dashicon',
-		'dashicons-arrow-down-alt2',
-		className
-	);
 	return (
 		<SVG
 			xmlns="http://www.w3.org/2000/svg"
 			viewBox="0 0 20 20"
-			className={ iconClass }
+			className={ className }
 			width={ size }
 			height={ size }
 			{ ...extraProps }


### PR DESCRIPTION
Fixes #2846.

### How to test the changes in this Pull Request:

Testing means ensuring there are no visual regressions in the modified blocks:
1. Cart: verify coupon chip close icon looks as it did.
![imatge](https://user-images.githubusercontent.com/3616980/87140895-816b3a00-c2a2-11ea-95a8-4b2d13ff308e.png)
2. Attribute Filter: set Query Type: AND, Display Style: Dropdown. Then, select a value and check that the cross icon still shows up correct.
![imatge](https://user-images.githubusercontent.com/3616980/87140925-8cbe6580-c2a2-11ea-84da-24bd67923d0a.png)
