### PR TITLE
Enable testing-library/no-await-sync-query ESLint rule and fix rule violations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,28 +19,5 @@ module.exports = {
 	},
 	rules: {
 		'woocommerce/feature-flag': 'off',
-		// @todo Remove temporary disabling of various eslint rules.
-		// To keep pull request reviews smaller and changes more precise, new rules
-		// added via the adoption of `@woocommerce/eslint-plugin` that are failing
-		// will be handled in individual pulls. The following rules need to be turned
-		// back on (via individual pulls):
-		// - jsdoc/require-param
-		// - jsdoc/check-tag-names
-		// - jsdoc/check-param-names
-		// - jsdoc/require-property-description
-		// - jsdoc/valid-types
-		// - jsdoc/require-property
-		// - jsdoc/no-undefined-types
-		// - jsdoc/check-types
-		// - jsdoc/require-returns-description
-		// - jsdoc/require-param-type
-		// - jsdoc/require-returns-type
-		// - jsdoc/newline-after-description
-		// - @wordpress/i18n-translator-comments
-		// - @wordpress/valid-sprintf
-		// - @worpdress/no-unused-vars-before-return
-		// - testing-library/no-await-sync-query
-		// - @woocommerce/dependency-group
-		'testing-library/no-await-sync-query': 'off',
 	},
 };

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -37,7 +37,7 @@ describe( 'Testing cart', () => {
 		);
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect(
-			await screen.getByText( /Proceed to Checkout/i )
+			screen.getByText( /Proceed to Checkout/i )
 		).toBeInTheDocument();
 
 		/**
@@ -65,7 +65,7 @@ describe( 'Testing cart', () => {
 		);
 
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
-		expect( await screen.getByText( /Empty Cart/i ) ).toBeInTheDocument();
+		expect( screen.getByText( /Empty Cart/i ) ).toBeInTheDocument();
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 	} );
 } );


### PR DESCRIPTION
Part of #3118.

This pull enables the `testing-library/no-await-sync-query` rule that was temporarily disabled and fixes all violations.

No impact to user facing code so no testing required. I'll merge when travis passes.