### PR TITLE
Cart & Checkout: fix '0' visible when product stock was 0 and it allowed backorders

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -65,7 +65,7 @@ const OrderSummaryItem = ( { cartItem } ) => {
 				{ showBackorderBadge ? (
 					<ProductBackorderBadge />
 				) : (
-					lowStockRemaining && (
+					!! lowStockRemaining && (
 						<ProductLowStockBadge
 							lowStockRemaining={ lowStockRemaining }
 						/>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -116,7 +116,7 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 				{ showBackorderBadge ? (
 					<ProductBackorderBadge />
 				) : (
-					lowStockRemaining && (
+					!! lowStockRemaining && (
 						<ProductLowStockBadge
 							lowStockRemaining={ lowStockRemaining }
 						/>


### PR DESCRIPTION
### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/88063300-2bcc4280-cb6a-11ea-8e2d-e234d104b8f5.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/88063091-f0317880-cb69-11ea-9dd1-6b33eefa01be.png)

### How to test the changes in this Pull Request:

1. Edit a product inventory so its stock quantity is 0 and it allows backorders (but they are not notified to the user).
![imatge](https://user-images.githubusercontent.com/3616980/88062951-c2e4ca80-cb69-11ea-8764-f1063391d1b9.png)
2. Add that product to your cart and visit the Cart and Checkout blocks.
3. Verify no badge is displayed and there is no `0` visible.