### PR TITLE
Remove generic payment method icons (Stripe CC + Cheque)

### DIFF
--- a/assets/js/base/components/cart-checkout/payment-method-label/index.js
+++ b/assets/js/base/components/cart-checkout/payment-method-label/index.js
@@ -1,18 +1,44 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { Icon, bank, bill, card, checkPayment } from '@woocommerce/icons';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
+
+const namedIcons = {
+	bank,
+	bill,
+	card,
+	checkPayment,
+};
 
 /**
  * Exposed to payment methods for the label shown on checkout. Allows icons to be added as well as
  * text.
  *
  * @param {Object} props Component props.
+ * @param {*} props.icon Show an icon beside the text if provided. Can be a string to use a named
+ *                       icon, or an SVG element.
  * @param {string} props.text Text shown next to icon.
  */
-export const PaymentMethodLabel = ( { text = '' } ) => {
-	const className = 'wc-block-components-payment-method-label';
-	return <span className={ className }>{ text }</span>;
+export const PaymentMethodLabel = ( { icon = '', text = '' } ) => {
+	const hasIcon = !! icon;
+	const hasNamedIcon =
+		hasIcon && typeof icon === 'string' && namedIcons[ icon ];
+	const className = classnames( 'wc-block-components-payment-method-label', {
+		'wc-block-components-payment-method-label--with-icon': hasIcon,
+	} );
+
+	return (
+		<span className={ className }>
+			{ hasNamedIcon ? <Icon srcElement={ namedIcons[ icon ] } /> : icon }
+			{ text }
+		</span>
+	);
 };
 
 export default PaymentMethodLabel;

--- a/assets/js/base/components/cart-checkout/payment-method-label/index.js
+++ b/assets/js/base/components/cart-checkout/payment-method-label/index.js
@@ -1,44 +1,18 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-import { Icon, bank, bill, card, checkPayment } from '@woocommerce/icons';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
-
-const namedIcons = {
-	bank,
-	bill,
-	card,
-	checkPayment,
-};
 
 /**
  * Exposed to payment methods for the label shown on checkout. Allows icons to be added as well as
  * text.
  *
  * @param {Object} props Component props.
- * @param {*} props.icon Show an icon beside the text if provided. Can be a string to use a named
- *                       icon, or an SVG element.
  * @param {string} props.text Text shown next to icon.
  */
-export const PaymentMethodLabel = ( { icon = '', text = '' } ) => {
-	const hasIcon = !! icon;
-	const hasNamedIcon =
-		hasIcon && typeof icon === 'string' && namedIcons[ icon ];
-	const className = classnames( 'wc-block-components-payment-method-label', {
-		'wc-block-components-payment-method-label--with-icon': hasIcon,
-	} );
-
-	return (
-		<span className={ className }>
-			{ hasNamedIcon ? <Icon srcElement={ namedIcons[ icon ] } /> : icon }
-			{ text }
-		</span>
-	);
+export const PaymentMethodLabel = ( { text = '' } ) => {
+	const className = 'wc-block-components-payment-method-label';
+	return <span className={ className }>{ text }</span>;
 };
 
 export default PaymentMethodLabel;

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -33,7 +33,7 @@ const Content = () => {
  */
 const Label = ( props ) => {
 	const { PaymentMethodLabel } = props.components;
-	return <PaymentMethodLabel icon="checkPayment" text={ label } />;
+	return <PaymentMethodLabel text={ label } />;
 };
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -38,7 +38,6 @@ const StripeLabel = ( props ) => {
 
 	return (
 		<PaymentMethodLabel
-			icon="card"
 			text={ __( 'Credit / Debit Card', 'woo-gutenberg-products-block' ) }
 		/>
 	);


### PR DESCRIPTION
Fixes #2669 

This fixes a couple of issues by removing the generic icons for some payment methods.

- Based on previous discussion, we're [moving away from generic payment method icons (e.g. a card icon)](https://github.com/Automattic/woocommerce-payments/pull/723#discussion_r455190773); icons/imagery should be used for recognisable payment brands only (e.g. PayPal). cc @LevinMedia – can you confirm this is the current recommendation?
- #2669 is a specific wrap issue with Twenty Twenty theme. This is not an issue when the icons are not present.

The `PaymentMethodLabel` component now no longer needs support for icons - so I've removed this. We might simplify this further - remove the component and allow payment methods to provide a string or custom component for their label. cc @nerrad - this is an extensibility API change

### Screenshots

<img width="1018" alt="Screen Shot 2020-08-05 at 4 41 29 PM" src="https://user-images.githubusercontent.com/4167300/89372565-98cf0300-d73a-11ea-8258-2732f7523605.png">

### How to test the changes in this Pull Request:

1. Set up Stripe CC (Stripe extension) and Check (core) payment methods.
2. Set up a page with checkout block, add stuff to cart.
3. View checkout and confirm payment method tabs render and function correctly.

### Changelog

> Removed generic icons for Check and Stripe Credit Card to reduce visual clutter in Checkout block.

May need a dev note - this changes the API/docs for implementing a payment method - specifically the `PaymentMethodLabel` interface has changed.
