### PR TITLE
Update @wordpress/scripts to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,12 +73,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"lodash": {
@@ -1391,12 +1391,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"lodash": {
@@ -1557,6 +1557,11 @@
 					"version": "0.11.3",
 					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
 					"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+				},
+				"csstype": {
+					"version": "2.6.13",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+					"integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
 				}
 			}
 		},
@@ -1631,12 +1636,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"globals": {
@@ -2906,57 +2911,57 @@
 			}
 		},
 		"@mdx-js/loader": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.16.tgz",
-			"integrity": "sha512-jYIAav17lXmEvweO6bzbsqY9mRTm49UeXXSZPAB81uCX8j91Pgi50Z0NnEN777yQEgGm2Z5PMtnJdxGFQIAjJQ==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.18.tgz",
+			"integrity": "sha512-mCIt3dFc4p7y3ZqVda07grZDWgMcwSePT3k9vQfgfUcGWLeTFhp46fTbzagXVR/izldFSBLVYkouuH2PaI7Ecw==",
 			"dev": true,
 			"requires": {
-				"@mdx-js/mdx": "1.6.16",
-				"@mdx-js/react": "1.6.16",
+				"@mdx-js/mdx": "1.6.18",
+				"@mdx-js/react": "1.6.18",
 				"loader-utils": "2.0.0"
 			}
 		},
 		"@mdx-js/mdx": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.16.tgz",
-			"integrity": "sha512-jnYyJ0aCafCIehn3GjYcibIapaLBgs3YkoenNQBPcPFyyuUty7B3B07OE+pMllhJ6YkWeP/R5Ax19x0nqTzgJw==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.18.tgz",
+			"integrity": "sha512-RXtdFBP3cnf/RILx/ipp5TsSY1k75bYYmjorv7jTaPcHPQwhQdI6K4TrVUed/GL4f8zX5TN2QwO5g+3E/8RsXA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "7.10.5",
+				"@babel/core": "7.11.6",
 				"@babel/plugin-syntax-jsx": "7.10.4",
 				"@babel/plugin-syntax-object-rest-spread": "7.8.3",
-				"@mdx-js/util": "1.6.16",
-				"babel-plugin-apply-mdx-type-prop": "1.6.16",
-				"babel-plugin-extract-import-names": "1.6.16",
+				"@mdx-js/util": "1.6.18",
+				"babel-plugin-apply-mdx-type-prop": "1.6.18",
+				"babel-plugin-extract-import-names": "1.6.18",
 				"camelcase-css": "2.0.1",
 				"detab": "2.0.3",
-				"hast-util-raw": "6.0.0",
+				"hast-util-raw": "6.0.1",
 				"lodash.uniq": "4.5.0",
-				"mdast-util-to-hast": "9.1.0",
-				"remark-footnotes": "1.0.0",
-				"remark-mdx": "1.6.16",
+				"mdast-util-to-hast": "9.1.1",
+				"remark-footnotes": "2.0.0",
+				"remark-mdx": "1.6.18",
 				"remark-parse": "8.0.3",
 				"remark-squeeze-paragraphs": "4.0.0",
 				"style-to-object": "0.3.0",
-				"unified": "9.1.0",
+				"unified": "9.2.0",
 				"unist-builder": "2.0.3",
 				"unist-util-visit": "2.0.3"
 			},
 			"dependencies": {
 				"@babel/core": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-					"integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+					"version": "7.11.6",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+					"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.10.5",
-						"@babel/helper-module-transforms": "^7.10.5",
+						"@babel/generator": "^7.11.6",
+						"@babel/helper-module-transforms": "^7.11.0",
 						"@babel/helpers": "^7.10.4",
-						"@babel/parser": "^7.10.5",
+						"@babel/parser": "^7.11.5",
 						"@babel/template": "^7.10.4",
-						"@babel/traverse": "^7.10.5",
-						"@babel/types": "^7.10.5",
+						"@babel/traverse": "^7.11.5",
+						"@babel/types": "^7.11.5",
 						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"gensync": "^1.0.0-beta.1",
@@ -2968,12 +2973,12 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"lodash": {
@@ -2991,15 +2996,15 @@
 			}
 		},
 		"@mdx-js/react": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.16.tgz",
-			"integrity": "sha512-+FhuSVOPo7+4fZaRwWuCSRUcZkJOkZu0rfAbBKvoCg1LWb1Td8Vzi0DTLORdSvgWNbU6+EL40HIgwTOs00x2Jw==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.18.tgz",
+			"integrity": "sha512-aFHsZVu7r9WamlP+WO/lyvHHZAubkQjkcRYlvS7fQElypfJvjKdHevjC3xiqlsQpasx/4KqRMoEIb++wNtd+6w==",
 			"dev": true
 		},
 		"@mdx-js/util": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.16.tgz",
-			"integrity": "sha512-SFtLGIGZummuyMDPRL5KdmpgI8U19Ble28UjEWihPjGxF1Lgj8aDjLWY8KiaUy9eqb9CKiVCqEIrK9jbnANfkw==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.18.tgz",
+			"integrity": "sha512-axMe+NoLF55OlXPbhRn4GNCHcL1f5W3V3c0dWzg05S9JXm3Ecpxzxaht3g3vTP0dcqBL/yh/xCvzK0ZpO54Eug==",
 			"dev": true
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -3144,9 +3149,9 @@
 			}
 		},
 		"@popperjs/core": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.4.4.tgz",
-			"integrity": "sha512-1oO6+dN5kdIA3sKPZhRGJTfGVP4SWV6KqlMOwry4J3HfyD68sl/3KmG7DeYUzvN+RbhXDnv/D8vNNB8168tAMg=="
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.2.tgz",
+			"integrity": "sha512-tVkIU9JQw5fYPxLQgok/a7I6J1eEZ79svwQGpe2mb3jlVsPADOleefOnQBiS/takK7jQuNeswCUicMH1VWVziA=="
 		},
 		"@reach/router": {
 			"version": "1.3.4",
@@ -4283,9 +4288,9 @@
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
 		"@testing-library/dom": {
-			"version": "7.24.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.1.tgz",
-			"integrity": "sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==",
+			"version": "7.24.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.2.tgz",
+			"integrity": "sha512-ERxcZSoHx0EcN4HfshySEWmEf5Kkmgi+J7O79yCJ3xggzVlBJ2w/QjJUC+EBkJJ2OeSw48i3IoePN4w8JlVUIA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
@@ -4520,15 +4525,15 @@
 			}
 		},
 		"@types/history": {
-			"version": "4.7.7",
-			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.7.tgz",
-			"integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg==",
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
+			"integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==",
 			"dev": true
 		},
 		"@types/html-minifier-terser": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.0.tgz",
-			"integrity": "sha512-iYCgjm1dGPRuo12+BStjd1HiVQqhlRhWDOQigNxn023HcjnhsiFz9pc6CzJj4HwDCSQca9bxTL4PxJDbkdm3PA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+			"integrity": "sha512-giAlZwstKbmvMk1OO7WXSj4OZ0keXAcl2TQq4LWHiiPH2ByaH7WeUzng+Qej8UPxxv+8lRTuouo0iaNDBuzIBA==",
 			"dev": true
 		},
 		"@types/htmlparser2": {
@@ -4648,9 +4653,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.10.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.10.0.tgz",
-			"integrity": "sha512-SOIyrdADB4cq6eY1F+9iU48iIomFAPltu11LCvA9PKcyEwHadjCFzNVPotAR+oEJA0bCP4Xvvgy+vwu1ZjVh8g=="
+			"version": "14.11.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
+			"integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
 		},
 		"@types/node-fetch": {
 			"version": "2.5.7",
@@ -4700,8 +4705,7 @@
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-			"dev": true
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/q": {
 			"version": "1.5.4",
@@ -4710,9 +4714,9 @@
 			"dev": true
 		},
 		"@types/qs": {
-			"version": "6.9.4",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-			"integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==",
+			"version": "6.9.5",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+			"integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
 			"dev": true
 		},
 		"@types/reach__router": {
@@ -4733,14 +4737,6 @@
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
-			},
-			"dependencies": {
-				"csstype": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-					"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
-					"dev": true
-				}
 			}
 		},
 		"@types/react-color": {
@@ -4757,9 +4753,19 @@
 			"version": "16.9.8",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz",
 			"integrity": "sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==",
-			"dev": true,
 			"requires": {
 				"@types/react": "*"
+			},
+			"dependencies": {
+				"@types/react": {
+					"version": "16.9.49",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+					"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^3.0.2"
+					}
+				}
 			}
 		},
 		"@types/react-syntax-highlighter": {
@@ -4862,9 +4868,9 @@
 			}
 		},
 		"@types/webpack-env": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.2.tgz",
-			"integrity": "sha512-67ZgZpAlhIICIdfQrB5fnDvaKFcDxpKibxznfYRVAT4mQE41Dido/3Ty+E3xGBmTogc5+0Qb8tWhna+5B8z1iQ==",
+			"version": "1.15.3",
+			"resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.3.tgz",
+			"integrity": "sha512-5oiXqR7kwDGZ6+gmzIO2lTC+QsriNuQXZDWNYRV3l2XRN/zmPgnC21DLSx2D05zvD8vnXW6qUg7JnXZ4I6qLVQ==",
 			"dev": true
 		},
 		"@types/webpack-sources": {
@@ -4905,12 +4911,20 @@
 				"@types/react": "*",
 				"@types/react-dom": "*",
 				"csstype": "^2.2.0"
+			},
+			"dependencies": {
+				"csstype": {
+					"version": "2.6.13",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
+					"integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
+					"dev": true
+				}
 			}
 		},
 		"@types/yargs": {
-			"version": "15.0.5",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
-			"integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+			"version": "15.0.7",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
+			"integrity": "sha512-Gf4u3EjaPNcC9cTu4/j2oN14nSVhr8PQ+BvBcBQHAhDZfl0bVIiLgvnRXv/dn58XhTm9UXvBpvJpDlwV65QxOA==",
 			"dev": true,
 			"requires": {
 				"@types/yargs-parser": "*"
@@ -4945,16 +4959,22 @@
 			},
 			"dependencies": {
 				"eslint-scope": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-					"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
+						"esrecurse": "^4.3.0",
 						"estraverse": "^4.1.1"
 					}
 				}
 			}
+		},
+		"@typescript-eslint/types": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.10.1.tgz",
+			"integrity": "sha512-+3+FCUJIahE9q0lDi1WleYzjCwJs5hIsbugIgnbB+dSCYUxl8L6PwmsyOPFZde2hc1DlTo/xnkOgiTLSyAbHiQ==",
+			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
 			"version": "2.34.0",
@@ -4972,12 +4992,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -4992,6 +5012,15 @@
 					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
 					"dev": true
 				}
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.10.1.tgz",
+			"integrity": "sha512-9JgC82AaQeglebjZMgYR5wgmfUdUc+EitGUUMW8u2nDckaeimzW+VsoLV6FoimPv2id3VQzfjwBxEMVz08ameQ==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -5263,6 +5292,15 @@
 				"react-transition-group": "2.9.0"
 			},
 			"dependencies": {
+				"@types/react": {
+					"version": "16.9.49",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+					"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^3.0.2"
+					}
+				},
 				"@wordpress/components": {
 					"version": "8.4.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.4.0.tgz",
@@ -5295,12 +5333,12 @@
 					},
 					"dependencies": {
 						"@wordpress/compose": {
-							"version": "3.20.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-							"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+							"version": "3.20.1",
+							"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+							"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 							"requires": {
 								"@babel/runtime": "^7.9.2",
-								"@wordpress/element": "^2.17.0",
+								"@wordpress/element": "^2.17.1",
 								"@wordpress/is-shallow-equal": "^2.2.0",
 								"@wordpress/priority-queue": "^1.8.0",
 								"clipboard": "^2.0.1",
@@ -5325,11 +5363,13 @@
 							}
 						},
 						"@wordpress/element": {
-							"version": "2.17.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-							"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+							"version": "2.17.1",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+							"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 							"requires": {
 								"@babel/runtime": "^7.9.2",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
 								"@wordpress/escape-html": "^1.9.0",
 								"lodash": "^4.17.19",
 								"react": "^16.13.1",
@@ -5556,9 +5596,9 @@
 			}
 		},
 		"@wordpress/api-fetch": {
-			"version": "3.19.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.19.0.tgz",
-			"integrity": "sha512-5WPr8wZdS9kKMIJf2SlvC5RYiSmGellYtzIxt8/I2qWJdzXhJ/JCC1CbuaflsZcRpuP+rA6LYuVk+ntw0zg4iQ==",
+			"version": "3.19.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.19.1.tgz",
+			"integrity": "sha512-v9Qf/wmWec0H1sN1U2E++dFnx4/HrywRa1/x5nbHfM120ntcoHgQd1JECsH/5vOYHi9mYBiZCKRlJ14N+FvhEw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
@@ -5623,12 +5663,14 @@
 			},
 			"dependencies": {
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -5659,25 +5701,26 @@
 			}
 		},
 		"@wordpress/block-directory": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-directory/-/block-directory-1.14.0.tgz",
