### PR TITLE
Don't load contents of payment method hidden tabs

### DIFF
--- a/assets/js/base/components/tabs/index.js
+++ b/assets/js/base/components/tabs/index.js
@@ -69,7 +69,8 @@ const Tabs = ( {
 					tabId={ `${ instanceId }-${ name }` }
 					className="wc-block-components-tabs__content"
 				>
-					{ content }
+					{ tabState.selectedId === `${ instanceId }-${ name }` &&
+						content }
 				</TabPanel>
 			) ) }
 		</div>

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js
@@ -7,7 +7,6 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { PAYMENT_METHOD_NAME } from './constants';
 import { getStripeServerData } from '../stripe-utils';
 import { useCheckoutSubscriptions } from './use-checkout-subscriptions';
 import { InlineCard, CardElements } from './elements';
@@ -83,11 +82,11 @@ const CreditCardComponent = ( {
 
 export const StripeCreditCard = ( props ) => {
 	const { locale } = getStripeServerData().button;
-	const { activePaymentMethod, stripe } = props;
+	const { stripe } = props;
 
-	return activePaymentMethod === PAYMENT_METHOD_NAME ? (
+	return (
 		<Elements stripe={ stripe } locale={ locale }>
 			<CreditCardComponent { ...props } />
 		</Elements>
-	) : null;
+	);
 };


### PR DESCRIPTION
(Part of fixing #3166)

Currently, the contents of all payment methods tabs are loaded in the tree even if they are not in the selected tab.

![imatge](https://user-images.githubusercontent.com/3616980/94831508-177bb000-040d-11eb-9115-b66d2615444c.png)

This has the issue that payment methods that add required form elements break the purchase flow because required fields are loaded but invisible to the user. For Stripe, we added [a check](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/payment-method.js#L88) so its elements are not rendered if it's not active, but I don't think that's something payment methods need to check in their side if we can do it for them in Blocks.

### Breaking change?

I don't consider this to be a breaking change because I can't think of any legit case where an inactive payment method might need its contents to be loaded in the page before it's selected. So adding it to the changelog is enough in my opinion and no dev note is required.

### How to test the changes in this Pull Request:

This PR doesn't include any behavior change, so everything should keep working as before.
1. Go to the Checkout block and interact with the payment method tabs. Verify you can toggle them and tab contents always appear.
2. Finish a purchase with one of the tabs and verify the order was done with the correct payment method.

### Changelog

> Developers: payment method components are no longer loaded in tree if they are not selected in the UI.