### PR TITLE
Fixed issue current values doesn't persist in Products by Attribute block

### DIFF
--- a/assets/js/hocs/with-attributes.js
+++ b/assets/js/hocs/with-attributes.js
@@ -53,7 +53,7 @@ const withAttributes = ( OriginalComponent ) => {
 							? getAttributeData(
 									selected[ 0 ].attr_slug,
 									newAttributes,
-									'slug'
+									'taxonomy'
 							  )
 							: null;
 


### PR DESCRIPTION
Fixes #3084

## To reproduce
Steps to reproduce the behavior:

1. Add a Products by Attribute block.
2. Select some attributes and click on Done.
3. Click on the pencil icon to edit the block again.
4. Notice the attributes you previously selected are not checked by default, so it's easy to forget what was your previous attribute selection.

## Expected behavior
When clicking on the edit button, the currently selected attributes should be checked by default, like it happens with the Products by Category block, for example.

## How to test the changes in this Pull Request:

1. Add a Products by Attribute block.
2. Select some attributes and click on Done.
3. Click on the pencil icon to edit the block again.
4. Now selected attributes checked by default.

## Screenshots:

![91700882-cad75780-eb76-11ea-9257-c339e7d8bb4a.gif](https://user-images.githubusercontent.com/3616980/91700882-cad75780-eb76-11ea-9257-c339e7d8bb4a.gif)

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/10401366/94019332-45d70b00-fdcf-11ea-9bca-db365eb6e35b.gif)

