### PR TITLE
Re-enable WooCommerce dependency group rule for linting and fix errors.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,5 @@ module.exports = {
 		'@wordpress/valid-sprintf': 'off',
 		'@wordpress/no-unused-vars-before-return': 'off',
 		'testing-library/no-await-sync-query': 'off',
-		'@woocommerce/dependency-group': 'off',
 	},
 };

--- a/assets/js/base/components/payment-methods/express-payment-methods.js
+++ b/assets/js/base/components/payment-methods/express-payment-methods.js
@@ -15,6 +15,10 @@ import {
 	useEditorContext,
 	usePaymentMethodDataContext,
 } from '@woocommerce/base-context';
+
+/**
+ * Internal dependencies
+ */
 import PaymentMethodErrorBoundary from './payment-method-error-boundary';
 
 const ExpressPaymentMethods = () => {

--- a/assets/js/base/components/payment-methods/express-payment/checkout-express-payment.js
+++ b/assets/js/base/components/payment-methods/express-payment/checkout-express-payment.js
@@ -11,13 +11,13 @@ import {
 	useEditorContext,
 } from '@woocommerce/base-context';
 import Title from '@woocommerce/base-components/title';
+import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
  */
 import ExpressPaymentMethods from '../express-payment-methods';
 import './style.scss';
-import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
 
 const CheckoutExpressPayment = () => {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();

--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -1,12 +1,12 @@
 /**
- * Internal dependencies
- */
-import { allSettings } from './settings-init';
-
-/**
  * External dependencies
  */
 import deprecated from '@wordpress/deprecated';
+
+/**
+ * Internal dependencies
+ */
+import { allSettings } from './settings-init';
 
 /**
  * Sets a value to a property on the settings state.


### PR DESCRIPTION
Part of #3118 

In this pull the `@woocommerce/dependency-group` eslint rule is re-enabled and all errors are fixed.

There is no impact to user facing code.