### PR TITLE
Fix esLint rule violations for @wordpress/i18n-translator-comments rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'@wordpress/i18n-translator-comments': 'off',
 		'@wordpress/valid-sprintf': 'off',
 		'@wordpress/no-unused-vars-before-return': 'off',
 		'testing-library/no-await-sync-query': 'off',

--- a/assets/js/atomic/blocks/product-elements/rating/block.js
+++ b/assets/js/atomic/blocks/product-elements/rating/block.js
@@ -36,6 +36,7 @@ const Block = ( { className } ) => {
 	};
 
 	const ratingText = sprintf(
+		/* Translators: %f is referring to the average rating value */
 		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
 		rating
 	);

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -58,6 +58,7 @@ const CheckboxList = ( {
 						} }
 						aria-expanded={ false }
 						aria-label={ sprintf(
+							/* Translators: %s is referring the remaining count of options */
 							_n(
 								'Show %s more option',
 								'Show %s more options',

--- a/assets/js/base/components/dropdown-selector/menu.js
+++ b/assets/js/base/components/dropdown-selector/menu.js
@@ -38,6 +38,7 @@ const DropdownSelectorMenu = ( {
 							item: option.value,
 							'aria-label': selected
 								? sprintf(
+										/* Translators: %s is referring to the filter option being removed. */
 										__(
 											'Remove %s filter',
 											'woo-gutenberg-products-block'

--- a/assets/js/base/components/dropdown-selector/selected-chip.js
+++ b/assets/js/base/components/dropdown-selector/selected-chip.js
@@ -13,6 +13,7 @@ const DropdownSelectorSelectedChip = ( { onRemoveItem, option } ) => {
 				onRemoveItem( option.value );
 			} }
 			ariaLabel={ sprintf(
+				/* Translators: %s is referring to the filter option being removed. */
 				__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
 				option.name
 			) }

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -31,6 +31,7 @@ const getCcOrEcheckPaymentMethodOption = (
 	return {
 		value: tokenId + '',
 		label: sprintf(
+			/* Translators: %1$s is referring to the payment method brand, %2$s is referring to the last 4 digits of the payment card, %3$s is referring to the expiry date.  */
 			__(
 				'%1$s ending in %2$s (expires %3$s)',
 				'woo-gutenberg-product-blocks'
@@ -69,6 +70,7 @@ const getDefaultPaymentMethodOptions = (
 	return {
 		value: tokenId + '',
 		label: sprintf(
+			// Translators: %s is the name of the payment method gateway.
 			__( 'Saved token for %s', 'woo-gutenberg-products-block' ),
 			method.gateway
 		),

--- a/assets/js/base/components/quantity-selector/index.js
+++ b/assets/js/base/components/quantity-selector/index.js
@@ -84,8 +84,8 @@ const QuantitySelector = ( {
 					}
 				} }
 				aria-label={ sprintf(
+					/* Translators: %s refers to the item name in the cart. */
 					__(
-						// translators: %s Item name.
 						'Quantity of %s in your cart.',
 						'woo-gutenberg-products-block'
 					),
@@ -104,8 +104,8 @@ const QuantitySelector = ( {
 					onChange( newQuantity );
 					speak(
 						sprintf(
+							/* Translators: %s refers to the item name in the cart. */
 							__(
-								// translators: %s Quantity amount.
 								'Quantity reduced to %s.',
 								'woo-gutenberg-products-block'
 							),
@@ -128,8 +128,8 @@ const QuantitySelector = ( {
 					onChange( newQuantity );
 					speak(
 						sprintf(
+							/* Translators: %s refers to the item name in the cart. */
 							__(
-								// translators: %s Quantity amount.
 								'Quantity increased to %s.',
 								'woo-gutenberg-products-block'
 							),

--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -132,6 +132,7 @@ function getReviewRating( review ) {
 			>
 				<span style={ starStyle }>
 					{ sprintf(
+						/* Translators: %f to the average rating for the review. */
 						__(
 							'Rated %f out of 5',
 							'woo-gutenberg-products-block'

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -256,8 +256,8 @@ const AttributeFilterBlock = ( {
 				if ( filterAddedName && filterRemovedName ) {
 					speak(
 						sprintf(
+							/* Translators: %s attribute terms (for example: 'red', 'blue', 'large'...). */
 							__(
-								// translators: %s attribute terms (for example: 'red', 'blue', 'large'...)
 								'%s filter replaced with %s.',
 								'woo-gutenberg-products-block'
 							),
@@ -268,7 +268,7 @@ const AttributeFilterBlock = ( {
 				} else if ( filterAddedName ) {
 					speak(
 						sprintf(
-							// translators: %s attribute term (for example: 'red', 'blue', 'large'...)
+							/* Translators: %s attribute term (for example: 'red', 'blue', 'large'...) */
 							__(
 								'%s filter added.',
 								'woo-gutenberg-products-block'
@@ -279,7 +279,7 @@ const AttributeFilterBlock = ( {
 				} else if ( filterRemovedName ) {
 					speak(
 						sprintf(
-							// translators: %s attribute term (for example: 'red', 'blue', 'large'...)
+							/* Translators: %s attribute term (for example: 'red', 'blue', 'large'...) */
 							__(
 								'%s filter removed.',
 								'woo-gutenberg-products-block'

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -315,6 +315,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			),
 			selected: ( n ) =>
 				sprintf(
+					// Translators: %d is the number of attributes selected.
 					_n(
 						'%d attribute selected',
 						'%d attributes selected',

--- a/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
@@ -49,6 +49,7 @@ const EmptyCartEdit = ( { hidden = false } ) => {
 						{
 							align: 'center',
 							content: sprintf(
+								// Translators: %s is the link to the store product directory.
 								__(
 									'<a href="%s">Browse store</a>.',
 									'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
@@ -9,6 +9,7 @@ const CartLineItemsTitle = ( { itemCount = 1 } ) => {
 	return (
 		<Title headingLevel="2">
 			{ sprintf(
+				// Translators: %d is the count of items in the cart.
 				_n(
 					'Your cart (%d item)',
 					'Your cart (%d items)',

--- a/assets/js/blocks/reviews/frontend-container-block.js
+++ b/assets/js/blocks/reviews/frontend-container-block.js
@@ -51,6 +51,7 @@ class FrontendContainerBlock extends Component {
 	onReviewsAppended( { newReviews } ) {
 		speak(
 			sprintf(
+				// Translators: %d is the count of reviews loaded.
 				_n(
 					'%d review loaded.',
 					'%d reviews loaded.',

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -62,6 +62,7 @@ const ReviewsByCategoryEditor = ( {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
+					// Translators: %s is the search term name, %d is the number of products returned for search query.
 					_n(
 						'%s, has %d product',
 						'%s, has %d products',

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -48,6 +48,7 @@ const ReviewsByProductEditor = ( {
 			<SearchListItem
 				{ ...args }
 				countLabel={ sprintf(
+					// Translators: %d is the review count.
 					_n(
 						'%d Review',
 						'%d Reviews',
@@ -58,6 +59,7 @@ const ReviewsByProductEditor = ( {
 				) }
 				showCount
 				aria-label={ sprintf(
+					// Translators: %s is the item name, and %d is the number of reviews for the item.
 					_n(
 						'%s, has %d review',
 						'%s, has %d reviews',

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -27,6 +27,7 @@ const NoReviewsPlaceholder = ( { error, getProduct, isLoading, product } ) => {
 			<Spinner />
 		) : (
 			sprintf(
+				// Translators: %s is the product name.
 				__(
 					"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
 					'woo-gutenberg-products-block'

--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -60,6 +60,7 @@ const ProductAttributeTermControl = ( {
 					disabled={ item.count === '0' }
 					aria-expanded={ expandedAttribute === item.id }
 					aria-label={ sprintf(
+						// Translators: %s is the item name, %d is the count of terms for the item.
 						_n(
 							'%s, has %d term',
 							'%s, has %d terms',
@@ -113,6 +114,7 @@ const ProductAttributeTermControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
+				// Translators: %d is the count of attributes selected.
 				_n(
 					'%d attribute selected',
 					'%d attributes selected',

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -42,6 +42,7 @@ const ProductCategoryControl = ( {
 
 		const listItemAriaLabel = showReviewCount
 			? sprintf(
+					// Translators: %s is the item name, %d is the count of reviews for the item.
 					_n(
 						'%s, has %d review',
 						'%s, has %d reviews',
@@ -52,6 +53,7 @@ const ProductCategoryControl = ( {
 					item.review_count
 			  )
 			: sprintf(
+					// Translators: %s is the item name, %d is the count of products for the item.
 					_n(
 						'%s, has %d product',
 						'%s, has %d products',
@@ -64,6 +66,7 @@ const ProductCategoryControl = ( {
 
 		const listItemCountLabel = showReviewCount
 			? sprintf(
+					// Translators: %d is the count of reviews.
 					_n(
 						'%d Review',
 						'%d Reviews',
@@ -73,6 +76,7 @@ const ProductCategoryControl = ( {
 					item.review_count
 			  )
 			: sprintf(
+					// Translators: %d is the count of products.
 					_n(
 						'%d Product',
 						'%d Products',
@@ -108,6 +112,7 @@ const ProductCategoryControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
+				// Translators: %d is the count of selected categories.
 				_n(
 					'%d category selected',
 					'%d categories selected',

--- a/assets/js/editor-components/product-control/index.js
+++ b/assets/js/editor-components/product-control/index.js
@@ -128,6 +128,7 @@ const ProductControl = ( {
 					{ variationsCount ? (
 						<span className="woocommerce-search-list__item-variation-count">
 							{ sprintf(
+								// Translators: %d is the count of variations.
 								_n(
 									'%d variation',
 									'%d variations',

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -74,6 +74,7 @@ class ProductTagControl extends Component {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
+					// Translators: %d is the count of products, %s is the name of the tag.
 					_n(
 						'%d product tagged as %s',
 						'%d products tagged as %s',
@@ -107,6 +108,7 @@ class ProductTagControl extends Component {
 			),
 			selected: ( n ) =>
 				sprintf(
+					// Translators: %d is the count of selected tags.
 					_n(
 						'%d tag selected',
 						'%d tags selected',

--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -42,6 +42,7 @@ const ProductsControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
+				// Translators: %d is the number of selected products.
 				_n(
 					'%d product selected',
 					'%d products selected',


### PR DESCRIPTION
Part of #3118.

This pull enables the `@wordpress/i18n-translator-comments` rule that was temporarily disabled and fixes all violations.

No impact to user facing code so not testing required. I'll merge when travis passes.