-			"integrity": "sha512-TfdA5LBSZ9bNigSrKTBkSI9rboMn3Cb8/sCRKhvgm9Sm7d+9SVEH+m2L862kwC5ao5dFuSXRwvqTvjrUXkO47g==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-directory/-/block-directory-1.15.0.tgz",
+			"integrity": "sha512-H/8Xn8glFCZIzOurKmwqfzWnZl5UBaoqBGKGXAi8nslpQv52CnW5ImB1J2ScYlDIp5LhMEyEhuqcpDYbbtc4Rg==",
 			"dev": true,
 			"requires": {
-				"@wordpress/api-fetch": "^3.19.0",
-				"@wordpress/block-editor": "^4.4.0",
-				"@wordpress/blocks": "^6.21.0",
-				"@wordpress/components": "^10.1.0",
-				"@wordpress/compose": "^3.20.0",
-				"@wordpress/data": "^4.23.0",
-				"@wordpress/data-controls": "^1.17.0",
-				"@wordpress/edit-post": "^3.22.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/api-fetch": "^3.19.1",
+				"@wordpress/block-editor": "^4.5.0",
+				"@wordpress/blocks": "^6.22.0",
+				"@wordpress/components": "^10.2.0",
+				"@wordpress/compose": "^3.20.1",
+				"@wordpress/data": "^4.23.1",
+				"@wordpress/data-controls": "^1.17.1",
+				"@wordpress/edit-post": "^3.23.0",
+				"@wordpress/element": "^2.17.1",
+				"@wordpress/hooks": "^2.9.0",
 				"@wordpress/html-entities": "^2.8.0",
 				"@wordpress/i18n": "^3.15.0",
-				"@wordpress/icons": "^2.5.0",
-				"@wordpress/notices": "^2.9.0",
-				"@wordpress/plugins": "^2.21.0",
+				"@wordpress/icons": "^2.6.0",
+				"@wordpress/notices": "^2.9.1",
+				"@wordpress/plugins": "^2.21.1",
 				"@wordpress/url": "^2.18.0",
 				"lodash": "^4.17.19"
 			},
@@ -5692,34 +5735,34 @@
 					}
 				},
 				"@wordpress/block-editor": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-4.4.0.tgz",
-					"integrity": "sha512-LIRTWIg633El0oXai7i9WSqdULwr85YPHofFzKYthSKeu/icynhHRw8tUcBjYuf8eHyTlemuYmJAzKrj4ZNWLw==",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-4.5.0.tgz",
+					"integrity": "sha512-6c6k9rre4gc+tcx5eM6Jf09vdeerUwGMjMvay/bR7oSsysgfoAD7wpxmOO5Hd3L5PSiijSuaxpvcyy3R78KhSQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/a11y": "^2.12.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/blocks": "^6.21.0",
-						"@wordpress/components": "^10.1.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/blocks": "^6.22.0",
+						"@wordpress/components": "^10.2.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
-						"@wordpress/keyboard-shortcuts": "^1.10.0",
+						"@wordpress/keyboard-shortcuts": "^1.10.1",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/notices": "^2.9.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/notices": "^2.9.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/shortcode": "^2.10.0",
 						"@wordpress/token-list": "^1.12.0",
 						"@wordpress/url": "^2.18.0",
-						"@wordpress/viewport": "^2.22.0",
+						"@wordpress/viewport": "^2.22.1",
 						"@wordpress/warning": "^1.3.0",
 						"@wordpress/wordcount": "^2.11.0",
 						"classnames": "^2.2.5",
@@ -5741,24 +5784,24 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.21.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.21.0.tgz",
-					"integrity": "sha512-zirBnjzfBYsLhtpedEzddVFSSHTest0zZD6bqZSEFVv4RdMDqv55dejBG3nOK+bOpZ4fQ+gDT7HaMJY4IpU9FA==",
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.22.0.tgz",
+					"integrity": "sha512-HGZVqajtk1c+EzixuFfvgsxpOFt3uk+LMemjGv29SVZA6d6uNaZhCCaht82p8HYQlgw8/UCbQAhQwdIo7cqxEw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/autop": "^2.9.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/block-serialization-default-parser": "^3.7.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/block-serialization-default-parser": "^3.7.1",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/shortcode": "^2.10.0",
 						"hpq": "^1.3.0",
@@ -5771,9 +5814,9 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.1.0.tgz",
-					"integrity": "sha512-5RSmgEaGzvGWYF9KS7a/wa84YollP2xUxJHrLPTWOBQgZoYx7jBb8J9dnVzmxGwngJnGsSNkNtEVzazAdTUwcA==",
+					"version": "10.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.2.0.tgz",
+					"integrity": "sha512-jXZgNVAlrQk1yR/Zkmmz6nEnKI4GPz5asSWtzVu5Php0ogzC3rgxikggJWrnDq5oCT+kRrar8eSpt6qP3NVfQg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
@@ -5782,18 +5825,18 @@
 						"@emotion/native": "^10.0.22",
 						"@emotion/styled": "^10.0.23",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/date": "^3.11.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/date": "^3.11.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/primitives": "^1.8.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/primitives": "^1.8.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/warning": "^1.3.0",
 						"classnames": "^2.2.5",
 						"dom-scroll-into-view": "^1.2.1",
@@ -5815,13 +5858,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -5831,24 +5874,24 @@
 					}
 				},
 				"@wordpress/data-controls": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.0.tgz",
-					"integrity": "sha512-caQZ5TJNGLDOUxdnNNIkn89Xt12ZGtNJ7OX8qQfW+NUkil9LbQtwUlVlLF1GJCooap05xZwzj0J9QA+sXM4UUA==",
+					"version": "1.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.1.tgz",
+					"integrity": "sha512-6HReDvd5mELCSYMrLHoBerVW7A0fPZS5MyfLHcfDv+Kjw+dAZb7x5+WNepHuxyMCT8tIvVsfMHsx5erqUqRqWQ==",
 					"dev": true,
 					"requires": {
-						"@wordpress/api-fetch": "^3.19.0",
-						"@wordpress/data": "^4.23.0"
+						"@wordpress/api-fetch": "^3.19.1",
+						"@wordpress/data": "^4.23.1"
 					}
 				},
 				"@wordpress/date": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.0.tgz",
-					"integrity": "sha512-ZOeSDu/stp7QHzFL6296GhmfqFwCQqurlcvZQkB7COzkaQoAkynx6cnzaDPDKKVoHowgh0A4EEDwtzw6L3KDOA==",
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.1.tgz",
+					"integrity": "sha512-Vxt102uR0ptQ/ec5TPL/JEtqShBRCuYSkP+uj9TJ7DdK97+D698c8GQ/2VFnzJ3VMb2Xq+4VFCXSw1vC5M3NMg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"moment": "^2.22.1",
-						"moment-timezone": "^0.5.16"
+						"moment-timezone": "^0.5.31"
 					}
 				},
 				"@wordpress/deprecated": {
@@ -5862,12 +5905,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -5907,15 +5952,15 @@
 					}
 				},
 				"@wordpress/keyboard-shortcuts": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.0.tgz",
-					"integrity": "sha512-eTh1cWIn4FoyaQ7vyTq17VUBWZfc8+wOrcSZuR4f4OnViiXr+z+1YmzKf680U+lutCVWQ2QerrDN4nXqBbvrJA==",
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.1.tgz",
+					"integrity": "sha512-yDn+yS9fe/cz2z+Md5Mq4jhecTf3nXiPy8I3i9xmYBlgHQCW6LmekdUkmbkDXsV28wo4J5E/1KsBd2ojCL3HUw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/keycodes": "^2.15.0",
 						"lodash": "^4.17.19",
 						"rememo": "^3.0.0"
@@ -5933,26 +5978,26 @@
 					}
 				},
 				"@wordpress/notices": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.9.0.tgz",
-					"integrity": "sha512-IA5jBILeV0gQAiS/J5EOZLRb2bUoqZY4pS0OnoOHzKBs0b50m/mZ0IWLKurXkC9LCQU0hAxdcAV+zOi68My0wg==",
+					"version": "2.9.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.9.1.tgz",
+					"integrity": "sha512-W2sU0MCoKIGmokjXyyqHfRBW1ZARVL/y3t/5jykAvWyoZhBLwCjof3ZnSKs1KXlpPAvz9hCxxtCKvP+Qs7azeg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@wordpress/viewport": {
-					"version": "2.22.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.0.tgz",
-					"integrity": "sha512-mr4yAsH4etbtos5fLLOKIUzhm4tI3SQ8lADaf/wmCP4XacFphM/Os1hly1bdZAH5JYotWQhMyNL6QgPZUvD19A==",
+					"version": "2.22.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.1.tgz",
+					"integrity": "sha512-eoXkWzkCVhiLBfyWhA9V7Wvkz8ynPMtU5TmvhxdQWVSEWv6Hwl174m7h0sujjb+8ghgPSgImoBApLcMBOJ97Lw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -6061,24 +6106,24 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.21.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.21.0.tgz",
-					"integrity": "sha512-zirBnjzfBYsLhtpedEzddVFSSHTest0zZD6bqZSEFVv4RdMDqv55dejBG3nOK+bOpZ4fQ+gDT7HaMJY4IpU9FA==",
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.22.0.tgz",
+					"integrity": "sha512-HGZVqajtk1c+EzixuFfvgsxpOFt3uk+LMemjGv29SVZA6d6uNaZhCCaht82p8HYQlgw8/UCbQAhQwdIo7cqxEw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/autop": "^2.9.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/block-serialization-default-parser": "^3.7.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/block-serialization-default-parser": "^3.7.1",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/shortcode": "^2.10.0",
 						"hpq": "^1.3.0",
@@ -6162,13 +6207,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -6186,12 +6231,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -6247,15 +6294,15 @@
 					}
 				},
 				"@wordpress/keyboard-shortcuts": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.0.tgz",
-					"integrity": "sha512-eTh1cWIn4FoyaQ7vyTq17VUBWZfc8+wOrcSZuR4f4OnViiXr+z+1YmzKf680U+lutCVWQ2QerrDN4nXqBbvrJA==",
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.1.tgz",
+					"integrity": "sha512-yDn+yS9fe/cz2z+Md5Mq4jhecTf3nXiPy8I3i9xmYBlgHQCW6LmekdUkmbkDXsV28wo4J5E/1KsBd2ojCL3HUw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/keycodes": "^2.15.0",
 						"lodash": "^4.17.19",
 						"rememo": "^3.0.0"
@@ -6289,14 +6336,14 @@
 					}
 				},
 				"@wordpress/viewport": {
-					"version": "2.22.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.0.tgz",
-					"integrity": "sha512-mr4yAsH4etbtos5fLLOKIUzhm4tI3SQ8lADaf/wmCP4XacFphM/Os1hly1bdZAH5JYotWQhMyNL6QgPZUvD19A==",
+					"version": "2.22.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.1.tgz",
+					"integrity": "sha512-eoXkWzkCVhiLBfyWhA9V7Wvkz8ynPMtU5TmvhxdQWVSEWv6Hwl174m7h0sujjb+8ghgPSgImoBApLcMBOJ97Lw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					},
 					"dependencies": {
@@ -6317,39 +6364,39 @@
 			}
 		},
 		"@wordpress/block-library": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.23.0.tgz",
-			"integrity": "sha512-kEzVAvXHZJYK5YD4NYM88Gy6Fsoh9MJJaAmv1Rgw/IAOeIC8AIjbfVV9xaEGwDgmY//8rtdA+Wh8fUVmyxnzQA==",
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.24.0.tgz",
+			"integrity": "sha512-Znwddz6F5FMhG0pplsjEoIDmLK4FpNdQTzErzc9NFmC1+MYPU00vYkKzYvxJTDBv+11957BIZbiBUD2D5Ihl/g==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"@wordpress/a11y": "^2.12.0",
-				"@wordpress/api-fetch": "^3.19.0",
+				"@wordpress/api-fetch": "^3.19.1",
 				"@wordpress/autop": "^2.9.0",
 				"@wordpress/blob": "^2.9.0",
