### PR TITLE
Deprecate wc.wcSettings.setSetting function.

### DIFF
--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -28,7 +28,7 @@ import deprecated from '@wordpress/deprecated';
 export function setSetting( name, value, filter = ( val ) => val ) {
 	deprecated( 'setSetting', {
 		version: '3.8.0',
-		alternative: `a locally scoped value for "${ name }" instead`,
+		alternative: `a locally scoped value for "${ name }"`,
 		plugin: 'WooCommerce Blocks',
 		hint:
 			'wc.wcSettings is a global settings configuration object that should not be mutated during a session. Hence the removal of this function.',

--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -28,7 +28,7 @@ import deprecated from '@wordpress/deprecated';
 export function setSetting( name, value, filter = ( val ) => val ) {
 	deprecated( 'setSetting', {
 		version: '3.8.0',
-		alternative: 'a locally scoped value instead',
+		alternative: `a locally scoped value for "${ name }" instead`,
 		plugin: 'WooCommerce Blocks',
 		hint:
 			'wc.wcSettings is a global settings configuration object that should not be mutated during a session. Hence the removal of this function.',

--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -19,7 +19,7 @@ import deprecated from '@wordpress/deprecated';
  *                                               to sanitize the setting (eg.
  *                                               ensure it's a number)
  *
- * @todo  Remove setSetting function from `@woocommerce/settings`
+ * @todo  Remove setSetting function from `@woocommerce/settings`.
  *
  *  The `wc.wcSettings.setSetting` function was deprecated beginning with WooCommerce Blocks 3.2.0
  *  and can be removed completely with WooCommerce Blocks 3.8.0 (that gives 6 versions of the

--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -23,7 +23,7 @@ import deprecated from '@wordpress/deprecated';
  *
  *  The `wc.wcSettings.setSetting` function was deprecated beginning with WooCommerce Blocks 3.2.0
  *  and can be removed completely with WooCommerce Blocks 3.8.0 (that gives 6 versions of the
- *  feature plugin for warning and 2 versions of WooCommerce core).
+ *  feature plugin for warning and 3 versions of WooCommerce core).
  */
 export function setSetting( name, value, filter = ( val ) => val ) {
 	deprecated( 'setSetting', {

--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -4,6 +4,11 @@
 import { allSettings } from './settings-init';
 
 /**
+ * External dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Sets a value to a property on the settings state.
  *
  * @export
@@ -15,5 +20,12 @@ import { allSettings } from './settings-init';
  *                                               ensure it's a number)
  */
 export function setSetting( name, value, filter = ( val ) => val ) {
+	deprecated( 'setSetting', {
+		version: '3.8.0',
+		alternative: 'a locally scoped value instead',
+		plugin: 'WooCommerce Blocks',
+		hint:
+			'wc.wcSettings is a global settings configuration object that should not be mutated during a session. Hence the removal of this function.',
+	} );
 	allSettings[ name ] = filter( value );
 }

--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -14,10 +14,16 @@ import deprecated from '@wordpress/deprecated';
  * @export
  * @param {string}   name                        The setting property key for the
  *                                               setting being mutated.
- * @param {*}    value                       The value to set.
+ * @param {*}        value                       The value to set.
  * @param {Function} [filter=( val ) => val]     Allows for providing a callback
  *                                               to sanitize the setting (eg.
  *                                               ensure it's a number)
+ *
+ * @todo  Remove setSetting function from `@woocommerce/settings`
+ *
+ *  The `wc.wcSettings.setSetting` function was deprecated beginning with WooCommerce Blocks 3.2.0
+ *  and can be removed completely with WooCommerce Blocks 3.8.0 (that gives 6 versions of the
+ *  feature plugin for warning and 2 versions of WooCommerce core).
  */
 export function setSetting( name, value, filter = ( val ) => val ) {
 	deprecated( 'setSetting', {

--- a/assets/js/settings/shared/test/compare-with-wp-version.js
+++ b/assets/js/settings/shared/test/compare-with-wp-version.js
@@ -4,6 +4,7 @@
 import { compareWithWpVersion, setSetting } from '..';
 
 describe( 'compareWithWpVersion', () => {
+	let initial = true;
 	it.each`
 		version             | operator | result
 		${'5.3-beta1'}      | ${'>'}   | ${true}
@@ -18,6 +19,12 @@ describe( 'compareWithWpVersion', () => {
 			'and `5.3` is the version compared using `$operator`',
 		( { version, operator, result } ) => {
 			setSetting( 'wpVersion', version );
+			// deprecated caches messages once per session, so we only check
+			// console warn on initial call.
+			if ( initial ) {
+				expect( console ).toHaveWarned();
+			}
+			initial = false;
 			expect( compareWithWpVersion( '5.3', operator ) ).toBe( result );
 		}
 	);

--- a/assets/js/settings/shared/test/set-setting.js
+++ b/assets/js/settings/shared/test/set-setting.js
@@ -7,14 +7,17 @@ import { getSetting } from '../get-setting';
 describe( 'setSetting', () => {
 	it( 'should add a new value to the settings state for value not present', () => {
 		setSetting( 'aSetting', 42 );
+		expect( console ).toHaveWarned();
 		expect( getSetting( 'aSetting' ) ).toBe( 42 );
 	} );
 	it( 'should replace existing value', () => {
 		setSetting( 'adminUrl', 'not original' );
+		expect( console ).toHaveWarned();
 		expect( getSetting( 'adminUrl' ) ).toBe( 'not original' );
 	} );
 	it( 'should save the value run through the provided filter', () => {
-		setSetting( 'aSetting', 'who', () => 42 );
+		setSetting( 'bSetting', 'who', () => 42 );
+		expect( console ).toHaveWarned();
 		expect( getSetting( 'aSetting' ) ).toBe( 42 );
 	} );
 } );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #1838

The `wc.wcSettings.setSetting` function should never have been added (I added it!) as global configuration settings coming from the server should be immutable. Allowing these values to be mutated means that code relying on these values can't trust them. Any code wanting to work with server side setting values that could be mutated over the life of a session should be using ajax or REST API endpoints to update and get current values.

Unfortunately, since this has been in the wild for a bit, we can't just completely remove this function. Instead this pull begins with a deprecation notice (powered by `@wordpress/deprecated`) and sets the version of `3.8.0` for when the function will be complete removed. This allows for 6 versions between when this is released (3.2.0) in the feature plugin and when it will be removed. It also allows for 3 releases of WooCommerce Core before removal (where the plugin is included as a package).

As far as _known_ impacts, WooCommerce Admin _was_ using this function a while ago (2019) but has long since stopped using it so I don't anticipate any issues there (cc @psealock and @timmyc for visibility)

## To Test

There's nothing user facing for this.

- with `WP_SCRIPT_DEBUG` set to true in your `wp-config.php` file.
- load any route that has a Woo block on it powered by REST API.
- type this in the browser console: `wc.wcSettings.setSetting( 'someValue', 10 )`
* [ ] Verify that you see the following message in the console:

> setSetting is deprecated and will be removed from WooCommerce Blocks in version 3.8.0. Please use a locally scoped value instead instead. Note: wc.wcSettings is a global settings configuration object that should not be mutated during a session. Hence the removal of this function.
