### PR TITLE
Use noticeContexts from useEmitResponse instead of hardcoded values

### DIFF
--- a/assets/js/base/components/payment-methods/express-payment/cart-express-payment.js
+++ b/assets/js/base/components/payment-methods/express-payment/cart-express-payment.js
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useExpressPaymentMethods } from '@woocommerce/base-hooks';
+import {
+	useEmitResponse,
+	useExpressPaymentMethods,
+} from '@woocommerce/base-hooks';
 import { StoreNoticesProvider } from '@woocommerce/base-context';
 
 /**
@@ -13,6 +16,7 @@ import './style.scss';
 
 const CartExpressPayment = () => {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
+	const { noticeContexts } = useEmitResponse();
 
 	if (
 		! isInitialized ||
@@ -25,7 +29,9 @@ const CartExpressPayment = () => {
 		<>
 			<div className="wc-block-components-express-payment wc-block-components-express-payment--cart">
 				<div className="wc-block-components-express-payment__content">
-					<StoreNoticesProvider context="wc/express-payment-area">
+					<StoreNoticesProvider
+						context={ noticeContexts.EXPRESS_PAYMENTS }
+					>
 						<ExpressPaymentMethods />
 					</StoreNoticesProvider>
 				</div>

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -195,17 +195,17 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		( message ) => {
 			if ( message ) {
 				addErrorNotice( message, {
-					context: 'wc/express-payment-area',
+					context: noticeContexts.EXPRESS_PAYMENTS,
 					id: 'wc-express-payment-error',
 				} );
 			} else {
 				removeNotice(
 					'wc-express-payment-error',
-					'wc/express-payment-area'
+					noticeContexts.EXPRESS_PAYMENTS
 				);
 			}
 		},
-		[ addErrorNotice, removeNotice ]
+		[ addErrorNotice, noticeContexts.EXPRESS_PAYMENTS, removeNotice ]
 	);
 	// ensure observers are always current.
 	useEffect( () => {

--- a/assets/js/blocks/cart-checkout/checkout/form/payment-method-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/payment-method-step.js
@@ -7,13 +7,18 @@ import {
 	useCheckoutContext,
 	StoreNoticesProvider,
 } from '@woocommerce/base-context';
-import { usePaymentMethods, useStoreCart } from '@woocommerce/base-hooks';
+import {
+	useEmitResponse,
+	usePaymentMethods,
+	useStoreCart,
+} from '@woocommerce/base-hooks';
 import { PaymentMethods } from '@woocommerce/base-components/payment-methods';
 
 const PaymentMethodStep = () => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { cartNeedsPayment } = useStoreCart();
 	const { paymentMethods } = usePaymentMethods();
+	const { noticeContexts } = useEmitResponse();
 
 	if ( ! cartNeedsPayment ) {
 		return null;
@@ -34,7 +39,7 @@ const PaymentMethodStep = () => {
 					: ''
 			}
 		>
-			<StoreNoticesProvider context="wc/payment-area">
+			<StoreNoticesProvider context={ noticeContexts.PAYMENTS }>
 				<PaymentMethods />
 			</StoreNoticesProvider>
 		</FormStep>


### PR DESCRIPTION
Inspired by https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3134#discussion_r490623807, this PR replaces all instances of `wc/payment-area` and `wc/express-payment-area` with their values from `useEmpitResponse`'s  `noticeContexts`.

### How to test the changes in this Pull Request:

I think changes are quite safe, but a good way to test would be forcing some errors to payment methods and ensuring they appear in the correct places.

1. Install & activate WooCommerce Stripe. 
2. Enable Stripe CC payment method - don't add an api key (or delete the option).
3. Add checkout block to checkout page.
4. On front end, add something to cart and proceed to checkout with an admin user.
5. Verify an error appears in the express payment methods section and in the payment methods step.

![checkout-errors](https://user-images.githubusercontent.com/3616980/93592030-b803b600-f9b1-11ea-976e-70c7b594f474.png)
