### PR TITLE
Don't throw an error when registering a payment method fails

### DIFF
--- a/assets/js/base/components/payment-methods/express-payment-methods.js
+++ b/assets/js/base/components/payment-methods/express-payment-methods.js
@@ -15,6 +15,7 @@ import {
 	useEditorContext,
 	usePaymentMethodDataContext,
 } from '@woocommerce/base-context';
+import PaymentMethodErrorBoundary from './payment-method-error-boundary';
 
 const ExpressPaymentMethods = () => {
 	const { isEditor } = useEditorContext();
@@ -59,9 +60,11 @@ const ExpressPaymentMethods = () => {
 			<li key="noneRegistered">No registered Payment Methods</li>
 		);
 	return (
-		<ul className="wc-block-components-express-payment__event-buttons">
-			{ content }
-		</ul>
+		<PaymentMethodErrorBoundary isEditor={ isEditor }>
+			<ul className="wc-block-components-express-payment__event-buttons">
+				{ content }
+			</ul>
+		</PaymentMethodErrorBoundary>
 	);
 };
 

--- a/assets/js/base/components/payment-methods/express-payment/checkout-express-payment.js
+++ b/assets/js/base/components/payment-methods/express-payment/checkout-express-payment.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useExpressPaymentMethods } from '@woocommerce/base-hooks';
-import { StoreNoticesProvider } from '@woocommerce/base-context';
+import {
+	StoreNoticesProvider,
+	useEditorContext,
+} from '@woocommerce/base-context';
 import Title from '@woocommerce/base-components/title';
 
 /**
@@ -11,14 +14,23 @@ import Title from '@woocommerce/base-components/title';
  */
 import ExpressPaymentMethods from '../express-payment-methods';
 import './style.scss';
