### PR TITLE
Add dark colors support to Cart & Checkout controls

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -51,4 +51,7 @@ $gray-60: #50575e;
 $gray-80: #2c3338;
 
 $input-border-gray: #8d96a0;
+$input-border-dark: rgba(255, 255, 255, 0.4);
 $input-text-active: #2b2d2f;
+$input-text-dark: rgba(255, 255, 255, 0.6);
+

--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -52,6 +52,7 @@ $gray-80: #2c3338;
 
 $input-border-gray: #8d96a0;
 $input-border-dark: rgba(255, 255, 255, 0.4);
+$controls-border-dark: rgba(255, 255, 255, 0.6);
 $input-text-active: #2b2d2f;
 $input-text-dark: rgba(255, 255, 255, 0.6);
 

--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -52,6 +52,7 @@ $gray-80: #2c3338;
 
 $input-border-gray: #8d96a0;
 $input-border-dark: rgba(255, 255, 255, 0.4);
+$input-disabled-dark: rgba(255, 255, 255, 0.3);
 $controls-border-dark: rgba(255, 255, 255, 0.6);
 $input-text-active: #2b2d2f;
 $input-text-dark: rgba(255, 255, 255, 0.6);

--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -55,5 +55,10 @@ $input-border-dark: rgba(255, 255, 255, 0.4);
 $input-disabled-dark: rgba(255, 255, 255, 0.3);
 $controls-border-dark: rgba(255, 255, 255, 0.6);
 $input-text-active: #2b2d2f;
-$input-text-dark: rgba(255, 255, 255, 0.6);
+$input-placeholder-dark: rgba(255, 255, 255, 0.6);
+$input-text-dark: #fff;
+$input-background-dark: rgba(0, 0, 0, 0.1);
+$select-dropdown-dark: #1e1e1e;
+$select-dropdown-light: #fff;
+$select-item-dark: rgba(0, 0, 0, 0.4);
 

