### PR TITLE
Move Draft order logic behind feature flag.

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\Blocks\Payments\Integrations\Cheque;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\PayPal;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\BankTransfer;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\CashOnDelivery;
+use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
 
 /**
  * Takes care of bootstrapping the plugin.
@@ -79,7 +80,7 @@ class Bootstrap {
 			$this->container->get( Installer::class );
 			BlockAssets::init();
 		}
-
+		$this->container->get( DraftOrders::class )->init();
 		$this->container->get( PaymentsApi::class );
 		$this->container->get( RestApi::class );
 		Library::init();
@@ -190,6 +191,12 @@ class Bootstrap {
 			Installer::class,
 			function ( Container $container ) {
 				return new Installer();
+			}
+		);
+		$this->container->register(
+			DraftOrders::class,
+			function( Container $container ) {
+				return new DraftOrders( $container->get( Package::class ) );
 			}
 		);
 	}

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -167,8 +167,7 @@ class DraftOrders {
 				as_enqueue_async_action( 'woocommerce_cleanup_draft_orders' );
 			}
 		} catch ( Exception $error ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( $error->getMessage() );
+			wc_caught_exception( $error, __METHOD__ );
 		}
 	}
 
@@ -187,21 +186,20 @@ class DraftOrders {
 			return;
 		}
 
-		$prefix = __CLASS__ . '::delete_expired_draft_orders ';
 		$suffix = ' This is an indicator that something is filtering WooCommerce or WordPress queries and modifying the query parameters.';
 
 		// if count is greater than our expected batch size, then that's a problem.
 		if ( count( $order_results ) > 20 ) {
-			throw new Exception( $prefix . ' is getting an unexpected number of results returned from the query.' . $suffix );
+			throw new Exception( 'There are an unexpected number of results returned from the query.' . $suffix );
 		}
 
 		// if any of the returned orders are not draft (or not a WC_Order), then that's a problem.
 		foreach ( $order_results as $order ) {
 			if ( ! ( $order instanceof WC_Order ) ) {
-				throw new Exception( $prefix . ' returned results containing a value that is not a WC_Order.' . $suffix );
+				throw new Exception( 'The returned results contain a value that is not a WC_Order.' . $suffix );
 			}
 			if ( ! $order->has_status( self::STATUS ) ) {
-				throw new Exception( $prefix . ' has an order that is not a `wc-checkout-draft` status in the results.' . $suffix );
+				throw new Exception( 'The results contain an order that is not a `wc-checkout-draft` status in the results.' . $suffix );
 			}
 		}
 	}

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -65,7 +65,7 @@ class DraftOrders {
 	 *
 	 * @internal
 	 */
