### PR TITLE
Fix typo in state property for idle status in checkout state reducer

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -75,7 +75,7 @@ export const reducer = (
 			break;
 		case SET_IDLE:
 			newState =
-				state.state !== IDLE
+				state.status !== IDLE
 					? {
 							...state,
 							status: IDLE,

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -42,7 +42,7 @@ class CartItems extends TestCase {
 		$this->products[0]->save();
 
 		// Create a test variable product.
-		$this->products[1] = ProductHelper::create_variation_product( false );
+		$this->products[1] = ProductHelper::create_variation_product();
 		$this->products[1]->set_weight( 10 );
 		$this->products[1]->set_regular_price( 10 );
 		$this->products[1]->save();


### PR DESCRIPTION
This was [first discovered](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2903#discussion_r459532569) while reviewing #2903. 

In the checkout state reducer, the comparison for the IDLE status change should be using `state.status` not `state.state`. The impact of the bug was minimal but did mean that everytime the IDLE state was explicitly set, if the status was _already_ IDLE, then a new state would be returned potentially increasing unnecessary renders.

## To test

This impacts the checkout flow so the following should be tested:

* [ ] Verify that validation works as expected (missing required fields, incorrect cc numbers in Stripe etc).
* [ ] Verify that a complete payment works. Best to test Stripe CC, one of the offline payment methods (eg BACS, or cheque), and Express payment method (Chrome or Apple Pay).