### PR TITLE
Add __experimental_woocommerce_blocks_checkout_order_processed action

### DIFF
--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -182,6 +182,10 @@ class Checkout extends AbstractRoute {
 		// Persist customer address data to account.
 		$order_controller->sync_customer_data_with_order( $order_object );
 
+		// Fire woocommerce_blocks_checkout_order_processed, should work the same way as woocommerce_checkout_order_processed
+		// But we're opting for a new action because the original ones attaches POST data.
+		do_action( 'woocommerce_blocks_checkout_order_processed', $order_object->get_id(), [] );
+
 		if ( ! $order_object->needs_payment() ) {
 			$payment_result = $this->process_without_payment( $order_object, $request );
 		} else {

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -184,7 +184,7 @@ class Checkout extends AbstractRoute {
 
 		// Fire woocommerce_blocks_checkout_order_processed, should work the same way as woocommerce_checkout_order_processed
 		// But we're opting for a new action because the original ones attaches POST data.
-		do_action( 'woocommerce_blocks_checkout_order_processed', $order_object->get_id(), [] );
+		do_action( 'woocommerce_blocks_checkout_order_processed', $order_object->get_id(), [], $order_object );
 
 		if ( ! $order_object->needs_payment() ) {
 			$payment_result = $this->process_without_payment( $order_object, $request );

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -188,7 +188,7 @@ class Checkout extends AbstractRoute {
 		* NOTE: this hook is still experimental, and might change or get removed.
 		* @todo: Document and stabilize __experimental_woocommerce_blocks_checkout_order_processed
 		*/
-		do_action( '__experimental_woocommerce_blocks_checkout_order_processed', $order_object->get_id(), $order_object );
+		do_action( '__experimental_woocommerce_blocks_checkout_order_processed', $order_object );
 
 		if ( ! $order_object->needs_payment() ) {
 			$payment_result = $this->process_without_payment( $order_object, $request );

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -182,9 +182,13 @@ class Checkout extends AbstractRoute {
 		// Persist customer address data to account.
 		$order_controller->sync_customer_data_with_order( $order_object );
 
-		// Fire woocommerce_blocks_checkout_order_processed, should work the same way as woocommerce_checkout_order_processed
-		// But we're opting for a new action because the original ones attaches POST data.
-		do_action( 'woocommerce_blocks_checkout_order_processed', $order_object->get_id(), $order_object );
+		/*
+		* Fire woocommerce_blocks_checkout_order_processed, should work the same way as woocommerce_checkout_order_processed
+		* But we're opting for a new action because the original ones attaches POST data.
+		* NOTE: this hook is still experimental, and might change or get removed.
+		* @todo: Document and stabilize __experimental_woocommerce_blocks_checkout_order_processed
+		*/
+		do_action( '__experimental_woocommerce_blocks_checkout_order_processed', $order_object->get_id(), $order_object );
 
 		if ( ! $order_object->needs_payment() ) {
 			$payment_result = $this->process_without_payment( $order_object, $request );

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -184,7 +184,7 @@ class Checkout extends AbstractRoute {
 
 		// Fire woocommerce_blocks_checkout_order_processed, should work the same way as woocommerce_checkout_order_processed
 		// But we're opting for a new action because the original ones attaches POST data.
-		do_action( 'woocommerce_blocks_checkout_order_processed', $order_object->get_id(), [], $order_object );
+		do_action( 'woocommerce_blocks_checkout_order_processed', $order_object->get_id(), $order_object );
 
 		if ( ! $order_object->needs_payment() ) {
 			$payment_result = $this->process_without_payment( $order_object, $request );


### PR DESCRIPTION
This is the first half of two PRs that should close this [issue](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3233)

It adds `__experimental_woocommerce_blocks_checkout_order_processed ` action that mimics `woocommerce_checkout_order_processed` but with a slightly different signutare.

```php
// blocks action
do_action( "__experimental_woocommerce_blocks_checkout_order_processed", $order_id, $order_object );
// classic action
do_action( "woocommerce_checkout_order_processed", $order_id, $posted_data, $order_object );
```

We omit $posted_data because we don't have any, and simply pass an empty array so we don't break any type check.

I decided to create `woocommerce_blocks_checkout_order_processed` instead of firing `woocommerce_checkout_order_processed` directly because of the missing post data issue.

This action was created for WooCommerce subscriptions, which thankfully doesn't use any `$_POST` data.


### How to test the changes in this Pull Request:
It's hard to test this right now, you will need to check out this PR in WooCommerce Subscriptions and follow the testing instructions there.