### PR TITLE
load `@woocommerce/components` from global, remove package dependency

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -1,6 +1,3 @@
-// Import the woocommerce components stylesheet
-@import "~@woocommerce/components/build-style/style.css";
-
 // Hack to hide preview overflow.
 .editor-block-preview__content {
 	overflow: hidden;

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -8,6 +8,7 @@ const FORCE_MAP = process.env.FORCE_MAP || false;
 
 const wcDepMap = {
 	'@woocommerce/blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
+	'@woocommerce/components': [ 'wc', 'components' ],
 	'@woocommerce/settings': [ 'wc', 'wcSettings' ],
 	'@woocommerce/block-data': [ 'wc', 'wcBlocksData' ],
 	'@woocommerce/shared-context': [ 'wc', 'wcSharedContext' ],
@@ -16,6 +17,7 @@ const wcDepMap = {
 
 const wcHandleMap = {
 	'@woocommerce/blocks-registry': 'wc-blocks-registry',
+	'@woocommerce/components': 'wc-components',
 	'@woocommerce/settings': 'wc-settings',
 	'@woocommerce/block-settings': 'wc-settings',
 	'@woocommerce/block-data': 'wc-blocks-data-store',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1427,15 +1427,6 @@
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
-		"@babel/runtime-corejs2": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-			"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.2"
-			}
-		},
 		"@babel/runtime-corejs3": {
 			"version": "7.11.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
@@ -5432,252 +5423,6 @@
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"@woocommerce/components": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/components/-/components-4.0.0.tgz",
-			"integrity": "sha512-eM0jqyBED4/qGZ7afkAtgqGGEp3z4cCpNrn+qGsdqng2CVq3AIydPh0pUskkElkACHJEMhRh09p6CFqwBJzyDw==",
-			"requires": {
-				"@babel/runtime-corejs2": "7.7.4",
-				"@woocommerce/csv-export": "1.2.0",
-				"@woocommerce/currency": "2.0.0",
-				"@woocommerce/date": "2.0.0",
-				"@woocommerce/navigation": "4.0.0",
-				"@wordpress/components": "8.4.0",
-				"@wordpress/compose": "3.7.1",
-				"@wordpress/date": "3.5.0",
-				"@wordpress/element": "2.8.1",
-				"@wordpress/html-entities": "2.5.0",
-				"@wordpress/i18n": "3.6.1",
-				"@wordpress/keycodes": "2.6.1",
-				"@wordpress/viewport": "2.8.1",
-				"classnames": "2.2.6",
-				"core-js": "2.6.10",
-				"d3-axis": "^1.0.12",
-				"d3-format": "^1.3.2",
-				"d3-scale": "^2.1.2",
-				"d3-scale-chromatic": "^1.3.3",
-				"d3-selection": "^1.3.2",
-				"d3-shape": "^1.2.2",
-				"d3-time-format": "^2.1.3",
-				"emoji-flags": "^1.2.0",
-				"gridicons": "3.3.1",
-				"interpolate-components": "1.1.1",
-				"lodash": "4.17.15",
-				"memoize-one": "5.1.1",
-				"moment": "2.22.1",
-				"prop-types": "15.7.2",
-				"qs": "6.9.1",
-				"react-dates": "17.2.0",
-				"react-router-dom": "5.1.2",
-				"react-transition-group": "2.9.0"
-			},
-			"dependencies": {
-				"@wordpress/components": {
-					"version": "8.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.4.0.tgz",
-					"integrity": "sha512-Fr2L8b8RxUC6hPiN2pMVKGaeB25RA+g4ENpA32LzmuEGd0ITBXtZfFUv3+5FMcUe4y9KFQZbXxBRElBf4xA+SQ==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.5.1",
-						"@wordpress/compose": "^3.8.0",
-						"@wordpress/deprecated": "^2.6.1",
-						"@wordpress/dom": "^2.6.0",
-						"@wordpress/element": "^2.9.0",
-						"@wordpress/hooks": "^2.6.0",
-						"@wordpress/i18n": "^3.7.0",
-						"@wordpress/is-shallow-equal": "^1.6.1",
-						"@wordpress/keycodes": "^2.7.0",
-						"@wordpress/rich-text": "^3.8.0",
-						"classnames": "^2.2.5",
-						"clipboard": "^2.0.1",
-						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"moment": "^2.22.1",
-						"mousetrap": "^1.6.2",
-						"re-resizable": "^6.0.0",
-						"react-dates": "^17.1.1",
-						"react-spring": "^8.0.20",
-						"rememo": "^3.0.0",
-						"tinycolor2": "^1.4.1",
-						"uuid": "^3.3.2"
-					},
-					"dependencies": {
-						"@wordpress/compose": {
-							"version": "3.19.3",
-							"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.19.3.tgz",
-							"integrity": "sha512-r00b7+tMn5+k5gdIjKi+tjAvcPBpNel9BPJrDQMZI4cc97BrOGHoTr2ZEiZ1yDB4FlV7vwQxPuc8ToS48DuTPA==",
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"@wordpress/element": "^2.16.0",
-								"@wordpress/is-shallow-equal": "^2.1.0",
-								"@wordpress/priority-queue": "^1.7.0",
-								"clipboard": "^2.0.1",
-								"lodash": "^4.17.15",
-								"mousetrap": "^1.6.5",
-								"react-resize-aware": "^3.0.1"
-							},
-							"dependencies": {
-								"@wordpress/is-shallow-equal": {
-									"version": "2.1.0",
-									"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.1.0.tgz",
-									"integrity": "sha512-xCphAZG60mnLhn+LitwfoercNxsPMvc0Yo96kBY7HAZgrPt+jNQ5Rv4M+FTlVnyLrkyxVxNdtGyuyR+Hpgi8Pg==",
-									"requires": {
-										"@babel/runtime": "^7.9.2"
-									}
-								}
-							}
-						},
-						"@wordpress/element": {
-							"version": "2.16.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.16.0.tgz",
-							"integrity": "sha512-1ijo/GR/uBfL4teCQ3oFdUTqkeV2EZ32SCvXl30iPbqYmaNSzT1ZI1dlW8GO5o5UBja9BG11hnaOwm93pE2y2A==",
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"@wordpress/escape-html": "^1.9.0",
-								"lodash": "^4.17.15",
-								"react": "^16.9.0",
-								"react-dom": "^16.9.0"
-							}
-						},
-						"@wordpress/i18n": {
-							"version": "3.14.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.14.0.tgz",
-							"integrity": "sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==",
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"gettext-parser": "^1.3.1",
-								"lodash": "^4.17.15",
-								"memize": "^1.1.0",
-								"sprintf-js": "^1.1.1",
-								"tannin": "^1.2.0"
-							}
-						},
-						"@wordpress/keycodes": {
-							"version": "2.14.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.14.0.tgz",
-							"integrity": "sha512-R/0orMutajuQ1d1kFFIvksXKR5C5TtszEkbnxSfdNlKaOW7p9Srv8+8m2QqM+AKNvEGMaq6cn7BfDtTbZ33Dbw==",
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"@wordpress/i18n": "^3.14.0",
-								"lodash": "^4.17.15"
-							}
-						}
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.8.1.tgz",
-					"integrity": "sha512-iKdeuf0aSKVO1PxjCCmCUBYk531Iesh6E2ayWsWjj/JNRAcVuAOGiAIxCxU7pE127upjSLmkRh+dXNZ244IWQw==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.5.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.6.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.1.tgz",
-					"integrity": "sha512-hrmhW53XZ5VAK9+DQjjTHoshnZHWGpj7w4q7jl7KMhONgzRtSdDaHtgNLHuwCZPAJzTFJbExU6b02lyrRogXzg==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
-			}
-		},
-		"@woocommerce/csv-export": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/csv-export/-/csv-export-1.2.0.tgz",
-			"integrity": "sha512-86kNC0C79YnaRv35zCo134p9mAXFz9y6JExcXCVLPgwvDqj9BOr8aWvgWuRBO7uOIdhFbOuK4rd4i/WNpPjPyw==",
-			"requires": {
-				"@babel/runtime-corejs2": "7.7.4",
-				"browser-filesaver": "1.1.1",
-				"moment": "2.22.2"
-			},
-			"dependencies": {
-				"moment": {
-					"version": "2.22.2",
-					"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-					"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
-				}
-			}
-		},
-		"@woocommerce/currency": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/currency/-/currency-2.0.0.tgz",
-			"integrity": "sha512-zoQbVBZTlgqT5uGTrEHhqQ5iUFZHuYZDyf/+nit3v2a9vUzZAQm1zuqRgu1cd8LbaAQgNHumEUArvXFzacsyVQ==",
-			"requires": {
-				"@babel/runtime-corejs2": "7.7.4",
-				"@woocommerce/number": "2.0.0"
-			}
-		},
-		"@woocommerce/date": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-2.0.0.tgz",
-			"integrity": "sha512-2urIGUXL+lywLBSBXUi4l0CKk3s3BHr8RAe8acsK1FCFV12HujuwT+TcIHcED0MI2w0DY9dg2mQ0/40ektj70A==",
-			"requires": {
-				"@babel/runtime-corejs2": "7.7.4",
-				"@wordpress/date": "3.5.0",
-				"@wordpress/i18n": "3.6.1",
-				"lodash": "4.17.15",
-				"moment": "2.22.2"
-			},
-			"dependencies": {
-				"@wordpress/i18n": {
-					"version": "3.6.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.1.tgz",
-					"integrity": "sha512-hrmhW53XZ5VAK9+DQjjTHoshnZHWGpj7w4q7jl7KMhONgzRtSdDaHtgNLHuwCZPAJzTFJbExU6b02lyrRogXzg==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.1.0"
-					}
-				},
-				"moment": {
-					"version": "2.22.2",
-					"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-					"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
-				}
-			}
-		},
-		"@woocommerce/navigation": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/navigation/-/navigation-4.0.0.tgz",
-			"integrity": "sha512-dwDyr54eKSa38bAP18ZEgs2POJI2NypIGGHXG7S5gjVwFYOi9t9zR4voso4CK/onH5Yc3Ql4Yi2tJqZq9issoA==",
-			"requires": {
-				"@babel/runtime-corejs2": "7.7.4",
-				"history": "4.10.1",
-				"lodash": "4.17.15",
-				"qs": "6.9.1"
-			}
-		},
-		"@woocommerce/number": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@woocommerce/number/-/number-2.0.0.tgz",
-			"integrity": "sha512-/YFkF0wwYmF0M58wPVrTtFopVwqdsmMAcrgQGnUFIj3JwXQumKR1co99DhDkjJm9vDMYXFTniwKqwvhBxdviSw==",
-			"requires": {
-				"@babel/runtime-corejs2": "7.7.4",
-				"locutus": "2.0.11"
-			}
-		},
 		"@woocommerce/woocommerce-rest-api": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@woocommerce/woocommerce-rest-api/-/woocommerce-rest-api-1.0.1.tgz",