-				"@wordpress/block-editor": "^4.4.0",
-				"@wordpress/blocks": "^6.21.0",
-				"@wordpress/components": "^10.1.0",
-				"@wordpress/compose": "^3.20.0",
-				"@wordpress/core-data": "^2.21.0",
-				"@wordpress/data": "^4.23.0",
-				"@wordpress/date": "^3.11.0",
+				"@wordpress/block-editor": "^4.5.0",
+				"@wordpress/blocks": "^6.22.0",
+				"@wordpress/components": "^10.2.0",
+				"@wordpress/compose": "^3.20.1",
+				"@wordpress/core-data": "^2.22.0",
+				"@wordpress/data": "^4.23.1",
+				"@wordpress/date": "^3.11.1",
 				"@wordpress/deprecated": "^2.9.0",
 				"@wordpress/dom": "^2.14.0",
-				"@wordpress/editor": "^9.21.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/editor": "^9.22.0",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/escape-html": "^1.9.0",
 				"@wordpress/hooks": "^2.9.0",
 				"@wordpress/i18n": "^3.15.0",
-				"@wordpress/icons": "^2.5.0",
+				"@wordpress/icons": "^2.6.0",
 				"@wordpress/is-shallow-equal": "^2.2.0",
 				"@wordpress/keycodes": "^2.15.0",
-				"@wordpress/notices": "^2.9.0",
-				"@wordpress/primitives": "^1.8.0",
-				"@wordpress/rich-text": "^3.21.0",
-				"@wordpress/server-side-render": "^1.17.0",
+				"@wordpress/notices": "^2.9.1",
+				"@wordpress/primitives": "^1.8.1",
+				"@wordpress/rich-text": "^3.21.1",
+				"@wordpress/server-side-render": "^1.17.1",
 				"@wordpress/url": "^2.18.0",
-				"@wordpress/viewport": "^2.22.0",
+				"@wordpress/viewport": "^2.22.1",
 				"classnames": "^2.2.5",
 				"fast-average-color": "4.3.0",
 				"lodash": "^4.17.19",
@@ -6369,34 +6416,34 @@
 					}
 				},
 				"@wordpress/block-editor": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-4.4.0.tgz",
-					"integrity": "sha512-LIRTWIg633El0oXai7i9WSqdULwr85YPHofFzKYthSKeu/icynhHRw8tUcBjYuf8eHyTlemuYmJAzKrj4ZNWLw==",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-4.5.0.tgz",
+					"integrity": "sha512-6c6k9rre4gc+tcx5eM6Jf09vdeerUwGMjMvay/bR7oSsysgfoAD7wpxmOO5Hd3L5PSiijSuaxpvcyy3R78KhSQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/a11y": "^2.12.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/blocks": "^6.21.0",
-						"@wordpress/components": "^10.1.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/blocks": "^6.22.0",
+						"@wordpress/components": "^10.2.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
-						"@wordpress/keyboard-shortcuts": "^1.10.0",
+						"@wordpress/keyboard-shortcuts": "^1.10.1",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/notices": "^2.9.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/notices": "^2.9.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/shortcode": "^2.10.0",
 						"@wordpress/token-list": "^1.12.0",
 						"@wordpress/url": "^2.18.0",
-						"@wordpress/viewport": "^2.22.0",
+						"@wordpress/viewport": "^2.22.1",
 						"@wordpress/warning": "^1.3.0",
 						"@wordpress/wordcount": "^2.11.0",
 						"classnames": "^2.2.5",
@@ -6418,24 +6465,24 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.21.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.21.0.tgz",
-					"integrity": "sha512-zirBnjzfBYsLhtpedEzddVFSSHTest0zZD6bqZSEFVv4RdMDqv55dejBG3nOK+bOpZ4fQ+gDT7HaMJY4IpU9FA==",
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.22.0.tgz",
+					"integrity": "sha512-HGZVqajtk1c+EzixuFfvgsxpOFt3uk+LMemjGv29SVZA6d6uNaZhCCaht82p8HYQlgw8/UCbQAhQwdIo7cqxEw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/autop": "^2.9.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/block-serialization-default-parser": "^3.7.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/block-serialization-default-parser": "^3.7.1",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/shortcode": "^2.10.0",
 						"hpq": "^1.3.0",
@@ -6448,9 +6495,9 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.1.0.tgz",
-					"integrity": "sha512-5RSmgEaGzvGWYF9KS7a/wa84YollP2xUxJHrLPTWOBQgZoYx7jBb8J9dnVzmxGwngJnGsSNkNtEVzazAdTUwcA==",
+					"version": "10.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.2.0.tgz",
+					"integrity": "sha512-jXZgNVAlrQk1yR/Zkmmz6nEnKI4GPz5asSWtzVu5Php0ogzC3rgxikggJWrnDq5oCT+kRrar8eSpt6qP3NVfQg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
@@ -6459,18 +6506,18 @@
 						"@emotion/native": "^10.0.22",
 						"@emotion/styled": "^10.0.23",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/date": "^3.11.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/date": "^3.11.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/primitives": "^1.8.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/primitives": "^1.8.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/warning": "^1.3.0",
 						"classnames": "^2.2.5",
 						"dom-scroll-into-view": "^1.2.1",
@@ -6492,13 +6539,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -6508,24 +6555,24 @@
 					}
 				},
 				"@wordpress/data-controls": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.0.tgz",
-					"integrity": "sha512-caQZ5TJNGLDOUxdnNNIkn89Xt12ZGtNJ7OX8qQfW+NUkil9LbQtwUlVlLF1GJCooap05xZwzj0J9QA+sXM4UUA==",
+					"version": "1.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.1.tgz",
+					"integrity": "sha512-6HReDvd5mELCSYMrLHoBerVW7A0fPZS5MyfLHcfDv+Kjw+dAZb7x5+WNepHuxyMCT8tIvVsfMHsx5erqUqRqWQ==",
 					"dev": true,
 					"requires": {
-						"@wordpress/api-fetch": "^3.19.0",
-						"@wordpress/data": "^4.23.0"
+						"@wordpress/api-fetch": "^3.19.1",
+						"@wordpress/data": "^4.23.1"
 					}
 				},
 				"@wordpress/date": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.0.tgz",
-					"integrity": "sha512-ZOeSDu/stp7QHzFL6296GhmfqFwCQqurlcvZQkB7COzkaQoAkynx6cnzaDPDKKVoHowgh0A4EEDwtzw6L3KDOA==",
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.1.tgz",
+					"integrity": "sha512-Vxt102uR0ptQ/ec5TPL/JEtqShBRCuYSkP+uj9TJ7DdK97+D698c8GQ/2VFnzJ3VMb2Xq+4VFCXSw1vC5M3NMg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"moment": "^2.22.1",
-						"moment-timezone": "^0.5.16"
+						"moment-timezone": "^0.5.31"
 					}
 				},
 				"@wordpress/deprecated": {
@@ -6539,38 +6586,38 @@
 					}
 				},
 				"@wordpress/editor": {
-					"version": "9.21.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.21.0.tgz",
-					"integrity": "sha512-9t0PyZy/8Aq2Hu+pEjMHsKThquW/10y8mMBICTeq+aiyInmh11Q0ZU/ny3CpVGdD9yUXTgJrWUmcX8XytdqqeA==",
+					"version": "9.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.22.0.tgz",
+					"integrity": "sha512-3WRNM5EyykxA/uK2wx8/7YOZfUeI2vkesKxCDOLMf1P0AS9UxCZDVqB75j23fVV+KvOudFey/lQHyA1u0tEiWA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/api-fetch": "^3.19.0",
+						"@wordpress/api-fetch": "^3.19.1",
 						"@wordpress/autop": "^2.9.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/block-editor": "^4.4.0",
-						"@wordpress/blocks": "^6.21.0",
-						"@wordpress/components": "^10.1.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/core-data": "^2.21.0",
-						"@wordpress/data": "^4.23.0",
-						"@wordpress/data-controls": "^1.17.0",
-						"@wordpress/date": "^3.11.0",
+						"@wordpress/block-editor": "^4.5.0",
+						"@wordpress/blocks": "^6.22.0",
+						"@wordpress/components": "^10.2.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/core-data": "^2.22.0",
+						"@wordpress/data": "^4.23.1",
+						"@wordpress/data-controls": "^1.17.1",
+						"@wordpress/date": "^3.11.1",
 						"@wordpress/deprecated": "^2.9.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
-						"@wordpress/keyboard-shortcuts": "^1.10.0",
+						"@wordpress/keyboard-shortcuts": "^1.10.1",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/media-utils": "^1.16.0",
-						"@wordpress/notices": "^2.9.0",
-						"@wordpress/rich-text": "^3.21.0",
-						"@wordpress/server-side-render": "^1.17.0",
+						"@wordpress/media-utils": "^1.16.1",
+						"@wordpress/notices": "^2.9.1",
+						"@wordpress/rich-text": "^3.21.1",
+						"@wordpress/server-side-render": "^1.17.1",
 						"@wordpress/url": "^2.18.0",
-						"@wordpress/viewport": "^2.22.0",
+						"@wordpress/viewport": "^2.22.1",
 						"@wordpress/wordcount": "^2.11.0",
 						"classnames": "^2.2.5",
 						"lodash": "^4.17.19",
@@ -6582,12 +6629,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -6627,15 +6676,15 @@
 					}
 				},
 				"@wordpress/keyboard-shortcuts": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.0.tgz",
-					"integrity": "sha512-eTh1cWIn4FoyaQ7vyTq17VUBWZfc8+wOrcSZuR4f4OnViiXr+z+1YmzKf680U+lutCVWQ2QerrDN4nXqBbvrJA==",
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.1.tgz",
+					"integrity": "sha512-yDn+yS9fe/cz2z+Md5Mq4jhecTf3nXiPy8I3i9xmYBlgHQCW6LmekdUkmbkDXsV28wo4J5E/1KsBd2ojCL3HUw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/keycodes": "^2.15.0",
 						"lodash": "^4.17.19",
 						"rememo": "^3.0.0"
@@ -6653,26 +6702,26 @@
 					}
 				},
 				"@wordpress/notices": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.9.0.tgz",
-					"integrity": "sha512-IA5jBILeV0gQAiS/J5EOZLRb2bUoqZY4pS0OnoOHzKBs0b50m/mZ0IWLKurXkC9LCQU0hAxdcAV+zOi68My0wg==",
+					"version": "2.9.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.9.1.tgz",
+					"integrity": "sha512-W2sU0MCoKIGmokjXyyqHfRBW1ZARVL/y3t/5jykAvWyoZhBLwCjof3ZnSKs1KXlpPAvz9hCxxtCKvP+Qs7azeg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@wordpress/viewport": {
-					"version": "2.22.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.0.tgz",
-					"integrity": "sha512-mr4yAsH4etbtos5fLLOKIUzhm4tI3SQ8lADaf/wmCP4XacFphM/Os1hly1bdZAH5JYotWQhMyNL6QgPZUvD19A==",
+					"version": "2.22.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.1.tgz",
+					"integrity": "sha512-eoXkWzkCVhiLBfyWhA9V7Wvkz8ynPMtU5TmvhxdQWVSEWv6Hwl174m7h0sujjb+8ghgPSgImoBApLcMBOJ97Lw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -6726,9 +6775,9 @@
 			}
 		},
 		"@wordpress/block-serialization-default-parser": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.7.0.tgz",
-			"integrity": "sha512-Q02yT1AKBTsWsqTi7ZwCIkzAHfL52txNJkRFH7Ln5B/WaMtPHm8EXIJV2BeNZnRjAxqL5zn5ZINJqJBjPX4bqg==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.7.1.tgz",
+			"integrity": "sha512-dps9iVfahF4ZT0k+sm1Y3wel7syjYtL6pMkRTDrigZinPqWm2F9G5tYPDMkawFMb2gYDcQDHygktLHR5yFbsig==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2"
@@ -6763,13 +6812,13 @@
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -6796,12 +6845,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -6902,13 +6953,13 @@
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -6918,12 +6969,14 @@
 					},
 					"dependencies": {
 						"@wordpress/element": {
-							"version": "2.17.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-							"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+							"version": "2.17.1",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+							"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.9.2",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
 								"@wordpress/escape-html": "^1.9.0",
 								"lodash": "^4.17.19",
 								"react": "^16.13.1",
@@ -7005,12 +7058,23 @@
 				"lodash": "^4.17.15"
 			},
 			"dependencies": {
+				"@types/react": {
+					"version": "16.9.49",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+					"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^3.0.2"
+					}
+				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -7035,18 +7099,18 @@
 			}
 		},
 		"@wordpress/core-data": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.21.0.tgz",
