### PR TITLE
Release: 3.1.0

### DIFF
--- a/.github/workflows/wordpress-deploy.yml
+++ b/.github/workflows/wordpress-deploy.yml
@@ -6,7 +6,13 @@ jobs:
   tag:
     name: New Release
     runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
+      - uses: act10ns/slack@v1
+        with:
+          status: starting
+        if: always()
       - name: Checkout code
         uses: actions/checkout@v2
       - name: WordPress Plugin Deploy
@@ -27,3 +33,8 @@ jobs:
           asset_path: ${{github.workspace}}/woo-gutenberg-products-block.zip
           asset_name: woo-gutenberg-products-block.zip
           asset_content_type: application/zip
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: always()

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -7,24 +7,25 @@
 }
 
 .wc-blocks-components-panel__button {
+	@include reset-box();
+	height: auto;
+	line-height: 1;
+	margin-bottom: em(6px);
+	margin-top: em(6px);
+	padding-bottom: em($gap-small - 6px);
+	padding-right: #{24px + $gap-smaller};
+	padding-top: em($gap-small - 6px);
+	position: relative;
+	text-align: left;
+	width: 100%;
+
 	&,
 	&:hover,
 	&:focus,
 	&:active {
-		@include reset-box();
 		@include reset-typography();
 		background: transparent;
 		box-shadow: none;
-		height: auto;
-		line-height: 1;
-		margin-bottom: em(6px);
-		margin-top: em(6px);
-		padding-bottom: em($gap-small - 6px);
-		padding-right: #{24px + $gap-smaller};
-		padding-top: em($gap-small - 6px);
-		position: relative;
-		text-align: left;
-		width: 100%;
 	}
 
 	> .wc-blocks-components-panel__button-icon {

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -75,7 +75,7 @@ export const reducer = (
 			break;
 		case SET_IDLE:
 			newState =
-				state.state !== IDLE
+				state.status !== IDLE
 					? {
 							...state,
 							status: IDLE,

--- a/assets/js/base/utils/render-frontend.js
+++ b/assets/js/base/utils/render-frontend.js
@@ -22,6 +22,13 @@ export const renderFrontend = ( {
 	const containers = document.querySelectorAll( selector );
 
 	if ( containers.length ) {
+		// @todo Remove Suspense compatibility fix once WP 5.2 is no longer supported.
+		// If Suspense is not available (WP 5.2), use a noop component instead.
+		const noopComponent = ( { children } ) => {
+			return <>{ children }</>;
+		};
+		const SuspenseComponent = Suspense || noopComponent;
+
 		// Use Array.forEach for IE11 compatibility.
 		Array.prototype.forEach.call( containers, ( el, i ) => {
 			const props = getProps( el, i );
@@ -34,11 +41,11 @@ export const renderFrontend = ( {
 
 			render(
 				<BlockErrorBoundary { ...errorBoundaryProps }>
-					<Suspense
+					<SuspenseComponent
 						fallback={ <div className="wc-block-placeholder" /> }
 					>
 						<Block { ...props } attributes={ attributes } />
-					</Suspense>
+					</SuspenseComponent>
 				</BlockErrorBoundary>,
 				el
 			);

--- a/assets/js/blocks/reviews/reviews-by-category/editor.scss
+++ b/assets/js/blocks/reviews/reviews-by-category/editor.scss
@@ -1,3 +1,0 @@
-.wc-block-reviews-by-category__selection {
-	width: 100%;
-}

--- a/assets/js/blocks/reviews/reviews-by-category/index.js
+++ b/assets/js/blocks/reviews/reviews-by-category/index.js
@@ -8,7 +8,6 @@ import { Icon, review } from '@woocommerce/icons';
 /**
  * Internal dependencies
  */
-import '../editor.scss';
 import Editor from './edit';
 import sharedAttributes from '../attributes';
 import save from '../save.js';

--- a/assets/js/blocks/reviews/reviews-by-product/editor.scss
+++ b/assets/js/blocks/reviews/reviews-by-product/editor.scss
@@ -1,7 +1,3 @@
-.wc-block-reviews-by-product__selection {
-	width: 100%;
-}
-
 .components-base-control {
 	+ .wc-block-reviews-by-product__notice {
 		margin: -$gap 0 $gap;

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -95,6 +95,7 @@ const entries = {
 			],
 		} ),
 
+		'reviews-style': './assets/js/blocks/reviews/editor.scss',
 		...getBlockEntries( '**/*.scss' ),
 	},
 	core: {

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -22,3 +22,43 @@ Now, let's make sure the bug is fixed:
 6. Click on Publish at the top right of the screen to publish the page.
 7. Click on the View Post button to view the post in the frontend side of your store.
 8. Verify the product summary block is rendered for products which have it.
+
+### Styling regressions
+
+This new release has a new system to generate the styles, so it would be great to test all blocks and verify there are no visual regressions or anything looking weird. The list of all blocks is:
+
+-   [ ] Featured Product Block
+-   [ ] Featured Category Block
+-   [ ] Hand-Picked products Block
+-   [ ] Best Selling Products Block
+-   [ ] Top Rated Products Block
+-   [ ] Newest Products Block
+-   [ ] On Sale Products Block
+-   [ ] Products by Category Block
+-   [ ] Products by Tag Block
+-   [ ] Products by Attribute Block
+-   [ ] Product Categories List Block
+-   [ ] Reviews by Product
+-   [ ] Reviews by Category
+-   [ ] All Reviews
+-   [ ] Product Search
+-   [ ] All Products
+-   [ ] Filter Products by Price
+-   [ ] Filter Products by Attribute
+-   [ ] Active Product Filters
+-   [ ] Cart
+-   [ ] Checkout
+
+### API regressions
+
+We also made some changes to our API endpoints to make them work correctly with WordPress 5.5. We should make sure interacting with the following blocks doesn't show errors in the console or the PHP logs:
+
+-   [ ] Reviews by Product
+-   [ ] Reviews by Category
+-   [ ] All Reviews
+-   [ ] All Products
+-   [ ] Filter Products by Price
+-   [ ] Filter Products by Attribute
+-   [ ] Active Product Filters
+-   [ ] Cart
+-   [ ] Checkout

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -1,0 +1,22 @@
+## Testing notes and ZIP for release 3.1.0
+
+### Product summary is rendered in All Products
+
+First, let's make sure at least one of the products has a summary:
+
+1. In the admin, go to Products > All Products.
+2. Edit any of the products.
+3. Scroll down to the Product short description text area.
+4. If it's blank, add some text there.
+5. In the sidebar, click on Update.
+
+Now, let's make sure the bug is fixed:
+
+1. Create a page and add the All Products block.
+2. Click on the pencil icon on the block toolbar to edit it.
+3. Below the image add an atomic block: the Product Summary.
+4. Verify a text has appeared: <i>Fly your WordPress banner...</i>.
+5. Click on Done at the bottom of the block.
+6. Click on Publish at the top right of the screen to publish the page.
+7. Click on the View Post button to view the post in the frontend side of your store.
+8. Verify the product summary block is rendered for products which have it.

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -1,5 +1,7 @@
 ## Testing notes and ZIP for release 3.1.0
 
+Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4994434/woocommerce-gutenberg-products-block.zip)
+
 ### Product summary is rendered in All Products
 
 First, let's make sure at least one of the products has a summary:

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -63,5 +63,7 @@ We also made some changes to our API endpoints to make them work correctly with 
 -   [ ] Filter Products by Price
 -   [ ] Filter Products by Attribute
 -   [ ] Active Product Filters
+
+**Note: The below blocks only need tested for the feature plugin**
 -   [ ] Cart
 -   [ ] Checkout

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -2,7 +2,9 @@
 
 Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4994434/woocommerce-gutenberg-products-block.zip)
 
-### Product summary is rendered in All Products
+## All Products
+
+### Product summary inner block renders in the frontend
 
 First, let's make sure at least one of the products has a summary:
 
@@ -21,7 +23,11 @@ Now, let's make sure the bug is fixed:
 5. Click on Done at the bottom of the block.
 6. Click on Publish at the top right of the screen to publish the page.
 7. Click on the View Post button to view the post in the frontend side of your store.
-8. Verify the product summary block is rendered for products which have it.
+8. Verify the Product summary block is rendered for products which have it.
+
+### There are no regressions with other inner blocks
+
+There have been changes in the way All Products inner blocks are loaded, so it should be tested that other inner blocks, in addition to the Product summary block, work fine in the editor and the frontend.
 
 ### Styling regressions
 
@@ -65,5 +71,6 @@ We also made some changes to our API endpoints to make them work correctly with 
 -   [ ] Active Product Filters
 
 **Note: The below blocks only need tested for the feature plugin**
+
 -   [ ] Cart
 -   [ ] Checkout

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -1,6 +1,6 @@
 ## Testing notes and ZIP for release 3.1.0
 
-Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4994434/woocommerce-gutenberg-products-block.zip)
+Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4995326/woocommerce-gutenberg-products-block.zip)
 
 ## All Products
 

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -46,6 +46,9 @@ This new release has a new system to generate the styles, so it would be great t
 -   [ ] Filter Products by Price
 -   [ ] Filter Products by Attribute
 -   [ ] Active Product Filters
+
+**Note: The below blocks only need tested for the feature plugin**
+
 -   [ ] Cart
 -   [ ] Checkout
 

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -2,9 +2,9 @@
 
 Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/4995326/woocommerce-gutenberg-products-block.zip)
 
-## All Products
+### All Products
 
-### Product summary inner block renders in the frontend
+#### Product summary inner block renders in the frontend
 
 First, let's make sure at least one of the products has a summary:
 
@@ -25,7 +25,7 @@ Now, let's make sure the bug is fixed:
 7. Click on the View Post button to view the post in the frontend side of your store.
 8. Verify the Product summary block is rendered for products which have it.
 
-### There are no regressions with other inner blocks
+#### There are no regressions with other inner blocks
 
 There have been changes in the way All Products inner blocks are loaded, so it should be tested that other inner blocks, in addition to the Product summary block, work fine in the editor and the frontend.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "3.1.0-dev",
+	"version": "3.1.0",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 3.0.0
+Stable tag: 3.1.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia, aljullu, mikejolley, nerrad, joshuawold, assassinateur, haszari
 Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.2
-Tested up to: 5.4
+Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 3.0.0
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,11 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 3.1.0 - 2020-07-29 =
+- Fix missing permissions_callback arg in StoreApi route definitions [#2926](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2926)
+- Fix 'Product Summary' in All Products block is not pulling in the short description of the product [#2913](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2913)
+- dev: Add query filter when searching for a table [#2886](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2886) 👏 @pkelbert
+
 = 3.0.0 - 2020-07-20 =
 
 This release adds support for Cash on Delivery and Bank Transfer payment methods to the checkout block. The payment method extension api for the blocks [has an update to the `canMakePayment` property](https://woocommerce.wordpress.com/?p=6830).

--- a/src/Package.php
+++ b/src/Package.php
@@ -101,7 +101,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '3.1.0-dev';
+					$version = '3.1.0';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/src/StoreApi/Routes/Cart.php
+++ b/src/StoreApi/Routes/Cart.php
@@ -32,9 +32,10 @@ class Cart extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],

--- a/src/StoreApi/Routes/CartAddItem.php
+++ b/src/StoreApi/Routes/CartAddItem.php
@@ -32,9 +32,10 @@ class CartAddItem extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'id'        => [
 						'description' => __( 'The cart item product or variation ID.', 'woo-gutenberg-products-block' ),
 						'type'        => 'integer',

--- a/src/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/CartApplyCoupon.php
@@ -32,9 +32,10 @@ class CartApplyCoupon extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'code' => [
 						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -33,20 +33,23 @@ class CartCoupons extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'permission_callback' => '__return_true',
+				'callback'            => [ $this, 'get_response' ],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/CartCouponsByCode.php
@@ -39,15 +39,17 @@ class CartCouponsByCode extends AbstractRoute {
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartItems.php
+++ b/src/StoreApi/Routes/CartItems.php
@@ -33,20 +33,23 @@ class CartItems extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => array( $this, 'get_response' ),
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -39,20 +39,23 @@ class CartItemsByKey extends AbstractRoute {
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::EDITABLE,
-				'callback' => array( $this, 'get_response' ),
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::DELETABLE,
-				'callback' => [ $this, 'get_response' ],
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/CartRemoveCoupon.php
@@ -32,9 +32,10 @@ class CartRemoveCoupon extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'code' => [
 						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -32,9 +32,10 @@ class CartRemoveItem extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'key' => [
 						'description' => __( 'Unique identifier (key) for the cart item.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -32,9 +32,10 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'package_id' => array(
 						'description' => __( 'The ID of the package being shipped.', 'woo-gutenberg-products-block' ),
 						'type'        => 'integer',

--- a/src/StoreApi/Routes/CartUpdateItem.php
+++ b/src/StoreApi/Routes/CartUpdateItem.php
@@ -32,9 +32,10 @@ class CartUpdateItem extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'key'      => [
 						'description' => __( 'Unique identifier (key) for the cart item to update.', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',

--- a/src/StoreApi/Routes/CartUpdateShipping.php
+++ b/src/StoreApi/Routes/CartUpdateShipping.php
@@ -41,9 +41,10 @@ class CartUpdateShipping extends AbstractCartRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'first_name' => [
 						'description'       => __( 'Customer first name.', 'woo-gutenberg-products-block' ),
 						'type'              => 'string',

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -57,21 +57,24 @@ class Checkout extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => [
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			[
-				'methods'  => \WP_REST_Server::EDITABLE,
-				'callback' => array( $this, 'get_response' ),
-				'args'     => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'get_response' ),
+				'permission_callback' => '__return_true',
+				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
 			],
 			[
-				'methods'  => \WP_REST_Server::CREATABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array_merge(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array_merge(
 					[
 						'payment_data' => [
 							'description' => __( 'Data to pass through to the payment method when processing payment.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/ProductAttributeTerms.php
@@ -37,9 +37,10 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductAttributes.php
+++ b/src/StoreApi/Routes/ProductAttributes.php
@@ -31,9 +31,10 @@ class ProductAttributes extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductAttributesById.php
+++ b/src/StoreApi/Routes/ProductAttributesById.php
@@ -37,9 +37,10 @@ class ProductAttributesById extends AbstractRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'context' => $this->get_context_param(
 						array(
 							'default' => 'view',

--- a/src/StoreApi/Routes/ProductCategories.php
+++ b/src/StoreApi/Routes/ProductCategories.php
@@ -31,9 +31,10 @@ class ProductCategories extends AbstractTermsRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductCategoriesById.php
+++ b/src/StoreApi/Routes/ProductCategoriesById.php
@@ -37,9 +37,10 @@ class ProductCategoriesById extends AbstractRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'context' => $this->get_context_param(
 						array(
 							'default' => 'view',

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -35,9 +35,10 @@ class ProductCollectionData extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductReviews.php
+++ b/src/StoreApi/Routes/ProductReviews.php
@@ -34,9 +34,10 @@ class ProductReviews extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductTags.php
+++ b/src/StoreApi/Routes/ProductTags.php
@@ -31,9 +31,10 @@ class ProductTags extends AbstractTermsRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -34,9 +34,10 @@ class Products extends AbstractRoute {
 	public function get_args() {
 		return [
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => $this->get_collection_params(),
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];

--- a/src/StoreApi/Routes/ProductsById.php
+++ b/src/StoreApi/Routes/ProductsById.php
@@ -37,9 +37,10 @@ class ProductsById extends AbstractRoute {
 				),
 			),
 			[
-				'methods'  => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_response' ],
-				'args'     => array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'context' => $this->get_context_param(
 						array(
 							'default' => 'view',

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -42,7 +42,7 @@ class CartItems extends TestCase {
 		$this->products[0]->save();
 
 		// Create a test variable product.
-		$this->products[1] = ProductHelper::create_variation_product( false );
+		$this->products[1] = ProductHelper::create_variation_product();
 		$this->products[1]->set_weight( 10 );
 		$this->products[1]->set_regular_price( 10 );
 		$this->products[1]->save();

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 3.1.0-dev
+ * Version: 3.1.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This is the release pull request for WooCommerce Blocks **3.1**.

## Communication

<!--
  This section is for any notes related to communicating the release.
  Please include any extra details with each item as needed.
-->

This release fixes an issue with the Product summary inner block in the All Products block that was not being rendered correctly.

- Fix missing permissions_callback arg in StoreApi route definitions [#2926](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2926) 
- Fix 'Product Summary' in All Products block is not pulling in the short description of the product [#2913](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2913)
- dev: Add query filter when searching for a table [#2886](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2886) 👏 @pkelbert

<!--
In this section document an overview/summary of what this release includes. You can refer to
the changelog for more information
-->

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

<!--
In this section you are highlighting all the public facing documentation that is related to the
release. Feel free to remove anything that doesn't apply for this release.
-->

**Release announcement:** _in process_

**Developer Notes** - N/A

**Relevant developer documentation:** N/A

* [x] The release includes a changelog entry in the readme.txt?


## Quality

<!--
  This section is for any notes related to quality around the release.
  Please include any extra details with each item as needed. This can include notes about
  Why something isn't checked or expanding info on your response to an item.
-->

* [x] Changes in this release are covered by Automated Tests.
     <!--
      This section is for confirming that the release changeset is covered by automated tests. If not,
      please leave some details on why not and any relevant information indicating confidence without
      those tests.
      -->
     * [x] Unit tests
     * [x] E2E tests
     * [x] for each supported WordPress and WooCommerce core versions.

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [ ] This release affects public facing REST APIs.
    * [ ] It conforms to REST API versioning policy.

* [ ] This release impacts **other extensions** or **backward compatibility**.
    * [ ] The release changes the signature of public methods or functions
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)
    * [ ] The release affects filters or action hooks.
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)

* [x] Link to **testing instructions** for this release: [Testing Instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/release/3.1/docs/testing/releases/310.md)

* [x] The release has a negative performance impact on sites.
    * [ ] There are new assets (JavaScript or CSS bundles)
    * [x] There is an increase to the size of JavaScript or CSS bundles) <!-- please include rationale for this increase -->
    * [ ] Other negative performance impacts (if yes, include list below)

* [ ] The release has positive performance impact on sites. If checked, please document these improvements here.

### Notes on performance

#### New CSS webpack config

This release generates CSS files in a new way (see #2818 for more info). That resulted in a bigger CSS file for legacy builds. Non-legacy builds aren't affected (in fact, they got a small size decrease).
