### PR TITLE
Fix focus styles of error states for the text input and select components

### DIFF
--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -30,7 +30,16 @@
 
 	&.has-error {
 		.components-custom-select-control__button {
-			border-color: $error-red;
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				border-color: $error-red;
+			}
+			&:focus {
+				outline: 1px dotted $error-red;
+				outline-offset: 2px;
+			}
 		}
 	}
 

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -64,9 +64,15 @@
 	}
 
 	&.has-error input {
-		border-color: $error-red;
+		&,
+		&:hover,
+		&:focus,
+		&:active {
+			border-color: $error-red;
+		}
 		&:focus {
-			outline-color: $error-red;
+			outline: 1px dotted $error-red;
+			outline-offset: 2px;
 		}
 	}
 


### PR DESCRIPTION
To solve the issues above, this PR includes this changes:
1. Increase the specificity of the `border-color` declaration (fixes #2182).
2. Define the `outline-style` property for focus states (fixes #2973).

### Screenshots

#### Storefront

_Before (Chrome):_
![imatge](https://user-images.githubusercontent.com/3616980/89482827-fd21af00-d79a-11ea-8c91-30fbdbb311e9.png)

_After (Chrome):_
![imatge](https://user-images.githubusercontent.com/3616980/89482642-956b6400-d79a-11ea-9aa9-b729e52c9373.png)

_Before (Firefox):_
![imatge](https://user-images.githubusercontent.com/3616980/89482897-2a6e5d00-d79b-11ea-9b53-b0ea0b028759.png)

_After (Firefox):_
![imatge](https://user-images.githubusercontent.com/3616980/89482990-55f14780-d79b-11ea-83ac-7e0ed99e48aa.png)

#### Twenty Twenty
_Before (Chrome):_
![imatge](https://user-images.githubusercontent.com/3616980/89483216-cf893580-d79b-11ea-9a83-a580835eaadc.png)

_After (Chrome):_
![imatge](https://user-images.githubusercontent.com/3616980/89483155-acf71c80-d79b-11ea-9470-f9df45b07088.png)

_Before (Firefox):_
![imatge](https://user-images.githubusercontent.com/3616980/89483287-fd6e7a00-d79b-11ea-94cf-801da3722ffc.png)

_After (Firefox):_
![imatge](https://user-images.githubusercontent.com/3616980/89483086-918c1180-d79b-11ea-9523-b23b9efd3acc.png)

### How to test the changes in this Pull Request:

1. Go to the Checkout block and press 'Place order` without filling any form detail.
2. Tab through the input fields under 'Shipping address' and verify the outline that appears on focus is red in text inputs and selects.
3. Repeat the steps above at least with Storefront and Twenty Twenty and with Firefox, Chrome and Safari.

### Changelog

> Improved focus styles of error states on form elements.