### PR TITLE
Tweak insertOnce tests and fix reviews tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,17 +155,4 @@ jobs:
               local_dir: storybook/dist
               on:
                   branch: trunk
-    # @TODO: Investigate why is WP 5.4 + GB e2e test failing and don't allow it to fail.
-    allow_failures:
-      - name: E2E Tests (WP 5.5 with Gutenberg plugin)
-        script:
-          - npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
-          - npm install @wordpress/e2e-test-utils@latest
-          - chmod -R 767 ./
-          - npm run test:e2e
-        env:
-          - WP_VERSION=5.5
-          - E2E_TESTS=1
-          - GUTENBERG_LATEST=true
-          - WOOCOMMERCE_BLOCKS_PHASE=3
 

--- a/tests/e2e/specs/backend/all-products.test.js
+++ b/tests/e2e/specs/backend/all-products.test.js
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	insertBlock,
-	getAllBlocks,
-	switchUserToAdmin,
-} from '@wordpress/e2e-test-utils';
+import { switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
@@ -26,11 +22,6 @@ describe( `${ block.name } Block`, () => {
 	beforeAll( async () => {
 		await switchUserToAdmin();
 		await visitBlockPage( `${ block.name } Block` );
-	} );
-
-	it( 'can only be inserted once', async () => {
-		await insertBlock( block.name );
-		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );
 
 	it( 'renders without crashing', async () => {

--- a/tests/e2e/specs/backend/all-products.test.js
+++ b/tests/e2e/specs/backend/all-products.test.js
@@ -1,9 +1,13 @@
 /**
  * External dependencies
  */
-import { switchUserToAdmin } from '@wordpress/e2e-test-utils';
+import { searchForBlock, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	findElementWithText,
+	closeInserter,
+} from '@woocommerce/blocks-test-utils';
 
 const block = {
 	name: 'All Products',
@@ -23,7 +27,17 @@ describe( `${ block.name } Block`, () => {
 		await switchUserToAdmin();
 		await visitBlockPage( `${ block.name } Block` );
 	} );
-
+	it( 'can only be inserted once', async () => {
+		await searchForBlock( block.name );
+		const disabledInsertButton = await findElementWithText(
+			'button.editor-block-list-item-woocommerce-all-products',
+			block.name
+		);
+		expect(
+			await disabledInsertButton.evaluate( ( button ) => button.disabled )
+		).toBe( true );
+		await closeInserter();
+	} );
 	it( 'renders without crashing', async () => {
 		await expect( page ).toRenderBlock( block );
 	} );

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -3,23 +3,20 @@
  */
 import {
 	clickButton,
+	searchForBlock,
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
 import {
 	findLabelWithText,
 	visitBlockPage,
+	closeInserter,
 } from '@woocommerce/blocks-test-utils';
 
 const block = {
 	name: 'Cart',
 	slug: 'woocommerce/cart',
 	class: '.wc-block-cart',
-};
-
-// eslint-disable-next-line no-unused-vars
-const closeInserter = async () => {
-	await page.click( '.edit-post-header [aria-label="Add block"]' );
 };
 
 if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
@@ -30,6 +27,18 @@ describe( `${ block.name } Block`, () => {
 	beforeAll( async () => {
 		await switchUserToAdmin();
 		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'can only be inserted once', async () => {
+		await searchForBlock( block.name );
+		const disabledInsertButton = await findElementWithText(
+			'button.editor-block-list-item-woocommerce-cart',
+			block.name
+		);
+		expect(
+			await disabledInsertButton.evaluate( ( button ) => button.disabled )
+		).toBe( true );
+		await closeInserter();
 	} );
 
 	it( 'renders without crashing', async () => {

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -3,8 +3,6 @@
  */
 import {
 	clickButton,
-	getAllBlocks,
-	insertBlock,
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
@@ -19,6 +17,7 @@ const block = {
 	class: '.wc-block-cart',
 };
 
+// eslint-disable-next-line no-unused-vars
 const closeInserter = async () => {
 	await page.click( '.edit-post-header [aria-label="Add block"]' );
 };
@@ -31,12 +30,6 @@ describe( `${ block.name } Block`, () => {
 	beforeAll( async () => {
 		await switchUserToAdmin();
 		await visitBlockPage( `${ block.name } Block` );
-	} );
-
-	it( 'can only be inserted once', async () => {
-		await insertBlock( block.name );
-		await closeInserter();
-		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );
 
 	it( 'renders without crashing', async () => {

--- a/tests/e2e/specs/backend/reviews-by-category.test.js
+++ b/tests/e2e/specs/backend/reviews-by-category.test.js
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { switchUserToAdmin, clickButton } from '@wordpress/e2e-test-utils';
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	findElementWithText,
+} from '@woocommerce/blocks-test-utils';
 
 const block = {
 	name: 'Reviews by Category',
@@ -32,7 +35,11 @@ describe( `${ block.name } Block`, () => {
 		await page.waitForSelector(
 			`${ block.class } .woocommerce-search-list__item`
 		);
-		await page.click( `${ block.class } .woocommerce-search-list__item` );
+		const productWithReviews = await findElementWithText(
+			`.woocommerce-search-list__item-count`,
+			'[1-9]+ Reviews'
+		);
+		await productWithReviews.click();
 		await clickButton( 'Done' );
 		// Selected.
 		await page.waitForSelector(

--- a/tests/e2e/specs/backend/reviews-by-category.test.js
+++ b/tests/e2e/specs/backend/reviews-by-category.test.js
@@ -42,7 +42,7 @@ describe( `${ block.name } Block`, () => {
 		);
 		const categoryWithReviews = await findElementWithText(
 			`.woocommerce-search-list__item`,
-			fixtureProducts[ 0 ].categories[ 0 ]
+			fixtureProducts()[ 0 ].categories[ 0 ]
 		);
 		await categoryWithReviews.click();
 		await clickButton( 'Done' );

--- a/tests/e2e/specs/backend/reviews-by-category.test.js
+++ b/tests/e2e/specs/backend/reviews-by-category.test.js
@@ -7,6 +7,11 @@ import {
 	findElementWithText,
 } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
+import { Products as fixtureProducts } from '../../fixtures/fixture-data';
+
 const block = {
 	name: 'Reviews by Category',
 	slug: 'woocommerce/reviews-by-category',
@@ -35,11 +40,11 @@ describe( `${ block.name } Block`, () => {
 		await page.waitForSelector(
 			`${ block.class } .woocommerce-search-list__item`
 		);
-		const productWithReviews = await findElementWithText(
-			`.woocommerce-search-list__item-count`,
-			'[1-9]+ Reviews'
+		const categoryWithReviews = await findElementWithText(
+			`.woocommerce-search-list__item`,
+			fixtureProducts[ 0 ].categories[ 0 ]
 		);
-		await productWithReviews.click();
+		await categoryWithReviews.click();
 		await clickButton( 'Done' );
 		// Selected.
 		await page.waitForSelector(

--- a/tests/e2e/specs/backend/reviews-by-product.test.js
+++ b/tests/e2e/specs/backend/reviews-by-product.test.js
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { switchUserToAdmin, clickButton } from '@wordpress/e2e-test-utils';
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	findElementWithText,
+} from '@woocommerce/blocks-test-utils';
 
 const block = {
 	name: 'Reviews by Product',
@@ -30,9 +33,13 @@ describe( `${ block.name } Block`, () => {
 		// we focus on the block
 		await page.click( block.class );
 		await page.waitForSelector(
-			`${ block.class } .woocommerce-search-list__item`
+			`${ block.class } .woocommerce-search-list__item-count`
 		);
-		await page.click( `${ block.class } .woocommerce-search-list__item` );
+		const productWithReviews = await findElementWithText(
+			`.woocommerce-search-list__item-count`,
+			'[1-9]+ Reviews'
+		);
+		await productWithReviews.click();
 		await clickButton( 'Done' );
 		// Selected.
 		await page.waitForSelector(

--- a/tests/e2e/specs/backend/reviews-by-product.test.js
+++ b/tests/e2e/specs/backend/reviews-by-product.test.js
@@ -42,7 +42,7 @@ describe( `${ block.name } Block`, () => {
 		);
 		const productWithReviews = await findElementWithText(
 			`.woocommerce-search-list__item`,
-			fixtureProducts[ 0 ].name
+			fixtureProducts()[ 0 ].name
 		);
 		await productWithReviews.click();
 		await clickButton( 'Done' );

--- a/tests/e2e/specs/backend/reviews-by-product.test.js
+++ b/tests/e2e/specs/backend/reviews-by-product.test.js
@@ -7,6 +7,11 @@ import {
 	findElementWithText,
 } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
+import { Products as fixtureProducts } from '../../fixtures/fixture-data';
+
 const block = {
 	name: 'Reviews by Product',
 	slug: 'woocommerce/reviews-by-product',
@@ -36,8 +41,8 @@ describe( `${ block.name } Block`, () => {
 			`${ block.class } .woocommerce-search-list__item-count`
 		);
 		const productWithReviews = await findElementWithText(
-			`.woocommerce-search-list__item-count`,
-			'[1-9]+ Reviews'
+			`.woocommerce-search-list__item`,
+			fixtureProducts[ 0 ].name
 		);
 		await productWithReviews.click();
 		await clickButton( 'Done' );

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	insertBlock,
-	getAllBlocks,
-	switchUserToAdmin,
-} from '@wordpress/e2e-test-utils';
+import { switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -1,9 +1,13 @@
 /**
  * External dependencies
  */
-import { switchUserToAdmin } from '@wordpress/e2e-test-utils';
+import { searchForBlock, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	findElementWithText,
+	closeInserter,
+} from '@woocommerce/blocks-test-utils';
 
 if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 )
 	// eslint-disable-next-line jest/no-focused-tests

--- a/tests/utils/close-inserter.js
+++ b/tests/utils/close-inserter.js
@@ -1,0 +1,3 @@
+export async function closeInserter() {
+	await page.click( '.edit-post-header [aria-label="Add block"]' );
+}

--- a/tests/utils/find-element-with-text.js
+++ b/tests/utils/find-element-with-text.js
@@ -1,0 +1,13 @@
+export async function findElementWithText( selector, pattern ) {
+	const elements = await page.$$( selector );
+	for ( let i = 0; i < elements.length; i++ ) {
+		if (
+			await elements[ i ].evaluate( ( tag, _pattern ) => {
+				const regex = new RegExp( _pattern );
+				return regex.test( tag.textContent );
+			}, pattern )
+		) {
+			return elements[ i ];
+		}
+	}
+}

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,3 +1,4 @@
 export { findLabelWithText } from './find-label-with-text';
 export { visitBlockPage } from './visit-block-page';
+export { closeInserter } from './close-inserter';
 export { findElementWithText } from './find-element-with-text';

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,2 +1,3 @@
 export { findLabelWithText } from './find-label-with-text';
 export { visitBlockPage } from './visit-block-page';
+export { findElementWithText } from './find-element-with-text';


### PR DESCRIPTION
This PR does a couple of things:

- Fixes some fragile Reviews tests that relied on all products having a review, now we will select products or categories that actually have reviews (using fixture data), it also introduces a new helper function `getElementByText` that gets an element by class name and content (static or regex).

- Refactor our `can only be inserted once` tests, we had problems with `insertBlock` helper function because it waited for the block to actually insert before moving forward, causing a timeout, we now search for the block and check if the button is disabled or not.

### New utilities

- `async closeInserter()` is now a global utility that you can use, it will close the inserter after failed inserts.
- `async getElementByText( selector<String>, pattern<String> )` that will return an element using a selector and a pattern that can be a regular expression.

fixes #2993, I removed the allow fail declaration. 
### How to confirm changes
Travis should pass for this test.
