### PR TITLE
remove suspense polyfill

### DIFF
--- a/assets/js/base/utils/render-frontend.js
+++ b/assets/js/base/utils/render-frontend.js
@@ -43,13 +43,6 @@ const renderBlockInContainers = ( {
 		return;
 	}
 
-	// @todo Remove Suspense compatibility fix once WP 5.2 is no longer supported.
-	// If Suspense is not available (WP 5.2), use a noop component instead.
-	const noopComponent = ( { children } ) => {
-		return <>{ children }</>;
-	};
-	const SuspenseComponent = Suspense || noopComponent;
-
 	// Use Array.forEach for IE11 compatibility.
 	Array.prototype.forEach.call( containers, ( el, i ) => {
 		const props = getProps( el, i );
@@ -62,11 +55,9 @@ const renderBlockInContainers = ( {
 
 		render(
 			<BlockErrorBoundary { ...errorBoundaryProps }>
-				<SuspenseComponent
-					fallback={ <div className="wc-block-placeholder" /> }
-				>
+				<Suspense fallback={ <div className="wc-block-placeholder" /> }>
 					<Block { ...props } attributes={ attributes } />
-				</SuspenseComponent>
+				</Suspense>
 			</BlockErrorBoundary>,
 			el
 		);


### PR DESCRIPTION
Fixes #2942

Now that we support 5.3 and up, we don't need this polyfill anymore.

### How to test the changes in this Pull Request:
This shouldn't affect anything
1. Smoke test several JS-rendred blocks, like Cart, both in normal and empty state, Checkout, All Products, and some filters.

<!-- If you can, add the appropriate labels -->


