### PR TITLE
Use position: static for payment errors to prevent overlap with card icons

### DIFF
--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -91,6 +91,10 @@ $border-radius: 5px;
 .wc-block-card-elements {
 	display: flex;
 	width: 100%;
+
+	.wc-block-components-validation-error {
+		position: static;
+	}
 }
 
 .wc-block-gateway-container {


### PR DESCRIPTION
Fixes #2641

Normally our validation errors use `position: absolute` so they overlay specific areas of layout - e.g. under edit box. The form layout is consistent with or without validation errors.

In the credit card form (specifically Stripe elements form as reported), the layout is much more compact. This means that the errors can look ugly (wrap) and/or overlap other content, especially if the checkout is in a narrow view (small window, or caused by theme, e.g. sidebar layout).

In this PR I've fixed the issue by using `position: static` specifically for payment form errors. Note this currently applies to any payment field errors (unless overridden by gateway plugin?). This only affects Stripe form, and doesn't apply to the "inline" Stripe variation - this has other custom overrides.

The `Place Order` button and other content is pushed down by any errors now - see gif:

![Screen Capture on 2020-08-06 at 16-53-33](https://user-images.githubusercontent.com/4167300/89492695-4a873600-d806-11ea-84b8-c39fcd5ecbbd.gif)

### How to test the changes in this Pull Request:

1. Set up store: activate and set up Stripe CC, disable `Inline Credit Card Form` option, set up checkout block.
2. Add stuff to cart and proceed to checkout.
3. Select stripe credit card payment, don't enter any card details.
4. Click `Place Order`.
5. Error messages should be readable and help resolve input errors ⏰ 

Repeat tests in different browsers, test other payment methods and Stripe settings to confirm no regressions.

### Changelog

> Checkout block: fix a cosmetic issue where payment form errors sometimes overlap with card icons.
