### PR TITLE
Fix undefined index 'enabled' for multiple payment method registrations

### DIFF
--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -25,6 +25,24 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	protected $name = '';
 
 	/**
+	 * Settings from the WP options table
+	 *
+	 * @var array
+	 */
+	protected $settings = [];
+
+	/**
+	 * Get a setting from the settings array if set.
+	 *
+	 * @param string $name Setting name.
+	 * @param mixed  $default Value that is returned if the setting does not exist.
+	 * @return mixed
+	 */
+	protected function get_setting( $name, $default = '' ) {
+		return isset( $this->settings[ $name ] ) ? $this->settings[ $name ] : $default;
+	}
+
+	/**
 	 * Returns the name of the payment method.
 	 */
 	public function get_name() {

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -52,7 +52,7 @@ final class BankTransfer extends AbstractPaymentMethodType {
 	 * @return boolean
 	 */
 	public function is_active() {
-		return filter_var( $this->settings['enabled'], FILTER_VALIDATE_BOOLEAN );
+		return filter_var( $this->get_setting( 'enabled', false ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -75,8 +75,8 @@ final class BankTransfer extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'title'       => isset( $this->settings['title'] ) ? $this->settings['title'] : '',
-			'description' => isset( $this->settings['description'] ) ? $this->settings['description'] : '',
+			'title'       => $this->get_setting( 'title' ),
+			'description' => $this->get_setting( 'description' ),
 		];
 	}
 }

--- a/src/Payments/Integrations/CashOnDelivery.php
+++ b/src/Payments/Integrations/CashOnDelivery.php
@@ -52,7 +52,7 @@ final class CashOnDelivery extends AbstractPaymentMethodType {
 	 * @return boolean
 	 */
 	public function is_active() {
-		return filter_var( $this->settings['enabled'], FILTER_VALIDATE_BOOLEAN );
+		return filter_var( $this->get_setting( 'enabled', false ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -61,7 +61,7 @@ final class CashOnDelivery extends AbstractPaymentMethodType {
 	 * @return boolean True if store allows COD payment for orders containing only virtual products.
 	 */
 	private function get_enable_for_virtual() {
-		return filter_var( $this->settings['enable_for_virtual'], FILTER_VALIDATE_BOOLEAN );
+		return filter_var( $this->get_setting( 'enable_for_virtual', false ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -70,7 +70,7 @@ final class CashOnDelivery extends AbstractPaymentMethodType {
 	 * @return array Array of shipping methods (string ids) that allow COD. (If empty, all support COD.)
 	 */
 	private function get_enable_for_methods() {
-		return $this->settings['enable_for_methods'];
+		return $this->get_setting( 'enable_for_methods', [] );
 	}
 
 
@@ -94,8 +94,8 @@ final class CashOnDelivery extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'title'                    => isset( $this->settings['title'] ) ? $this->settings['title'] : '',
-			'description'              => isset( $this->settings['description'] ) ? $this->settings['description'] : '',
+			'title'                    => $this->get_setting( 'title' ),
+			'description'              => $this->get_setting( 'description' ),
 			'enableForVirtual'         => $this->get_enable_for_virtual(),
 			'enableForShippingMethods' => $this->get_enable_for_methods(),
 		];

--- a/src/Payments/Integrations/Cheque.php
+++ b/src/Payments/Integrations/Cheque.php
@@ -27,13 +27,6 @@ final class Cheque extends AbstractPaymentMethodType {
 	protected $name = 'cheque';
 
 	/**
-	 * Settings from the WP options table
-	 *
-	 * @var array
-	 */
-	private $settings;
-
-	/**
 	 * An instance of the Asset Api
 	 *
 	 * @var Api
@@ -62,7 +55,7 @@ final class Cheque extends AbstractPaymentMethodType {
 	 * @return boolean
 	 */
 	public function is_active() {
-		return filter_var( $this->settings['enabled'], FILTER_VALIDATE_BOOLEAN );
+		return filter_var( $this->get_setting( 'enabled', false ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -85,8 +78,8 @@ final class Cheque extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'title'       => isset( $this->settings['title'] ) ? $this->settings['title'] : '',
-			'description' => isset( $this->settings['description'] ) ? $this->settings['description'] : '',
+			'title'       => $this->get_setting( 'title' ),
+			'description' => $this->get_setting( 'description' ),
 		];
 	}
 }

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -27,13 +27,6 @@ final class PayPal extends AbstractPaymentMethodType {
 	protected $name = 'paypal';
 
 	/**
-	 * Settings from the WP options table
-	 *
-	 * @var array
-	 */
-	private $settings;
-
-	/**
 	 * An instance of the Asset Api
 	 *
 	 * @var Api
@@ -62,7 +55,7 @@ final class PayPal extends AbstractPaymentMethodType {
 	 * @return boolean
 	 */
 	public function is_active() {
-		return ! empty( $this->settings['enabled'] ) && 'yes' === $this->settings['enabled'];
+		return filter_var( $this->get_setting( 'enabled', false ), FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
@@ -85,8 +78,8 @@ final class PayPal extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'title'       => isset( $this->settings['title'] ) ? $this->settings['title'] : '',
-			'description' => isset( $this->settings['description'] ) ? $this->settings['description'] : '',
+			'title'       => $this->get_setting( 'title' ),
+			'description' => $this->get_setting( 'description' ),
 		];
 	}
 }

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -31,13 +31,6 @@ final class Stripe extends AbstractPaymentMethodType {
 	protected $name = 'stripe';
 
 	/**
-	 * Stripe settings from the WP options table
-	 *
-	 * @var array
-	 */
-	private $settings;
-
-	/**
 	 * An instance of the Asset Api
 	 *
 	 * @var Api


### PR DESCRIPTION
Prevents notices by checking first if values are set. Adds a helper to get a setting from the array of settings, with optional fallback.

Fixes #2873

### How to test the changes in this Pull Request:

On a clean install (without first saving gateway settings) check no notices are shown in the backend with debug mode enabled.