@@ -7013,39 +6758,6 @@
 				}
 			}
 		},
-		"@wordpress/compose": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.7.1.tgz",
-			"integrity": "sha512-OFcPu/EYL9/LqO2fq9Frxmx2cVmQly8XqzOUq525ytGb4fadBUkNJepdGMo+V7+13zV8FzZpX1f8AfidBig3MQ==",
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/element": "^2.8.1",
-				"@wordpress/is-shallow-equal": "^1.6.0",
-				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.16.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.16.0.tgz",
-					"integrity": "sha512-1ijo/GR/uBfL4teCQ3oFdUTqkeV2EZ32SCvXl30iPbqYmaNSzT1ZI1dlW8GO5o5UBja9BG11hnaOwm93pE2y2A==",
-					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"@wordpress/escape-html": "^1.9.0",
-						"lodash": "^4.17.15",
-						"react": "^16.9.0",
-						"react-dom": "^16.9.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.8.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
-					"requires": {
-						"@babel/runtime": "^7.8.3"
-					}
-				}
-			}
-		},
 		"@wordpress/core-data": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.20.3.tgz",
@@ -7269,16 +6981,6 @@
 			"requires": {
 				"@wordpress/api-fetch": "^3.9.0",
 				"@wordpress/data": "^4.12.0"
-			}
-		},
-		"@wordpress/date": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.5.0.tgz",
-			"integrity": "sha512-eg3/o7Z0SgeXtPhJxMuxSQUk9Lx0GGgQptpnparsFzgW69KgibLmGuDqepEhfClhKLeIR3kDVf/m1HRPSosbRA==",
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"moment": "^2.22.1",
-				"moment-timezone": "^0.5.16"
 			}
 		},
 		"@wordpress/dependency-extraction-webpack-plugin": {
@@ -8102,6 +7804,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
 			"integrity": "sha512-7TKaJKkOX2Tas0OyXNPz1kA2my1Z804weBf2RsPLiNXm593JDsf6Em8z1TA4mXtn7FO2ZAKTj/3yRemKK4PhnA==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
@@ -8410,31 +8113,6 @@
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/i18n": "^3.14.0",
 						"lodash": "^4.17.15"
-					}
-				}
-			}
-		},
-		"@wordpress/keycodes": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.6.1.tgz",
-			"integrity": "sha512-xsQKiknpybwNsJkfIj8JyORhvRqDNagQm5dCKs5CZ5AvmOqS43Qghn8DLccBQPpnSevlDyb9ZwuyA+VCOBBzdQ==",
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/i18n": "^3.6.1",
-				"lodash": "^4.17.15"
-			},
-			"dependencies": {
-				"@wordpress/i18n": {
-					"version": "3.14.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.14.0.tgz",
-					"integrity": "sha512-FQbSggdvkdS+IWMNhTl3n1nThqfzAPxORvoFpjDma7DOwuRKOA8iPyomwacfeG/krAeaurj1DIDzDvZh9Ex79w==",
-					"requires": {
-						"@babel/runtime": "^7.9.2",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.15",
-						"memize": "^1.1.0",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.2.0"
 					}
 				}
 			}
