### PR TITLE
Fix JS console error when COD is enabled and no shipping method is available.

### DIFF
--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -34,7 +34,9 @@ export const useSelectShippingRate = ( shippingRates ) => {
 				)
 				// A fromEntries ponyfill, creates an object from an array of arrays.
 				.reduce( ( obj, [ key, val ] ) => {
-					obj[ key ] = val;
+					if ( val ) {
+						obj[ key ] = val;
+					}
 					return obj;
 				}, {} ),
 		[ shippingRates ]

--- a/assets/js/base/hooks/shipping/use-select-shipping-rate.js
+++ b/assets/js/base/hooks/shipping/use-select-shipping-rate.js
@@ -15,7 +15,9 @@ See also: https://github.com/woocommerce/woocommerce-gutenberg-products-block/tr
  * - selectShippingRate    A function that immediately returns the selected
  * rate and dispatches an action generator.
  * - selectedShippingRates An object of selected shipping rates and package id as key, maintained
- * locally by a state and updated optimistically.
+ * locally by a state and updated optimistically, this will only return packages that has selected
+ * shipping rates.
+ *
  */
 export const useSelectShippingRate = ( shippingRates ) => {
 	const throwError = useThrowError();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Only return selected shipping methods from useSelectShippingRate, this fixes an issue with COD in which we try to see if user can make a payment based on the selected shipping method, the hook returned a broken object `{ 0: undefined }` but it should have returned an empty object instead.
<!-- Reference any related issues or PRs here -->
Fixes #2987

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Enable COD and limit it to a certain shipping method type.
2. Add that method to a certain address.
3. Select another address on the Checkout block, you shouldn't see an error with `selectedMethod is undefined` on the console.


### Changelog

> Fix JS console error when COD is enabled and no shipping method is available.
