### PR TITLE
Add attributes and view toggle tests to the Cart block

### DIFF
--- a/tests/e2e-tests/config/setup.js
+++ b/tests/e2e-tests/config/setup.js
@@ -8,6 +8,7 @@ import { setup as setupPuppeteer } from 'jest-environment-puppeteer';
  */
 import {
 	setupSettings,
+	setupPageSettings,
 	createTaxes,
 	createCoupons,
 	createProducts,
@@ -36,6 +37,7 @@ module.exports = async ( globalConfig ) => {
 			createShippingZones(),
 			createBlockPages(),
 			enablePaymentGateways(),
+			setupPageSettings(),
 		] );
 		const [ , taxes, coupons, categories, shippingZones, pages ] = results;
 

--- a/tests/e2e-tests/fixtures/fixture-data.js
+++ b/tests/e2e-tests/fixtures/fixture-data.js
@@ -192,6 +192,33 @@ const Settings = () => [
 ];
 
 /**
+ * Page settings fixture data, using the update batch endpoint.
+ *
+ * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-setting-options|Batch update setting options}
+ */
+const PageSettings = ( pages = [] ) => {
+	const pageSettings = pages
+		.map( ( page ) => {
+			if ( page.slug.includes( 'cart-block' ) ) {
+				return {
+					id: 'woocommerce_cart_page_id',
+					value: page.id.toString(),
+				};
+			}
+			if ( page.slug.includes( 'checkout-block' ) ) {
+				return {
+					id: 'woocommerce_checkout_page_id',
+					value: page.id.toString(),
+				};
+			}
+			return null;
+		} )
+		.filter( Boolean );
+
+	return pageSettings;
+};
+
+/**
  * Shipping Zones fixture data, using the shipping zone endpoint, shipping
  * location, and shipping method endpoint.
  *
@@ -261,6 +288,7 @@ module.exports = {
 	Categories,
 	Products,
 	Settings,
+	PageSettings,
 	Shipping,
 	Taxes,
 };

--- a/tests/e2e-tests/fixtures/fixture-data.js
+++ b/tests/e2e-tests/fixtures/fixture-data.js
@@ -197,25 +197,23 @@ const Settings = () => [
  * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-setting-options|Batch update setting options}
  */
 const PageSettings = ( pages = [] ) => {
-	const pageSettings = pages
-		.map( ( page ) => {
-			if ( page.slug.includes( 'cart-block' ) ) {
-				return {
-					id: 'woocommerce_cart_page_id',
-					value: page.id.toString(),
-				};
-			}
-			if ( page.slug.includes( 'checkout-block' ) ) {
-				return {
-					id: 'woocommerce_checkout_page_id',
-					value: page.id.toString(),
-				};
-			}
-			return null;
-		} )
-		.filter( Boolean );
+	const cartPage = pages.find( ( page ) =>
+		page.slug.includes( 'cart-block' )
+	);
+	const checkoutPage = pages.find( ( page ) =>
+		page.slug.includes( 'checkout-block' )
+	);
 
-	return pageSettings;
+	return [
+		{
+			id: 'woocommerce_cart_page_id',
+			value: cartPage.id.toString(),
+		},
+		{
+			id: 'woocommerce_checkout_page_id',
+			value: checkoutPage.id.toString(),
+		},
+	];
 };
 
 /**

--- a/tests/e2e-tests/fixtures/fixture-loaders.js
+++ b/tests/e2e-tests/fixtures/fixture-loaders.js
@@ -48,6 +48,22 @@ const setupSettings = ( fixture = fixtures.Settings() ) =>
 		update: fixture,
 	} );
 
+const setupPageSettings = () => {
+	axios
+		.get( WPAPI, {
+			auth: {
+				username: process.env.WORDPRESS_LOGIN,
+				password: process.env.WORDPRESS_PASSWORD,
+			},
+		} )
+		.then( ( response ) => {
+			const fixture = fixtures.PageSettings( response.data );
+			WooCommerce.post( 'settings/advanced/batch', {
+				update: fixture,
+			} );
+		} );
+};
+
 /**
  * Create taxes.
  *
@@ -341,6 +357,7 @@ const deleteBlockPages = ( ids ) => {
 
 module.exports = {
 	setupSettings,
+	setupPageSettings,
 	createTaxes,
 	deleteTaxes,
 	createCoupons,

--- a/tests/e2e-tests/fixtures/fixture-loaders.js
+++ b/tests/e2e-tests/fixtures/fixture-loaders.js
@@ -49,19 +49,12 @@ const setupSettings = ( fixture = fixtures.Settings() ) =>
 	} );
 
 const setupPageSettings = () => {
-	axios
-		.get( WPAPI, {
-			auth: {
-				username: process.env.WORDPRESS_LOGIN,
-				password: process.env.WORDPRESS_PASSWORD,
-			},
-		} )
-		.then( ( response ) => {
-			const fixture = fixtures.PageSettings( response.data );
-			WooCommerce.post( 'settings/advanced/batch', {
-				update: fixture,
-			} );
+	axios.get( WPAPI ).then( ( response ) => {
+		const fixture = fixtures.PageSettings( response.data );
+		WooCommerce.post( 'settings/advanced/batch', {
+			update: fixture,
 		} );
+	} );
 };
 
 /**

--- a/tests/e2e-tests/specs/backend/cart.test.js
+++ b/tests/e2e-tests/specs/backend/cart.test.js
@@ -46,7 +46,6 @@ describe( `${ block.name } Block`, () => {
 
 	it( 'can toggle Shipping calculator', async () => {
 		await openDocumentSettingsSidebar();
-		// Focus on the block.
 		await page.click( block.class );
 		const toggle = await findToggleWithLabel( 'Shipping calculator' );
 		await toggle.click();
@@ -61,7 +60,6 @@ describe( `${ block.name } Block`, () => {
 
 	it( 'can toggle shipping costs', async () => {
 		await openDocumentSettingsSidebar();
-		// we focus on the block
 		await page.click( block.class );
 		const toggle = await findToggleWithLabel(
 			'Hide shipping costs until an address is entered'
@@ -78,7 +76,6 @@ describe( `${ block.name } Block`, () => {
 
 	it( 'shows empty cart when changing the view', async () => {
 		await openDocumentSettingsSidebar();
-		// we focus on the block
 		await page.click( block.class );
 		await expect( page ).toMatchElement(
 			'[hidden] .wc-block-cart__empty-cart__title'

--- a/tests/e2e-tests/specs/backend/cart.test.js
+++ b/tests/e2e-tests/specs/backend/cart.test.js
@@ -2,17 +2,26 @@
  * External dependencies
  */
 import {
-	insertBlock,
+	clickButton,
 	getAllBlocks,
+	insertBlock,
+	openDocumentSettingsSidebar,
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
 
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	findToggleWithLabel,
+	visitBlockPage,
+} from '@woocommerce/blocks-test-utils';
 
 const block = {
 	name: 'Cart',
 	slug: 'woocommerce/cart',
 	class: '.wc-block-cart',
+};
+
+const closeInserter = async () => {
+	await page.click( '.edit-post-header [aria-label="Add block"]' );
 };
 
 if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
