### PR TITLE
Add missing class dot in theming docs

### DIFF
--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -49,8 +49,8 @@ Those classes are:
 As an example, if we wanted to do the Checkout font size 10% larger when the container has a width of 521px or wider, we could do so with this code:
 
 ```CSS
-.wc-block-checkout is-medium,
-.wc-block-checkout is-large {
+.wc-block-checkout.is-medium,
+.wc-block-checkout.is-large {
 	font-size: 1.1em;
 }
 ```


### PR DESCRIPTION
CSS selectors were wrong in theming docs.