### PR TITLE
Remove selectedToken state from PaymentMethods

### DIFF
--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -11,7 +11,6 @@ import {
 	cloneElement,
 	useRef,
 	useEffect,
-	useState,
 	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -56,6 +55,7 @@ const PaymentMethods = () => {
 	const { isEditor } = useEditorContext();
 	const {
 		customerPaymentMethods = {},
+		paymentMethodData,
 		setActivePaymentMethod,
 		shouldSavePayment,
 		setShouldSavePayment,
@@ -67,7 +67,6 @@ const PaymentMethods = () => {
 		...paymentMethodInterface
 	} = usePaymentMethodInterface();
 	const currentPaymentMethodInterface = useRef( paymentMethodInterface );
-	const [ selectedToken, setSelectedToken ] = useState( '0' );
 	const { noticeContexts } = useEmitResponse();
 	const { removeNotice } = useStoreNotices();
 	const { customerId } = useCheckoutContext();
@@ -158,9 +157,7 @@ const PaymentMethods = () => {
 		/>
 	);
 
-	const renderedSavedPaymentOptions = (
-		<SavedPaymentMethodOptions onSelect={ setSelectedToken } />
-	);
+	const renderedSavedPaymentOptions = <SavedPaymentMethodOptions />;
 
 	const renderedTabsAndSavedPaymentOptions = (
 		<>
@@ -170,7 +167,7 @@ const PaymentMethods = () => {
 	);
 
 	return Object.keys( customerPaymentMethods ).length > 0 &&
-		selectedToken !== '0'
+		paymentMethodData.isSavedToken
 		? renderedSavedPaymentOptions
 		: renderedTabsAndSavedPaymentOptions;
 };

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -87,7 +87,7 @@ const getDefaultPaymentMethodOptions = (
 	};
 };
 
-const SavedPaymentMethodOptions = ( { onSelect } ) => {
+const SavedPaymentMethodOptions = () => {
 	const { isEditor } = useEditorContext();
 	const {
 		setPaymentStatus,
@@ -148,9 +148,8 @@ const SavedPaymentMethodOptions = ( { onSelect } ) => {
 				setPaymentStatus().started();
 			}
 			setSelectedToken( token );
-			onSelect( token );
 		},
-		[ setSelectedToken, setPaymentStatus, onSelect ]
+		[ setSelectedToken, setPaymentStatus ]
 	);
 	useEffect( () => {
 		if ( selectedToken && currentOptions.current.length > 0 ) {


### PR DESCRIPTION
Small refactor: there is no need to keep `selectedToken` in the state of PaymentMethods if we can directly read it from `paymentMethodData` in the context.

### How to test the changes in this Pull Request:

1. Without any previous saved payment method, open the Checkout block and verify the payment method tabs are displayed normally.
2. With a user with previous saved payment methods<sup>*</sup>, open the Checkout block and verify the payment method tabs are hidden by default until you select `Use a new payment method`.

<sup>*</sup> In order to save a payment method with a user. Enable the WooCommerce Stripe plugin, set the keys and make a purchase with a user selecting the `Save payment information to my account for future purchases.` option. Next time you visit the Checkout with that user, the saved payment method will show up.