### PR TITLE
Update ⚛️ Product Price

### DIFF
--- a/assets/js/atomic/blocks/product/price/attributes.js
+++ b/assets/js/atomic/blocks/product/price/attributes.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+
+let blockAttributes = {};
+
+if ( isFeaturePluginBuild() ) {
+	blockAttributes = {
+		...blockAttributes,
+		align: {
+			type: 'string',
+		},
+		fontSize: {
+			type: 'string',
+		},
+		customFontSize: {
+			type: 'number',
+		},
+		saleFontSize: {
+			type: 'string',
+		},
+		customSaleFontSize: {
+			type: 'number',
+		},
+		color: {
+			type: 'string',
+		},
+		saleColor: {
+			type: 'string',
+		},
+		customColor: {
+			type: 'string',
+		},
+		customSaleColor: {
+			type: 'string',
+		},
+	};
+}
+export default blockAttributes;

--- a/assets/js/atomic/blocks/product/price/block.js
+++ b/assets/js/atomic/blocks/product/price/block.js
@@ -21,6 +21,7 @@ import './style.scss';
  *
  * @param {Object} props                      Incoming props.
  * @param {string} [props.className]          CSS Class name for the component.
+ * @param {string} [props.align]              Text alignment.
  * @param {string} [props.fontSize]           Normal Price font size name.
  * @param {number} [props.customFontSize]     Normal Price custom font size.
  * @param {string} [props.saleFontSize]       Sale Price font size name.
