### PR TITLE
Exclude storybook from released ZIP

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -60,39 +60,6 @@ warning () {
 	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
 }
 
-copy_dest_files() {
-	CURRENT_DIR=$(pwd)
-	cd "$1" || exit
-	rsync ./ "$2"/ --recursive --delete --delete-excluded \
-		--exclude=".*/" \
-		--exclude="*.md" \
-		--exclude=".*" \
-		--exclude="composer.*" \
-		--exclude="*.lock" \
-		--exclude=bin/ \
-		--exclude=node_modules/ \
-		--exclude=tests/ \
-		--exclude=docs/ \
-		--exclude=phpcs.xml \
-		--exclude=phpunit.xml.dist \
-		--exclude=CODEOWNERS \
-		--exclude=renovate.json \
-		--exclude="*.config.js" \
-		--exclude="*-config.js" \
-		--exclude="*.config.json" \
-		--exclude=package.json \
-		--exclude=package-lock.json \
-		--exclude=none \
-		--exclude=blocks.ini \
-		--exclude=docker-compose.yml \
-		--exclude=tsconfig.json \
-		--exclude=woocommerce-gutenberg-products-block.zip \
-		--exclude="zip-file/" \
-		--exclude=globals.d.ts
-	status "Done copying files!"
-	cd "$CURRENT_DIR" || exit
-}
-
 status "💃 Time to build a WooCommerce Blocks ZIP 🕺"
 
 if [ -z "$NO_CHECKS" ]; then
@@ -145,8 +112,8 @@ fi
 status "Creating archive... 🎁"
 mkdir zip-file
 mkdir zip-file/build
-copy_dest_files $SOURCE_PATH "$SOURCE_PATH/zip-file"
-cd zip-file
+sh $SOURCE_PATH/bin/copy-plugin-files.sh $SOURCE_PATH "$SOURCE_PATH/zip-file"
+cd $(pwd)/zip-file
 zip -r ../woocommerce-gutenberg-products-block.zip ./
 cd ..
 rm -r zip-file

--- a/bin/copy-plugin-files.sh
+++ b/bin/copy-plugin-files.sh
@@ -1,0 +1,28 @@
+cd "$1" || exit
+rsync ./ "$2"/ --recursive --delete --delete-excluded \
+	--exclude=".*/" \
+	--exclude="*.md" \
+	--exclude=".*" \
+	--exclude="composer.*" \
+	--exclude="*.lock" \
+	--exclude=bin/ \
+	--exclude=node_modules/ \
+	--exclude=tests/ \
+	--exclude=docs/ \
+	--exclude=phpcs.xml \
+	--exclude=phpunit.xml.dist \
+	--exclude=CODEOWNERS \
+	--exclude=renovate.json \
+	--exclude="*.config.js" \
+	--exclude="*-config.js" \
+	--exclude="*.config.json" \
+	--exclude=package.json \
+	--exclude=package-lock.json \
+	--exclude=none \
+	--exclude=blocks.ini \
+	--exclude=docker-compose.yml \
+	--exclude=tsconfig.json \
+	--exclude=woocommerce-gutenberg-products-block.zip \
+	--exclude="zip-file/" \
+	--exclude=globals.d.ts
+echo -e "\nDone copying files!\n"

--- a/bin/copy-plugin-files.sh
+++ b/bin/copy-plugin-files.sh
@@ -24,5 +24,6 @@ rsync ./ "$2"/ --recursive --delete --delete-excluded \
 	--exclude=tsconfig.json \
 	--exclude=woocommerce-gutenberg-products-block.zip \
 	--exclude="zip-file/" \
-	--exclude=globals.d.ts
+	--exclude=globals.d.ts \
+	--exclude=storybook/
 echo -e "\nDone copying files!\n"

--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -40,37 +40,6 @@ output_list() {
   echo "$(tput setaf "$1") • $2:$(tput sgr0) \"$3\""
 }
 
-# Sync dest files
-copy_dest_files() {
-  cd "$2" || exit
-  rsync ./ "$3"/"$1"/ --recursive --delete --delete-excluded \
-	--exclude=".*/" \
-	--exclude="*.md" \
-	--exclude=".*" \
-	--exclude="composer.*" \
-	--exclude="*.lock" \
-	--exclude=bin/ \
-	--exclude=node_modules/ \
-	--exclude=tests/ \
-	--exclude=docs/ \
-	--exclude=phpcs.xml \
-	--exclude=phpunit.xml.dist \
-	--exclude=CODEOWNERS \
-	--exclude=renovate.json \
-	--exclude="*.config.js" \
-	--exclude="*-config.js" \
-	--exclude="*.config.json" \
-	--exclude=package.json \
-	--exclude=package-lock.json \
-	--exclude=none \
-	--exclude=blocks.ini \
-	--exclude=docker-compose.yml \
-	--exclude=tsconfig.json \
-	--exclude=globals.d.ts
-  output 2 "Done copying files!"
-  cd "$3" || exit
-}
-
 # Release script
 echo
 output 4 "BLOCKS->WordPress.org RELEASE SCRIPT"
@@ -173,7 +142,8 @@ fi
 
 # Copy GIT directory to trunk
 output 2 "Copying project files to SVN trunk..."
-copy_dest_files "trunk" "$GIT_PATH" "$SVN_PATH"
+sh ${RELEASER_PATH}/bin/copy-plugin-files.sh "$GIT_PATH" "$SVN_PATH/trunk"
+cd "$SVN_PATH"
 
 # Update stable tag on trunk/readme.txt
 if [ $IS_PRE_RELEASE = false ]; then


### PR DESCRIPTION
Fixes #2671. 

This PR excludes `storybook` from being included in the release ZIP. In addition, it abstracts the logic to copy the plugin files into its own script, so we don't need to maintain the list in two different places.

### How to test the changes in this Pull Request:

1. Run `npm run package-plugin` and verify the `storybook` folder is not included in the generated ZIP.
2. **Important:** in `bin/wordpress-deploy.sh` remove or comment out everything below the line `# Update stable tag on trunk/readme.txt`. Otherwise the script would deploy a new version to .org directory.
3. Run `npm run release`.
4. Go to the `/blocks-deployment/woo-gutenberg-products-block-svn/trunk` folder under your user directory (the full path might vary depending on your OS) and verify `storybook` is not there.

### Changelog

> Exclude storybook from release ZIP.