### PR TITLE
Restore saved payment method data after closing an express payment method

### DIFF
--- a/assets/js/base/components/payment-methods/express-payment-methods.js
+++ b/assets/js/base/components/payment-methods/express-payment-methods.js
@@ -26,23 +26,34 @@ const ExpressPaymentMethods = () => {
 	const {
 		setActivePaymentMethod,
 		activePaymentMethod,
+		paymentMethodData,
 		setPaymentStatus,
 	} = usePaymentMethodDataContext();
 	const paymentMethodInterface = usePaymentMethodInterface();
 	const { paymentMethods } = useExpressPaymentMethods();
 	const previousActivePaymentMethod = useRef( activePaymentMethod );
+	const previousPaymentMethodData = useRef( paymentMethodData );
 
 	const onExpressPaymentClick = useCallback(
 		( paymentMethodId ) => () => {
 			previousActivePaymentMethod.current = activePaymentMethod;
+			previousPaymentMethodData.current = paymentMethodData;
 			setPaymentStatus().started();
 			setActivePaymentMethod( paymentMethodId );
 		},
-		[ setActivePaymentMethod, setPaymentStatus, activePaymentMethod ]
+		[
+			activePaymentMethod,
+			paymentMethodData,
+			setActivePaymentMethod,
+			setPaymentStatus,
+		]
 	);
 	const onExpressPaymentClose = useCallback( () => {
 		setActivePaymentMethod( previousActivePaymentMethod.current );
-	}, [ setActivePaymentMethod ] );
+		if ( previousPaymentMethodData.current.isSavedToken ) {
+			setPaymentStatus().success( previousPaymentMethodData.current );
+		}
+	}, [ setActivePaymentMethod, setPaymentStatus ] );
 	const paymentMethodIds = Object.keys( paymentMethods );
 	const content =
 		paymentMethodIds.length > 0 ? (

--- a/assets/js/base/components/payment-methods/index.js
+++ b/assets/js/base/components/payment-methods/index.js
@@ -1,3 +1,4 @@
 export { default as PaymentMethods } from './payment-methods';
 export { default as ExpressPaymentMethods } from './express-payment-methods';
 export { CartExpressPayment, CheckoutExpressPayment } from './express-payment';
+export { default as SavedPaymentMethodOptions } from './saved-payment-method-options';

--- a/assets/js/base/components/title/index.js
+++ b/assets/js/base/components/title/index.js
@@ -15,10 +15,10 @@ import './style.scss';
  * Component that renders a block title.
  *
  * @param {Object} props Incoming props for the component.
- * @param {React.ReactChildren} props.children Children elements this component wraps.
- * @param {string} props.className CSS class used.
+ * @param {React.ReactChildren} [props.children] Children elements this component wraps.
+ * @param {string} [props.className] CSS class used.
  * @param {string} props.headingLevel Heading level for title.
- * @param {Object} props.props Rest of props passed through to component.
+ * @param {Object} [props.props] Rest of props passed through to component.
  */
 const Title = ( { children, className, headingLevel, ...props } ) => {
 	const buttonClassName = classNames(


### PR DESCRIPTION
Fixes #3166.

This PR resets the the `paymentMethodData` when the express payment method is closed and the previous payment method is a saved one.

### How to test the changes in this Pull Request:

Copied from #3166:

This bug surfaces when a shopper that is logged in and has a saved payment method does the following steps when checking out using the checkout block:

1. Click Express Payment method (chrome pay or apple pay).
2. Abandon paying by the express payment method (cancelling or closing the modal).
3. Leaving the saved payment method option selected without choosing any other payment method.
4. Submitting the order.
5. Verify the payment is processed correctly.

Repeat the process above but instead of using a saved payment method, select a new one.

### Changelog

> Fixed paying with a saved payment method after cancelling an express payment.