### PR TITLE
Add defensive checks for cart instance

### DIFF
--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -32,6 +32,7 @@ class CartController {
 	 * @return string|Error
 	 */
 	public function add_to_cart( $request ) {
+		$cart    = $this->get_cart_instance();
 		$request = wp_parse_args(
 			$request,
 			[
@@ -44,7 +45,7 @@ class CartController {
 
 		$request = $this->filter_request_data( $this->parse_variation_data( $request ) );
 		$product = $this->get_product_for_cart( $request );
-		$cart_id = wc()->cart->generate_cart_id(
+		$cart_id = $cart->generate_cart_id(
 			$this->get_product_id( $product ),
 			$this->get_variation_id( $product ),
 			$request['variation'],
@@ -53,7 +54,7 @@ class CartController {
 
 		$this->validate_add_to_cart( $product, $request );
 
-		$existing_cart_id = wc()->cart->find_product_in_cart( $cart_id );
+		$existing_cart_id = $cart->find_product_in_cart( $cart_id );
 
 		if ( $existing_cart_id ) {
 			if ( $product->is_sold_individually() ) {
@@ -67,12 +68,12 @@ class CartController {
 					400
 				);
 			}
-			wc()->cart->set_quantity( $existing_cart_id, $request['quantity'] + wc()->cart->cart_contents[ $existing_cart_id ]['quantity'], true );
+			$cart->set_quantity( $existing_cart_id, $request['quantity'] + $cart->cart_contents[ $existing_cart_id ]['quantity'], true );
 
 			return $existing_cart_id;
 		}
 
-		wc()->cart->cart_contents[ $cart_id ] = apply_filters(
+		$cart->cart_contents[ $cart_id ] = apply_filters(
 			'woocommerce_add_cart_item',
 			array_merge(
 				$request['cart_item_data'],
@@ -89,7 +90,7 @@ class CartController {
 			$cart_id
 		);
 
-		wc()->cart->cart_contents = apply_filters( 'woocommerce_cart_contents_changed', wc()->cart->cart_contents );
+		$cart->cart_contents = apply_filters( 'woocommerce_cart_contents_changed', $cart->cart_contents );
 
 		do_action(
 			'woocommerce_add_to_cart',
@@ -136,8 +137,8 @@ class CartController {
 				400
 			);
 		}
-
-		wc()->cart->set_quantity( $item_id, $quantity );
+		$cart = $this->get_cart_instance();
+		$cart->set_quantity( $item_id, $quantity );
 	}
 
 	/**
@@ -223,6 +224,7 @@ class CartController {
 	 * @throws RouteException Exception if invalid data is detected.
 	 */
 	public function validate_cart_items() {
+		$cart       = $this->get_cart_instance();
 		$cart_items = $this->get_cart_items();
 
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
@@ -230,8 +232,8 @@ class CartController {
 		}
 
 		// Before running the woocommerce_check_cart_items hook, unhook validation from the core cart.
-		remove_action( 'woocommerce_check_cart_items', array( wc()->cart, 'check_cart_items' ), 1 );
-		remove_action( 'woocommerce_check_cart_items', array( wc()->cart, 'check_cart_coupons' ), 1 );
+		remove_action( 'woocommerce_check_cart_items', array( $cart, 'check_cart_items' ), 1 );
+		remove_action( 'woocommerce_check_cart_items', array( $cart, 'check_cart_coupons' ), 1 );
 
 		/**
 		 * Hook: woocommerce_check_cart_items
@@ -397,7 +399,8 @@ class CartController {
 	 * @return array
 	 */
 	public function get_cart_item( $item_id ) {
-		return isset( wc()->cart->cart_contents[ $item_id ] ) ? wc()->cart->cart_contents[ $item_id ] : [];
+		$cart = $this->get_cart_instance();
+		return isset( $cart->cart_contents[ $item_id ] ) ? $cart->cart_contents[ $item_id ] : [];
 	}
 
 	/**
@@ -407,7 +410,8 @@ class CartController {
 	 * @return array
 	 */
 	public function get_cart_items( $callback = null ) {
-		return $callback ? array_filter( wc()->cart->get_cart(), $callback ) : array_filter( wc()->cart->get_cart() );
+		$cart = $this->get_cart_instance();
+		return $callback ? array_filter( $cart->get_cart(), $callback ) : array_filter( $cart->get_cart() );
 	}
 
 	/**
@@ -416,12 +420,13 @@ class CartController {
 	 * @return array
 	 */
 	public function get_cart_hashes() {
+		$cart = $this->get_cart_instance();
 		return [
-			'line_items' => wc()->cart->get_cart_hash(),
-			'shipping'   => md5( wp_json_encode( wc()->cart->shipping_methods ) ),
-			'fees'       => md5( wp_json_encode( wc()->cart->get_fees() ) ),
-			'coupons'    => md5( wp_json_encode( wc()->cart->get_applied_coupons() ) ),
-			'taxes'      => md5( wp_json_encode( wc()->cart->get_taxes() ) ),
+			'line_items' => $cart->get_cart_hash(),
+			'shipping'   => md5( wp_json_encode( $cart->shipping_methods ) ),
+			'fees'       => md5( wp_json_encode( $cart->get_fees() ) ),
+			'coupons'    => md5( wp_json_encode( $cart->get_applied_coupons() ) ),
+			'taxes'      => md5( wp_json_encode( $cart->get_taxes() ) ),
 		];
 	}
 
@@ -429,7 +434,8 @@ class CartController {
 	 * Empty cart contents.
 	 */
 	public function empty_cart() {
-		wc()->cart->empty_cart();
+		$cart = $this->get_cart_instance();
+		$cart->empty_cart();
 	}
 
 	/**
@@ -439,7 +445,8 @@ class CartController {
 	 * @return bool
 	 */
 	public function has_coupon( $coupon_code ) {
-		return wc()->cart->has_discount( $coupon_code );
+		$cart = $this->get_cart_instance();
+		return $cart->has_discount( $coupon_code );
 	}
 
 	/**
@@ -449,7 +456,8 @@ class CartController {
 	 * @return array
 	 */
 	public function get_cart_coupons( $callback = null ) {
-		return $callback ? array_filter( wc()->cart->get_applied_coupons(), $callback ) : array_filter( wc()->cart->get_applied_coupons() );
+		$cart = $this->get_cart_instance();
+		return $callback ? array_filter( $cart->get_applied_coupons(), $callback ) : array_filter( $cart->get_applied_coupons() );
 	}
 
 	/**
@@ -591,8 +599,9 @@ class CartController {
 	 */
 	protected function validate_cart_coupon( \WC_Coupon $coupon ) {
 		if ( ! $coupon->is_valid() ) {
-			wc()->cart->remove_coupon( $coupon->get_code() );
-			wc()->cart->calculate_totals();
+			$cart = $this->get_cart_instance();
+			$cart->remove_coupon( $coupon->get_code() );
+			$cart->calculate_totals();
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
@@ -613,7 +622,8 @@ class CartController {
 	 * @return int
 	 */
 	protected function get_product_quantity_in_cart( $product ) {
-		$product_quantities = wc()->cart->get_cart_item_quantities();
+		$cart               = $this->get_cart_instance();
+		$product_quantities = $cart->get_cart_item_quantities();
 		$product_id         = $product->get_stock_managed_by_id();
 
 		return isset( $product_quantities[ $product_id ] ) ? $product_quantities[ $product_id ] : 0;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2924

If a site is being crawled by a bot (malicious or otherwise) hitting it's REST endpoints, there's the possibility of direct calls to code invoking the StoreApi/CartController.php in a context where there is no `WC_Cart` instance available which will result in the fatal errors in the logs reported in #2924. For normal site visitors this isn't an issue but it does mean potential extra noise in PHP error logs.

In this pull I've gone through the entire cart controller and added some defensive checks for the cart instance where a RouteError exception is thrown if the cart is is not available. That should prevent a fatal error appearing in logs and crawlers will get an appropriate error code on requests.

## To test

There is some phpunit test coverage already for this code however it does potentially impact anything using the `wc/store/cart` endpoint. So it'd be good to do smoke tests of cart and checkout block flows. Any issues should surface fairly quickly.