@@ -9801,17 +9479,6 @@
 				"react-native-url-polyfill": "^1.1.2"
 			}
 		},
-		"@wordpress/viewport": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.8.1.tgz",
-			"integrity": "sha512-2e+tkxc/UIYfEP5JxkRmIubWpEfOqnXorb9xSIyfq+ZRQsLm7Zy7CwHHk/C48dE7u3iXdncdmw4MMt0sm3SbAg==",
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.7.1",
-				"@wordpress/data": "^4.9.1",
-				"lodash": "^4.17.15"
-			}
-		},
 		"@wordpress/warning": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-1.2.0.tgz",
@@ -10060,11 +9727,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
 			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
 			"dev": true
-		},
-		"ansi-regex": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-			"integrity": "sha1-QchHGUZGN15qGl0Qw8oFTvn8mA0="
 		},
 		"ansi-styles": {
 			"version": "4.2.1",
@@ -11812,11 +11474,6 @@
 			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
 			"dev": true
 		},
-		"browser-filesaver": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/browser-filesaver/-/browser-filesaver-1.1.1.tgz",
-			"integrity": "sha1-HDUbL1dvWwDx0p1EIcTAQo7uX6E="
-		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
@@ -12816,7 +12473,8 @@
 		"clone": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+			"dev": true
 		},
 		"clone-deep": {
 			"version": "0.2.4",
@@ -13027,15 +12685,6 @@
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
 			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
 			"dev": true
-		},
-		"columnify": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.1.tgz",
-			"integrity": "sha1-Ff3agDo4dfh/nTArO8goky1mQAM=",
-			"requires": {
-				"strip-ansi": "^2.0.1",
-				"wcwidth": "^1.0.0"
-			}
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -13318,7 +12967,8 @@
 		"core-js": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+			"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
