### PR TITLE
Fix Cash on Delivery not accounting for global rate values

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/cod/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cod/index.js
@@ -12,10 +12,7 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { PAYMENT_METHOD_NAME } from './constants';
 
 const settings = getSetting( 'cod_data', {} );
-const defaultLabel = __(
-	'Cash on delivery',
-	'woo-gutenberg-products-block'
-);
+const defaultLabel = __( 'Cash on delivery', 'woo-gutenberg-products-block' );
 const label = decodeEntities( settings.title ) || defaultLabel;
 
 /**
@@ -57,16 +54,16 @@ const canMakePayment = ( { cartNeedsShipping, selectedShippingMethods } ) => {
 		return true;
 	}
 
-	// Look for an not-supported shipping method in the user's selected
-	// shipping methods. If one is found, then COD is not allowed.
-	const selectedNotSupported = Object.values( selectedShippingMethods ).some(
-		( shippingMethodId ) => {
-			return ! settings.enableForShippingMethods.includes(
-				shippingMethodId
-			);
-		}
-	);
-	return ! selectedNotSupported;
+	// Look for a supported shipping method in the user's selected
+	// shipping methods. If one is found, then COD is allowed.
+	const selectedMethods = Object.values( selectedShippingMethods );
+	// supported shipping methods might be global (eg. "Any flat rate"), hence
+	// this is doing a `String.prototype.includes` match vs a `Array.prototype.includes` match.
+	return settings.enableForShippingMethods.some( ( shippingMethodId ) => {
+		return selectedMethods.some( ( selectedMethod ) => {
+			return selectedMethod.includes( shippingMethodId );
+		} );
+	} );
 };
 
 /**
@@ -82,4 +79,6 @@ const cashOnDeliveryPaymentMethod = {
 	ariaLabel: label,
 };
 
-registerPaymentMethod( ( Config ) => new Config( cashOnDeliveryPaymentMethod ) );
+registerPaymentMethod(
+	( Config ) => new Config( cashOnDeliveryPaymentMethod )
+);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2892

See #2892 for details. In this pull I reversed the matcher for the `canMakePayment` callback on the COD payment method so that it considers potential global rate matching (eg. "Any flat rate"). 

<!-- Don't forget to update the title with something descriptive. -->

## To Test

Testing notes are similar to #2831 which are added below:

1. Go to `WooCommerce > Settings > Payments` and configure `Cash on Delivery` payment gateway.
2. Set up cart & checkout pages with blocks.
3. Add stuff to cart, proceed to checkout.
4. Complete purchase with COD and confirm everything's working as expected.
5. COD has options so merchant can limit it to shippable products and / or specific shipping methods. Experiment with these settings and confirm that COD works correctly, and is only available when appropriate.
6. Confirm that all other payment gateways still work correctly.

Specific to this branch, verify that if you select "Any Flat Rate Method" for COD support, then any (and only) flat rate shipping rate selection will result in COD being available.