### PR TITLE
Load WC Blocks CSS after editor CSS

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -35,7 +35,17 @@ class Assets {
 	 */
 	public static function register_assets() {
 		$asset_api = Package::container()->get( AssetApi::class );
-		self::register_style( 'wc-block-vendors-style', plugins_url( $asset_api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ), [] );
+
+		// In the editor, we want our stylesheets to load after editor CSS (see #3068).
+		// This might be no longer necessary when https://github.com/WordPress/gutenberg/issues/20797
+		// is merged.
+		if ( is_admin() ) {
+			$block_style_dependencies = array( 'wp-edit-post' );
+		} else {
+			$block_style_dependencies = array();
+		}
+
+		self::register_style( 'wc-block-vendors-style', plugins_url( $asset_api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ), $block_style_dependencies );
 		self::register_style( 'wc-block-editor', plugins_url( $asset_api->get_block_asset_build_path( 'editor', 'css' ), __DIR__ ), array( 'wp-edit-blocks' ) );
 		wp_style_add_data( 'wc-block-editor', 'rtl', 'replace' );
 		self::register_style( 'wc-block-style', plugins_url( $asset_api->get_block_asset_build_path( 'style', 'css' ), __DIR__ ), array( 'wc-block-vendors-style' ) );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -36,9 +36,9 @@ class Assets {
 	public static function register_assets() {
 		$asset_api = Package::container()->get( AssetApi::class );
 
-		// In the editor, we want our stylesheets to load after editor CSS (see #3068).
-		// This might be no longer necessary when https://github.com/WordPress/gutenberg/issues/20797
-		// is merged.
+		// @todo Remove fix to load our stylesheets after editor CSS.
+		// See #3068 for the rationale of this fix. It should be no longer
+		// necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
 		if ( is_admin() ) {
 			$block_style_dependencies = array( 'wp-edit-post' );
 		} else {


### PR DESCRIPTION
Fixes #3068.

The issue was caused because editor CSS was leaking into the block. It could be fixed ensuring our CSS is loaded after `wp-edit-post-css`. Notice this fix might no longer be needed if https://github.com/WordPress/gutenberg/issues/20797 gets merged into Gutenberg.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/94667550-401d8000-030f-11eb-8d38-b9ffa1e98dfa.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/94667483-29772900-030f-11eb-8b82-1a792c693e2e.png)

### How to test the changes in this Pull Request:

1. Edit a page with checkout block.
2. Scroll down to country input.
3. Verify it has rounded corners and the correct height.

Notice the semi-transparent background is not fixed since it's a different issue (#2487).

### Changelog

> Fix wrong styling of Checkout's country input in the editor.