+			"dev": true
 		},
 		"core-js-compat": {
 			"version": "3.6.5",
@@ -13929,92 +13579,6 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
-		"d3-array": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-			"integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
-		},
-		"d3-axis": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz",
-			"integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
-		},
-		"d3-collection": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-			"integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
-		},
-		"d3-color": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-			"integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
-		},
-		"d3-format": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.4.tgz",
-			"integrity": "sha512-TWks25e7t8/cqctxCmxpUuzZN11QxIA7YrMbram94zMQ0PXjE4LVIMe/f6a4+xxL8HQ3OsAFULOINQi1pE62Aw=="
-		},
-		"d3-interpolate": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-			"integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-			"requires": {
-				"d3-color": "1"
-			}
-		},
-		"d3-path": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
-		},
-		"d3-scale": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-2.2.2.tgz",
-			"integrity": "sha512-LbeEvGgIb8UMcAa0EATLNX0lelKWGYDQiPdHj+gLblGVhGLyNbaCn3EvrJf0A3Y/uOOU5aD6MTh5ZFCdEwGiCw==",
-			"requires": {
-				"d3-array": "^1.2.0",
-				"d3-collection": "1",
-				"d3-format": "1",
-				"d3-interpolate": "1",
-				"d3-time": "1",
-				"d3-time-format": "2"
-			}
-		},
-		"d3-scale-chromatic": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-1.5.0.tgz",
-			"integrity": "sha512-ACcL46DYImpRFMBcpk9HhtIyC7bTBR4fNOPxwVSl0LfulDAwyiHyPOTqcDG1+t5d4P9W7t/2NAuWu59aKko/cg==",
-			"requires": {
-				"d3-color": "1",
-				"d3-interpolate": "1"
-			}
-		},
-		"d3-selection": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
-			"integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
-		},
-		"d3-shape": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-			"requires": {
-				"d3-path": "1"
-			}
-		},
-		"d3-time": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-			"integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
-		},
-		"d3-time-format": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.2.3.tgz",
-			"integrity": "sha512-RAHNnD8+XvC4Zc4d2A56Uw0yJoM7bsvOlJR33bclxq399Rak/b9bhvu/InjxdWhPtkgU53JJcleJTGkNRnN6IA==",
-			"requires": {
-				"d3-time": "1"
-			}
-		},
 		"damerau-levenshtein": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
