### PR TITLE
Fix phpunit test config

### DIFF
--- a/tests/bin/Dockerfile
+++ b/tests/bin/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
 CMD echo "Installing tests..."
 
 ENV WP_TESTS_DIR=/tmp/wordpress-tests-lib
-ENV WP_CORE_DIR=/usr/src/wordpress
+ENV WP_CORE_DIR=/tmp/src/wordpress
 
 COPY install-wp-tests.sh /usr/local/bin/dockerInit
 RUN chmod +x /usr/local/bin/dockerInit

--- a/tests/php/StoreApi/Utilities/ReserveStock.php
+++ b/tests/php/StoreApi/Utilities/ReserveStock.php
@@ -25,8 +25,8 @@ class ReserveStockTests extends TestCase {
 
 		$product = ProductHelper::create_simple_product();
 		$product->set_manage_stock( true );
-		$product->set_stock( 10 );
-		$product->save();
+		// this also saves product
+		wc_update_product_stock( $product, 10 );
 
 		$order = OrderHelper::create_order( 1, $product ); // Note this adds 4 to the order.
 		$order->set_status( 'checkout-draft' );
@@ -54,8 +54,8 @@ class ReserveStockTests extends TestCase {
 
 		$product = ProductHelper::create_simple_product();
 		$product->set_manage_stock( true );
-		$product->set_stock( 10 );
-		$product->save();
+		// this also saves product
+		wc_update_product_stock( $product, 10 );
 
 		$order = OrderHelper::create_order( 1, $product ); // Note this adds 4 to the order.
 		$order->set_status( 'checkout-draft' );


### PR DESCRIPTION
WordPress 5.5 was released and our phpunit tests started failing. I traced the problem to a few causes:

- The docker configuration for the test suite uses the "official" WordPress docker image which does not have a WP 5.5 update yet.
- `tests/bin/install-wp-tests.sh` was _always_ installing the WordPress test suite from the corresponding WP version svn but for the WordPress _core source_ files it was using what was already installed in the image.

Thus in this case since the image doesn't have 5.5 as the latest available version yet, the test downloads were ahead of the WordPress core version and this created the fatal because tests expected PHPMailer at a different location than what is found in earlier versions of WP.

The fix is to just always download the WP core source files for the requested version for phpunit runs. It adds minimal time to the test setup and should be resilient against future WP changes.

After fixing, I noticed that our tests are using a _now_ deprecated WooCommerce method for updating stock so I fixed that in the two affected tests. 

## To test

You can run phpunit locally if you want (you may need to delete cached containers via `docker system prune -a`) but the run on travis should be sufficient to verify things work.
