### PR TITLE
Don't show saving badge if the value is negative

### DIFF
--- a/assets/js/base/components/cart-checkout/product-price/index.js
+++ b/assets/js/base/components/cart-checkout/product-price/index.js
@@ -13,7 +13,7 @@ import './style.scss';
 
 const ProductPrice = ( { className, currency, regularValue, value } ) => {
 	const isDiscounted =
-		Number.isFinite( regularValue ) && regularValue !== value;
+		Number.isFinite( regularValue ) && regularValue > value;
 
 	if ( isDiscounted ) {
 		return (

--- a/assets/js/base/components/cart-checkout/product-sale-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-sale-badge/index.js
@@ -21,7 +21,7 @@ import ProductBadge from '../product-badge';
  * @return {*} The component.
  */
 const ProductSaleBadge = ( { currency, saleAmount } ) => {
-	if ( ! saleAmount ) {
+	if ( ! saleAmount || saleAmount <= 0 ) {
 		return null;
 	}
 	return (


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Fixes a case in which having the current price higher than the regular price causes the cart to show negative savings.

<!-- Reference any related issues or PRs here -->
Fixes #2627

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/6165348/89299952-60a6c200-d65f-11ea-93fb-15fa3b983ad3.png)

After:
![image](https://user-images.githubusercontent.com/6165348/89300001-74522880-d65f-11ea-867a-33472757e8ec.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

I didn't know how to reproduce using native WooCommerce features, you will need [Product Add-ons](https://woocommerce.com/products/product-add-ons/) extension.
1. Add a product with a priced add on.
2. Add the product to your cart, with the add on enabled.
3. See that the price is shown without a negative discount value.

<!-- If you can, add the appropriate labels -->

### Changelog

> Hide the discount badge from Cart items if the value is negative.
