### PR TITLE
Enable and fix all jsdoc rule violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/require-param': 'off',
 		'jsdoc/check-tag-names': 'off',
 		'jsdoc/check-param-names': 'off',
 		'jsdoc/require-property-description': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/check-tag-names': 'off',
 		'jsdoc/check-param-names': 'off',
 		'jsdoc/require-property-description': 'off',
 		'jsdoc/valid-types': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/check-types': 'off',
 		'jsdoc/require-returns-description': 'off',
 		'jsdoc/require-returns-type': 'off',
 		'jsdoc/newline-after-description': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
 		'jsdoc/no-undefined-types': 'off',
 		'jsdoc/check-types': 'off',
 		'jsdoc/require-returns-description': 'off',
-		'jsdoc/require-param-type': 'off',
 		'jsdoc/require-returns-type': 'off',
 		'jsdoc/newline-after-description': 'off',
 		'@wordpress/i18n-translator-comments': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/require-returns-type': 'off',
 		'jsdoc/newline-after-description': 'off',
 		'@wordpress/i18n-translator-comments': 'off',
 		'@wordpress/valid-sprintf': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/no-undefined-types': 'off',
 		'jsdoc/check-types': 'off',
 		'jsdoc/require-returns-description': 'off',
 		'jsdoc/require-returns-type': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/require-returns-description': 'off',
 		'jsdoc/require-returns-type': 'off',
 		'jsdoc/newline-after-description': 'off',
 		'@wordpress/i18n-translator-comments': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/require-property-description': 'off',
 		'jsdoc/valid-types': 'off',
 		'jsdoc/require-property': 'off',
 		'jsdoc/no-undefined-types': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/check-param-names': 'off',
 		'jsdoc/require-property-description': 'off',
 		'jsdoc/valid-types': 'off',
 		'jsdoc/require-property': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/newline-after-description': 'off',
 		'@wordpress/i18n-translator-comments': 'off',
 		'@wordpress/valid-sprintf': 'off',
 		'@wordpress/no-unused-vars-before-return': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,9 @@ module.exports = {
 		context: 'readonly',
 		jestPuppeteer: 'readonly',
 	},
