### PR TITLE
Add storybook demo for Chip

### DIFF
--- a/assets/js/base/components/chip/stories/index.js
+++ b/assets/js/base/components/chip/stories/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { text, select } from '@storybook/addon-knobs';
+import { text, select, boolean } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -19,6 +19,11 @@ export const Chip = () => (
 	<components.Chip
 		text={ text( 'Text', 'example' ) }
 		radius={ select( 'Radius', radii ) }
+		screenReaderText={ text(
+			'Screen reader text',
+			'Example screen reader text'
+		) }
+		element={ select( 'Element', [ 'li', 'div', 'span' ], 'li' ) }
 	/>
 );
 
@@ -26,5 +31,12 @@ export const RemovableChip = () => (
 	<components.RemovableChip
 		text={ text( 'Text', 'example' ) }
 		radius={ select( 'Radius', radii ) }
+		screenReaderText={ text(
+			'Screen reader text',
+			'Example screen reader text'
+		) }
+		disabled={ boolean( 'Disabled', false ) }
+		removeOnAnyClick={ boolean( 'Remove on any click', false ) }
+		element={ select( 'Element', [ 'li', 'div', 'span' ], 'li' ) }
 	/>
 );

--- a/assets/js/base/components/chip/stories/index.js
+++ b/assets/js/base/components/chip/stories/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { text, select } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import * as components from '../';
+
+export default {
+	title: 'WooCommerce Blocks/@base-components/Chip',
+	component: Chip,
+};
+
+const radii = [ 'none', 'small', 'medium', 'large' ];
+
+export const Chip = () => (
+	<components.Chip
+		text={ text( 'Text', 'example' ) }
+		radius={ select( 'Radius', radii ) }
+	/>
+);
+
+export const RemovableChip = () => (
+	<components.RemovableChip
+		text={ text( 'Text', 'example' ) }
+		radius={ select( 'Radius', radii ) }
+	/>
+);


### PR DESCRIPTION
Part of #3031 

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] ~~All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)~~
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
### How to test the changes in this Pull Request:

1. Execute `npm run storybook` and visit the URL (mine is http://localhost:6006/)
2. Navigate to `@base-components` > `Chip` and apply the following testing steps to both `Chip` and `RemovableChip`
3. Change the knobs at the bottom of the storybook panel and ensure the expected changes occur to the component.
4. Test with screen reader on and by using only the keyboard.
5. Check the accessibility tab of Storybook and verify that the contrast of the component is ok.
