### PR TITLE
Add useStoreNotices tests

### DIFF
--- a/assets/js/base/hooks/test/use-store-notices.js
+++ b/assets/js/base/hooks/test/use-store-notices.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { render, act } from '@testing-library/react';
+import { StoreNoticesProvider } from '@woocommerce/base-context';
+
+/**
+ * Internal dependencies
+ */
+import { useStoreNotices } from '../use-store-notices';
+
+describe( 'useStoreNotices', () => {
+	function setup() {
+		const returnVal = {};
+
+		function TestComponent() {
+			Object.assign( returnVal, useStoreNotices() );
+
+			return null;
+		}
+
+		render(
+			<StoreNoticesProvider>
+				<TestComponent />
+			</StoreNoticesProvider>
+		);
+
+		return returnVal;
+	}
+
+	test( 'allows adding and removing notices and checking if there are notices of a specific type', () => {
+		const storeNoticesData = setup();
+
+		// Assert initial state.
+		expect( storeNoticesData.notices ).toEqual( [] );
+		expect( storeNoticesData.hasNoticesOfType( 'default' ) ).toBe( false );
+		expect( storeNoticesData.hasNoticesOfType( 'snackbar' ) ).toBe( false );
+
+		// Add error notice.
+		act( () => {
+			storeNoticesData.addErrorNotice( 'Error notice' );
+		} );
+
+		expect( storeNoticesData.notices.length ).toBe( 1 );
+		expect( storeNoticesData.hasNoticesOfType( 'default' ) ).toBe( true );
+		expect( storeNoticesData.hasNoticesOfType( 'snackbar' ) ).toBe( false );
+
+		// Add snackbar notice.
+		act( () => {
+			storeNoticesData.addSnackbarNotice( 'Snackbar notice' );
+		} );
+
+		expect( storeNoticesData.notices.length ).toBe( 2 );
+		expect( storeNoticesData.hasNoticesOfType( 'default' ) ).toBe( true );
+		expect( storeNoticesData.hasNoticesOfType( 'snackbar' ) ).toBe( true );
+
+		// Remove error notice.
+		act( () => {
+			storeNoticesData.removeNotices( 'error' );
+		} );
+
+		expect( storeNoticesData.notices.length ).toBe( 1 );
+		expect( storeNoticesData.hasNoticesOfType( 'default' ) ).toBe( false );
+		expect( storeNoticesData.hasNoticesOfType( 'snackbar' ) ).toBe( true );
+
+		// Remove all remaining notices.
+		act( () => {
+			storeNoticesData.removeNotices();
+		} );
+
+		expect( storeNoticesData.notices.length ).toBe( 0 );
+		expect( storeNoticesData.hasNoticesOfType( 'default' ) ).toBe( false );
+		expect( storeNoticesData.hasNoticesOfType( 'snackbar' ) ).toBe( false );
+	} );
+} );

--- a/assets/js/base/hooks/use-store-notices.js
+++ b/assets/js/base/hooks/use-store-notices.js
@@ -29,11 +29,10 @@ export const useStoreNotices = () => {
 				);
 			},
 			removeNotices: ( status = null ) => {
-				currentNotices.current.map( ( notice ) => {
+				currentNotices.current.forEach( ( notice ) => {
 					if ( status === null || notice.status === status ) {
 						removeNotice( notice.id );
 					}
-					return true;
 				} );
 			},
 			removeNotice,

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -330,7 +330,7 @@
  * @property {string}                                context              The current context
  *                                                                        identifier for the notice
  *                                                                        provider
- * @property {function(boolean):void}                setSuppressed        Consumers can use this
+ * @property {function(boolean):void}                setIsSuppressed      Consumers can use this
  *                                                                        setter to suppress
  */
 


### PR DESCRIPTION
Part of #1475.

This PR adds test coverage to `useStoreNotices`.

### How to test the changes in this Pull Request:

Basically, verify Travis tests pass or test it locally (`npm run test`).