-			"integrity": "sha512-MO+JN4Z2IqcLvkFtiuszhXtQMqd4Xr7qCpYj1ScnXn2c2zCK1m3+f8gHsY+thM1seu03EZUBkgQrTd9mTYptqQ==",
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.22.0.tgz",
+			"integrity": "sha512-YdCPfmnR6jkCcvn10J2MlBgaq+Fr19LJqHVt6V7Ns10PyXJpbzTJv7VRuz3EpE+KkCu7Nhz37B3KbyxYrvnGpQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/api-fetch": "^3.19.0",
-				"@wordpress/blocks": "^6.21.0",
-				"@wordpress/data": "^4.23.0",
-				"@wordpress/data-controls": "^1.17.0",
+				"@wordpress/api-fetch": "^3.19.1",
+				"@wordpress/blocks": "^6.22.0",
+				"@wordpress/data": "^4.23.1",
+				"@wordpress/data-controls": "^1.17.1",
 				"@wordpress/deprecated": "^2.9.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/i18n": "^3.15.0",
 				"@wordpress/is-shallow-equal": "^2.2.0",
 				"@wordpress/url": "^2.18.0",
@@ -7065,24 +7129,24 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.21.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.21.0.tgz",
-					"integrity": "sha512-zirBnjzfBYsLhtpedEzddVFSSHTest0zZD6bqZSEFVv4RdMDqv55dejBG3nOK+bOpZ4fQ+gDT7HaMJY4IpU9FA==",
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.22.0.tgz",
+					"integrity": "sha512-HGZVqajtk1c+EzixuFfvgsxpOFt3uk+LMemjGv29SVZA6d6uNaZhCCaht82p8HYQlgw8/UCbQAhQwdIo7cqxEw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/autop": "^2.9.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/block-serialization-default-parser": "^3.7.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/block-serialization-default-parser": "^3.7.1",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/shortcode": "^2.10.0",
 						"hpq": "^1.3.0",
@@ -7095,13 +7159,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -7111,13 +7175,13 @@
 					}
 				},
 				"@wordpress/data-controls": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.0.tgz",
-					"integrity": "sha512-caQZ5TJNGLDOUxdnNNIkn89Xt12ZGtNJ7OX8qQfW+NUkil9LbQtwUlVlLF1GJCooap05xZwzj0J9QA+sXM4UUA==",
+					"version": "1.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.1.tgz",
+					"integrity": "sha512-6HReDvd5mELCSYMrLHoBerVW7A0fPZS5MyfLHcfDv+Kjw+dAZb7x5+WNepHuxyMCT8tIvVsfMHsx5erqUqRqWQ==",
 					"dev": true,
 					"requires": {
-						"@wordpress/api-fetch": "^3.19.0",
-						"@wordpress/data": "^4.23.0"
+						"@wordpress/api-fetch": "^3.19.1",
+						"@wordpress/data": "^4.23.1"
 					}
 				},
 				"@wordpress/deprecated": {
@@ -7131,12 +7195,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -7190,14 +7256,14 @@
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.23.0.tgz",
-			"integrity": "sha512-plJZkf4otm8TupoA4B0RSmhdZptJOJshiMS02ihkvj0c2WdDomV5ERjOGBSVtJK30mm5ItOQjRIeH95v+EJURg==",
+			"version": "4.23.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.23.1.tgz",
+			"integrity": "sha512-PKX5UNZkJ1QxGpc9HjHynhtMk1Qo2ASXM53tHk90Rw94TGVSp/4jkcvwwtml05RjTyuDAqFD2D8AGnzsR98Cpg==",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/compose": "^3.20.0",
+				"@wordpress/compose": "^3.20.1",
 				"@wordpress/deprecated": "^2.9.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/is-shallow-equal": "^2.2.0",
 				"@wordpress/priority-queue": "^1.8.0",
 				"@wordpress/redux-routine": "^3.11.0",
@@ -7210,13 +7276,22 @@
 				"use-memo-one": "^1.1.1"
 			},
 			"dependencies": {
+				"@types/react": {
+					"version": "16.9.49",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+					"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^3.0.2"
+					}
+				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -7235,11 +7310,13 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -7382,36 +7459,36 @@
 			}
 		},
 		"@wordpress/edit-post": {
-			"version": "3.22.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.22.0.tgz",
-			"integrity": "sha512-YxnHP6BhhxBA/jxVm5yToV4sAtOBYdnreQL1QQvfOQUwdly68ZfTKqG7IFbWt8gTyb1iLkRmJISiIH/BtGyfIg==",
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/edit-post/-/edit-post-3.23.0.tgz",
+			"integrity": "sha512-MiGJdF8g7f24Nr98LJGGGz39eQqYIpOVuGNWjL47yAZFfJHDFkobcgB3m4VK12XfV1uvIlQ4fGSv9z5EnrxCvw==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
 				"@wordpress/a11y": "^2.12.0",
-				"@wordpress/api-fetch": "^3.19.0",
-				"@wordpress/block-editor": "^4.4.0",
-				"@wordpress/block-library": "^2.23.0",
-				"@wordpress/blocks": "^6.21.0",
-				"@wordpress/components": "^10.1.0",
-				"@wordpress/compose": "^3.20.0",
-				"@wordpress/core-data": "^2.21.0",
-				"@wordpress/data": "^4.23.0",
-				"@wordpress/data-controls": "^1.17.0",
-				"@wordpress/editor": "^9.21.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/api-fetch": "^3.19.1",
+				"@wordpress/block-editor": "^4.5.0",
+				"@wordpress/block-library": "^2.24.0",
+				"@wordpress/blocks": "^6.22.0",
+				"@wordpress/components": "^10.2.0",
+				"@wordpress/compose": "^3.20.1",
+				"@wordpress/core-data": "^2.22.0",
+				"@wordpress/data": "^4.23.1",
+				"@wordpress/data-controls": "^1.17.1",
+				"@wordpress/editor": "^9.22.0",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/hooks": "^2.9.0",
 				"@wordpress/i18n": "^3.15.0",
-				"@wordpress/icons": "^2.5.0",
-				"@wordpress/interface": "^0.8.0",
-				"@wordpress/keyboard-shortcuts": "^1.10.0",
+				"@wordpress/icons": "^2.6.0",
+				"@wordpress/interface": "^0.8.1",
+				"@wordpress/keyboard-shortcuts": "^1.10.1",
 				"@wordpress/keycodes": "^2.15.0",
-				"@wordpress/media-utils": "^1.16.0",
-				"@wordpress/notices": "^2.9.0",
-				"@wordpress/plugins": "^2.21.0",
-				"@wordpress/primitives": "^1.8.0",
+				"@wordpress/media-utils": "^1.16.1",
+				"@wordpress/notices": "^2.9.1",
+				"@wordpress/plugins": "^2.21.1",
+				"@wordpress/primitives": "^1.8.1",
 				"@wordpress/url": "^2.18.0",
-				"@wordpress/viewport": "^2.22.0",
+				"@wordpress/viewport": "^2.22.1",
 				"@wordpress/warning": "^1.3.0",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19",
@@ -7430,34 +7507,34 @@
 					}
 				},
 				"@wordpress/block-editor": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-4.4.0.tgz",
-					"integrity": "sha512-LIRTWIg633El0oXai7i9WSqdULwr85YPHofFzKYthSKeu/icynhHRw8tUcBjYuf8eHyTlemuYmJAzKrj4ZNWLw==",
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-4.5.0.tgz",
+					"integrity": "sha512-6c6k9rre4gc+tcx5eM6Jf09vdeerUwGMjMvay/bR7oSsysgfoAD7wpxmOO5Hd3L5PSiijSuaxpvcyy3R78KhSQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/a11y": "^2.12.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/blocks": "^6.21.0",
-						"@wordpress/components": "^10.1.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/blocks": "^6.22.0",
+						"@wordpress/components": "^10.2.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
-						"@wordpress/keyboard-shortcuts": "^1.10.0",
+						"@wordpress/keyboard-shortcuts": "^1.10.1",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/notices": "^2.9.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/notices": "^2.9.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/shortcode": "^2.10.0",
 						"@wordpress/token-list": "^1.12.0",
 						"@wordpress/url": "^2.18.0",
-						"@wordpress/viewport": "^2.22.0",
+						"@wordpress/viewport": "^2.22.1",
 						"@wordpress/warning": "^1.3.0",
 						"@wordpress/wordcount": "^2.11.0",
 						"classnames": "^2.2.5",
@@ -7479,24 +7556,24 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.21.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.21.0.tgz",
-					"integrity": "sha512-zirBnjzfBYsLhtpedEzddVFSSHTest0zZD6bqZSEFVv4RdMDqv55dejBG3nOK+bOpZ4fQ+gDT7HaMJY4IpU9FA==",
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.22.0.tgz",
+					"integrity": "sha512-HGZVqajtk1c+EzixuFfvgsxpOFt3uk+LMemjGv29SVZA6d6uNaZhCCaht82p8HYQlgw8/UCbQAhQwdIo7cqxEw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/autop": "^2.9.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/block-serialization-default-parser": "^3.7.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/block-serialization-default-parser": "^3.7.1",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/shortcode": "^2.10.0",
 						"hpq": "^1.3.0",
@@ -7509,9 +7586,9 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.1.0.tgz",
-					"integrity": "sha512-5RSmgEaGzvGWYF9KS7a/wa84YollP2xUxJHrLPTWOBQgZoYx7jBb8J9dnVzmxGwngJnGsSNkNtEVzazAdTUwcA==",
+					"version": "10.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.2.0.tgz",
+					"integrity": "sha512-jXZgNVAlrQk1yR/Zkmmz6nEnKI4GPz5asSWtzVu5Php0ogzC3rgxikggJWrnDq5oCT+kRrar8eSpt6qP3NVfQg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
@@ -7520,18 +7597,18 @@
 						"@emotion/native": "^10.0.22",
 						"@emotion/styled": "^10.0.23",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/date": "^3.11.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/date": "^3.11.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/primitives": "^1.8.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/primitives": "^1.8.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/warning": "^1.3.0",
 						"classnames": "^2.2.5",
 						"dom-scroll-into-view": "^1.2.1",
@@ -7553,13 +7630,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -7569,24 +7646,24 @@
 					}
 				},
 				"@wordpress/data-controls": {
-					"version": "1.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.0.tgz",
-					"integrity": "sha512-caQZ5TJNGLDOUxdnNNIkn89Xt12ZGtNJ7OX8qQfW+NUkil9LbQtwUlVlLF1GJCooap05xZwzj0J9QA+sXM4UUA==",
+					"version": "1.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.17.1.tgz",
+					"integrity": "sha512-6HReDvd5mELCSYMrLHoBerVW7A0fPZS5MyfLHcfDv+Kjw+dAZb7x5+WNepHuxyMCT8tIvVsfMHsx5erqUqRqWQ==",
 					"dev": true,
 					"requires": {
-						"@wordpress/api-fetch": "^3.19.0",
-						"@wordpress/data": "^4.23.0"
+						"@wordpress/api-fetch": "^3.19.1",
+						"@wordpress/data": "^4.23.1"
 					}
 				},
 				"@wordpress/date": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.0.tgz",
