### PR TITLE
Fix All Products block 'No products' placeholder link

### DIFF
--- a/assets/js/blocks/products/utils.js
+++ b/assets/js/blocks/products/utils.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Button, Placeholder } from '@wordpress/components';
 import classNames from 'classnames';
-import { adminUrl } from '@woocommerce/settings';
+import { ADMIN_URL } from '@woocommerce/settings';
 import { Icon, external } from '@woocommerce/icons';
 
 export const getBlockClassName = ( blockClassName, attributes ) => {
@@ -35,7 +35,7 @@ export const renderNoProductsPlaceholder = ( blockTitle, blockIcon ) => (
 			className="wc-block-products__add-product-button"
 			isDefault
 			isLarge
-			href={ adminUrl + 'post-new.php?post_type=product' }
+			href={ ADMIN_URL + 'post-new.php?post_type=product' }
 		>
 			{ __( 'Add new product', 'woo-gutenberg-products-block' ) + ' ' }
 			<Icon srcElement={ external } />


### PR DESCRIPTION
While working on #2904 I noticed we were using the wrong variable name when importing the admin URL in the 'No products' placeholder of the All Products block.

### How to test the changes in this Pull Request:

1. Replace [line 283](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/assets/js/blocks/products/all-products/edit.js#L283) from `all-products/edit.js` as follows:
```diff
-if ( ! HAS_PRODUCTS ) {
+if ( true ) {
```
2. Create a new page and add the All Products block (you might notice there are some layout issues if you use WP 5.5, they are reported in #2959).
3. Click on the `Add new product` link and verify it works.

### Changelog

> Fix 'Add new product' link in All Products block 'No products' placeholder.