@@ -14185,6 +13749,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+			"dev": true,
 			"requires": {
 				"clone": "^1.0.2"
 			}
@@ -14533,14 +14098,6 @@
 				"utila": "~0.4"
 			}
 		},
-		"dom-helpers": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-			"integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-			"requires": {
-				"@babel/runtime": "^7.1.2"
-			}
-		},
 		"dom-scroll-into-view": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
@@ -14801,15 +14358,6 @@
 					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
 					"dev": true
 				}
-			}
-		},
-		"emoji-flags": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/emoji-flags/-/emoji-flags-1.3.0.tgz",
-			"integrity": "sha512-cw6zdVlLPtFhpTurp9AM7c6+dBeCQAu0PrGpUQ9lA1XWsWW9lNEEbnAF9gtf8acb4jTSpUTOFZ1hHsBdSTQZGg==",
-			"requires": {
-				"columnify": "1.5.1",
-				"lodash.find": "3.2.1"
 			}
 		},
 		"emoji-regex": {
@@ -15112,11 +14660,6 @@
 			"resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.14.tgz",
 			"integrity": "sha512-7SwlpL+2JpymWTt8sNLuC2zdhhc+wrfe5cMPI2j0o6WsPdfAiPwmFy2f0AocPB4RQVBOZ9kNTgi5YF7TdhkvEg==",
 			"dev": true
-		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
 		},
 		"es6-shim": {
 			"version": "0.35.5",
@@ -17809,14 +17352,6 @@
 			"resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
 			"integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw="
 		},
-		"gridicons": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/gridicons/-/gridicons-3.3.1.tgz",
-			"integrity": "sha512-eQsmujjLptLtyhGuu31US3mXkcptYHkgEE/s277HWv+j6c3Z2gYyjoHcBKwSFbQwxbfhToRd5uzYimR2ExWJdQ==",
-			"requires": {
-				"prop-types": "^15.5.7"
-			}
-		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -17826,7 +17361,8 @@
 		"gud": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
+			"dev": true
 		},
 		"gzip-size": {
 			"version": "5.1.1",
@@ -18081,19 +17617,6 @@
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
 			"integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
 			"dev": true
-		},
-		"history": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-			"integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"loose-envify": "^1.2.0",
-				"resolve-pathname": "^3.0.0",
-				"tiny-invariant": "^1.0.2",
-				"tiny-warning": "^1.0.0",
-				"value-equal": "^1.0.1"
-			}
 		},
 		"hjson": {
 			"version": "1.8.4",
@@ -18784,16 +18307,6 @@
 				"side-channel": "^1.0.2"
 			}
 		},
-		"interpolate-components": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/interpolate-components/-/interpolate-components-1.1.1.tgz",
-			"integrity": "sha1-aZ//RdFSXpjHzntxWVkdmStd1t8=",
-			"requires": {
-				"react": "^0.14.3 || ^15.1.0 || ^16.0.0",
-				"react-addons-create-fragment": "^0.14.3 || ^15.1.0",
-				"react-dom": "^0.14.3 || ^15.1.0 || ^16.0.0"
-			}
-		},
 		"interpret": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
@@ -19309,7 +18822,8 @@
 		"isarray": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"dev": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -25166,67 +24680,10 @@
 				"path-exists": "^3.0.0"
 			}
 		},
