### PR TITLE
Fix State label for Spain

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/country-address-fields.js
+++ b/assets/js/base/components/cart-checkout/address-form/country-address-fields.js
@@ -198,9 +198,9 @@ const countryAddressFields = {
 	ES: {
 		...postcodeBeforeCity,
 		state: {
-			label: __( 'State', 'woo-gutenberg-products-block' ),
+			label: __( 'Province', 'woo-gutenberg-products-block' ),
 			optionalLabel: __(
-				'State (optional)',
+				'Province (optional)',
 				'woo-gutenberg-products-block'
 			),
 		},


### PR DESCRIPTION
Small PR fixing the _State_ label for Spain. It should be `Province` instead of `State`. You can see WC Core for reference: https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-countries.php#L1250

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/93193649-6952e380-f747-11ea-9f99-9e406041c39a.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/93193625-60faa880-f747-11ea-8354-53e29d3ed21e.png)

### How to test the changes in this Pull Request:

1. Go to the Checkout block and change the country to Spain.
2. Verify the field below the country changes its label to `Province` instead of `State`.

### Changelog

> In address forms, the 'State' label is now correctly replaced with 'Province' when the country is Spain.