@@ -35,6 +36,7 @@ import './style.scss';
  */
 const Block = ( {
 	className,
+	align,
 	fontSize,
 	customFontSize,
 	saleFontSize,
@@ -99,7 +101,11 @@ const Block = ( {
 				className,
 				'price',
 				'wc-block-components-product-price',
-				`${ parentClassName }__product-price`
+				`${ parentClassName }__product-price`,
+				{
+					[ `wc-block-components-product-price__align-${ align }` ]:
+						align && isFeaturePluginBuild(),
+				}
 			) }
 		>
 			{ hasPriceRange( prices ) ? (

--- a/assets/js/atomic/blocks/product/price/block.js
+++ b/assets/js/atomic/blocks/product/price/block.js
@@ -158,7 +158,7 @@ const PriceRange = ( { currency, minAmount, maxAmount, classes, style } ) => {
 				`${ parentClassName }__product-price__value`,
 				{ [ classes ]: isFeaturePluginBuild() }
 			) }
-			style={ isFeaturePluginBuild ? style : {} }
+			style={ isFeaturePluginBuild() ? style : {} }
 		>
 			<FormattedMonetaryAmount
 				currency={ currency }
@@ -191,7 +191,7 @@ const SalePrice = ( {
 					`${ parentClassName }__product-price__regular`,
 					{ [ classes ]: isFeaturePluginBuild() }
 				) }
-				style={ isFeaturePluginBuild ? style : {} }
+				style={ isFeaturePluginBuild() ? style : {} }
 			>
 				<FormattedMonetaryAmount
 					currency={ currency }
@@ -204,7 +204,7 @@ const SalePrice = ( {
 					`${ parentClassName }__product-price__value`,
 					{ [ saleClasses ]: isFeaturePluginBuild() }
 				) }
-				style={ isFeaturePluginBuild ? saleStyle : {} }
+				style={ isFeaturePluginBuild() ? saleStyle : {} }
 			>
 				<FormattedMonetaryAmount
 					currency={ currency }
@@ -224,7 +224,7 @@ const Price = ( { currency, price, classes = '', style = {} } ) => {
 				`${ parentClassName }__product-price__value`,
 				{ [ classes ]: isFeaturePluginBuild() }
 			) }
-			style={ isFeaturePluginBuild ? style : {} }
+			style={ isFeaturePluginBuild() ? style : {} }
 		>
 			<FormattedMonetaryAmount currency={ currency } value={ price } />
 		</span>

--- a/assets/js/atomic/blocks/product/price/edit.js
+++ b/assets/js/atomic/blocks/product/price/edit.js
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody } from '@wordpress/components';
+import { PanelBody, BaseControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import {
 	InspectorControls,
 	BlockControls,
 	AlignmentToolbar,
 	withColors,
-	PanelColorSettings,
+	ColorPalette,
 	FontSizePicker,
 	withFontSizes,
 } from '@wordpress/block-editor';
@@ -19,6 +19,26 @@ import { isFeaturePluginBuild } from '@woocommerce/block-settings';
  */
 import Block from './block';
 
+const TextControl = ( {
+	fontSize,
+	setFontSize,
+	color,
+	setColor,
+	colorLabel,
+} ) => (
+	<>
+		<FontSizePicker value={ fontSize.size } onChange={ setFontSize } />
+		{ /* ColorPalette doesn't accept an id. */
+		/* eslint-disable-next-line @wordpress/no-base-control-with-label-without-id */ }
+		<BaseControl label={ colorLabel }>
+			<ColorPalette
+				value={ color.color }
+				onChange={ setColor }
+				label={ __( 'Color' ) }
+			/>
+		</BaseControl>
+	</>
+);
 const PriceEdit = ( {
 	fontSize,
 	saleFontSize,
@@ -47,38 +67,40 @@ const PriceEdit = ( {
 			<InspectorControls>
 				{ isFeaturePluginBuild() && (
 					<>
-						<PanelBody title={ __( 'Normal price' ) }>
-							<FontSizePicker
-								value={ fontSize.size }
-								onChange={ setFontSize }
+						<PanelBody
+							title={ __(
+								'Price',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							<TextControl
+								color={ color }
+								setColor={ setColor }
+								fontSize={ fontSize }
+								setFontSize={ setFontSize }
+								colorLabel={ __(
+									'Color',
+									'woo-gutenberg-products-block'
+								) }
 							/>
 						</PanelBody>
-						<PanelColorSettings
-							title={ __( 'Normal price color' ) }
-							colorSettings={ [
-								{
-									value: color.color,
-									onChange: setColor,
-									label: __( 'Color' ),
-								},
-							] }
-						></PanelColorSettings>
-						<PanelBody title={ __( 'Sale price' ) }>
-							<FontSizePicker
-								value={ saleFontSize.size }
-								onChange={ setSaleFontSize }
+						<PanelBody
+							title={ __(
+								'Sale price',
+								'woo-gutenberg-products-block'
+							) }
+						>
+							<TextControl
+								color={ saleColor }
+								setColor={ setSaleColor }
+								fontSize={ saleFontSize }
+								setFontSize={ setSaleFontSize }
+								colorLabel={ __(
+									'Color',
+									'woo-gutenberg-products-block'
+								) }
 							/>
 						</PanelBody>
-						<PanelColorSettings
-							title={ __( 'Sale price color' ) }
-							colorSettings={ [
-								{
-									value: saleColor.color,
-									onChange: setSaleColor,
-									label: __( 'Color' ),
-								},
-							] }
-						></PanelColorSettings>
 					</>
 				) }
 			</InspectorControls>
@@ -91,8 +113,10 @@ const Price = isFeaturePluginBuild()
 	? compose( [
 			withFontSizes( 'fontSize' ),
 			withFontSizes( 'saleFontSize' ),
+			withFontSizes( 'originalFontSize' ),
 			withColors( 'color', { textColor: 'color' } ),
 			withColors( 'saleColor', { textColor: 'saleColor' } ),
+			withColors( 'originalColor', { textColor: 'originalColor' } ),
 	  ] )( PriceEdit )
 	: PriceEdit;
 

--- a/assets/js/atomic/blocks/product/price/edit.js
+++ b/assets/js/atomic/blocks/product/price/edit.js
@@ -1,8 +1,99 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import {
+	InspectorControls,
+	BlockControls,
+	AlignmentToolbar,
+	withColors,
+	PanelColorSettings,
+	FontSizePicker,
+	withFontSizes,
+} from '@wordpress/block-editor';
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+/**
  * Internal dependencies
  */
 import Block from './block';
 
-export default ( { attributes } ) => {
-	return <Block { ...attributes } />;
+const PriceEdit = ( {
+	fontSize,
+	saleFontSize,
+	setFontSize,
+	setSaleFontSize,
+	color,
+	saleColor,
+	setColor,
+	setSaleColor,
+	attributes,
+	setAttributes,
+} ) => {
+	const { align } = attributes;
+	return (
+		<>
+			{ isFeaturePluginBuild() && (
+				<BlockControls>
+					<AlignmentToolbar
+						value={ align }
+						onChange={ ( nextAlign ) => {
+							setAttributes( { align: nextAlign } );
+						} }
+					/>
+				</BlockControls>
+			) }
+			<InspectorControls>
+				{ isFeaturePluginBuild() && (
+					<>
+						<PanelBody title={ __( 'Normal price' ) }>
+							<FontSizePicker
+								value={ fontSize.size }
+								onChange={ setFontSize }
+							/>
+						</PanelBody>
+						<PanelColorSettings
+							title={ __( 'Normal price color' ) }
+							colorSettings={ [
+								{
+									value: color.color,
+									onChange: setColor,
+									label: __( 'Color' ),
+								},
+							] }
+						></PanelColorSettings>
+						<PanelBody title={ __( 'Sale price' ) }>
+							<FontSizePicker
+								value={ saleFontSize.size }
+								onChange={ setSaleFontSize }
+							/>
+						</PanelBody>
+						<PanelColorSettings
+							title={ __( 'Sale price color' ) }
+							colorSettings={ [
+								{
+									value: saleColor.color,
+									onChange: setSaleColor,
+									label: __( 'Color' ),
+								},
+							] }
+						></PanelColorSettings>
+					</>
+				) }
+			</InspectorControls>
+			<Block { ...attributes } />
+		</>
+	);
 };
+
+const Price = isFeaturePluginBuild()
+	? compose( [
+			withFontSizes( 'fontSize' ),
+			withFontSizes( 'saleFontSize' ),
+			withColors( 'color', { textColor: 'color' } ),
+			withColors( 'saleColor', { textColor: 'saleColor' } ),
+	  ] )( PriceEdit )
+	: PriceEdit;
+
+export default Price;

--- a/assets/js/atomic/blocks/product/price/index.js
+++ b/assets/js/atomic/blocks/product/price/index.js
@@ -9,6 +9,7 @@ import { CURRENCY } from '@woocommerce/settings';
  * Internal dependencies
  */
 import sharedConfig from '../shared-config';
+import attributes from './attributes';
 import edit from './edit';
 
 const blockConfig = {
@@ -22,6 +23,7 @@ const blockConfig = {
 		foreground: '#96588a',
 	},
 	edit,
+	attributes,
 };
 
 registerBlockType( 'woocommerce/product-price', {

--- a/assets/js/atomic/blocks/product/price/index.js
+++ b/assets/js/atomic/blocks/product/price/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { Icon, bill } from '@woocommerce/icons';
+import { CURRENCY } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ const blockConfig = {
 		'woo-gutenberg-products-block'
 	),
 	icon: {
-		src: <Icon srcElement={ bill } />,
+		src: <b style={ { color: '$96588a' } }>{ CURRENCY.symbol }</b>,
 		foreground: '#96588a',
 	},
 	edit,

--- a/assets/js/atomic/blocks/product/price/style.scss
+++ b/assets/js/atomic/blocks/product/price/style.scss
@@ -16,4 +16,15 @@
 			width: 5em;
 		}
 	}
+	/*rtl:begin:ignore*/
+	.wc-block-components-product-price__align-left {
+		text-align: left;
+	}
+	.wc-block-components-product-price__align-center {
+		text-align: center;
+	}
+	.wc-block-components-product-price__align-right {
+		text-align: right;
+	}
+	/*rtl:end:ignore*/
 }


### PR DESCRIPTION
Closes #2853

This PR adds several options to Product Price:

- Block Icon is derived from the store currency
<img width="122" alt="Screen Shot 2020-07-15 at 6 39 02 PM" src="https://user-images.githubusercontent.com/6165348/87702012-be4a9b80-c790-11ea-8566-b8493622c3cc.png">
<img width="184" alt="Screen Shot 2020-07-15 at 6 43 26 PM" src="https://user-images.githubusercontent.com/6165348/87702016-bf7bc880-c790-11ea-9f0e-ba440e339bba.png">
<img width="128" alt="Screen Shot 2020-07-15 at 6 39 43 PM" src="https://user-images.githubusercontent.com/6165348/87702017-bf7bc880-c790-11ea-9617-5b5c6defd16a.png">

- Block supports alignment, defaults values are set in CSS, not as an attribute, to allow better RTL integration, the value is applied as classname instead of inline, `.wc-block-components-product-price__align-(left|center|right)`.

- two new panels to control text size and color, one for the price, one for the undiscounted old price.


### Screenshots
![ezgif com-video-to-gif (9)](https://user-images.githubusercontent.com/6165348/87703161-4d0be800-c792-11ea-8177-5f3c43f73594.gif)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Insert a single product or All product
2. Edit the product Price, using alignment, color, or size.
3. Confirm changes in frontend.
4. run a Core build `WOOCOMMERCE_BLOCKS_PHASE=1 npm run build` and confirm changes are not visible.

<!-- If you can, add the appropriate labels -->

### Changelog

> All Products Product Price supports alignment control, color control, and font size control.

