### PR TITLE
Update package-lock.json (fix e2e tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3064,20 +3064,20 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "6.0.5",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
-			"integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.6.tgz",
+			"integrity": "sha512-7Cc8olaCoL/mtquB7j/HTbPM+sY6Ebr4k2X2y4JoXpVKQ7r5xB4iGQE0IoO58wIPsUk4AzoT65AMEpymSbWTgQ==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^5.0.0",
-				"is-plain-object": "^4.0.0",
+				"is-plain-object": "^5.0.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				}
 			}
@@ -3094,25 +3094,25 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.4.7",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
-			"integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
+			"version": "5.4.8",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.8.tgz",
+			"integrity": "sha512-mWbxjsARJzAq5xp+ZrQfotc+MHFz3/Am2qATJwflv4PZ1TjhgIJnr60PCVdZT9Z/tl+uPXooaVgeviy1KkDlLQ==",
 			"dev": true,
 			"requires": {
 				"@octokit/endpoint": "^6.0.1",
 				"@octokit/request-error": "^2.0.0",
 				"@octokit/types": "^5.0.0",
 				"deprecation": "^2.0.0",
-				"is-plain-object": "^4.0.0",
+				"is-plain-object": "^5.0.0",
 				"node-fetch": "^2.3.0",
 				"once": "^1.4.0",
 				"universal-user-agent": "^6.0.0"
 			},
 			"dependencies": {
 				"is-plain-object": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
-					"integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				},
 				"node-fetch": {
@@ -3501,6 +3501,18 @@
 				"telejson": "^5.0.2",
 				"ts-dedent": "^1.1.1",
 				"util-deprecate": "^1.0.2"
+			},
+			"dependencies": {
+				"@storybook/semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.6.5",
+						"find-up": "^4.1.0"
+					}
+				}
 			}
 		},
 		"@storybook/channel-postmessage": {
@@ -3699,6 +3711,16 @@
 				"webpack-virtual-modules": "^0.2.2"
 			},
 			"dependencies": {
+				"@storybook/semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.6.5",
+						"find-up": "^4.1.0"
+					}
+				},
 				"ansi-styles": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -3930,6 +3952,18 @@
 				"regenerator-runtime": "^0.13.3",
 				"ts-dedent": "^1.1.1",
 				"webpack": "^4.43.0"
+			},
+			"dependencies": {
+				"@storybook/semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.6.5",
+						"find-up": "^4.1.0"
+					}
+				}
 			}
 		},
 		"@storybook/router": {
@@ -3944,16 +3978,6 @@
 				"global": "^4.3.2",
 				"memoizerific": "^1.11.3",
 				"qs": "^6.6.0"
-			}
-		},
-		"@storybook/semver": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
-			"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
-			"dev": true,
-			"requires": {
-				"core-js": "^3.6.5",
-				"find-up": "^4.1.0"
 			}
 		},
 		"@storybook/source-loader": {
@@ -4041,6 +4065,16 @@
 				"store2": "^2.7.1"
 			},
 			"dependencies": {
+				"@storybook/semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/@storybook/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
+					"dev": true,
+					"requires": {
+						"core-js": "^3.6.5",
+						"find-up": "^4.1.0"
+					}
+				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -4406,9 +4440,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-			"integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.14.tgz",
+			"integrity": "sha512-8w9szzKs14ZtBVuP6Wn7nMLRJ0D6dfB0VEBEyRgxrZ/Ln49aNMykrghM2FaNn4FJRzNppCSa0Rv9pBRM5Xc3wg==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -4444,11 +4478,11 @@
 			"integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA=="
 		},
 		"@types/domutils": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/@types/domutils/-/domutils-1.7.2.tgz",
