### PR TITLE
Add JETPACK_AUTOLOAD_DEV to wp-env instances

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -9,5 +9,8 @@
 	],
 	"mappings": {
 		".htaccess": "./bin/.htaccess"
+	},
+	"config": {
+		"JETPACK_AUTOLOAD_DEV": true
 	}
 }


### PR DESCRIPTION
Recently, we started requiring `JETPACK_AUTOLOAD_DEV` constant in order to run the latest plugin package files (see PR https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2949 and parent issue https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2945).

This PR defines that constant for wp-env controlled environments, this means the e2e environment and any local environment, this is done thanks to `.wp-env.json config` field, in which you define key-value pairs of constants and their values.

### How to test

- on `main`, run `npm run wp-env start`, visit  `https://localhost:8889/wp-admin` you will see the error `WooCommerce Blocks development mode requires the JETPACK_AUTOLOAD_DEV constant to be defined and true in your wp-config.php file. Otherwise you are loading the blocks package from WooCommerce core.`.
- on this branch, start the env again `npm run wp-env start` and check the page again, you will see the notice gone.