### PR TITLE
Fix unnecessary checks happening for wc_reserved_stock table in site dashboard

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -43,7 +43,7 @@ class Installer {
 		$schema_version    = 260;
 		$db_schema_version = (int) get_option( 'wc_blocks_db_schema_version', 0 );
 
-		if ( $db_schema_version > $schema_version ) {
+		if ( $db_schema_version >= $schema_version && 0 !== $db_schema_version ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2893 

The check running in `src/Installer.php` was running more than needed because of a flaw in the conditional comparing against saved db_schema_version. In this pull the `wc_reserve_stock` table check will _only_ run more than once in the admin if the table is not created successfully. 

<!-- Don't forget to update the title with something descriptive. -->

## To Test

- Add some debugging code (or a breakpoint if using xdebug) after the conditional around line 50 in `src/Installer.php`. If you are testing on an existing development site that already has this table, then you shouldn't see the breakpoint/debugging hit when browsing the admin.
- Delete the `wc_blocks_db_schema_version` option in your db and re-run the test. This time the breakpoint _should_ be hit, but only on the first admin page load, subsequent loads should not hit the breakpoint/debugging code.
