### PR TITLE
Fix Cart & Checkout sidebar layout broken in some themes

### DIFF
--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -5,6 +5,7 @@
 	position: relative;
 
 	.wc-block-components-main {
+		box-sizing: border-box;
 		margin: 0;
 		padding-right: percentage($gap-largest / 1060px); // ~1060px is the default width of the content area in Storefront.
 		width: 65%;
@@ -12,6 +13,7 @@
 }
 
 .wc-block-components-sidebar {
+	box-sizing: border-box;
 	margin: 0;
 	padding-left: percentage($gap-large / 1060px);
 	width: 35%;


### PR DESCRIPTION
Cart and Checkout blocks were not playing well with themes that didn't define `box-sizing: border-box;` for all elements. I discovered that while investigating #3110, but it has been for some time in my todo list, so I decided to create a PR directly.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/92132121-0ab46e00-ee07-11ea-8418-0cd59b3b2d04.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/92132043-f2dcea00-ee06-11ea-895b-afda511e36f8.png)

### How to test the changes in this Pull Request:

1. Install and activate [Artisan](https://woocommerce.com/products/artisan/) or [Threads](https://woocommerce.com/products/threads/) theme.
2. Go to the Cart or Checkout blocks and verify the sidebar is shown on the right instead of below.
3. Switch back to Storefront or Twenty Twenty and verify there are no regressions.

### Changelog

> Fixed a style conflict that was affecting some themes and was breaking their sidebar layout in the Cart and Checkout blocks.