### PR TITLE
update minimum required version of WordPress core to 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,13 +104,6 @@ jobs:
               - npm run lint:ci
           env:
               - WOOCOMMERCE_BLOCKS_PHASE=3
-        - name: E2E Tests (WP 5.2)
-          script:
-              - npm run test:e2e
-          env:
-              - WP_VERSION=5.2
-              - E2E_TESTS=1
-              - WOOCOMMERCE_BLOCKS_PHASE=3
         - name: E2E Tests (WP 5.3)
           script:
               - npm run test:e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,14 +118,21 @@ jobs:
               - WP_VERSION=5.4
               - E2E_TESTS=1
               - WOOCOMMERCE_BLOCKS_PHASE=3
-        - name: E2E Tests (WP 5.4 with Gutenberg plugin)
+        - name: E2E Tests (WP 5.5)
+          script:
+              - npm run test:e2e
+          env:
+              - WP_VERSION=5.5
+              - E2E_TESTS=1
+              - WOOCOMMERCE_BLOCKS_PHASE=3
+        - name: E2E Tests (WP 5.5 with Gutenberg plugin)
           script:
               - npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
               - npm install @wordpress/e2e-test-utils@latest
               - chmod -R 767 ./
               - npm run test:e2e
           env:
-              - WP_VERSION=5.4
+              - WP_VERSION=5.5
               - E2E_TESTS=1
               - GUTENBERG_LATEST=true
               - WOOCOMMERCE_BLOCKS_PHASE=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -155,14 +155,14 @@ jobs:
                   branch: main
     # @TODO: Investigate why is WP 5.4 + GB e2e test failing and don't allow it to fail.
     allow_failures:
-      - name: E2E Tests (WP 5.4 with Gutenberg plugin)
+      - name: E2E Tests (WP 5.5 with Gutenberg plugin)
         script:
           - npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
           - npm install @wordpress/e2e-test-utils@latest
           - chmod -R 767 ./
           - npm run test:e2e
         env:
-          - WP_VERSION=5.4
+          - WP_VERSION=5.5
           - E2E_TESTS=1
           - GUTENBERG_LATEST=true
           - WOOCOMMERCE_BLOCKS_PHASE=3

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ We release a new version of WooCommerce Blocks onto WordPress.org every few week
 >
 > We **recommend** you always keep WordPress and WooCommerce core up to date in order to ensure your store is running with the most recent fixes and enhancements to help your store be successful.
 
-1. Make sure you have WordPress 5.2+ and WooCommerce 4.0+
+1. Make sure you have WordPress 5.3+ and WooCommerce 4.0+
 2. The plugin version is available on WordPress.org. [Download the plugin version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
 3. Activate the plugin.
 
 ## Installing the development version
 
-1. Make sure you have WordPress 5.2+ and WooCommerce 4.0+
+1. Make sure you have WordPress 5.3+ and WooCommerce 4.0+
 2. Get a copy of this plugin using the green "Clone or download" button on the right.
 3. `npm install` to install the dependencies.
 4. `composer install` to install core dependencies.

--- a/docs/releases/handling-releases.md
+++ b/docs/releases/handling-releases.md
@@ -199,6 +199,23 @@ Use previous posts for inspiration. If the release contains new features, or API
 
 _Outcome:_ __There's a public release announcement, with clear info about what's new, roughly within a day of actual release.__
 
+#### Update user-facing documentation as needed
+
+When the plugin is released, ensure user-facing documentation is kept up to date with new blocks and compatibility information. The dev team should update documents in collaboration with support team and WooCommerce docs guild.
+
+In particular, please review and update as needed:
+
+- Are there any new blocks in this release? Ensure they have adequate user documentation.
+- Ensure any major improvements or changes are documented.
+- Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including: 
+  - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
+  - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)
+
+Documentation should be updated as part of regular development, but this item is here as a reminder :)
+
+_Outcome:_ __All user documentation and requirements info is up to date with this release.__
+
+
 ## Appendix: Versions
 
 We have _major_, _minor_ and _patch_ releases.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Blocks ===
 Contributors: automattic, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia, aljullu, mikejolley, nerrad, joshuawold, assassinateur, haszari
 Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
-Requires at least: 5.2
+Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 5.6
 Stable tag: 3.2.0-dev
@@ -44,7 +44,7 @@ Use this plugin if you want access to the bleeding edge of available blocks for 
 
 = Minimum Requirements =
 
-* WordPress 5.2 or greater
+* WordPress 5.3 or greater
 * WooCommerce 4.0 or greater
 * PHP version 5.6 or greater (PHP 7.2 or greater is recommended)
 * MySQL version 5.0 or greater (MySQL 5.6 or greater is recommended)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,6 +72,10 @@ const StylingConfig = {
 /**
  * Legacy Configs are for builds targeting < WP5.3 and handle backwards compatibility and disabling
  * unsupported features.
+ *
+ * Now that WordPress 5.5 is released, as of WooCommerce Blocks 3.2.0 we don't support WP <5.3,
+ * so these legacy builds are not used. Keeping the config so we can conveniently reinstate
+ * these builds as needed (hence eslint-disable).
  */
 const LegacyMainConfig = {
 	...sharedConfig,
@@ -135,13 +139,22 @@ const LegacyStylingConfig = {
 	} ),
 };
 
+/**
+ * Now that WordPress 5.5 is released, as of WooCommerce Blocks 3.2.0 we don't support WP <5.3,
+ * so the legacy builds are not used. Keeping the config so we can conveniently reinstate
+ * these builds as needed (hence eslint-disable).
+ */
+// eslint-disable-next-line no-unused-vars
+const legacyConfigs = [
+	LegacyMainConfig,
+	LegacyFrontendConfig,
+	LegacyStylingConfig,
+];
+
 module.exports = [
 	CoreConfig,
 	MainConfig,
 	FrontendConfig,
 	PaymentsConfig,
 	StylingConfig,
-	LegacyMainConfig,
-	LegacyFrontendConfig,
-	LegacyStylingConfig,
 ];

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * Requires at least: 5.2
+ * Requires at least: 5.3
  * Requires PHP: 5.6
  * WC requires at least: 4.0
  * WC tested up to: 4.4
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$minimum_wp_version = '5.2';
+$minimum_wp_version = '5.3';
 
 if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
 	define( 'WC_BLOCKS_IS_FEATURE_PLUGIN', true );


### PR DESCRIPTION
Fixes #2995

With our L-2 policy for minimum WordPress version, with WooCommerce Blocks 3.2.0 our new min WP is 5.3 (up from 5.2).

This PR updates this everywhere needed (see diff for details).

Also, the "legacy" webpack builds are all disabled - these are only needed for WordPress 5.2 and earlier. The config is still available, just not enabled. (If we need to reinstate these builds we can.)

The release process doc has also been updated, with a new step for checking/updating user-facing docs. The main reason for this is to update the minimum requirements mentioned on WCCOM / docs site when these change. Also it's a handy reminder to ensure we have nice docs for new features!

### How to test the changes in this Pull Request:

1. Run release build `npm run build` and smoke test to ensure things are all working correctly.
2. Test dev build and ensure there are no problems.
3. Review the diff/codebase and ensure that WP version has been updated everywhere it should be!

### Changelog

> WooCommerce Blocks now requires WordPress 5.3 or greater (recommend latest).
