### PR TITLE
Fix deploy scripts for handling composer.json version and version string validation

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -138,4 +138,7 @@ rm -r zip-file
 # cleanup composer.json
 git checkout -- composer.json
 
+# regenerate classmap for development use
+composer dump-autoload
+
 success "Done. You've built WooCommerce Blocks! 🎉"

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -110,6 +110,7 @@ if [ $TYPE = 'DEV' ]; then
 	npm run dev
 	status "==========================="
 elif [ $TYPE = 'ZIP_ONLY' ]; then
+	composer dump-autoload
 	status "Skipping build commands - using current built assets on disk for built archive...👷‍♀️"
 	status "==========================="
 else

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -3,7 +3,7 @@
 # Exit if any command fails.
 set -e
 
-TYPE='PRODUCTION';
+TYPE='PRODUCTION'
 
 print_usage() {
 	echo "build-plugin-zip - attempt to build a plugin"
@@ -33,6 +33,17 @@ while getopts 'hdz' flag; do
 	esac
 done
 
+# Tool for grabbing version from package.json
+get_version() {
+	grep '\"version\"' package.json \
+	| cut -d ':' -f 2 \
+	| sed 's/"//g' \
+	| sed 's/,//g' \
+	| sed 's/ //g'
+}
+
+# Set version
+VERSION=$(get_version)
 
 # Store paths
 SOURCE_PATH=$(pwd)
@@ -80,6 +91,11 @@ if [ -z "$NO_CHECKS" ]; then
 	fi
 fi
 
+# Add version to composer.json
+echo $(pwd)
+perl -i -pe "s/\"type\":*.+/\"type\":\"wordpress-plugin\",\n\t\"version\": \"${VERSION}\",/" composer.json
+
+
 # Run the build.
 npm list webpack
 if [ $TYPE = 'DEV' ]; then
@@ -117,5 +133,8 @@ cd $(pwd)/zip-file
 zip -r ../woocommerce-gutenberg-products-block.zip ./
 cd ..
 rm -r zip-file
+
+# cleanup composer.json
+git checkout -- composer.json
 
 success "Done. You've built WooCommerce Blocks! 🎉"

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -92,9 +92,7 @@ if [ -z "$NO_CHECKS" ]; then
 fi
 
 # Add version to composer.json
-echo $(pwd)
 perl -i -pe "s/\"type\":*.+/\"type\":\"wordpress-plugin\",\n\t\"version\": \"${VERSION}\",/" composer.json
-
 
 # Run the build.
 npm list webpack

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -77,7 +77,7 @@ fi
 
 
 echo
-output 3 "Will this release get published to WordPress.org (if no, then only a tag will be created)? [y/N]:"
+output 3 "Will this release get published to WordPress.org? Note: If the version on WordPress.org is greater ${VERSION}, then you should answer 'N' here. [y/N]:"
 read -r DO_WP_DEPLOY
 echo
 

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -77,7 +77,7 @@ fi
 
 
 echo
-output 3 "Will this release get published to WordPress.org? Note: If the version on WordPress.org is greater ${VERSION}, then you should answer 'N' here. [y/N]:"
+output 3 "Will this release get published to WordPress.org? Note: If the version on WordPress.org is greater than ${VERSION}, then you should answer 'N' here. [y/N]:"
 read -r DO_WP_DEPLOY
 echo
 

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -88,14 +88,32 @@ fi
 
 # Safety check, if a patch release is detected ask for verification.
 VERSION_PIECES=${VERSION//[^.]}
-if [[ "${#VERSION_PIECES}" -ge "2" && "$(echo "${DO_WP_DEPLOY:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]]; then
+
+# explode version parts
+SAVEIFS=${IFS}
+IFS='.'
+set -- $(echo ${VERSION})
+IFS=${SAVEIFS}
+
+# IF VERSION_PIECES is less than 2 then its invalid so let's update it and notify
+if [[ "${#VERSION_PIECES}" -lt "2" ]]; then
+	if [[ ${#VERSION_PIECES} -eq "0" ]]; then
+		VERSION=${VERSION}.0.0
+	else
+		VERSION=${VERSION}.0
+	fi
+fi
+
+if [[ "${#VERSION_PIECES}" -ge "2" && "${3}" -eq "0" && "$(echo "${DO_WP_DEPLOY:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]]; then
 	output 1 "The version you entered (${VERSION}) looks like a patch version. Since this version will be deployed to WordPress.org, it will become the latest available version. Are you sure you want that (no will abort)?: [y/N]"
 	read -r ABORT
+	echo
 	if [ "$(echo "${ABORT:-n}" | tr "[:upper:]" "[:lower:]")" != "y" ]; then
 		output 1 "Release cancelled!"
 		exit 1
 	fi
 else
+	echo "$(output 4 "The version is set as ") $(output 3 "${VERSION}") $(output 4 " and the next step will be to bump all the version strings in relevant files.")"
 	printf "Ready to proceed? [y/N]: "
 	read -r PROCEED
 	echo

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -90,10 +90,12 @@ fi
 VERSION_PIECES=${VERSION//[^.]}
 
 # explode version parts
-SAVEIFS=${IFS}
-IFS='.'
-set -- $(echo ${VERSION})
-IFS=${SAVEIFS}
+split_version() {
+	echo ${VERSION} \
+	| sed 's/\./ /g'
+}
+
+SPLIT_VERSION=($(split_version))
 
 # IF VERSION_PIECES is less than 2 then its invalid so let's update it and notify
 if [[ "${#VERSION_PIECES}" -lt "2" ]]; then
@@ -104,7 +106,7 @@ if [[ "${#VERSION_PIECES}" -lt "2" ]]; then
 	fi
 fi
 
-if [[ "${#VERSION_PIECES}" -ge "2" && "${3}" -ne "0" && "$(echo "${DO_WP_DEPLOY:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]]; then
+if [[ "${#VERSION_PIECES}" -ge "2" && "${SPLIT_VERSION[2]}" -ne "0" && "$(echo "${DO_WP_DEPLOY:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]]; then
 	output 1 "The version you entered (${VERSION}) looks like a patch version. Since this version will be deployed to WordPress.org, it will become the latest available version. Are you sure you want that (no will abort)?: [y/N]"
 	read -r ABORT
 	echo

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -130,6 +130,9 @@ source $RELEASER_PATH/bin/version-changes.sh
 
 composer dump-autoload
 
+# remove composer.json version bump after autoload regen (we don't commit it)
+git checkout -- composer.json
+
 output 2 "Committing version change..."
 echo
 

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -104,7 +104,7 @@ if [[ "${#VERSION_PIECES}" -lt "2" ]]; then
 	fi
 fi
 
-if [[ "${#VERSION_PIECES}" -ge "2" && "${3}" -eq "0" && "$(echo "${DO_WP_DEPLOY:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]]; then
+if [[ "${#VERSION_PIECES}" -ge "2" && "${3}" -ne "0" && "$(echo "${DO_WP_DEPLOY:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]]; then
 	output 1 "The version you entered (${VERSION}) looks like a patch version. Since this version will be deployed to WordPress.org, it will become the latest available version. Are you sure you want that (no will abort)?: [y/N]"
 	read -r ABORT
 	echo

--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -179,4 +179,7 @@ git checkout $CURRENTBRANCH
 git branch -D $BRANCH
 git push origin --delete $BRANCH
 
+# regenerate classmap for development
+composer dump-autoload
+
 output 2 "GitHub release complete."

--- a/docs/releases/handling-releases.md
+++ b/docs/releases/handling-releases.md
@@ -158,7 +158,7 @@ _Outcome_: **Customers can install/update via WPORG; WPORG plugin page is up to 
 
 -   Merge the release branch back into `main` (without the branch being up to date with `main`). This may have merge conflicts needing resolved if there are cherry-picked commits in the release branch.
 -   Restore the branch if it is deleted. Release branches are kept open for potential patch releases for that version.
--   For _major_ & _minor_ releases, update version on `main` with dev suffix, e.g. [`2.6-dev`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/e27f053e7be0bf7c1d376f5bdb9d9999190ce158).
+-   For _major_ & _minor_ releases, update version on `main` with dev suffix, e.g. [`2.6-dev`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/e27f053e7be0bf7c1d376f5bdb9d9999190ce158). **Note:** this should have already been taken care for you by the release deploy script, just verify that the versions have been updated correctly.
 -   Update the schedules p2 with the shipped date for the release (Pca54o-1N-p2).
 
 _Outcome:_ __Main branch contains all changes and metadata tweaks for the release.__
@@ -207,7 +207,7 @@ In particular, please review and update as needed:
 
 - Are there any new blocks in this release? Ensure they have adequate user documentation.
 - Ensure any major improvements or changes are documented.
-- Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including: 
+- Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
   - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
   - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)
 

--- a/docs/releases/handling-releases.md
+++ b/docs/releases/handling-releases.md
@@ -158,7 +158,7 @@ _Outcome_: **Customers can install/update via WPORG; WPORG plugin page is up to 
 
 -   Merge the release branch back into `main` (without the branch being up to date with `main`). This may have merge conflicts needing resolved if there are cherry-picked commits in the release branch.
 -   Restore the branch if it is deleted. Release branches are kept open for potential patch releases for that version.
--   For _major_ & _minor_ releases, update version on `main` with dev suffix, e.g. [`2.6-dev`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/e27f053e7be0bf7c1d376f5bdb9d9999190ce158). **Note:** this should have already been taken care for you by the release deploy script, just verify that the versions have been updated correctly.
+-   For _major_ & _minor_ releases, confirm version on `main` is correct and has dev suffix [`2.6-dev`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/e27f053e7be0bf7c1d376f5bdb9d9999190ce158). **Note:** this should have already been taken care for you by the release deploy script, just verify that the versions have been updated correctly.
 -   Update the schedules p2 with the shipped date for the release (Pca54o-1N-p2).
 
 _Outcome:_ __Main branch contains all changes and metadata tweaks for the release.__


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3026 

During the release of 3.2.0 there were a number of issues that popped up for @senadir around the [recent changes for handling correct autoload class map generation](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2949) using `npm run package-plugin/*` variations etc. There were also some issues related to the `npm run deploy` script and validation happening around the version string provided by user prompt.

In this pull:

- `npm run deploy` will now automatically coerce incorrect provided version strings to a semantic value that we use for releases. Concretely, this means:
    - If just the major version is provided, it will be automatically fixed. Example: `4` would become `4.0.0`.
    - If just the minor version is provided, it will be automatically fixed. Example: `3.3` would become `3.3`.
    - Minor patch versions are respected. Example: `3.3.1` would stay the same.
- `npm run deploy` will only warn on patch versions for _actual_ patch version. In other words, `3.3.0` would not be warned on because that's actually a minor release. Whereas `3.3.1` would receive the wp.org release warning.
- `npm run deploy` will no longer _commit_ the `composer.json` version bump but still commits the autoload class map generated with `version` in `composer.json`. For releases, `composer.json` doesn't actually need the version we just need to make sure we're generating the classmap with it.
- `npm run package-plugin/*` variations will now correctly account for generating the correct classmap in the built zip. This is done by updating the version in `composer.json` before the classmap is generated. After the zip is built, the version property is removed from `composer.json` and then the classmap is regenerated for the development environment.

<!-- Don't forget to update the title with something descriptive. -->

## Testing

Testing these changes requires commenting out some lines to avoid unintentionally doing deploys! 

### For `npm run deploy` test

- in the file `./bin/github-deploy.sh`, comment out any line that is a `git` command _except_ `git checkout -- composer.json`.
- comment out the `hub` related commands.
- comment out the final `composer dump-autoload` in the file (near the end of the file)
* [ ]  execute `sh ./bin/github-deploy.sh` and answer with different variations of version strings and verify the correct versions are updated in files for the string given.
- [ ] verify the correct classmap generation has occurred. You do this by opening up `vendor/composer/jetpack_autoload_classmap.php`, search for anything "Blocks" related, and check that the `version` property for the class uses the string you passed in as the version for the script run. **Note:** it's expected that the version string in jetpack has a trailing `.0`in version strings.
- re-enable the final `composer dump-autoload` in the file you commented out earlier.
- [ ] re-execute the script and verify the correct classmap has occurred. This time the classmap should have the branch name for the `version` string.
- [ ] verify that `composer.json` does not have a "version" property after running the script.

### For `npm run package-plugin` test

Note: before you run each of these scripts you either have to [comment out this code](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/0fdf262bfb350d91a4fd55faf7900397f21e52c7/bin/build-plugin-zip.sh#L65-L81) or commit your changes locally (and don't push) to avoid the dirty repo bail in `build-plugin-zip.sh`.

- in the file `./bin/build-plugin-zip.sh`, comment out the final `composer dump-autoload` (near the end of the file).
* [ ] execute `npm run package-plugin:deploy` (you can do whatever package-plugin command you want, but this is the critical one) and verify that the generated autoloader class map (same location as previous test) has the expected "version" property for Blocks classes. The expected value should match whatever version is in `package.json`.
- [ ] verify that `composer.json` does not have a "version" property after running the script.
- re-enable the final `composer dump-autoload` in the file you commented out earlier.
* [ ] re-execute the `npm run package-plugin:deploy` command. This time the generated autoloader classmap in your local directory should be using the branch name as the "version" property value for blocks classes. However, in the **built zip**, the autoloader classmap should have the same value for the "version" property as the version property in `package.json`.