### PR TITLE
Remove "package" tag from files inside "src" and "tests/php"

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -36,6 +36,15 @@
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 
+	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/php</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/php</exclude-pattern>
+	</rule>
+
 	<rule ref="Generic.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
 	</rule>

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Initializes block assets.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks;

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -1,17 +1,14 @@
 <?php
-/**
- * Initializes block assets.
- */
-
 namespace Automattic\WooCommerce\Blocks;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 
 /**
  * Assets class.
+ * Initializes block assets.
+ *
+ * @internal
  */
 class Assets {
 

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Contains asset api methods
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Assets;

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -1,14 +1,12 @@
 <?php
-/**
- * Contains asset api methods
- */
-
 namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
 
 /**
  * The Api class provides an interface to various asset registration helpers.
+ *
+ * Contains asset api methods
  *
  * @since 2.5.0
  */

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -2,6 +2,7 @@
 /**
  * Holds data registered for output on the current view session when
  * `wc-settings` is enqueued (directly or via dependency)
+ *
  * @since 2.5.0
  */
 

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -2,8 +2,6 @@
 /**
  * Holds data registered for output on the current view session when
  * `wc-settings` is enqueued (directly or via dependency)
- *
- * @package WooCommerce/Blocks
  * @since 2.5.0
  */
 

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Holds data registered for output on the current view session when
- * `wc-settings` is enqueued (directly or via dependency)
- *
- * @since 2.5.0
- */
-
 namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Exception;
@@ -14,6 +7,9 @@ use InvalidArgumentException;
 /**
  * Class instance for registering data used on the current view session by
  * assets.
+ *
+ * Holds data registered for output on the current view session when
+ * `wc-settings` is enqueued( directly or via dependency )
  *
  * @since 2.5.0
  */

--- a/src/Assets/BackCompatAssetDataRegistry.php
+++ b/src/Assets/BackCompatAssetDataRegistry.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Backwards Compatibility file for plugins using wcSettings in prior versions
- *
- * @package WooCommerce/Blocks
  * @since 2.5.0
  */
 

--- a/src/Assets/BackCompatAssetDataRegistry.php
+++ b/src/Assets/BackCompatAssetDataRegistry.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Backwards Compatibility file for plugins using wcSettings in prior versions
+ *
  * @since 2.5.0
  */
 

--- a/src/Assets/BackCompatAssetDataRegistry.php
+++ b/src/Assets/BackCompatAssetDataRegistry.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Backwards Compatibility file for plugins using wcSettings in prior versions
- *
- * @since 2.5.0
- */
-
 namespace Automattic\WooCommerce\Blocks\Assets;
 
 /**
@@ -12,6 +6,7 @@ namespace Automattic\WooCommerce\Blocks\Assets;
  *
  * Note: This will be removed at some point.
  *
+ * @internal
  * @since 2.5.0
  */
 class BackCompatAssetDataRegistry extends AssetDataRegistry {

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Abstract block class.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Abstract block class.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * AbstractBlock class.

--- a/src/BlockTypes/AbstractDynamicBlock.php
+++ b/src/BlockTypes/AbstractDynamicBlock.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Abstract dynamic block class.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/AbstractDynamicBlock.php
+++ b/src/BlockTypes/AbstractDynamicBlock.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Abstract dynamic block class.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * AbstractDynamicBlock class.

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Class for product grid functionality
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Class for product grid functionality
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Utils\BlocksWpQuery;
 

--- a/src/BlockTypes/ActiveFilters.php
+++ b/src/BlockTypes/ActiveFilters.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Active filters block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ActiveFilters.php
+++ b/src/BlockTypes/ActiveFilters.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Active filters block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Assets;
 

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * All products block.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * All products block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * AllProducts class.

--- a/src/BlockTypes/AllReviews.php
+++ b/src/BlockTypes/AllReviews.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Reviews by Product block.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/AllReviews.php
+++ b/src/BlockTypes/AllReviews.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Reviews by Product block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Assets;
 

--- a/src/BlockTypes/AtomicBlock.php
+++ b/src/BlockTypes/AtomicBlock.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Atomic blocks.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/AtomicBlock.php
+++ b/src/BlockTypes/AtomicBlock.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Atomic blocks.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * AtomicBlock class.
+ *
+ * @internal
  */
 class AtomicBlock extends AbstractBlock {
 	/**

--- a/src/BlockTypes/AttributeFilter.php
+++ b/src/BlockTypes/AttributeFilter.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Attribute filter block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/AttributeFilter.php
+++ b/src/BlockTypes/AttributeFilter.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Attribute filter block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Assets;
 

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -1,18 +1,14 @@
 <?php
-/**
- * Cart block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 
-defined( 'ABSPATH' ) || exit;
-
 /**
  * Cart class.
+ *
+ * @internal
  */
 class Cart extends AbstractBlock {
 	/**

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Checkout block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -1,18 +1,14 @@
 <?php
-/**
- * Checkout block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 
-defined( 'ABSPATH' ) || exit;
-
 /**
  * Checkout class.
+ *
+ * @internal
  */
 class Checkout extends AbstractBlock {
 

--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Featured category block.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Featured category block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * FeaturedCategory class.

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Featured products block.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Featured products block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * FeaturedProduct class.

--- a/src/BlockTypes/HandpickedProducts.php
+++ b/src/BlockTypes/HandpickedProducts.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Hand-picked Products block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/HandpickedProducts.php
+++ b/src/BlockTypes/HandpickedProducts.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Hand-picked Products block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * HandpickedProducts class.

--- a/src/BlockTypes/PriceFilter.php
+++ b/src/BlockTypes/PriceFilter.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Price filter block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/PriceFilter.php
+++ b/src/BlockTypes/PriceFilter.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Price filter block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Assets;
 

--- a/src/BlockTypes/ProductBestSellers.php
+++ b/src/BlockTypes/ProductBestSellers.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product best sellers block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductBestSellers.php
+++ b/src/BlockTypes/ProductBestSellers.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Product best sellers block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductBestSellers class.

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product categories block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Product categories block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductCategories class.

--- a/src/BlockTypes/ProductCategory.php
+++ b/src/BlockTypes/ProductCategory.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product category block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductCategory.php
+++ b/src/BlockTypes/ProductCategory.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Product category block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductCategory class.

--- a/src/BlockTypes/ProductNew.php
+++ b/src/BlockTypes/ProductNew.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * New products block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductNew.php
+++ b/src/BlockTypes/ProductNew.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * New products block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductNew class.

--- a/src/BlockTypes/ProductOnSale.php
+++ b/src/BlockTypes/ProductOnSale.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * On-sale products block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductOnSale.php
+++ b/src/BlockTypes/ProductOnSale.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * On-sale products block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductOnSale class.

--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product search block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Product search block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductSearch class.

--- a/src/BlockTypes/ProductTag.php
+++ b/src/BlockTypes/ProductTag.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product tag block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductTag.php
+++ b/src/BlockTypes/ProductTag.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Product tag block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductTag class.

--- a/src/BlockTypes/ProductTopRated.php
+++ b/src/BlockTypes/ProductTopRated.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Top rated products block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductTopRated.php
+++ b/src/BlockTypes/ProductTopRated.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Top rated products block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductTopRated class.

--- a/src/BlockTypes/ProductsByAttribute.php
+++ b/src/BlockTypes/ProductsByAttribute.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Products by attribute block.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ProductsByAttribute.php
+++ b/src/BlockTypes/ProductsByAttribute.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Products by attribute block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductsByAttribute class.

--- a/src/BlockTypes/ReviewsByCategory.php
+++ b/src/BlockTypes/ReviewsByCategory.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Reviews by Product block.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ReviewsByCategory.php
+++ b/src/BlockTypes/ReviewsByCategory.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Reviews by Product block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Assets;
 

--- a/src/BlockTypes/ReviewsByProduct.php
+++ b/src/BlockTypes/ReviewsByProduct.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Reviews by Product block.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/ReviewsByProduct.php
+++ b/src/BlockTypes/ReviewsByProduct.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Reviews by Product block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Assets;
 

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Single Product block.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes;

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Single Product block.
- */
-
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Assets;
 

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Contains the Bootstrap class
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Domain;

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Contains the Bootstrap class
- */
-
 namespace Automattic\WooCommerce\Blocks\Domain;
 
 use Automattic\WooCommerce\Blocks\Assets as BlockAssets;

--- a/src/Domain/Package.php
+++ b/src/Domain/Package.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Returns information about the package and handles init.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Domain;

--- a/src/Domain/Package.php
+++ b/src/Domain/Package.php
@@ -1,12 +1,10 @@
 <?php
-/**
- * Returns information about the package and handles init.
- */
-
 namespace Automattic\WooCommerce\Blocks\Domain;
 
 /**
  * Main package class.
+ *
+ * Returns information about the package and handles init.
  *
  * @since 2.5.0
  */

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Sets up all logic related to the Checkout Draft Orders service
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Domain\Services;

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Sets up all logic related to the Checkout Draft Orders service
- */
-
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
@@ -11,6 +7,10 @@ use WC_Order;
 
 /**
  * Service class for adding DraftOrder functionality to WooCommerce core.
+ *
+ * Sets up all logic related to the Checkout Draft Orders service
+ *
+ * @internal
  */
 class DraftOrders {
 

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Handles installation of Blocks plugin dependencies.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks;

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Handles installation of Blocks plugin dependencies.
- */
-
 namespace Automattic\WooCommerce\Blocks;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * Installer class.
+ * Handles installation of Blocks plugin dependencies.
+ *
+ * @internal
  */
 class Installer {
 	/**

--- a/src/Library.php
+++ b/src/Library.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Initializes blocks in WordPress.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks;

--- a/src/Library.php
+++ b/src/Library.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Initializes blocks in WordPress.
- */
-
 namespace Automattic\WooCommerce\Blocks;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Package;
 
 /**
  * Library class.
+ * Initializes blocks in WordPress.
+ *
+ * @internal
  */
 class Library {
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -7,8 +7,6 @@
  *
  * In the context of WooCommere core, it handles init and is called from
  * WooCommerce's package loader. The main plugin file is _not_ loaded.
- *
- * @package Automattic/WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks;

--- a/src/Package.php
+++ b/src/Package.php
@@ -1,5 +1,13 @@
 <?php
+namespace Automattic\WooCommerce\Blocks;
+
+use Automattic\WooCommerce\Blocks\Domain\Package as NewPackage;
+use Automattic\WooCommerce\Blocks\Domain\Bootstrap;
+use Automattic\WooCommerce\Blocks\Registry\Container;
+
 /**
+ * Main package class.
+ *
  * Returns information about the package and handles init.
  *
  * In the context of this plugin, it handles init and is called from the main
@@ -7,18 +15,6 @@
  *
  * In the context of WooCommere core, it handles init and is called from
  * WooCommerce's package loader. The main plugin file is _not_ loaded.
- */
-
-namespace Automattic\WooCommerce\Blocks;
-
-use Automattic\WooCommerce\Blocks\Domain\Package as NewPackage;
-use Automattic\WooCommerce\Blocks\Domain\Bootstrap;
-use Automattic\WooCommerce\Blocks\Registry\Container;
-
-defined( 'ABSPATH' ) || exit;
-
-/**
- * Main package class.
  *
  * @since 2.5.0
  */

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Payment Api class.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Payments;

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Payment Api class.
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Abstract payment method type class.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Abstract payment method type class.
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodTypeInterface;
 

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Bank Transfer (BACS) (core) gateway implementation.
- *
- * @package WooCommerce/Blocks
  * @since 3.0.0
  */
 

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Bank Transfer (BACS) (core) gateway implementation.
+ *
  * @since 3.0.0
  */
 

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Bank Transfer (BACS) (core) gateway implementation.
- *
- * @since 3.0.0
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
 use Automattic\WooCommerce\Blocks\Assets\Api;

--- a/src/Payments/Integrations/CashOnDelivery.php
+++ b/src/Payments/Integrations/CashOnDelivery.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Cash on Delivery (COD) (core) gateway implementation.
+ *
  * @since 3.0.0
  */
 

--- a/src/Payments/Integrations/CashOnDelivery.php
+++ b/src/Payments/Integrations/CashOnDelivery.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cash on Delivery (COD) (core) gateway implementation.
- *
- * @package WooCommerce/Blocks
  * @since 3.0.0
  */
 

--- a/src/Payments/Integrations/CashOnDelivery.php
+++ b/src/Payments/Integrations/CashOnDelivery.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Cash on Delivery (COD) (core) gateway implementation.
- *
- * @since 3.0.0
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
 use Automattic\WooCommerce\Blocks\Assets\Api;

--- a/src/Payments/Integrations/Cheque.php
+++ b/src/Payments/Integrations/Cheque.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Cheque (core) gateway implementation.
+ *
  * @since 2.6.0
  */
 

--- a/src/Payments/Integrations/Cheque.php
+++ b/src/Payments/Integrations/Cheque.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cheque (core) gateway implementation.
- *
- * @package WooCommerce/Blocks
  * @since 2.6.0
  */
 

--- a/src/Payments/Integrations/Cheque.php
+++ b/src/Payments/Integrations/Cheque.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Cheque (core) gateway implementation.
- *
- * @since 2.6.0
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
 use Exception;

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * PayPal Standard (core) gateway implementation.
- *
- * @package WooCommerce/Blocks
  * @since 2.6.0
  */
 

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * PayPal Standard (core) gateway implementation.
+ *
  * @since 2.6.0
  */
 

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * PayPal Standard (core) gateway implementation.
- *
- * @since 2.6.0
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
 use Exception;

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -3,6 +3,7 @@
  * Temporary integration of the stripe payment method for the new cart and
  * checkout blocks. Once the api is demonstrated to be stable, this integration
  * will be moved to the Stripe extension
+ *
  * @since 2.6.0
  */
 

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -3,8 +3,6 @@
  * Temporary integration of the stripe payment method for the new cart and
  * checkout blocks. Once the api is demonstrated to be stable, this integration
  * will be moved to the Stripe extension
- *
- * @package WooCommerce/Blocks
  * @since 2.6.0
  */
 

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -1,12 +1,4 @@
 <?php
-/**
- * Temporary integration of the stripe payment method for the new cart and
- * checkout blocks. Once the api is demonstrated to be stable, this integration
- * will be moved to the Stripe extension
- *
- * @since 2.6.0
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
 use Exception;
@@ -18,6 +10,10 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
 
 /**
  * Stripe payment method integration
+ *
+ * Temporary integration of the stripe payment method for the new cart and
+ * checkout blocks. Once the api is demonstrated to be stable, this integration
+ * will be moved to the Stripe extension
  *
  * @since 2.6.0
  */

--- a/src/Payments/PaymentContext.php
+++ b/src/Payments/PaymentContext.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Payment context.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Payments;

--- a/src/Payments/PaymentContext.php
+++ b/src/Payments/PaymentContext.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Payment context.
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * PaymentContext class.

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Holds data about registered payment methods.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Payments;

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Holds data about registered payment methods.
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments;
 
 /**

--- a/src/Payments/PaymentMethodTypeInterface.php
+++ b/src/Payments/PaymentMethodTypeInterface.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Payment method type interface.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Payments;

--- a/src/Payments/PaymentMethodTypeInterface.php
+++ b/src/Payments/PaymentMethodTypeInterface.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Payment method type interface.
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments;
-
-defined( 'ABSPATH' ) || exit;
 
 interface PaymentMethodTypeInterface {
 	/**

--- a/src/Payments/PaymentResult.php
+++ b/src/Payments/PaymentResult.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Payment result.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Payments;

--- a/src/Payments/PaymentResult.php
+++ b/src/Payments/PaymentResult.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Payment result.
- */
-
 namespace Automattic\WooCommerce\Blocks\Payments;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * PaymentResult class.

--- a/src/Registry/AbstractDependencyType.php
+++ b/src/Registry/AbstractDependencyType.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Holds the AbstractDependencyType class.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Registry;

--- a/src/Registry/AbstractDependencyType.php
+++ b/src/Registry/AbstractDependencyType.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Holds the AbstractDependencyType class.
- */
-
 namespace Automattic\WooCommerce\Blocks\Registry;
 
 /**

--- a/src/Registry/Container.php
+++ b/src/Registry/Container.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Contains the Container class.
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Registry;

--- a/src/Registry/Container.php
+++ b/src/Registry/Container.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Contains the Container class.
- */
-
 namespace Automattic\WooCommerce\Blocks\Registry;
 
 use Closure;
@@ -28,7 +24,7 @@ class Container {
 	 * Public api for adding a factory to the container.
 	 *
 	 * Factory dependencies will have the instantiation callback invoked
-	 * everytime the dependency is requested.
+	 * every time the dependency is requested.
 	 *
 	 * Typical Usage:
 	 *
@@ -56,7 +52,7 @@ class Container {
 	 * that it will be a single instance shared among any other classes having
 	 * that dependency.
 	 *
-	 * If you want a new instance everytime it's required, then wrap the value
+	 * If you want a new instance every time it's required, then wrap the value
 	 * in a call to the factory method (@see Container::factory for example)
 	 *
 	 * Note: Currently if the provided id already is registered in the container,

--- a/src/Registry/FactoryType.php
+++ b/src/Registry/FactoryType.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Holds the FactoryType class
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Registry;

--- a/src/Registry/FactoryType.php
+++ b/src/Registry/FactoryType.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Holds the FactoryType class
- */
-
 namespace Automattic\WooCommerce\Blocks\Registry;
 
 /**

--- a/src/Registry/SharedType.php
+++ b/src/Registry/SharedType.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Holds the SharedType class definition
- *
- * @package WooCommerce\Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Registry;

--- a/src/Registry/SharedType.php
+++ b/src/Registry/SharedType.php
@@ -1,8 +1,4 @@
 <?php
-/**
- * Holds the SharedType class definition
- */
-
 namespace Automattic\WooCommerce\Blocks\Registry;
 
 /**

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Registers controllers in the blocks REST API namespace.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks;

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -1,17 +1,14 @@
 <?php
-/**
- * Registers controllers in the blocks REST API namespace.
- */
-
 namespace Automattic\WooCommerce\Blocks;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\RoutesController;
 use Automattic\WooCommerce\Blocks\StoreApi\SchemaController;
 
 /**
  * RestApi class.
+ * Registers controllers in the blocks REST API namespace.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class RestApi {
 	/**

--- a/src/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/AbstractCartRoute.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Abstract Cart route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/AbstractCartRoute.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Abstract Cart route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
- * Cart class.
+ * Abstract Cart Route
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractCartRoute extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Abstract route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -2,8 +2,6 @@
 /**
  * Abstract route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Abstract route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\AbstractSchema;
 
 /**
  * AbstractRoute class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractRoute implements RouteInterface {
 	/**

--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Abstract Terms route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -2,8 +2,6 @@
 /**
  * Abstract Terms route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Abstract Terms route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\Pagination;
 use WP_Term_Query;
 
 /**
  * AbstractTermsRoute class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractTermsRoute extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/Cart.php
+++ b/src/StoreApi/Routes/Cart.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/Cart.php
+++ b/src/StoreApi/Routes/Cart.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * Cart class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class Cart extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/CartAddItem.php
+++ b/src/StoreApi/Routes/CartAddItem.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart add item route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartAddItem.php
+++ b/src/StoreApi/Routes/CartAddItem.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart add item route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartAddItem class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartAddItem extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/CartApplyCoupon.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart apply coupon route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/CartApplyCoupon.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart apply coupon route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartApplyCoupon class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartApplyCoupon extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -2,8 +2,6 @@
 /**
  * Cart Coupons route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Cart Coupons route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart Coupons route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartCoupons class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartCoupons extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/CartCouponsByCode.php
@@ -2,8 +2,6 @@
 /**
  * Cart Coupons route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/CartCouponsByCode.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Cart Coupons route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/CartCouponsByCode.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart Coupons route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartCouponsByCode class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartCouponsByCode extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/CartItems.php
+++ b/src/StoreApi/Routes/CartItems.php
@@ -2,8 +2,6 @@
 /**
  * Cart items route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartItems.php
+++ b/src/StoreApi/Routes/CartItems.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Cart items route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartItems.php
+++ b/src/StoreApi/Routes/CartItems.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart items route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartItems class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartItems extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -2,8 +2,6 @@
 /**
  * Cart item route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Cart item route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart item route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartItemsByKey class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartItemsByKey extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/CartRemoveCoupon.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart remove coupon route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/CartRemoveCoupon.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart remove coupon route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartRemoveCoupon class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartRemoveCoupon extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart remove item route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart remove item route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartRemoveItem class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartRemoveItem extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart select shipping rate route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart select shipping rate route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartSelectShippingRate class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartSelectShippingRate extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/CartUpdateItem.php
+++ b/src/StoreApi/Routes/CartUpdateItem.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart update item route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartUpdateItem.php
+++ b/src/StoreApi/Routes/CartUpdateItem.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart update item route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartUpdateItem class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartUpdateItem extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/CartUpdateShipping.php
+++ b/src/StoreApi/Routes/CartUpdateShipping.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart update shipping route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/CartUpdateShipping.php
+++ b/src/StoreApi/Routes/CartUpdateShipping.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart update shipping route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartUpdateShipping class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartUpdateShipping extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Checkout route.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Checkout route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\OrderController;
@@ -16,6 +10,8 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentContext;
 
 /**
  * Checkout class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class Checkout extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/ProductAttributeTerms.php
@@ -2,8 +2,6 @@
 /**
  * Product Attribute Terms route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/ProductAttributeTerms.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Product Attribute Terms route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/ProductAttributeTerms.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Attribute Terms route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductAttributeTerms class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductAttributeTerms extends AbstractTermsRoute {
 	/**

--- a/src/StoreApi/Routes/ProductAttributes.php
+++ b/src/StoreApi/Routes/ProductAttributes.php
@@ -2,8 +2,6 @@
 /**
  * Product Attributes route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductAttributes.php
+++ b/src/StoreApi/Routes/ProductAttributes.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Product Attributes route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductAttributes.php
+++ b/src/StoreApi/Routes/ProductAttributes.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Attributes route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductAttributes class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductAttributes extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/ProductAttributesById.php
+++ b/src/StoreApi/Routes/ProductAttributesById.php
@@ -2,8 +2,6 @@
 /**
  * Product Attributes route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductAttributesById.php
+++ b/src/StoreApi/Routes/ProductAttributesById.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Product Attributes route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductAttributesById.php
+++ b/src/StoreApi/Routes/ProductAttributesById.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Attributes route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductAttributesById class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductAttributesById extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/ProductCategories.php
+++ b/src/StoreApi/Routes/ProductCategories.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Product Categories route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductCategories.php
+++ b/src/StoreApi/Routes/ProductCategories.php
@@ -2,8 +2,6 @@
 /**
  * Product Categories route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductCategories.php
+++ b/src/StoreApi/Routes/ProductCategories.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Categories route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductCategories class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCategories extends AbstractTermsRoute {
 	/**

--- a/src/StoreApi/Routes/ProductCategoriesById.php
+++ b/src/StoreApi/Routes/ProductCategoriesById.php
@@ -2,8 +2,6 @@
 /**
  * Product Category route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductCategoriesById.php
+++ b/src/StoreApi/Routes/ProductCategoriesById.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Product Category route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductCategoriesById.php
+++ b/src/StoreApi/Routes/ProductCategoriesById.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Category route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductCategoriesById class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCategoriesById extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -3,7 +3,6 @@
  * Products collection data route. Get aggregate data from a collection of products.
  *
  * Supports the same parameters as /products, but returns a different response.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -4,8 +4,6 @@
  *
  * Supports the same parameters as /products, but returns a different response.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductCollectionData.php
+++ b/src/StoreApi/Routes/ProductCollectionData.php
@@ -1,18 +1,15 @@
 <?php
-/**
- * Products collection data route. Get aggregate data from a collection of products.
- *
- * Supports the same parameters as /products, but returns a different response.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\ProductQueryFilters;
 
 /**
  * ProductCollectionData route.
+ * Get aggregate data from a collection of products.
+ *
+ * Supports the same parameters as /products, but returns a different response.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCollectionData extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/ProductReviews.php
+++ b/src/StoreApi/Routes/ProductReviews.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Product Reviews route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductReviews.php
+++ b/src/StoreApi/Routes/ProductReviews.php
@@ -2,8 +2,6 @@
 /**
  * Product Reviews route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductReviews.php
+++ b/src/StoreApi/Routes/ProductReviews.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Product Reviews route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use WP_Comment_Query;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\Pagination;
 
 /**
  * ProductReviews class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductReviews extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/ProductTags.php
+++ b/src/StoreApi/Routes/ProductTags.php
@@ -2,8 +2,6 @@
 /**
  * Product Tags route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductTags.php
+++ b/src/StoreApi/Routes/ProductTags.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Product Tags route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductTags.php
+++ b/src/StoreApi/Routes/ProductTags.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Tags route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductTags class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductTags extends AbstractTermsRoute {
 	/**

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Products route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -2,8 +2,6 @@
 /**
  * Products route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Products route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\Pagination;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\ProductQuery;
 
 /**
  * Products class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class Products extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/ProductsById.php
+++ b/src/StoreApi/Routes/ProductsById.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Products route.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductsById.php
+++ b/src/StoreApi/Routes/ProductsById.php
@@ -2,8 +2,6 @@
 /**
  * Products route.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/ProductsById.php
+++ b/src/StoreApi/Routes/ProductsById.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Products route.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductsById class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductsById extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/RouteException.php
+++ b/src/StoreApi/Routes/RouteException.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Exceptions for rest routes.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/RouteException.php
+++ b/src/StoreApi/Routes/RouteException.php
@@ -1,12 +1,10 @@
 <?php
-/**
- * Exceptions for rest routes.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
 /**
  * ReserveStockRouteExceptionException class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class RouteException extends \Exception {
 	/**

--- a/src/StoreApi/Routes/RouteInterface.php
+++ b/src/StoreApi/Routes/RouteInterface.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Route interface.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;

--- a/src/StoreApi/Routes/RouteInterface.php
+++ b/src/StoreApi/Routes/RouteInterface.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Route interface.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * RouteInterface.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 interface RouteInterface {
 	/**

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Register Routes.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi;

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -2,8 +2,6 @@
 /**
  * Register Routes.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi;

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Register Routes.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi;
-
-defined( 'ABSPATH' ) || exit;
 
 use Routes\AbstractRoute;
 
 /**
  * RoutesController class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class RoutesController {
 

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -2,8 +2,6 @@
 /**
  * Register Schemas.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi;

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Register Schemas.
- *
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi;

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Register Schemas.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi;
-
-defined( 'ABSPATH' ) || exit;
 
 use Exception;
 use Schemas\AbstractSchema;
 
 /**
  * SchemaController class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class SchemaController {
 

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -3,8 +3,6 @@
  * Abstract Schema.
  *
  * Rest API schema class.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -1,17 +1,12 @@
 <?php
-/**
- * Abstract Schema.
- *
- * Rest API schema class.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
-defined( 'ABSPATH' ) || exit;
-
 /**
- * AbstractBlock class.
+ * AbstractSchema class.
  *
+ * For REST Route Schemas
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 abstract class AbstractSchema {

--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Billing Address Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Billing Address Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\Routes;
 
@@ -13,6 +7,8 @@ use Automattic\WooCommerce\Blocks\RestApi\Routes;
  * BillingAddressSchema class.
  *
  * Provides a generic billing address schema for composition in other schemas.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class BillingAddressSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart Coupon Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -1,17 +1,12 @@
 <?php
-/**
- * Cart Coupon Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * CartCouponSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class CartCouponSchema extends AbstractSchema {

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart Item Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Cart Item Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * CartItemSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class CartItemSchema extends ProductSchema {

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -1,17 +1,12 @@
 <?php
-/**
- * Cart schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
-defined( 'ABSPATH' ) || exit;
-
 /**
  * CartSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class CartSchema extends AbstractSchema {

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Cart shipping rate schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Cart shipping rate schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 use WC_Shipping_Rate as ShippingRate;
 
 /**
  * CartShippingRateSchema class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartShippingRateSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Checkout schema for the Store API.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Checkout schema for the Store API.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
 
 /**
  * CheckoutSchema class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CheckoutSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/ErrorSchema.php
+++ b/src/StoreApi/Schemas/ErrorSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Error Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ErrorSchema.php
+++ b/src/StoreApi/Schemas/ErrorSchema.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Error Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ErrorSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class ErrorSchema extends AbstractSchema {

--- a/src/StoreApi/Schemas/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/ImageAttachmentSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Image Attachment Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/ImageAttachmentSchema.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Image Attachment Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ImageAttachmentSchema class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ImageAttachmentSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/OrderCouponSchema.php
+++ b/src/StoreApi/Schemas/OrderCouponSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Order Coupon Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/OrderCouponSchema.php
+++ b/src/StoreApi/Schemas/OrderCouponSchema.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Order Coupon Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * OrderCouponSchema class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class OrderCouponSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/ProductAttributeSchema.php
+++ b/src/StoreApi/Schemas/ProductAttributeSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product Attribute Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ProductAttributeSchema.php
+++ b/src/StoreApi/Schemas/ProductAttributeSchema.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Product Attribute Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductAttributeSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class ProductAttributeSchema extends AbstractSchema {

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product Category Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Category Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductCategorySchema class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCategorySchema extends TermSchema {
 	/**

--- a/src/StoreApi/Schemas/ProductCollectionDataSchema.php
+++ b/src/StoreApi/Schemas/ProductCollectionDataSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product Collection Data Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ProductCollectionDataSchema.php
+++ b/src/StoreApi/Schemas/ProductCollectionDataSchema.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Product Collection Data Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductCollectionDataSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class ProductCollectionDataSchema extends AbstractSchema {

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product Review Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -1,14 +1,10 @@
 <?php
-/**
- * Product Review Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductReviewSchema class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductReviewSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Product Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * ProductSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class ProductSchema extends AbstractSchema {

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Shipping Address Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -1,11 +1,5 @@
 <?php
-/**
- * Shipping Address Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\RestApi\Routes;
 
@@ -14,6 +8,7 @@ use Automattic\WooCommerce\Blocks\RestApi\Routes;
  *
  * Provides a generic shipping address schema for composition in other schemas.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class ShippingAddressSchema extends AbstractSchema {

--- a/src/StoreApi/Schemas/TermSchema.php
+++ b/src/StoreApi/Schemas/TermSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Term Schema.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;

--- a/src/StoreApi/Schemas/TermSchema.php
+++ b/src/StoreApi/Schemas/TermSchema.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Term Schema.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * TermSchema class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class TermSchema extends AbstractSchema {

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Helper class to bridge the gap between the cart API and Woo core.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -1,18 +1,14 @@
 <?php
-/**
- * Helper class to bridge the gap between the cart API and Woo core.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\NoticeHandler;
 
 /**
  * Woo Cart Controller class.
+ * Helper class to bridge the gap between the cart API and Woo core.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class CartController {

--- a/src/StoreApi/Utilities/NoticeHandler.php
+++ b/src/StoreApi/Utilities/NoticeHandler.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Helper class to convert notices to exceptions.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/NoticeHandler.php
+++ b/src/StoreApi/Utilities/NoticeHandler.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Helper class to convert notices to exceptions.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
 
 /**
  * NoticeHandler class.
+ * Helper class to convert notices to exceptions.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class NoticeHandler {
 

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Helper class which creates and syncs orders with the cart.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -1,16 +1,13 @@
 <?php
-/**
- * Helper class which creates and syncs orders with the cart.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
 
 /**
  * OrderController class.
+ * Helper class which creates and syncs orders with the cart.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class OrderController {
 

--- a/src/StoreApi/Utilities/Pagination.php
+++ b/src/StoreApi/Utilities/Pagination.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Pagination helper.
- *
- * @package Automattic/WooCommerce/RestApi
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/Pagination.php
+++ b/src/StoreApi/Utilities/Pagination.php
@@ -1,15 +1,10 @@
 <?php
-/**
- * Pagination helper.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * Pagination class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class Pagination {

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Helper class to handle product queries for the API.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -1,17 +1,13 @@
 <?php
-/**
- * Helper class to handle product queries for the API.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
-
-defined( 'ABSPATH' ) || exit;
 
 use WC_Tax;
 
 /**
  * Product Query class.
+ * Helper class to handle product queries for the API.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class ProductQuery {

--- a/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Product Query filters helper.
- *
- * @package Automattic/WooCommerce/RestApi
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -1,17 +1,12 @@
 <?php
-/**
- * Product Query filters helper.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
-
-defined( 'ABSPATH' ) || exit;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\ProductQuery;
 
 /**
  * Product Query filters class.
  *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
  */
 class ProductQueryFilters {

--- a/src/StoreApi/Utilities/ReserveStock.php
+++ b/src/StoreApi/Utilities/ReserveStock.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Handle product stock reservation during checkout.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/ReserveStock.php
+++ b/src/StoreApi/Utilities/ReserveStock.php
@@ -1,14 +1,11 @@
 <?php
-/**
- * Handle product stock reservation during checkout.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
-
-defined( 'ABSPATH' ) || exit;
 
 /**
  * Stock Reservation class.
+ * Handle product stock reservation during checkout.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 final class ReserveStock {
 	/**

--- a/src/StoreApi/Utilities/ReserveStockException.php
+++ b/src/StoreApi/Utilities/ReserveStockException.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Exceptions for stock reservation.
- *
- * @package WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;

--- a/src/StoreApi/Utilities/ReserveStockException.php
+++ b/src/StoreApi/Utilities/ReserveStockException.php
@@ -1,12 +1,11 @@
 <?php
-/**
- * Exceptions for stock reservation.
- */
-
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
 
 /**
  * ReserveStockException class.
+ * Exceptions for stock reservation.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ReserveStockException extends \Exception {
 	/**

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -3,8 +3,6 @@
  * Wrapper for WP Query with additonal helper methods.
  *
  * Allows query args to be set and parsed without doing running it, so that a cache can be used.
- *
- * @package Automattic/WooCommerce/Blocks
  */
 
 namespace Automattic\WooCommerce\Blocks\Utils;

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -1,18 +1,13 @@
 <?php
-/**
- * Wrapper for WP Query with additonal helper methods.
- *
- * Allows query args to be set and parsed without doing running it, so that a cache can be used.
- */
-
 namespace Automattic\WooCommerce\Blocks\Utils;
 
 use WP_Query;
 
-defined( 'ABSPATH' ) || exit;
-
 /**
  * BlocksWpQuery query.
+ *
+ * Wrapper for WP Query with additonal helper methods.
+ * Allows query args to be set and parsed without doing running it, so that a cache can be used.
  *
  * @deprecated 2.5.0
  */

--- a/tests/php/Bootstrap/MainFile.php
+++ b/tests/php/Bootstrap/MainFile.php
@@ -2,8 +2,6 @@
 /**
  *  Contains Tests for the main file (woocommerce-gutenberg-products-blocks.php)
  *  bootstrap.
- *
- *  @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\Bootstrap;

--- a/tests/php/Helpers/TestValidateSchema.php
+++ b/tests/php/Helpers/TestValidateSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Ensures the helper works.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\Helpers;

--- a/tests/php/Helpers/ValidateSchema.php
+++ b/tests/php/Helpers/ValidateSchema.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Helper used to validate schema differences.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\Helpers;

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Controller Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Controllers;

--- a/tests/php/StoreApi/Routes/CartCoupons.php
+++ b/tests/php/StoreApi/Routes/CartCoupons.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Controller Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Controllers;

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Controller Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Controllers;

--- a/tests/php/StoreApi/Routes/ProductAttributeTerms.php
+++ b/tests/php/StoreApi/Routes/ProductAttributeTerms.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Controller Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Controllers;

--- a/tests/php/StoreApi/Routes/ProductAttributes.php
+++ b/tests/php/StoreApi/Routes/ProductAttributes.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Controller Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Controllers;

--- a/tests/php/StoreApi/Routes/ProductCollectionData.php
+++ b/tests/php/StoreApi/Routes/ProductCollectionData.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Controller Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Controllers;

--- a/tests/php/StoreApi/Routes/Products.php
+++ b/tests/php/StoreApi/Routes/Products.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Controller Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Controllers;

--- a/tests/php/StoreApi/Utilities/ReserveStock.php
+++ b/tests/php/StoreApi/Utilities/ReserveStock.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Utility Tests.
- *
- * @package WooCommerce\Blocks\Tests
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;


### PR DESCRIPTION
On WooCommerce core we don't require a `@package` tag inside the `src` directory anymore, see: https://github.com/woocommerce/woocommerce/pull/27239
We are doing it because those classes already use namespaces and those will get rendered correctly by our code reference: https://docs.woocommerce.com/wc-apidocs/

Good news is that Blocks only use code with namespaces, so mostly of the time you folks don't need to worry about a `@package` tag.

--- Below Added by @nerrad  ----

I continued the changes @claudiosanches started in this pull. This pull includes:

- Adding exclusions to WooCommerce PHPCS rules for file comment block and tag requirements. This is not needed for namespace files.
- Remove file comment blocks for all namespaced files.
- Remove the unnecessary usage of `defined( 'ABSPATH' ) || exit;` from files. This is a holdover from days when files had executed code. With class declarations this is no longer the case.
- Implemented `@internal` tag on all `StoreAPI` classes to make explicit these are internal only. Also added this tag to a couple other classes that are internal only (I think that was Cart and Checkout blocks and Atomic block classes). While there's others that could probably use this, I think the ship has sailed on the public status of the classes. Even the ones I marked internal only we'll have to make changes on carefully.

## To Test

The impact of these changes is nil on deployed code because it's just phpdoc block changes. Any syntax mistakes (accidental removal of an import, or non-closing comment block) should surface fairly quickly in existing linting and automated tests).

So there should be no need for manual testing of this pull.