### PR TITLE
Improve behaviour of draft order cleanup to account for clobbered custom shop order status.

### DIFF
--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -110,7 +110,17 @@ class DraftOrders {
 	 * @return array
 	 */
 	public function register_draft_order_post_status( array $statuses ) {
-		$statuses[ self::DB_STATUS ] = [
+		$statuses[ self::DB_STATUS ] = $this->get_post_status_properties();
+		return $statuses;
+	}
+
+	/**
+	 * Returns the properties of this post status for registration.
+	 *
+	 * @return array
+	 */
+	private function get_post_status_properties() {
+		return [
 			'label'                     => _x( 'Draft', 'Order status', 'woo-gutenberg-products-block' ),
 			'public'                    => false,
 			'exclude_from_search'       => false,
@@ -119,7 +129,6 @@ class DraftOrders {
 			/* translators: %s: number of orders */
 			'label_count'               => _n_noop( 'Drafts <span class="count">(%s)</span>', 'Drafts <span class="count">(%s)</span>', 'woo-gutenberg-products-block' ),
 		];
-		return $statuses;
 	}
 
 	/**
@@ -145,7 +154,8 @@ class DraftOrders {
 	public function delete_expired_draft_orders() {
 		$count      = 0;
 		$batch_size = 20;
-		$orders     = wc_get_orders(
+		$this->ensure_draft_status_registered();
+		$orders = wc_get_orders(
 			[
 				'date_modified' => '<=' . strtotime( '-1 DAY' ),
 				'limit'         => $batch_size,
@@ -168,6 +178,22 @@ class DraftOrders {
 			}
 		} catch ( Exception $error ) {
 			wc_caught_exception( $error, __METHOD__ );
+		}
+	}
+
+	/**
+	 * Since it's possible for third party code to clobber the `$wp_post_statuses` global,
+	 * we need to do a final check here to make sure the draft post status is
+	 * registered with the global so that it is not removed by WP_Query status
+	 * validation checks.
+	 */
+	private function ensure_draft_status_registered() {
+		$is_registered = get_post_stati( [ self::DB_STATUS ] );
+		if ( empty( $is_registered ) ) {
+			register_post_status(
+				self::DB_STATUS,
+				$this->get_post_status_properties()
+			);
 		}
 	}
 

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -188,7 +188,7 @@ class DraftOrders {
 	 * validation checks.
 	 */
 	private function ensure_draft_status_registered() {
-		$is_registered = get_post_stati( [ self::DB_STATUS ] );
+		$is_registered = get_post_stati( [ 'name' => self::DB_STATUS ] );
 		if ( empty( $is_registered ) ) {
 			register_post_status(
 				self::DB_STATUS,

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -80,8 +80,7 @@ class DeleteDraftOrders extends TestCase {
 			$this->caught_exception = $exception_object;
 		});
 
-		// temporarily hide error logging we don't care (and keeps from polluting)
-		// stdout
+		// temporarily hide error logging we don't care about (and keeps from polluting stdout)
 		$this->original_logging_destination = ini_get('error_log');
 		ini_set('error_log', '/dev/null');
 	}

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -83,6 +83,7 @@ class DeleteDraftOrders extends TestCase {
 		// temporarily hide error logging we don't care about (and keeps from polluting stdout)
 		$this->original_logging_destination = ini_get('error_log');
 		ini_set('error_log', '/dev/null');
+		parent::setUp();
 	}
 
 	public function tearDown() {
@@ -95,6 +96,7 @@ class DeleteDraftOrders extends TestCase {
 		remove_all_actions( 'woocommerce_caught_exception' );
 		//restore original logging destination
 		ini_set('error_log', $this->original_logging_destination);
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -16,6 +16,7 @@ class DeleteDraftOrders extends TestCase {
 
 	private $draft_orders_instance;
 	private $caught_exception;
+	private $original_logging_destination;
 
 	/**
 	 * During setup create some draft orders.
@@ -78,6 +79,11 @@ class DeleteDraftOrders extends TestCase {
 		add_action( 'woocommerce_caught_exception', function($exception_object){
 			$this->caught_exception = $exception_object;
 		});
+
+		// temporarily hide error logging we don't care (and keeps from polluting)
+		// stdout
+		$this->original_logging_destination = ini_get('error_log');
+		ini_set('error_log', '/dev/null');
 	}
 
 	public function tearDown() {
@@ -88,6 +94,8 @@ class DeleteDraftOrders extends TestCase {
 			$order->delete( true );
 		}
 		remove_all_actions( 'woocommerce_caught_exception' );
+		//restore original logging destination
+		ini_set('error_log', $this->original_logging_destination);
 	}
 
 	/**
@@ -144,6 +152,7 @@ class DeleteDraftOrders extends TestCase {
 		$this->assertContains( 'order that is not a `wc-checkout-draft`', $this->caught_exception->getMessage() );
 		$this->unset_mock_results_for_wc_query( $sample_results );
 	}
+
 	public function test_order_status_verification() {
 		global $wp_post_statuses, $wpdb;
 		$original_statuses = $wp_post_statuses;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
This pull is a companion to the work begun in #2874. We had a customer with a site that had _any_ order get deleted when the draft order cleanup logic was being executed. In the linked pull I added code that not only placed this logic behind a feature gate, but also verified orders returned were of the expected status before deleting.  However, we still did not know how `wc_get_orders` was returning non `wc-checkout-draft` status orders to begin with.

Fortunately, after the customer graciously gave access to their site files, I was able to debug this further and discovered some code hooking into the `woocommerce_register_shop_order_post_statuses` filter and was doing something like this in their theme (sanitized a bit):

```php
function rename_order_status_type($order_statuses) {
	$key_order = array("wc-on-hold","wc-processing","wc-completed","wc-incident","wc-final-incident","wc-refunded","wc-returned","wc-cancelled","wc-failed","wc-pending");
	return reorder_associate_arr($key_order, $order_statuses);
}
add_filter( 'woocommerce_register_shop_order_post_statuses', 'rename_order_status_type');
```

Notice how the `$key_order` array is a static list of statuses. Also (not shown here), the custom `reorder_associate_arr` function does not merge what's in `$order_statuses` but instead _replaces_ the incoming statuses with the statuses ordered by and matching this static array.

Now take a look at [the applied filter in Woo core here](https://github.com/woocommerce/woocommerce/blob/8c2412ea7d7d452eb022f7225cd228b00cb144c1/includes/class-wc-post-types.php#L548-L551), notice, how this array is used to determine which _statuses actually get registered_.  Now you may think, what does this have to do with the `wc_get_orders` query? 

Eventually, the query string generated by the Woo Core Data store logic will make its way to an instantiated `WP_Query` instance for performing the actual query. Along the way, any query parameters are converted to the WP equivalents, so in this case, `status` is converted to `post_status` because orders are stored in the `wp_post` table and custom statuses are stored in the `post_status` field. In this `WP_Query` instance, the query arguments are sanitized, validated and prepared for the actual query. Within the logic doing this we have this little gem:

https://github.com/WordPress/wordpress-develop/blob/9bd4234bf6e39189fb76ee5161bdba38d087b251/src/wp-includes/class-wp-query.php#L2454-L2480

In the above code, what's happening is any incoming `post_status` query argument is checked against _currently registered post statuses_ to see if it exists there. If it doesn't, then _the argument is dropped from the query_.

Starting to see the problem here? In case you aren't, the problem turned out to be pretty much this:

- `Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders` uses the `woocommerce_register_shop_order_post_statuses` filter to pass through the `wc-checkout-draft` status to Woo Core's mechanism for registering custom order statuses.
- The site's theme hooked into the same filter, and returned an array of statuses _without_ what `DraftOrders` had registered.
- `DraftOrders::delete_expired_draft_orders` executed `wc_get_orders` and when the query passed through `WP_Query` the `status` argument was dropped because `wc-checkout-draft` does not exist in array of post statuses.
- All orders were returned from the query.

So essentially, a filter you would _think_ has **nothing** to do with any queries, actually does as a side-effect.

Of note, it's entirely possible for **any** WooCommerce core statuses to be clobbered this way, which essentially means that the results from **any** query depending on a specific WC order status can't be trusted! 

In this pull the fix addresses the potential for `wc-checkout-draft` status to not be registered by verifying it is registered before doing the query. I also added unit tests that verify the fix (and verified against the customers site I had setup for debugging). I've left the other exception handling in as a failsafe because there's still plenty of other places where third party code could potentially affect the actual results from the query.

I also intend on doing a pull request to WooCommerce core to hopefully add some protection against queries being made with a `status` argument that does not match a registered post_status (essentially throwing an error and abandoning the query). I'll add that mostly to get the ball rolling on a potential fix, because as it is now, any queries including status filters are super fragile.

## To test

The code in this pull is covered fairly thoroughly by unit tests so I'm confident things behave as expected. However as a confidence check:

* [x] `woocommerce_cleanup_draft_orders` action **should** appear in the scheduled tasks for Action Scheduler (Tools->Scheduled Actions) (when the feature plugin is active).
* [x] Create a draft order (on the frontend load the checkout block with products in the cart and do not complete the order).
* [x] Trigger the scheduled action for `woocommerce_cleanup_draft_orders` and verify the just created draft order and none of the other orders on your test site have been deleted.
* [ ] Modify the draft order date so that it's greater than 24 hours in the past from now (you need to modify the `post_modifed_gmt` field)
* [ ] Trigger the scheduled action again, this time the draft order you modified (and only that draft order) should be deleted.