--- a/assets/js/base/components/checkbox-control/index.js
+++ b/assets/js/base/components/checkbox-control/index.js
@@ -38,6 +38,7 @@ const CheckboxControl = ( {
 				onChange={ ( event ) => onChange( event.target.checked ) }
 				{ ...rest }
 			/>
+			<div className="wc-block-checkbox__box"></div>
 			<svg
 				className="wc-block-components-checkbox__mark"
 				aria-hidden="true"

--- a/assets/js/base/components/checkbox-control/index.js
+++ b/assets/js/base/components/checkbox-control/index.js
@@ -38,7 +38,6 @@ const CheckboxControl = ( {
 				onChange={ ( event ) => onChange( event.target.checked ) }
 				{ ...rest }
 			/>
-			<div className="wc-block-checkbox__box"></div>
 			<svg
 				className="wc-block-components-checkbox__mark"
 				aria-hidden="true"

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -19,7 +19,7 @@
 		vertical-align: middle;
 		background-color: #fff;
 
-		&:checked + .wc-block-checkbox__box {
+		&:checked {
 			background: currentColor;
 			border-color: currentColor;
 		}

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -30,6 +30,7 @@
 
 		.has-dark-styles & {
 			border-color: $controls-border-dark;
+			background-color: transparent;
 
 			&:checked {
 				background: transparent;
@@ -53,6 +54,8 @@
 	}
 }
 
+// Hack to hide the check mark in IE11
+// See comment: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2320/#issuecomment-621936576
 @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
 	.wc-block-components-checkbox__mark {
 		display: none;

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -27,6 +27,15 @@
 		&:not(:checked) + .wc-block-components-checkbox__mark {
 			display: none;
 		}
+
+		.has-dark-styles & {
+			border-color: $controls-border-dark;
+
+			&:checked {
+				background: transparent;
+				border-color: $controls-border-dark;
+			}
+		}
 	}
 
 	.wc-block-components-checkbox__mark {

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -19,7 +19,7 @@
 		vertical-align: middle;
 		background-color: #fff;
 
-		&:checked {
+		&:checked + .wc-block-checkbox__box {
 			background: currentColor;
 			border-color: currentColor;
 		}

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -28,7 +28,7 @@
 			display: none;
 		}
 
-		.has-dark-styles & {
+		.has-dark-controls & {
 			border-color: $controls-border-dark;
 			background-color: transparent;
 

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -43,6 +43,8 @@
 	overflow: auto;
 }
 
-.theme-twentytwenty .wc-blocks-components-panel__button {
+.theme-twentytwenty .wc-blocks-components-panel__button,
+.theme-twentyseventeen .wc-blocks-components-panel__button {
 	background: transparent;
+	color: inherit;
 }

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -8,6 +8,9 @@
 	&:focus {
 		outline: 2px solid $core-grey-light-600;
 	}
+	.has-dark-styles &:focus {
+		outline-width: 1px;
+	}
 }
 
 .wc-block-components-quantity-selector {
@@ -16,6 +19,13 @@
 	border: 1px solid $core-grey-light-600;
 	background: #fff;
 	border-radius: 4px;
+	// needed so that buttons fill the container.
+	box-sizing: content-box;
+
+	.has-dark-styles & {
+		background-color: transparent;
+		border-color: $input-border-dark;
+	}
 
 	// Extra label for specificity needed in the editor.
 	input.wc-block-components-quantity-selector__input {
@@ -41,6 +51,18 @@
 		&:disabled {
 			color: $core-grey-dark-100;
 		}
+
+		.has-dark-styles & {
+			color: #fff;
+
+			&:focus {
+				background: transparent;
+				outline: 1px solid $core-grey-light-600;
+			}
+			&:disabled {
+				color: $input-disabled-dark;
+			}
+		}
 	}
 	input::-webkit-outer-spin-button,
 	input::-webkit-inner-spin-button {
@@ -65,6 +87,19 @@
 			color: $core-grey-dark-100;
 			cursor: default;
 			@include reset-button;
+		}
+
+		.has-dark-styles & {
+			color: #fff;
+
+			&:hover,
+			&:focus {
+				color: #fff;
+			}
+			&:disabled {
+				color: $input-disabled-dark;
+				cursor: default;
+			}
 		}
 	}
 	.wc-block-components-quantity-selector__button--minus {

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -51,6 +51,7 @@
 
 		.has-dark-controls & {
 			color: $input-text-dark;
+			background: transparent;
 
 			&:focus {
 				background: transparent;

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -55,7 +55,6 @@
 
 			&:focus {
 				background: transparent;
-				outline: 1px solid $core-grey-light-600;
 			}
 			&:disabled {
 				color: $input-disabled-dark;

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -8,7 +8,7 @@
 	&:focus {
 		outline: 2px solid $core-grey-light-600;
 	}
-	.has-dark-styles &:focus {
+	.has-dark-controls &:focus {
 		outline-width: 1px;
 	}
 }
@@ -22,7 +22,7 @@
 	// needed so that buttons fill the container.
 	box-sizing: content-box;
 
-	.has-dark-styles & {
+	.has-dark-controls & {
 		background-color: transparent;
 		border-color: $input-border-dark;
 	}
@@ -52,7 +52,7 @@
 			color: $core-grey-dark-100;
 		}
 
-		.has-dark-styles & {
+		.has-dark-controls & {
 			color: #fff;
 
 			&:focus {
@@ -89,7 +89,7 @@
 			@include reset-button;
 		}
 
-		.has-dark-styles & {
+		.has-dark-controls & {
 			color: #fff;
 
 			&:hover,

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -98,7 +98,6 @@
 			}
 			&:disabled {
 				color: $input-disabled-dark;
-				cursor: default;
 			}
 		}
 	}

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -8,9 +8,6 @@
 	&:focus {
 		outline: 2px solid $core-grey-light-600;
 	}
-	.has-dark-controls &:focus {
-		outline-width: 1px;
-	}
 }
 
 .wc-block-components-quantity-selector {
@@ -53,7 +50,7 @@
 		}
 
 		.has-dark-controls & {
-			color: #fff;
+			color: $input-text-dark;
 
 			&:focus {
 				background: transparent;
@@ -90,11 +87,11 @@
 		}
 
 		.has-dark-controls & {
-			color: #fff;
+			color: $input-text-dark;
 
 			&:hover,
 			&:focus {
-				color: #fff;
+				color: $input-text-dark;
 			}
 			&:disabled {
 				color: $input-disabled-dark;

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -89,7 +89,7 @@
 				border-color: $controls-border-dark;
 
 				&:checked::before {
-					background: $controls-border-dark;
+					background: #fff;
 				}
 			}
 		}

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -60,7 +60,7 @@
 	.wc-block-components-radio-control {
 		.wc-block-components-radio-control__input {
 			appearance: none;
-			background: #fff;
+			background: transparent;
 			border: 2px solid currentColor;
 			border-radius: 50%;
 			display: inline-block;
@@ -83,6 +83,14 @@
 				top: 50%;
 				transform: translate(-50%, -50%);
 				width: 0.625em;
+			}
+
+			.has-dark-styles & {
+				border-color: $controls-border-dark;
+
+				&:checked::before {
+					background: $controls-border-dark;
+				}
 			}
 		}
 

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -89,7 +89,7 @@
 				border-color: $controls-border-dark;
 
 				&:checked::before {
-					background: #fff;
+					background: $input-text-dark;
 				}
 			}
 		}

--- a/assets/js/base/components/radio-control/_mixin.scss
+++ b/assets/js/base/components/radio-control/_mixin.scss
@@ -85,7 +85,7 @@
 				width: 0.625em;
 			}
 
-			.has-dark-styles & {
+			.has-dark-controls & {
 				border-color: $controls-border-dark;
 
 				&:checked::before {

--- a/assets/js/base/components/radio-control/editor.scss
+++ b/assets/js/base/components/radio-control/editor.scss
@@ -1,6 +1,0 @@
-@import "./mixin";
-
-// We need to increase the styles specificity in the editor, to avoid wp-admin styles taking preference.
-#wpbody .edit-post-visual-editor {
-	@include radio-control-input-styles;
-}

--- a/assets/js/base/components/radio-control/index.js
+++ b/assets/js/base/components/radio-control/index.js
@@ -8,7 +8,6 @@ import { withInstanceId } from '@woocommerce/base-hocs/with-instance-id';
  * Internal dependencies
  */
 import RadioControlOption from './option';
-import './editor.scss';
 import './style.scss';
 
 const RadioControl = ( {

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -71,7 +71,7 @@
 			white-space: nowrap;
 			width: 100%;
 			.has-dark-controls & {
-				background-color: rgba(#000, 0.1);
+				background-color: $input-background-dark;
 				border-color: $input-border-dark;
 				color: $input-text-dark;
 			}

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -67,6 +67,11 @@
 			text-transform: none;
 			white-space: nowrap;
 			width: 100%;
+			.has-dark-styles & {
+				background-color: rgba(#000, 0.1);
+				border: 1px solid $input-border-dark;
+				color: $input-text-dark;
+			}
 		}
 	}
 
@@ -84,12 +89,23 @@
 		&:empty {
 			display: none;
 		}
+		.has-dark-styles & {
+			background-color: #1e1e1e;
+			color: $input-text-dark;
+		}
 	}
 
 	.components-custom-select-control__item {
 		@include font-size(regular);
 		margin-left: 0;
 		padding-left: $gap;
+		&:hover,
+		&:focus,
+		&.is-highlighted {
+			.has-dark-styles & {
+				background-color: rgba(#000, 0.1);
+			}
+		}
 	}
 
 	.components-custom-select-control__item-icon {

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -106,7 +106,7 @@
 		&:focus,
 		&.is-highlighted {
 			.has-dark-styles & {
-				background-color: rgba(#000, 0.1);
+				background-color: rgba(#000, 0.4);
 			}
 		}
 	}

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -67,7 +67,7 @@
 			text-transform: none;
 			white-space: nowrap;
 			width: 100%;
-			.has-dark-styles & {
+			.has-dark-controls & {
 				background-color: rgba(#000, 0.1);
 				border-color: $input-border-dark;
 				color: #fff;
@@ -77,7 +77,7 @@
 
 	.components-custom-select-control__button-icon {
 		right: #{$gap - 4px};
-		.has-dark-styles & {
+		.has-dark-controls & {
 			fill: #fff;
 		}
 	}
@@ -92,7 +92,7 @@
 		&:empty {
 			display: none;
 		}
-		.has-dark-styles & {
+		.has-dark-controls & {
 			background-color: #1e1e1e;
 			color: $input-text-dark;
 		}
@@ -105,7 +105,7 @@
 		&:hover,
 		&:focus,
 		&.is-highlighted {
-			.has-dark-styles & {
+			.has-dark-controls & {
 				background-color: rgba(#000, 0.4);
 			}
 		}

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -18,6 +18,9 @@
 		max-width: calc(100% - #{2 * $gap});
 		white-space: nowrap;
 
+		.has-dark-controls & {
+			color: $input-placeholder-dark;
+		}
 		@media screen and (prefers-reduced-motion: reduce) {
 			transition: none;
 		}
@@ -70,7 +73,7 @@
 			.has-dark-controls & {
 				background-color: rgba(#000, 0.1);
 				border-color: $input-border-dark;
-				color: #fff;
+				color: $input-text-dark;
 			}
 		}
 	}
@@ -78,12 +81,12 @@
 	.components-custom-select-control__button-icon {
 		right: #{$gap - 4px};
 		.has-dark-controls & {
-			fill: #fff;
+			fill: $input-text-dark;
 		}
 	}
 
 	.components-custom-select-control__menu {
-		background-color: #fff;
+		background-color: $select-dropdown-dark;
 		margin: 0;
 		max-height: 300px;
 		overflow: auto;
@@ -93,7 +96,7 @@
 			display: none;
 		}
 		.has-dark-controls & {
-			background-color: #1e1e1e;
+			background-color: $select-dropdown-dark;
 			color: $input-text-dark;
 		}
 	}
@@ -106,7 +109,7 @@
 		&:focus,
 		&.is-highlighted {
 			.has-dark-controls & {
-				background-color: rgba(#000, 0.4);
+				background-color: $select-item-dark;
 			}
 		}
 	}

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -69,7 +69,7 @@
 			width: 100%;
 			.has-dark-styles & {
 				background-color: rgba(#000, 0.1);
-				border: 1px solid $input-border-dark;
+				border-color: $input-border-dark;
 				color: #fff;
 			}
 		}

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -70,13 +70,16 @@
 			.has-dark-styles & {
 				background-color: rgba(#000, 0.1);
 				border: 1px solid $input-border-dark;
-				color: $input-text-dark;
+				color: #fff;
 			}
 		}
 	}
 
 	.components-custom-select-control__button-icon {
 		right: #{$gap - 4px};
+		.has-dark-styles & {
+			fill: #fff;
+		}
 	}
 
 	.components-custom-select-control__menu {

--- a/assets/js/base/components/tabs/style.scss
+++ b/assets/js/base/components/tabs/style.scss
@@ -14,6 +14,7 @@
 			text-align: center;
 			transition: box-shadow 0.1s linear;
 			box-shadow: inset 0 -1px currentColor;
+			border-radius: 0;
 			&.is-active {
 				box-shadow: inset 0 -3px currentColor;
 				font-weight: 600;
@@ -22,6 +23,10 @@
 			&:focus {
 				outline-offset: -1px;
 				outline: 1px dotted currentColor;
+			}
+			&:hover,
+			&:active {
+				background: transparent;
 			}
 			.wc-block-components-tabs__item-content {
 				@include font-size(regular);

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -57,9 +57,12 @@
 		.has-dark-styles & {
 			background-color: rgba(#000, 0.1);
 			border: 1px solid $input-border-dark;
-			color: $input-text-dark;
+			color: #fff;
 			&:focus {
 				background-color: rgba(#000, 0.1);
+			}
+			&::placeholder {
+				color: $input-text-dark;
 			}
 		}
 	}

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -54,6 +54,14 @@
 		&:focus {
 			background-color: #fff;
 		}
+		.has-dark-styles & {
+			background-color: rgba(#000, 0.1);
+			border: 1px solid $input-border-dark;
+			color: $input-text-dark;
+			&:focus {
+				background-color: rgba(#000, 0.1);
+			}
+		}
 	}
 
 	&.is-active input[type="tel"],

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -54,7 +54,7 @@
 		&:focus {
 			background-color: #fff;
 		}
-		.has-dark-styles & {
+		.has-dark-controls & {
 			background-color: rgba(#000, 0.1);
 			border-color: $input-border-dark;
 			color: #fff;

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -20,6 +20,9 @@
 		max-width: calc(100% - #{2 * $gap});
 		cursor: text;
 
+		.has-dark-controls & {
+			color: $input-placeholder-dark;
+		}
 		@media screen and (prefers-reduced-motion: reduce) {
 			transition: none;
 		}
@@ -55,15 +58,9 @@
 			background-color: #fff;
 		}
 		.has-dark-controls & {
-			background-color: rgba(#000, 0.1);
+			background-color: $input-background-dark;
 			border-color: $input-border-dark;
-			color: #fff;
-			&:focus {
-				background-color: rgba(#000, 0.1);
-			}
-			&::placeholder {
-				color: $input-text-dark;
-			}
+			color: $input-text-dark;
 		}
 	}
 

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -56,7 +56,7 @@
 		}
 		.has-dark-styles & {
 			background-color: rgba(#000, 0.1);
-			border: 1px solid $input-border-dark;
+			border-color: $input-border-dark;
 			color: #fff;
 			&:focus {
 				background-color: rgba(#000, 0.1);

--- a/assets/js/base/components/textarea/style.scss
+++ b/assets/js/base/components/textarea/style.scss
@@ -9,4 +9,14 @@
 	margin: 0;
 	padding: em($gap-small) $gap;
 	width: 100%;
+
+	.has-dark-controls & {
+		background-color: $input-background-dark;
+		border-color: rgba(255, 255, 255, 0.4);
+		color: #fff;
+
+		&::placeholder {
+			color: rgba(255, 255, 255, 0.6);
+		}
+	}
 }

--- a/assets/js/base/components/textarea/style.scss
+++ b/assets/js/base/components/textarea/style.scss
@@ -12,11 +12,11 @@
 
 	.has-dark-controls & {
 		background-color: $input-background-dark;
-		border-color: rgba(255, 255, 255, 0.4);
-		color: #fff;
+		border-color: $input-border-dark;
+		color: $input-text-dark;
 
 		&::placeholder {
-			color: rgba(255, 255, 255, 0.6);
+			color: $input-placeholder-dark;
 		}
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/attributes.js
+++ b/assets/js/blocks/cart-checkout/cart/attributes.js
@@ -4,6 +4,7 @@
 import {
 	IS_SHIPPING_CALCULATOR_ENABLED,
 	IS_SHIPPING_COST_HIDDEN,
+	HAS_DARK_STYLES,
 } from '@woocommerce/block-settings';
 
 const blockAttributes = {
@@ -23,6 +24,10 @@ const blockAttributes = {
 	checkoutPageId: {
 		type: 'number',
 		default: 0,
+	},
+	darkInputs: {
+		type: 'boolean',
+		default: HAS_DARK_STYLES,
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/cart/attributes.js
+++ b/assets/js/blocks/cart-checkout/cart/attributes.js
@@ -4,7 +4,7 @@
 import {
 	IS_SHIPPING_CALCULATOR_ENABLED,
 	IS_SHIPPING_COST_HIDDEN,
-	HAS_DARK_STYLES,
+	HAS_DARK_EDITOR_STYLE_SUPPORT,
 } from '@woocommerce/block-settings';
 
 const blockAttributes = {
@@ -25,9 +25,9 @@ const blockAttributes = {
 		type: 'number',
 		default: 0,
 	},
-	darkInputs: {
+	hasDarkControls: {
 		type: 'boolean',
-		default: HAS_DARK_STYLES,
+		default: HAS_DARK_EDITOR_STYLE_SUPPORT,
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -37,6 +37,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		isShippingCalculatorEnabled,
 		isShippingCostHidden,
 		checkoutPageId,
+		darkInputs,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCheckoutPageId } = useRef( checkoutPageId );
@@ -68,6 +69,24 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 				</Notice>
 			) }
+			<PanelBody title={ __( 'Styles', 'woo-gutenberg-products-block' ) }>
+				<ToggleControl
+					label={ __(
+						'Dark inputs',
+						'woo-gutenberg-products-block'
+					) }
+					help={ __(
+						'Enables dark colors and backgrounds for inputs.',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ darkInputs }
+					onChange={ () =>
+						setAttributes( {
+							darkInputs: ! darkInputs,
+						} )
+					}
+				/>
+			</PanelBody>
 			{ SHIPPING_ENABLED && (
 				<PanelBody
 					title={ __(

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -37,7 +37,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		isShippingCalculatorEnabled,
 		isShippingCostHidden,
 		checkoutPageId,
-		darkInputs,
+		hasDarkControls,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCheckoutPageId } = useRef( checkoutPageId );
@@ -69,20 +69,20 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 				</Notice>
 			) }
-			<PanelBody title={ __( 'Styles', 'woo-gutenberg-products-block' ) }>
+			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
 				<ToggleControl
 					label={ __(
-						'Dark inputs',
+						'Dark mode inputs',
 						'woo-gutenberg-products-block'
 					) }
 					help={ __(
-						'Enables dark colors and backgrounds for inputs.',
+						'Inputs styled specifically for use on dark background colors.',
 						'woo-gutenberg-products-block'
 					) }
-					checked={ darkInputs }
+					checked={ hasDarkControls }
 					onChange={ () =>
 						setAttributes( {
-							darkInputs: ! darkInputs,
+							hasDarkControls: ! hasDarkControls,
 						} )
 					}
 				/>

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -69,24 +69,6 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 				</Notice>
 			) }
-			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
-				<ToggleControl
-					label={ __(
-						'Dark mode inputs',
-						'woo-gutenberg-products-block'
-					) }
-					help={ __(
-						'Inputs styled specifically for use on dark background colors.',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ hasDarkControls }
-					onChange={ () =>
-						setAttributes( {
-							hasDarkControls: ! hasDarkControls,
-						} )
-					}
-				/>
-			</PanelBody>
 			{ SHIPPING_ENABLED && (
 				<PanelBody
 					title={ __(
@@ -148,6 +130,24 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					} }
 				/>
 			) }
+			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
+				<ToggleControl
+					label={ __(
+						'Dark mode inputs',
+						'woo-gutenberg-products-block'
+					) }
+					help={ __(
+						'Inputs styled specifically for use on dark background colors.',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ hasDarkControls }
+					onChange={ () =>
+						setAttributes( {
+							hasDarkControls: ! hasDarkControls,
+						} )
+					}
+				/>
+			</PanelBody>
 			<CartCheckoutFeedbackPrompt />
 		</InspectorControls>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -86,7 +86,7 @@ const Cart = ( { attributes } ) => {
 
 	const cartClassName = classnames( 'wc-block-cart', {
 		'wc-block-cart--is-loading': cartIsLoading,
-		'wc-block-cart--has-dark-styles': darkInputs,
+		'has-dark-styles': darkInputs,
 	} );
 
 	return (

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -47,7 +47,11 @@ import './style.scss';
  * Component that renders the Cart block when user has something in cart aka "full".
  */
 const Cart = ( { attributes } ) => {
-	const { isShippingCalculatorEnabled, isShippingCostHidden } = attributes;
+	const {
+		isShippingCalculatorEnabled,
+		isShippingCostHidden,
+		darkInputs,
+	} = attributes;
 
 	const {
 		cartItems,
@@ -82,6 +86,7 @@ const Cart = ( { attributes } ) => {
 
 	const cartClassName = classnames( 'wc-block-cart', {
 		'wc-block-cart--is-loading': cartIsLoading,
+		'wc-block-cart--has-dark-styles': darkInputs,
 	} );
 
 	return (

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -50,7 +50,7 @@ const Cart = ( { attributes } ) => {
 	const {
 		isShippingCalculatorEnabled,
 		isShippingCostHidden,
-		darkInputs,
+		hasDarkControls,
 	} = attributes;
 
 	const {
@@ -86,7 +86,7 @@ const Cart = ( { attributes } ) => {
 
 	const cartClassName = classnames( 'wc-block-cart', {
 		'wc-block-cart--is-loading': cartIsLoading,
-		'has-dark-styles': darkInputs,
+		'has-dark-controls': hasDarkControls,
 	} );
 
 	return (

--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -1,3 +1,8 @@
+/**
+ * External dependencies
+ */
+import { HAS_DARK_STYLES } from '@woocommerce/block-settings';
+
 const blockAttributes = {
 	isPreview: {
 		type: 'boolean',
@@ -39,6 +44,10 @@ const blockAttributes = {
 	cartPageId: {
 		type: 'number',
 		default: 0,
+	},
+	darkInputs: {
+		type: 'boolean',
+		default: HAS_DARK_STYLES,
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { HAS_DARK_STYLES } from '@woocommerce/block-settings';
+import { HAS_DARK_EDITOR_STYLE_SUPPORT } from '@woocommerce/block-settings';
 
 const blockAttributes = {
 	isPreview: {
@@ -45,9 +45,9 @@ const blockAttributes = {
 		type: 'number',
 		default: 0,
 	},
-	darkInputs: {
+	hasDarkControls: {
 		type: 'boolean',
-		default: HAS_DARK_STYLES,
+		default: HAS_DARK_EDITOR_STYLE_SUPPORT,
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -213,7 +213,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		);
 
 	const checkoutClassName = classnames( 'wc-block-checkout', {
-		'wc-block-checkout--has-dark-styles': attributes.darkInputs,
+		'has-dark-styles': attributes.darkInputs,
 	} );
 	return (
 		<>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useMemo, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -211,9 +212,12 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 			</>
 		);
 
+	const checkoutClassName = classnames( 'wc-block-checkout', {
+		'wc-block-checkout--has-dark-styles': attributes.darkInputs,
+	} );
 	return (
 		<>
-			<SidebarLayout className="wc-block-checkout">
+			<SidebarLayout className={ checkoutClassName }>
 				<Main className="wc-block-checkout__main">
 					{ cartNeedsPayment && <ExpressCheckoutFormControl /> }
 					<CheckoutForm onSubmit={ onSubmit }>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -213,7 +213,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		);
 
 	const checkoutClassName = classnames( 'wc-block-checkout', {
-		'has-dark-styles': attributes.darkInputs,
+		'has-dark-controls': attributes.hasDarkControls,
 	} );
 	return (
 		<>

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -45,6 +45,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		showPolicyLinks,
 		showReturnToCart,
 		cartPageId,
+		darkInputs,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCartPageId } = useRef( cartPageId );
@@ -76,6 +77,24 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 				</Notice>
 			) }
+			<PanelBody title={ __( 'Styles', 'woo-gutenberg-products-block' ) }>
+				<ToggleControl
+					label={ __(
+						'Dark inputs',
+						'woo-gutenberg-products-block'
+					) }
+					help={ __(
+						'Enables dark colors and backgrounds for inputs.',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ darkInputs }
+					onChange={ () =>
+						setAttributes( {
+							darkInputs: ! darkInputs,
+						} )
+					}
+				/>
+			</PanelBody>
 			<PanelBody
 				title={ __(
 					'Address options',

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -45,7 +45,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		showPolicyLinks,
 		showReturnToCart,
 		cartPageId,
-		darkInputs,
+		hasDarkControls,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCartPageId } = useRef( cartPageId );
@@ -77,20 +77,20 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 				</Notice>
 			) }
-			<PanelBody title={ __( 'Styles', 'woo-gutenberg-products-block' ) }>
+			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
 				<ToggleControl
 					label={ __(
-						'Dark inputs',
+						'Dark mode inputs',
 						'woo-gutenberg-products-block'
 					) }
 					help={ __(
-						'Enables dark colors and backgrounds for inputs.',
+						'Inputs styled specifically for use on dark background colors.',
 						'woo-gutenberg-products-block'
 					) }
-					checked={ darkInputs }
+					checked={ hasDarkControls }
 					onChange={ () =>
 						setAttributes( {
-							darkInputs: ! darkInputs,
+							hasDarkControls: ! hasDarkControls,
 						} )
 					}
 				/>

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -77,24 +77,6 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					) }
 				</Notice>
 			) }
-			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
-				<ToggleControl
-					label={ __(
-						'Dark mode inputs',
-						'woo-gutenberg-products-block'
-					) }
-					help={ __(
-						'Inputs styled specifically for use on dark background colors.',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ hasDarkControls }
-					onChange={ () =>
-						setAttributes( {
-							hasDarkControls: ! hasDarkControls,
-						} )
-					}
-				/>
-			</PanelBody>
 			<PanelBody
 				title={ __(
 					'Address options',
@@ -281,7 +263,24 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						} }
 					/>
 				) }
-
+			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
+				<ToggleControl
+					label={ __(
+						'Dark mode inputs',
+						'woo-gutenberg-products-block'
+					) }
+					help={ __(
+						'Inputs styled specifically for use on dark background colors.',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ hasDarkControls }
+					onChange={ () =>
+						setAttributes( {
+							hasDarkControls: ! hasDarkControls,
+						} )
+					}
+				/>
+			</PanelBody>
 			<CartCheckoutFeedbackPrompt />
 		</InspectorControls>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -217,6 +217,9 @@
 			.wc-block-components-checkbox {
 				clear: both;
 			}
+			& + .wc-block-components-text-input {
+				margin-top: 1.5em;
+			}
 		}
 	}
 }

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -217,9 +217,7 @@
 			.wc-block-components-checkbox {
 				clear: both;
 			}
-			& + .wc-block-components-text-input {
-				margin-top: 1.5em;
-			}
+
 		}
 	}
 }

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -31,6 +31,7 @@ export const DISPLAY_ITEMIZED_TAXES = getSetting(
 	'displayItemizedTaxes',
 	false
 );
+export const HAS_DARK_STYLES = getSetting( 'hasDarkStyles', false );
 export const DISPLAY_SHOP_PRICES_INCLUDING_TAX = getSetting(
 	'displayShopPricesIncludingTax',
 	false
@@ -64,7 +65,10 @@ export const SHIPPING_METHODS_EXIST = getSetting(
 	false
 );
 
-export const PAYMENT_GATEWAY_SORT_ORDER = getSetting( 'paymentGatewaySortOrder', [] );
+export const PAYMENT_GATEWAY_SORT_ORDER = getSetting(
+	'paymentGatewaySortOrder',
+	[]
+);
 
 export const CHECKOUT_SHOW_LOGIN_REMINDER = getSetting(
 	'checkoutShowLoginReminder',

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -31,7 +31,10 @@ export const DISPLAY_ITEMIZED_TAXES = getSetting(
 	'displayItemizedTaxes',
 	false
 );
-export const HAS_DARK_STYLES = getSetting( 'hasDarkStyles', false );
+export const HAS_DARK_EDITOR_STYLE_SUPPORT = getSetting(
+	'hasDarkEditorStyleSupport',
+	false
+);
 export const DISPLAY_SHOP_PRICES_INCLUDING_TAX = getSetting(
 	'displayShopPricesIncludingTax',
 	false

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -186,6 +186,7 @@ class Assets {
 				'checkoutAllowsSignup'          => 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout' ),
 				'baseLocation'                  => wc_get_base_location(),
 				'woocommerceBlocksPhase'        => WOOCOMMERCE_BLOCKS_PHASE,
+				'hasDarkStyles'                 => current_theme_supports( 'dark-editor-style' ),
 
 				/*
 				 * translators: If your word count is based on single characters (e.g. East Asian characters),

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -186,7 +186,7 @@ class Assets {
 				'checkoutAllowsSignup'          => 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout' ),
 				'baseLocation'                  => wc_get_base_location(),
 				'woocommerceBlocksPhase'        => WOOCOMMERCE_BLOCKS_PHASE,
-				'hasDarkStyles'                 => current_theme_supports( 'dark-editor-style' ),
+				'hasDarkEditorStyleSupport'     => current_theme_supports( 'dark-editor-style' ),
 
 				/*
 				 * translators: If your word count is based on single characters (e.g. East Asian characters),

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -84,6 +84,7 @@ class Bootstrap {
 		$this->container->get( PaymentsApi::class );
 		$this->container->get( RestApi::class );
 		Library::init();
+		add_theme_support( 'dark-editor-style' );
 	}
 
 	/**

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -84,7 +84,6 @@ class Bootstrap {
 		$this->container->get( PaymentsApi::class );
 		$this->container->get( RestApi::class );
 		Library::init();
-		add_theme_support( 'dark-editor-style' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Closes #2320
Fixes #2986

This PR introduces dark styles to our controls, it adds them to:

- Text Control Inputs.
- Select Control.
- Checkbox Control.
- Radio Control.
- Quantity Selector.
- Textarea Control.
- Panel title in Twentyseventeen. 

## Screenshots

### Dark mode (in storefront)
<img width="132" alt="Screen Shot 2020-08-07 at 10 57 06 AM" src="https://user-images.githubusercontent.com/6165348/89634678-abae1880-d89d-11ea-9218-1d0dffda496d.png">
<img width="655" alt="Screen Shot 2020-08-07 at 10 58 10 AM" src="https://user-images.githubusercontent.com/6165348/89634682-ac46af00-d89d-11ea-9eb3-dc85e609b558.png">
<img width="710" alt="Screen Shot 2020-08-07 at 10 58 10 AM" src="https://user-images.githubusercontent.com/6165348/89636514-a4d4d500-d8a0-11ea-97d7-958152a3486b.png">



### Light mode 
<img width="146" alt="Screen Shot 2020-08-07 at 11 00 27 AM" src="https://user-images.githubusercontent.com/6165348/89634738-c1234280-d89d-11ea-8f90-11b83833f2c2.png">
<img width="347" alt="Screen Shot 2020-08-07 at 11 01 15 AM" src="https://user-images.githubusercontent.com/6165348/89634745-c2ed0600-d89d-11ea-83ec-87cbc0455415.png">
<img width="671" alt="Screen Shot 2020-08-07 at 11 00 03 AM" src="https://user-images.githubusercontent.com/6165348/89634753-c41e3300-d89d-11ea-93ff-dc944725e68e.png">


It also introduces the option to toggle this mode or not, the default value of that attribute is inherited from the theme, themes can ask GB for dark mode support by defining `add_theme_support( 'dark-editor-style' )`, we look for that and decide accordingly. 
By default, previous blocks will stay on light mode, even if the theme has dark styles enabled, if they resave the block again, or insert it again, the new default value will be inherited from dark styles option.

<img width="280" alt="Screen Shot 2020-08-07 at 11 00 14 AM" src="https://user-images.githubusercontent.com/6165348/89634946-24ad7000-d89e-11ea-9786-1d79ed7f21f1.png">

<!-- Don't forget to update the title with something descriptive. -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
 Up to the designs.

### How to test the changes in this Pull Request:

1. First, pull this PR and make sure nothing is broken by default, this means in light mode with normal colors, test inputs, select, radio, checkbox, quantity selectors.
2. Switch the colors of your theme to a dark variation, you can do that in the customizer for storefront.
3. Switch the block to use dark colors and test the inputs again, make sure nothing is broken.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add dark colors and background for Cart & Checkout blocks to support dark backgrounds.
