### PR TITLE
Release 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ before_script:
           composer install --no-dev
           npm ci
           if [[ ! -z "$GUTENBERG_LATEST" ]]; then
-            JSON='{"config": { "SCRIPT_DEBUG": false } }'
+            JSON='{"config": { "SCRIPT_DEBUG": false, "JETPACK_AUTOLOAD_DEV": true } }'
           else
-            JSON='{"core": "WordPress/WordPress#'"$WP_VERSION"'", "config": { "SCRIPT_DEBUG": false } }'
+            JSON='{"core": "WordPress/WordPress#'"$WP_VERSION"'", "config": { "SCRIPT_DEBUG": false, "JETPACK_AUTOLOAD_DEV": true } }'
           fi
           echo $JSON > .wp-env.override.json
           npm run build:e2e-test

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"plugins": [
-		"https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip",
+		"https://downloads.wordpress.org/plugin/woocommerce.4.3.3.zip",
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"."
 	],

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"plugins": [
-		"https://downloads.wordpress.org/plugin/woocommerce.4.3.3.zip",
+		"https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip",
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",
 		"."
 	],

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://woocommerce.com/",
 	"type":"wordpress-plugin",
-	"version": "3.2",
 	"keywords": [
 		"gutenberg",
 		"woocommerce",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
 	"name": "woocommerce/woocommerce-blocks",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://woocommerce.com/",
-	"type": "wordpress-plugin",
+	"type":"wordpress-plugin",
+	"version": "3.2",
 	"keywords": [
 		"gutenberg",
 		"woocommerce",

--- a/docs/testing/releases/320.md
+++ b/docs/testing/releases/320.md
@@ -1,0 +1,105 @@
+## Testing notes and ZIP for release 3.2.0
+
+Zip file: [woocommerce-gutenberg-products-block.zip]()
+
+### Cart & Checkout   <!-- heading -->
+
+#### Order note   <!-- heading -->
+
+- [ ] Go to the Checkout block and check the 'Add a note to your order' checkbox.
+- [ ] Introduce some text in the text area that appeared.
+- [ ] Place the order and go to the admin, WooCommerce > Orders and verify the order has the note under Customer provided note.
+
+#### Autocapitalize address form fields   <!-- heading -->
+
+- [ ] Visit the Checkout page with a handheld device with Chrome for Android or iOS Safari.
+- [ ] Navigate through the input fields in the address form.
+- [ ] Verify when a field is focused, the keyboard shows capital letters by default according to the settings.
+
+#### JS-Rendered blocks inside Empty Cart   <!-- heading -->
+
+- [ ] Add the Cart block and switch to the Empty Cart edit mode.
+- [ ] Replace the Newest products block with the All Products block. Feel free to add other JS-rendered blocks like a filter or a Reviews block.
+- [ ] View the page in the frontend.
+- [ ] Verify all blocks render correctly when the cart is empty.
+- [ ] Try adding a product to the cart (so it switches to the Full Cart view) and removing it (so it switches back to the Empty Cart view).
+- [ ] Verify the blocks still render correctly.
+
+#### Don't show sale badge if saving are negative   <!-- heading -->
+
+You will need Product Add-ons extension to test this.   <!-- heading -->
+
+- [ ] Add a product with a priced add on.
+- [ ] Add the product to your cart, with the add on enabled.
+- [ ] See that the price is shown without a negative discount value.
+
+#### Respect payment gateways order set by merchant   <!-- heading -->
+
+- [ ] Set up a few different payment methods.
+- [ ] Reorder your payment methods how you like in WooCommerce > Settings > Payments, then click Save changes to persist.
+- [ ] On front end, add stuff to cart and proceed to checkout.
+- [ ] Payment methods should display using the order you chose.
+- [ ] Complete a few test purchases to confirm that payment methods are still working and there are no regressions in checkout.
+- [ ] Also test payment methods that may be hidden based on checkout state, e.g. make COD only available with specific shipping methods.
+
+#### Show Checkout block in Editor when 'guest checkout' is disabled   <!-- heading -->
+
+- [ ] Go to WooCommerce > Settings > Accounts & Privacy and uncheck Allow customers to place orders without an account.
+- [ ] Edit a page with the Checkout block.
+- [ ] Verify the whole Checkout block is rendered in the editor, instead of only showing the `You must be logged in to checkout. Click here to log in`. message.
+
+#### Remove generic payment methods icons   <!-- heading -->
+
+- [ ] Set up Stripe CC (Stripe extension) and Cheque (core) payment methods.
+- [ ] Set up a page with checkout block, add stuff to cart.
+- [ ] View checkout and confirm payment method tabs render and function correctly without icons.
+
+#### Error focus styles for inputs and select   <!-- heading -->
+
+- [ ] Go to the Checkout block and press 'Place order` without filling any form detail.
+- [ ] Tab through the input fields under 'Shipping address' and verify the outline that appears on focus is red in text inputs and selects.
+- [ ] Repeat the steps above at least with Storefront and Twenty Twenty and with Firefox, Chrome and Safari.
+
+#### Hide saved payment methods if their gateway is disabled   <!-- heading -->
+
+- [ ] Set up checkout block, Stripe CC payment method, check Enable Payment via Saved Cards.
+- [ ] Complete a purchase with Stripe test card and check the `Save payment information to my account for future purchases.` checkbox on checkout.
+- [ ] Go to WooCommerce > Settings > Payments and disable Stripe CC payment method.
+- [ ] Add new stuff to cart, proceed to checkout.
+- [ ] Scroll down and verify saved card (e.g. Visa ending in 4242 (expires 02/22)) is not there.
+
+#### Text overlap with errors and icons   <!-- heading -->
+
+- [ ] activate and set up Stripe CC, disable Inline Credit Card Form option.
+- [ ] Add stuff to cart and proceed to checkout.
+- [ ] Select stripe credit card payment, don't enter any card details.
+- [ ] Click Place Order.
+- [ ] Error messages shouldn't overlap with credit card icons.
+
+#### Dark mode support for fields and controls   <!-- heading -->
+
+- [ ] Test inputs, select, radio, checkbox, quantity selectors, and textarea of Cart and Checkout, they should have light colors and text should be readable.
+- [ ] Switch the colors of your theme to a dark variation, you can do that in the customizer for storefront or dark mode for TwentyTwenty or TwentySeventeen.
+- [ ] Switch the blocks to use dark colors in the blocks settings.
+- [ ] Test inputs, select, radio, checkbox, quantity selectors, and textarea again, make sure nothing is broken and everything is visible.
+
+#### Use real previews for Cart and Checkout   <!-- heading -->
+
+- [ ] Preview the cart and checkout blocks inside the block inserter.
+- [ ] You should see the actual block, not a white placeholder.
+- [ ] Make sure the block is not very long and overflowing.
+- [ ] Make sure the changes didn't leak to the actual block or the editor block, the block should not be cut.
+
+### All Products   <!-- heading -->
+
+#### Broken link for "No Products" placeholder
+
+- [ ] In a store with no products (move them to trash).
+- [ ] Create a new page and add the All Products block.
+- [ ] Click on the Add new product link and verify it works.
+
+#### PHP Error notices
+
+- [ ] Make sure you have WP_DEBUG set to true.
+- [ ] Load a page that already contains a product data, so single product or All Products, either in the editor or frontend.
+- [ ] Make sure no notices are printed to the page, you can check the source code or at the top of the page.

--- a/docs/testing/releases/320.md
+++ b/docs/testing/releases/320.md
@@ -1,6 +1,9 @@
 ## Testing notes and ZIP for release 3.2.0
 
-Zip file: [woocommerce-gutenberg-products-block.zip]()
+[![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
+
+
+Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/5090607/woocommerce-gutenberg-products-block.zip)
 
 ### Cart & Checkout   <!-- heading -->
 
@@ -103,3 +106,11 @@ You will need Product Add-ons extension to test this.   <!-- heading -->
 - [ ] Make sure you have WP_DEBUG set to true.
 - [ ] Load a page that already contains a product data, so single product or All Products, either in the editor or frontend.
 - [ ] Make sure no notices are printed to the page, you can check the source code or at the top of the page.
+
+### Product Search   <!-- heading -->
+
+#### Updated styling in Editor
+
+- [ ] In the editor, confirm that Product Search input has borders.
+- [ ] the input should be functional.
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "3.2.0-dev",
+	"version": "3.2",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "3.2",
+	"version": "3.2.0",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 3.2.0-dev
+Stable tag: 3.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,25 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 3.2.0 - 2020-08-17 =
+- Fix 'Add new product' link in All Products block 'No products' placeholder. [#2961](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2961)
+- Fix an undefined variable PHP notice related to Product REST API. [#2962](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2962)
+- Fixed an issue that was making some blocks not to render correctly in the Empty cart template. [#2904](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2904)
+- Fixed an issue that was not rendering the Checkout block in editor when guest checkout was not allowed. [#2958](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2958)
+- Hide the discount badge from Cart items if the value is negative. [#2955](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2955)
+- Hide saved payment methods if their payment gateway has been disabled. [#2975](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2975)
+- Add dark colors and background for Cart & Checkout blocks inputs to support dark backgrounds. [#2981](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2981)
+- The Checkout block allows customers to introduce an order note. This feature can be disabled in the editor. [#2877](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2877)
+- Cart and Checkout form fields show autocapitalized keyboard on mobile depending on the expected value. [#2884](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2884)
+- Cart and Checkout will show a live preview inside the block inserter and style selector. [#2992](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2992)
+- Payment gateways are shown in the correct order as configured in store settings. [#2934](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2934)
+- Fix a cosmetic issue where payment form errors sometimes overlap with card icons. [#2977](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2977)
+- Fixes a styling issue in the Product Search block in the editor. [#3014](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3014)
+- Improved focus styles of error states on form elements. [#2974](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2974)
+- Removed generic icons for Check and Stripe Credit Card to reduce visual clutter in Checkout block. [#2968](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2968)
+- Deprecate wc.wcSettings.setSetting function. [#3010](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3010)
+- Improve behaviour of draft order cleanup to account for clobbered custom shop order status. [#2912](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2912)
+
 = 3.1.0 - 2020-07-29 =
 - Fix missing permissions_callback arg in StoreApi route definitions [#2926](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2926)
 - Fix 'Product Summary' in All Products block is not pulling in the short description of the product [#2913](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2913)

--- a/src/Package.php
+++ b/src/Package.php
@@ -101,7 +101,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '3.2.0-dev';
+					$version = '3.2';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ )

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 3.2.0-dev
+ * Version: 3.2
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This is the release pull request for 3.2.0 of the WooCommerce Blocks plugin.

## Communication


This release introduces several improvements to Cart and Checkout blocks, this includes:
- Dark color support for Cart and Checkout.
- More control over payment gateways order.
- Order notes, which you can enable from the block settings.
- Live previews when inserting a block.
We're also dropping support for 5.2, so update your WP version if you're still on 5.2.
Other bugs fixes and styling enhancements are also included, see the full changelog for all changes.

<!--
  This section is for any notes related to communicating the release.
  Please include any extra details with each item as needed.
-->


<!--
In this section document an overview/summary of what this release includes. You can refer to
the changelog for more information
-->

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release: 
https://woocommerce.wordpress.com/2020/08/18/woocommerce-blocks-3-2-release-notes/

Changelog:
- Fix 'Add new product' link in All Products block 'No products' placeholder. [#2961](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2961)
- Fix an undefined variable PHP notice related to Product REST API. [#2962](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2962)
- Fixed an issue that was making some blocks not to render correctly in the Empty cart template. [#2904](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2904)
- Fixed an issue that was not rendering the Checkout block in editor when guest checkout was not allowed. [#2958](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2958)
- Hide the discount badge from Cart items if the value is negative. [#2955](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2955)
- Hide saved payment methods if their payment gateway has been disabled. [#2975](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2975)
- Add dark colors and background for Cart & Checkout blocks inputs to support dark backgrounds. [#2981](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2981)
- The Checkout block allows customers to introduce an order note. This feature can be disabled in the editor. [#2877](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2877)
- Cart and Checkout form fields show autocapitalized keyboard on mobile depending on the expected value. [#2884](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2884)
- Cart and Checkout will show a live preview inside the block inserter and style selector. [#2992](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2992)
- Payment gateways are shown in the correct order as configured in store settings. [#2934](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2934)
- Fix a cosmetic issue where payment form errors sometimes overlap with card icons. [#2977](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2977)
- Fixes a styling issue in the Product Search block in the editor. [#3014](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3014)
- Improved focus styles of error states on form elements. [#2974](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2974)
- Removed generic icons for Check and Stripe Credit Card to reduce visual clutter in Checkout block. [#2968](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2968)
- Deprecate wc.wcSettings.setSetting function. [#3010](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3010)
- Improve behaviour of draft order cleanup to account for clobbered custom shop order status. [#2912](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2912)

<!--
In this section you are highlighting all the public facing documentation that is related to the
release. Feel free to remove anything that doesn't apply for this release.
-->

**Release announcement:** <!-- Link to release announcement post on developer.woocommerce.com (published after release) -->

**Developer Notes** - The following issues require developer notes in the release post:
- wc.wcSettings.setSetting is deprecated and will be removed from WooCommerce Blocks in version 3.8.0. Please use a locally scoped value instead instead. wc.wcSettings is a global settings configuration object that should not be mutated during a session. Hence the removal of this function. #3010 

- This release drops support for WP 5.2.
<!--
Issues or pulls needing a developer note are labelled with `status: needs-dev-note`. Review
those and list here as checklist items. You can have different engineers write the notes
(usually the engineer that did the changes) if needed, but they should be summarized and included in the release post.
-->


* [x] The release includes a changelog entry in the readme.txt?


## Quality

<!--
  This section is for any notes related to quality around the release.
  Please include any extra details with each item as needed. This can include notes about
  Why something isn't checked or expanding info on your response to an item.
-->

* [ ] Changes in this release are covered by Automated Tests.
     <!--
      This section is for confirming that the release changeset is covered by automated tests. If not,
      please leave some details on why not and any relevant information indicating confidence without
      those tests.
      -->
     * [ ] Unit tests
     * [ ] E2E tests
     * [x] for each supported WordPress and WooCommerce core versions.

* This release has been tested on the following platforms:
     * [ ] mobile
     * [x] desktop

* [x] This release affects public facing REST APIs.
    * [x] It conforms to REST API versioning policy.

* [ ] This release impacts **other extensions** or **backward compatibility**.
    * [ ] The release changes the signature of public methods or functions
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)
    * [ ] The release affects filters or action hooks.
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)

* [x] Link to **testing instructions** for this release: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/74c2ae9525cc62cd8b07cc4f6e701e3ada6de51e/docs/testing/releases/320.md

* [ ] The release has a negative performance impact on sites.
    * [ ] There are new assets (JavaScript or CSS bundles)
    * [ ] There is an increase to the size of JavaScrip or CSS bundles) <!-- please include rationale for this increase -->
    * [ ] Other negative performance impacts (if yes, include list below)

* [x] The release has positive performance impact on sites. If checked, please document these improvements here.

- Legacy blocks are not included anymore, moving users to lighter versions of the same blocks.