-			"integrity": "sha512-Nnwy1Ztwq42SSNSZSh9EXBJGrOZPR+PQ2sRT4VZy8hnsFXfCil7YlKO2hd2360HyrtFz2qwnKQ13ENrgXNxJbw==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/@types/domutils/-/domutils-1.7.3.tgz",
+			"integrity": "sha512-EucnS75OnnEdypNt+UpARisSF8eJBq4no+aVOis3Bs5kyABDXm1hEDv6jJxcMJPjR+a2YCrEANaW+BMT2QVG2Q==",
 			"requires": {
-				"@types/domhandler": "*"
+				"domhandler": "^2.4.0"
 			}
 		},
 		"@types/glob": {
@@ -4614,9 +4648,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.6.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
-			"integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ=="
+			"version": "14.10.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.0.tgz",
+			"integrity": "sha512-SOIyrdADB4cq6eY1F+9iU48iIomFAPltu11LCvA9PKcyEwHadjCFzNVPotAR+oEJA0bCP4Xvvgy+vwu1ZjVh8g=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.7",
@@ -8035,6 +8069,7 @@
 			"version": "2.10.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.10.0.tgz",
 			"integrity": "sha512-CedhhFfcubM/lsluY7JPC49VG0/Ee0chOBJ1vyDEvIJmQk0bM3sLfgt5qVK773yivVOqD9blQMO+JihnaMXF8w==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"@wordpress/escape-html": "^1.6.0",
@@ -8188,6 +8223,7 @@
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
 			"integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"gettext-parser": "^1.3.1",
@@ -8404,6 +8440,7 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.7.0.tgz",
 			"integrity": "sha512-fRHTAivQlWOQVn8wu8NHM8D5sacSvY6upJ+MgWSu1Q7pqy51zaCPE2T9lhym3GC1QzABus6VjDctR8jwfNfd/g==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
@@ -9003,27 +9040,6 @@
 						"color-convert": "^2.0.1"
 					}
 				},
-				"bl": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
-					"dev": true,
-					"requires": {
-						"buffer": "^5.5.0",
-						"inherits": "^2.0.4",
-						"readable-stream": "^3.4.0"
-					}
-				},
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				},
 				"chalk": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -9033,12 +9049,6 @@
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
 					}
-				},
-				"chownr": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-					"dev": true
 				},
 				"clone-deep": {
 					"version": "4.0.1",
@@ -9077,15 +9087,6 @@
 						"which": "^1.2.9"
 					}
 				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
 				"dir-glob": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -9093,27 +9094,6 @@
 					"dev": true,
 					"requires": {
 						"path-type": "^4.0.0"
-					}
-				},
-				"extract-zip": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-					"dev": true,
-					"requires": {
-						"@types/yauzl": "^2.9.1",
-						"debug": "^4.1.1",
-						"get-stream": "^5.1.0",
-						"yauzl": "^2.10.0"
-					}
-				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
 					}
 				},
 				"has-flag": {
@@ -9176,12 +9156,6 @@
 						"webpack-sources": "^1.1.0"
 					}
 				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				},
 				"normalize-url": {
 					"version": "1.9.1",
 					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
@@ -9192,26 +9166,6 @@
 						"prepend-http": "^1.0.0",
 						"query-string": "^4.1.0",
 						"sort-keys": "^1.0.0"
-					}
-				},
-				"puppeteer": {
-					"version": "npm:puppeteer-core@3.0.0",
-					"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
-					"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
-					"dev": true,
-					"requires": {
-						"@types/mime-types": "^2.1.0",
-						"debug": "^4.1.0",
-						"extract-zip": "^2.0.0",
-						"https-proxy-agent": "^4.0.0",
-						"mime": "^2.0.3",
-						"mime-types": "^2.1.25",
-						"progress": "^2.0.1",
-						"proxy-from-env": "^1.0.0",
-						"rimraf": "^3.0.2",
-						"tar-fs": "^2.0.0",
-						"unbzip2-stream": "^1.3.3",
-						"ws": "^7.2.3"
 					}
 				},
 				"sass-loader": {
@@ -9273,31 +9227,6 @@
 					"dev": true,
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"tar-fs": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-					"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
-					"dev": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"mkdirp-classic": "^0.5.2",
-						"pump": "^3.0.0",
-						"tar-stream": "^2.0.0"
-					}
-				},
-				"tar-stream": {
-					"version": "2.1.3",
-					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
-					"integrity": "sha512-Z9yri56Dih8IaK8gncVPx4Wqt86NDmQTSh49XLZgjWpGZL9GK9HKParS2scqHCC4w6X9Gh2jwaU45V47XTKwVA==",
-					"dev": true,
-					"requires": {
-						"bl": "^4.0.1",
-						"end-of-stream": "^1.4.1",
-						"fs-constants": "^1.0.0",
-						"inherits": "^2.0.3",
-						"readable-stream": "^3.1.1"
 					}
 				},
 				"url-loader": {
@@ -9651,9 +9580,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -11718,15 +11647,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.14.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.1.tgz",
-			"integrity": "sha512-zyBTIHydW37pnb63c7fHFXUG6EcqWOqoMdDx6cdyaDFriZ20EoVxcE95S54N+heRqY8m8IUgB5zYta/gCwSaaA==",
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
+			"integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001124",
-				"electron-to-chromium": "^1.3.562",
+				"caniuse-lite": "^1.0.30001125",
+				"electron-to-chromium": "^1.3.564",
 				"escalade": "^3.0.2",
-				"node-releases": "^1.1.60"
+				"node-releases": "^1.1.61"
 			}
 		},
 		"bser": {
@@ -11997,9 +11926,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001124",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001124.tgz",
-			"integrity": "sha512-zQW8V3CdND7GHRH6rxm6s59Ww4g/qGWTheoboW9nfeMg7sUoopIfKCcNZUjwYRCOrvereh3kwDpZj4VLQ7zGtA==",
+			"version": "1.0.30001125",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
+			"integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -13102,18 +13031,18 @@
 			}
 		},
 		"cross-fetch": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
