### PR TITLE
Fix product element styling class names

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -23,14 +23,14 @@
 	}
 
 	.wc-block-components-product-sale-badge {
-		&--alignleft {
+		&--align-left {
 			position: absolute;
 			left: $gap-smaller/2;
 			top: $gap-smaller/2;
 			right: auto;
 			margin: 0;
 		}
-		&--aligncenter {
+		&--align-center {
 			position: absolute;
 			top: $gap-smaller/2;
 			left: 50%;
@@ -38,7 +38,7 @@
 			transform: translateX(-50%);
 			margin: 0;
 		}
-		&--alignright {
+		&--align-right {
 			position: absolute;
 			right: $gap-smaller/2;
 			top: $gap-smaller/2;

--- a/assets/js/atomic/blocks/product-elements/price/block.js
+++ b/assets/js/atomic/blocks/product-elements/price/block.js
@@ -159,7 +159,7 @@ const PriceRange = ( { currency, minAmount, maxAmount, classes, style } ) => {
 				'wc-block-components-product-price__value',
 				{
 					[ `${ parentClassName }__product-price__value` ]: parentClassName,
-					[ classes ]: isFeaturePluginBuild()
+					[ classes ]: isFeaturePluginBuild(),
 				}
 			) }
 			style={ isFeaturePluginBuild() ? style : {} }
@@ -194,7 +194,8 @@ const SalePrice = ( {
 					'wc-block-components-product-price__regular',
 					{
 						[ `${ parentClassName }__product-price__regular` ]: parentClassName,
-						[ classes ]: isFeaturePluginBuild() }
+						[ classes ]: isFeaturePluginBuild(),
+					}
 				) }
 				style={ isFeaturePluginBuild() ? style : {} }
 			>
@@ -209,7 +210,8 @@ const SalePrice = ( {
 					'is-discounted',
 					{
 						[ `${ parentClassName }__product-price__value` ]: parentClassName,
-						[ saleClasses ]: isFeaturePluginBuild() }
+						[ saleClasses ]: isFeaturePluginBuild(),
+					}
 				) }
 				style={ isFeaturePluginBuild() ? saleStyle : {} }
 			>

--- a/assets/js/atomic/blocks/product-elements/price/block.js
+++ b/assets/js/atomic/blocks/product-elements/price/block.js
@@ -106,7 +106,7 @@ const Block = ( {
 				'wc-block-components-product-price',
 				{
 					[ `${ parentClassName }__product-price` ]: parentClassName,
-					[ `wc-block-components-product-price__align-${ align }` ]:
+					[ `wc-block-components-product-price--align-${ align }` ]:
 						align && isFeaturePluginBuild(),
 				}
 			) }

--- a/assets/js/atomic/blocks/product-elements/price/style.scss
+++ b/assets/js/atomic/blocks/product-elements/price/style.scss
@@ -1,11 +1,11 @@
 /*rtl:begin:ignore*/
-.wc-block-components-product-price__align-left {
+.wc-block-components-product-price--align-left {
 	text-align: left;
 }
-.wc-block-components-product-price__align-center {
+.wc-block-components-product-price--align-center {
 	text-align: center;
 }
-.wc-block-components-product-price__align-right {
+.wc-block-components-product-price--align-right {
 	text-align: right;
 }
 /*rtl:end:ignore*/

--- a/assets/js/atomic/blocks/product-elements/sale-badge/block.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/block.js
@@ -34,7 +34,7 @@ const Block = ( { className, align } ) => {
 
 	const alignClass =
 		typeof align === 'string'
-			? `wc-block-components-product-sale-badge--align${ align }`
+			? `wc-block-components-product-sale-badge--align-${ align }`
 			: '';
 
 	return (

--- a/assets/js/atomic/blocks/product-elements/title/block.js
+++ b/assets/js/atomic/blocks/product-elements/title/block.js
@@ -91,9 +91,9 @@ export const Block = ( {
 				'wc-block-components-product-title',
 				{
 					[ `${ parentClassName }__product-title` ]: parentClassName,
-					[ `wc-block-components-product-title__align-${ align }` ]:
+					[ `wc-block-components-product-title--align-${ align }` ]:
 						align && isFeaturePluginBuild(),
-				},
+				}
 			) }
 		>
 			{ productLink ? (

--- a/assets/js/atomic/blocks/product-elements/title/block.js
+++ b/assets/js/atomic/blocks/product-elements/title/block.js
@@ -69,9 +69,8 @@ export const Block = ( {
 						[ `${ parentClassName }__product-title` ]: parentClassName,
 						[ `wc-block-components-product-title--align-${ align }` ]:
 							align && isFeaturePluginBuild(),
-						[ titleClasses ]: isFeaturePluginBuild()
-					},
-
+						[ titleClasses ]: isFeaturePluginBuild(),
+					}
 				) }
 				style={ gatedStyledText( {
 					color: customColor,

--- a/assets/js/atomic/blocks/product-elements/title/block.js
+++ b/assets/js/atomic/blocks/product-elements/title/block.js
@@ -111,7 +111,17 @@ export const Block = ( {
 					{ productName }
 				</a>
 			) : (
-				productName
+				<span
+					className={ classnames( {
+						[ titleClasses ]: isFeaturePluginBuild(),
+					} ) }
+					style={ gatedStyledText( {
+						color: customColor,
+						fontSize: customFontSize,
+					} ) }
+				>
+					{ productName }
+				</span>
 			) }
 		</TagName>
 	);


### PR DESCRIPTION
Fixes #3093.
Fixes #3094.

### Screenshots

![Peek 2020-09-01 12-13](https://user-images.githubusercontent.com/3616980/91837523-90d88500-ec4c-11ea-9353-3162c8394928.gif)

### How to test the changes in this Pull Request:

1. Create a page with the _All Products_ block.
2. Edit it and click on the Product title.
3. In the sidebar, change the color and font size. In the toolbar, change the alignment.
4. Verify all styles are applied correctly.
5. Toggle the 'Link to Product Page' attribute and verify styles are still applied.
6. Click on 'Update' and preview the page in the frontend.
6. Verify styles are applied there as well.

It would be good to test two additional blocks to make sure there are no regressions:
1. While editing the _All Products_ block, click on the Product price.
2. In the sidebar, change the colors and font size. In the toolbar, change the alignment.
3. Verify all styles are applied correctly.
4. Now click on the product image block and change the 'Sale Badge Alignment' attribute.
5. Verify the 'Sale Badge' changes its position according to the attribute.
7. Click on 'Update' and preview the page in the frontend.
8. Verify styles are applied there as well.

cc @haszari I'm adding this to the 3.3.0 milestone in case you want to include it, but feel free to move it to 3.4.0 if you don't want to rush this fix.

### Changelog

> Fixed styling options of the Product Title block.
