### PR TITLE
Update wp.deploy workflow adding slack hook

### DIFF
--- a/.github/workflows/wordpress-deploy.yml
+++ b/.github/workflows/wordpress-deploy.yml
@@ -6,7 +6,13 @@ jobs:
   tag:
     name: New Release
     runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
+      - uses: act10ns/slack@v1
+        with:
+          status: starting
+        if: always()
       - name: Checkout code
         uses: actions/checkout@v2
       - name: WordPress Plugin Deploy
@@ -27,3 +33,8 @@ jobs:
           asset_path: ${{github.workspace}}/woo-gutenberg-products-block.zip
           asset_name: woo-gutenberg-products-block.zip
           asset_content_type: application/zip
+      - uses: act10ns/slack@v1
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+        if: always()


### PR DESCRIPTION
This will notify rubik's slack channel when this workflow starts and finishes.

For the 3.1.0 release this will also need cherry-picked into the 3.1.0 release branch.

The action being used is https://github.com/marketplace/actions/slack-github-actions-slack-integration
