### PR TITLE
Enable @wordpress/no-unused-vars-before-return eslint rule and fix rule violations.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,6 @@ module.exports = {
 		// - @worpdress/no-unused-vars-before-return
 		// - testing-library/no-await-sync-query
 		// - @woocommerce/dependency-group
-		'@wordpress/no-unused-vars-before-return': 'off',
 		'testing-library/no-await-sync-query': 'off',
 	},
 };

--- a/assets/js/base/components/store-notices-container/snackbar-notices.js
+++ b/assets/js/base/components/store-notices-container/snackbar-notices.js
@@ -8,13 +8,15 @@ import { useEditorContext } from '@woocommerce/base-context';
 const NoticesContainer = () => {
 	const { isEditor } = useEditorContext();
 	const { notices, removeNotice } = useStoreNotices();
-	const snackbarNotices = notices.filter(
-		( notice ) => notice.type === 'snackbar'
-	);
 
 	if ( isEditor ) {
 		return null;
 	}
+
+	const snackbarNotices = notices.filter(
+		( notice ) => notice.type === 'snackbar'
+	);
+
 	return (
 		<SnackbarList
 			notices={ snackbarNotices }

--- a/assets/js/base/components/store-notices-container/store-notices-container.js
+++ b/assets/js/base/components/store-notices-container/store-notices-container.js
@@ -26,7 +26,6 @@ const getWooClassName = ( { status = 'default' } ) => {
 
 const StoreNoticesContainer = ( { className, notices } ) => {
 	const { removeNotice } = useStoreNoticesContext();
-	const wrapperClass = classnames( className, 'wc-block-components-notices' );
 	const regularNotices = notices.filter(
 		( notice ) => notice.type !== 'snackbar'
 	);
@@ -34,6 +33,8 @@ const StoreNoticesContainer = ( { className, notices } ) => {
 	if ( ! regularNotices.length ) {
 		return null;
 	}
+
+	const wrapperClass = classnames( className, 'wc-block-components-notices' );
 
 	return (
 		<div className={ wrapperClass }>


### PR DESCRIPTION
Part of #3118.

This pull enables the `@wordpress/no-unused-vars-before-return` rule that was temporarily disabled and fixes all violations.

Impact to user-facing interfaces is minimal and easy to resolve. So when travis passes green, I'll go ahead and merge this.