### PR TITLE
Fix spelling of "its" in product element block placeholder screens

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/edit.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/edit.js
@@ -80,7 +80,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's add to cart form.",
+		"Choose a product to display its add to cart form.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/button/edit.js
+++ b/assets/js/atomic/blocks/product-elements/button/edit.js
@@ -23,7 +23,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's add to cart button.",
+		"Choose a product to display its add to cart button.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/category-list/edit.js
+++ b/assets/js/atomic/blocks/product-elements/category-list/edit.js
@@ -27,7 +27,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's categories.",
+		"Choose a product to display its categories.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/image/edit.js
+++ b/assets/js/atomic/blocks/product-elements/image/edit.js
@@ -153,7 +153,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's image.",
+		"Choose a product to display its image.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/price/edit.js
+++ b/assets/js/atomic/blocks/product-elements/price/edit.js
@@ -123,7 +123,7 @@ const Price = isFeaturePluginBuild()
 				icon: BLOCK_ICON,
 				label: BLOCK_TITLE,
 				description: __(
-					"Choose a product to display it's price.",
+					"Choose a product to display its price.",
 					'woo-gutenberg-products-block'
 				),
 			} ),

--- a/assets/js/atomic/blocks/product-elements/rating/edit.js
+++ b/assets/js/atomic/blocks/product-elements/rating/edit.js
@@ -17,7 +17,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's rating.",
+		"Choose a product to display its rating.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/sale-badge/edit.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/edit.js
@@ -18,7 +18,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's sale-badge.",
+		"Choose a product to display its sale-badge.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/sku/edit.js
+++ b/assets/js/atomic/blocks/product-elements/sku/edit.js
@@ -24,7 +24,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's SKU.",
+		"Choose a product to display its SKU.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/edit.js
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/edit.js
@@ -24,7 +24,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's stock.",
+		"Choose a product to display its stock.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/summary/edit.js
+++ b/assets/js/atomic/blocks/product-elements/summary/edit.js
@@ -18,7 +18,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's short description.",
+		"Choose a product to display its short description.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/tag-list/edit.js
+++ b/assets/js/atomic/blocks/product-elements/tag-list/edit.js
@@ -27,7 +27,7 @@ export default withProductSelector( {
 	icon: BLOCK_ICON,
 	label: BLOCK_TITLE,
 	description: __(
-		"Choose a product to display it's tags.",
+		"Choose a product to display its tags.",
 		'woo-gutenberg-products-block'
 	),
 } )( Edit );

--- a/assets/js/atomic/blocks/product-elements/title/edit.js
+++ b/assets/js/atomic/blocks/product-elements/title/edit.js
@@ -121,7 +121,7 @@ const Title = isFeaturePluginBuild()
 				icon: BLOCK_ICON,
 				label: BLOCK_TITLE,
 				description: __(
-					"Choose a product to display it's title.",
+					"Choose a product to display its title.",
 					'woo-gutenberg-products-block'
 				),
 			} ),


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2969

Updates the spelling of "it's" to "its" 