-	protected function uninstall() {
+	public function uninstall() {
 		$this->maybe_remove_cronjobs();
 	}
 

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Sets up all logic related to the Checkout Draft Orders service
+ *
+ * @package WooCommerce/Blocks
+ */
+
+namespace Automattic\WooCommerce\Blocks\Domain\Services;
+
+use Automattic\WooCommerce\Blocks\Domain\Package;
+
+/**
+ * Service class for adding DraftOrder functionality to WooCommerce core.
+ */
+class DraftOrders {
+
+	/**
+	 * Holds the Package instance
+	 *
+	 * @var Package
+	 */
+	private $package;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Package $package An instance of the package class.
+	 */
+	public function __construct( Package $package ) {
+		$this->package = $package;
+	}
+
+	/**
+	 * Set all hooks related to adding Checkout Draft order functionality to Woo Core.
+	 */
+	public function init() {
+		if ( $this->package->is_feature_plugin_build() ) {
+			add_filter( 'wc_order_statuses', [ __CLASS__, 'register_draft_order_status' ] );
+			add_filter( 'woocommerce_register_shop_order_post_statuses', [ __CLASS__, 'register_draft_order_post_status' ] );
+			add_filter( 'woocommerce_valid_order_statuses_for_payment', [ __CLASS__, 'append_draft_order_post_status' ] );
+			add_action( 'woocommerce_cleanup_draft_orders', [ __CLASS__, 'delete_expired_draft_orders' ] );
+			add_action( 'admin_init', [ $this, 'install' ] );
+		} else {
+			// Maybe remove existing cronjob if present because it shouldn't be needed in the environment.
+			$this->maybe_remove_cronjobs();
+		}
+	}
+
+	/**
+	 * Installation related logic for Draft order functionality.
+	 */
+	public function install() {
+		$this->maybe_create_cronjobs();
+	}
+
+
+	/**
+	 * Remove cronjobs if they exist (but only from admin).
+	 */
+	protected function maybe_remove_cronjobs() {
+		if ( ! is_admin() ) {
+			return;
+		}
+		if ( function_exists( 'as_next_scheduled_action' ) && true === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
+			as_unschedule_all_actions( 'woocommerce_cleanup_draft_orders' );
+		}
+	}
+
+	/**
+	 * Maybe create cron events.
+	 */
+	protected function maybe_create_cronjobs() {
+		if ( function_exists( 'as_next_scheduled_action' ) && false === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
+			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'woocommerce_cleanup_draft_orders' );
+		}
+	}
+
+
+	/**
+	 * Register custom order status for orders created via the API during checkout.
+	 *
+	 * Draft order status is used before payment is attempted, during checkout, when a cart is converted to an order.
+	 *
+	 * @param array $statuses Array of statuses.
+	 * @return array
+	 */
+	public static function register_draft_order_status( array $statuses ) {
+		$statuses['wc-checkout-draft'] = _x( 'Draft', 'Order status', 'woo-gutenberg-products-block' );
+		return $statuses;
+	}
+
+	/**
+	 * Register custom order post status for orders created via the API during checkout.
+	 *
+	 * @param array $statuses Array of statuses.
+	 * @return array
+	 */
+	public static function register_draft_order_post_status( array $statuses ) {
+		$statuses['wc-checkout-draft'] = [
+			'label'                     => _x( 'Draft', 'Order status', 'woo-gutenberg-products-block' ),
+			'public'                    => false,
+			'exclude_from_search'       => false,
+			'show_in_admin_all_list'    => false,
+			'show_in_admin_status_list' => true,
+			/* translators: %s: number of orders */
+			'label_count'               => _n_noop( 'Drafts <span class="count">(%s)</span>', 'Drafts <span class="count">(%s)</span>', 'woo-gutenberg-products-block' ),
+		];
+		return $statuses;
+	}
+
+	/**
+	 * Append draft status to a list of statuses.
+	 *
+	 * @param array $statuses Array of statuses.
+	 * @return array
+	 */
+	public static function append_draft_order_post_status( $statuses ) {
+		$statuses[] = 'checkout-draft';
+		return $statuses;
+	}
+
+	/**
+	 * Delete draft orders older than a day in batches of 20.
+	 *
+	 * Ran on a daily cron schedule.
+	 */
+	public static function delete_expired_draft_orders() {
+		$count      = 0;
+		$batch_size = 20;
+		$orders     = wc_get_orders(
+			[
+				'date_modified' => '<=' . strtotime( '-1 DAY' ),
+				'limit'         => $batch_size,
+				'status'        => 'wc-checkout-draft',
+				'type'          => 'shop_order',
+			]
+		);
+
+		if ( $orders ) {
+			foreach ( $orders as $order ) {
+				$order->delete( true );
+				$count ++;
+			}
+		}
+
+		if ( $batch_size === $count && function_exists( 'as_enqueue_async_action' ) ) {
+			as_enqueue_async_action( 'woocommerce_cleanup_draft_orders' );
+		}
+	}
+
+}

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -82,7 +82,7 @@ class DraftOrders {
 	 * Unschedule cron jobs that are present.
 	 */
 	protected function maybe_remove_cronjobs() {
-		if ( function_exists( 'as_next_scheduled_action' ) && true === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
+		if ( function_exists( 'as_next_scheduled_action' ) && as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
 			as_unschedule_all_actions( 'woocommerce_cleanup_draft_orders' );
 		}
 	}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -25,7 +25,6 @@ class Installer {
 	 */
 	public function install() {
 		$this->maybe_create_tables();
-		$this->maybe_create_cronjobs();
 	}
 
 	/**
@@ -119,14 +118,5 @@ class Installer {
 				echo '</p></div>';
 			}
 		);
-	}
-
-	/**
-	 * Maybe create cron events.
-	 */
-	protected function maybe_create_cronjobs() {
-		if ( function_exists( 'as_next_scheduled_action' ) && false === as_next_scheduled_action( 'woocommerce_cleanup_draft_orders' ) ) {
-			as_schedule_recurring_action( strtotime( 'midnight tonight' ), DAY_IN_SECONDS, 'woocommerce_cleanup_draft_orders' );
-		}
 	}
 }

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\Blocks\Tests\Library;
 
 use PHPUnit\Framework\TestCase;
 use \WC_Order;
-use Automattic\WooCommerce\Blocks\Library;
+use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
 
 /**
  * Tests Delete Draft Orders functionality
@@ -66,7 +66,7 @@ class DeleteDraftOrders extends TestCase {
 		$this->assertEquals( 3, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-checkout-draft'" ) );
 
 		// Run delete query.
-		Library::delete_expired_draft_orders();
+		DraftOrders::delete_expired_draft_orders();
 
 		// Only 1 should remain.
 		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-checkout-draft'" ) );

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -52,6 +52,21 @@ class DeleteDraftOrders extends TestCase {
 				'ID' => $order->get_id()
 			)
 		);
+
+		// set a non-draft order to make sure it's unaffected
+		$order = new WC_Order();
+		$order->set_status( 'wc-on-hold' );
+		$order->save();
+		$wpdb->update(
+			$wpdb->posts,
+			array(
+				'post_modified'     => date( 'Y-m-d H:i:s', strtotime( '-2 DAY', current_time( 'timestamp' ) ) ),
+				'post_modified_gmt' => gmdate( 'Y-m-d H:i:s', strtotime( '-2 DAY' ) )
+			),
+			array(
+				'ID' => $order->get_id()
+			)
+		);
 	}
 
 	/**
@@ -70,5 +85,8 @@ class DeleteDraftOrders extends TestCase {
 
 		// Only 1 should remain.
 		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-checkout-draft'" ) );
+
+		// The non-draft order should still be present
+		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-on-hold'" ) );
 	}
 }

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -11,7 +11,6 @@ use Automattic\WooCommerce\Blocks\Domain\Package;
  * Tests Delete Draft Orders functionality
  *
  * @since $VID:$
- * @group testing
  */
 class DeleteDraftOrders extends TestCase {
 
@@ -96,13 +95,13 @@ class DeleteDraftOrders extends TestCase {
 		$status = DraftOrders::DB_STATUS;
 
 		// Check there are 3 draft orders from our setup before running tests.
-		$this->assertEquals( 3, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = '$status'" ) );
+		$this->assertEquals( 3, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = '%s'", [ $status ] ) ) );
 
 		// Run delete query.
 		$this->draft_orders_instance->delete_expired_draft_orders();
 
 		// Only 1 should remain.
-		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = '$status'" ) );
+		$this->assertEquals( 1, (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = '%s'", [ $status ] ) ) );
 
 		// The non-draft order should still be present
 		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-on-hold'" ) );

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -16,6 +16,7 @@ use Automattic\WooCommerce\Blocks\Domain\Package;
 class DeleteDraftOrders extends TestCase {
 
 	private $draft_orders_instance;
+	private $caught_exception;
 
 	/**
 	 * During setup create some draft orders.
@@ -61,7 +62,7 @@ class DeleteDraftOrders extends TestCase {
 
 		// set a non-draft order to make sure it's unaffected
 		$order = new WC_Order();
-		$order->set_status( 'wc-on-hold' );
+		$order->set_status( 'on-hold' );
 		$order->save();
 		$wpdb->update(
 			$wpdb->posts,
@@ -73,10 +74,16 @@ class DeleteDraftOrders extends TestCase {
 				'ID' => $order->get_id()
 			)
 		);
+
+		// set listening for exceptions
+		add_action( 'woocommerce_caught_exception', function($exception_object){
+			$this->caught_exception = $exception_object;
+		});
 	}
 
 	public function tearDown() {
 		$this->draft_orders_instance = null;
+		remove_all_actions( 'woocommerce_caught_exception' );
 	}
 
 	/**
@@ -99,5 +106,46 @@ class DeleteDraftOrders extends TestCase {
 
 		// The non-draft order should still be present
 		$this->assertEquals( 1, (int) $wpdb->get_var( "SELECT COUNT(ID) from $wpdb->posts posts WHERE posts.post_status = 'wc-on-hold'" ) );
+	}
+
+	public function test_greater_than_batch_results_error() {
+		$sample_results = function() {
+			return array_fill( 0, 21, ( new WC_Order ) );
+
+		};
+		$this->mock_results_for_wc_query($sample_results);
+		$this->draft_orders_instance->delete_expired_draft_orders();
+		$this->assertContains( 'unexpected number of results', $this->caught_exception->getMessage() );
+		$this->unset_mock_results_for_wc_query( $sample_results );
+	}
+
+	public function test_order_not_instance_of_wc_order_error() {
+		$sample_results = function() {
+			return [ 10 ];
+		};
+		$this->mock_results_for_wc_query( $sample_results );
+		$this->draft_orders_instance->delete_expired_draft_orders();
+		$this->assertContains( 'value that is not a WC_Order', $this->caught_exception->getMessage() );
+		$this->unset_mock_results_for_wc_query( $sample_results );
+	}
+
+	public function test_order_incorrect_status_error() {
+		$sample_results = function() {
+			$test_order = new WC_Order();
+			$test_order->set_status( 'on-hold' );
+			return [ $test_order ];
+		};
+		$this->mock_results_for_wc_query( $sample_results );
+		$this->draft_orders_instance->delete_expired_draft_orders();
+		$this->assertContains( 'order that is not a `wc-checkout-draft`', $this->caught_exception->getMessage() );
+		$this->unset_mock_results_for_wc_query( $sample_results );
+	}
+
+	private function mock_results_for_wc_query( $mock_callback ) {
+		add_filter( 'woocommerce_order_query', $mock_callback );
+	}
+
+	private function unset_mock_results_for_wc_query( $mock_callback ) {
+		remove_filter( 'woocommerce_order_query', $mock_callback );
 	}
 }


### PR DESCRIPTION
Fixes: #2872 

Since much of the draft order functionality was spread throughout the codebase, in this pull I refactored all the draft order logic into a service class. This made it easier to put all it's logic behind a single feature flag conditional and gives us one class to go to for draft order implementation. If/when this moves to core, it also provides a single point of reference for what needs moved into WC Core.

As noted in #2872, there's not much sense in setting up a scheduled action for deleting draft orders if the environment won't have any. So this pull not only prevents adding the schedule if in the Woo Core package environment, but also unschedules any existing schedules that might be present (being schedules might be running in that environment unnecessarily if folks already upgraded to WC 4.3).

While technically, the unscheduling is not _necessary_. This is a good preventative measure for folks that have already installed WC 4.3 which has added the schedules unnecessarily.

## To test

The same steps can be followed as noted in #2574 (which I've included here to make it easier):

1. Create draft orders
2. Run job manually in Tools > Scheduled actions.
3. Change order dates, re-run to ensure orders are deleted.

Besides the above, it'd be good to simulate behaviour when in a non-feature plugin environment. This can be done by setting `woocommerce_blocks_phase = 1` in the `blocks.ini` file in your local environment and checking to see that the scheduled actions have disappeared.

~**Note:** Besides running phpunit, I have _not_ tested this yet because I ran out of time before a meeting and the end of my day. I thought I'd still throw this up for review and possible testing anyways, but I do hope to get to testing this later.~

I have tested the above steps and simulating behaviour when in a non-feature plugin environment.
