### PR TITLE
Add autocapitalize attribute to Address Form fields

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
+++ b/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
@@ -26,7 +26,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'given-name',
-		autocapitalize: 'words',
+		autocapitalize: 'sentences',
 		required: true,
 		hidden: false,
 		index: 1,
@@ -38,7 +38,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'family-name',
-		autocapitalize: 'words',
+		autocapitalize: 'sentences',
 		required: true,
 		hidden: false,
 		index: 2,
@@ -50,7 +50,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'organization',
-		autocapitalize: 'words',
+		autocapitalize: 'sentences',
 		required: false,
 		hidden: false,
 		index: 3,
@@ -62,7 +62,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'address-line1',
-		autocapitalize: 'words',
+		autocapitalize: 'sentences',
 		required: true,
 		hidden: false,
 		index: 4,
@@ -74,7 +74,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'address-line2',
-		autocapitalize: 'words',
+		autocapitalize: 'sentences',
 		required: false,
 		hidden: false,
 		index: 5,
@@ -94,7 +94,7 @@ const AddressFields = {
 		label: __( 'City', 'woo-gutenberg-products-block' ),
 		optionalLabel: __( 'City (optional)', 'woo-gutenberg-products-block' ),
 		autocomplete: 'address-level2',
-		autocapitalize: 'words',
+		autocapitalize: 'sentences',
 		required: true,
 		hidden: false,
 		index: 7,
@@ -106,7 +106,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'address-level1',
-		autocapitalize: 'words',
+		autocapitalize: 'sentences',
 		required: true,
 		hidden: false,
 		index: 8,

--- a/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
+++ b/assets/js/base/components/cart-checkout/address-form/default-address-fields.js
@@ -26,6 +26,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'given-name',
+		autocapitalize: 'words',
 		required: true,
 		hidden: false,
 		index: 1,
@@ -37,6 +38,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'family-name',
+		autocapitalize: 'words',
 		required: true,
 		hidden: false,
 		index: 2,
@@ -48,6 +50,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'organization',
+		autocapitalize: 'words',
 		required: false,
 		hidden: false,
 		index: 3,
@@ -59,6 +62,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'address-line1',
+		autocapitalize: 'words',
 		required: true,
 		hidden: false,
 		index: 4,
@@ -70,6 +74,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'address-line2',
+		autocapitalize: 'words',
 		required: false,
 		hidden: false,
 		index: 5,
@@ -89,6 +94,7 @@ const AddressFields = {
 		label: __( 'City', 'woo-gutenberg-products-block' ),
 		optionalLabel: __( 'City (optional)', 'woo-gutenberg-products-block' ),
 		autocomplete: 'address-level2',
+		autocapitalize: 'words',
 		required: true,
 		hidden: false,
 		index: 7,
@@ -100,6 +106,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'address-level1',
+		autocapitalize: 'words',
 		required: true,
 		hidden: false,
 		index: 8,
@@ -111,6 +118,7 @@ const AddressFields = {
 			'woo-gutenberg-products-block'
 		),
 		autocomplete: 'postal-code',
+		autocapitalize: 'characters',
 		required: true,
 		hidden: false,
 		index: 9,

--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -180,6 +180,7 @@ const AddressForm = ( {
 							field.required ? field.label : field.optionalLabel
 						}
 						value={ values[ field.key ] }
+						autoCapitalize={ field.autocapitalize }
 						autoComplete={ field.autocomplete }
 						onChange={ ( newValue ) =>
 							onChange( {

--- a/assets/js/base/components/text-input/index.js
+++ b/assets/js/base/components/text-input/index.js
@@ -24,6 +24,7 @@ const TextInput = forwardRef(
 			screenReaderLabel,
 			disabled,
 			help,
+			autoCapitalize = 'off',
 			autoComplete = 'off',
 			value = '',
 			onChange,
@@ -50,6 +51,7 @@ const TextInput = forwardRef(
 					id={ id }
 					value={ value }
 					ref={ ref }
+					autoCapitalize={ autoCapitalize }
 					autoComplete={ autoComplete }
 					onChange={ ( event ) => {
 						onChange( event.target.value );
@@ -101,6 +103,7 @@ TextInput.propTypes = {
 	screenReaderLabel: PropTypes.string,
 	disabled: PropTypes.bool,
 	help: PropTypes.string,
+	autoCapitalize: PropTypes.string,
 	autoComplete: PropTypes.string,
 	required: PropTypes.bool,
 };


### PR DESCRIPTION
Fixes #2564.

### How to test the changes in this Pull Request:

1. In order to test this, you will need to visit the Checkout page with a handheld device with Chrome for Android or iOS Safari.
2. Navigate through the input fields in the address form.
3. Verify when a field is focused, the keyboard shows capital letters by default according to the settings.

I took the [suggested capitalization settings](https://developers.google.com/web/updates/2015/04/autocapitalize#when_should_i_use_this) from this article.

### Changelog

> Cart and Checkout form fields show autocapitalized keyboard on mobile depending on the expected value.