### PR TITLE
Ensure shopper saved card is used as default payment method (default was being overwritten in some circumstances)

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -341,6 +341,11 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 			return;
 		}
 
+		// Customer has saved card/payment methods - no need to set a default.
+		if ( customerPaymentMethods ) {
+			return;
+		}
+
 		// If there's no active payment method, or the active payment method has
 		// been removed (e.g. COD vs shipping methods), set one as active.
 		if (
@@ -356,6 +361,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		paymentMethodsInitialized,
 		paymentData.paymentMethods,
 		setActivePaymentMethod,
+		customerPaymentMethods,
 	] );
 
 	// emit events.

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -353,12 +353,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 			}
 			return currentActivePaymentMethod;
 		} );
-	}, [
-		paymentMethodsInitialized,
-		paymentData.paymentMethods,
-		setActive,
-		customerPaymentMethods,
-	] );
+	}, [ paymentMethodsInitialized, paymentData.paymentMethods, setActive ] );
 
 	// emit events.
 	useEffect( () => {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -341,26 +341,22 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 			return;
 		}
 
-		// Customer has saved card/payment methods - no need to set a default.
-		if ( customerPaymentMethods ) {
-			return;
-		}
-
-		// If there's no active payment method, or the active payment method has
-		// been removed (e.g. COD vs shipping methods), set one as active.
-		if (
-			! activePaymentMethod ||
-			! paymentMethodKeys.includes( activePaymentMethod )
-		) {
-			setActivePaymentMethod(
-				Object.keys( paymentData.paymentMethods )[ 0 ]
-			);
-		}
+		setActive( ( currentActivePaymentMethod ) => {
+			// If there's no active payment method, or the active payment method has
+			// been removed (e.g. COD vs shipping methods), set one as active.
+			if (
+				! currentActivePaymentMethod ||
+				! paymentMethodKeys.includes( currentActivePaymentMethod )
+			) {
+				dispatch( statusOnly( PRISTINE ) );
+				return Object.keys( paymentData.paymentMethods )[ 0 ];
+			}
+			return currentActivePaymentMethod;
+		} );
 	}, [
-		activePaymentMethod,
 		paymentMethodsInitialized,
 		paymentData.paymentMethods,
-		setActivePaymentMethod,
+		setActive,
 		customerPaymentMethods,
 	] );
 


### PR DESCRIPTION
Fixes #3120

The issue here is that when a user has saved payment method(s) - e.g. a Stripe saved credit card (token), the logic that sets an initial default payment method can overwrite the saved payment method. 

~~This PR fixes this by adding a guard to the default / init effect. If there's a saved payment method, it now exits early; previously was overwriting the saved payment method, causing #3120.~~

Update: this PR now uses the [functional form of `setState`](https://reactjs.org/docs/faq-state.html#how-do-i-update-state-with-values-that-depend-on-the-current-state) to apply the default payment method. This ensures that the default is only set if there is no payment method active (selected); previously this decision was made using a stale copy of state. Hat tip @Aljullu for the suggestion 🎉 

### How to test the changes in this Pull Request:
- Set up checkout page using block.
- Enable BACS and Stripe payment methods (only, though may reproduce with other combinations). Note BACS needs to be earlier in the order than Stripe (drag handle in `WooCommerce > Settings > Payments`).
- Complete a purchase using a new payment method, Stripe CC, check `Save payment information to my account for future purchases`.
- Add something to cart, proceed to checkout.
- Leave the default selected payment method - i.e. the first saved payment method. Submit checkout.

Should always complete the purchase with the correct payment method - the one visibly selected when user clicks submit, i.e. the saved card.

Please also test a variety of other payment method scenarios and ordering - with / without saved cards (are there any other gateways that support saved payment methods?), with more/less gateways available, in different orders, and with dynamically-available gateways (COD can depend on shipping option). In all cases confirm the following:

- There is a payment method tab selected by default. 
- Submitting checkout without touching payment section uses the correct payment method (i.e. saved card, payment method tab).
- Selecting a non-default saved card (from the default) works correctly, uses correct card/token (may need to check network requests to check token).
- Selecting a non-default payment method uses correct method.
- Saving a payment method (card) works and is available for use next checkout with that account.
- Payment tab order should match the configured order.

### Changelog

> Fix: Ensure that the checkout correctly uses shopper's previously-saved payment method when selected by default (e.g. Stripe saved card). In some circumstances, a different payment method was used (e.g. BACS).
