### PR TITLE
Show payment gateways in correct (merchant-configured) order

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -12,7 +12,10 @@ import {
 	useShippingDataContext,
 } from '@woocommerce/base-context';
 import { useStoreCart, useShallowEqual } from '@woocommerce/base-hooks';
-import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
+import {
+	CURRENT_USER_IS_ADMIN,
+	PAYMENT_GATEWAY_ORDER,
+} from '@woocommerce/block-settings';
 
 /**
  * If there was an error registering a payment method, alert the admin.
@@ -86,8 +89,13 @@ const usePaymentMethodRegistration = (
 				[ paymentMethod.name ]: paymentMethod,
 			};
 		};
-		for ( const paymentMethodName in registeredPaymentMethods ) {
+
+		for ( let i=0; i<PAYMENT_GATEWAY_ORDER.length; i++  ) {
+			const paymentMethodName = PAYMENT_GATEWAY_ORDER[i];
 			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
+			if ( ! paymentMethod ) {
+				continue;
+			}
 
 			// In editor, shortcut so all payment methods show as available.
 			if ( isEditor ) {

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -90,8 +90,8 @@ const usePaymentMethodRegistration = (
 			};
 		};
 
-		for ( let i=0; i<PAYMENT_GATEWAY_SORT_ORDER.length; i++  ) {
-			const paymentMethodName = PAYMENT_GATEWAY_SORT_ORDER[i];
+		for ( let i = 0; i < PAYMENT_GATEWAY_SORT_ORDER.length; i++ ) {
+			const paymentMethodName = PAYMENT_GATEWAY_SORT_ORDER[ i ];
 			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
 			if ( ! paymentMethod ) {
 				continue;

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -14,7 +14,7 @@ import {
 import { useStoreCart, useShallowEqual } from '@woocommerce/base-hooks';
 import {
 	CURRENT_USER_IS_ADMIN,
-	PAYMENT_GATEWAY_ORDER,
+	PAYMENT_GATEWAY_SORT_ORDER,
 } from '@woocommerce/block-settings';
 
 /**
@@ -90,8 +90,8 @@ const usePaymentMethodRegistration = (
 			};
 		};
 
-		for ( let i=0; i<PAYMENT_GATEWAY_ORDER.length; i++  ) {
-			const paymentMethodName = PAYMENT_GATEWAY_ORDER[i];
+		for ( let i=0; i<PAYMENT_GATEWAY_SORT_ORDER.length; i++  ) {
+			const paymentMethodName = PAYMENT_GATEWAY_SORT_ORDER[i];
 			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
 			if ( ! paymentMethod ) {
 				continue;

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -6,7 +6,13 @@ import {
 	getPaymentMethods,
 	getExpressPaymentMethods,
 } from '@woocommerce/blocks-registry';
-import { useState, useEffect, useRef, useCallback, useMemo } from '@wordpress/element';
+import {
+	useState,
+	useEffect,
+	useRef,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import {
 	useEditorContext,
 	useShippingDataContext,
@@ -149,6 +155,6 @@ export const usePaymentMethods = ( dispatcher ) => {
 		return ordered;
 	}, [ paymentMethods, PAYMENT_GATEWAY_SORT_ORDER ] );
 	return usePaymentMethodRegistration( dispatcher, orderedPaymentMethods );
-}
+};
 export const useExpressPaymentMethods = ( dispatcher ) =>
 	usePaymentMethodRegistration( dispatcher, getExpressPaymentMethods() );

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -7,12 +7,7 @@ import {
 	getPaymentMethods,
 	getExpressPaymentMethods,
 } from '@woocommerce/blocks-registry';
-import {
-	useState,
-	useEffect,
-	useRef,
-	useCallback,
-} from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import {
 	useEditorContext,
 	useShippingDataContext,
@@ -137,7 +132,12 @@ const usePaymentMethodRegistration = (
 		// Example: Stripe CC, Stripe Payment Request.
 		// That's why we track "is initialised" state here.
 		setIsInitialized( true );
-	}, [ dispatcher, isEditor, registeredPaymentMethods, paymentMethodsSortOrder ] );
+	}, [
+		dispatcher,
+		isEditor,
+		registeredPaymentMethods,
+		paymentMethodsSortOrder,
+	] );
 
 	// Determine which payment methods are available initially and whenever
 	// shipping methods change.

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -6,7 +6,7 @@ import {
 	getPaymentMethods,
 	getExpressPaymentMethods,
 } from '@woocommerce/blocks-registry';
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { useState, useEffect, useRef, useCallback, useMemo } from '@wordpress/element';
 import {
 	useEditorContext,
 	useShippingDataContext,
@@ -90,12 +90,8 @@ const usePaymentMethodRegistration = (
 			};
 		};
 
-		for ( let i = 0; i < PAYMENT_GATEWAY_SORT_ORDER.length; i++ ) {
-			const paymentMethodName = PAYMENT_GATEWAY_SORT_ORDER[ i ];
+		for ( const paymentMethodName in registeredPaymentMethods ) {
 			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
-			if ( ! paymentMethod ) {
-				continue;
-			}
 
 			// In editor, shortcut so all payment methods show as available.
 			if ( isEditor ) {
@@ -139,7 +135,20 @@ const usePaymentMethodRegistration = (
 	return isInitialized;
 };
 
-export const usePaymentMethods = ( dispatcher ) =>
-	usePaymentMethodRegistration( dispatcher, getPaymentMethods() );
+export const usePaymentMethods = ( dispatcher ) => {
+	const paymentMethods = getPaymentMethods();
+	const orderedPaymentMethods = useMemo( () => {
+		const ordered = [];
+		for ( let i = 0; i < PAYMENT_GATEWAY_SORT_ORDER.length; i++ ) {
+			const paymentMethodName = PAYMENT_GATEWAY_SORT_ORDER[ i ];
+			const paymentMethod = paymentMethods[ paymentMethodName ];
+			if ( paymentMethod ) {
+				ordered.push( paymentMethods[ paymentMethodName ] );
+			}
+		}
+		return ordered;
+	}, [ paymentMethods, PAYMENT_GATEWAY_SORT_ORDER ] );
+	return usePaymentMethodRegistration( dispatcher, orderedPaymentMethods );
+}
 export const useExpressPaymentMethods = ( dispatcher ) =>
 	usePaymentMethodRegistration( dispatcher, getExpressPaymentMethods() );

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -64,6 +64,7 @@ const usePaymentMethodRegistration = (
 	const { isEditor } = useEditorContext();
 	const { selectedRates, shippingAddress } = useShippingDataContext();
 	const selectedShippingMethods = useShallowEqual( selectedRates );
+	const paymentMethodsOrder = useShallowEqual( paymentMethodsSortOrder );
 	const { cartTotals, cartNeedsShipping } = useStoreCart();
 	const canPayArgument = useRef( {
 		cartTotals,
@@ -95,8 +96,8 @@ const usePaymentMethodRegistration = (
 			};
 		};
 
-		for ( let i = 0; i < paymentMethodsSortOrder.length; i++ ) {
-			const paymentMethodName = paymentMethodsSortOrder[ i ];
+		for ( let i = 0; i < paymentMethodsOrder.length; i++ ) {
+			const paymentMethodName = paymentMethodsOrder[ i ];
 			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
 			if ( ! paymentMethod ) {
 				continue;
@@ -136,7 +137,7 @@ const usePaymentMethodRegistration = (
 		dispatcher,
 		isEditor,
 		registeredPaymentMethods,
-		paymentMethodsSortOrder,
+		paymentMethodsOrder,
 	] );
 
 	// Determine which payment methods are available initially and whenever

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -156,10 +156,13 @@ export const usePaymentMethods = ( dispatcher ) => {
 	// depend on state, e.g. COD can depend on shipping method.
 	const displayOrder = new Set( [
 		...PAYMENT_GATEWAY_SORT_ORDER,
-		...Object.keys( standardMethods )
-
+		...Object.keys( standardMethods ),
 	] );
-	usePaymentMethodRegistration( dispatcher, standardMethods, Array.from( displayOrder ) );
+	usePaymentMethodRegistration(
+		dispatcher,
+		standardMethods,
+		Array.from( displayOrder )
+	);
 };
 export const useExpressPaymentMethods = ( dispatcher ) => {
 	const expressMethods = getExpressPaymentMethods();

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -158,7 +158,7 @@ export const usePaymentMethods = ( dispatcher ) => {
 		...PAYMENT_GATEWAY_SORT_ORDER,
 		...Object.keys( standardMethods ),
 	] );
-	usePaymentMethodRegistration(
+	return usePaymentMethodRegistration(
 		dispatcher,
 		standardMethods,
 		Array.from( displayOrder )

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { union } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	getPaymentMethods,
@@ -155,11 +154,12 @@ export const usePaymentMethods = ( dispatcher ) => {
 	// Ensure all methods are present in order.
 	// Some payment methods may not be present in PAYMENT_GATEWAY_SORT_ORDER if they
 	// depend on state, e.g. COD can depend on shipping method.
-	const displayOrder = union(
-		PAYMENT_GATEWAY_SORT_ORDER,
-		Object.keys( standardMethods )
-	);
-	usePaymentMethodRegistration( dispatcher, standardMethods, displayOrder );
+	const displayOrder = new Set( [
+		...PAYMENT_GATEWAY_SORT_ORDER,
+		...Object.keys( standardMethods )
+
+	] );
+	usePaymentMethodRegistration( dispatcher, standardMethods, Array.from( displayOrder ) );
 };
 export const useExpressPaymentMethods = ( dispatcher ) => {
 	const expressMethods = getExpressPaymentMethods();

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -149,6 +149,13 @@ const usePaymentMethodRegistration = (
 	return isInitialized;
 };
 
+/**
+ * Custom hook for setting up payment methods (standard, non-express).
+ *
+ * @param  {function(Object):undefined} dispatcher
+ *
+ * @return {boolean} True when standard payment methods have been initialized.
+ */
 export const usePaymentMethods = ( dispatcher ) => {
 	const standardMethods = getPaymentMethods();
 	// Ensure all methods are present in order.
@@ -164,6 +171,14 @@ export const usePaymentMethods = ( dispatcher ) => {
 		Array.from( displayOrder )
 	);
 };
