### PR TITLE
Add query filter when searching for a table

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -89,13 +89,13 @@ class Installer {
 	protected function maybe_create_table( $table_name, $create_sql ) {
 		global $wpdb;
 
-		if ( in_array( $table_name, $wpdb->get_col( "SHOW TABLES LIKE '$table_name'", 0 ), true ) ) {
+		if ( in_array( $table_name, $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ), 0 ), true ) ) {
 			return true;
 		}
 
 		$wpdb->query( $create_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
-		return in_array( $table_name, $wpdb->get_col( "SHOW TABLES LIKE '$table_name'", 0 ), true );
+		return in_array( $table_name, $wpdb->get_col( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ), 0 ), true );
 	}
 
 	/**

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -89,13 +89,13 @@ class Installer {
 	protected function maybe_create_table( $table_name, $create_sql ) {
 		global $wpdb;
 
-		if ( in_array( $table_name, $wpdb->get_col( 'SHOW TABLES', 0 ), true ) ) {
+		if ( in_array( $table_name, $wpdb->get_col( "SHOW TABLES LIKE '$table_name'", 0 ), true ) ) {
 			return true;
 		}
 
 		$wpdb->query( $create_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
-		return in_array( $table_name, $wpdb->get_col( 'SHOW TABLES', 0 ), true );
+		return in_array( $table_name, $wpdb->get_col( "SHOW TABLES LIKE '$table_name'", 0 ), true );
 	}
 
 	/**


### PR DESCRIPTION
This change adds a filter to queries `SHOW TABLES` on function `Installer::maybe_create_table()`. The queries are used intending to check if a table exists. It's faster to search only for the given name than to search among all database tables.

Fixes #2885 