@@ -27,10 +36,60 @@ describe( `${ block.name } Block`, () => {
 
 	it( 'can only be inserted once', async () => {
 		await insertBlock( block.name );
+		await closeInserter();
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );
 
 	it( 'renders without crashing', async () => {
 		await expect( page ).toRenderBlock( block );
+	} );
+
+	it( 'can toggle Shipping calculator', async () => {
+		await openDocumentSettingsSidebar();
+		// Focus on the block.
+		await page.click( block.class );
+		const toggle = await findToggleWithLabel( 'Shipping calculator' );
+		await toggle.click();
+		await expect( page ).not.toMatchElement(
+			`${ block.class } .wc-block-components-totals-shipping__change-address-button`
+		);
+		await toggle.click();
+		await expect( page ).toMatchElement(
+			`${ block.class } .wc-block-components-totals-shipping__change-address-button`
+		);
+	} );
+
+	it( 'can toggle shipping costs', async () => {
+		await openDocumentSettingsSidebar();
+		// we focus on the block
+		await page.click( block.class );
+		const toggle = await findToggleWithLabel(
+			'Hide shipping costs until an address is entered'
+		);
+		await toggle.click();
+		await expect( page ).not.toMatchElement(
+			`${ block.class } .wc-block-components-totals-shipping__fieldset`
+		);
+		await toggle.click();
+		await expect( page ).toMatchElement(
+			`${ block.class } .wc-block-components-totals-shipping__fieldset`
+		);
+	} );
+
+	it( 'shows empty cart when changing the view', async () => {
+		await openDocumentSettingsSidebar();
+		// we focus on the block
+		await page.click( block.class );
+		await expect( page ).toMatchElement(
+			'[hidden] .wc-block-cart__empty-cart__title'
+		);
+		await clickButton( 'Empty Cart' );
+		await expect( page ).not.toMatchElement(
+			'[hidden] .wc-block-cart__empty-cart__title'
+		);
+		await clickButton( 'Full Cart' );
+		await expect( page ).toMatchElement(
+			'[hidden] .wc-block-cart__empty-cart__title'
+		);
 	} );
 } );

--- a/tests/e2e-tests/specs/backend/product-search.test.js
+++ b/tests/e2e-tests/specs/backend/product-search.test.js
@@ -7,7 +7,10 @@ import {
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 import { clearAndFillInput } from '@woocommerce/e2e-tests/utils';
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	findToggleWithLabel,
+	visitBlockPage,
+} from '@woocommerce/blocks-test-utils';
 
 const block = {
 	name: 'Product Search',
@@ -29,11 +32,12 @@ describe( `${ block.name } Block`, () => {
 		await openDocumentSettingsSidebar();
 		// we focus on the block
 		await page.click( block.class );
-		await page.click( '.components-form-toggle__input' );
+		const toggle = await findToggleWithLabel( 'Show search field label' );
+		await toggle.click();
 		await expect( page ).not.toMatchElement(
 			`${ block.class } .wc-block-product-search__label`
 		);
-		await page.click( '.components-form-toggle__input' );
+		await toggle.click();
 		await expect( page ).toMatchElement(
 			`${ block.class } .wc-block-product-search__label`
 		);

--- a/tests/utils/find-toggle-with-label.js
+++ b/tests/utils/find-toggle-with-label.js
@@ -1,0 +1,13 @@
+/**
+ * Finds the label of a toggle control.
+ *
+ * @param {string} label The label associated with a toggle control.
+ *
+ * @return {?ElementHandle} Object that represents an in-page DOM element.
+ */
+export async function findToggleWithLabel( label ) {
+	const [ toggle ] = await page.$x(
+		`//div[contains(@class,"components-toggle-control")]//label[contains(text(), '${ label }')]`
+	);
+	return toggle;
+}

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,1 +1,2 @@
+export { findToggleWithLabel } from './find-toggle-with-label';
 export { visitBlockPage } from './visit-block-page';


### PR DESCRIPTION
This PR adds 3 new tests to the Cart block and creates a new `PageSettings` setup script that updates WC options so Cart and Checkout pages link to the pages with the Cart and Checkout blocks.

### How to test the changes in this Pull Request:

Basically, [run e2e tests](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/contributors/javascript-testing.md#how-to-run-end-to-end-tests) and verify they pass.