### PR TITLE
Fix CartItems unit tests

### DIFF
--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -51,7 +51,15 @@ class CartItems extends TestCase {
 
 		$this->keys   = [];
 		$this->keys[] = wc()->cart->add_to_cart( $this->products[0]->get_id(), 2 );
-		$this->keys[] = wc()->cart->add_to_cart( $this->products[1]->get_id(), 1, current( $this->products[1]->get_children() ), [ 'size' => 'small' ] );
+		$this->keys[] = wc()->cart->add_to_cart(
+			$this->products[1]->get_id(),
+			1,
+			current( $this->products[1]->get_children() ),
+			array(
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => '2',
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
PHP unit tests started to fail recently, the issue is that we were adding a variable product to the cart via `WC()->cart->add_to_cart()` with the wrong attributes. The issue only became visible after this PR in Core: https://github.com/woocommerce/woocommerce/pull/27115. It sets some stricter validation rules that our tests were not complying with. After updating the attributes, tests pass again.

### How to test the changes in this Pull Request:

1. Run `npm run phpunit` and verify all tests pass.
2. Verify PHP tests pass in Travis too.