### PR TITLE
fix issue with no margins on phone input

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-calculator/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-calculator/style.scss
@@ -4,6 +4,7 @@
 
 .wc-block-components-shipping-calculator-address__button {
 	width: 100%;
+	margin-top: em($gap-large);
 }
 
 .wc-block-components-shipping-calculator {

--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -10,6 +10,7 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { ValidatedSelect } from '../select';
+import './style.scss';
 
 const CountryInput = ( {
 	className,

--- a/assets/js/base/components/country-input/style.scss
+++ b/assets/js/base/components/country-input/style.scss
@@ -1,0 +1,5 @@
+.wc-block-components-country-input,
+.wc-block-components-state-input {
+	margin-top: em($gap-large);
+	position: relative;
+}

--- a/assets/js/base/components/country-input/style.scss
+++ b/assets/js/base/components/country-input/style.scss
@@ -1,5 +1,3 @@
-.wc-block-components-country-input,
-.wc-block-components-state-input {
+.wc-block-components-country-input {
 	margin-top: em($gap-large);
-	position: relative;
 }

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,7 +1,7 @@
 .wc-block-components-select {
 	height: 3em;
 	position: relative;
-	margin-bottom: em($gap-large);
+	margin-top: em($gap-large);
 
 	label {
 		@include reset-typography();

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,7 +1,6 @@
 .wc-block-components-select {
 	height: 3em;
 	position: relative;
-	margin-top: em($gap-large);
 
 	label {
 		@include reset-typography();

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -12,6 +12,7 @@ import classnames from 'classnames';
  */
 import { ValidatedTextInput } from '../text-input';
 import { ValidatedSelect } from '../select';
+import './style.scss';
 
 const StateInput = ( {
 	className,

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useCallback } from '@wordpress/element';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -56,7 +57,10 @@ const StateInput = ( {
 		return (
 			<>
 				<ValidatedSelect
-					className={ className }
+					className={ classnames(
+						className,
+						'wc-block-components-state-input'
+					) }
 					id={ id }
 					label={ label }
 					onChange={ onChangeState }

--- a/assets/js/base/components/state-input/style.scss
+++ b/assets/js/base/components/state-input/style.scss
@@ -1,0 +1,3 @@
+.wc-block-components-state-input {
+	margin-top: em($gap-large);
+}

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -1,6 +1,6 @@
 .wc-block-components-text-input {
 	position: relative;
-	margin-bottom: em($gap-large);
+	margin-top: em($gap-large);
 	white-space: nowrap;
 
 	label {
@@ -75,6 +75,6 @@
 	}
 
 	&:only-child {
-		margin-bottom: 0;
+		margin-top: 0;
 	}
 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -6,6 +6,15 @@
 	.wc-block-components-product-name {
 		color: inherit;
 	}
+	.wc-block-components-address-form {
+		.wc-block-components-text-input,
+		.wc-block-components-country-input,
+		.wc-block-components-state-input {
+			&:first-of-type {
+				margin-top: 0;
+			}
+		}
+	}
 }
 
 table.wc-block-cart-items,

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -194,7 +194,8 @@
 			}
 
 			.wc-block-components-text-input,
-			.wc-block-components-country-input {
+			.wc-block-components-country-input,
+			.wc-block-components-state-input {
 				float: left;
 				margin-left: #{$gap-small / 2};
 				margin-right: #{$gap-small / 2};

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -194,24 +194,16 @@
 			}
 
 			.wc-block-components-text-input,
-			.wc-block-components-country-input,
-			.wc-block-components-select {
+			.wc-block-components-country-input {
 				float: left;
 				margin-left: #{$gap-small / 2};
 				margin-right: #{$gap-small / 2};
 				position: relative;
 				width: calc(50% - #{$gap-small});
 
-				.wc-block-components-select {
-					float: none;
-					width: 100%;
-					margin-left: 0;
-					margin-right: 0;
-				}
-
-				&:nth-last-of-type(2),
-				&:last-of-type {
-					margin-bottom: 0;
+				&:nth-of-type(2),
+				&:first-of-type {
+					margin-top: 0;
 				}
 			}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2979 

This PR fixes the issue with overlapping margins, I simply switched to top margins, moved some styles, and added a new classname `.wc-block-components-state-input`.

### How to test

1- Verify the Checkout block for any possible changes, change to countries with three fields like Afghanistan and countries with predefined states like Spain.
2- Verify the Cart shipping calculator form.
3- Verify any weird spacing in other inputs in the Checkout form.

### Screenshots

![image](https://user-images.githubusercontent.com/6165348/89808072-76b9f400-db31-11ea-8f07-aa30cc9d38c6.png)
![image](https://user-images.githubusercontent.com/6165348/89808095-820d1f80-db31-11ea-9100-bf48b408bfd9.png)
![image](https://user-images.githubusercontent.com/6165348/89808113-8cc7b480-db31-11ea-870d-d5401e69139a.png)