-		"locutus": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
-			"integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
-			"requires": {
-				"es6-promise": "^4.2.5"
-			}
-		},
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-		},
-		"lodash._basecallback": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
-			"integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
-			"requires": {
-				"lodash._baseisequal": "^3.0.0",
-				"lodash._bindcallback": "^3.0.0",
-				"lodash.isarray": "^3.0.0",
-				"lodash.pairs": "^3.0.0"
-			}
-		},
-		"lodash._baseeach": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
-			"integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
-			"requires": {
-				"lodash.keys": "^3.0.0"
-			}
-		},
-		"lodash._basefind": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
-			"integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4="
-		},
-		"lodash._basefindindex": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
-			"integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8="
-		},
-		"lodash._baseisequal": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-			"integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
-			"requires": {
-				"lodash.isarray": "^3.0.0",
-				"lodash.istypedarray": "^3.0.0",
-				"lodash.keys": "^3.0.0"
-			}
-		},
-		"lodash._bindcallback": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-		},
-		"lodash._getnative": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
 		},
 		"lodash.assign": {
 			"version": "4.2.0",
@@ -25252,55 +24709,17 @@
 			"integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
 			"dev": true
 		},
-		"lodash.find": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
-			"integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
-			"requires": {
-				"lodash._basecallback": "^3.0.0",
-				"lodash._baseeach": "^3.0.0",
-				"lodash._basefind": "^3.0.0",
-				"lodash._basefindindex": "^3.0.0",
-				"lodash.isarray": "^3.0.0",
-				"lodash.keys": "^3.0.0"
-			}
-		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
-		"lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-		},
 		"lodash.isequal": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
 			"dev": true
-		},
-		"lodash.istypedarray": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
-			"integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
-		},
-		"lodash.keys": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"requires": {
-				"lodash._getnative": "^3.0.0",
-				"lodash.isarguments": "^3.0.0",
-				"lodash.isarray": "^3.0.0"
-			}
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -25313,14 +24732,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
-		},
-		"lodash.pairs": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
-			"integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
-			"requires": {
-				"lodash.keys": "^3.0.0"
-			}
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -25820,7 +25231,8 @@
 		"memoize-one": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+			"integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
+			"dev": true
 		},
 		"memoizerific": {
 			"version": "1.11.3",
@@ -26365,16 +25777,6 @@
 			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
 			"dev": true
 		},
-		"mini-create-react-context": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-			"integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
-			"requires": {
-				"@babel/runtime": "^7.4.0",
-				"gud": "^1.0.0",
-				"tiny-warning": "^1.0.2"
-			}
-		},
 		"mini-css-extract-plugin": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.10.0.tgz",
@@ -26600,6 +26002,7 @@
 			"version": "0.5.31",
 			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
 			"integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+			"dev": true,
 			"requires": {
 				"moment": ">= 2.9.0"
 			}
@@ -28228,14 +27631,6 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
-		"path-to-regexp": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-			"requires": {
-				"isarray": "0.0.1"
-			}
-		},
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -29809,7 +29204,8 @@
 		"qs": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
+			"dev": true
 		},
 		"query-string": {
 			"version": "4.3.4",
@@ -29995,16 +29391,6 @@
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2"
-			}
-		},
-		"react-addons-create-fragment": {
-			"version": "15.6.2",
-			"resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.2.tgz",
-			"integrity": "sha1-o5TefCx77Na1R1uhuXrEcs58dPg=",
-			"requires": {
-				"fbjs": "^0.8.4",
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.0"
 			}
 		},
 		"react-addons-shallow-compare": {
@@ -30517,7 +29903,8 @@
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+			"dev": true
 		},
 		"react-moment-proptypes": {
 			"version": "1.7.0",
@@ -30611,37 +29998,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.0.1.tgz",
 			"integrity": "sha512-HdPzwdcAv+BMFQEgyacFB40G4IxNMO7tSqaMjbnAouot8LXi5/Rx3/Fv+LU2cQekqiivE1LF4sGnwQ7SnoHrpg=="
-		},
-		"react-router": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-5.1.2.tgz",
-			"integrity": "sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==",
-			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"history": "^4.9.0",
-				"hoist-non-react-statics": "^3.1.0",
-				"loose-envify": "^1.3.1",
-				"mini-create-react-context": "^0.3.0",
-				"path-to-regexp": "^1.7.0",
-				"prop-types": "^15.6.2",
-				"react-is": "^16.6.0",
-				"tiny-invariant": "^1.0.2",
-				"tiny-warning": "^1.0.0"
-			}
-		},
-		"react-router-dom": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.1.2.tgz",
-			"integrity": "sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==",
-			"requires": {
-				"@babel/runtime": "^7.1.2",
-				"history": "^4.9.0",
-				"loose-envify": "^1.3.1",
-				"prop-types": "^15.6.2",
-				"react-router": "5.1.2",
-				"tiny-invariant": "^1.0.2",
-				"tiny-warning": "^1.0.0"
-			}
 		},
 		"react-select": {
 			"version": "3.1.0",
@@ -30743,17 +30099,6 @@
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"prop-types": "^15.6.0"
-			}
-		},
-		"react-transition-group": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-			"integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-			"requires": {
-				"dom-helpers": "^3.4.0",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2",
-				"react-lifecycles-compat": "^3.0.4"
 			}
 		},
 		"react-use-gesture": {
@@ -31912,11 +31257,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
-		},
-		"resolve-pathname": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-			"integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
 		},
 		"resolve-url": {
 			"version": "0.2.1",
@@ -33762,14 +33102,6 @@
 				}
 			}
 		},
