### PR TITLE
Fix reviews blocks in WP 5.2

### DIFF
--- a/assets/js/base/utils/render-frontend.js
+++ b/assets/js/base/utils/render-frontend.js
@@ -22,6 +22,7 @@ export const renderFrontend = ( {
 	const containers = document.querySelectorAll( selector );
 
 	if ( containers.length ) {
+		// @todo Remove Suspense compatibility fix once WP 5.2 is no longer supported.
 		// If Suspense is not available (WP 5.2), use a noop component instead.
 		const noopComponent = ( { children } ) => {
 			return <>{ children }</>;

--- a/assets/js/base/utils/render-frontend.js
+++ b/assets/js/base/utils/render-frontend.js
@@ -22,6 +22,12 @@ export const renderFrontend = ( {
 	const containers = document.querySelectorAll( selector );
 
 	if ( containers.length ) {
+		// If Suspense is not available (WP 5.2), use a noop component instead.
+		const noopComponent = ( { children } ) => {
+			return <>{ children }</>;
+		};
+		const SuspenseComponent = Suspense || noopComponent;
+
 		// Use Array.forEach for IE11 compatibility.
 		Array.prototype.forEach.call( containers, ( el, i ) => {
 			const props = getProps( el, i );
@@ -34,11 +40,11 @@ export const renderFrontend = ( {
 
 			render(
 				<BlockErrorBoundary { ...errorBoundaryProps }>
-					<Suspense
+					<SuspenseComponent
 						fallback={ <div className="wc-block-placeholder" /> }
 					>
 						<Block { ...props } attributes={ attributes } />
-					</Suspense>
+					</SuspenseComponent>
 				</BlockErrorBoundary>,
 				el
 			);


### PR DESCRIPTION
While testing 3.1.0, I noticed reviews blocks were not working on WP 5.2. That seems to be because `renderFrontend()` relies on `Suspense`, which is not available in the React version of WP 5.2.

This PR replaces Suspense with a noop component if it's not available.

### How to test the changes in this Pull Request:

1. In a WP 5.2 install, create a page with the All Reviews block, view it in the frontend and verify the block shows correctly.
2. In dev build of `main`, verify there are no regressions with the All Products and Single Product block.

This regression was introduced after 3.0 was released, so I don't think we need to add anything to the changelog.