### PR TITLE
Fix Reviews editor styles

### DIFF
--- a/assets/js/blocks/reviews/reviews-by-category/editor.scss
+++ b/assets/js/blocks/reviews/reviews-by-category/editor.scss
@@ -1,3 +1,0 @@
-.wc-block-reviews-by-category__selection {
-	width: 100%;
-}

--- a/assets/js/blocks/reviews/reviews-by-category/index.js
+++ b/assets/js/blocks/reviews/reviews-by-category/index.js
@@ -8,7 +8,6 @@ import { Icon, review } from '@woocommerce/icons';
 /**
  * Internal dependencies
  */
-import '../editor.scss';
 import Editor from './edit';
 import sharedAttributes from '../attributes';
 import save from '../save.js';

--- a/assets/js/blocks/reviews/reviews-by-product/editor.scss
+++ b/assets/js/blocks/reviews/reviews-by-product/editor.scss
@@ -1,7 +1,3 @@
-.wc-block-reviews-by-product__selection {
-	width: 100%;
-}
-
 .components-base-control {
 	+ .wc-block-reviews-by-product__notice {
 		margin: -$gap 0 $gap;

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -95,6 +95,7 @@ const entries = {
 			],
 		} ),
 
+		'reviews-style': './assets/js/blocks/reviews/editor.scss',
 		...getBlockEntries( '**/*.scss' ),
 	},
 	core: {


### PR DESCRIPTION
The reviews blocks use a different folder structure from the rest of the blocks, and the `editor.scss` file was not being included by Webpack. This PR explicitly define the Reviews `editor.scss` file as an entry. I also took the chance to remove a couple of selectors that don't seem to be used anywhere.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/88806079-390faf80-d1b0-11ea-9090-e110180b7751.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/88805644-b2f36900-d1af-11ea-9602-1b4d95fa108a.png)


### How to test the changes in this Pull Request:

1. Add a Reviews by Product and Reviews by Category blocks.
2. Verify the products/categories list takes the entire width and there are no weird reflows while loading.