-					"integrity": "sha512-ZOeSDu/stp7QHzFL6296GhmfqFwCQqurlcvZQkB7COzkaQoAkynx6cnzaDPDKKVoHowgh0A4EEDwtzw6L3KDOA==",
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.1.tgz",
+					"integrity": "sha512-Vxt102uR0ptQ/ec5TPL/JEtqShBRCuYSkP+uj9TJ7DdK97+D698c8GQ/2VFnzJ3VMb2Xq+4VFCXSw1vC5M3NMg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"moment": "^2.22.1",
-						"moment-timezone": "^0.5.16"
+						"moment-timezone": "^0.5.31"
 					}
 				},
 				"@wordpress/deprecated": {
@@ -7600,38 +7677,38 @@
 					}
 				},
 				"@wordpress/editor": {
-					"version": "9.21.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.21.0.tgz",
-					"integrity": "sha512-9t0PyZy/8Aq2Hu+pEjMHsKThquW/10y8mMBICTeq+aiyInmh11Q0ZU/ny3CpVGdD9yUXTgJrWUmcX8XytdqqeA==",
+					"version": "9.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.22.0.tgz",
+					"integrity": "sha512-3WRNM5EyykxA/uK2wx8/7YOZfUeI2vkesKxCDOLMf1P0AS9UxCZDVqB75j23fVV+KvOudFey/lQHyA1u0tEiWA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/api-fetch": "^3.19.0",
+						"@wordpress/api-fetch": "^3.19.1",
 						"@wordpress/autop": "^2.9.0",
 						"@wordpress/blob": "^2.9.0",
-						"@wordpress/block-editor": "^4.4.0",
-						"@wordpress/blocks": "^6.21.0",
-						"@wordpress/components": "^10.1.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/core-data": "^2.21.0",
-						"@wordpress/data": "^4.23.0",
-						"@wordpress/data-controls": "^1.17.0",
-						"@wordpress/date": "^3.11.0",
+						"@wordpress/block-editor": "^4.5.0",
+						"@wordpress/blocks": "^6.22.0",
+						"@wordpress/components": "^10.2.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/core-data": "^2.22.0",
+						"@wordpress/data": "^4.23.1",
+						"@wordpress/data-controls": "^1.17.1",
+						"@wordpress/date": "^3.11.1",
 						"@wordpress/deprecated": "^2.9.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/html-entities": "^2.8.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
-						"@wordpress/keyboard-shortcuts": "^1.10.0",
+						"@wordpress/keyboard-shortcuts": "^1.10.1",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/media-utils": "^1.16.0",
-						"@wordpress/notices": "^2.9.0",
-						"@wordpress/rich-text": "^3.21.0",
-						"@wordpress/server-side-render": "^1.17.0",
+						"@wordpress/media-utils": "^1.16.1",
+						"@wordpress/notices": "^2.9.1",
+						"@wordpress/rich-text": "^3.21.1",
+						"@wordpress/server-side-render": "^1.17.1",
 						"@wordpress/url": "^2.18.0",
-						"@wordpress/viewport": "^2.22.0",
+						"@wordpress/viewport": "^2.22.1",
 						"@wordpress/wordcount": "^2.11.0",
 						"classnames": "^2.2.5",
 						"lodash": "^4.17.19",
@@ -7643,12 +7720,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -7688,15 +7767,15 @@
 					}
 				},
 				"@wordpress/keyboard-shortcuts": {
-					"version": "1.10.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.0.tgz",
-					"integrity": "sha512-eTh1cWIn4FoyaQ7vyTq17VUBWZfc8+wOrcSZuR4f4OnViiXr+z+1YmzKf680U+lutCVWQ2QerrDN4nXqBbvrJA==",
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-1.10.1.tgz",
+					"integrity": "sha512-yDn+yS9fe/cz2z+Md5Mq4jhecTf3nXiPy8I3i9xmYBlgHQCW6LmekdUkmbkDXsV28wo4J5E/1KsBd2ojCL3HUw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/keycodes": "^2.15.0",
 						"lodash": "^4.17.19",
 						"rememo": "^3.0.0"
@@ -7714,26 +7793,26 @@
 					}
 				},
 				"@wordpress/notices": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.9.0.tgz",
-					"integrity": "sha512-IA5jBILeV0gQAiS/J5EOZLRb2bUoqZY4pS0OnoOHzKBs0b50m/mZ0IWLKurXkC9LCQU0hAxdcAV+zOi68My0wg==",
+					"version": "2.9.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.9.1.tgz",
+					"integrity": "sha512-W2sU0MCoKIGmokjXyyqHfRBW1ZARVL/y3t/5jykAvWyoZhBLwCjof3ZnSKs1KXlpPAvz9hCxxtCKvP+Qs7azeg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@wordpress/viewport": {
-					"version": "2.22.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.0.tgz",
-					"integrity": "sha512-mr4yAsH4etbtos5fLLOKIUzhm4tI3SQ8lADaf/wmCP4XacFphM/Os1hly1bdZAH5JYotWQhMyNL6QgPZUvD19A==",
+					"version": "2.22.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.1.tgz",
+					"integrity": "sha512-eoXkWzkCVhiLBfyWhA9V7Wvkz8ynPMtU5TmvhxdQWVSEWv6Hwl174m7h0sujjb+8ghgPSgImoBApLcMBOJ97Lw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					}
 				},
@@ -7882,12 +7961,14 @@
 							}
 						},
 						"@wordpress/element": {
-							"version": "2.17.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-							"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+							"version": "2.17.1",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+							"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.9.2",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
 								"@wordpress/escape-html": "^1.9.0",
 								"lodash": "^4.17.19",
 								"react": "^16.13.1",
@@ -7936,13 +8017,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -7952,12 +8033,14 @@
 					},
 					"dependencies": {
 						"@wordpress/element": {
-							"version": "2.17.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-							"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+							"version": "2.17.1",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+							"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.9.2",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
 								"@wordpress/escape-html": "^1.9.0",
 								"lodash": "^4.17.19",
 								"react": "^16.13.1",
@@ -7982,14 +8065,14 @@
 					}
 				},
 				"@wordpress/date": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.0.tgz",
-					"integrity": "sha512-ZOeSDu/stp7QHzFL6296GhmfqFwCQqurlcvZQkB7COzkaQoAkynx6cnzaDPDKKVoHowgh0A4EEDwtzw6L3KDOA==",
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.1.tgz",
+					"integrity": "sha512-Vxt102uR0ptQ/ec5TPL/JEtqShBRCuYSkP+uj9TJ7DdK97+D698c8GQ/2VFnzJ3VMb2Xq+4VFCXSw1vC5M3NMg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"moment": "^2.22.1",
-						"moment-timezone": "^0.5.16"
+						"moment-timezone": "^0.5.31"
 					}
 				},
 				"@wordpress/keycodes": {
@@ -8038,14 +8121,14 @@
 					}
 				},
 				"@wordpress/viewport": {
-					"version": "2.22.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.0.tgz",
-					"integrity": "sha512-mr4yAsH4etbtos5fLLOKIUzhm4tI3SQ8lADaf/wmCP4XacFphM/Os1hly1bdZAH5JYotWQhMyNL6QgPZUvD19A==",
+					"version": "2.22.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.22.1.tgz",
+					"integrity": "sha512-eoXkWzkCVhiLBfyWhA9V7Wvkz8ynPMtU5TmvhxdQWVSEWv6Hwl174m7h0sujjb+8ghgPSgImoBApLcMBOJ97Lw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/data": "^4.23.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/data": "^4.23.1",
 						"lodash": "^4.17.19"
 					},
 					"dependencies": {
@@ -8159,9 +8242,9 @@
 			}
 		},
 		"@wordpress/eslint-plugin": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-7.2.0.tgz",
-			"integrity": "sha512-dp6Egzg1pm3YAnwgWb471FP0g2hedl+8TyfUxkO1gTD01ueriosqS1caAZDiaswmYEY6N6Wkzf7WI8w+dOE+uw==",
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-7.2.1.tgz",
+			"integrity": "sha512-p4LrUukVyuZAH/vSHFOV5L0NHW2i8WegOYFDgYCIzcWCi/A7jW1O+vUA5ylm1rRCKqj8Z/4WIMOGflf/8delYw==",
 			"dev": true,
 			"requires": {
 				"@wordpress/prettier-config": "^0.4.0",
@@ -8234,23 +8317,25 @@
 			}
 		},
 		"@wordpress/icons": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.5.0.tgz",
-			"integrity": "sha512-dT/SCp3l/5i5QNBef9B8GhVRNCNQ4RC5z8lc2IuAF2KbLDgujxZL/82qbQyADtRZYp7CqBbVrX2PVr5bz5k+ew==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.6.0.tgz",
+			"integrity": "sha512-cVy2r9mMZiTdQlhkrb3IIbAfdMndI52spQlxRhv2Yzsjec97vMNyX7x6S8Amz/0JBttNDnxhQ9To8xrRBhMBlg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/element": "^2.17.0",
-				"@wordpress/primitives": "^1.8.0"
+				"@wordpress/element": "^2.17.1",
+				"@wordpress/primitives": "^1.8.1"
 			},
 			"dependencies": {
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -8266,26 +8351,26 @@
 			}
 		},
 		"@wordpress/interface": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-0.8.0.tgz",
-			"integrity": "sha512-lJ5bjmVDx5of0/smvk9dGdj7joYJVf36dzCe8/oupg+yhL1+f66nkpkBAzv0vpXJcDPiVax05J8msCrMYrrvCw==",
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-0.8.1.tgz",
+			"integrity": "sha512-MtPVLLKO/gC16yPJCJ4Mvs1S1Nkhn0kk2b49xsDTtg72EHmThWFA7h7vEVeHi2cIruDLtOChXU3kA+oQeG18yQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/components": "^10.1.0",
-				"@wordpress/data": "^4.23.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/components": "^10.2.0",
+				"@wordpress/data": "^4.23.1",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/i18n": "^3.15.0",
-				"@wordpress/icons": "^2.5.0",
-				"@wordpress/plugins": "^2.21.0",
+				"@wordpress/icons": "^2.6.0",
+				"@wordpress/plugins": "^2.21.1",
 				"classnames": "^2.2.5",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"@wordpress/components": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.1.0.tgz",
-					"integrity": "sha512-5RSmgEaGzvGWYF9KS7a/wa84YollP2xUxJHrLPTWOBQgZoYx7jBb8J9dnVzmxGwngJnGsSNkNtEVzazAdTUwcA==",
+					"version": "10.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.2.0.tgz",
+					"integrity": "sha512-jXZgNVAlrQk1yR/Zkmmz6nEnKI4GPz5asSWtzVu5Php0ogzC3rgxikggJWrnDq5oCT+kRrar8eSpt6qP3NVfQg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
@@ -8294,18 +8379,18 @@
 						"@emotion/native": "^10.0.22",
 						"@emotion/styled": "^10.0.23",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/date": "^3.11.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/date": "^3.11.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/primitives": "^1.8.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/primitives": "^1.8.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/warning": "^1.3.0",
 						"classnames": "^2.2.5",
 						"dom-scroll-into-view": "^1.2.1",
@@ -8327,13 +8412,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -8343,14 +8428,14 @@
 					}
 				},
 				"@wordpress/date": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.0.tgz",
-					"integrity": "sha512-ZOeSDu/stp7QHzFL6296GhmfqFwCQqurlcvZQkB7COzkaQoAkynx6cnzaDPDKKVoHowgh0A4EEDwtzw6L3KDOA==",
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.1.tgz",
+					"integrity": "sha512-Vxt102uR0ptQ/ec5TPL/JEtqShBRCuYSkP+uj9TJ7DdK97+D698c8GQ/2VFnzJ3VMb2Xq+4VFCXSw1vC5M3NMg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"moment": "^2.22.1",
-						"moment-timezone": "^0.5.16"
+						"moment-timezone": "^0.5.31"
 					}
 				},
 				"@wordpress/deprecated": {
@@ -8364,12 +8449,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -8494,13 +8581,13 @@
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -8510,12 +8597,14 @@
 					},
 					"dependencies": {
 						"@wordpress/element": {
-							"version": "2.17.0",
-							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-							"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+							"version": "2.17.1",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+							"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 							"dev": true,
 							"requires": {
 								"@babel/runtime": "^7.9.2",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
 								"@wordpress/escape-html": "^1.9.0",
 								"lodash": "^4.17.19",
 								"react": "^16.13.1",
@@ -8615,26 +8704,28 @@
 			}
 		},
 		"@wordpress/media-utils": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.16.0.tgz",
-			"integrity": "sha512-Zh8e5PQLXwvFRTlXjckC0c/CNfnDvvXjG2d+5AAYz6UOEiflBgU5mgqqyGCnGy34VtO+BzIauR9oSZbdCDS+CQ==",
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.16.1.tgz",
+			"integrity": "sha512-WKeXxB0NF8/P6MEo9c0ELbwJZgNBEZ/8xvBSsfUDb2FokbkJ9jA+b8KqLcWJLpFlaWhE22vHiPnopkUyGCdL2w==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/api-fetch": "^3.19.0",
+				"@wordpress/api-fetch": "^3.19.1",
 				"@wordpress/blob": "^2.9.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/i18n": "^3.15.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -8681,27 +8772,27 @@
 			"dev": true
 		},
 		"@wordpress/plugins": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.21.0.tgz",
-			"integrity": "sha512-u9Ihy3odUX0LW5FMHupLHhx4B15TsOAO1Q6W47kLdwumLhgVjlFD+uxPVBzXKQvfDsO22eP3JTWiOFJF5WR1Vw==",
+			"version": "2.21.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.21.1.tgz",
+			"integrity": "sha512-F7zEqL3eS27zO4ObnbpcupoVqXlg2XrJ6ZWAdfrjydScEqqjZPBY2qgE0IsUatT1WMUug8b38xMj0Gwxldy4+w==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/compose": "^3.20.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/compose": "^3.20.1",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/hooks": "^2.9.0",
-				"@wordpress/icons": "^2.5.0",
+				"@wordpress/icons": "^2.6.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -8711,12 +8802,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -8741,21 +8834,21 @@
 			}
 		},
 		"@wordpress/postcss-plugins-preset": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.4.0.tgz",
