### PR TITLE
Fix broken Express Payment Method use in the Checkout block for logged out or incognito users.

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -344,10 +344,10 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		setActive( ( currentActivePaymentMethod ) => {
 			// If there's no active payment method, or the active payment method has
 			// been removed (e.g. COD vs shipping methods), set one as active.
-			if (
-				! currentActivePaymentMethod ||
-				! paymentMethodKeys.includes( currentActivePaymentMethod )
-			) {
+			// Note: It's possible that the active payment method might be an
+			// express payment method. So we only reset this if there's no
+			// current active payment method.
+			if ( ! currentActivePaymentMethod ) {
 				dispatch( statusOnly( PRISTINE ) );
 				return Object.keys( paymentData.paymentMethods )[ 0 ];
 			}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -337,6 +337,10 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 	// Set active (selected) payment method as needed.
 	useEffect( () => {
 		const paymentMethodKeys = Object.keys( paymentData.paymentMethods );
+		const allPaymentMethodKeys = [
+			...paymentMethodKeys,
+			...Object.keys( paymentData.expressPaymentMethods ),
+		];
 		if ( ! paymentMethodsInitialized || ! paymentMethodKeys.length ) {
 			return;
 		}
@@ -345,15 +349,23 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 			// If there's no active payment method, or the active payment method has
 			// been removed (e.g. COD vs shipping methods), set one as active.
 			// Note: It's possible that the active payment method might be an
-			// express payment method. So we only reset this if there's no
-			// current active payment method.
-			if ( ! currentActivePaymentMethod ) {
+			// express payment method. So registered express payment methods are
+			// included in the check here.
+			if (
+				! currentActivePaymentMethod ||
+				! allPaymentMethodKeys.includes( currentActivePaymentMethod )
+			) {
 				dispatch( statusOnly( PRISTINE ) );
 				return Object.keys( paymentData.paymentMethods )[ 0 ];
 			}
 			return currentActivePaymentMethod;
 		} );
-	}, [ paymentMethodsInitialized, paymentData.paymentMethods, setActive ] );
+	}, [
+		paymentMethodsInitialized,
+		paymentData.paymentMethods,
+		paymentData.expressPaymentMethods,
+		setActive,
+	] );
 
 	// emit events.
 	useEffect( () => {

--- a/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { previewCart } from '@woocommerce/resource-previews';
+import { dispatch } from '@wordpress/data';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import {
+	registerPaymentMethod,
+	registerExpressPaymentMethod,
+	__experimentalDeRegisterPaymentMethod,
+	__experimentalDeRegisterExpressPaymentMethod,
+} from '@woocommerce/blocks-registry';
+import { CheckoutExpressPayment } from '@woocommerce/base-components/payment-methods';
+/**
+ * Internal dependencies
+ */
+import {
+	usePaymentMethodDataContext,
+	PaymentMethodDataProvider,
+} from '../payment-method-data-context';
+import { defaultCartState } from '../../../../../data/default-states';
+
+const registerMockPaymentMethods = () => {
+	[ 'cheque', 'bacs' ].forEach( ( name ) => {
+		registerPaymentMethod(
+			( Config ) =>
+				new Config( {
+					name,
+					label: name,
+					content: <div>A payment method</div>,
+					edit: <div>A payment method</div>,
+					icons: null,
+					canMakePayment: () => true,
+					ariaLabel: name,
+				} )
+		);
+	} );
+	[ 'express-payment' ].forEach( ( name ) => {
+		registerExpressPaymentMethod( ( Config ) => {
+			const Content = ( {
+				onClose = () => void null,
+				onClick = () => void null,
+			} ) => {
+				return (
+					<>
+						<button onClick={ onClick }>
+							{ name + ' express payment method' }
+						</button>
+						<button onClick={ onClose }>
+							{ name + ' express payment method close' }
+						</button>
+					</>
+				);
+			};
+			return new Config( {
+				name,
+				content: <Content />,
+				edit: <div>An express payment method</div>,
+				canMakePayment: () => true,
+				paymentMethodId: name,
+			} );
+		} );
+	} );
+};
+
+const resetMockPaymentMethods = () => {
+	[ 'cheque', 'bacs' ].forEach( ( name ) => {
+		__experimentalDeRegisterPaymentMethod( name );
+	} );
+	[ 'express-payment' ].forEach( ( name ) => {
+		__experimentalDeRegisterExpressPaymentMethod( name );
+	} );
+};
+
+describe( 'Testing Payment Method Data Context Provider', () => {
+	beforeEach( async () => {
+		registerMockPaymentMethods();
+		fetchMock.mockResponse( ( req ) => {
+			if ( req.url.match( /wc\/store\/cart/ ) ) {
+				return Promise.resolve( JSON.stringify( previewCart ) );
+			}
+		} );
+		// need to clear the store resolution state between tests.
+		await dispatch( storeKey ).invalidateResolutionForStore();
+		await dispatch( storeKey ).receiveCart( defaultCartState );
+	} );
+	afterEach( async () => {
+		resetMockPaymentMethods();
+		fetchMock.resetMocks();
+	} );
+	it( 'toggles active payment method correctly for express payment activation and close', async () => {
+		const TriggerActiveExpressPaymentMethod = () => {
+			const { activePaymentMethod } = usePaymentMethodDataContext();
+			return (
+				<>
+					<CheckoutExpressPayment />
+					{ 'Active Payment Method: ' + activePaymentMethod }
+				</>
+			);
+		};
+		const TestComponent = () => {
+			return (
+				<PaymentMethodDataProvider>
+					<TriggerActiveExpressPaymentMethod />
+				</PaymentMethodDataProvider>
+			);
+		};
+		render( <TestComponent /> );
+		// should initialize by default the first payment method.
+		await waitFor( () => {
+			const activePaymentMethod = screen.queryByText(
+				/Active Payment Method: cheque/
+			);
+			expect( activePaymentMethod ).not.toBeNull();
+		} );
+		// Express payment method clicked.
+		fireEvent.click(
+			screen.getByText( 'express-payment express payment method' )
+		);
+		await waitFor( () => {
+			const activePaymentMethod = screen.queryByText(
+				/Active Payment Method: express-payment/
+			);
+			expect( activePaymentMethod ).not.toBeNull();
+		} );
+		// Express payment method closed.
+		fireEvent.click(
+			screen.getByText( 'express-payment express payment method close' )
+		);
+		await waitFor( () => {
+			const activePaymentMethod = screen.queryByText(
+				/Active Payment Method: cheque/
+			);
+			expect( activePaymentMethod ).not.toBeNull();
+		} );
+	} );
+} );

--- a/assets/js/blocks-registry/payment-methods/registry.js
+++ b/assets/js/blocks-registry/payment-methods/registry.js
@@ -32,6 +32,16 @@ export const registerExpressPaymentMethod = ( expressPaymentMethodCreator ) => {
 	}
 };
 
+export const __experimentalDeRegisterPaymentMethod = ( paymentMethodName ) => {
+	delete paymentMethods[ paymentMethodName ];
+};
+
+export const __experimentalDeRegisterExpressPaymentMethod = (
+	paymentMethodName
+) => {
+	delete expressPaymentMethods[ paymentMethodName ];
+};
+
 export const getPaymentMethods = () => {
 	return paymentMethods;
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3163 

Details about the issue can be found in #3163. The bug was introduced with the work done in #2831. 

In this pull:

- I modified the offending condition causing the bug (See details inline on the changeset).
- I added some tests that both replicate the bug (without the fix) and demonstrate things work after applying the fix (prevents against regressions). The test also verifies that closing express payment method modal will result in the correct active payment state change.
- Needed for the tests was a way to de-register registered payment methods. This is something queued for development (see #2122) anyways. I added the apis as "experimental" for now, since it's only used for the tests I added and this may need some more thought before making it more public.

## To Test

Make sure you are either logged out or using an incognito mode browser instance.

* Add a product to cart.
* Load the page with the checkout block.
* Click express payment (Chrome Pay if using Chrome, Apple Pay if using Safari).
* [ ]  Choose account details in the express payment modal and submit. Verify that the checkout processes correctly.

### Other scenarios

Since any change in the checkout flow can have an unexpected impact (especially since automated test coverage is still small), there's other scenarios that should be tested as a part of this work:

- Start paying with Express payment method and then close the modal and attempt to pay via another payment method. That should work. (note, closing and immediately paying by the already selected _saved payment method_ is currently expected to not work due to [bug outlined here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3165#issuecomment-695348865))
- Try switching between various payment methods before making a payment and completing the order. There should be no errors and the correct payment method is attached to the order.
- Verify COD payment method works as expected (especially when changes in address result in it not being available).
- Try flipping between saved payment methods and new payment methods and verify completing an order works as expected.
- Try the above in incognito and logged in and verify things work as expected.
