### PR TITLE
remove duplicate back order badge for cart

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -122,7 +122,6 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 						/>
 					)
 				) }
-				{ showBackorderBadge && <ProductBackorderBadge /> }
 				<ProductMetadata
 					shortDescription={ shortDescription }
 					fullDescription={ fullDescription }


### PR DESCRIPTION
While testing the `release/3.0` branch, I noticed this for the product backorder badge in the cart.

<img width="824" alt="Image 2020-07-21 at 8 08 25 AM" src="https://user-images.githubusercontent.com/1429108/88054014-ab3a2180-cb2a-11ea-95b3-0888322c434b.png">

The work for this badge was done in #2833. I suspect that this is a case of potential bad merge conflict resolution.

## To Test

- Follow the testing steps in #2833 and ensure the Product backorder badge shows up as expected (not duplicated) in both the cart and checkout.
- Ensure low stock remaining badge still shows up as expected given the conditions for it to show up.

**Note: This branch is based off of release/3.0. It will be merged into master once 3.0 is released.**