### PR TITLE
Add 'Order notes'  to Checkout block

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -35,22 +35,34 @@ const FormStep = ( {
 	description,
 	children,
 	disabled = false,
+	showCounter = false,
 	stepHeadingContent = () => {},
 } ) => {
+	const Element = legend || title ? 'fieldset' : 'div';
+
 	return (
-		<fieldset
+		<Element
 			className={ classnames(
 				className,
-				'wc-block-components-checkout-step'
+				'wc-block-components-checkout-step',
+				{
+					'wc-block-components-checkout-step--with-counter': showCounter,
+				}
 			) }
 			id={ id }
 			disabled={ disabled }
 		>
-			<legend className="screen-reader-text">{ legend || title }</legend>
-			<StepHeading
-				title={ title }
-				stepHeadingContent={ stepHeadingContent() }
-			/>
+			{ !! ( legend || title ) && (
+				<legend className="screen-reader-text">
+					{ legend || title }
+				</legend>
+			) }
+			{ !! title && (
+				<StepHeading
+					title={ title }
+					stepHeadingContent={ stepHeadingContent() }
+				/>
+			) }
 			<div className="wc-block-components-checkout-step__container">
 				{ !! description && (
 					<p className="wc-block-components-checkout-step__description">
@@ -61,7 +73,7 @@ const FormStep = ( {
 					{ children }
 				</div>
 			</div>
-		</fieldset>
+		</Element>
 	);
 };
 
@@ -71,6 +83,7 @@ FormStep.propTypes = {
 	title: PropTypes.string,
 	description: PropTypes.string,
 	children: PropTypes.node,
+	showCounter: PropTypes.bool,
 	stepHeadingContent: PropTypes.func,
 	disabled: PropTypes.bool,
 	legend: PropTypes.string,

--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -38,6 +38,8 @@ const FormStep = ( {
 	showStepNumber = false,
 	stepHeadingContent = () => {},
 } ) => {
+	// If the form step doesn't have a legend or title, render a <div> instead
+	// of a <fieldset>.
 	const Element = legend || title ? 'fieldset' : 'div';
 
 	return (

--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -35,7 +35,7 @@ const FormStep = ( {
 	description,
 	children,
 	disabled = false,
-	showCounter = false,
+	showStepNumber = false,
 	stepHeadingContent = () => {},
 } ) => {
 	const Element = legend || title ? 'fieldset' : 'div';
@@ -46,7 +46,7 @@ const FormStep = ( {
 				className,
 				'wc-block-components-checkout-step',
 				{
-					'wc-block-components-checkout-step--with-counter': showCounter,
+					'wc-block-components-checkout-step--with-counter': showStepNumber,
 				}
 			) }
 			id={ id }
@@ -83,7 +83,7 @@ FormStep.propTypes = {
 	title: PropTypes.string,
 	description: PropTypes.string,
 	children: PropTypes.node,
-	showCounter: PropTypes.bool,
+	showStepNumber: PropTypes.bool,
 	stepHeadingContent: PropTypes.func,
 	disabled: PropTypes.bool,
 	legend: PropTypes.string,

--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -48,7 +48,7 @@ const FormStep = ( {
 				className,
 				'wc-block-components-checkout-step',
 				{
-					'wc-block-components-checkout-step--with-counter': showStepNumber,
+					'wc-block-components-checkout-step--with-step-number': showStepNumber,
 				}
 			) }
 			id={ id }

--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -35,7 +35,7 @@ const FormStep = ( {
 	description,
 	children,
 	disabled = false,
-	showStepNumber = false,
+	showStepNumber = true,
 	stepHeadingContent = () => {},
 } ) => {
 	// If the form step doesn't have a legend or title, render a <div> instead

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -2,7 +2,7 @@
 	counter-reset: checkout-step;
 }
 
-.wc-block-components-checkout-form fieldset.wc-block-components-checkout-step {
+.wc-block-components-checkout-form .wc-block-components-checkout-step {
 	position: relative;
 	border: none;
 	padding: 0 0 0 $gap-larger;
@@ -22,7 +22,7 @@
 	padding-bottom: em($gap-large);
 }
 
-.wc-block-components-checkout-form fieldset.wc-block-components-checkout-step:disabled {
+.wc-block-components-checkout-form .wc-block-components-checkout-step:disabled {
 	opacity: 0.6;
 }
 
@@ -60,30 +60,32 @@
 	margin-bottom: $gap;
 }
 
-.wc-block-components-checkout-step__title::before {
-	@include reset-box();
-	background: transparent;
-	counter-increment: checkout-step;
-	content: "\00a0" counter(checkout-step) ".";
-	content: "\00a0" counter(checkout-step) "." / "";
-	position: absolute;
-	width: $gap-larger;
-	left: -$gap-larger/2;
-	top: 0;
-	text-align: center;
-	transform: translateX(-50%);
-}
+.wc-block-components-checkout-step--with-counter {
+	.wc-block-components-checkout-step__title::before {
+		@include reset-box();
+		background: transparent;
+		counter-increment: checkout-step;
+		content: "\00a0" counter(checkout-step) ".";
+		content: "\00a0" counter(checkout-step) "." / "";
+		position: absolute;
+		width: $gap-larger;
+		left: -$gap-larger/2;
+		top: 0;
+		text-align: center;
+		transform: translateX(-50%);
+	}
 
-.wc-block-components-checkout-step__container::after {
-	content: "";
-	height: 100%;
-	border-left: 1px solid;
-	opacity: 0.3;
-	position: absolute;
-	left: -$gap-larger/2;
-	top: 0;
-}
+	.wc-block-components-checkout-step__container::after {
+		content: "";
+		height: 100%;
+		border-left: 1px solid;
+		opacity: 0.3;
+		position: absolute;
+		left: -$gap-larger/2;
+		top: 0;
+	}
 
-.wc-block-components-checkout-step:last-child .wc-block-components-checkout-step__container::after {
-	content: none;
+	&:last-of-type .wc-block-components-checkout-step__container::after {
+		content: none;
+	}
 }

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -60,7 +60,7 @@
 	margin-bottom: $gap;
 }
 
-.wc-block-components-checkout-step--with-counter {
+.wc-block-components-checkout-step--with-step-number {
 	.wc-block-components-checkout-step__title::before {
 		@include reset-box();
 		background: transparent;

--- a/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
@@ -34,7 +34,7 @@ exports[`FormStep fieldset legend should default to legend prop when title and l
 
 exports[`FormStep should apply correct class when showStepNumber is true 1`] = `
 <fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-counter"
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
   disabled={false}
 >
   <legend

--- a/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
@@ -1,0 +1,262 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormStep fieldset legend should default to legend prop when title and legend are defined 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum 2
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__heading"
+  >
+    <h2
+      aria-hidden="true"
+      className="wc-block-components-title wc-block-components-checkout-step__title"
+    >
+      Lorem Ipsum
+    </h2>
+  </div>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should apply correct class when showStepNumber is true 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-counter"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__heading"
+  >
+    <h2
+      aria-hidden="true"
+      className="wc-block-components-title wc-block-components-checkout-step__title"
+    >
+      Lorem Ipsum
+    </h2>
+  </div>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should apply id and className props 1`] = `
+<div
+  className="my-classname wc-block-components-checkout-step"
+  disabled={false}
+  id="my-id"
+>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FormStep should render a div if no title or legend is provided 1`] = `
+<div
+  className="wc-block-components-checkout-step"
+  disabled={false}
+>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FormStep should render a fieldset if a legend is provided 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum 2
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should render a fieldset with heading if a title is provided 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__heading"
+  >
+    <h2
+      aria-hidden="true"
+      className="wc-block-components-title wc-block-components-checkout-step__title"
+    >
+      Lorem Ipsum
+    </h2>
+  </div>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should render step description 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__heading"
+  >
+    <h2
+      aria-hidden="true"
+      className="wc-block-components-title wc-block-components-checkout-step__title"
+    >
+      Lorem Ipsum
+    </h2>
+  </div>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <p
+      className="wc-block-components-checkout-step__description"
+    >
+      This is the description
+    </p>
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should render step heading content 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__heading"
+  >
+    <h2
+      aria-hidden="true"
+      className="wc-block-components-title wc-block-components-checkout-step__title"
+    >
+      Lorem Ipsum
+    </h2>
+    <span
+      className="wc-block-components-checkout-step__heading-content"
+    >
+      <span>
+        Some context to render next to the heading
+      </span>
+    </span>
+  </div>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should set disabled prop to the fieldset element when disabled is true 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step"
+  disabled={true}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__heading"
+  >
+    <h2
+      aria-hidden="true"
+      className="wc-block-components-title wc-block-components-checkout-step__title"
+    >
+      Lorem Ipsum
+    </h2>
+  </div>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;

--- a/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
@@ -2,7 +2,7 @@
 
 exports[`FormStep fieldset legend should default to legend prop when title and legend are defined 1`] = `
 <fieldset
-  className="wc-block-components-checkout-step"
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
   disabled={false}
 >
   <legend
@@ -32,7 +32,96 @@ exports[`FormStep fieldset legend should default to legend prop when title and l
 </fieldset>
 `;
 
-exports[`FormStep should apply correct class when showStepNumber is true 1`] = `
+exports[`FormStep should apply id and className props 1`] = `
+<div
+  className="my-classname wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+  disabled={false}
+  id="my-id"
+>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FormStep should remove step number CSS class if prop is false 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__heading"
+  >
+    <h2
+      aria-hidden="true"
+      className="wc-block-components-title wc-block-components-checkout-step__title"
+    >
+      Lorem Ipsum
+    </h2>
+  </div>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should render a div if no title or legend is provided 1`] = `
+<div
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+  disabled={false}
+>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FormStep should render a fieldset if a legend is provided 1`] = `
+<fieldset
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+  disabled={false}
+>
+  <legend
+    className="screen-reader-text"
+  >
+    Lorem Ipsum 2
+  </legend>
+  <div
+    className="wc-block-components-checkout-step__container"
+  >
+    <div
+      className="wc-block-components-checkout-step__content"
+    >
+      Dolor sit amet
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`FormStep should render a fieldset with heading if a title is provided 1`] = `
 <fieldset
   className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
   disabled={false}
@@ -64,98 +153,9 @@ exports[`FormStep should apply correct class when showStepNumber is true 1`] = `
 </fieldset>
 `;
 
-exports[`FormStep should apply id and className props 1`] = `
-<div
-  className="my-classname wc-block-components-checkout-step"
-  disabled={false}
-  id="my-id"
->
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
-    <div
-      className="wc-block-components-checkout-step__content"
-    >
-      Dolor sit amet
-    </div>
-  </div>
-</div>
-`;
-
-exports[`FormStep should render a div if no title or legend is provided 1`] = `
-<div
-  className="wc-block-components-checkout-step"
-  disabled={false}
->
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
-    <div
-      className="wc-block-components-checkout-step__content"
-    >
-      Dolor sit amet
-    </div>
-  </div>
-</div>
-`;
-
-exports[`FormStep should render a fieldset if a legend is provided 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
-  >
-    Lorem Ipsum 2
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
-    <div
-      className="wc-block-components-checkout-step__content"
-    >
-      Dolor sit amet
-    </div>
-  </div>
-</fieldset>
-`;
-
-exports[`FormStep should render a fieldset with heading if a title is provided 1`] = `
-<fieldset
-  className="wc-block-components-checkout-step"
-  disabled={false}
->
-  <legend
-    className="screen-reader-text"
-  >
-    Lorem Ipsum
-  </legend>
-  <div
-    className="wc-block-components-checkout-step__heading"
-  >
-    <h2
-      aria-hidden="true"
-      className="wc-block-components-title wc-block-components-checkout-step__title"
-    >
-      Lorem Ipsum
-    </h2>
-  </div>
-  <div
-    className="wc-block-components-checkout-step__container"
-  >
-    <div
-      className="wc-block-components-checkout-step__content"
-    >
-      Dolor sit amet
-    </div>
-  </div>
-</fieldset>
-`;
-
 exports[`FormStep should render step description 1`] = `
 <fieldset
-  className="wc-block-components-checkout-step"
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
   disabled={false}
 >
   <legend
@@ -192,7 +192,7 @@ exports[`FormStep should render step description 1`] = `
 
 exports[`FormStep should render step heading content 1`] = `
 <fieldset
-  className="wc-block-components-checkout-step"
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
   disabled={false}
 >
   <legend
@@ -231,7 +231,7 @@ exports[`FormStep should render step heading content 1`] = `
 
 exports[`FormStep should set disabled prop to the fieldset element when disabled is true 1`] = `
 <fieldset
-  className="wc-block-components-checkout-step"
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
   disabled={true}
 >
   <legend

--- a/assets/js/base/components/cart-checkout/form-step/test/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/test/index.js
@@ -53,9 +53,9 @@ describe( 'FormStep', () => {
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
-	test( 'should apply correct class when showStepNumber is true', () => {
+	test( 'should remove step number CSS class if prop is false', () => {
 		const component = TestRenderer.create(
-			<FormStep title="Lorem Ipsum" showStepNumber={ true }>
+			<FormStep title="Lorem Ipsum" showStepNumber={ false }>
 				Dolor sit amet
 			</FormStep>
 		);

--- a/assets/js/base/components/cart-checkout/form-step/test/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/test/index.js
@@ -1,0 +1,100 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import FormStep from '..';
+
+describe( 'FormStep', () => {
+	test( 'should render a div if no title or legend is provided', () => {
+		const component = TestRenderer.create(
+			<FormStep>Dolor sit amet</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should apply id and className props', () => {
+		const component = TestRenderer.create(
+			<FormStep id="my-id" className="my-classname">
+				Dolor sit amet
+			</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a fieldset if a legend is provided', () => {
+		const component = TestRenderer.create(
+			<FormStep legend="Lorem Ipsum 2">Dolor sit amet</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a fieldset with heading if a title is provided', () => {
+		const component = TestRenderer.create(
+			<FormStep title="Lorem Ipsum">Dolor sit amet</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'fieldset legend should default to legend prop when title and legend are defined', () => {
+		const component = TestRenderer.create(
+			<FormStep title="Lorem Ipsum" legend="Lorem Ipsum 2">
+				Dolor sit amet
+			</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should apply correct class when showStepNumber is true', () => {
+		const component = TestRenderer.create(
+			<FormStep title="Lorem Ipsum" showStepNumber={ true }>
+				Dolor sit amet
+			</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render step heading content', () => {
+		const component = TestRenderer.create(
+			<FormStep
+				title="Lorem Ipsum"
+				stepHeadingContent={ () => (
+					<span>Some context to render next to the heading</span>
+				) }
+			>
+				Dolor sit amet
+			</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render step description', () => {
+		const component = TestRenderer.create(
+			<FormStep title="Lorem Ipsum" description="This is the description">
+				Dolor sit amet
+			</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should set disabled prop to the fieldset element when disabled is true', () => {
+		const component = TestRenderer.create(
+			<FormStep title="Lorem Ipsum" disabled={ true }>
+				Dolor sit amet
+			</FormStep>
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+} );

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -1,19 +1,21 @@
 .wc-block-components-checkbox {
 	@include reset-typography();
-	display: block;
+	align-items: center;
+	display: flex;
+	height: 1em;
 	position: relative;
 
 	.wc-block-components-checkbox__input[type="checkbox"] {
 		appearance: none;
 		border: 1px solid currentColor;
-		height: 1rem;
+		height: 1em;
 		margin: 0;
 		min-height: 16px;
 		min-width: 16px;
 		overflow: hidden;
 		position: static;
 		vertical-align: middle;
-		width: 1rem;
+		width: 1em;
 
 		&:checked {
 			background: currentColor;

--- a/assets/js/base/components/textarea/index.js
+++ b/assets/js/base/components/textarea/index.js
@@ -12,8 +12,8 @@ import './style.scss';
 const Textarea = ( {
 	className = '',
 	disabled = false,
-	placeholder,
 	onChange,
+	placeholder,
 	value = '',
 } ) => {
 	return (

--- a/assets/js/base/components/textarea/index.js
+++ b/assets/js/base/components/textarea/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const Textarea = ( {
+	className = '',
+	disabled = false,
+	placeholder,
+	onChange,
+	value = '',
+} ) => {
+	return (
+		<textarea
+			className={ classnames(
+				'wc-block-components-textarea',
+				className
+			) }
+			disabled={ disabled }
+			onChange={ ( event ) => {
+				onChange( event.target.value );
+			} }
+			placeholder={ placeholder }
+			rows={ 2 }
+			value={ value }
+		/>
+	);
+};
+
+Textarea.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	disabled: PropTypes.bool,
+	placeholder: PropTypes.string,
+	value: PropTypes.string,
+};
+
+export default Textarea;

--- a/assets/js/base/components/textarea/index.js
+++ b/assets/js/base/components/textarea/index.js
@@ -12,7 +12,7 @@ import './style.scss';
 const Textarea = ( {
 	className = '',
 	disabled = false,
-	onChange,
+	onTextChange,
 	placeholder,
 	value = '',
 } ) => {
@@ -24,7 +24,7 @@ const Textarea = ( {
 			) }
 			disabled={ disabled }
 			onChange={ ( event ) => {
-				onChange( event.target.value );
+				onTextChange( event.target.value );
 			} }
 			placeholder={ placeholder }
 			rows={ 2 }
@@ -34,7 +34,7 @@ const Textarea = ( {
 };
 
 Textarea.propTypes = {
-	onChange: PropTypes.func.isRequired,
+	onTextChange: PropTypes.func.isRequired,
 	disabled: PropTypes.bool,
 	placeholder: PropTypes.string,
 	value: PropTypes.string,

--- a/assets/js/base/components/textarea/style.scss
+++ b/assets/js/base/components/textarea/style.scss
@@ -1,0 +1,12 @@
+.wc-block-components-textarea {
+	@include font-size(regular);
+	background-color: #fff;
+	border: 1px solid $input-border-gray;
+	border-radius: 4px;
+	color: $input-text-active;
+	font-family: inherit;
+	line-height: 1.375; // =22px when font-size is 16px.
+	margin: 0;
+	padding: em($gap-small) $gap;
+	width: 100%;
+}

--- a/assets/js/base/context/cart-checkout/checkout-state/actions.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/actions.js
@@ -17,6 +17,7 @@ const {
 	INCREMENT_CALCULATING,
 	DECREMENT_CALCULATING,
 	SET_ORDER_ID,
+	SET_ORDER_NOTES,
 } = TYPES;
 
 /**
@@ -63,5 +64,9 @@ export const actions = {
 	setOrderId: ( orderId ) => ( {
 		type: SET_ORDER_ID,
 		orderId,
+	} ),
+	setOrderNotes: ( orderNotes ) => ( {
+		type: SET_ORDER_NOTES,
+		orderNotes,
 	} ),
 };

--- a/assets/js/base/context/cart-checkout/checkout-state/constants.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/constants.js
@@ -26,6 +26,7 @@ export const DEFAULT_STATE = {
 	hasError: false,
 	calculatingCount: 0,
 	orderId: checkoutData.order_id,
+	orderNotes: '',
 	customerId: checkoutData.customer_id,
 	processingResponse: null,
 };
@@ -42,6 +43,7 @@ export const TYPES = {
 	SET_HAS_ERROR: 'set_checkout_has_error',
 	SET_NO_ERROR: 'set_checkout_no_error',
 	SET_ORDER_ID: 'set_checkout_order_id',
+	SET_ORDER_NOTES: 'set_checkout_order_notes',
 	INCREMENT_CALCULATING: 'increment_calculating',
 	DECREMENT_CALCULATING: 'decrement_calculating',
 };

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -43,6 +43,7 @@ const CheckoutContext = createContext( {
 	hasError: false,
 	redirectUrl: '',
 	orderId: 0,
+	orderNotes: '',
 	customerId: 0,
 	onSubmit: () => void null,
 	onCheckoutAfterProcessingWithSuccess: ( callback ) => void callback,
@@ -56,6 +57,7 @@ const CheckoutContext = createContext( {
 		incrementCalculating: () => void null,
 		decrementCalculating: () => void null,
 		setOrderId: ( id ) => void id,
+		setOrderNotes: ( orderNotes ) => void orderNotes,
 	},
 	hasOrder: false,
 	isCart: false,
@@ -137,6 +139,8 @@ export const CheckoutStateProvider = ( {
 				void dispatch( actions.decrementCalculating() ),
 			setOrderId: ( orderId ) =>
 				void dispatch( actions.setOrderId( orderId ) ),
+			setOrderNotes: ( orderNotes ) =>
+				void dispatch( actions.setOrderNotes( orderNotes ) ),
 			setAfterProcessing: ( response ) => {
 				// capture general error message if this is an error response.
 				if (
@@ -330,6 +334,7 @@ export const CheckoutStateProvider = ( {
 		orderId: checkoutState.orderId,
 		hasOrder: !! checkoutState.orderId,
 		customerId: checkoutState.customerId,
+		orderNotes: checkoutState.orderNotes,
 	};
 	return (
 		<CheckoutContext.Provider value={ checkoutData }>

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -17,6 +17,7 @@ const {
 	INCREMENT_CALCULATING,
 	DECREMENT_CALCULATING,
 	SET_ORDER_ID,
+	SET_ORDER_NOTES,
 } = TYPES;
 
 const {
@@ -66,9 +67,9 @@ export const prepareResponseData = ( data ) => {
  */
 export const reducer = (
 	state = DEFAULT_STATE,
-	{ url, type, orderId, data }
+	{ url, type, orderId, orderNotes, data }
 ) => {
-	let newState;
+	let newState = state;
 	switch ( type ) {
 		case SET_PRISTINE:
 			newState = DEFAULT_STATE;
@@ -182,6 +183,12 @@ export const reducer = (
 			newState = {
 				...state,
 				orderId,
+			};
+			break;
+		case SET_ORDER_NOTES:
+			newState = {
+				...state,
+				orderNotes,
 			};
 			break;
 	}

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -186,10 +186,12 @@ export const reducer = (
 			};
 			break;
 		case SET_ORDER_NOTES:
-			newState = {
-				...state,
-				orderNotes,
-			};
+			if ( state.orderNotes !== orderNotes ) {
+				newState = {
+					...state,
+					orderNotes,
+				};
+			}
 			break;
 	}
 	// automatically update state to idle from pristine as soon as it

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -62,6 +62,7 @@ const CheckoutProcessor = () => {
 		isProcessing: checkoutIsProcessing,
 		isBeforeProcessing: checkoutIsBeforeProcessing,
 		isComplete: checkoutIsComplete,
+		orderNotes,
 	} = useCheckoutContext();
 	const { hasValidationErrors } = useValidationContext();
 	const { shippingAddress, shippingErrorStatus } = useShippingDataContext();
@@ -186,7 +187,7 @@ const CheckoutProcessor = () => {
 		let data = {
 			billing_address: currentBillingData.current,
 			shipping_address: currentShippingAddress.current,
-			customer_note: '',
+			customer_note: orderNotes,
 		};
 		if ( cartNeedsPayment ) {
 			data = {
@@ -256,6 +257,7 @@ const CheckoutProcessor = () => {
 		cartNeedsPayment,
 		receiveCart,
 		dispatchActions,
+		orderNotes,
 	] );
 	// redirect when checkout is complete and there is a redirect url.
 	useEffect( () => {

--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -24,6 +24,10 @@ const blockAttributes = {
 		type: 'boolean',
 		default: false,
 	},
+	showOrderNotes: {
+		type: 'boolean',
+		default: true,
+	},
 	showPolicyLinks: {
 		type: 'boolean',
 		default: true,

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -119,7 +119,10 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		isProcessing: checkoutIsProcessing,
 		customerId,
 		onSubmit,
+		orderNotes,
+		dispatchActions,
 	} = useCheckoutContext();
+	const { setOrderNotes } = dispatchActions;
 	const {
 		hasValidationErrors,
 		showAllValidationErrors,

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -170,7 +170,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 			showAllValidationErrors();
 			scrollToTop( { focusableSelector: 'input:invalid' } );
 		}
-	}, [ hasErrorsToDisplay ] );
+	}, [ hasErrorsToDisplay, scrollToTop, showAllValidationErrors ] );
 
 	if ( ! isEditor && ! hasOrder ) {
 		return <CheckoutOrderError />;

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -57,6 +57,7 @@ import {
  */
 import CheckoutSidebar from './sidebar';
 import CheckoutOrderError from './checkout-order-error';
+import CheckoutOrderNotes from './checkout-order-notes';
 import NoShippingPlaceholder from './no-shipping-placeholder';
 import './style.scss';
 
@@ -226,6 +227,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							stepHeadingContent={ loginPrompt }
+							showCounter={ true }
 						>
 							<ValidatedTextInput
 								id="email"
@@ -253,6 +255,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Enter the physical address where you want us to deliver your order.',
 									'woo-gutenberg-products-block'
 								) }
+								showCounter={ true }
 							>
 								<AddressForm
 									id="shipping"
@@ -312,6 +315,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Enter the address that matches your card or payment method.',
 									'woo-gutenberg-products-block'
 								) }
+								showCounter={ true }
 							>
 								<AddressForm
 									id="billing"
@@ -343,6 +347,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										  )
 										: ''
 								}
+								showCounter={ true }
 							>
 								{ isEditor &&
 								! getShippingRatesPackageCount(
@@ -383,10 +388,31 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										  )
 										: ''
 								}
+								showCounter={ true }
 							>
 								<StoreNoticesProvider context="wc/payment-area">
 									<PaymentMethods />
 								</StoreNoticesProvider>
+							</FormStep>
+						) }
+						{ attributes.showOrderNotes && (
+							<FormStep id="order-notes">
+								<CheckoutOrderNotes
+									disabled={ checkoutIsProcessing }
+									onChange={ setOrderNotes }
+									placeholder={
+										needsShipping
+											? __(
+													'Notes about your order, e.g. special notes for delivery.',
+													'woo-gutenberg-products-block'
+											  )
+											: __(
+													'Notes about your order.',
+													'woo-gutenberg-products-block'
+											  )
+									}
+									value={ orderNotes }
+								/>
 							</FormStep>
 						) }
 					</CheckoutForm>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -230,7 +230,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							stepHeadingContent={ loginPrompt }
-							showStepNumber={ true }
 						>
 							<ValidatedTextInput
 								id="email"
@@ -258,7 +257,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Enter the physical address where you want us to deliver your order.',
 									'woo-gutenberg-products-block'
 								) }
-								showStepNumber={ true }
 							>
 								<AddressForm
 									id="shipping"
@@ -318,7 +316,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Enter the address that matches your card or payment method.',
 									'woo-gutenberg-products-block'
 								) }
-								showStepNumber={ true }
 							>
 								<AddressForm
 									id="billing"
@@ -350,7 +347,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										  )
 										: ''
 								}
-								showStepNumber={ true }
 							>
 								{ isEditor &&
 								! getShippingRatesPackageCount(
@@ -391,7 +387,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										  )
 										: ''
 								}
-								showStepNumber={ true }
 							>
 								<StoreNoticesProvider context="wc/payment-area">
 									<PaymentMethods />
@@ -399,7 +394,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 							</FormStep>
 						) }
 						{ attributes.showOrderNotes && (
-							<FormStep id="order-notes">
+							<FormStep id="order-notes" showStepNumber={ false }>
 								<CheckoutOrderNotes
 									disabled={ checkoutIsProcessing }
 									onChange={ setOrderNotes }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -230,7 +230,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							stepHeadingContent={ loginPrompt }
-							showCounter={ true }
+							showStepNumber={ true }
 						>
 							<ValidatedTextInput
 								id="email"
@@ -258,7 +258,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Enter the physical address where you want us to deliver your order.',
 									'woo-gutenberg-products-block'
 								) }
-								showCounter={ true }
+								showStepNumber={ true }
 							>
 								<AddressForm
 									id="shipping"
@@ -318,7 +318,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 									'Enter the address that matches your card or payment method.',
 									'woo-gutenberg-products-block'
 								) }
-								showCounter={ true }
+								showStepNumber={ true }
 							>
 								<AddressForm
 									id="billing"
@@ -350,7 +350,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										  )
 										: ''
 								}
-								showCounter={ true }
+								showStepNumber={ true }
 							>
 								{ isEditor &&
 								! getShippingRatesPackageCount(
@@ -391,7 +391,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 										  )
 										: ''
 								}
-								showCounter={ true }
+								showStepNumber={ true }
 							>
 								<StoreNoticesProvider context="wc/payment-area">
 									<PaymentMethods />

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 import Textarea from '@woocommerce/base-components/textarea';
@@ -18,7 +19,10 @@ const CheckoutOrderNotes = ( { disabled, onChange, placeholder, value } ) => {
 		<div className="wc-block-checkout__add-note">
 			<CheckboxControl
 				disabled={ disabled }
-				label="Add a note to your order"
+				label={ __(
+					'Add a note to your order',
+					'woo-gutenberg-products-block'
+				) }
 				checked={ withOrderNotes }
 				onChange={ ( isChecked ) => {
 					setWithOrderNotes( isChecked );

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import CheckboxControl from '@woocommerce/base-components/checkbox-control';
+import Textarea from '@woocommerce/base-components/textarea';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const CheckoutOrderNotes = ( { disabled, onChange, placeholder, value } ) => {
+	const [ withOrderNotes, setWithOrderNotes ] = useState( false );
+
+	return (
+		<div className="wc-block-checkout__add-note">
+			<CheckboxControl
+				disabled={ disabled }
+				label="Add a note to your order"
+				checked={ withOrderNotes }
+				onChange={ ( isChecked ) => {
+					setWithOrderNotes( isChecked );
+					onChange( '' );
+				} }
+			/>
+			{ withOrderNotes && (
+				<Textarea
+					disabled={ disabled }
+					onChange={ onChange }
+					placeholder={ placeholder }
+					value={ value }
+				/>
+			) }
+		</div>
+	);
+};
+
+Textarea.propTypes = {
+	onChange: PropTypes.func.isRequired,
+	disabled: PropTypes.bool,
+	placeholder: PropTypes.string,
+	value: PropTypes.string,
+};
+
+export default CheckoutOrderNotes;

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
@@ -42,7 +42,7 @@ const CheckoutOrderNotes = ( { disabled, onChange, placeholder, value } ) => {
 };
 
 Textarea.propTypes = {
-	onChange: PropTypes.func.isRequired,
+	onTextChange: PropTypes.func.isRequired,
 	disabled: PropTypes.bool,
 	placeholder: PropTypes.string,
 	value: PropTypes.string,

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
@@ -32,7 +32,7 @@ const CheckoutOrderNotes = ( { disabled, onChange, placeholder, value } ) => {
 			{ withOrderNotes && (
 				<Textarea
 					disabled={ disabled }
-					onChange={ onChange }
+					onTextChange={ onChange }
 					placeholder={ placeholder }
 					value={ value }
 				/>

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/index.js
@@ -14,6 +14,10 @@ import './style.scss';
 
 const CheckoutOrderNotes = ( { disabled, onChange, placeholder, value } ) => {
 	const [ withOrderNotes, setWithOrderNotes ] = useState( false );
+	// Store order notes when the textarea is hidden. This allows us to recover
+	// text entered previously by the user when the checkbox is re-enabled
+	// while keeping the context clean if the checkbox is disabled.
+	const [ hiddenOrderNotesText, setHiddenOrderNotesText ] = useState( '' );
 
 	return (
 		<div className="wc-block-checkout__add-note">
@@ -26,7 +30,20 @@ const CheckoutOrderNotes = ( { disabled, onChange, placeholder, value } ) => {
 				checked={ withOrderNotes }
 				onChange={ ( isChecked ) => {
 					setWithOrderNotes( isChecked );
-					onChange( '' );
+					if ( isChecked ) {
+						// When re-enabling the checkbox, store in context the
+						// order notes value previously stored in the component
+						// state.
+						if ( value !== hiddenOrderNotesText ) {
+							onChange( hiddenOrderNotesText );
+						}
+					} else {
+						// When un-checking the checkbox, clear the order notes
+						// value in the context but store it in the component
+						// state.
+						onChange( '' );
+						setHiddenOrderNotesText( value );
+					}
 				} }
 			/>
 			{ withOrderNotes && (

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-notes/style.scss
@@ -1,0 +1,8 @@
+.wc-block-checkout__add-note {
+	@include with-translucent-border(1px 0);
+	padding: $gap;
+}
+
+.wc-block-checkout__add-note .wc-block-components-textarea {
+	margin-top: $gap;
+}

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -41,6 +41,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		showPhoneField,
 		requireCompanyField,
 		requirePhoneField,
+		showOrderNotes,
 		showPolicyLinks,
 		showReturnToCart,
 		cartPageId,
@@ -147,6 +148,40 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						className="components-base-control--nested"
 					/>
 				) }
+				<ToggleControl
+					label={ __(
+						'Allow customers to optionally add order notes',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ showOrderNotes }
+					onChange={ () =>
+						setAttributes( {
+							showOrderNotes: ! showOrderNotes,
+						} )
+					}
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Order notes', 'woo-gutenberg-products-block' ) }
+			>
+				<p className="wc-block-checkout__controls-text">
+					{ __(
+						'Reduce the number of fields to checkout.',
+						'woo-gutenberg-products-block'
+					) }
+				</p>
+				<ToggleControl
+					label={ __(
+						'Allow customers to optionally add order notes',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ showOrderNotes }
+					onChange={ () =>
+						setAttributes( {
+							showOrderNotes: ! showOrderNotes,
+						} )
+					}
+				/>
 			</PanelBody>
 			<PanelBody
 				title={ __(

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -148,18 +148,6 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						className="components-base-control--nested"
 					/>
 				) }
-				<ToggleControl
-					label={ __(
-						'Allow customers to optionally add order notes',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ showOrderNotes }
-					onChange={ () =>
-						setAttributes( {
-							showOrderNotes: ! showOrderNotes,
-						} )
-					}
-				/>
 			</PanelBody>
 			<PanelBody
 				title={ __( 'Order notes', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -3,7 +3,7 @@
 }
 
 .wc-block-checkout__use-address-for-billing {
-	margin-top: $gap;
+	margin-top: em($gap-large);
 }
 
 .wc-block-checkout__shipping-option {
@@ -183,7 +183,6 @@
 .is-large {
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {
-
 		.wc-block-components-address-form {
 			margin-left: #{-$gap-small / 2};
 			margin-right: #{-$gap-small / 2};

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -2,8 +2,7 @@
 	top: -96px;
 }
 
-.wc-block-checkout__add-note,
-.wc-block-checkout__keep-updated {
+.wc-block-checkout__use-address-for-billing {
 	margin-top: $gap;
 }
 
@@ -184,6 +183,7 @@
 .is-large {
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {
+
 		.wc-block-components-address-form {
 			margin-left: #{-$gap-small / 2};
 			margin-right: #{-$gap-small / 2};
@@ -208,6 +208,11 @@
 					width: 100%;
 					margin-left: 0;
 					margin-right: 0;
+				}
+
+				&:nth-last-of-type(2),
+				&:last-of-type {
+					margin-bottom: 0;
 				}
 			}
 

--- a/assets/js/type-defs/checkout.js
+++ b/assets/js/type-defs/checkout.js
@@ -16,6 +16,8 @@
  *                                                           the calculating state for checkout by one.
  * @property {function(number|string)}  setOrderId           Dispatches an action that stores the draft
  *                                                           order ID and key to state.
+ * @property {function(string)}         setOrderNotes        Dispatches an action that sets the order
+ *                                                           notes.
  */
 
 /**

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -241,6 +241,8 @@
  *                                                                     context data.
  * @property {number}                       orderId                    This is the ID for the draft
  *                                                                     order if one exists.
+ * @property {number}                       orderNotes                 Order notes introduced by the
+ *                                                                     user in the checkout form.
  * @property {boolean}                      hasOrder                   True when the checkout has a
  *                                                                     draft order from the API.
  * @property {boolean}                      isCart                     When true, means the provider


### PR DESCRIPTION
Fixes #1483.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/87674576-76b71600-c776-11ea-899e-70850108fde3.png)

### How to test the changes in this Pull Request:

1. Go to the Checkout block and check the 'Add a note to your order' checkbox.
2. Introduce some text in the text area that appeared.
3. Place the order and go to the admin, WooCommerce > Orders and verify the order has the note under `Customer provided note`.

### Changelog

> The Checkout block allows customers to introduce an order note. This feature can be disabled in the editor.