+
+/**
+ * Custom hook for setting up express payment methods.
+ *
+ * @param  {function(Object):undefined} dispatcher
+ *
+ * @return {boolean} True when express payment methods have been initialized.
+ */
 export const useExpressPaymentMethods = ( dispatcher ) => {
 	const expressMethods = getExpressPaymentMethods();
 	return usePaymentMethodRegistration(

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -64,6 +64,8 @@ export const SHIPPING_METHODS_EXIST = getSetting(
 	false
 );
 
+export const PAYMENT_GATEWAY_ORDER = getSetting( 'paymentGatewayOrder', [] );
+
 export const CHECKOUT_SHOW_LOGIN_REMINDER = getSetting(
 	'checkoutShowLoginReminder',
 	true

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -64,7 +64,7 @@ export const SHIPPING_METHODS_EXIST = getSetting(
 	false
 );
 
-export const PAYMENT_GATEWAY_ORDER = getSetting( 'paymentGatewayOrder', [] );
+export const PAYMENT_GATEWAY_SORT_ORDER = getSetting( 'paymentGatewaySortOrder', [] );
 
 export const CHECKOUT_SHOW_LOGIN_REMINDER = getSetting(
 	'checkoutShowLoginReminder',

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -80,8 +80,12 @@ class Api {
 	 * Add payment method data to Asset Registry.
 	 */
 	public function add_payment_method_script_data() {
-		$script_data = $this->payment_method_registry->get_all_registered_script_data();
+		// Enqueue the order of enabled gateways as `paymentGatewayOrder`.
+		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+		$this->asset_registry->add( 'paymentGatewayOrder', array_keys( $available_gateways ) );
 
+		// Enqueue all registered gateway data (settings/config etc).
+		$script_data = $this->payment_method_registry->get_all_registered_script_data();
 		foreach ( $script_data as $asset_data_key => $asset_data_value ) {
 			if ( ! $this->asset_registry->exists( $asset_data_key ) ) {
 				$this->asset_registry->add( $asset_data_key, $asset_data_value );

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -80,9 +80,9 @@ class Api {
 	 * Add payment method data to Asset Registry.
 	 */
 	public function add_payment_method_script_data() {
-		// Enqueue the order of enabled gateways as `paymentGatewayOrder`.
+		// Enqueue the order of enabled gateways as `paymentGatewaySortOrder`.
 		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		$this->asset_registry->add( 'paymentGatewayOrder', array_keys( $available_gateways ) );
+		$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $available_gateways ) );
 
 		// Enqueue all registered gateway data (settings/config etc).
 		$script_data = $this->payment_method_registry->get_all_registered_script_data();

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -81,8 +81,10 @@ class Api {
 	 */
 	public function add_payment_method_script_data() {
 		// Enqueue the order of enabled gateways as `paymentGatewaySortOrder`.
-		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $available_gateways ) );
+		if ( ! $this->asset_registry->exists( 'paymentGatewaySortOrder' ) ) {
+			$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $available_gateways ) );
+		}
 
 		// Enqueue all registered gateway data (settings/config etc).
 		$script_data = $this->payment_method_registry->get_all_registered_script_data();

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -82,7 +82,7 @@ class Api {
 	public function add_payment_method_script_data() {
 		// Enqueue the order of enabled gateways as `paymentGatewaySortOrder`.
 		if ( ! $this->asset_registry->exists( 'paymentGatewaySortOrder' ) ) {
-			$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+			$available_gateways = WC()->payment_gateways->payment_gateways();
 			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $available_gateways ) );
 		}
 


### PR DESCRIPTION
Fixes #2157

Merchants can configure the order that payment methods / gateways are displayed, by reordering them in `WooCommerce > Settings > Payments`. This PR uses this configured order in the checkout block.

This is achieved by:

- Adding a new bit of script data `wcSettings.paymentGatewaySortOrder`. This is an array of payment method names.
- In `usePaymentMethodRegistration`, we're now iterating over `paymentGatewaySortOrder` when determining whether each payment method should be presented (`refreshCanMakePayments`).

The result is that the payment method tabs should be in the same order as the store settings, and consistent with the order of the radiobuttons in classic / shortcode checkout.

##### Note - COD is not always displayed in merchant-configured order

Note there is one exception to the ordering. COD can be configured to require a specific shipping method. When the page is rendered, the current shipping option affects `wcSettings.paymentGatewaySortOrder` - i.e. COD may be excluded. If it is excluded from the list, then it will be added to the end if user selects a relevant shipping option in checkout. This might be different if COD is ordered first in config.

This is an edge case and shouldn't cause any major issues. However, we may want to reconsider (in future) and implement our own `wcSettings.paymentGatewaySortOrder`, or potentially allow reordering as a block setting, edited wysiwyg in Gutenberg.

### Screenshots

<img width="664" alt="Screen Shot 2020-07-29 at 4 22 55 PM" src="https://user-images.githubusercontent.com/4167300/88756446-c571a080-d1b7-11ea-8ee4-d35c0520215c.png">

### How to test the changes in this Pull Request:

1. Set up a few different payment methods. Also set up checkout block.
2. Reorder your payment methods how you like in `WooCommerce > Settings > Payments`, then click `Save changes` to persist.
3. On front end, add stuff to cart and proceed to checkout. 

Payment methods should display using the order you chose. 

Complete a few test purchases to confirm that payment methods are still working and there are no regressions in checkout.

Also test payment methods that may be hidden based on checkout state, e.g. make COD only available with specific shipping methods.

### Changelog

> Checkout block: Payment gateways are shown in the correct order as configured in store settings.
