### PR TITLE
Simplify reviews render method

### DIFF
--- a/assets/js/blocks/reviews/all-reviews/edit.js
+++ b/assets/js/blocks/reviews/all-reviews/edit.js
@@ -62,7 +62,6 @@ const AllReviewsEditor = ( { attributes, setAttributes } ) => {
 			{ getInspectorControls() }
 			<EditorContainerBlock
 				attributes={ attributes }
-				className="wc-block-all-reviews"
 				icon={
 					<Icon
 						icon={ discussion }

--- a/assets/js/blocks/reviews/editor-container-block.js
+++ b/assets/js/blocks/reviews/editor-container-block.js
@@ -31,7 +31,7 @@ class EditorContainerBlock extends Component {
 	}
 
 	render() {
-		const { attributes, className, noReviewsPlaceholder } = this.props;
+		const { attributes, noReviewsPlaceholder } = this.props;
 		const {
 			categoryIds,
 			productId,
@@ -57,7 +57,7 @@ class EditorContainerBlock extends Component {
 		}
 
 		return (
-			<div className={ getBlockClassName( className, attributes ) }>
+			<div className={ getBlockClassName( attributes ) }>
 				<EditorBlock
 					attributes={ attributes }
 					categoryIds={ categoryIds }

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -174,7 +174,6 @@ const ReviewsByCategoryEditor = ( {
 			{ getInspectorControls() }
 			<EditorContainerBlock
 				attributes={ attributes }
-				className="wc-block-reviews-by-category"
 				icon={
 					<Icon
 						srcElement={ review }

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -162,7 +162,6 @@ const ReviewsByProductEditor = ( {
 			{ getInspectorControls() }
 			<EditorContainerBlock
 				attributes={ attributes }
-				className="wc-block-reviews-by-product"
 				icon={
 					<Icon
 						icon={ comment }

--- a/assets/js/blocks/reviews/save.js
+++ b/assets/js/blocks/reviews/save.js
@@ -2,44 +2,13 @@
  * Internal dependencies
  */
 import './editor.scss';
-import { getBlockClassName } from './utils.js';
+import { getBlockClassName, getDataAttrs } from './utils.js';
 
 export default ( { attributes } ) => {
-	const {
-		categoryIds,
-		imageType,
-		orderby,
-		productId,
-		reviewsOnPageLoad,
-		reviewsOnLoadMore,
-		showLoadMore,
-		showOrderby,
-	} = attributes;
-
-	const data = {
-		'data-image-type': imageType,
-		'data-orderby': orderby,
-		'data-reviews-on-page-load': reviewsOnPageLoad,
-		'data-reviews-on-load-more': reviewsOnLoadMore,
-		'data-show-load-more': showLoadMore,
-		'data-show-orderby': showOrderby,
-	};
-	let className = 'wc-block-all-reviews';
-
-	if ( productId ) {
-		data[ 'data-product-id' ] = productId;
-		className = 'wc-block-reviews-by-product';
-	}
-
-	if ( Array.isArray( categoryIds ) ) {
-		data[ 'data-category-ids' ] = categoryIds.join( ',' );
-		className = 'wc-block-reviews-by-category';
-	}
-
 	return (
 		<div
-			className={ getBlockClassName( className, attributes ) }
-			{ ...data }
+			className={ getBlockClassName( attributes ) }
+			{ ...getDataAttrs( attributes ) }
 		/>
 	);
 };

--- a/assets/js/blocks/reviews/utils.js
+++ b/assets/js/blocks/reviews/utils.js
@@ -46,9 +46,11 @@ export const getReviews = ( args ) => {
 	} );
 };
 
-export const getBlockClassName = ( blockClassName, attributes ) => {
+export const getBlockClassName = ( attributes ) => {
 	const {
 		className,
+		categoryIds,
+		productId,
 		showReviewDate,
 		showReviewerName,
 		showReviewContent,
@@ -56,6 +58,16 @@ export const getBlockClassName = ( blockClassName, attributes ) => {
 		showReviewImage,
 		showReviewRating,
 	} = attributes;
+
+	let blockClassName = 'wc-block-all-reviews';
+
+	if ( productId ) {
+		blockClassName = 'wc-block-reviews-by-product';
+	}
+
+	if ( Array.isArray( categoryIds ) ) {
+		blockClassName = 'wc-block-reviews-by-category';
+	}
 
 	return classNames( blockClassName, className, {
 		'has-image': showReviewImage,
@@ -65,4 +77,36 @@ export const getBlockClassName = ( blockClassName, attributes ) => {
 		'has-content': showReviewContent,
 		'has-product-name': showProductName,
 	} );
+};
+
+export const getDataAttrs = ( attributes ) => {
+	const {
+		categoryIds,
+		imageType,
+		orderby,
+		productId,
+		reviewsOnPageLoad,
+		reviewsOnLoadMore,
+		showLoadMore,
+		showOrderby,
+	} = attributes;
+
+	const data = {
+		'data-image-type': imageType,
+		'data-orderby': orderby,
+		'data-reviews-on-page-load': reviewsOnPageLoad,
+		'data-reviews-on-load-more': reviewsOnLoadMore,
+		'data-show-load-more': showLoadMore,
+		'data-show-orderby': showOrderby,
+	};
+
+	if ( productId ) {
+		data[ 'data-product-id' ] = productId;
+	}
+
+	if ( Array.isArray( categoryIds ) ) {
+		data[ 'data-category-ids' ] = categoryIds.join( ',' );
+	}
+
+	return data;
 };


### PR DESCRIPTION
I originally thought I needed to do a deprecation of the Reviews blocks in #2904, so ended up cleaning a bit the render logic to make my life easier. In the end, there is no need for the deprecation, but I still think the refactor is worth merging, so I split it into this PR. The changes include:
1. The logic to know which class name to use (`wc-block-all-reviews`, `wc-block-reviews-by-product`, `wc-block-reviews-by-category`) is now in `getBlockClassName`. Previously, those classes were explicitly defined in the editor but inferred from `attributes` in the frontend which I found a bit confusing. With the changes in this PR they are always inferred from `attributes` inside `getBlockClassName`, so there is a single source of truth.
2. I moved the logic to calculate the `data` attributes to its own util function (`getDataAttrs`) so it's easier to reuse if we ever write deprecations and makes code more organized.

### How to test the changes in this Pull Request:

1. Still in `main`, add the three reviews blocks (All Reviews, Reviews by Product, Reviews by Category) to a page.
2. Checkout this branch.
3. Verify the previously added blocks didn't invalidate.
4. Verify the blocks still work fine in the frontend.