-		"strip-ansi": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-			"integrity": "sha1-32LBqpTtLxFOHQ8h/R1QSCt5pg4=",
-			"requires": {
-				"ansi-regex": "^1.0.0"
-			}
-		},
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -35026,11 +34358,6 @@
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
 			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
 		},
-		"tiny-invariant": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-			"integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-		},
 		"tiny-lr": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
@@ -35070,11 +34397,6 @@
 					"dev": true
 				}
 			}
-		},
-		"tiny-warning": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-			"integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
 		},
 		"tinycolor2": {
 			"version": "1.4.1",
@@ -35903,11 +35225,6 @@
 				"spdx-expression-parse": "^3.0.0"
 			}
 		},
-		"value-equal": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-			"integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
-		},
 		"vary": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -36268,6 +35585,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+			"dev": true,
 			"requires": {
 				"defaults": "^1.0.3"
 			}

--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
 	"dependencies": {
 		"@stripe/react-stripe-js": "1.1.2",
 		"@stripe/stripe-js": "1.8.0",
-		"@woocommerce/components": "4.0.0",
 		"@wordpress/autop": "2.7.0",
 		"@wordpress/deprecated": "2.8.0",
 		"@wordpress/notices": "2.0.0",


### PR DESCRIPTION
Fixes #2419

WooCommerce Blocks has required Woo 4.0+ for a while now. This includes WooCommerce Admin, so we have the opportunity to load `@woocommerce/components` from an external (global) instead of pulling in the npm package.

This PR loads `@woocommerce/components`  from `wc.components` JS global and removes the dependency on the package.

We'll need to take care with this – any components we need will need to be available in the min Woo (wc-admin) version we support; and/or we'll need defensive checks to only use them if available. Also, if we start iterating on `@woocommerce/components` – e.g. adding or improving components – then we'll need to wait until they are released (and in min supported version?).

Alternatively, if we need to stay on the latest `@woocommerce/components`, we can abandon this PR and use the package. Note there's an upstream issue blocking us from using 5.0.0 of the package: https://github.com/woocommerce/woocommerce-admin/issues/5006

### How to test the changes in this Pull Request:

1. Clean build: `npm ci`, `composer install` then build (dev or production)
2. Smoke test all blocks, focus on blocks that use `@woocommerce/components` - some info below.
3. Edit / add new blocks, change settings etc – everything should work correctly.
4. Front end behaviour should be unaffected.

I believe we use woo components in editor only (`SearchListControl` `SearchListItem`); so best to focus testing on editing blocks.

Repeat tests with older versions of Woo, in particular, oldest supported version.

#### Blocks that use `@woocommerce/components` 
##### All Products family
- `Filter by Attribute`

##### Reviews
- `Reviews by Category`
- `Reviews by Product`

##### Blocks Components
These components are used when configuring blocks, e.g. selecting product(s) or product attributes. Ensure you've tested each dependent component at least once 🥇 

- `ProductsControl`
- `ProductTagControl`
- `ProductControl`
- `ProductCategoryControl`
- `ProductAttributeTermControl`

### Changelog

> Dev: Load `@woocommerce/components` from JS global (was previously loaded from npm package dependency).
