### PR TITLE
Use store-themed set password form for checkout signup

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -27,7 +27,7 @@ import {
 	CHECKOUT_ALLOWS_GUEST,
 	isExperimentalBuild,
 } from '@woocommerce/block-settings';
-import { compareVersions, getSetting } from '@woocommerce/settings';
+import { compareWithWooVersion, getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -91,7 +91,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	const allowCreateAccount =
 		attributes.allowCreateAccount &&
 		isExperimentalBuild() &&
-		compareVersions( getSetting( 'wcVersion' ), '4.7', '>=' );
+		compareWithWooVersion( '4.7.0', '<=' );
 
 	useEffect( () => {
 		if ( hasErrorsToDisplay ) {

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -22,9 +22,12 @@ import {
 	SidebarLayout,
 	Main,
 } from '@woocommerce/base-components/sidebar-layout';
-import { getSetting } from '@woocommerce/settings';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import { CHECKOUT_ALLOWS_GUEST } from '@woocommerce/block-settings';
+import {
+	CHECKOUT_ALLOWS_GUEST,
+	isExperimentalBuild,
+} from '@woocommerce/block-settings';
+import { compareVersions, getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -81,6 +84,15 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		checkoutHasError &&
 		( hasValidationErrors || hasNoticesOfType( 'default' ) );
 
+	// Checkout signup is feature gated to WooCommerce 4.7 and newer;
+	// uses updated my-account/lost-password screen from 4.7+ for
+	// setting initial password.
+	// Also currently gated to dev builds only.
+	const allowCreateAccount =
+		attributes.allowCreateAccount &&
+		isExperimentalBuild() &&
+		compareVersions( getSetting( 'wcVersion' ), '4.7', '>=' );
+
 	useEffect( () => {
 		if ( hasErrorsToDisplay ) {
 			showAllValidationErrors();
@@ -96,7 +108,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		! isEditor &&
 		! customerId &&
 		! CHECKOUT_ALLOWS_GUEST &&
-		! attributes.allowCreateAccount
+		! allowCreateAccount
 	) {
 		return (
 			<>
@@ -128,7 +140,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 						showPhoneField={ attributes.showPhoneField }
 						requireCompanyField={ attributes.requireCompanyField }
 						requirePhoneField={ attributes.requirePhoneField }
-						allowCreateAccount={ attributes.allowCreateAccount }
+						allowCreateAccount={ allowCreateAccount }
 					/>
 					<div className="wc-block-checkout__actions">
 						{ attributes.showReturnToCart && (

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -19,7 +19,11 @@ import {
 	CHECKOUT_PAGE_ID,
 	isExperimentalBuild,
 } from '@woocommerce/block-settings';
-import { getAdminLink } from '@woocommerce/settings';
+import {
+	compareVersions,
+	getAdminLink,
+	getSetting,
+} from '@woocommerce/settings';
 import { createInterpolateElement } from 'wordpress-element';
 import { useRef } from '@wordpress/element';
 import {
@@ -55,6 +59,13 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCartPageId } = useRef( cartPageId );
+	// Checkout signup is feature gated to WooCommerce 4.7 and newer;
+	// uses updated my-account/lost-password screen from 4.7+ for
+	// setting initial password.
+	// Also currently gated to dev builds only.
+	const showCreateAccountOption =
+		isExperimentalBuild() &&
+		compareVersions( getSetting( 'wcVersion' ), '4.7', '>=' );
 	return (
 		<InspectorControls>
 			{ currentPostId !== CHECKOUT_PAGE_ID && (
@@ -156,7 +167,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					/>
 				) }
 			</PanelBody>
-			{ isExperimentalBuild() && (
+			{ showCreateAccountOption && (
 				<PanelBody
 					title={ __(
 						'Account options',

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -19,11 +19,7 @@ import {
 	CHECKOUT_PAGE_ID,
 	isExperimentalBuild,
 } from '@woocommerce/block-settings';
-import {
-	compareVersions,
-	getAdminLink,
-	getSetting,
-} from '@woocommerce/settings';
+import { compareWithWooVersion, getAdminLink } from '@woocommerce/settings';
 import { createInterpolateElement } from 'wordpress-element';
 import { useRef } from '@wordpress/element';
 import {
@@ -64,8 +60,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 	// setting initial password.
 	// Also currently gated to dev builds only.
 	const showCreateAccountOption =
-		isExperimentalBuild() &&
-		compareVersions( getSetting( 'wcVersion' ), '4.7', '>=' );
+		isExperimentalBuild() && compareWithWooVersion( '4.7.0', '<=' );
 	return (
 		<InspectorControls>
 			{ currentPostId !== CHECKOUT_PAGE_ID && (

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -23,10 +23,15 @@ export { setSetting } from './set-setting';
  * to `rc`.
  *
  * @param {string} version Version to compare.
+ * @param {string} setting Setting name (e.g. wpVersion or wcVersion).
  * @param {string} operator Comparison operator.
  */
-export const compareWithWpVersion = ( version, operator ) => {
-	let replacement = getSetting( 'wpVersion', '' ).replace(
+const compareVersionSettingIgnorePrerelease = (
+	version,
+	setting,
+	operator
+) => {
+	let replacement = getSetting( setting, '' ).replace(
 		/-[a-zA-Z0-9]*[\-]*/,
 		'.0-rc.'
 	);
@@ -34,6 +39,22 @@ export const compareWithWpVersion = ( version, operator ) => {
 		? replacement.substring( 0, replacement.length - 1 )
 		: replacement;
 	return compareVersions.compare( version, replacement, operator );
+};
+
+export const compareWithWpVersion = ( version, operator ) => {
+	return compareVersionSettingIgnorePrerelease(
+		version,
+		'wpVersion',
+		operator
+	);
+};
+
+export const compareWithWooVersion = ( version, operator ) => {
+	return compareVersionSettingIgnorePrerelease(
+		version,
+		'wcVersion',
+		operator
+	);
 };
 
 export { compareVersions, getSetting };

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -72,6 +72,7 @@ class AssetDataRegistry {
 		$currency = get_woocommerce_currency();
 		return [
 			'wpVersion'     => get_bloginfo( 'version' ),
+			'wcVersion'     => defined( 'WC_VERSION' ) ? WC_VERSION : '',
 			'adminUrl'      => admin_url(),
 			'countries'     => WC()->countries->get_countries(),
 			'currency'      => [

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -36,15 +36,14 @@ class CreateAccount {
 		// uses updated my-account/lost-password screen from 4.7+ for
 		// setting initial password.
 		// Also currently gated to dev builds only.
-		$woo_47_or_newer = ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '>=' ) );
-		return Package::is_experimental_build() && $woo_47_or_newer;
+		return Package::is_experimental_build();
 	}
 
 	/**
 	 * Init - register handlers for WooCommerce core email hooks.
 	 */
 	public function init() {
-		if ( ! self::is_feature_enabled() ) {
+		if ( ! self::is_feature_enabled() || defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '<' ) ) {
 			return;
 		}
 

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -32,12 +32,12 @@ class CreateAccount {
 	 * @return True if Checkout sign-up feature should be made available.
 	 */
 	private static function is_feature_enabled() {
-		// This new checkout signup flow is gated to dev builds for now.
-		// The main reason for this is that we are waiting on an new
-		// set-password endpoint/form in WooCommerce Core.
-		// When that's available we can review this and include in feature
-		// plugin alongside checkout block.
-		return Package::is_experimental_build();
+		// Checkout signup is feature gated to WooCommerce 4.7 and newer;
+		// uses updated my-account/lost-password screen from 4.7+ for
+		// setting initial password.
+		// Also currently gated to dev builds only.
+		$woo_47_or_newer = ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '>=' ) );
+		return Package::is_experimental_build() && $woo_47_or_newer;
 	}
 
 	/**

--- a/src/Domain/Services/Email/CustomerNewAccount.php
+++ b/src/Domain/Services/Email/CustomerNewAccount.php
@@ -105,7 +105,16 @@ class CustomerNewAccount extends \WC_Email {
 			// Generate a magic link so user can set initial password.
 			$key = get_password_reset_key( $this->object );
 			if ( ! is_wp_error( $key ) ) {
-				$this->set_password_url = wc_get_account_endpoint_url( 'set-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
+				if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '<' ) ) {
+					// Fall back to wp-admin/unbranded reset password route/handler.
+					$this->set_password_url = network_site_url(
+						"wp-login.php?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login ),
+						'login'
+					);
+				} else {
+					// From v4.7 (TBC) WooCommerce core has a themed set-password endpoint we can use.
+					$this->set_password_url = wc_get_account_endpoint_url( 'set-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
+				}
 			}
 
 			$this->user_login = stripslashes( $this->object->user_login );

--- a/src/Domain/Services/Email/CustomerNewAccount.php
+++ b/src/Domain/Services/Email/CustomerNewAccount.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\Domain\Services\Email;
 
 use \WP_User;
 use \WC_Email;
+use \WC_Logger;
 use Automattic\WooCommerce\Blocks\Domain\Package;
 
 /**
@@ -96,16 +97,15 @@ class CustomerNewAccount extends \WC_Email {
 	public function trigger( $user_id, $user_pass = '', $password_generated = false ) {
 		$this->setup_locale();
 
+		$log = new WC_Logger();
+
 		if ( $user_id ) {
 			$this->object = new \WP_User( $user_id );
 
 			// Generate a magic link so user can set initial password.
 			$key = get_password_reset_key( $this->object );
 			if ( ! is_wp_error( $key ) ) {
-				$this->set_password_url = network_site_url(
-					"wp-login.php?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login ),
-					'login'
-				);
+				$this->set_password_url = wc_get_account_endpoint_url( 'lost-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
 			}
 
 			$this->user_login = stripslashes( $this->object->user_login );

--- a/src/Domain/Services/Email/CustomerNewAccount.php
+++ b/src/Domain/Services/Email/CustomerNewAccount.php
@@ -3,7 +3,6 @@ namespace Automattic\WooCommerce\Blocks\Domain\Services\Email;
 
 use \WP_User;
 use \WC_Email;
-use \WC_Logger;
 use Automattic\WooCommerce\Blocks\Domain\Package;
 
 /**
@@ -97,24 +96,13 @@ class CustomerNewAccount extends \WC_Email {
 	public function trigger( $user_id, $user_pass = '', $password_generated = false ) {
 		$this->setup_locale();
 
-		$log = new WC_Logger();
-
 		if ( $user_id ) {
 			$this->object = new \WP_User( $user_id );
 
 			// Generate a magic link so user can set initial password.
 			$key = get_password_reset_key( $this->object );
 			if ( ! is_wp_error( $key ) ) {
-				if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '<' ) ) {
-					// Fall back to wp-admin/unbranded reset password route/handler.
-					$this->set_password_url = network_site_url(
-						"wp-login.php?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login ),
-						'login'
-					);
-				} else {
-					// From v4.7 (TBC) WooCommerce core has a themed set-password endpoint we can use.
-					$this->set_password_url = wc_get_account_endpoint_url( 'set-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
-				}
+				$this->set_password_url = wc_get_account_endpoint_url( 'lost-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
 			}
 
 			$this->user_login = stripslashes( $this->object->user_login );

--- a/src/Domain/Services/Email/CustomerNewAccount.php
+++ b/src/Domain/Services/Email/CustomerNewAccount.php
@@ -105,7 +105,7 @@ class CustomerNewAccount extends \WC_Email {
 			// Generate a magic link so user can set initial password.
 			$key = get_password_reset_key( $this->object );
 			if ( ! is_wp_error( $key ) ) {
-				$this->set_password_url = wc_get_account_endpoint_url( 'lost-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
+				$this->set_password_url = wc_get_account_endpoint_url( 'set-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
 			}
 
 			$this->user_login = stripslashes( $this->object->user_login );

--- a/src/Domain/Services/Email/CustomerNewAccount.php
+++ b/src/Domain/Services/Email/CustomerNewAccount.php
@@ -102,7 +102,14 @@ class CustomerNewAccount extends \WC_Email {
 			// Generate a magic link so user can set initial password.
 			$key = get_password_reset_key( $this->object );
 			if ( ! is_wp_error( $key ) ) {
-				$this->set_password_url = wc_get_account_endpoint_url( 'lost-password' ) . "?action=rp&key=$key&login=" . rawurlencode( $this->object->user_login );
+				// In Woo 4.7 (tbc) and newer, we can use different `action` values
+				// to customise the "Lost password" page title.
+				// In older versions of Woo, we use lost-password endpoint as is.
+				$action = 'newaccount';
+				if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '<' ) ) {
+					$action = 'rp';
+				}
+				$this->set_password_url = wc_get_account_endpoint_url( 'lost-password' ) . "?action=$action&key=$key&login=" . rawurlencode( $this->object->user_login );
 			}
 
 			$this->user_login = stripslashes( $this->object->user_login );

--- a/src/Domain/Services/Email/CustomerNewAccount.php
+++ b/src/Domain/Services/Email/CustomerNewAccount.php
@@ -102,13 +102,7 @@ class CustomerNewAccount extends \WC_Email {
 			// Generate a magic link so user can set initial password.
 			$key = get_password_reset_key( $this->object );
 			if ( ! is_wp_error( $key ) ) {
-				// In Woo 4.7 (tbc) and newer, we can use different `action` values
-				// to customise the "Lost password" page title.
-				// In older versions of Woo, we use lost-password endpoint as is.
-				$action = 'newaccount';
-				if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '<' ) ) {
-					$action = 'rp';
-				}
+				$action                 = 'newaccount';
 				$this->set_password_url = wc_get_account_endpoint_url( 'lost-password' ) . "?action=$action&key=$key&login=" . rawurlencode( $this->object->user_login );
 			}
 

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -167,11 +167,16 @@ class Checkout extends AbstractRoute {
 		// Create a new user account as necessary.
 		// Note - CreateAccount class includes feature gating logic (i.e. this
 		// may not create an account depending on build).
-		try {
-			$create_account = Package::container()->get( CreateAccount::class );
-			$create_account->from_order_request( $order_object, $request );
-		} catch ( Exception $error ) {
-			$this->handle_error( $error );
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '>=' ) ) {
+			// Checkout signup is feature gated to WooCommerce 4.7 and newer;
+			// Because it requires updated my-account/lost-password screen in 4.7+
+			// for setting initial password.
+			try {
+				$create_account = Package::container()->get( CreateAccount::class );
+				$create_account->from_order_request( $order_object, $request );
+			} catch ( Exception $error ) {
+				$this->handle_error( $error );
+			}
 		}
 
 		// Persist customer address data to account.


### PR DESCRIPTION
Fixes #3237

This PR is a companion with https://github.com/woocommerce/woocommerce/pull/27898 in WooCommerce core - recommend testing them together.

This PR uses `my-account/lost-password` endpoint for the set-password flow for checkout signup. The endpoint uses store theme, so that improves the experience and makes setting a password more reassuring. (The flow currently uses a wp-admin themed password set form.)

The lost password form provides the functionality we need – securely set an account password. However, it is not ideal from a UX point of view as the page title (`Lost password`) doesn't match the user scenario - the user is setting their password for the first time, they have not lost anything!

To improve that part of the experience, there are changes in Woo Core to allow customizing the endpoint page title based on the `action` url param (https://github.com/woocommerce/woocommerce/pull/27898). Once this is available (aiming for Woo 4.7), we'll use `action=newaccount` to trigger the new page title (`Set password`).

### Screenshots

Existing behaviour (`master`, dev build of blocks plugin):

<img width="1122" alt="Screen Shot 2020-08-05 at 4 00 54 PM" src="https://user-images.githubusercontent.com/4167300/89370444-d92b8280-d734-11ea-9ce6-25979b5309e6.png">

Using `lost-password` endpoint, no core changes (this PR, any supported Woo version):

<img width="1407" alt="Screen Shot 2020-10-08 at 10 01 53 AM" src="https://user-images.githubusercontent.com/4167300/95387521-50f07600-094d-11eb-8e0c-49999f75eb09.png">

Using `lost-password` endpoint, new title in Woo core (this PR + https://github.com/woocommerce/woocommerce/pull/27898):

<img width="1407" alt="Screen Shot 2020-10-08 at 10 01 22 AM" src="https://user-images.githubusercontent.com/4167300/95387459-39b18880-094d-11eb-8440-7a193eec2725.png">

### How to test the changes in this Pull Request:
Follow the detailed instructions in https://github.com/woocommerce/woocommerce/pull/27898.

Also repeat the test with different versions of Woo core - e.g. oldest supported version - to ensure everything works as expected.

### Changelog

> Enhancement: Use a store-themed set password page when creating an account from Checkout block. #3236