-			"integrity": "sha512-jg94GYU8h2UJ+5kmLdKG7FCIkgOYFKRFcmKnQKZifKTB6mRxG7u+ioIBsEipkQkt82wMKG7p2l8rtH+NWIcbDw==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-1.4.1.tgz",
+			"integrity": "sha512-f4YJ6qR5sP7N0sq1qtiU355xORTE44osAUPxbtxvFMqDadfdEdW0HUP+QddKTgv0wgTof7Y2bUSR5IH2VLtMuA==",
 			"dev": true,
 			"requires": {
-				"@wordpress/base-styles": "^2.1.0",
+				"@wordpress/base-styles": "^3.0.0",
 				"@wordpress/postcss-themes": "^2.6.0",
 				"autoprefixer": "^9.4.5",
 				"postcss-custom-properties": "^9.1.1"
 			},
 			"dependencies": {
 				"@wordpress/base-styles": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-2.1.0.tgz",
-					"integrity": "sha512-Ljb1xX4fYHSzvw+p8NnCF3WCNPEY6RlDrtWbJvAOeJe2LiAxiQcbgQa/WdFd21jdSgfet0Wmqk+YwwUyyeermw==",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.0.0.tgz",
+					"integrity": "sha512-4pS37OtcG6cuXOigJS8t62QQoh+Inm2jwoAcdRxDfoyB6rjpyjYaRBG6AOHPvux/4lbKG8QMTYIuIhD7yBoJ1Q==",
 					"dev": true
 				}
 			}
@@ -8776,23 +8869,25 @@
 			"dev": true
 		},
 		"@wordpress/primitives": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.8.0.tgz",
-			"integrity": "sha512-kmxJvyiotYGCNLE3z9V1vz5WrcLHIKlc2JM5RY7F+vYWUXxMzyTAiwFqkW+ulWCa1LYUU8Gai0LY5E2dusR8PA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.8.1.tgz",
+			"integrity": "sha512-5aDsNtVD+LfH9+EAIa9BAD5E5q3q325qz75XY8KquxYGM8/xPPVvDjj8fV78UZyBQ9Q0GLCyLyWs+8xoGlgW8w==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/element": "^2.17.1",
 				"classnames": "^2.2.5"
 			},
 			"dependencies": {
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -8834,15 +8929,15 @@
 			}
 		},
 		"@wordpress/rich-text": {
-			"version": "3.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.21.0.tgz",
-			"integrity": "sha512-hx1Pz/lFQtMe1G2hHZ4WPt3CAHl/RVshei0qvk72adtntv0ZdW5ptIyC+3oHiASqolRCTm9l5b7coUZv6fwn7g==",
+			"version": "3.21.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.21.1.tgz",
+			"integrity": "sha512-3whSSmvpXfTbI56dWe594654USOV6lUj3Tw+xvRxgpi0wSq9ca9om+g7dmlM9nwJ8BZGrl/AKpY5/ldN7QEsEQ==",
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/compose": "^3.20.0",
-				"@wordpress/data": "^4.23.0",
+				"@wordpress/compose": "^3.20.1",
+				"@wordpress/data": "^4.23.1",
 				"@wordpress/deprecated": "^2.9.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/escape-html": "^1.9.0",
 				"@wordpress/is-shallow-equal": "^2.2.0",
 				"@wordpress/keycodes": "^2.15.0",
@@ -8852,13 +8947,22 @@
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {
+				"@types/react": {
+					"version": "16.9.49",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+					"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^3.0.2"
+					}
+				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -8877,11 +8981,13 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -8927,18 +9033,18 @@
 			}
 		},
 		"@wordpress/scripts": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.0.0.tgz",
-			"integrity": "sha512-nYRPbt9Ii6GZC1irmMRxYENiZ47lUqdl5d5UyUb75MDTmAWdN3e+56lVHFGiGhqflw1AyiU+l1DTJWkGXSPs7w==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-12.1.0.tgz",
+			"integrity": "sha512-/++aorfRCUOrWi5Skgsu4O+Xwe6YGP03iQhaMsz53TGQwmxbFbYkYE+B3T+36eoIPSSmubH6BcCOU7HusUXlhQ==",
 			"dev": true,
 			"requires": {
 				"@svgr/webpack": "^5.2.0",
-				"@wordpress/babel-preset-default": "^4.16.0",
+				"@wordpress/babel-preset-default": "^4.17.0",
 				"@wordpress/dependency-extraction-webpack-plugin": "^2.8.0",
 				"@wordpress/eslint-plugin": "^7.1.0",
 				"@wordpress/jest-preset-default": "^6.2.0",
 				"@wordpress/npm-package-json-lint-config": "^3.1.0",
-				"@wordpress/postcss-plugins-preset": "^1.2.0",
+				"@wordpress/postcss-plugins-preset": "^1.3.0",
 				"@wordpress/prettier-config": "^0.3.0",
 				"babel-jest": "^25.3.0",
 				"babel-loader": "^8.1.0",
@@ -8968,6 +9074,7 @@
 				"source-map-loader": "^0.2.4",
 				"stylelint": "^13.6.0",
 				"stylelint-config-wordpress": "^17.0.0",
+				"terser-webpack-plugin": "^3.0.3",
 				"thread-loader": "^2.1.3",
 				"url-loader": "^3.0.0",
 				"webpack": "^4.42.0",
@@ -8977,9 +9084,9 @@
 			},
 			"dependencies": {
 				"@wordpress/babel-preset-default": {
-					"version": "4.18.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.18.0.tgz",
-					"integrity": "sha512-YahhYqhIFRsSGeufkBoOnfdyBASk9SlzxTWLUYmg6RTv46RruIBaOWp2w4FIMwIijMMbFJEFb8w4VMTIZ733Fg==",
+					"version": "4.18.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.18.1.tgz",
+					"integrity": "sha512-yqU3Gfqj2m2LMimTO5enPIQVzC53hZ0HXmN4bjp2HoMpz69C0fGLzxIKjTjAceA8yhVCiRJYIHsKXmUDDn9BjA==",
 					"dev": true,
 					"requires": {
 						"@babel/core": "^7.9.0",
@@ -8989,7 +9096,7 @@
 						"@babel/runtime": "^7.9.2",
 						"@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
 						"@wordpress/browserslist-config": "^2.7.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/warning": "^1.3.0",
 						"core-js": "^3.6.4"
 					}
@@ -9012,12 +9119,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -9262,26 +9371,26 @@
 			}
 		},
 		"@wordpress/server-side-render": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.17.0.tgz",
-			"integrity": "sha512-RQRiqUDC8qCU/kt3FbZAn+DYfKq93xL1FSDhjKzpRHIKEA+mEK2V5fdUclarKsvjfUAoLK389cUvdlN2wlAtxA==",
+			"version": "1.17.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.17.1.tgz",
+			"integrity": "sha512-gLusGUUMMU48hCwSrUkf9ECftA9R8ZHggUQB5cpayKphl4cO9nfUD6bp5heFqnn2wnt9XKP24W+aDlLzCr72eA==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2",
-				"@wordpress/api-fetch": "^3.19.0",
-				"@wordpress/components": "^10.1.0",
-				"@wordpress/data": "^4.23.0",
+				"@wordpress/api-fetch": "^3.19.1",
+				"@wordpress/components": "^10.2.0",
+				"@wordpress/data": "^4.23.1",
 				"@wordpress/deprecated": "^2.9.0",
-				"@wordpress/element": "^2.17.0",
+				"@wordpress/element": "^2.17.1",
 				"@wordpress/i18n": "^3.15.0",
 				"@wordpress/url": "^2.18.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
 				"@wordpress/components": {
-					"version": "10.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.1.0.tgz",
-					"integrity": "sha512-5RSmgEaGzvGWYF9KS7a/wa84YollP2xUxJHrLPTWOBQgZoYx7jBb8J9dnVzmxGwngJnGsSNkNtEVzazAdTUwcA==",
+					"version": "10.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-10.2.0.tgz",
+					"integrity": "sha512-jXZgNVAlrQk1yR/Zkmmz6nEnKI4GPz5asSWtzVu5Php0ogzC3rgxikggJWrnDq5oCT+kRrar8eSpt6qP3NVfQg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
@@ -9290,18 +9399,18 @@
 						"@emotion/native": "^10.0.22",
 						"@emotion/styled": "^10.0.23",
 						"@wordpress/a11y": "^2.12.0",
-						"@wordpress/compose": "^3.20.0",
-						"@wordpress/date": "^3.11.0",
+						"@wordpress/compose": "^3.20.1",
+						"@wordpress/date": "^3.11.1",
 						"@wordpress/deprecated": "^2.9.0",
 						"@wordpress/dom": "^2.14.0",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/hooks": "^2.9.0",
 						"@wordpress/i18n": "^3.15.0",
-						"@wordpress/icons": "^2.5.0",
+						"@wordpress/icons": "^2.6.0",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/keycodes": "^2.15.0",
-						"@wordpress/primitives": "^1.8.0",
-						"@wordpress/rich-text": "^3.21.0",
+						"@wordpress/primitives": "^1.8.1",
+						"@wordpress/rich-text": "^3.21.1",
 						"@wordpress/warning": "^1.3.0",
 						"classnames": "^2.2.5",
 						"dom-scroll-into-view": "^1.2.1",
@@ -9323,13 +9432,13 @@
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -9339,14 +9448,14 @@
 					}
 				},
 				"@wordpress/date": {
-					"version": "3.11.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.0.tgz",
-					"integrity": "sha512-ZOeSDu/stp7QHzFL6296GhmfqFwCQqurlcvZQkB7COzkaQoAkynx6cnzaDPDKKVoHowgh0A4EEDwtzw6L3KDOA==",
+					"version": "3.11.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.11.1.tgz",
+					"integrity": "sha512-Vxt102uR0ptQ/ec5TPL/JEtqShBRCuYSkP+uj9TJ7DdK97+D698c8GQ/2VFnzJ3VMb2Xq+4VFCXSw1vC5M3NMg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
 						"moment": "^2.22.1",
-						"moment-timezone": "^0.5.16"
+						"moment-timezone": "^0.5.31"
 					}
 				},
 				"@wordpress/deprecated": {
@@ -9360,12 +9469,14 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -9528,9 +9639,9 @@
 			"dev": true
 		},
 		"abab": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-			"integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
 			"dev": true
 		},
 		"abbrev": {
@@ -9655,9 +9766,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.12.4",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-			"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+			"version": "6.12.5",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+			"integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
 			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -10665,13 +10776,13 @@
 			"dev": true
 		},
 		"babel-plugin-apply-mdx-type-prop": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.16.tgz",
-			"integrity": "sha512-hjUd24Yhnr5NKtHpC2mcRBGjC6RUKGzSzjN9g5SdjT4WpL/JDlpmjyBf7vWsJJSXFvMIbzRyxF4lT9ukwOnj/w==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.18.tgz",
+			"integrity": "sha512-lcpbj/GatKQp48jsJ8Os/ZXv381ZYFNKA27EPllcpFMpqiS696XkoK+xie/2GjzQSe5IIbo3srsXpd6/ik8PsQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "7.10.4",
-				"@mdx-js/util": "1.6.16"
+				"@mdx-js/util": "1.6.18"
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
@@ -10701,9 +10812,9 @@
 			}
 		},
 		"babel-plugin-extract-import-names": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.16.tgz",
-			"integrity": "sha512-Da6Ra0sbA/1Iavli8LdMbTjyrsOPaxMm4lrKl8VJN4sJI5F64qy2EpLj3+5INLvNPfW4ddwpStbfP3Rf3jIgcw==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.18.tgz",
+			"integrity": "sha512-2EyZia3Ezl3UdhBcgDl6KZTNkYa2VhmAHHbJdhCroa1pZD/E56BulVsSKIhm/kza9agnabDR2VEHO+ZnqpfxbQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "7.10.4"
@@ -10844,9 +10955,9 @@
 			"dev": true
 		},
 		"babel-plugin-react-docgen": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-4.1.0.tgz",
-			"integrity": "sha512-vzpnBlfGv8XOhJM2zbPyyqw2OLEbelgZZsaaRRTpVwNKuYuc+pUg4+dy7i9gCRms0uOQn4osX571HRcCJMJCmA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-4.2.0.tgz",
+			"integrity": "sha512-B3tjZwKskcia9TsqkND+9OTjl/F5A5OBvRJ6Ktg34CONoxm+kB3CJ52wk5TjbszX9gqCPcAuc0GgkhT0CLuT/Q==",
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.15",
@@ -11421,9 +11532,9 @@
 			}
 		},
 		"body-scroll-lock": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.3.tgz",
