### PR TITLE
improve appearance/layout of many (or few) payment methods

### DIFF
--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -21,6 +21,7 @@ import {
 	usePaymentMethodDataContext,
 } from '@woocommerce/base-context';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -120,15 +121,25 @@ const PaymentMethods = () => {
 			customerId,
 		]
 	);
-	if (
-		isInitialized &&
-		Object.keys( currentPaymentMethods.current ).length === 0
-	) {
+	const paymentMethodCount = Object.keys( currentPaymentMethods.current )
+		.length;
+	if ( isInitialized && paymentMethodCount === 0 ) {
 		return <NoPaymentMethods />;
 	}
+
 	const renderedTabs = (
 		<Tabs
-			className="wc-block-components-checkout-payment-methods"
+			className={ classnames(
+				'wc-block-components-checkout-payment-methods',
+				{
+					'wc-block-components-checkout-payment-methods--single':
+						paymentMethodCount === 1,
+				},
+				{
+					'wc-block-components-checkout-payment-methods--pair':
+						paymentMethodCount === 2,
+				}
+			) }
 			onSelect={ ( tabName ) => {
 				setActivePaymentMethod( tabName );
 				removeNotice( 'wc-payment-error', noticeContexts.PAYMENTS );

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -246,6 +246,15 @@ $border-radius: 5px;
 
 .wc-block-components-checkout-payment-methods * {
 	pointer-events: all; // Overrides parent disabled component in editor context
+
+}
+
+.wc-block-components-checkout-payment-methods {
+	@include with-translucent-border(1px);
+
+	&::after {
+		border-radius: 4px;
+	}
 }
 
 .is-mobile,

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -1,9 +1,15 @@
 @mixin radio-control-styles {
 	.wc-block-components-radio-control__option {
 		@include reset-typography();
-		@include with-translucent-border(0 0 1px);
 		display: block;
 		padding: $gap-small $gap-small 0 #{$gap-larger * 2};
+
+		&:not(:last-child) {
+			@include with-translucent-border(0 0 1px);
+		}
+		&:last-child {
+			@include with-translucent-border(0 0 1px, 0);
+		}
 	}
 
 	.wc-block-components-radio-control__option-layout {

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -49,7 +49,7 @@
 		}
 	}
 	.wc-block-components-tabs__content {
-		padding: $gap 0;
+		padding: $gap;
 		text-transform: none;
 	}
 }


### PR DESCRIPTION
_In progress_ cc @Aljullu 

- add border using transparent border mixin
- remove last border-bottom from radio buttons, so doesn't clash with box
  - NOTE this affects all radio buttons (tbd)
- add side padding to (bordered) payment method tab content pane

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2628

<!-- Don't forget to update the title with something descriptive. -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<img width="715" alt="Screen Shot 2020-07-29 at 12 11 59 PM" src="https://user-images.githubusercontent.com/4167300/88748507-48d5c680-d1a5-11ea-9ab9-c91892234fb9.png">

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.
