### PR TITLE
Update .gitattributes to reduce what is pulled into projects via composer.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,17 @@
+# Ignore all hidden files and directories
 /.* export-ignore
+
+# Ignore all markdown files
 /*.md export-ignore
+
+# Ignore following directories and contents
 /node_modules* export-ignore
 /tests export-ignore
 /bin export-ignore
+/docs export-ignore
+/storybook export-ignore
+
+# Ignore following configuration files
 /phpcs.xml export-ignore
 /phpunit.* export-ignore
 /composer.lock export-ignore
@@ -14,5 +23,8 @@
 /bundlesize.config.json export-ignore
 /package.json export-ignore
 /package-lock.json export-ignore
-/babel-config.js export-ignore
-/docs export-ignore
+/babel.config.js export-ignore
+/docker-compose.yml export-ignore
+/globals.d.ts export-ignore
+/tsconfig.json export-ignore
+/webpack.config.js export-ignore


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3140

This pull updates the `.gitattributes` file to cover all folders and files we want excluded when this project is pulled in as a dependency via composer. 

## Testing

If you run `git archive --format=zip -o test.zip HEAD` while checked out on this branch, and then check the contents of test.zip, it should only have the following files:

<img width="625" alt="Image 2020-09-14 at 11 43 25 AM" src="https://user-images.githubusercontent.com/1429108/93107420-91770f80-f67f-11ea-9dae-b8f3a2f6493e.png">

Note that `vendor` and `build` folders are not explicitly excluded but are just not showing up in this test because `git archive` only includes what's being tracked by the branch. Our releases add `vendor` and `build` folders so composer will pull those in too.