### PR TITLE
Use light default background colour for country/state dropdowns

### DIFF
--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -86,7 +86,7 @@
 	}
 
 	.components-custom-select-control__menu {
-		background-color: $select-dropdown-dark;
+		background-color: $select-dropdown-light;
 		margin: 0;
 		max-height: 300px;
 		overflow: auto;


### PR DESCRIPTION
Fixes #3145

Nice easy one 👍 

The `Select` (aka dropdown list/combobox) control has support for a dark mode. The drop-down menu background was defaulting to dark variant, which was jarring and hard to read. The css simply had the wrong default colour; this PR switches to light bg for the default.

### Screenshots

Fixed:

<img width="444" alt="Screen Shot 2020-09-24 at 2 48 01 PM" src="https://user-images.githubusercontent.com/4167300/94095023-f519ed80-fe74-11ea-84cb-10b498abf17f.png">


### How to test the changes in this Pull Request:
#### Test light mode / default
1. Add checkout block to a page. Disable `Dark mode inputs` option and publish.
2. View checkout on front end and expand country or state input.
3. Background/colours should be consistent - e.g. white background, black text.

#### Test dark mode
0. Optional: switch to a dark theme, or customise your theme so it's dark.
1. Add checkout block to a page. Enable `Dark mode inputs` option and publish.
2. View checkout on front end and expand country or state input.
3. Background/colours should look reasonable; text should be white on black.

### Changelog

> Fix: Checkout Block country and select dropdown list now uses appropriate colours for dark/light mode. #3189
