### PR TITLE
Fix WP_CONTENT_DIR path in PHP unit tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -27,8 +27,8 @@ require_once $_tests_dir . '/includes/functions.php';
 function wc_dir() {
 	static $dir = '';
 	if ( $dir === '' ) {
-		if ( file_exists( WP_CONTENT_DIR . '/woocommerce/woocommerce.php' ) ) {
-			$dir = WP_CONTENT_DIR . '/woocommerce';
+		if ( file_exists( WP_CONTENT_DIR . '/plugins/woocommerce/woocommerce.php' ) ) {
+			$dir = WP_CONTENT_DIR . '/plugins/woocommerce';
 			echo "Found WooCommerce plugin in content dir." . PHP_EOL;
 		} elseif ( file_exists( dirname( dirname( __DIR__ ) ) . '/woocommerce/woocommerce.php' ) ) {
 			$dir = dirname( dirname( __DIR__ ) ) . '/woocommerce';


### PR DESCRIPTION
PHP unit tests were not working for me because the path seems to be wrong. This PR should fix this.

### How to test the changes in this Pull Request:

1. Run `npm run phpunit` and verify tests pass (except for the failing tests reported in #2936).
2. Verify tests still pass in Travis (except for the failing tests reported in #2936).