### PR TITLE
use TextControl instead of PlainText

### DIFF
--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -4,8 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { InspectorControls, PlainText } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 
 /**
@@ -66,7 +66,7 @@ const Edit = ( {
 			</InspectorControls>
 			<div className={ classes }>
 				{ !! hasLabel && (
-					<PlainText
+					<TextControl
 						className="wc-block-product-search__label"
 						value={ label }
 						onChange={ ( value ) =>
@@ -75,7 +75,7 @@ const Edit = ( {
 					/>
 				) }
 				<div className="wc-block-product-search__fields">
-					<PlainText
+					<TextControl
 						className="wc-block-product-search__field input-control"
 						value={ placeholder }
 						onChange={ ( value ) =>

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, PlainText } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 
@@ -66,7 +66,7 @@ const Edit = ( {
 			</InspectorControls>
 			<div className={ classes }>
 				{ !! hasLabel && (
-					<TextControl
+					<PlainText
 						className="wc-block-product-search__label"
 						value={ label }
 						onChange={ ( value ) =>

--- a/tests/e2e-tests/specs/backend/product-search.test.js
+++ b/tests/e2e-tests/specs/backend/product-search.test.js
@@ -45,21 +45,21 @@ describe( `${ block.name } Block`, () => {
 
 	it( 'can change field labels in editor', async () => {
 		await expect( page ).toFill(
-			'textarea.wc-block-product-search__label',
+			'.wc-block-product-search__label input',
 			'I am a new label'
 		);
 
 		await expect( page ).toFill(
-			'textarea.wc-block-product-search__field',
+			'.wc-block-product-search__field input',
 			'I am a new placeholder'
 		);
 
 		await clearAndFillInput(
-			'textarea.wc-block-product-search__label',
+			'.wc-block-product-search__label input',
 			'The Label'
 		);
 		await clearAndFillInput(
-			'textarea.wc-block-product-search__field',
+			'.wc-block-product-search__field input',
 			'The Placeholder'
 		);
 

--- a/tests/e2e-tests/specs/backend/product-search.test.js
+++ b/tests/e2e-tests/specs/backend/product-search.test.js
@@ -45,7 +45,7 @@ describe( `${ block.name } Block`, () => {
 
 	it( 'can change field labels in editor', async () => {
 		await expect( page ).toFill(
-			'.wc-block-product-search__label input',
+			'textarea.wc-block-product-search__label',
 			'I am a new label'
 		);
 
@@ -55,7 +55,7 @@ describe( `${ block.name } Block`, () => {
 		);
 
 		await clearAndFillInput(
-			'.wc-block-product-search__label input',
+			'textarea.wc-block-product-search__label',
 			'The Label'
 		);
 		await clearAndFillInput(


### PR DESCRIPTION
Fixes #2947

In Recent versions of GB, the textarea design changed to a borderless area, this caused a change in our block, however, we shouldn't be using a textarea anyway, a text input should be enough, I couldn't find anything in the original PR (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/697) that references why `PlainText` was used.


### Screenshots

![image](https://user-images.githubusercontent.com/6165348/90402293-272a7980-e097-11ea-9e7a-65add033989f.png)
![image](https://user-images.githubusercontent.com/6165348/90402357-3d383a00-e097-11ea-8309-dc91b29904ab.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Insert Product Search block, make sure nothing is broken on the editor.
2. Make sure you can write and replace the text in both inputs of Product Search.
3. Make sure you can toggle the label input off and on.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fixes a styling issue in the Product Search block in the editor.
