### PR TITLE
Show Checkout block in editor also when guest checkout is not allowed

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -180,7 +180,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		window.location.href
 	) }`;
 
-	if ( ! customerId && ! CHECKOUT_ALLOWS_GUEST ) {
+	if ( ! isEditor && ! customerId && ! CHECKOUT_ALLOWS_GUEST ) {
 		return (
 			<>
 				{ __(


### PR DESCRIPTION
Fixes #2943.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Accounts & Privacy and uncheck Allow customers to place orders without an account.
2. Edit a page with the Checkout block.
3. Verify the whole Checkout block is rendered in the editor, instead of only showing the `You must be logged in to checkout. Click here to log in.` message.

### Changelog

> Fixed an issue that was not rendering the Checkout block in editor when gues checkout was not allowed.