### PR TITLE
Fixes related to Jetpack Autoloader 2.0 package bump

### DIFF
--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -107,8 +107,10 @@ if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" != "y" ]; then
 fi
 
 # Version changes
-output 2 "Updating version numbers in files (note pre-releases will not have the readme.txt stable tag updated)..."
+output 2 "Updating version numbers in files and regenerating php autoload classmap (note pre-releases will not have the readme.txt stable tag updated)..."
 source $RELEASER_PATH/bin/version-changes.sh
+
+composer dump-autoload
 
 output 2 "Committing version change..."
 echo

--- a/bin/version-changes.sh
+++ b/bin/version-changes.sh
@@ -17,3 +17,6 @@ perl -i -pe 's/"version":*.+/"version": "'${VERSION}'",/' package.json
 
 # Update version in src/Package.php
 perl -i -pe "s/version \= '*.+';/version = '${VERSION}';/" src/Package.php
+
+# Add version to composer.json
+perl -i -pe 's/"type":*.+/"type":"wordpress-plugin",\n\t"version": "'${VERSION}'",/' composer.json

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -10,7 +10,7 @@
  * Requires at least: 5.2
  * Requires PHP: 5.6
  * WC requires at least: 4.0
- * WC tested up to: 4.2
+ * WC tested up to: 4.4
  *
  * @package WooCommerce\Blocks
  * @internal This file is only used when running as a feature plugin.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -65,6 +65,44 @@ if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
 }
 
 /**
+ * Returns whether the current version is a development version
+ * Note this relies on composer.json version, not plugin version.
+ * Development installs of the plugin don't have a version defined in
+ * composer json.
+ *
+ * @return bool True means the current version is a development version.
+ */
+function woocommerce_blocks_is_development_version() {
+	$composer_file = __DIR__ . '/composer.json';
+	if ( ! is_readable( $composer_file ) ) {
+		return false;
+	}
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- including local file
+	$composer_config = json_decode( file_get_contents( $composer_file ), true );
+	return ! isset( $composer_config['version'] );
+}
+
+/**
+ * If development version is detected and the Jetpack constant is not defined, show a notice.
+ */
+if ( woocommerce_blocks_is_development_version() && ! defined( 'JETPACK_AUTOLOAD_DEV' ) ) {
+	add_action(
+		'admin_notices',
+		function() {
+			echo '<div class="error"><p>';
+			printf(
+				/* Translators: %1$s is referring to a php constant name, %2$s is referring to the wp-config.php file. */
+				esc_html__( 'WooCommerce Blocks development mode requires the %1$s constant to be defined and true in your %2$s file. Otherwise you are loading the blocks package from WooCommerce core.', 'woo-gutenberg-products-block' ),
+				'JETPACK_AUTOLOAD_DEV',
+				'wp-config.php'
+			);
+			echo '</p></div>';
+		}
+	);
+}
+
+
+/**
  * Autoload packages.
  *
  * The package autoloader includes version information which prevents classes in this feature plugin


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2945 

See #2945 for details and rationale.

## To test

### Testing version bump changes.

In this pull the `./bin/version-changes.sh` script was modified to add an `"version"` entry to `composer.json` for the version being bumped to.

To verify things work as expected, you can run this script locally:

```bash
VERSION=3.0.0 sh ./bin/version-changes.sh
```

After running that you should note the following:

- `composer.json`, `package.json`, `readme.txt`, `src/Package.php`, `woocommerce-gutenberg-products-block.php` should be changed.
- The above files should only have a version bump to the specified version (in this case `3.0.0`)
- `composer.json`, should have the `version` property added by the script (otherwise it exists without a `version` property in development).

### Testing missing development constant notice

This will require a bit additional setup:

1. Make sure you are running WooCommerce 4.4 beta 1 (or checked out the built release branch for that version - it must be that version, not beta2).
2. Make sure you are running the latest WP 5.5 release candidate.
3. Without doing anything in this branch, you should see the following notice:

<img width="1744" alt="Image 2020-07-31 at 12 09 51 PM" src="https://user-images.githubusercontent.com/1429108/89054422-c1b05c00-d326-11ea-80d2-b4559bfe67a6.png">

4. Go to the frontend of your site and load a page that has one of our blocks that pulls from the REST API. You should see a bunch of deprecation notices related to our endpoints. This is an indicator that the package from Woo Core is being run rather than the classes from this branch (which have the REST API fixes).
5. Add `define( 'JETPACK_AUTOLOAD_DEV', true )` to your `wp-config.php` file (you'll want to leave it defined there when developing Woo Blocks going forward). **Note:** You _may_ get a fatal error because your checked out version of Woo Core has the constant defined, in that case just comment out the constant definition in Woo Core (Woo core 4.4. will not be released with the defined constant as it's being removed).
6. Verify that the notice disappears in your wp-admin dashboard. Also the deprecated REST API notices should disappear as well.

### Testing deploy

This is a bit trickier because we don't actually want to deploy. What I do is just add an exit right after this line in `bin/github-deploy.sh`

```
output 2 "Committing version change..."
echo
```
Essentially make sure you either comment out all `git` related commands in the script or do an exit before they run.

Then I'll do `sh ./bin/github-deploy.sh` and after it executes, take a look at the `vendor/composer/jetpack_autoload_classmap.php` file and look for any of the plugin classes defined in there. There should be a `'version' => '3.0.0.0',` string in the map that matches whatever version you entered during the deploy script (the extra `.0` appended is expected).
