### PR TITLE
Fix  missing permissions_callback arg in StoreApi route definitions

### DIFF
--- a/src/StoreApi/Routes/Cart.php
+++ b/src/StoreApi/Routes/Cart.php
@@ -32,9 +32,10 @@ class Cart extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],

--- a/src/StoreApi/Routes/CartAddItem.php
+++ b/src/StoreApi/Routes/CartAddItem.php
@@ -32,9 +32,10 @@ class CartAddItem extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'id'        => [
 						'description' => __( 'The cart item product or variation ID.', 'woo-gutenberg-products-block' ),
 						'type'        => 'integer',

--- a/src/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/CartApplyCoupon.php
@@ -32,9 +32,10 @@ class CartApplyCoupon extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'code' => [
 						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -33,20 +33,23 @@ class CartCoupons extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'permission_callback' => '__return_true',
+				'callback'            => [ $this, 'get_response' ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/CartCouponsByCode.php
@@ -39,15 +39,17 @@ class CartCouponsByCode extends AbstractRoute {
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartItems.php
+++ b/src/StoreApi/Routes/CartItems.php
@@ -33,20 +33,23 @@ class CartItems extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => array( $this, 'get_response' ),
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -39,20 +39,23 @@ class CartItemsByKey extends AbstractRoute {
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::EDITABLE,
-				'callback' => array( $this, 'get_response' ),
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/CartRemoveCoupon.php
@@ -32,9 +32,10 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'code' => [
 						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -32,9 +32,10 @@ class CartRemoveItem extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'key' => [
 						'description' => __( 'Unique identifier (key) for the cart item.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -32,9 +32,10 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'package_id' => array(
 						'description' => __( 'The ID of the package being shipped.', 'woo-gutenberg-products-block' ),
 						'type'        => 'integer',

--- a/src/StoreApi/Routes/CartUpdateItem.php
+++ b/src/StoreApi/Routes/CartUpdateItem.php
@@ -32,9 +32,10 @@ class CartUpdateItem extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'key'      => [
 						'description' => __( 'Unique identifier (key) for the cart item to update.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartUpdateShipping.php
+++ b/src/StoreApi/Routes/CartUpdateShipping.php
@@ -41,9 +41,10 @@ class CartUpdateShipping extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'first_name' => [
 						'description'       => __( 'Customer first name.', 'woo-gutenberg-products-block' ),
 						'type'              => 'string',

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -57,21 +57,24 @@ class Checkout extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::EDITABLE,
-				'callback' => array( $this, 'get_response' ),
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array_merge(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array_merge(
 					[
 						'payment_data' => [
 							'description' => __( 'Data to pass through to the payment method when processing payment.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/ProductAttributeTerms.php
@@ -37,9 +37,10 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductAttributes.php
+++ b/src/StoreApi/Routes/ProductAttributes.php
@@ -31,9 +31,10 @@ class ProductAttributes extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductAttributesById.php
+++ b/src/StoreApi/Routes/ProductAttributesById.php
@@ -37,9 +37,10 @@ class ProductAttributesById extends AbstractRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'context' => $this->get_context_param(
 						array(
 							'default' => 'view',

--- a/src/StoreApi/Routes/ProductCategories.php
+++ b/src/StoreApi/Routes/ProductCategories.php
@@ -31,9 +31,10 @@ class ProductCategories extends AbstractTermsRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductCategoriesById.php
+++ b/src/StoreApi/Routes/ProductCategoriesById.php
@@ -37,9 +37,10 @@ class ProductCategoriesById extends AbstractRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'context' => $this->get_context_param(
 						array(
 							'default' => 'view',

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -35,9 +35,10 @@ class ProductCollectionData extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductReviews.php
+++ b/src/StoreApi/Routes/ProductReviews.php
@@ -34,9 +34,10 @@ class ProductReviews extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductTags.php
+++ b/src/StoreApi/Routes/ProductTags.php
@@ -31,9 +31,10 @@ class ProductTags extends AbstractTermsRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -34,9 +34,10 @@ class Products extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductsById.php
+++ b/src/StoreApi/Routes/ProductsById.php
@@ -37,9 +37,10 @@ class ProductsById extends AbstractRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'context' => $this->get_context_param(
 						array(
 							'default' => 'view',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2908 

See #2908 for details. WordPress 5.5 introduces tighter requirements for the REST API endpoint registration which includes the requirement that `permission_callback` argument is included with the configuration object for each route.

Our StoreApi is all publicly accessible routes, so this property was excluded. The fix was just to be explicit about these routes being public and thus the property is included with the WordPress `__return_true` callback provided as the value.

## To test

Unfortunately, this does impact all routes (but should be minimal impact, it's just explicitly defining behaviour that was already present). There's two primary things to watch for while testing:

- The PHP notice for missing `permission_callback` is no longer logged.
- There is no breakage to existing behaviour.

Some REST API test coverage for this does exist in the PHP unit tests.

Basically you can smoke test all behaviour for:

* [ ] Reviews block
* [ ] All Products and filter blocks
* [ ] Cart Block
* [ ] Checkout Block

Watch for any console/network errors and unexpected (and unreported) behaviour.
