### PR TITLE
Hide saved payment methods if their gateway is disabled

### DIFF
--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -131,15 +131,17 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 					);
 				}
 			} );
-			currentOptions.current = options;
-			currentOptions.current.push( {
-				value: '0',
-				label: __(
-					'Use a new payment method',
-					'woo-gutenberg-product-blocks'
-				),
-				name: `wc-saved-payment-method-token-new`,
-			} );
+			if ( options.length > 0 ) {
+				currentOptions.current = options;
+				currentOptions.current.push( {
+					value: '0',
+					label: __(
+						'Use a new payment method',
+						'woo-gutenberg-product-blocks'
+					),
+					name: `wc-saved-payment-method-token-new`,
+				} );
+			}
 		}
 	}, [
 		customerPaymentMethods,

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -8,7 +8,6 @@ import {
 	usePaymentMethodDataContext,
 } from '@woocommerce/base-context';
 import RadioControl from '@woocommerce/base-components/radio-control';
-import { PAYMENT_GATEWAY_SORT_ORDER } from '@woocommerce/block-settings';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').CustomerPaymentMethod} CustomerPaymentMethod
@@ -105,15 +104,9 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 		if ( paymentMethodKeys.length > 0 ) {
 			paymentMethodKeys.forEach( ( type ) => {
 				const paymentMethods = customerPaymentMethods[ type ];
-				const enabledPaymentMethods = paymentMethods.filter(
-					( paymentMethod ) =>
-						PAYMENT_GATEWAY_SORT_ORDER.includes(
-							paymentMethod.method.gateway
-						)
-				);
-				if ( enabledPaymentMethods.length > 0 ) {
+				if ( paymentMethods.length > 0 ) {
 					options = options.concat(
-						enabledPaymentMethods.map( ( paymentMethod ) => {
+						paymentMethods.map( ( paymentMethod ) => {
 							const option =
 								type === 'cc' || type === 'echeck'
 									? getCcOrEcheckPaymentMethodOption(
@@ -138,17 +131,15 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 					);
 				}
 			} );
-			if ( options.length > 0 ) {
-				currentOptions.current = options;
-				currentOptions.current.push( {
-					value: '0',
-					label: __(
-						'Use a new payment method',
-						'woo-gutenberg-product-blocks'
-					),
-					name: `wc-saved-payment-method-token-new`,
-				} );
-			}
+			currentOptions.current = options;
+			currentOptions.current.push( {
+				value: '0',
+				label: __(
+					'Use a new payment method',
+					'woo-gutenberg-product-blocks'
+				),
+				name: `wc-saved-payment-method-token-new`,
+			} );
 		}
 	}, [
 		customerPaymentMethods,

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -8,6 +8,7 @@ import {
 	usePaymentMethodDataContext,
 } from '@woocommerce/base-context';
 import RadioControl from '@woocommerce/base-components/radio-control';
+import { PAYMENT_GATEWAY_SORT_ORDER } from '@woocommerce/block-settings';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').CustomerPaymentMethod} CustomerPaymentMethod
@@ -104,9 +105,15 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 		if ( paymentMethodKeys.length > 0 ) {
 			paymentMethodKeys.forEach( ( type ) => {
 				const paymentMethods = customerPaymentMethods[ type ];
-				if ( paymentMethods.length > 0 ) {
+				const enabledPaymentMethods = paymentMethods.filter(
+					( paymentMethod ) =>
+						PAYMENT_GATEWAY_SORT_ORDER.includes(
+							paymentMethod.method.gateway
+						)
+				);
+				if ( enabledPaymentMethods.length > 0 ) {
 					options = options.concat(
-						paymentMethods.map( ( paymentMethod ) => {
+						enabledPaymentMethods.map( ( paymentMethod ) => {
 							const option =
 								type === 'cc' || type === 'echeck'
 									? getCcOrEcheckPaymentMethodOption(
@@ -131,15 +138,17 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 					);
 				}
 			} );
-			currentOptions.current = options;
-			currentOptions.current.push( {
-				value: '0',
-				label: __(
-					'Use a new payment method',
-					'woo-gutenberg-product-blocks'
-				),
-				name: `wc-saved-payment-method-token-new`,
-			} );
+			if ( options.length > 0 ) {
+				currentOptions.current = options;
+				currentOptions.current.push( {
+					value: '0',
+					label: __(
+						'Use a new payment method',
+						'woo-gutenberg-product-blocks'
+					),
+					name: `wc-saved-payment-method-token-new`,
+				} );
+			}
 		}
 	}, [
 		customerPaymentMethods,

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -78,6 +78,32 @@ export const usePaymentMethodDataContext = () => {
 };
 
 /**
+ * Gets the payment methods saved for the current user after filtering out
+ * disabled ones.
+ *
+ * @param {Object[]} availablePaymentMethods List of available payment methods.
+ * @return {Object} Object containing the payment methods saved for a specific user which are available.
+ */
+const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
+	const customerPaymentMethods = getSetting( 'customerPaymentMethods', {} );
+	const paymentMethodKeys = Object.keys( customerPaymentMethods );
+	if ( paymentMethodKeys.length === 0 ) {
+		return {};
+	}
+	const enabledCustomerPaymentMethods = {};
+	paymentMethodKeys.forEach( ( type ) => {
+		enabledCustomerPaymentMethods[ type ] = customerPaymentMethods[
+			type
+		].filter( ( paymentMethod ) => {
+			return Object.keys( availablePaymentMethods ).includes(
+				paymentMethod.method.gateway
+			);
+		} );
+	} );
+	return enabledCustomerPaymentMethods;
+};
+
+/**
  * PaymentMethodDataProvider is automatically included in the
  * CheckoutDataProvider.
  *
@@ -107,10 +133,6 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 	const currentObservers = useRef( observers );
 
 	const { isEditor, previewData } = useEditorContext();
-	const customerPaymentMethods =
-		isEditor && previewData?.previewSavedPaymentMethods
-			? previewData?.previewSavedPaymentMethods
-			: getSetting( 'customerPaymentMethods', {} );
 	const [ paymentData, dispatch ] = useReducer(
 		reducer,
 		DEFAULT_PAYMENT_DATA
@@ -149,6 +171,21 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		},
 		[ dispatch ]
 	);
+
+	const customerPaymentMethods = useMemo( () => {
+		if ( isEditor && previewData.previewSavedPaymentMethods ) {
+			return previewData.previewSavedPaymentMethods;
+		}
+		if ( ! paymentMethodsInitialized ) {
+			return {};
+		}
+		return getCustomerPaymentMethods( paymentData.paymentMethods );
+	}, [
+		isEditor,
+		previewData.previewSavedPaymentMethods,
+		paymentMethodsInitialized,
+		paymentData.paymentMethods,
+	] );
 
 	const setExpressPaymentError = useCallback(
 		( message ) => {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -82,7 +82,8 @@ export const usePaymentMethodDataContext = () => {
  * disabled ones.
  *
  * @param {Object[]} availablePaymentMethods List of available payment methods.
- * @return {Object} Object containing the payment methods saved for a specific user which are available.
+ * @return {Object} Object containing the payment methods saved for a specific
+ *                  user which are available.
  */
 const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 	const customerPaymentMethods = getSetting( 'customerPaymentMethods', {} );
@@ -176,7 +177,10 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		if ( isEditor && previewData.previewSavedPaymentMethods ) {
 			return previewData.previewSavedPaymentMethods;
 		}
-		if ( ! paymentMethodsInitialized ) {
+		if (
+			! paymentMethodsInitialized ||
+			paymentData.paymentMethods.length === 0
+		) {
 			return {};
 		}
 		return getCustomerPaymentMethods( paymentData.paymentMethods );

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -256,9 +256,9 @@
 /**
  * @typedef {Object} EditorDataContext
  *
- * @property {number} isEditor      Indicates whether in the editor context.
- * @property {number} currentPostId The post ID being edited.
- * @property {Object} previewData   Object containing preview data for the editor.
+ * @property {boolean} isEditor      Indicates whether in the editor context.
+ * @property {number}  currentPostId The post ID being edited.
+ * @property {Object}  previewData   Object containing preview data for the editor.
  */
 
 /**

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -76,7 +76,6 @@ class Api {
 		return array_merge( $dependencies, $this->payment_method_registry->get_all_registered_script_handles() );
 	}
 
-
 	/**
 	 * Returns true if the payment gateway is enabled.
 	 *

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -83,7 +83,7 @@ class Api {
 	 * @return boolean
 	 */
 	private function is_payment_gateway_enabled( $gateway ) {
-		return 'yes' === $gateway->enabled;
+		return filter_var( $gateway->enabled, FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -92,8 +92,8 @@ class Api {
 	public function add_payment_method_script_data() {
 		// Enqueue the order of enabled gateways as `paymentGatewaySortOrder`.
 		if ( ! $this->asset_registry->exists( 'paymentGatewaySortOrder' ) ) {
-			$available_gateways = WC()->payment_gateways->payment_gateways();
-			$enabled_gateways   = array_filter( $available_gateways, array( $this, 'is_payment_gateway_enabled' ) );
+			$payment_gateways = WC()->payment_gateways->payment_gateways();
+			$enabled_gateways = array_filter( $payment_gateways, array( $this, 'is_payment_gateway_enabled' ) );
 			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $enabled_gateways ) );
 		}
 

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -76,6 +76,17 @@ class Api {
 		return array_merge( $dependencies, $this->payment_method_registry->get_all_registered_script_handles() );
 	}
 
+
+	/**
+	 * Returns true if the payment gateway is enabled.
+	 *
+	 * @param object $gateway Payment gateway.
+	 * @return boolean
+	 */
+	private function is_payment_gateway_enabled( $gateway ) {
+		return 'yes' === $gateway->enabled;
+	}
+
 	/**
 	 * Add payment method data to Asset Registry.
 	 */
@@ -83,7 +94,8 @@ class Api {
 		// Enqueue the order of enabled gateways as `paymentGatewaySortOrder`.
 		if ( ! $this->asset_registry->exists( 'paymentGatewaySortOrder' ) ) {
 			$available_gateways = WC()->payment_gateways->payment_gateways();
-			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $available_gateways ) );
+			$enabled_gateways   = array_filter( $available_gateways, array( $this, 'is_payment_gateway_enabled' ) );
+			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $enabled_gateways ) );
 		}
 
 		// Enqueue all registered gateway data (settings/config etc).


### PR DESCRIPTION
Fix #2850.

### How to test the changes in this Pull Request:

Steps from #2850.

1. Set up checkout block, Stripe CC payment method, check `Enable Payment via Saved Cards`.
2. Complete a purchase with [Stripe test card](https://stripe.com/docs/testing) and check the `Save payment information to my account for future purchases.` checkbox on checkout.
7. Go to `WooCommerce > Settings > Payments` and disable Stripe CC payment method.
3. Add new stuff to cart, proceed to checkout.
4. Scroll down and verify saved card (e.g. `Visa ending in 4242 (expires 02/22)`) is not there.

Also, test there are no regressions with the testing steps introduced in #2934.

### Changelog

> Saved payment methods are not shown to the user if their payment gateway has been disabled.