-			"integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
 			"dev": true,
 			"requires": {
-				"node-fetch": "2.6.0"
+				"node-fetch": "2.6.1"
 			},
 			"dependencies": {
 				"node-fetch": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
 					"dev": true
 				}
 			}
@@ -14310,9 +14239,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.562",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.562.tgz",
-			"integrity": "sha512-WhRe6liQ2q/w1MZc8mD8INkenHivuHdrr4r5EQHNomy3NJux+incP6M6lDMd0paShP3MD0WGe5R1TWmEClf+Bg==",
+			"version": "1.3.565",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.565.tgz",
+			"integrity": "sha512-me5dGlHFd8Q7mKhqbWRLIYnKjw4i0fO6hmW0JBxa7tM87fBfNEjWokRnDF7V+Qme/9IYpwhfMn+soWs40tXWqg==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -15029,9 +14958,9 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "30.3.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.3.2.tgz",
-			"integrity": "sha512-52p1xlKNm2Rodo51jUPIQ1ytKXH6Uj88mDJgmZ1znRKjynDQOO4ZS9cx5FqFoRXk/iqHv15QxHkQCBVeWViIog==",
+			"version": "30.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.4.0.tgz",
+			"integrity": "sha512-eb22QADWcISPQJwFJ+rUAl1NXdyOq3qy0Cp0+MZzpwlqFgJ+eJ7Fd/jYTfwDuN8QyFWumuyzSpwQBnF4PfM9Wg==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "^0.7.6",
@@ -15261,9 +15190,9 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.0.tgz",
-			"integrity": "sha512-36zilUcDwDReiORXmcmTc6rRumu9JIM3WjSvV0nclHoUQ0CNrX866EwONvLR/UqaeqFutbAnVu8PEmctdo2SRQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.1.tgz",
+			"integrity": "sha512-vFJNwsf4MLYS0lHYfz9LqxQ+GccYsGGeKPHDxgkIaKbAhNuTLnST+q44pt81MzJZyFU5K4XLF6WiCGv3Yb6tCg==",
 			"dev": true
 		},
 		"eslint-plugin-testing-library": {
@@ -18076,9 +18005,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
+			"integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -23616,9 +23545,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.60",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-			"integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
+			"version": "1.1.61",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+			"integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g==",
 			"dev": true
 		},
 		"node-sass": {
@@ -26196,6 +26125,122 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"puppeteer": {
+			"version": "npm:puppeteer-core@3.0.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
+			"integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
+			"dev": true,
+			"requires": {
+				"@types/mime-types": "^2.1.0",
+				"debug": "^4.1.0",
+				"extract-zip": "^2.0.0",
+				"https-proxy-agent": "^4.0.0",
+				"mime": "^2.0.3",
+				"mime-types": "^2.1.25",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+					"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+					"dev": true,
+					"requires": {
+						"buffer": "^5.5.0",
+						"inherits": "^2.0.4",
+						"readable-stream": "^3.4.0"
+					}
+				},
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"dev": true,
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				},
+				"chownr": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+					"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+					"dev": true
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"extract-zip": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+					"dev": true,
+					"requires": {
+						"@types/yauzl": "^2.9.1",
+						"debug": "^4.1.1",
+						"get-stream": "^5.1.0",
+						"yauzl": "^2.10.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"mime": {
+					"version": "2.4.6",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+					"integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"tar-fs": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+					"integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+					"dev": true,
+					"requires": {
+						"chownr": "^1.1.1",
+						"mkdirp-classic": "^0.5.2",
+						"pump": "^3.0.0",
+						"tar-stream": "^2.0.0"
+					}
+				},
+				"tar-stream": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
+					"integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+					"dev": true,
+					"requires": {
+						"bl": "^4.0.3",
+						"end-of-stream": "^1.4.1",
+						"fs-constants": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.1.1"
+					}
+				}
+			}
+		},
 		"q": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -27038,14 +27083,14 @@
 			}
 		},
 		"react-inspector": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.0.1.tgz",
