### PR TITLE
Wrap complex computations in Country/State inputs with useMemo

### DIFF
--- a/assets/js/base/components/country-input/country-input.js
+++ b/assets/js/base/components/country-input/country-input.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -27,10 +28,14 @@ const CountryInput = ( {
 		'woo-gutenberg-products-block'
 	),
 } ) => {
-	const options = Object.keys( countries ).map( ( key ) => ( {
-		key,
-		name: decodeEntities( countries[ key ] ),
-	} ) );
+	const options = useMemo(
+		() =>
+			Object.keys( countries ).map( ( key ) => ( {
+				key,
+				name: decodeEntities( countries[ key ] ),
+			} ) ),
+		[ countries ]
+	);
 
 	return (
 		<div

--- a/assets/js/base/components/state-input/state-input.js
+++ b/assets/js/base/components/state-input/state-input.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import classnames from 'classnames';
 
 /**
@@ -26,12 +26,16 @@ const StateInput = ( {
 	required = false,
 } ) => {
 	const countryStates = states[ country ];
-	const options = countryStates
-		? Object.keys( countryStates ).map( ( key ) => ( {
-				key,
-				name: decodeEntities( countryStates[ key ] ),
-		  } ) )
-		: [];
+	const options = useMemo(
+		() =>
+			countryStates
+				? Object.keys( countryStates ).map( ( key ) => ( {
+						key,
+						name: decodeEntities( countryStates[ key ] ),
+				  } ) )
+				: [],
+		[ countryStates ]
+	);
 
 	/**
 	 * Handles state selection onChange events. Finds a matching state by key or value.


### PR DESCRIPTION
While investigating #2319, I noticed `CountryInput` and `StateInput` components were taking quite a bit of time to render. I think we can improve that wrapping the options parse function in a `useMemo()` hook.

### Screenshots & performance info

Using Chrome devtools with CPU 6x slowdown ([see how](https://calibreapp.com/blog/react-performance-profiling-optimization)), I could see a small performance improvement. Notice the screenshots below are just an example, performance really varies each time the component is rendered.

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/91975833-4d4f4b00-ed20-11ea-8631-b6f0c81e0ed0.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/91975876-5fc98480-ed20-11ea-9bc0-023a260c7bf2.png)

Also, notice this PR by itself doesn't fix 2319, but I still think it's worth merging.

### How to test the changes in this Pull Request:

Go to the Checkout block and verify you can select a custom country and state and no JS error is shown in the console when changing it.
