### PR TITLE
Update WP tested up to version to 5.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia, aljullu, mikejolley, nerrad, joshuawold, assassinateur, haszari
 Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
-Tested up to: 5.4
+Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 3.0.0
 License: GPLv3


### PR DESCRIPTION
WP 5.5 is already in beta and WC Blocks 3.1 is the last release we will do before WP 5.5 final release.