-			"integrity": "sha512-qRIENuAIcRaytrmg/TL5nN5igYZMzyQqIKlWA8zoYRDltULsZC1bWy2Ua5wYJuwEYnC3gK4FCjcIQnb+5OyLsQ==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-5.1.0.tgz",
+			"integrity": "sha512-JAwswiengIcxi4X/Ssb8nf6suOuQsyit8Fxo04+iPKTnPNY3XIOuagjMZSzpJDDKkYcc/ARlySOYZZv626WUvA==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.8.7",
-				"is-dom": "^1.1.0",
-				"prop-types": "^15.6.1"
+				"@babel/runtime": "^7.0.0",
+				"is-dom": "^1.0.0",
+				"prop-types": "^15.0.0"
 			}
 		},
 		"react-is": {
@@ -32883,9 +32928,9 @@
 			}
 		},
 		"whatwg-fetch": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.0.tgz",
-			"integrity": "sha512-rsum2ulz2iuZH08mJkT0Yi6JnKhwdw4oeyMjokgxd+mmqYSd9cPpOQf01TIWgjxG/U4+QR+AwKq6lSbXVxkyoQ=="
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
+			"integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
@@ -33076,18 +33121,6 @@
 						"react-resize-aware": "^3.0.1"
 					},
 					"dependencies": {
-						"@wordpress/element": {
-							"version": "2.17.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-							"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"@wordpress/escape-html": "^1.9.0",
-								"lodash": "^4.17.19",
-								"react": "^16.13.1",
-								"react-dom": "^16.13.1"
-							}
-						},
 						"@wordpress/is-shallow-equal": {
 							"version": "2.2.0",
 							"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.2.0.tgz",
@@ -33103,6 +33136,53 @@
 						}
 					}
 				},
+				"@wordpress/element": {
+					"version": "2.17.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
+					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"@wordpress/escape-html": "^1.9.0",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.20",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+							"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+						}
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.15.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.15.0.tgz",
+					"integrity": "sha512-AawJgHEGPyMoPATl8a3Qa+cCZV3S6azPfvqeStbN2pSc7v0HqYhJhWaw80WToHkN4kyOsfu1PUVf1wefuoMNEA==",
+					"requires": {
+						"@babel/runtime": "^7.9.2",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					},
+					"dependencies": {
+						"lodash": {
+							"version": "4.17.20",
+							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+							"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+						}
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
+					"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
+					"requires": {
+						"@babel/runtime": "^7.8.3"
+					}
+				},
 				"@wordpress/keycodes": {
 					"version": "2.15.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.15.0.tgz",
@@ -33113,19 +33193,6 @@
 						"lodash": "^4.17.19"
 					},
 					"dependencies": {
-						"@wordpress/i18n": {
-							"version": "3.15.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.15.0.tgz",
-							"integrity": "sha512-AawJgHEGPyMoPATl8a3Qa+cCZV3S6azPfvqeStbN2pSc7v0HqYhJhWaw80WToHkN4kyOsfu1PUVf1wefuoMNEA==",
-							"requires": {
-								"@babel/runtime": "^7.9.2",
-								"gettext-parser": "^1.3.1",
-								"lodash": "^4.17.19",
-								"memize": "^1.1.0",
-								"sprintf-js": "^1.1.1",
-								"tannin": "^1.2.0"
-							}
-						},
 						"lodash": {
 							"version": "4.17.20",
 							"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",


### PR DESCRIPTION
It looks like Travis tests were failing because they couldn't find puppeteer. Adding it back to package.json fixes the issue.

cc @nerrad since puppeteer was removed in #3115. I'm not sure why tests were passing in that PR but suddenly stopped passing in `main`. Let me know if I'm missing something or you have a better idea of what might be going on. :slightly_smiling_face: 