-			"integrity": "sha512-KMV9MT96y2PFUL2C98e2nx/Gs2mhCAzYP6Gsu/9r7Rhn27qxu1yTnQBqHogUuvwVSbstEHNXTaToPNsL7oBZ9g=="
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+			"integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg=="
 		},
 		"boolbase": {
 			"version": "1.0.0",
@@ -11647,14 +11758,14 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.14.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.2.tgz",
-			"integrity": "sha512-HI4lPveGKUR0x2StIz+2FXfDk9SfVMrxn6PLh1JeGUwcuoDkdKZebWiyLRJ68iIPDpMI4JLVDf7S7XzslgWOhw==",
+			"version": "4.14.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.4.tgz",
+			"integrity": "sha512-7FOuawafVdEwa5Jv4nzeik/PepAjVte6HmVGHsjt2bC237jeL9QlcTBDF3PnHEvcC6uHwLGYPwZHNZMB7wWAnw==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001125",
-				"electron-to-chromium": "^1.3.564",
-				"escalade": "^3.0.2",
+				"caniuse-lite": "^1.0.30001135",
+				"electron-to-chromium": "^1.3.570",
+				"escalade": "^3.1.0",
 				"node-releases": "^1.1.61"
 			}
 		},
@@ -11926,9 +12037,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001125",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001125.tgz",
-			"integrity": "sha512-9f+r7BW8Qli917mU3j0fUaTweT3f3vnX/Lcs+1C73V+RADmFme+Ih0Br8vONQi3X0lseOe6ZHfsZLCA8MSjxUA==",
+			"version": "1.0.30001135",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001135.tgz",
+			"integrity": "sha512-ziNcheTGTHlu9g34EVoHQdIu5g4foc8EsxMGC7Xkokmvw0dqNtX8BS8RgCgFBaAiSp2IdjvBxNdh0ssib28eVQ==",
 			"dev": true
 		},
 		"capture-exit": {
@@ -13444,9 +13555,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.13",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-			"integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
+			"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag=="
 		},
 		"currently-unhandled": {
 			"version": "0.4.1",
@@ -14029,9 +14140,9 @@
 			},
 			"dependencies": {
 				"domelementtype": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+					"integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
 				},
 				"entities": {
 					"version": "2.0.3",
@@ -14239,9 +14350,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.565",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.565.tgz",
-			"integrity": "sha512-me5dGlHFd8Q7mKhqbWRLIYnKjw4i0fO6hmW0JBxa7tM87fBfNEjWokRnDF7V+Qme/9IYpwhfMn+soWs40tXWqg==",
+			"version": "1.3.571",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.571.tgz",
+			"integrity": "sha512-UYEQ2Gtc50kqmyOmOVtj6Oqi38lm5yRJY3pLuWt6UIot0No1L09uu6Ja6/1XKwmz/p0eJFZTUZi+khd1PV1hHA==",
 			"dev": true
 		},
 		"elegant-spinner": {
@@ -14460,9 +14571,9 @@
 			}
 		},
 		"enzyme-adapter-react-16": {
-			"version": "1.15.4",
-			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.4.tgz",
-			"integrity": "sha512-wPzxs+JaGDK2TPYzl5a9YWGce6i2SQ3Cg51ScLeyj2WotUZ8Obcq1ke/U1Y2VGpYlb9rrX2yCjzSMgtKCeAt5w==",
+			"version": "1.15.5",
+			"resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.5.tgz",
+			"integrity": "sha512-33yUJGT1nHFQlbVI5qdo5Pfqvu/h4qPwi1o0a6ZZsjpiqq92a3HjynDhwd1IeED+Su60HDWV8mxJqkTnLYdGkw==",
 			"dev": true,
 			"requires": {
 				"enzyme-adapter-utils": "^1.13.1",
@@ -14648,9 +14759,9 @@
 			}
 		},
 		"escalade": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-			"integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+			"integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
 			"dev": true
 		},
 		"escape-html": {
@@ -14687,9 +14798,9 @@
 			}
 		},
 		"eslint": {
-			"version": "7.8.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
-			"integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
+			"integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -14784,21 +14895,21 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"eslint-scope": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-					"integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 					"dev": true,
 					"requires": {
-						"esrecurse": "^4.1.0",
+						"esrecurse": "^4.3.0",
 						"estraverse": "^4.1.1"
 					}
 				},
@@ -14958,9 +15069,9 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "30.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.4.0.tgz",
-			"integrity": "sha512-eb22QADWcISPQJwFJ+rUAl1NXdyOq3qy0Cp0+MZzpwlqFgJ+eJ7Fd/jYTfwDuN8QyFWumuyzSpwQBnF4PfM9Wg==",
+			"version": "30.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-30.5.1.tgz",
+			"integrity": "sha512-cY3YNxdhFcQVkcQLnZw/iZGsTPMuWa9yWZclorMWkjdHprBQX0TMWMEcmJYM3IjHp1HJr7aD0Z0sCRifEBhnzg==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "^0.7.6",
@@ -14973,12 +15084,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"lodash": {
@@ -15160,9 +15271,9 @@
 			}
 		},
 		"eslint-plugin-react": {
-			"version": "7.20.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz",
-			"integrity": "sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==",
+			"version": "7.21.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.1.tgz",
+			"integrity": "sha512-TGtWzWrFjZtrD1giMz0O6a9ul++YR9vZSzIL/a7qlb5I/ra/O5RkMGMJK+KKYnJrzz884kyAkEyWiU4Hg2HTrg==",
 			"dev": true,
 			"requires": {
 				"array-includes": "^3.1.1",
@@ -15190,18 +15301,80 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.1.tgz",
-			"integrity": "sha512-vFJNwsf4MLYS0lHYfz9LqxQ+GccYsGGeKPHDxgkIaKbAhNuTLnST+q44pt81MzJZyFU5K4XLF6WiCGv3Yb6tCg==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.2.tgz",
+			"integrity": "sha512-ykUeqkGyUGgwTtk78C0o8UG2fzwmgJ0qxBGPp2WqRKsTwcLuVf01kTDRAtOsd4u6whX2XOC8749n2vPydP82fg==",
 			"dev": true
 		},
 		"eslint-plugin-testing-library": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.8.0.tgz",
-			"integrity": "sha512-PNWuIOxnCcElexd/mDjlnPw9cd70JEzeIm/8dsfsyTr8wsTPCZmVqmv7I0rd7I8z7j/FdFqt0vzL8om3GMYCaA==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-3.9.0.tgz",
+			"integrity": "sha512-86GULfQGAyaygbkemFmDgcTW0TUYO7mwkZMZ7lcawOkDra+iYWUHFf2Fr/QMfeFQHuc7v++G35gToJ7Vaamgow==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "^2.29.0"
+				"@typescript-eslint/experimental-utils": "^3.10.1"
+			},
+			"dependencies": {
+				"@typescript-eslint/experimental-utils": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.10.1.tgz",
+					"integrity": "sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==",
+					"dev": true,
+					"requires": {
+						"@types/json-schema": "^7.0.3",
+						"@typescript-eslint/types": "3.10.1",
+						"@typescript-eslint/typescript-estree": "3.10.1",
+						"eslint-scope": "^5.0.0",
+						"eslint-utils": "^2.0.0"
+					}
+				},
+				"@typescript-eslint/typescript-estree": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.10.1.tgz",
+					"integrity": "sha512-QbcXOuq6WYvnB3XPsZpIwztBoquEYLXh2MtwVU+kO8jgYCiv4G5xrSP/1wg4tkvrEE+esZVquIPX/dxPlePk1w==",
+					"dev": true,
+					"requires": {
+						"@typescript-eslint/types": "3.10.1",
+						"@typescript-eslint/visitor-keys": "3.10.1",
+						"debug": "^4.1.1",
+						"glob": "^7.1.6",
+						"is-glob": "^4.0.1",
+						"lodash": "^4.17.15",
+						"semver": "^7.3.2",
+						"tsutils": "^3.17.1"
+					}
+				},
+				"debug": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+					"dev": true
+				}
 			}
 		},
 		"eslint-plugin-woocommerce": {
@@ -17111,9 +17284,9 @@
 			"dev": true
 		},
 		"hast-util-raw": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-6.0.0.tgz",
-			"integrity": "sha512-IQo6tv3bMMKxk53DljswliucCJOQxaZFCuKEJ7X80249dmJ1nA9LtOnnylsLlqTG98NjQ+iGcoLAYo9q5FRhRg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-6.0.1.tgz",
+			"integrity": "sha512-ZMuiYA+UF7BXBtsTBNcLBF5HzXzkyE6MLzJnL605LKE8GJylNjGc4jjxazAHUtcwT5/CEt6afRKViYB4X66dig==",
 			"dev": true,
 			"requires": {
 				"@types/hast": "^2.0.0",
@@ -17333,9 +17506,9 @@
 			"dev": true
 		},
 		"html-webpack-plugin": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.4.1.tgz",
-			"integrity": "sha512-nEtdEIsIGXdXGG7MjTTZlmhqhpHU9pJFc1OYxcP36c5/ZKP6b0BJMww2QTvJGQYA9aMxUnjDujpZdYcVOXiBCQ==",
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.0.tgz",
+			"integrity": "sha512-MouoXEYSjTzCrjIxWwg8gxL5fE2X2WZJLmBYXlaJhQUH5K/b5OrqmV7T4dB7iu0xkmJ6JlUuV6fFVtnqbPopZw==",
 			"dev": true,
 			"requires": {
 				"@types/html-minifier-terser": "^5.0.0",
@@ -17445,12 +17618,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -18005,9 +18178,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
-			"integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -18190,8 +18363,7 @@
 		"is-negative-zero": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
-			"dev": true
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -18537,12 +18709,12 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -21051,9 +21223,9 @@
 			}
 		},
 		"keyv": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.1.tgz",
-			"integrity": "sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+			"integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
 			"dev": true,
 			"requires": {
 				"json-buffer": "3.0.1"
@@ -21269,12 +21441,12 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"del": {
@@ -22383,18 +22555,15 @@
 			}
 		},
 		"mdast-util-to-hast": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-9.1.0.tgz",
-			"integrity": "sha512-Akl2Vi9y9cSdr19/Dfu58PVwifPXuFt1IrHe7l+Crme1KvgUT+5z+cHLVcQVGCiNTZZcdqjnuv9vPkGsqWytWA==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-9.1.1.tgz",
+			"integrity": "sha512-vpMWKFKM2mnle+YbNgDXxx95vv0CoLU0v/l3F5oFAG5DV7qwkZVWA206LsAdOnEVyf5vQcLnb3cWJywu7mUxsQ==",
 			"dev": true,
 			"requires": {
 				"@types/mdast": "^3.0.0",
 				"@types/unist": "^2.0.3",
-				"collapse-white-space": "^1.0.0",
-				"detab": "^2.0.0",
 				"mdast-util-definitions": "^3.0.0",
 				"mdurl": "^1.0.0",
-				"trim-lines": "^1.0.0",
 				"unist-builder": "^2.0.0",
 				"unist-util-generated": "^1.0.0",
 				"unist-util-position": "^3.0.0",
@@ -23138,9 +23307,9 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.19.6",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.6.tgz",
-			"integrity": "sha512-OV3Lx+o5iIGWVY38zs+7aiSnBqaHTFAOQiz83VHJje/wOOaSgzE3H0S/xfISxJhFSoPcX611OEDV9sCT8F283g==",
+			"version": "2.19.7",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.7.tgz",
+			"integrity": "sha512-Y+KNwhBPcSJKeyQCFjn8B/MIe+DDlhaaDgjVldhy5xtFewIbiQgcbZV8k2gCVwkI1ZsKCnjIYZbR+0Fim5QYgg==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -23907,12 +24076,12 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"dir-glob": {
@@ -24253,14 +24422,35 @@
 			}
 		},
 		"object.assign": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+			"integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
 			"requires": {
-				"define-properties": "^1.1.2",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
-				"object-keys": "^1.0.11"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.0",
+				"has-symbols": "^1.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.0",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
 			}
 		},
 		"object.entries": {
@@ -24929,9 +25119,9 @@
 			}
 		},
 		"polished": {
-			"version": "3.6.6",
-			"resolved": "https://registry.npmjs.org/polished/-/polished-3.6.6.tgz",
-			"integrity": "sha512-yiB2ims2DZPem0kCD6V0wnhcVGFEhNh0Iw0axNpKU+oSAgFt6yx6HxIT23Qg0WWvgS379cS35zT4AOyZZRzpQQ==",
+			"version": "3.6.7",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz",
+			"integrity": "sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2"
@@ -24987,9 +25177,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "7.0.32",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-			"integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+			"version": "7.0.34",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
+			"integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -25087,9 +25277,9 @@
 			}
 		},
 		"postcss-custom-properties": {
-			"version": "9.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-9.1.1.tgz",
-			"integrity": "sha512-GVu+j7vwMTKUGhGXckYAFAAG5tTJUkSt8LuSyimtZdVVmdAEZYYqserkAgX8vwMhgGDPA4vJtWt7VgFxgiooDA==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-9.2.0.tgz",
+			"integrity": "sha512-IFRV7LwapFkNa3MtvFpw+MEhgyUpaVZ62VlR5EM0AbmnGbNhU9qIE8u02vgUbl1gLkHK6sterEavamVPOwdE8g==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.17",
@@ -25160,9 +25350,9 @@
 			}
 		},
 		"postcss-load-config": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
