### PR TITLE
Re-enable @wordpress/valid-sprintf eslint rule and fix violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'@wordpress/valid-sprintf': 'off',
 		'@wordpress/no-unused-vars-before-return': 'off',
 		'testing-library/no-await-sync-query': 'off',
 	},

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
@@ -49,10 +49,10 @@ const Package = ( {
 								<Label
 									label={ `${ name } ×${ quantity }` }
 									screenReaderLabel={ sprintf(
-										// translators: %s name of the product (ie: Sunglasses), %d number of units in the current cart package
+										// translators: %1$s name of the product (ie: Sunglasses), %2$d number of units in the current cart package
 										_n(
-											'%s (%d unit)',
-											'%s (%d units)',
+											'%1$s (%2$d unit)',
+											'%1$s (%2$d units)',
 											quantity,
 											'woo-gutenberg-products-block'
 										),

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -14,8 +14,8 @@ import { RemovableChip } from '@woocommerce/base-components/chip';
 export const formatPriceRange = ( minPrice, maxPrice ) => {
 	if ( Number.isFinite( minPrice ) && Number.isFinite( maxPrice ) ) {
 		return sprintf(
-			/* translators: %s min price, %s max price */
-			__( 'Between %s and %s', 'woo-gutenberg-products-block' ),
+			/* translators: %1$s min price, %2$s max price */
+			__( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ),
 			formatPrice( minPrice ),
 			formatPrice( maxPrice )
 		);

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -256,9 +256,9 @@ const AttributeFilterBlock = ( {
 				if ( filterAddedName && filterRemovedName ) {
 					speak(
 						sprintf(
-							/* Translators: %s attribute terms (for example: 'red', 'blue', 'large'...). */
+							/* Translators: %1$s and %2$s are attribute terms (for example: 'red', 'blue', 'large'...). */
 							__(
-								'%s filter replaced with %s.',
+								'%1$s filter replaced with %2$s.',
 								'woo-gutenberg-products-block'
 							),
 							filterAddedName,

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -62,10 +62,10 @@ const ReviewsByCategoryEditor = ( {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
-					// Translators: %s is the search term name, %d is the number of products returned for search query.
+					// Translators: %1$s is the search term name, %2$d is the number of products returned for search query.
 					_n(
-						'%s, has %d product',
-						'%s, has %d products',
+						'%1$s, has %2$d product',
+						'%1$s, has %2$d products',
 						item.count,
 						'woo-gutenberg-products-block'
 					),

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -59,10 +59,10 @@ const ReviewsByProductEditor = ( {
 				) }
 				showCount
 				aria-label={ sprintf(
-					// Translators: %s is the item name, and %d is the number of reviews for the item.
+					// Translators: %1$s is the item name, and %2$d is the number of reviews for the item.
 					_n(
-						'%s, has %d review',
-						'%s, has %d reviews',
+						'%1$s, has %2$d review',
+						'%1$s, has %2$d reviews',
 						item.review_count,
 						'woo-gutenberg-products-block'
 					),

--- a/assets/js/data/schema/selectors.js
+++ b/assets/js/data/schema/selectors.js
@@ -63,7 +63,7 @@ export const getRoute = createRegistrySelector(
 			if ( hasResolved ) {
 				throw new Error(
 					sprintf(
-						'While there is a route for the given namespace (%s) and resource name (%s), there is no route utilizing the number of ids you included in the select arguments. The available routes are: (%s)',
+						'While there is a route for the given namespace (%1$s) and resource name (%2$s), there is no route utilizing the number of ids you included in the select arguments. The available routes are: (%3$s)',
 						namespace,
 						resourceName,
 						JSON.stringify( state[ namespace ][ resourceName ] )

--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -60,10 +60,10 @@ const ProductAttributeTermControl = ( {
 					disabled={ item.count === '0' }
 					aria-expanded={ expandedAttribute === item.id }
 					aria-label={ sprintf(
-						// Translators: %s is the item name, %d is the count of terms for the item.
+						// Translators: %1$s is the item name, %2$d is the count of terms for the item.
 						_n(
-							'%s, has %d term',
-							'%s, has %d terms',
+							'%1$s, has %2$d term',
+							'%1$s, has %2$d terms',
 							item.count,
 							'woo-gutenberg-products-block'
 						),

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -42,10 +42,10 @@ const ProductCategoryControl = ( {
 
 		const listItemAriaLabel = showReviewCount
 			? sprintf(
-					// Translators: %s is the item name, %d is the count of reviews for the item.
+					// Translators: %1$s is the item name, %2$d is the count of reviews for the item.
 					_n(
-						'%s, has %d review',
-						'%s, has %d reviews',
+						'%1$s, has %2$d review',
+						'%1$s, has %2$d reviews',
 						item.review_count,
 						'woo-gutenberg-products-block'
 					),
@@ -53,10 +53,10 @@ const ProductCategoryControl = ( {
 					item.review_count
 			  )
 			: sprintf(
-					// Translators: %s is the item name, %d is the count of products for the item.
+					// Translators: %1$s is the item name, %2$d is the count of products for the item.
 					_n(
-						'%s, has %d product',
-						'%s, has %d products',
+						'%1$s, has %2$d product',
+						'%1$s, has %2$d products',
 						item.count,
 						'woo-gutenberg-products-block'
 					),

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -74,10 +74,10 @@ class ProductTagControl extends Component {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
-					// Translators: %d is the count of products, %s is the name of the tag.
+					// Translators: %1$d is the count of products, %2$s is the name of the tag.
 					_n(
-						'%d product tagged as %s',
-						'%d products tagged as %s',
+						'%1$d product tagged as %2$s',
+						'%1$d products tagged as %2$s',
 						item.count,
 						'woo-gutenberg-products-block'
 					),


### PR DESCRIPTION
Part of #3118.

This pull enables the `@wordpress/valid-sprintf` rule that was temporarily disabled and fixes all violations.

No impact to user facing code so no testing required. I'll merge when travis passes.