### PR TITLE
Fix Credit Card input font size in some themes

### DIFF
--- a/assets/css/abstracts/_variables.scss
+++ b/assets/css/abstracts/_variables.scss
@@ -22,5 +22,5 @@ $block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $bloc
 $cart-image-width: 5rem;
 
 // Card element widths
-$card-element-small-width: 5rem;
-$card-element-width: 7rem;
+$card-element-small-width: 5em;
+$card-element-width: 7em;

--- a/assets/css/abstracts/_variables.scss
+++ b/assets/css/abstracts/_variables.scss
@@ -20,7 +20,3 @@ $block-container-side-padding: $block-side-ui-width + $block-padding + 2 * $bloc
 
 // Cart block
 $cart-image-width: 5rem;
-
-// Card element widths
-$card-element-small-width: 5em;
-$card-element-width: 7em;

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -100,12 +100,13 @@ $border-radius: 5px;
 
 	&.wc-card-number-element {
 		flex: auto;
+		width: $card-element-width;
 	}
 
 	&.wc-card-expiry-element,
 	&.wc-card-cvc-element {
-		width: $card-element-width;
 		margin-left: $gap-small;
+		width: $card-element-small-width;
 	}
 
 	.wc-block-gateway-input {

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -100,20 +100,27 @@ $border-radius: 5px;
 
 	&.wc-card-number-element {
 		flex: auto;
-		width: $card-element-width;
+		flex-basis: 15em;
+		min-width: 14.75em;
 	}
 
-	&.wc-card-expiry-element,
-	&.wc-card-cvc-element {
+	&.wc-card-expiry-element {
+		flex-basis: 7em;
 		margin-left: $gap-small;
-		width: $card-element-small-width;
+		min-width: 5em;
+	}
+
+	&.wc-card-cvc-element {
+		flex-basis: 7em;
+		margin-left: $gap-small;
+		min-width: 3.5em;
 	}
 
 	.wc-block-gateway-input {
 		@include font-size(regular);
 		line-height: 1.375; // =22px when font-size is 16px.
 		background-color: #fff;
-		padding: em($gap-small) $gap;
+		padding: em($gap-small) 0 em($gap-small) $gap;
 		border-radius: 4px;
 		border: 1px solid $input-border-gray;
 		width: 100%;
@@ -147,7 +154,7 @@ $border-radius: 5px;
 		margin: 0 0 0 #{$gap + 1px};
 		overflow: hidden;
 		text-overflow: ellipsis;
-		max-width: calc(100% - #{2 * $gap});
+		max-width: calc(100% - #{$gap + $gap-smaller});
 		cursor: text;
 
 		@media screen and (prefers-reduced-motion: reduce) {
@@ -177,7 +184,7 @@ $border-radius: 5px;
 
 	.wc-block-gateway-input.focused.empty,
 	.wc-block-gateway-input:not(.empty) {
-		padding: em($gap-large) $gap em($gap-smallest);
+		padding: em($gap-large) 0 em($gap-smallest) $gap;
 		& + label {
 			transform: translateY(#{$gap-smallest}) scale(0.75);
 		}
@@ -237,7 +244,8 @@ $border-radius: 5px;
 	pointer-events: all; // Overrides parent disabled component in editor context
 }
 
-@include breakpoint( "<782px" ) {
+.is-mobile,
+.is-small {
 	.wc-block-card-elements {
 		flex-wrap: wrap;
 	}

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -156,7 +156,10 @@ $border-radius: 5px;
 
 	&.wc-inline-card-element {
 		label {
-			margin-left: $gap-largest;
+			// $gap is the padding of the input box, 1.5em the width of the card
+			// icon and $gap-smaller the space between the card
+			// icon and the label.
+			margin-left: calc(#{$gap + $gap-smaller} + 1.5em);
 		}
 		.wc-block-gateway-input.focused.empty,
 		.wc-block-gateway-input:not(.empty) {

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -99,21 +99,25 @@ $border-radius: 5px;
 	white-space: nowrap;
 
 	&.wc-card-number-element {
-		flex: auto;
 		flex-basis: 15em;
-		min-width: 14.75em;
+		flex-grow: 1;
+		// Currently, min() CSS function calls need to be wrapped with unquote.
+		min-width: unquote("min(15em, 60%)");
 	}
 
 	&.wc-card-expiry-element {
 		flex-basis: 7em;
 		margin-left: $gap-small;
-		min-width: 5em;
+		min-width: unquote("min(7em, calc(24% - #{$gap-small}))");
 	}
 
 	&.wc-card-cvc-element {
 		flex-basis: 7em;
 		margin-left: $gap-small;
-		min-width: 3.5em;
+		// Notice the min width ems value is smaller than flex-basis. That's because
+		// by default we want it to have the same width as `expiry-element`, but
+		// if available space is scarce, `cvc-element` should get smaller faster.
+		min-width: unquote("min( 5em, calc(16% - #{$gap-small}))");
 	}
 
 	.wc-block-gateway-input {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-element-options.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-element-options.js
@@ -8,8 +8,9 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
  */
 
 /**
- * Returns the CSS value of the specified property in the document element.
+ * Returns the value of a specific CSS property for the element matched by the provided selector.
  *
+ * @param {string} selector     CSS selector that matches the element to query.
  * @param {string} property     Name of the property to retrieve the style
  *                              value from.
  * @param {string} defaultValue Fallback value if the value for the property
@@ -17,15 +18,21 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
  *
  * @return {string} The style value of that property in the document element.
  */
-const getDocumentStyle = ( property, defaultValue ) => {
-	let documentStyle = {};
+const getComputedStyle = ( selector, property, defaultValue ) => {
+	let elementStyle = {};
+
 	if (
-		typeof window === 'object' &&
+		typeof document === 'object' &&
+		typeof document.querySelector === 'function' &&
 		typeof window.getComputedStyle === 'function'
 	) {
-		documentStyle = window.getComputedStyle( document.documentElement );
+		const element = document.querySelector( selector );
+		if ( element ) {
+			elementStyle = window.getComputedStyle( element );
+		}
 	}
-	return documentStyle[ property ] || defaultValue;
+
+	return elementStyle[ property ] || defaultValue;
 };
 
 /**
@@ -36,7 +43,11 @@ const elementOptions = {
 		base: {
 			iconColor: '#666EE8',
 			color: '#31325F',
-			fontSize: getDocumentStyle( 'fontSize', '16px' ),
+			fontSize: getComputedStyle(
+				'.wc-block-checkout',
+				'fontSize',
+				'16px'
+			),
 			lineHeight: 1.375, // With a font-size of 16px, line-height will be 22px.
 			'::placeholder': {
 				color: '#fff',


### PR DESCRIPTION
Fixes #2668.
Fixes #2867.
Fixes #2868.

### How to test the changes in this Pull Request:

#2668:

1. Change your store theme to Twenty Twenty.
2. Go to the Checkout block and select the Credit Card payment method provided by Stripe.
3. Introduce some numbers to Credit Card inputs and verify they have the same font size as the rest of the block.

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/87529018-a854b200-c68e-11ea-954f-c1843e0bd341.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/87527780-e4871300-c68c-11ea-9549-92d59b1a544c.png)


1. Go to Stripe settings and check 'Inline Credit Card Form'.
2. Go back to the Checkout block and notice the card icon is not too small and the label doesn't overlap the card icon.

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/87528904-7d6a5e00-c68e-11ea-8a46-689817e0e985.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/87528730-33817800-c68e-11ea-92ab-e82e9de58d0b.png)

#2867:
#2868:

1. Check the credit card inputs when in a wide viewport and verify 'Expiry Date' and 'CVV/CVC' input fields have the same width.
2. Make the viewport smaller and verify 'CVV/CVC' field gets smaller faster, since it will have fewer characters than 'Expiry Date'.
3. Also notice 'Card Number' doesn't become too narrow.

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/87537963-c83ea280-c69b-11ea-89b9-0e3b5427cee9.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/87537884-a6ddb680-c69b-11ea-8e74-4aa806bd46fa.png)

Bonus points for doing some testing with other themes, changing the default font size of your browser, etc.

### Changelog

> Several improvements to make Credit Card input fields display more consistent accross different themes and viewport sizes.