-			"integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.1.tgz",
+			"integrity": "sha512-D2ENobdoZsW0+BHy4x1CAkXtbXtYWYRIxL/JbtRBqrRGOPtJ2zoga/bEZWhV/ShWB5saVxJMzbMdSyA/vv4tXw==",
 			"dev": true,
 			"requires": {
 				"cosmiconfig": "^5.0.0",
@@ -25694,14 +25884,15 @@
 			}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-			"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.3.tgz",
+			"integrity": "sha512-0ClFaY4X1ra21LRqbW6y3rUbWcxnSVkDFG57R7Nxus9J9myPFlv+jYDMohzpkBx0RrjjiqjtycpchQ+PLGmZ9w==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
 				"indexes-of": "^1.0.1",
-				"uniq": "^1.0.1"
+				"uniq": "^1.0.1",
+				"util-deprecate": "^1.0.2"
 			}
 		},
 		"postcss-svgo": {
@@ -26173,12 +26364,12 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"extract-zip": {
@@ -26396,9 +26587,9 @@
 			}
 		},
 		"re-resizable": {
-			"version": "6.5.5",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.5.5.tgz",
-			"integrity": "sha512-z7Vl5PStOxSDlpeLz73+hIKBC3raoy00KYNVGz1G4C01Q1goog6061lbXhWQsjS16DV59IPA2snjvZYPkxc2Vw==",
+			"version": "6.6.1",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.6.1.tgz",
+			"integrity": "sha512-ttWVasZ9X7c0ir0+4YK47tkmm9EAFssW07YLkeLzG5HCOuFgFAlSVzMlzAH0h3i6hDShQCHHJecVx5rk+snoFA==",
 			"requires": {
 				"fast-memoize": "^2.5.1"
 			}
@@ -26918,12 +27109,12 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"fill-range": {
@@ -27052,15 +27243,15 @@
 			"dev": true
 		},
 		"react-helmet-async": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.6.tgz",
-			"integrity": "sha512-t+bhAI4NgxfEv8ez4r77cLfR4O4Z55E/FH2DT+uiE4U7yfWgAk7OAOi7IxHxuYEVLI26bqjZvlVCkpC5/5AoNA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.7.tgz",
+			"integrity": "sha512-By90p5uxAriGukbyejq2poK41DwTxpNWOpOjN8mIyX/BKrCd3+sXZ5pHUZXjHyjR5OYS7PGsOD9dbM61YxfFmA==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.9.2",
+				"@babel/runtime": "^7.11.2",
 				"invariant": "^2.2.4",
 				"prop-types": "^15.7.2",
-				"react-fast-compare": "^3.0.1",
+				"react-fast-compare": "^3.2.0",
 				"shallowequal": "^1.1.0"
 			}
 		},
@@ -27236,12 +27427,6 @@
 				"react-transition-group": "^4.3.0"
 			},
 			"dependencies": {
-				"csstype": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.3.tgz",
-					"integrity": "sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==",
-					"dev": true
-				},
 				"dom-helpers": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
@@ -27739,9 +27924,9 @@
 			"dev": true
 		},
 		"regexpu-core": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-			"integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+			"integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
 			"dev": true,
 			"requires": {
 				"regenerate": "^1.4.0",
@@ -27823,41 +28008,41 @@
 			}
 		},
 		"remark-footnotes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-1.0.0.tgz",
-			"integrity": "sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
+			"integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==",
 			"dev": true
 		},
 		"remark-mdx": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.16.tgz",
-			"integrity": "sha512-xqZhBQ4TonFiSFpVt6SnTLRnxstu7M6pcaOibKZhqzk4zMRVacVenD7iECjfESK+72LkPm/NW+0r5ahJAg7zlQ==",
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.18.tgz",
+			"integrity": "sha512-xNhjv4kJZ8L6RV68yK8fQ6XWlvSIFOE5VPmM7wMKSwkvwBu6tlUJy0gRF2WiZ4fPPOj6jpqlVB9QakipvZuEqg==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "7.10.5",
+				"@babel/core": "7.11.6",
 				"@babel/helper-plugin-utils": "7.10.4",
-				"@babel/plugin-proposal-object-rest-spread": "7.10.4",
+				"@babel/plugin-proposal-object-rest-spread": "7.11.0",
 				"@babel/plugin-syntax-jsx": "7.10.4",
-				"@mdx-js/util": "1.6.16",
+				"@mdx-js/util": "1.6.18",
 				"is-alphabetical": "1.0.4",
 				"remark-parse": "8.0.3",
-				"unified": "9.1.0"
+				"unified": "9.2.0"
 			},
 			"dependencies": {
 				"@babel/core": {
-					"version": "7.10.5",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-					"integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
+					"version": "7.11.6",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+					"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.10.5",
-						"@babel/helper-module-transforms": "^7.10.5",
+						"@babel/generator": "^7.11.6",
+						"@babel/helper-module-transforms": "^7.11.0",
 						"@babel/helpers": "^7.10.4",
-						"@babel/parser": "^7.10.5",
+						"@babel/parser": "^7.11.5",
 						"@babel/template": "^7.10.4",
-						"@babel/traverse": "^7.10.5",
-						"@babel/types": "^7.10.5",
+						"@babel/traverse": "^7.11.5",
+						"@babel/types": "^7.11.5",
 						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"gensync": "^1.0.0-beta.1",
@@ -27868,24 +28053,13 @@
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-					"integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
-					"dev": true,
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.10.4",
-						"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-						"@babel/plugin-transform-parameters": "^7.10.4"
-					}
-				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"lodash": {
@@ -29494,9 +29668,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+			"integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
 			"dev": true
 		},
 		"specificity": {
@@ -29872,14 +30046,35 @@
 			}
 		},
 		"string.prototype.trim": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
-			"integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz",
+			"integrity": "sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==",
 			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.18.0-next.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.0",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+					"integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.0",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				}
 			}
 		},
 		"string.prototype.trimend": {
@@ -30036,9 +30231,9 @@
 			}
 		},
 		"stylelint": {
-			"version": "13.7.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.0.tgz",
-			"integrity": "sha512-1wStd4zVetnlHO98VjcHQbjSDmvcA39smkZQMct2cf+hom40H0xlQNdzzbswoG/jGBh61/Ue9m7Lu99PY51O6A==",
+			"version": "13.7.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.1.tgz",
+			"integrity": "sha512-qzqazcyRxrSRdmFuO0/SZOJ+LyCxYy0pwcvaOBBnl8/2VfHSMrtNIE+AnyJoyq6uKb+mt+hlgmVrvVi6G6XHfQ==",
 			"dev": true,
 			"requires": {
 				"@stylelint/postcss-css-in-js": "^0.37.2",
@@ -30184,12 +30379,12 @@
 					}
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"dir-glob": {
@@ -31295,12 +31490,6 @@
 			"resolved": "https://registry.npmjs.org/trim-html/-/trim-html-0.1.9.tgz",
 			"integrity": "sha1-puYK1yFeItozcOR7bDRTp8ydSz4="
 		},
-		"trim-lines": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
-			"integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
-			"dev": true
-		},
 		"trim-newlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -31458,9 +31647,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.21",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+			"version": "0.7.22",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
 		},
 		"uc.micro": {
 			"version": "1.0.6",
@@ -31535,9 +31724,9 @@
 			"dev": true
 		},
 		"unified": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-9.1.0.tgz",
-			"integrity": "sha512-VXOv7Ic6twsKGJDeZQ2wwPqXs2hM0KNu5Hkg9WgAZbSD1pxhZ7p8swqg583nw1Je2fhwHy6U8aEjiI79x1gvag==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.0.tgz",
+			"integrity": "sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==",
 			"dev": true,
 			"requires": {
 				"bail": "^1.0.0",
@@ -32108,12 +32297,12 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+					"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.2"
 					}
 				},
 				"ms": {
@@ -32457,9 +32646,9 @@
 			}
 		},
 		"webpack-bundle-analyzer": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.8.0.tgz",
-			"integrity": "sha512-PODQhAYVEourCcOuU+NiYI7WdR8QyELZGgPvB1y2tjbUpbmcQOt5Q7jEK+ttd5se0KSBKD9SXHCEozS++Wllmw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.9.0.tgz",
+			"integrity": "sha512-Ob8amZfCm3rMB1ScjQVlbYYUEJyEjdEtQ92jqiFUYt5VkEeO2v5UMbv49P/gnmCZm3A6yaFQzCBvpZqN4MUsdA==",
 			"dev": true,
 			"requires": {
 				"acorn": "^7.1.1",
@@ -32471,7 +32660,7 @@
 				"express": "^4.16.3",
 				"filesize": "^3.6.1",
 				"gzip-size": "^5.0.0",
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.19",
 				"mkdirp": "^0.5.1",
 				"opener": "^1.5.1",
 				"ws": "^6.0.0"
@@ -32504,6 +32693,12 @@
 					"version": "3.6.1",
 					"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
 					"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 					"dev": true
 				},
 				"ws": {
@@ -33106,13 +33301,22 @@
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
+				"@types/react": {
+					"version": "16.9.49",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+					"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^3.0.2"
+					}
+				},
 				"@wordpress/compose": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.0.tgz",
-					"integrity": "sha512-uOsfVuWOYtMUIOAk2dqiqKvg62WwMqAJG/ysBExM1imIofzIvTN2bhnVwy2yThBcQMIN/wdKBfhbZaLw2erRhA==",
+					"version": "3.20.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.20.1.tgz",
+					"integrity": "sha512-hi6VRXBte26A1QObx1PvqPIvpfhquDn3IUaw1wCPsaZBqayPx8Os9L9h3nVtqDGs439N5Qvb3FvdXN1eDJk8Zw==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
-						"@wordpress/element": "^2.17.0",
+						"@wordpress/element": "^2.17.1",
 						"@wordpress/is-shallow-equal": "^2.2.0",
 						"@wordpress/priority-queue": "^1.8.0",
 						"clipboard": "^2.0.1",
@@ -33137,11 +33341,13 @@
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
@@ -33226,12 +33432,23 @@
 				"react-resize-aware": "^3.0.0"
 			},
 			"dependencies": {
+				"@types/react": {
+					"version": "16.9.49",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
+					"integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^3.0.2"
+					}
+				},
 				"@wordpress/element": {
-					"version": "2.17.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.0.tgz",
-					"integrity": "sha512-WVhJXa2zhleG9nYl139T6ZBmpBw/UcXYkIpvnF6KA27H1EXyyoaUDPU0EfHfn8/T67IXd+gUxjyrvYdFFJwgHw==",
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.17.1.tgz",
+					"integrity": "sha512-7MTmd2wy0tslZK/q+zLfMrdIkflcd77Zts+jUhoWFBTqwNMTaod4QggCM8fveXxrcrPCFfv86aslrI0D9zCWeQ==",
 					"requires": {
 						"@babel/runtime": "^7.9.2",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
 						"@wordpress/escape-html": "^1.9.0",
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"@wordpress/html-entities": "2.5.0",
 		"@wordpress/i18n": "3.8.0",
 		"@wordpress/is-shallow-equal": "1.7.0",
-		"@wordpress/scripts": "12.0.0",
+		"@wordpress/scripts": "12.1.0",
 		"autoprefixer": "9.8.6",
 		"axios": "0.19.2",
 		"babel-plugin-transform-async-generator-functions": "6.24.1",


### PR DESCRIPTION
This updates the `@wordpress/scripts` package to the latest version.

I started this as a part of working on #3141 thinking it might help with the dependency issue for puppeteer but I don't think it makes much difference. The update is still useful in keeping the package up to date.

Since this mostly just impacts the scripts we use for running e2e and jest tests, the travis build should be sufficient coverage for whether this gets merged or not.