+import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 
 const CheckoutExpressPayment = () => {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
+	const { isEditor } = useEditorContext();
 
 	if (
 		! isInitialized ||
 		( isInitialized && Object.keys( paymentMethods ).length === 0 )
 	) {
+		// Make sure errors are shown in the editor and for admins. For example,
+		// when a payment method fails to register.
+		if ( isEditor || CURRENT_USER_IS_ADMIN ) {
+			return (
+				<StoreNoticesProvider context="wc/express-payment-area"></StoreNoticesProvider>
+			);
+		}
 		return null;
 	}
 

--- a/assets/js/base/components/payment-methods/express-payment/checkout-express-payment.js
+++ b/assets/js/base/components/payment-methods/express-payment/checkout-express-payment.js
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useExpressPaymentMethods } from '@woocommerce/base-hooks';
+import {
+	useEmitResponse,
+	useExpressPaymentMethods,
+} from '@woocommerce/base-hooks';
 import {
 	StoreNoticesProvider,
 	useEditorContext,
@@ -19,6 +22,7 @@ import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 const CheckoutExpressPayment = () => {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
 	const { isEditor } = useEditorContext();
+	const { noticeContexts } = useEmitResponse();
 
 	if (
 		! isInitialized ||
@@ -28,7 +32,9 @@ const CheckoutExpressPayment = () => {
 		// when a payment method fails to register.
 		if ( isEditor || CURRENT_USER_IS_ADMIN ) {
 			return (
-				<StoreNoticesProvider context="wc/express-payment-area"></StoreNoticesProvider>
+				<StoreNoticesProvider
+					context={ noticeContexts.EXPRESS_PAYMENTS }
+				></StoreNoticesProvider>
 			);
 		}
 		return null;
@@ -49,7 +55,9 @@ const CheckoutExpressPayment = () => {
 					</Title>
 				</div>
 				<div className="wc-block-components-express-payment__content">
-					<StoreNoticesProvider context="wc/express-payment-area">
+					<StoreNoticesProvider
+						context={ noticeContexts.EXPRESS_PAYMENTS }
+					>
 						<p>
 							{ __(
 								'In a hurry? Use one of our express checkout options below:',

--- a/assets/js/base/components/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/base/components/payment-methods/payment-method-error-boundary.js
@@ -38,6 +38,7 @@ class PaymentMethodErrorBoundary extends Component {
 			}
 			const notices = [
 				{
+					id: '0',
 					content: errorText,
 					isDismissible: false,
 					status: 'error',

--- a/assets/js/base/components/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/base/components/payment-methods/payment-method-error-boundary.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from 'react';
-import { Notice } from 'wordpress-components';
+import { StoreNoticesContainer } from '@woocommerce/base-components/store-notices-container';
 import PropTypes from 'prop-types';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 
@@ -36,11 +36,14 @@ class PaymentMethodErrorBoundary extends Component {
 					);
 				}
 			}
-			return (
-				<Notice isDismissible={ false } status="error">
-					{ errorText }
-				</Notice>
-			);
+			const notices = [
+				{
+					content: errorText,
+					isDismissible: false,
+					status: 'error',
+				},
+			];
+			return <StoreNoticesContainer notices={ notices } />;
 		}
 
 		return this.props.children;

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -144,51 +144,40 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 			customerPaymentMethods
 		);
 
-		let options = [];
-		const paymentMethodKeys = Object.keys( filteredPaymentMethods );
-		if ( paymentMethodKeys.length > 0 ) {
-			paymentMethodKeys.forEach( ( type ) => {
-				const paymentMethods = filteredPaymentMethods[ type ];
-				if ( paymentMethods.length > 0 ) {
-					options = options.concat(
-						paymentMethods.map( ( paymentMethod ) => {
-							const option =
-								type === 'cc' || type === 'echeck'
-									? getCcOrEcheckPaymentMethodOption(
-											paymentMethod,
-											setActivePaymentMethod,
-											setPaymentStatus
-									  )
-									: getDefaultPaymentMethodOptions(
-											paymentMethod,
-											setActivePaymentMethod,
-											setPaymentStatus
-									  );
-							if (
-								paymentMethod.is_default &&
-								selectedToken === ''
-							) {
-								setSelectedToken( paymentMethod.tokenId + '' );
-								option.onChange( paymentMethod.tokenId );
-							}
-							return option;
-						} )
-					);
+		const types = Object.keys( filteredPaymentMethods );
+		const options = types.flatMap( ( type ) => {
+			const typeMethods = filteredPaymentMethods[ type ];
+			return typeMethods.map( ( paymentMethod ) => {
+				const option =
+					type === 'cc' || type === 'echeck'
+						? getCcOrEcheckPaymentMethodOption(
+								paymentMethod,
+								setActivePaymentMethod,
+								setPaymentStatus
+						  )
+						: getDefaultPaymentMethodOptions(
+								paymentMethod,
+								setActivePaymentMethod,
+								setPaymentStatus
+						  );
+				if ( paymentMethod.is_default && selectedToken === '' ) {
+					setSelectedToken( paymentMethod.tokenId + '' );
+					option.onChange( paymentMethod.tokenId );
 				}
+				return option;
 			} );
-			if ( options.length > 0 ) {
-				currentOptions.current = options;
-				currentOptions.current.push( {
-					value: '0',
-					label: __(
-						'Use a new payment method',
-						'woo-gutenberg-product-blocks'
-					),
-					name: `wc-saved-payment-method-token-new`,
-				} );
-			}
-		}
-		currentOptions.current = options;
+		} );
+		currentOptions.current = [
+			...options,
+			{
+				value: '0',
+				label: __(
+					'Use a new payment method',
+					'woo-gutenberg-product-blocks'
+				),
+				name: `wc-saved-payment-method-token-new`,
+			},
+		];
 	}, [
 		customerPaymentMethods,
 		isEditor,
@@ -219,7 +208,7 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 
 	// In the editor, show `Use a new payment method` option as selected.
 	const selectedOption = isEditor ? '0' : selectedToken + '';
-	return currentOptions.current.length > 0 ? (
+	return currentOptions.current.length > 1 ? (
 		<RadioControl
 			id={ 'wc-payment-method-saved-tokens' }
 			selected={ selectedOption }

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -167,17 +167,7 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 				return option;
 			} );
 		} );
-		currentOptions.current = [
-			...options,
-			{
-				value: '0',
-				label: __(
-					'Use a new payment method',
-					'woo-gutenberg-product-blocks'
-				),
-				name: `wc-saved-payment-method-token-new`,
-			},
-		];
+		currentOptions.current = options;
 	}, [
 		customerPaymentMethods,
 		isEditor,
@@ -208,12 +198,17 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 
 	// In the editor, show `Use a new payment method` option as selected.
 	const selectedOption = isEditor ? '0' : selectedToken + '';
-	return currentOptions.current.length > 1 ? (
+	const newPaymentMethodOption = {
+		value: '0',
+		label: __( 'Use a new payment method', 'woo-gutenberg-product-blocks' ),
+		name: `wc-saved-payment-method-token-new`,
+	};
+	return currentOptions.current.length > 0 ? (
 		<RadioControl
 			id={ 'wc-payment-method-saved-tokens' }
 			selected={ selectedOption }
 			onChange={ updateToken }
-			options={ currentOptions.current }
+			options={ [ ...currentOptions.current, newPaymentMethodOption ] }
 		/>
 	) : null;
 };

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -102,6 +102,13 @@ const usePaymentMethodRegistration = (
 				// If user is admin, add payment methods that failed so the error
 				// boundary can make the error visible.
 				if ( CURRENT_USER_IS_ADMIN ) {
+					const ComponentWithError = ( { error } ) => {
+						throw new Error( error );
+					};
+					paymentMethod.content = <ComponentWithError error={ e } />;
+					if ( paymentMethod?.supports?.savePaymentInfo ) {
+						paymentMethod.supports.savePaymentInfo = false;
+					}
 					addAvailablePaymentMethod( paymentMethod );
 				}
 			}

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -115,7 +115,7 @@ const usePaymentMethodRegistration = (
 					);
 					addErrorNotice( `${ errorText } ${ e }`, {
 						context: noticeContext,
-						id: `wc-${ paymentMethod.paymentMethodId }-registration-error-${ noticeContext }`,
+						id: `wc-${ paymentMethod.paymentMethodId }-registration-error`,
 					} );
 				}
 			}

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -102,10 +102,15 @@ const usePaymentMethodRegistration = (
 				// If user is admin, add payment methods that failed so the error
 				// boundary can make the error visible.
 				if ( CURRENT_USER_IS_ADMIN ) {
+					// Create a simple component whose only responsibility is to
+					// throw an error and use it as the `content` of the failing
+					// payment method.
 					const ComponentWithError = ( { error } ) => {
 						throw new Error( error );
 					};
 					paymentMethod.content = <ComponentWithError error={ e } />;
+					// If `savePaymentInfo` is true, make it false so saved
+					// payment methods will not show up in the UI.
 					if ( paymentMethod?.supports?.savePaymentInfo ) {
 						paymentMethod.supports.savePaymentInfo = false;
 					}

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -81,10 +81,8 @@ const usePaymentMethodRegistration = (
 				continue;
 			}
 
-			// In editor and for admin users in the frontend, shortcut so all
-			// payment methods show as available and let the payment method
-			// error boundary handle any errors.
-			if ( isEditor || CURRENT_USER_IS_ADMIN ) {
+			// In editor, shortcut so all payment methods show as available.
+			if ( isEditor ) {
 				addAvailablePaymentMethod( paymentMethod );
 				continue;
 			}
@@ -93,8 +91,14 @@ const usePaymentMethodRegistration = (
 			const canPay = await Promise.resolve(
 				paymentMethod.canMakePayment( canPayArgument.current )
 			);
-			if ( canPay && ! canPay.error ) {
-				addAvailablePaymentMethod( paymentMethod );
+			if ( canPay ) {
+				if ( ! canPay.error ) {
+					addAvailablePaymentMethod( paymentMethod );
+				} else if ( CURRENT_USER_IS_ADMIN ) {
+					// For admins, show payment methods that failed so the error
+					// boundary can make the error visible.
+					addAvailablePaymentMethod( paymentMethod );
+				}
 			}
 		}
 

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -89,12 +89,6 @@ const usePaymentMethodRegistration = (
 				continue;
 			}
 
-			// In editor, shortcut so all payment methods show as available.
-			if ( isEditor ) {
-				addAvailablePaymentMethod( paymentMethod );
-				continue;
-			}
-
 			// In front end, ask payment method if it should be available.
 			try {
 				const canPay = await Promise.resolve(
@@ -110,9 +104,9 @@ const usePaymentMethodRegistration = (
 					);
 				}
 			} catch ( e ) {
-				if ( CURRENT_USER_IS_ADMIN ) {
+				if ( CURRENT_USER_IS_ADMIN || isEditor ) {
 					const errorText = sprintf(
-						/* translators: %s the name of the payment method being registered (bank transfer, Stripe...) */
+						/* translators: %s the id of the payment method being registered (bank transfer, Stripe...) */
 						__(
 							`There was an error registering the payment method with id '%s': `,
 							'woo-gutenberg-products-block'

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -42,7 +42,8 @@ import {
 const usePaymentMethodRegistration = (
 	dispatcher,
 	registeredPaymentMethods,
-	paymentMethodsSortOrder
+	paymentMethodsSortOrder,
+	noticeContext
 ) => {
 	const [ isInitialized, setIsInitialized ] = useState( false );
 	const { isEditor } = useEditorContext();
@@ -57,7 +58,6 @@ const usePaymentMethodRegistration = (
 		selectedShippingMethods,
 	} );
 	const { addErrorNotice, removeNotice } = useStoreNotices();
-	const { noticeContexts } = useEmitResponse();
 
 	useEffect( () => {
 		canPayArgument.current = {
@@ -120,8 +120,8 @@ const usePaymentMethodRegistration = (
 						paymentMethod.paymentMethodId
 					);
 					addErrorNotice( `${ errorText } ${ e }`, {
-						context: noticeContexts.PAYMENTS,
-						id: `wc-${ paymentMethod.paymentMethodId }-registration-error`,
+						context: noticeContext,
+						id: `wc-${ paymentMethod.paymentMethodId }-registration-error-${ noticeContext }`,
 					} );
 				}
 			}
@@ -138,7 +138,7 @@ const usePaymentMethodRegistration = (
 		addErrorNotice,
 		dispatcher,
 		isEditor,
-		noticeContexts.PAYMENTS,
+		noticeContext,
 		paymentMethodsOrder,
 		registeredPaymentMethods,
 		removeNotice,
@@ -163,6 +163,7 @@ const usePaymentMethodRegistration = (
  */
 export const usePaymentMethods = ( dispatcher ) => {
 	const standardMethods = getPaymentMethods();
+	const { noticeContexts } = useEmitResponse();
 	// Ensure all methods are present in order.
 	// Some payment methods may not be present in PAYMENT_GATEWAY_SORT_ORDER if they
 	// depend on state, e.g. COD can depend on shipping method.
@@ -173,7 +174,8 @@ export const usePaymentMethods = ( dispatcher ) => {
 	return usePaymentMethodRegistration(
 		dispatcher,
 		standardMethods,
-		Array.from( displayOrder )
+		Array.from( displayOrder ),
+		noticeContexts.PAYMENTS
 	);
 };
 
@@ -186,9 +188,11 @@ export const usePaymentMethods = ( dispatcher ) => {
  */
 export const useExpressPaymentMethods = ( dispatcher ) => {
 	const expressMethods = getExpressPaymentMethods();
+	const { noticeContexts } = useEmitResponse();
 	return usePaymentMethodRegistration(
 		dispatcher,
 		expressMethods,
-		Object.keys( expressMethods )
+		Object.keys( expressMethods ),
+		noticeContexts.EXPRESS_PAYMENTS
 	);
 };

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -35,6 +35,8 @@ import {
  * @param  {Array}                      paymentMethodsSortOrder  Array of payment method names to
  *                                                               sort by. This should match keys of
  *                                                               registeredPaymentMethods.
+ * @param  {string}                     noticeContext            Id of the context to append
+ *                                                               notices to.
  *
  * @return {boolean} Whether the payment methods have been initialized or not. True when all payment
  *                   methods have been initialized.

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -59,7 +59,7 @@ const usePaymentMethodRegistration = (
 		shippingAddress,
 		selectedShippingMethods,
 	} );
-	const { addErrorNotice, removeNotice } = useStoreNotices();
+	const { addErrorNotice } = useStoreNotices();
 
 	useEffect( () => {
 		canPayArgument.current = {
@@ -101,9 +101,6 @@ const usePaymentMethodRegistration = (
 						throw new Error( canPay.error.message );
 					}
 					addAvailablePaymentMethod( paymentMethod );
-					removeNotice(
-						`wc-${ paymentMethod.paymentMethodId }-registration-error`
-					);
 				}
 			} catch ( e ) {
 				if ( CURRENT_USER_IS_ADMIN || isEditor ) {
@@ -137,7 +134,6 @@ const usePaymentMethodRegistration = (
 		noticeContext,
 		paymentMethodsOrder,
 		registeredPaymentMethods,
-		removeNotice,
 	] );
 
 	// Determine which payment methods are available initially and whenever

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -88,15 +88,20 @@ const usePaymentMethodRegistration = (
 			}
 
 			// In front end, ask payment method if it should be available.
-			const canPay = await Promise.resolve(
-				paymentMethod.canMakePayment( canPayArgument.current )
-			);
-			if ( canPay ) {
-				if ( ! canPay.error ) {
+			try {
+				const canPay = await Promise.resolve(
+					paymentMethod.canMakePayment( canPayArgument.current )
+				);
+				if ( canPay ) {
+					if ( canPay.error ) {
+						throw new Error( canPay.error.message );
+					}
 					addAvailablePaymentMethod( paymentMethod );
-				} else if ( CURRENT_USER_IS_ADMIN ) {
-					// For admins, show payment methods that failed so the error
-					// boundary can make the error visible.
+				}
+			} catch ( e ) {
+				// If user is admin, add payment methods that failed so the error
+				// boundary can make the error visible.
+				if ( CURRENT_USER_IS_ADMIN ) {
 					addAvailablePaymentMethod( paymentMethod );
 				}
 			}

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -21,7 +21,11 @@ import {
 import { getAdminLink } from '@woocommerce/settings';
 import { __experimentalCreateInterpolateElement } from 'wordpress-element';
 import { useRef } from '@wordpress/element';
-import { EditorProvider, useEditorContext } from '@woocommerce/base-context';
+import {
+	EditorProvider,
+	useEditorContext,
+	StoreNoticesProvider,
+} from '@woocommerce/base-context';
 import PageSelector from '@woocommerce/editor-components/page-selector';
 import {
 	previewCart,
@@ -320,9 +324,11 @@ const CheckoutEditor = ( { attributes, setAttributes } ) => {
 						'woo-gutenberg-products-block'
 					) }
 				>
-					<Disabled>
-						<Block attributes={ attributes } />
-					</Disabled>
+					<StoreNoticesProvider context="wc/checkout">
+						<Disabled>
+							<Block attributes={ attributes } />
+						</Disabled>
+					</StoreNoticesProvider>
 				</BlockErrorBoundary>
 			</div>
 		</EditorProvider>

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -32,6 +32,9 @@ function paymentRequestAvailable( currencyCode ) {
 			isStripeInitialized = true;
 			return canPay;
 		}
+		if ( stripe.error && stripe.error instanceof Error ) {
+			throw stripe.error;
+		}
 		// Do a test payment to confirm if payment method is available.
 		const paymentRequest = stripe.paymentRequest( {
 			total: {


### PR DESCRIPTION
Fixes #3125.
Fixes #3157.

This PR has some changes in how failing payment methods are handled: they will silently fail for shoppers, but a notice will be shown for admins.

### How to test the changes in this Pull Request:

Excuses in advance for the long testing steps, this PR touches some logic that affects several critical flows so I tried to list the steps as detailed as possible.

### Test #3125.
##### Preparation
Steps from #3125:
1. Install & activate WooCommerce Stripe. 
2. Enable Stripe CC payment method - don't add an api key (or delete the option).
3. Enable BACS or other payment methods (e.g. cheque).
3. Add checkout block to checkout page.
4. On front end, add something to cart and proceed to checkout.

##### Tests
1. Make sure you have an admin user with saved payment methods<sup>*</sup> and a user without saved payment methods (or a guest).
2. With those two users, check the Checkout page in the frontend. Also open the Checkout page in the editor.
3. Verify the statements below are true. :point_down: 

| Scenario | With Stripe API key | Without Stripe API key |
| --- | --- | --- |
| Admin with saved payment methods / Editor | <ul><li>Saved payment methods are displayed.</li><li>Credit Card payment method is displayed (under use a new payment method).</li><li>There is no error notice.</li></ul> | <ul><li>Saved payment methods are not displayed.</li><li>There is an error notice about Stripe not being registered correctly.</li><li>Other payment methods are displayed as usual.</li></ul> |
| Guest user | <ul><li>Saved payment methods are not displayed.</li><li>Credit Card payment method is displayed.</li><li>There is no error notice.</li></ul> | <ul><li>Saved payment methods are not displayed.</li><li>Credit Card payment method is not displayed.</li><li>There is no error notice.</li><li>Other payment methods are displayed as usual.</li></ul> |

<sup>*</sup> In order to save a payment method with a user. Enable the WooCommerce Stripe plugin, set the keys and make a purchase with a user selecting the `Save payment information to my account for future purchases.` option. Next time you visit the Checkout with that user, the saved payment method will show up.

#### Test #3157
Assuming you already have a user with saved credit cards in Stripe from the steps above.
1. Go to Stripe settings and uncheck `Enable Payment via Saved Cards`. Make sure you have added back the API keys that you might have removed in the steps above.
2. Start a purchase with a user that has saved payment methods and go to the Checkout block.
3. Verify saved credit cards are not shown in the Payment method options.

#### Regression testing

It would also be great to do a purchase flow with some of the scenarios described above to ensure the payment flow still works properly.

### Changelog

> Fixed an issue that was not showing other payment methods if one failed to load when the user was an admin.