### PR TITLE
add hover style to ensure consistent margin/padding for order summary so it doesn't jump on mouseover

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -1,6 +1,5 @@
 .wc-block-components-order-summary {
-	.wc-blocks-components-panel__button,
-	.wc-blocks-components-panel__button:hover {
+	.wc-blocks-components-panel__button {
 		margin-top: 0;
 		padding-top: 0;
 	}

--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -1,5 +1,6 @@
 .wc-block-components-order-summary {
-	.wc-blocks-components-panel__button {
+	.wc-blocks-components-panel__button,
+	.wc-blocks-components-panel__button:hover {
 		margin-top: 0;
 		padding-top: 0;
 	}

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -7,24 +7,25 @@
 }
 
 .wc-blocks-components-panel__button {
+	@include reset-box();
+	height: auto;
+	line-height: 1;
+	margin-bottom: em(6px);
+	margin-top: em(6px);
+	padding-bottom: em($gap-small - 6px);
+	padding-right: #{24px + $gap-smaller};
+	padding-top: em($gap-small - 6px);
+	position: relative;
+	text-align: left;
+	width: 100%;
+
 	&,
 	&:hover,
 	&:focus,
 	&:active {
-		@include reset-box();
 		@include reset-typography();
 		background: transparent;
 		box-shadow: none;
-		height: auto;
-		line-height: 1;
-		margin-bottom: em(6px);
-		margin-top: em(6px);
-		padding-bottom: em($gap-small - 6px);
-		padding-right: #{24px + $gap-smaller};
-		padding-top: em($gap-small - 6px);
-		position: relative;
-		text-align: left;
-		width: 100%;
 	}
 
 	> .wc-blocks-components-panel__button-icon {


### PR DESCRIPTION
Fixes #2914

Our order summary has `margin-top: 0`/`padding-top: 0` so box aligns with top of checkout left pane (form/steps). This rule is applied to a button component, and there's a hover style rule with a different (default) margin. So we need to override the `:hover` rule too so the order summary doesn't bounce on mouse-over.

### How to test the changes in this Pull Request:

1. Set up checkout block, add stuff to cart, proceed to checkout.
2. On desktop, mouseover order summary. 
3. Shouldn't bounce / jump.

