### PR TITLE
Add inspector notice for unsupported product types

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/block.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/block.js
@@ -3,7 +3,10 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { AddToCartFormContextProvider } from '@woocommerce/base-context';
+import {
+	AddToCartFormContextProvider,
+	useAddToCartFormContext,
+} from '@woocommerce/base-context';
 import { useProductDataContext } from '@woocommerce/shared-context';
 import { isEmpty } from 'lodash';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
@@ -46,32 +49,35 @@ const Block = ( { className, showFormElements } ) => {
 			showFormElements={ showFormElements }
 		>
 			<div className={ componentClass }>
-				<>
-					{ showFormElements ? (
-						<AddToCartForm productType={ product.type } />
-					) : (
-						<AddToCartButton />
-					) }
-				</>
+				<AddToCartForm />
 			</div>
 		</AddToCartFormContextProvider>
 	);
 };
 
-const AddToCartForm = ( { productType } ) => {
-	if ( productType === 'variable' ) {
-		return <VariableProductForm />;
+/**
+ * Renders the add to cart form using useAddToCartFormContext.
+ */
+const AddToCartForm = () => {
+	const { showFormElements, productType } = useAddToCartFormContext();
+
+	if ( showFormElements ) {
+		if ( productType === 'variable' ) {
+			return <VariableProductForm />;
+		}
+		if ( productType === 'grouped' ) {
+			return <GroupedProductForm />;
+		}
+		if ( productType === 'external' ) {
+			return <ExternalProductForm />;
+		}
+		if ( productType === 'simple' || productType === 'variation' ) {
+			return <SimpleProductForm />;
+		}
+		return null;
 	}
-	if ( productType === 'grouped' ) {
-		return <GroupedProductForm />;
-	}
-	if ( productType === 'external' ) {
-		return <ExternalProductForm />;
-	}
-	if ( productType === 'simple' || productType === 'variation' ) {
-		return <SimpleProductForm />;
-	}
-	return null;
+
+	return <AddToCartButton />;
 };
 
 Block.propTypes = {

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/edit.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/edit.js
@@ -5,8 +5,14 @@ import { __ } from '@wordpress/i18n';
 import EditProductLink from '@woocommerce/block-components/edit-product-link';
 import { useProductDataContext } from '@woocommerce/shared-context';
 import classnames from 'classnames';
-import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	Disabled,
+	PanelBody,
+	ToggleControl,
+	Notice,
+} from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
+import { productSupportsAddToCartForm } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -28,11 +34,11 @@ const Edit = ( { attributes, setAttributes } ) => {
 			) }
 		>
 			<EditProductLink productId={ product.id } />
-			{ product.type !== 'external' && (
-				<InspectorControls>
-					<PanelBody
-						title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
-					>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				>
+					{ productSupportsAddToCartForm( product ) ? (
 						<ToggleControl
 							label={ __(
 								'Display form elements',
@@ -49,9 +55,20 @@ const Edit = ( { attributes, setAttributes } ) => {
 								} )
 							}
 						/>
-					</PanelBody>
-				</InspectorControls>
-			) }
+					) : (
+						<Notice
+							className="wc-block-components-product-add-to-cart-notice"
+							isDismissible={ false }
+							status="info"
+						>
+							{ __(
+								'This product does not support the block based add to cart form. A link to the product page will be shown instead.',
+								'woo-gutenberg-products-block'
+							) }
+						</Notice>
+					) }
+				</PanelBody>
+			</InspectorControls>
 			<Disabled>
 				<Block { ...attributes } />
 			</Disabled>

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
@@ -14,6 +14,8 @@ import { useStoreAddToCart } from '@woocommerce/base-hooks';
 const AddToCartButton = () => {
 	const {
 		showFormElements,
+		productIsPurchasable,
+		productHasOptions,
 		product,
 		isDisabled,
 		isProcessing,
@@ -23,8 +25,6 @@ const AddToCartButton = () => {
 	} = useAddToCartFormContext();
 	const { cartQuantity } = useStoreAddToCart( product.id || 0 );
 	const [ addedToCart, setAddedToCart ] = useState( false );
-	const isPurchasable = product.is_purchasable;
-	const hasOptions = product.has_options;
 	const addToCartButtonData = product.add_to_cart || {
 		url: '',
 		text: '',
@@ -47,23 +47,28 @@ const AddToCartButton = () => {
 		};
 	}, [ eventRegistration, hasError ] );
 
-	// If we are showing form elements, OR if the product has no additional form options, we can show
-	// a functional direct add to cart button, provided that the product is purchasable.
-	// No link is required to the full form under these circumstances.
-	if ( ( showFormElements || ! hasOptions ) && isPurchasable ) {
-		return (
-			<ButtonComponent
-				className="wc-block-components-product-add-to-cart-button"
-				quantityInCart={ cartQuantity }
-				isDisabled={ isDisabled }
-				isProcessing={ isProcessing }
-				isDone={ addedToCart }
-				onClick={ () => dispatchActions.submitForm() }
-			/>
-		);
-	}
+	/**
+	 * We can show a real button if we are:
+	 *
+	 *  	a) Showing a full add to cart form.
+	 * 		b) The product doesn't have options and can therefore be added directly to the cart.
+	 * 		c) The product is purchasable.
+	 *
+	 * Otherwise we show a link instead.
+	 */
+	const showButton =
+		( showFormElements || ! productHasOptions ) && productIsPurchasable;
 
-	return (
+	return showButton ? (
+		<ButtonComponent
+			className="wc-block-components-product-add-to-cart-button"
+			quantityInCart={ cartQuantity }
+			isDisabled={ isDisabled }
+			isProcessing={ isProcessing }
+			isDone={ addedToCart }
+			onClick={ () => dispatchActions.submitForm() }
+		/>
+	) : (
 		<LinkComponent
 			className="wc-block-components-product-add-to-cart-button"
 			href={ addToCartButtonData.url }

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
@@ -17,6 +17,7 @@ const AddToCartButton = () => {
 		productIsPurchasable,
 		productHasOptions,
 		product,
+		productType,
 		isDisabled,
 		isProcessing,
 		eventRegistration,
@@ -57,7 +58,9 @@ const AddToCartButton = () => {
 	 * Otherwise we show a link instead.
 	 */
 	const showButton =
-		( showFormElements || ! productHasOptions ) && productIsPurchasable;
+		( showFormElements ||
+			( ! productHasOptions && productType === 'simple' ) ) &&
+		productIsPurchasable;
 
 	return showButton ? (
 		<ButtonComponent

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/style.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/style.scss
@@ -43,3 +43,7 @@
 .wc-block-grid .wc-block-components-product-add-to-cart {
 	justify-content: center;
 }
+
+.wc-block-components-product-add-to-cart-notice {
+	margin: 0;
+}

--- a/assets/js/base/utils/index.js
+++ b/assets/js/base/utils/index.js
@@ -5,3 +5,4 @@ export * from './shipping-rates';
 export * from './legacy-events';
 export * from './render-frontend';
 export * from './get-valid-block-attributes';
+export * from './product-data';

--- a/assets/js/base/utils/product-data.js
+++ b/assets/js/base/utils/product-data.js
@@ -1,0 +1,31 @@
+/**
+ * Check a product object to see if it can be purchased.
+ *
+ * @param {Object} product Product object.
+ * @return {boolean} True if purchasable.
+ */
+export const productIsPurchasable = ( product ) => {
+	return product.is_purchasable || false;
+};
+
+/**
+ * Check if the product is supported by the blocks add to cart form.
+ *
+ * @param {Object} product Product object.
+ * @return {boolean} True if supported.
+ */
+export const productSupportsAddToCartForm = ( product ) => {
+	/**
+	 * @todo Define supported product types for add to cart form.
+	 *
+	 * When introducing the form-element registration system, include a method of defining if a
+	 * product type has support.
+	 *
+	 * If, as an example, we went with an inner block system for the add to cart form, we could allow
+	 * a type to be registered along with it's default Block template. Registered types would then be
+	 * picked up here, as well as the core types which would be defined elsewhere.
+	 */
+	const supportedTypes = [ 'simple', 'variable' ];
+
+	return supportedTypes.includes( product.type || 'simple' );
+};

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -262,20 +262,24 @@
 /**
  * @typedef {Object} AddToCartFormContext
  *
- * @property {boolean}                        showFormElements   True if showing a full add to cart form.
- * @property {Object}                         product            The product object to add to the cart.
- * @property {number}                         quantity           Stores the quantity being added to the cart.
- * @property {number}                         minQuantity        Min quantity that can be added to the cart.
- * @property {number}                         maxQuantity        Max quantity than can be added to the cart.
- * @property {Object}                         requestParams      List of params to send to the API.
- * @property {boolean}                        isIdle             True when the form state has changed and has no activity.
- * @property {boolean}                        isDisabled         True when the form cannot be submitted.
- * @property {boolean}                        isProcessing       True when the form has been submitted and is being processed.
- * @property {boolean}                        isBeforeProcessing True during any observers executing logic before form processing (eg. validation).
- * @property {boolean}                        isAfterProcessing  True when form status is AFTER_PROCESSING.
- * @property {boolean}                        hasError           True when the form is in an error state. Whatever caused the error (validation/payment method) will likely have triggered a notice.
- * @property {AddToCartFormEventRegistration} eventRegistration  Event emitters that can be subscribed to.
- * @property {AddToCartFormDispatchActions}   dispatchActions    Various actions that can be dispatched for the add to cart form context data.
+ * @property {Object}                         product              The product object to add to the cart.
+ * @property {string}                         productType          The name of the product type.
+ * @property {boolean}                        productIsPurchasable True if the product can be purchased.
+ * @property {boolean}                        productHasOptions    True if the product has additonal options and thus needs a cart form.
+ * @property {boolean}                        supportsFormElements True if the product type supports form elements.
+ * @property {boolean}                        showFormElements     True if showing a full add to cart form (enabled and supported).
+ * @property {number}                         quantity             Stores the quantity being added to the cart.
+ * @property {number}                         minQuantity          Min quantity that can be added to the cart.
+ * @property {number}                         maxQuantity          Max quantity than can be added to the cart.
+ * @property {Object}                         requestParams        List of params to send to the API.
+ * @property {boolean}                        isIdle               True when the form state has changed and has no activity.
+ * @property {boolean}                        isDisabled           True when the form cannot be submitted.
+ * @property {boolean}                        isProcessing         True when the form has been submitted and is being processed.
+ * @property {boolean}                        isBeforeProcessing   True during any observers executing logic before form processing (eg. validation).
+ * @property {boolean}                        isAfterProcessing    True when form status is AFTER_PROCESSING.
+ * @property {boolean}                        hasError             True when the form is in an error state. Whatever caused the error (validation/payment method) will likely have triggered a notice.
+ * @property {AddToCartFormEventRegistration} eventRegistration    Event emitters that can be subscribed to.
+ * @property {AddToCartFormDispatchActions}   dispatchActions      Various actions that can be dispatched for the add to cart form context data.
  */
 
 /**


### PR DESCRIPTION
This PR adds a notice element if a product type is not supported by the add to cart form.

Products which support form elements have the toggle in the inspector like this:

![Edit Page ‹ one wordpress test — WordPress 2020-07-30 14-38-25](https://user-images.githubusercontent.com/90977/88930129-f662db80-d272-11ea-8bec-aa86fd7518d1.png)

Products which are unsupported (external, and currently grouped) instead show a notice:

![Edit Page ‹ one wordpress test — WordPress 2020-07-30 14-39-00](https://user-images.githubusercontent.com/90977/88930126-f4991800-d272-11ea-9a3c-5a18f7dcd7a3.png)

I've added an inline todo for the follow up which is to introduce a system of registering support for a product type.

Closes #2857

In #2857 I proposed an experiment/idea to use SSR for fallback forms if the product type is unsupported. This did not work unfortunately. This is what I tried:

**1) SSR to load the cart form from the API**

SSR did work in rendering the form, eventually, but I faced many issues:

- Templates are not available on REST endpoints, so I had to manually include woo core template hooks + files
- Whilst the forms did render, scripts and other assets were missing
- Because SSR is an ajaxified request, when the form does eventually render, any scripts that handle add to cart functionality have already fired on `jquery.ready()`, so the forms are non-functional.

We did talk about perhaps deferring the load of the assets, but we realised 3rd party product types would be completely out of our control.

**2) Rendering the template directly, or using a shortcode**

I tired rendering the template to the page directly instead, in the hopes that the jquery events would still fire. But this was also problematic:

- The events were inconsistent. Depending on where the render occured the form was non-functional.
- Getting the form in the correct position meant rendering it within a specific atomic block. These blocks had no product ID context and so would need it saved to attributes. Even then, it didn't render in the correct position.

Since these methods failed, I've gone with a notice instead. Non supported types will link through to the product pages.

### How to test the changes in this Pull Request:

1. Add the single product block to a page
2. Select a supported type (simple or variable) - check inspector controls
3. Support a non-supported type (external or grouped) - check notice in inspector controls
4. Repeat for a 3rd party product type such as bookings. It should show a link and the notice in the inspector.
