### PR TITLE
enqueue and respect merchant option for disabling stripe express pay

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/stripe/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/index.js
@@ -11,8 +11,15 @@ import {
  */
 import stripeCcPaymentMethod from './credit-card';
 import PaymentRequestPaymentMethod from './payment-request';
+import { getStripeServerData } from './stripe-utils';
 
+// Register Stripe Credit Card.
 registerPaymentMethod( ( Config ) => new Config( stripeCcPaymentMethod ) );
-registerExpressPaymentMethod(
-	( Config ) => new Config( PaymentRequestPaymentMethod )
-);
+
+// Register Stripe Payment Request (Apple/Chrome Pay) if enabled.
+if ( getStripeServerData().allowPaymentRequest ) {
+	registerExpressPaymentMethod(
+		( Config ) => new Config( PaymentRequestPaymentMethod )
+	);
+}
+

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -9,7 +9,7 @@ import { getSetting } from '@woocommerce/settings';
 import { PAYMENT_METHOD_NAME } from './constants';
 import { PaymentRequestExpress } from './payment-request-express';
 import { applePayImage } from './apple-pay-preview';
-import { loadStripe } from '../stripe-utils';
+import { getStripeServerData, loadStripe } from '../stripe-utils';
 
 const ApplePayPreview = () => <img src={ applePayImage } alt="" />;
 
@@ -22,6 +22,10 @@ let isStripeInitialized = false,
 // Initialise stripe API client and determine if payment method can be used
 // in current environment (e.g. geo + shopper has payment settings configured).
 function paymentRequestAvailable( currencyCode ) {
+	if ( ! getStripeServerData().allowPaymentRequest ) {
+		return false;
+	}
+
 	// If we've already initialised, return the cached results.
 	if ( isStripeInitialized ) {
 		return canPay;

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -9,7 +9,7 @@ import { getSetting } from '@woocommerce/settings';
 import { PAYMENT_METHOD_NAME } from './constants';
 import { PaymentRequestExpress } from './payment-request-express';
 import { applePayImage } from './apple-pay-preview';
-import { getStripeServerData, loadStripe } from '../stripe-utils';
+import { loadStripe } from '../stripe-utils';
 
 const ApplePayPreview = () => <img src={ applePayImage } alt="" />;
 
@@ -22,10 +22,6 @@ let isStripeInitialized = false,
 // Initialise stripe API client and determine if payment method can be used
 // in current environment (e.g. geo + shopper has payment settings configured).
 function paymentRequestAvailable( currencyCode ) {
-	if ( ! getStripeServerData().allowPaymentRequest ) {
-		return false;
-	}
-
 	// If we've already initialised, return the cached results.
 	if ( isStripeInitialized ) {
 		return canPay;

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
@@ -277,25 +277,27 @@
 /**
  * @typedef {Object} StripeServerData
  *
- * @property {string}                      stripeTotalLabel The string used for payment
- *                                                          descriptor.
- * @property {string}                      publicKey        The public api key for stripe
- *                                                          requests.
- * @property {boolean}                     allowPrepaidCard True means that prepaid cards
- *                                                          can be used for payment.
- * @property {Object}                      button           Contains button styles
- * @property {string}                      button.type      The type of button.
- * @property {string}                      button.theme     The theme for the button.
- * @property {string}                      button.height    The height (in pixels) for
- *                                                          the button.
- * @property {string}                      button.locale    The locale to use for stripe
- *                                                          elements.
- * @property {boolean}                     inline_cc_form   Whether stripe cc should use
- *                                                          inline cc
- *                                                          form or separate inputs.
- * @property {{[k:string]:CreditCardIcon}} icons            Contains supported cc icons.
- * @property {boolean}                     allowSavedCards  Used to indicate whether saved cards
- *                                                          can be used.
+ * @property {string}                      stripeTotalLabel     The string used for payment
+ *                                                              descriptor.
+ * @property {string}                      publicKey            The public api key for stripe
+ *                                                              requests.
+ * @property {boolean}                     allowPrepaidCard     True means that prepaid cards
+ *                                                              can be used for payment.
+ * @property {Object}                      button               Contains button styles
+ * @property {string}                      button.type          The type of button.
+ * @property {string}                      button.theme         The theme for the button.
+ * @property {string}                      button.height        The height (in pixels) for
+ *                                                              the button.
+ * @property {string}                      button.locale        The locale to use for stripe
+ *                                                              elements.
+ * @property {boolean}                     inline_cc_form       Whether stripe cc should use
+ *                                                              inline cc
+ *                                                              form or separate inputs.
+ * @property {{[k:string]:CreditCardIcon}} icons                Contains supported cc icons.
+ * @property {boolean}                     allowSavedCards      Used to indicate whether saved cards
+ *                                                              can be used.
+ * @property {boolean}                     allowPaymentRequest  True if merchant has enabled payment
+ *                                                              request (Chrome/Apple Pay).
  */
 
 /**

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -86,18 +86,19 @@ final class Stripe extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'stripeTotalLabel' => $this->get_total_label(),
-			'publicKey'        => $this->get_publishable_key(),
-			'allowPrepaidCard' => $this->get_allow_prepaid_card(),
-			'button'           => [
+			'stripeTotalLabel'    => $this->get_total_label(),
+			'publicKey'           => $this->get_publishable_key(),
+			'allowPrepaidCard'    => $this->get_allow_prepaid_card(),
+			'button'              => [
 				'type'   => $this->get_button_type(),
 				'theme'  => $this->get_button_theme(),
 				'height' => $this->get_button_height(),
 				'locale' => $this->get_button_locale(),
 			],
-			'inline_cc_form'   => $this->get_inline_cc_form(),
-			'icons'            => $this->get_icons(),
-			'allowSavedCards'  => $this->get_allow_saved_cards(),
+			'inline_cc_form'      => $this->get_inline_cc_form(),
+			'icons'               => $this->get_icons(),
+			'allowSavedCards'     => $this->get_allow_saved_cards(),
+			'allowPaymentRequest' => $this->get_allow_payment_request(),
 		];
 	}
 
@@ -142,6 +143,16 @@ final class Stripe extends AbstractPaymentMethodType {
 	 */
 	private function get_allow_prepaid_card() {
 		return apply_filters( 'wc_stripe_allow_prepaid_card', true );
+	}
+
+	/**
+	 * Determine if store allows Payment Request buttons - e.g. Apple Pay / Chrome Pay.
+	 *
+	 * @return bool True if merchant has opted into payment request.
+	 */
+	private function get_allow_payment_request() {
+		$option = isset( $this->settings['payment_request'] ) ? $this->settings['payment_request'] : false;
+		return filter_var( $option, FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2754

This PR enqueues a new `allowPaymentRequest` option in stripe settings blob, with the value of the `Enable Payment Request Buttons` Stripe/store setting:

<img width="883" alt="Screen Shot 2020-07-28 at 3 50 48 PM" src="https://user-images.githubusercontent.com/4167300/88617207-1d41d600-d0ea-11ea-96ce-a5d8767506e5.png">

If the merchant disables the option, the stripe express payment method is not set up in the front end (or any UI shown).

<img width="1274" alt="Screen Shot 2020-07-28 at 4 06 51 PM" src="https://user-images.githubusercontent.com/4167300/88618184-8aef0180-d0ec-11ea-82b6-3c02cec1ebca.png">


### How to test the changes in this Pull Request:

#### Prerequisite - ensure Payment Request is configured and working on your site
1. Set up Stripe in test mode, add your API keys. 
2. Set up a page with the checkout block.
3. Payment request is only available if store is served over https. I tested this locally by using ngrok tunnel (see below for details).
4. Ensure that at least one of the Payment Request providers works for your geo & client config. Where I am, Apple Pay works in Safari (I think because I've previously configured it). Chrome Pay and Apple Pay both are only available in certain regions, and require user/client config (e.g. browser setup, add card number to browser settings).
5. Add stuff to cart, view checkout - should see payment request buttons. 

_If payment request isn't working for you, you can't test this feature (as far as I'm aware)._

##### https option 1 - setting up ngrok
- Download and install [ngrok](https://ngrok.com/).
- Set up a tunnel to your site, e.g. `ngrok http 8222` (if your site is running on 8222 like mine).
- Reconfigure your site settings to use the new ngrok https url, e.g. 
    - `wp-env run cli wp option set siteurl https://01de67263b69.ngrok.io`
    - `wp-env run cli wp option set home https://01de67263b69.ngrok.io`
- Re-log in to your site at https url.

##### https option 2 - custom built plugin on atomic ephemeral or other "real" hosting environment
- Clone this branch.
- Build a plugin zip `npm run package-plugin`.
- Upload the built plugin zip to a hosted WordPress with https :)

#### Test fix
5. Visit `WooCommerce > Settings > Payments` and click through to `Stripe Credit Card` settings.
6. Disable (uncheck) `Enable Payment Request Buttons` option and save settings.
7. View checkout - payment request UI should not show (at top).
6. Repeat with payment request enabled, complete a test purchase.

#### Regression testing
- Ensure payment works correctly with all Stripe flows (express, regular).
- Ensure express payment methods work correctly when merchant has enabled. Please comment in your review which methods you've tested, so we can confirm they're all fixed.

- [ ] Apple Pay tested
- [ ] Chrome Pay tested 

### Changelog

> Checkout block: Support disabling Stripe Payment Request express payment method (e.g. Chrome/Apple Pay).