+	settings: {
+		jsdoc: { mode: 'typescript' },
+	},
 	rules: {
 		'woocommerce/feature-flag': 'off',
 		// @todo Remove temporary disabling of various eslint rules.
@@ -38,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/valid-types': 'off',
 		'jsdoc/require-property': 'off',
 		'jsdoc/no-undefined-types': 'off',
 		'jsdoc/check-types': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'jsdoc/require-property': 'off',
 		'jsdoc/no-undefined-types': 'off',
 		'jsdoc/check-types': 'off',
 		'jsdoc/require-returns-description': 'off',

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/index.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/index.js
@@ -7,6 +7,10 @@ import { getAttributes, getVariationAttributes } from './utils';
 
 /**
  * VariationAttributes component.
+ *
+ * @param {Object} props             Incoming props
+ * @param {Object} props.product     Product
+ * @param {Object} props.dispatchers An object where values are dispatching functions.
  */
 const VariationAttributes = ( { product, dispatchers } ) => {
 	const attributes = getAttributes( product.attributes );

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
@@ -84,7 +84,12 @@ const AddToCartButton = () => {
 };
 
 /**
- * Button for non-purchasable products.
+ * Button component for non-purchasable products.
+ *
+ * @param {Object} props           Incoming props.
+ * @param {string} props.className Css classnames.
+ * @param {string} props.href      Link for button.
+ * @param {string} props.text      Text content for button.
  */
 const LinkComponent = ( { className, href, text } ) => {
 	return (
@@ -96,6 +101,14 @@ const LinkComponent = ( { className, href, text } ) => {
 
 /**
  * Button for purchasable products.
+ *
+ * @param {Object} props                 Incoming props for component
+ * @param {string} props.className       Incoming css class name.
+ * @param {number} props.quantityInCart  Quantity of item in cart.
+ * @param {boolean} props.isProcessing   Whether processing action is occurring.
+ * @param {boolean} props.isDisabled     Whether the button is disabled or not.
+ * @param {boolean} props.isDone         Whether processing is done.
+ * @param {function():any} props.onClick Callback to execute when button is clicked.
  */
 const ButtonComponent = ( {
 	className,

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/shared/quantity-input.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/shared/quantity-input.js
@@ -1,5 +1,12 @@
 /**
  * Quantity Input Component.
+ *
+ * @param {Object}         props          Incoming props for component
+ * @param {boolean}        props.disabled Whether input is disabled or not.
+ * @param {number}         props.min      Minimum value for input.
+ * @param {number}         props.max      Maximum value for input.
+ * @param {number}         props.value    Value for input.
+ * @param {function():any} props.onChange Function to call on input change event.
  */
 const QuantityInput = ( { disabled, min, max, value, onChange } ) => {
 	return (

--- a/assets/js/atomic/blocks/product-elements/price/block.js
+++ b/assets/js/atomic/blocks/product-elements/price/block.js
@@ -27,7 +27,6 @@ import { withProductDataContext } from '@woocommerce/shared-hocs';
  * @param {string} [props.customColor]            Normal Price custom text color.
  * @param {string} [props.saleColor]              Original Price text color.
  * @param {string} [props.customSaleColor]        Original Price custom text color.
- * @param {Object} [props.product]                Optional product object. Product from
  * context will be used if this is not provided.
  * @return {*} The component.
  */

--- a/assets/js/atomic/blocks/product-elements/title/block.js
+++ b/assets/js/atomic/blocks/product-elements/title/block.js
@@ -30,7 +30,6 @@ import './style.scss';
  * @param {string}  [props.customColor]    Custom title color value.
  * @param {string}  [props.fontSize]       Title font size name.
  * @param {number } [props.customFontSize] Custom font size value.
- * @param {Object}  [props.product]        Optional product object. Product from context
  * will be used if this is not provided.
  * @return {*} The component.
  */

--- a/assets/js/base/components/button/index.js
+++ b/assets/js/base/components/button/index.js
@@ -11,7 +11,14 @@ import classNames from 'classnames';
 import './style.scss';
 
 /**
- * Component that visually renders a button but semantically might be `<button>` or `<a>` depending on the props.
+ * Component that visually renders a button but semantically might be `<button>` or `<a>` depending
+ * on the props.
+ *
+ * @param {Object}              props             Incoming props for the component.
+ * @param {string}              props.className   CSS classname used.
+ * @param {boolean}             props.showSpinner Whether to show spinner or not.
+ * @param {React.ReactChildren} props.children    Child components passed in.
+ * @param {Object}              props.props       Rest of incoming props.
  */
 const Button = ( { className, showSpinner = false, children, ...props } ) => {
 	const buttonClassName = classNames(

--- a/assets/js/base/components/button/index.js
+++ b/assets/js/base/components/button/index.js
@@ -10,6 +10,8 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
+/** @typedef {import('react')} React */
+
 /**
  * Component that visually renders a button but semantically might be `<button>` or `<a>` depending
  * on the props.

--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -55,7 +55,7 @@ const validateShippingCountry = (
  *
  * @param {Object} props Incoming props for component.
  * @param {string} props.id Id for component.
- * @param {array}  props.fields Array of fields in form.
+ * @param {Array}  props.fields Array of fields in form.
  * @param {Object} props.fieldConfig Field configuration for fields in form.
  * @param {string} props.instanceId Unique id for form.
  * @param {function(any):any} props.onChange Function to all for an form onChange event.

--- a/assets/js/base/components/cart-checkout/address-form/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/index.js
@@ -52,6 +52,15 @@ const validateShippingCountry = (
 
 /**
  * Checkout address form.
+ *
+ * @param {Object} props Incoming props for component.
+ * @param {string} props.id Id for component.
+ * @param {array}  props.fields Array of fields in form.
+ * @param {Object} props.fieldConfig Field configuration for fields in form.
+ * @param {string} props.instanceId Unique id for form.
+ * @param {function(any):any} props.onChange Function to all for an form onChange event.
+ * @param {string} props.type Type of form.
+ * @param {Object} props.values Values for fields.
  */
 const AddressForm = ( {
 	id,

--- a/assets/js/base/components/cart-checkout/payment-method-icons/index.js
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/index.js
@@ -15,8 +15,9 @@ import './style.scss';
  * For a given list of icons, render each as a list item, using common icons
  * where available.
  *
- * @param {Object} props Component props.
- * @param {Array} props.icons  Array of icons object configs or ids as strings.
+ * @param {Object} props       Component props.
+ * @param {Array}  props.icons Array of icons object configs or ids as strings.
+ * @param {string} props.align How to align the icon.
  */
 export const PaymentMethodIcons = ( { icons = [], align = 'center' } ) => {
 	const iconConfigs = normalizeIconConfig( icons );

--- a/assets/js/base/components/cart-checkout/payment-method-icons/payment-method-icon.js
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/payment-method-icon.js
@@ -9,6 +9,11 @@ const getIconClassName = ( id ) => {
 
 /**
  * Return an element for an icon.
+ *
+ * @param {Object}      props     Incoming props for component.
+ * @param {string}      props.id  Id for component.
+ * @param {string|null} props.src Optional src value for icon.
+ * @param {string}      props.alt Optional alt value for icon.
  */
 const PaymentMethodIcon = ( { id, src = null, alt = '' } ) => {
 	if ( ! src ) {

--- a/assets/js/base/components/cart-checkout/product-image/index.js
+++ b/assets/js/base/components/cart-checkout/product-image/index.js
@@ -7,6 +7,9 @@ import PropTypes from 'prop-types';
 
 /**
  * Formats and returns an image element.
+ *
+ * @param {Object} props       Incoming props for the component.
+ * @param {Object} props.image Image properties.
  */
 const ProductImage = ( { image = {} } ) => {
 	const imageProps = {

--- a/assets/js/base/components/cart-checkout/product-low-stock-badge/index.js
+++ b/assets/js/base/components/cart-checkout/product-low-stock-badge/index.js
@@ -11,6 +11,9 @@ import ProductBadge from '../product-badge';
 
 /**
  * Returns a low stock badge.
+ *
+ * @param {Object}  props                   Incoming props for the component.
+ * @param {boolean} props.lowStockRemaining Whether or not there is low stock remaining.
  */
 const ProductLowStockBadge = ( { lowStockRemaining } ) => {
 	if ( ! lowStockRemaining ) {

--- a/assets/js/base/components/cart-checkout/product-summary/index.js
+++ b/assets/js/base/components/cart-checkout/product-summary/index.js
@@ -7,6 +7,11 @@ import { getSetting } from '@woocommerce/settings';
 
 /**
  * Returns an element containing a summary of the product.
+ *
+ * @param {Object} props                  Incoming props for the component.
+ * @param {string} props.className        CSS class name used.
+ * @param {string} props.shortDescription Short description for the product.
+ * @param {string} props.fullDescription  Full description for the product.
  */
 const ProductSummary = ( {
 	className,

--- a/assets/js/base/components/cart-checkout/product-variation-data/index.js
+++ b/assets/js/base/components/cart-checkout/product-variation-data/index.js
@@ -7,6 +7,10 @@ import classNames from 'classnames';
 
 /**
  * Returns a formatted element containing variation details.
+ *
+ * @param {Object}        props           Incoming props for the component.
+ * @param {string}        props.className CSS class used.
+ * @param {Array<Object>} props.variation Variations in use.
  */
 const ProductVariationData = ( { className, variation = [] } ) => {
 	if ( ! variation || variation.length === 0 ) {

--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -11,6 +11,9 @@ import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Shows a formatted shipping location.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.address Incoming address information.
  */
 const ShippingLocation = ( { address } ) => {
 	// we bail early if we don't have an address.

--- a/assets/js/base/components/cart-checkout/totals/totals-shipping-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-shipping-item/index.js
@@ -21,6 +21,13 @@ import './style.scss';
 
 /**
  * Renders the shipping totals row, rates, and calculator if enabled.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.currency Currency information.
+ * @param {Object} props.values Values in use.
+ * @param {boolean} props.isCheckout Whether in checkout or not.
+ * @param {boolean} props.showCalculator Whether to show shipping calculator or not.
+ * @param {boolean} props.showRatesWithoutAddress Whether to show rates without address or not.
  */
 const TotalsShippingItem = ( {
 	currency,

--- a/assets/js/base/components/checkbox-control/index.js
+++ b/assets/js/base/components/checkbox-control/index.js
@@ -12,6 +12,14 @@ import './style.scss';
 
 /**
  * Component used to show a checkbox control with styles.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.className CSS class used.
+ * @param {string} props.label Label for component.
+ * @param {string} props.id Id for component.
+ * @param {string} props.instanceId Unique id for instance of component.
+ * @param {function():any} props.onChange Function called when input changes.
+ * @param {Object} props.rest Rest of properties spread.
  */
 const CheckboxControl = ( {
 	className,

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -13,6 +13,15 @@ import './style.scss';
 
 /**
  * Component used to show a list of checkboxes in a group.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.className CSS class used.
+ * @param {function():any} props.onChange Function called when inputs change.
+ * @param {Array} props.options Options for list.
+ * @param {Array} props.checked Which items are checked.
+ * @param {boolean} props.isLoading If loading or not.
+ * @param {boolean} props.isDisabled If inputs are disabled or not.
+ * @param {number} props.limit Whether to limit the number of inputs showing.
  */
 const CheckboxList = ( {
 	className,

--- a/assets/js/base/components/chip/chip.js
+++ b/assets/js/base/components/chip/chip.js
@@ -14,6 +14,15 @@ import './style.scss';
  *
  * Each chip defaults to a list element but this can be customized by providing
  * a wrapperElement.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.text Text for chip content.
+ * @param {string} props.screenReaderText Screenreader text for the content.
+ * @param {string} props.element The element type for the chip.
+ * @param {string} props.className CSS class used.
+ * @param {string} props.radius Radius size.
+ * @param {React.ReactChildren|null} props.children React children.
+ * @param {Object} props.props Rest of props passed through to component.
  */
 const Chip = ( {
 	text,

--- a/assets/js/base/components/chip/chip.js
+++ b/assets/js/base/components/chip/chip.js
@@ -9,6 +9,8 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
+/** @typedef {import('react')} React */
+
 /**
  * Component used to render a "chip" -- a list item containing some text.
  *

--- a/assets/js/base/components/chip/removable-chip.js
+++ b/assets/js/base/components/chip/removable-chip.js
@@ -14,6 +14,16 @@ import { Chip } from './index.js';
 /**
  * Component used to render a "chip" -- an item containing some text with
  * an X button to remove/dismiss each chip.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.ariaLabel Aria label content.
+ * @param {string} props.className CSS class used.
+ * @param {boolean} props.disabled Whether action is disabled or not.
+ * @param {function():any} props.onRemove Function to call when remove event is fired.
+ * @param {boolean} props.removeOnAnyClick Whether to expand click area for remove event.
+ * @param {string} props.text The text for the chip.
+ * @param {string} props.screenReaderText The screen reader text for the chip.
+ * @param {Object} props.props Rest of props passed into component.
  */
 const RemovableChip = ( {
 	ariaLabel = '',

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -19,6 +19,17 @@ import './style.scss';
 
 /**
  * Component used to show an input box with a dropdown with suggestions.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.attributeLabel Label for the attributes.
+ * @param {string} props.className CSS class used.
+ * @param {Array} props.checked Which items are checked.
+ * @param {string} props.inputLabel Label used for the input.
+ * @param {boolean} props.isDisabled Whether the input is disabled or not.
+ * @param {boolean} props.isLoading Whether the input is loading.
+ * @param {boolean} props.multiple Whether multi-select is allowed.
+ * @param {function():any} props.onChange Function to be called when onChange event fires.
+ * @param {Array} props.options The option values to show in the select.
  */
 const DropdownSelector = ( {
 	attributeLabel = '',

--- a/assets/js/base/components/formatted-monetary-amount/index.js
+++ b/assets/js/base/components/formatted-monetary-amount/index.js
@@ -33,6 +33,11 @@ const currencyToNumberFormat = ( currency ) => {
  * Takes a price and returns a formatted price using the NumberFormat component.
  *
  * @param {Object} props Component props.
+ * @param {string} props.className CSS class used.
+ * @param {number} props.value Value of money amount.
+ * @param {Object} props.currency Currency configuration object.
+ * @param {function():any} props.onValueChange Function to call when value changes.
+ * @param {Object} props.props Rest of props passed into component.
  */
 const FormattedMonetaryAmount = ( {
 	className,

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -9,6 +9,12 @@ import classNames from 'classnames';
  * Component used to render an accessible text given a label and/or a
  * screenReaderLabel. The wrapper element and wrapper props can also be
  * specified via props.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.label Label content.
+ * @param {string} props.screenReaderLabel Content for screen readers.
+ * @param {string} props.wrapperElement What element is used to wrap the label.
+ * @param {Object} props.wrapperProps Props passed into wrapper element.
  */
 const Label = ( {
 	label,

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -25,6 +25,17 @@ import FilterSubmitButton from '../filter-submit-button';
  * Price slider component.
  *
  * @param {Object} props Component props.
+ * @param {number} props.minPrice Minimum price for slider.
+ * @param {number} props.maxPrice Maximum price for slider.
+ * @param {number} props.minConstraint Minimum constraint.
+ * @param {number} props.maxConstraint Maximum constraint.
+ * @param {function(any):any} props.onChange Function to call on the change event.
+ * @param {number} props.step What step values the slider uses.
+ * @param {Object} props.currency Currency configuration object.
+ * @param {boolean} props.showInputFields Whether to show input fields for the values or not.
+ * @param {boolean} props.showFilterButton Whether to show the filter button for the slider.
+ * @param {boolean} props.isLoading Whether values are loading or not.
+ * @param {function():any} props.onSubmit Function to call when submit event fires.
  */
 const PriceSlider = ( {
 	minPrice,

--- a/assets/js/base/components/sort-select/index.js
+++ b/assets/js/base/components/sort-select/index.js
@@ -14,6 +14,17 @@ import './style.scss';
 /**
  * Component used for 'Order by' selectors, which renders a label
  * and a <select> with the options provided in the props.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.className CSS class used.
+ * @param {string} props.instanceId Unique id for component instance.
+ * @param {string} props.defaultValue Default value for the select.
+ * @param {string} props.label Label for the select.
+ * @param {function():any} props.onChange Function to call on the change event.
+ * @param {Array} props.options Option values for the select.
+ * @param {string} props.screenReaderLabel Screen reader label.
+ * @param {boolean} props.readOnly Whether the select is read only or not.
+ * @param {string} props.value The selected value.
  */
 const SortSelect = ( {
 	className,

--- a/assets/js/base/components/summary/utils.js
+++ b/assets/js/base/components/summary/utils.js
@@ -6,7 +6,7 @@ import { autop } from '@wordpress/autop';
 
 /**
  * Generates the summary text from a string of text.
- *a
+ *
  * @param {string} source Source text.
  * @param {number} maxLength Limit number of countType returned if text has multiple paragraphs.
  * @param {string} countType What is being counted. One of words, characters_excluding_spaces, or characters_including_spaces.

--- a/assets/js/base/components/title/index.js
+++ b/assets/js/base/components/title/index.js
@@ -11,6 +11,12 @@ import './style.scss';
 
 /**
  * Component that renders a block title.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {React.ReactChildren} props.children Children elements this component wraps.
+ * @param {string} props.className CSS class used.
+ * @param {string} props.headingLevel Heading level for title.
+ * @param {Object} props.props Rest of props passed through to component.
  */
 const Title = ( { children, className, headingLevel, ...props } ) => {
 	const buttonClassName = classNames(

--- a/assets/js/base/components/title/index.js
+++ b/assets/js/base/components/title/index.js
@@ -9,6 +9,8 @@ import PropTypes from 'prop-types';
  */
 import './style.scss';
 
+/** @typedef {import('react')} React */
+
 /**
  * Component that renders a block title.
  *

--- a/assets/js/base/context/add-to-cart-form/form-state/reducer.js
+++ b/assets/js/base/context/add-to-cart-form/form-state/reducer.js
@@ -31,6 +31,9 @@ const {
  *
  * @param {Object} state  Current state.
  * @param {Object} action Incoming action object.
+ * @param {number} action.quantity Incoming quantity.
+ * @param {string} action.type Type of action.
+ * @param {Object} action.data Incoming payload for action.
  */
 export const reducer = ( state = DEFAULT_STATE, { quantity, type, data } ) => {
 	let newState;

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -64,6 +64,11 @@ export const prepareResponseData = ( data ) => {
  *
  * @param {Object} state  Current state.
  * @param {Object} action Incoming action object.
+ * @param {string} action.url URL passed in.
+ * @param {string} action.type Type of action.
+ * @param {string} action.orderId Order ID.
+ * @param {Array} action.orderNotes Order notes.
+ * @param {Object} action.data Other action payload.
  */
 export const reducer = (
 	state = DEFAULT_STATE,

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -26,6 +26,11 @@ const hasSavedPaymentToken = ( paymentMethodData ) => {
  *
  * @param {Object} state  Current state.
  * @param {Object} action Current action.
+ * @param {string} action.type Action type.
+ * @param {Object} action.paymentMethodData Payment method data payload.
+ * @param {boolean} action.shouldSavePaymentMethod Should save payment method flag.
+ * @param {string} action.errorMessage Error message to store in state.
+ * @param {Object} action.paymentMethods Registered payment methods.
  */
 const reducer = (
 	state = DEFAULT_PAYMENT_DATA,

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -77,6 +77,7 @@ const hasInvalidShippingAddress = ( errors ) => {
 /**
  * The shipping data provider exposes the interface for shipping in the
  * checkout/cart.
+ *
  * @param {Object} props Incoming props for provider
  * @param {React.ReactElement} props.children
  */

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -33,6 +33,7 @@ import {
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').ShippingDataContext} ShippingDataContext
+ * @typedef {import('react')} React
  */
 
 const { NONE, INVALID_ADDRESS, UNKNOWN } = ERROR_TYPES;

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -77,7 +77,7 @@ const hasInvalidShippingAddress = ( errors ) => {
  * The shipping data provider exposes the interface for shipping in the
  * checkout/cart.
  * @param {Object} props Incoming props for provider
- * @param props.children
+ * @param {React.ReactElement} props.children
  */
 export const ShippingDataProvider = ( { children } ) => {
 	const { dispatchActions } = useCheckoutContext();

--- a/assets/js/base/context/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/cart-checkout/shipping/index.js
@@ -42,6 +42,7 @@ const { NONE, INVALID_ADDRESS, UNKNOWN } = ERROR_TYPES;
  *
  * @param {string} state  The current status.
  * @param {Object} action The incoming action.
+ * @param {string} action.type The type of action.
  */
 const errorStatusReducer = ( state, { type } ) => {
 	if ( Object.values( ERROR_TYPES ).includes( type ) ) {
@@ -75,8 +76,8 @@ const hasInvalidShippingAddress = ( errors ) => {
 /**
  * The shipping data provider exposes the interface for shipping in the
  * checkout/cart.
- *
  * @param {Object} props Incoming props for provider
+ * @param props.children
  */
 export const ShippingDataProvider = ( { children } ) => {
 	const { dispatchActions } = useCheckoutContext();

--- a/assets/js/base/context/container-width-context.js
+++ b/assets/js/base/context/container-width-context.js
@@ -29,6 +29,10 @@ export const useContainerWidthContext = () => {
 /**
  * Provides an interface to useContainerQueries so children can see what size is being used by the
  * container.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {React.ReactChildren} props.children React elements wrapped by the component.
+ * @param {string} props.className CSS class in use.
  */
 export const ContainerWidthContextProvider = ( {
 	children,

--- a/assets/js/base/context/container-width-context.js
+++ b/assets/js/base/context/container-width-context.js
@@ -8,6 +8,7 @@ import classNames from 'classnames';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').ContainerWidthContext} ContainerWidthContext
+ * @typedef {import('react')} React
  */
 
 const ContainerWidthContext = createContext( {

--- a/assets/js/base/context/shared/event-emit/reducer.js
+++ b/assets/js/base/context/shared/event-emit/reducer.js
@@ -32,6 +32,11 @@ export const actions = {
  *
  * @param {Object} state  Current state.
  * @param {Object} action Incoming action object
+ * @param {string} action.type The type of action.
+ * @param {string} action.eventType What type of event is emitted.
+ * @param {string} action.id The id for the event.
+ * @param {function(any):any} action.callback The registered callback for the event.
+ * @param {number} action.priority The priority for the event.
  */
 export const reducer = (
 	state = {},

--- a/assets/js/base/context/shared/validation/index.js
+++ b/assets/js/base/context/shared/validation/index.js
@@ -12,6 +12,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * @typedef { import('@woocommerce/type-defs/contexts').ValidationContext } ValidationContext
+ * @typedef {import('react')} React
  */
 
 const ValidationContext = createContext( {

--- a/assets/js/base/context/shared/validation/index.js
+++ b/assets/js/base/context/shared/validation/index.js
@@ -38,6 +38,9 @@ export const useValidationContext = () => {
  *
  * Any children of this context will be exposed to validation state and helpers
  * for tracking validation.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {React.ReactChildren} props.children What react elements are wrapped by this component.
  */
 export const ValidationContextProvider = ( { children } ) => {
 	const [ validationErrors, updateValidationErrors ] = useState( {} );

--- a/assets/js/base/context/store-notices-context.js
+++ b/assets/js/base/context/store-notices-context.js
@@ -45,6 +45,12 @@ export const useStoreNoticesContext = () => {
  *  - Warning
  *  - Info
  *  - Success
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {React.ReactChildren} props.children The Elements wrapped by this component.
+ * @param {string} props.className CSS class used.
+ * @param {boolean} props.createNoticeContainer Whether to create a notice container or not.
+ * @param {string} props.context The notice context for notices being rendered.
  */
 export const StoreNoticesProvider = ( {
 	children,

--- a/assets/js/base/context/store-notices-context.js
+++ b/assets/js/base/context/store-notices-context.js
@@ -16,6 +16,7 @@ import {
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').NoticeContext} NoticeContext
+ * @typedef {import('react')} React
  */
 
 const StoreNoticesContext = createContext( {

--- a/assets/js/base/hooks/use-position-relative-to-viewport.js
+++ b/assets/js/base/hooks/use-position-relative-to-viewport.js
@@ -4,6 +4,8 @@
 import { useRef, useLayoutEffect, useState } from '@wordpress/element';
 import { getIntersectionObserver } from '@woocommerce/base-utils';
 
+/** @typedef {import('react')} React */
+
 /** @type {React.CSSProperties} */
 const style = {
 	bottom: 0,

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -3,6 +3,10 @@
  * shipping, so we can track when one of them change to update rates.
  *
  * @param {Object} address          An object containing all address information
+ * @param {string} address.country  The country.
+ * @param {string} address.state    The state.
+ * @param {string} address.city     The city.
+ * @param {string} address.postcode The postal code.
  *
  * @return {Object} pluckedAddress  An object containing shipping address that are needed to fetch an address.
  */

--- a/assets/js/base/utils/get-intersection-observer.js
+++ b/assets/js/base/utils/get-intersection-observer.js
@@ -8,8 +8,8 @@
  *
  * @param {IntersectionObserverCallback} callback Callback function for the
  *                                                Intersection Observer.
- * @param {object}                       options  Intersection Observer options.
- * @return {object|IntersectionObserver} Intersection Observer if available,
+ * @param {Object}                       options  Intersection Observer options.
+ * @return {Object|IntersectionObserver} Intersection Observer if available,
  *                                       otherwise a shim object.
  *
  * @todo Remove IntersectionObserver shim when we drop IE11 support.

--- a/assets/js/base/utils/get-intersection-observer.js
+++ b/assets/js/base/utils/get-intersection-observer.js
@@ -1,3 +1,5 @@
+/** @typedef {import('window').IntersectionObserverCallback} IntersectionObserverCallback */
+
 /**
  * Util that returns an IntersectionObserver if supported by the browser. If
  * it's not supported, it returns a shim object with the methods to prevent JS

--- a/assets/js/base/utils/legacy-events.js
+++ b/assets/js/base/utils/legacy-events.js
@@ -48,7 +48,7 @@ export const triggerFragmentRefresh = () => {
  * @param {boolean} bubbles         Whether the event bubbles.
  * @param {boolean} cancelable      Whether the event is cancelable.
  *
- * @returns {Function} Function to remove the jQuery event handler. Ideally it
+ * @return {Function} Function to remove the jQuery event handler. Ideally it
  * should be used when the component is unmounted.
  */
 export const translateJQueryEventToNative = (

--- a/assets/js/base/utils/legacy-events.js
+++ b/assets/js/base/utils/legacy-events.js
@@ -1,5 +1,7 @@
 const Event = window.Event || null;
 
+/** @typedef {import('window').HTMLNode} HTMLNode */
+
 /**
  * Wrapper function to dispatch an event so it's compatible with IE11.
  *

--- a/assets/js/blocks-registry/block-components/get-registered-block-components.js
+++ b/assets/js/blocks-registry/block-components/get-registered-block-components.js
@@ -16,7 +16,6 @@ import { registeredBlockComponents } from './registered-block-components-init';
  *
  * This gets all registered Block Components so we know which Blocks map to which React Components.
  *
- * @export
  * @param {string} context Current context (a named parent Block). If Block Components were only
  *                         registered under a certain context, those Components will be returned,
  *                         as well as any Components registered under all contexts.
@@ -38,7 +37,6 @@ export function getRegisteredBlockComponents( context ) {
 /**
  * Alias of getRegisteredBlockComponents kept for backwards compatibility.
  *
- * @export
  * @param {string} main Name of the parent block to retrieve children of.
  * @return {Object} List of registered inner blocks.
  */

--- a/assets/js/blocks-registry/block-components/register-block-component.js
+++ b/assets/js/blocks-registry/block-components/register-block-component.js
@@ -17,7 +17,6 @@ import { registeredBlockComponents } from './registered-block-components-init';
  * Registering a Block Component allows you to define which React Component should be used in place
  * of a registered Block. The Component, when rendered, will be passed all Block Attributes.
  *
- * @export
  * @param {Object}   options           Options to use when registering the block.
  * @param {Function} options.component React component that will be rendered, or the return value from  React.lazy if
  *                                     dynamically imported.
@@ -87,7 +86,6 @@ const assertOption = ( options, optionName, expectedType ) => {
 /**
  * Alias of registerBlockComponent kept for backwards compatibility.
  *
- * @export
  * @param {Object}   options           Options to use when registering the block.
  * @param {string}   options.main      Name of the parent block.
  * @param {string}   options.blockName Name of the child block being registered.

--- a/assets/js/blocks/active-filters/active-attribute-filters.js
+++ b/assets/js/blocks/active-filters/active-attribute-filters.js
@@ -13,6 +13,12 @@ import { removeAttributeFilterBySlug } from '../../utils/attributes-query';
 
 /**
  * Component that renders active attribute (terms) filters.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributeObject The attribute object.
+ * @param {Array} props.slugs The slugs for attributes.
+ * @param {string} props.operator The operator for the filter.
+ * @param {string} props.displayStyle The style used for displaying the filters.
  */
 const ActiveAttributeFilters = ( {
 	attributeObject = {},

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -18,6 +18,10 @@ import ActiveAttributeFilters from './active-attribute-filters';
 
 /**
  * Component displaying active filters.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming attributes for the block.
+ * @param {boolean} props.isEditor Whether or not in the editor context.
  */
 const ActiveFiltersBlock = ( {
 	attributes: blockAttributes,

--- a/assets/js/blocks/active-filters/index.js
+++ b/assets/js/blocks/active-filters/index.js
@@ -45,9 +45,7 @@ registerBlockType( 'woocommerce/active-filters', {
 		},
 	},
 	edit,
-	/**
-	 * Save the props to post content.
-	 */
+	// Save the props to post content.
 	save( { attributes } ) {
 		const { className, displayStyle, heading, headingLevel } = attributes;
 		const data = {

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -34,6 +34,10 @@ import './style.scss';
 
 /**
  * Component displaying an attribute filter.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {boolean} props.isEditor
  */
 const AttributeFilterBlock = ( {
 	attributes: blockAttributes,

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -72,9 +72,7 @@ registerBlockType( 'woocommerce/attribute-filter', {
 		},
 	},
 	edit,
-	/**
-	 * Save the props to post content.
-	 */
+	// Save the props to post content.
 	save( { attributes } ) {
 		const {
 			className,

--- a/assets/js/blocks/attribute-filter/label.js
+++ b/assets/js/blocks/attribute-filter/label.js
@@ -7,6 +7,10 @@ import Label from '@woocommerce/base-components/label';
 
 /**
  * The label for an attribute term filter.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.name The name for the label.
+ * @param {number} props.count The count of products this attribute is attached to.
  */
 const AttributeFilterLabel = ( { name, count } ) => {
 	return (

--- a/assets/js/blocks/cart-checkout/cart/checkout-button/index.js
+++ b/assets/js/blocks/cart-checkout/cart/checkout-button/index.js
@@ -28,6 +28,9 @@ const getIconsFromPaymentMethods = ( paymentMethods ) => {
 
 /**
  * Checkout button rendered in the full cart page.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.link What the button is linked to.
  */
 const CheckoutButton = ( { link } ) => {
 	const { isCalculating } = useCheckoutContext();

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -161,6 +161,11 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
  *       if the user saves the page without having triggered the 'Empty Cart'
  *       view, inner blocks would not be saved and they wouldn't be visible
  *       in the frontend.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.className CSS class used.
+ * @param {Object} props.attributes Attributes available.
+ * @param {function(any):any} props.setAttributes Setter for attributes.
  */
 const CartEditor = ( { className, attributes, setAttributes } ) => {
 	return (

--- a/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
@@ -14,6 +14,9 @@ import './style.scss';
 
 /**
  * Component to handle edit mode for the Cart block when cart is empty.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {boolean} props.hidden Whether this component is hidden or not.
  */
 const EmptyCartEdit = ( { hidden = false } ) => {
 	return (

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -46,6 +46,9 @@ import './style.scss';
 
 /**
  * Component that renders the Cart block when user has something in cart aka "full".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming attributes for block.
  */
 const Cart = ( { attributes } ) => {
 	const {

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -38,9 +38,7 @@ const settings = {
 	attributes: blockAttributes,
 	edit,
 
-	/**
-	 * Save the props to post content.
-	 */
+	// Save the props to post content.
 	save( { attributes } ) {
 		return (
 			<div className={ classnames( 'is-loading', attributes.className ) }>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -53,7 +53,8 @@ const Block = ( props ) => {
  * Main Checkout Component.
  *
  * @param {Object} props Component props.
- * @return {*} The component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.scrollToTop Function for scrolling to top.
  */
 const Checkout = ( { attributes, scrollToTop } ) => {
 	const { isEditor } = useEditorContext();

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
@@ -63,7 +63,8 @@ const CheckoutOrderError = () => {
 /**
  * Get the error message to display.
  *
- * @param {Object} errorData Object containing code and message.
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.errorData Object containing code and message.
  */
 const ErrorTitle = ( { errorData } ) => {
 	let heading = __( 'Checkout error', 'woo-gutenberg-products-block' );
@@ -83,7 +84,8 @@ const ErrorTitle = ( { errorData } ) => {
 /**
  * Get the error message to display.
  *
- * @param {Object} errorData Object containing code and message.
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.errorData Object containing code and message.
  */
 const ErrorMessage = ( { errorData } ) => {
 	let message = errorData.message;
@@ -104,7 +106,8 @@ const ErrorMessage = ( { errorData } ) => {
 /**
  * Get the CTA button to display.
  *
- * @param {Object} errorData Object containing code and message.
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.errorData Object containing code and message.
  */
 const ErrorButton = ( { errorData } ) => {
 	let buttonText = __( 'Retry', 'woo-gutenberg-products-block' );

--- a/assets/js/blocks/cart-checkout/checkout/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/index.js
@@ -37,9 +37,8 @@ const settings = {
 	},
 	attributes: blockAttributes,
 	edit,
-	/**
-	 * Save the props to post content.
-	 */
+
+	//Save the props to post content.
 	save( { attributes } ) {
 		return (
 			<div

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -48,6 +48,18 @@ import { withCategory } from '../../hocs';
 
 /**
  * Component to handle edit mode of "Featured Category".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {boolean} props.isSelected Whether block is selected or not.
+ * @param {function(any):any} props.setAttributes Function for setting new attributes.
+ * @param {string} props.error Error message
+ * @param {function(any):any} props.getCategory Function for getting category details.
+ * @param {boolean} props.isLoading Whether loading or not.
+ * @param {Object} props.category The product category object.
+ * @param {Object} props.overlayColor Overlay color object for content.
+ * @param {function(any):any} props.setOverlayColor Setter for overlay color.
+ * @param {function(any):any} props.debouncedSpeak Function for delayed speak.
  */
 const FeaturedCategory = ( {
 	attributes,

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -49,6 +49,19 @@ import {
 
 /**
  * Component to handle edit mode of "Featured Product".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.debouncedSpeak Function for delayed speak.
+ * @param {string} props.error Error message.
+ * @param {function(any):any} props.getProduct Function for getting the product.
+ * @param {boolean} props.isLoading Whether product is loading or not.
+ * @param {boolean} props.isSelected Whether block is selected or not.
+ * @param {Object} props.overlayColor Overlay color object.
+ * @param {Object} props.product Product object.
+ * @param {function(any):any} props.setAttributes Setter for attributes.
+ * @param {function(any):any} props.setOverlayColor Setter for overlay color.
+ * @param {function(any):any} props.triggerUrlUpdate Function for triggering a url update for product.
  */
 const FeaturedProduct = ( {
 	attributes,

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -21,6 +21,8 @@ import usePriceConstraints from './use-price-constraints.js';
  * Component displaying a price filter.
  *
  * @param {Object} props Component props.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {boolean} props.isEditor Whether in editor context or not.
  */
 const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 	const [ minPriceQuery, setMinPriceQuery ] = useQueryStateByKey(

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -49,9 +49,7 @@ registerBlockType( 'woocommerce/price-filter', {
 
 	edit,
 
-	/**
-	 * Save the props to post content.
-	 */
+	// Save the props to post content.
 	save( { attributes } ) {
 		const {
 			className,

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -28,6 +28,10 @@ const EmptyPlaceholder = () => (
 
 /**
  * Component displaying the categories as dropdown or list.
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
+ * @param {string} props.name Name for block.
  */
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	const getInspectorControls = () => {

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -28,6 +28,7 @@ const EmptyPlaceholder = () => (
 
 /**
  * Component displaying the categories as dropdown or list.
+ *
  * @param {Object} props Incoming props for the component.
  * @param {Object} props.attributes Incoming block attributes.
  * @param {function(any):any} props.setAttributes Setter for block attributes.

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -14,6 +14,7 @@ import './style.scss';
 
 /**
  * Component displaying a product search form.
+ *
  * @param {Object} props Incoming props for the component.
  * @param {Object} props.attributes Incoming block attributes.
  * @param {string} props.attributes.label

--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -14,6 +14,14 @@ import './style.scss';
 
 /**
  * Component displaying a product search form.
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {string} props.attributes.label
+ * @param {string} props.attributes.placeholder
+ * @param {string} props.attributes.formId
+ * @param {string} props.attributes.className
+ * @param {boolean} props.attributes.hasLabel
+ * @param {string} props.attributes.align
  */
 const ProductSearchBlock = ( {
 	attributes: { label, placeholder, formId, className, hasLabel, align },

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -16,6 +16,17 @@ import './style.scss';
 
 /**
  * Component displaying a product search form.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {string} props.attributes.label
+ * @param {string} props.attributes.placeholder
+ * @param {string} props.attributes.formId
+ * @param {string} props.attributes.className
+ * @param {boolean} props.attributes.hasLabel
+ * @param {string} props.attributes.align
+ * @param {string} props.instanceId
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
  */
 const Edit = ( {
 	attributes: { label, placeholder, formId, className, hasLabel, align },

--- a/assets/js/blocks/products/all-products/index.js
+++ b/assets/js/blocks/products/all-products/index.js
@@ -46,11 +46,7 @@ const blockSettings = {
 	edit( props ) {
 		return <Editor { ...props } />;
 	},
-	/**
-	 * Save the props to post content.
-	 *
-	 * @param {Object} attributes Attributes to save.
-	 */
+	// Save the props to post content.
 	save( { attributes } ) {
 		const dataAttributes = {};
 		Object.keys( attributes )

--- a/assets/js/blocks/reviews/all-reviews/edit.js
+++ b/assets/js/blocks/reviews/all-reviews/edit.js
@@ -20,6 +20,10 @@ import {
 
 /**
  * Component to handle edit mode of "All Reviews".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
  */
 const AllReviewsEditor = ( { attributes, setAttributes } ) => {
 	const getInspectorControls = () => {

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -14,6 +14,13 @@ import withReviews from '@woocommerce/base-hocs/with-reviews';
 
 /**
  * Block rendered in the frontend.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.onAppendReviews Function called when appending review.
+ * @param {function(any):any} props.onChangeOrderby
+ * @param {Array} props.reviews
+ * @param {number} props.totalReviews
  */
 const FrontendBlock = ( {
 	attributes,

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -29,6 +29,11 @@ import {
 
 /**
  * Component to handle edit mode of "Reviews by Category".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.debouncedSpeak
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
  */
 const ReviewsByCategoryEditor = ( {
 	attributes,

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -28,6 +28,11 @@ import {
 
 /**
  * Component to handle edit mode of "Reviews by Product".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.debouncedSpeak
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
  */
 const ReviewsByProductEditor = ( {
 	attributes,

--- a/assets/js/blocks/single-product/block.js
+++ b/assets/js/blocks/single-product/block.js
@@ -13,6 +13,8 @@ import { StoreNoticesProvider } from '@woocommerce/base-context';
  */
 import { BLOCK_NAME } from './constants';
 
+/** @typedef {import('react')} React */
+
 /**
  * The Single Product Block.
  *

--- a/assets/js/blocks/single-product/block.js
+++ b/assets/js/blocks/single-product/block.js
@@ -15,6 +15,11 @@ import { BLOCK_NAME } from './constants';
 
 /**
  * The Single Product Block.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {boolean} props.isLoading
+ * @param {Object} props.product
+ * @param {React.ReactChildren} props.children
  */
 const Block = ( { isLoading, product, children } ) => {
 	const className = 'wc-block-single-product wc-block-layout';

--- a/assets/js/blocks/single-product/edit/api-error.js
+++ b/assets/js/blocks/single-product/edit/api-error.js
@@ -5,6 +5,11 @@ import ErrorPlaceholder from '@woocommerce/editor-components/error-placeholder';
 
 /**
  * Shown when there is an API error getting a product.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.error
+ * @param {boolean} props.isLoading
+ * @param {function(any):any} props.getProduct
  */
 const ApiError = ( { error, isLoading, getProduct } ) => (
 	<ErrorPlaceholder

--- a/assets/js/blocks/single-product/edit/editor-block-controls.js
+++ b/assets/js/blocks/single-product/edit/editor-block-controls.js
@@ -7,6 +7,10 @@ import { Toolbar } from '@wordpress/components';
 
 /**
  * Adds controls to the editor toolbar.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {boolean} props.isEditing
+ * @param {function(boolean):any} props.setIsEditing
  */
 const EditorBlockControls = ( { isEditing, setIsEditing } ) => {
 	return (

--- a/assets/js/blocks/single-product/edit/index.js
+++ b/assets/js/blocks/single-product/edit/index.js
@@ -22,6 +22,16 @@ import { BLOCK_TITLE, BLOCK_ICON, BLOCK_DESCRIPTION } from '../constants';
 
 /**
  * Component to handle edit mode of the "Single Product Block".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.className
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
+ * @param {string} props.error
+ * @param {function(any):any} props.getProduct
+ * @param {Object} props.product
+ * @param {boolean} props.isLoading
+ * @param {string} props.clientId
  */
 const Editor = ( {
 	className,

--- a/assets/js/blocks/single-product/edit/layout-editor.js
+++ b/assets/js/blocks/single-product/edit/layout-editor.js
@@ -24,6 +24,11 @@ import {
 
 /**
  * Component to handle edit mode of the "Single Product Block".
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {boolean} props.isLoading
+ * @param {Object} props.product
+ * @param {string} props.clientId
  */
 const LayoutEditor = ( { isLoading, product, clientId } ) => {
 	const baseClassName = 'wc-block-single-product wc-block-layout';

--- a/assets/js/blocks/single-product/edit/shared-product-control.js
+++ b/assets/js/blocks/single-product/edit/shared-product-control.js
@@ -5,6 +5,10 @@ import ProductControl from '@woocommerce/editor-components/product-control';
 
 /**
  * Allows a product to be selected for display.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
  */
 const SharedProductControl = ( { attributes, setAttributes } ) => (
 	<ProductControl

--- a/assets/js/editor-components/feedback-prompt/index.js
+++ b/assets/js/editor-components/feedback-prompt/index.js
@@ -12,6 +12,10 @@ import './style.scss';
 
 /**
  * Component to render a Feedback prompt in the sidebar.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.text
+ * @param {string} props.url
  */
 const FeedbackPrompt = ( {
 	text,

--- a/assets/js/editor-components/grid-content-control/index.js
+++ b/assets/js/editor-components/grid-content-control/index.js
@@ -8,6 +8,10 @@ import { ToggleControl } from '@wordpress/components';
 
 /**
  * A combination of toggle controls for content visibility in product grids.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {function(any):any} props.onChange
+ * @param {Object} props.settings
  */
 const GridContentControl = ( { onChange, settings } ) => {
 	const { button, price, rating, title } = settings;

--- a/assets/js/editor-components/grid-layout-control/index.js
+++ b/assets/js/editor-components/grid-layout-control/index.js
@@ -15,6 +15,12 @@ import {
 
 /**
  * A combination of range controls for product grid layout settings.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {number} props.columns
+ * @param {number} props.rows
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
+ * @param {string} props.alignButtons
  */
 const GridLayoutControl = ( {
 	columns,

--- a/assets/js/editor-components/product-orderby-control/index.js
+++ b/assets/js/editor-components/product-orderby-control/index.js
@@ -7,6 +7,10 @@ import PropTypes from 'prop-types';
 
 /**
  * A pre-configured SelectControl for product orderby settings.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {string} props.value
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
  */
 const ProductOrderbyControl = ( { value, setAttributes } ) => {
 	return (

--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -12,6 +12,7 @@ import ErrorMessage from '@woocommerce/editor-components/error-placeholder/error
  * products.
  *
  * @param {Object} props Component props.
+ * @param {string} props.error
  * @param {Function} props.onChange  Callback fired when the selected item changes
  * @param {Function} props.onSearch  Callback fired when a search is triggered
  * @param {Array}    props.selected  An array of selected products.

--- a/assets/js/editor-components/utils/index.js
+++ b/assets/js/editor-components/utils/index.js
@@ -10,7 +10,7 @@ import { IS_LARGE_CATALOG, LIMIT_TAGS } from '@woocommerce/block-settings';
  * Get product query requests for the Store API.
  *
  * @param {Object} request A query object with the list of selected products and search term.
- * @param {string} request.selected Currently selected products.
+ * @param {Array} request.selected Currently selected products.
  * @param {string} request.search Search string.
  * @param {Array} request.queryArgs Query args to pass in.
  */
@@ -47,7 +47,7 @@ const getProductsRequests = ( {
  * Get a promise that resolves to a list of products from the Store API.
  *
  * @param {Object} request A query object with the list of selected products and search term.
- * @param {string} request.selected Currently selected products.
+ * @param {Array} request.selected Currently selected products.
  * @param {string} request.search Search string.
  * @param {Array} request.queryArgs Query args to pass in.
  */
@@ -107,7 +107,7 @@ export const getTerms = ( attribute ) => {
  * Get product tag query requests for the Store API.
  *
  * @param {Object} request A query object with the list of selected products and search term.
- * @param {string} request.selected Currently selected tags.
+ * @param {Array} request.selected Currently selected tags.
  * @param {string} request.search Search string.
  */
 const getProductTagsRequests = ( { selected = [], search } ) => {
@@ -134,8 +134,9 @@ const getProductTagsRequests = ( { selected = [], search } ) => {
 
 /**
  * Get a promise that resolves to a list of tags from the Store API.
- *
- * @param {Object} - A query object with the list of selected products and search term.
+ * @param {Object} props A query object with the list of selected products and search term.
+ * @param {Array} props.selected
+ * @param {string} props.search
  */
 export const getProductTags = ( { selected = [], search } ) => {
 	const requests = getProductTagsRequests( { selected, search } );

--- a/assets/js/editor-components/utils/index.js
+++ b/assets/js/editor-components/utils/index.js
@@ -134,6 +134,7 @@ const getProductTagsRequests = ( { selected = [], search } ) => {
 
 /**
  * Get a promise that resolves to a list of tags from the Store API.
+ *
  * @param {Object} props A query object with the list of selected products and search term.
  * @param {Array} props.selected
  * @param {string} props.search

--- a/assets/js/payment-method-extensions/payment-methods/cod/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cod/index.js
@@ -39,8 +39,11 @@ const Label = ( props ) => {
 /**
  * Determine whether COD is available for this cart/order.
  *
- * @param boolean cartNeedsShipping True if the cart contains any physical/shippable products.
- * @return boolean True if COD payment method should be displayed as a payment option.
+ * @param {Object} props Incoming props for the component.
+ * @param {boolean} props.cartNeedsShipping True if the cart contains any physical/shippable products.
+ * @param {boolean} props.selectedShippingMethods
+ *
+ * @return {boolean}  True if COD payment method should be displayed as a payment option.
  */
 const canMakePayment = ( { cartNeedsShipping, selectedShippingMethods } ) => {
 	if ( ! settings.enableForVirtual && ! cartNeedsShipping ) {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
@@ -15,6 +15,8 @@ import {
  */
 import { useElementOptions } from './use-element-options';
 
+/** @typedef {import('react')} React */
+
 const baseTextInputStyles = 'wc-block-gateway-input';
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
@@ -68,6 +68,7 @@ export const InlineCard = ( {
 
 /**
  * CardElements component.
+ *
  * @param {Object} props
  * @param {function(any):any} props.onChange
  * @param {React.ReactElement} props.inputErrorComponent

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
@@ -19,6 +19,10 @@ const baseTextInputStyles = 'wc-block-gateway-input';
 
 /**
  * InlineCard component
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {React.ReactElement} props.inputErrorComponent
+ * @param {function(any):any} props.onChange
  */
 export const InlineCard = ( {
 	inputErrorComponent: ValidationInputError,
@@ -62,6 +66,9 @@ export const InlineCard = ( {
 
 /**
  * CardElements component.
+ * @param {Object} props
+ * @param {function(any):any} props.onChange
+ * @param {React.ReactElement} props.inputErrorComponent
  */
 export const CardElements = ( {
 	onChange,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
@@ -265,6 +265,7 @@
 
 /**
  * @typedef {Object} Stripe Stripe api object.
+ * @property {any} api Various api properties
  */
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
@@ -274,6 +274,8 @@
  * @property {string} alt  Alt text for icon.
  */
 
+/* eslint-disable jsdoc/valid-types */
+// [k:string]:CreditCardIcon triggers the above rule even though VSCode interprets it fine.
 /**
  * @typedef {Object} StripeServerData
  *
@@ -299,6 +301,7 @@
  * @property {boolean}                     allowPaymentRequest  True if merchant has enabled payment
  *                                                              request (Chrome/Apple Pay).
  */
+/* eslint-enable jsdoc/valid-types */
 
 /**
  * @typedef {Object} StripeElementOptions

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -20,7 +20,7 @@ import { errorTypes, errorCodes } from './constants';
 /**
  * Stripe data comes form the server passed on a global object.
  *
- * @return  {StripeServerData}
+ * @return  {StripeServerData} Stripe server data.
  */
 const getStripeServerData = () => {
 	const stripeServerData = getSetting( 'stripe_data', null );

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -253,6 +253,10 @@ const getErrorMessageForTypeAndCode = ( type, code = '' ) => {
  * shipping, so we can track when one of them change to update rates.
  *
  * @param {Object} address          An object containing all address information
+ * @param {string} address.country
+ * @param {string} address.state
+ * @param {string} address.city
+ * @param {string} address.postcode
  *
  * @return {Object} pluckedAddress  An object containing shipping address that are needed to fetch an address.
  */

--- a/assets/js/settings/shared/get-setting.js
+++ b/assets/js/settings/shared/get-setting.js
@@ -6,7 +6,6 @@ import { allSettings } from './settings-init';
 /**
  * Retrieves a setting value from the setting state.
  *
- * @export
  * @param {string}   name                         The identifier for the setting.
  * @param {*}    [fallback=false]             The value to use as a fallback
  *                                                if the setting is not in the

--- a/assets/js/settings/shared/set-setting.js
+++ b/assets/js/settings/shared/set-setting.js
@@ -11,7 +11,6 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Sets a value to a property on the settings state.
  *
- * @export
  * @param {string}   name                        The setting property key for the
  *                                               setting being mutated.
  * @param {*}        value                       The value to set.

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -113,8 +113,8 @@
  *
  * This is an object where the keys are payment gateway slugs and the values are an array of
  * CustomerPaymentMethod objects.
- *
  * @typedef {Object} SavedCustomerPaymentMethods
+ * @property {any} any Various payment methods
  */
 
 /**

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -120,12 +120,12 @@
 /**
  * @typedef {Object} PaymentStatusDispatchers
  *
- * @property {function()}                        started
- * @property {function()}                        processing
- * @property {function()}                        completed
- * @property {function(string)}                  error
- * @property {function(string, Object, Object=)} failed
- * @property {function(Object=,Object=,Object=)} success
+ * @property {function()}                        started    Sets started status.
+ * @property {function()}                        processing Sets processing status.
+ * @property {function()}                        completed  Sets complete status.
+ * @property {function(string)}                  error      Sets error status.
+ * @property {function(string, Object, Object=)} failed     Sets failed status.
+ * @property {function(Object=,Object=,Object=)} success    Sets success status.
  */
 
 /**

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -113,6 +113,7 @@
  *
  * This is an object where the keys are payment gateway slugs and the values are an array of
  * CustomerPaymentMethod objects.
+ *
  * @typedef {Object} SavedCustomerPaymentMethods
  * @property {any} any Various payment methods
  */

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -34,7 +34,7 @@
  *                                                      being loaded.
  * @property {boolean}             hasShippingAddress   Whether or not the cart
  *                                                      has a shipping address yet.
- * @property {function}            receiveCart          Dispatcher to receive
+ * @property {function(Object):any} receiveCart         Dispatcher to receive
  *                                                      updated cart.
  */
 

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -90,6 +90,8 @@
  * @property {string} EXPRESS_PAYMENTS Notices for the express payments step.
  */
 
+/* eslint-disable jsdoc/valid-types */
+// Enum format below triggers the above rule even though VSCode interprets it fine.
 /**
  * @typedef {NoticeContexts['PAYMENTS']|NoticeContexts['EXPRESS_PAYMENTS']} NoticeContextsEnum
  */
@@ -137,6 +139,7 @@
  *                                                           response. This varies between context
  *                                                           emitters.
  */
+/* eslint-enable jsdoc/valid-types */
 
 /**
  * @typedef {Object} EmitResponseApi

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -17,12 +17,12 @@
  *
  * @typedef {Object} PaymentStatusActions
  *
- * @property {Function} started
- * @property {Function} processing
- * @property {Function} completed
- * @property {Function} error
- * @property {Function} failed
- * @property {Function} success
+ * @property {Function} started    Set started status.
+ * @property {Function} processing Set processing status.
+ * @property {Function} completed  Set completed status.
+ * @property {Function} error      Set error status.
+ * @property {Function} failed     Set failed status.
+ * @property {Function} success    Set success status.
  */
 
 /**

--- a/bin/eslint-plugin-woocommerce/rules/feature-flag.js
+++ b/bin/eslint-plugin-woocommerce/rules/feature-flag.js
@@ -35,7 +35,7 @@ function findParent( sourceNode, predicate ) {
  *
  * @param {Object} node    The WOOCOMMERCE_BLOCKS_PHASE identifier node.
  * @param {Object} context The eslint context object.
- * @todo: update this rule to match the new flags.
+ * @todo update this rule to match the new flags.
  */
 function testIsAccessedViaProcessEnv( node, context ) {
 	let parent = node.parent;

--- a/tests/e2e/fixtures/fixture-data.js
+++ b/tests/e2e/fixtures/fixture-data.js
@@ -194,6 +194,8 @@ const Settings = () => [
 /**
  * Page settings fixture data, using the update batch endpoint.
  *
+ * @param {Array} pages
+ *
  * @see {@link https://woocommerce.github.io/woocommerce-rest-api-docs/#batch-update-setting-options|Batch update setting options}
  */
 const PageSettings = ( pages = [] ) => {

--- a/tests/utils/find-label-with-text.js
+++ b/tests/utils/find-label-with-text.js
@@ -1,9 +1,11 @@
+/** @typedef {import('react')} React */
+
 /**
  * Finds the label of a toggle control.
  *
  * @param {string} label The label associated with a toggle control.
  *
- * @return {?ElementHandle} Object that represents an in-page DOM element.
+ * @return {?React.ReactElementHandle} Object that represents an in-page DOM element.
  */
 export async function findLabelWithText( label ) {
 	const [ toggle ] = await page.$x(


### PR DESCRIPTION
As a part of #3118, this pull enables all the jsdoc eslint rules and fixes the violations. Note I did each rule fix in it's own commit if that's easier for the reviewer.

This pull request does not impact any user facing features (only affects jsdocs).

Over time, there's more we can do to improve our jsdocs (custom typedefs etc) but for now I focused on the bare minimum to get the rule enabled so going forward we are following the WP standard.