### PR TITLE
Fix undefined variable in ProductSchema.php closure 

### DIFF
--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -555,7 +555,7 @@ class ProductSchema extends AbstractSchema {
 		$attributes                  = array_filter( $product->get_attributes(), [ $this, 'filter_variation_attribute' ] );
 		$default_variation_meta_data = array_reduce(
 			$attributes,
-			function( $defaults, $attribute ) {
+			function( $defaults, $attribute ) use ( $product ) {
 				$meta_key              = wc_variation_attribute_name( $attribute->get_name() );
 				$defaults[ $meta_key ] = [
 					'name'  => wc_attribute_label( $attribute->get_name(), $product ),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Fixes the issue by defining `use ( $product )` in the closure, as far as my googling went, this syntax is supported from PHP 5.3, so we're safe (WC requires 7.0).

<!-- Reference any related issues or PRs here -->
Fixes #2896
### How to test the changes in this Pull Request:

1. You shouldn't see the notice anymore

### How to test
0- Make sure you have WP_DEBUG set to true.
1- Load a page that already contains a product data, so single product or All Products, either in the editor or frontend.
2- Make sure no notices are printed to the page, you can check the source code or at the top of the page.

### Changelog

> Fix an undefined variable PHP notice related to Product REST API.
