### PR TITLE
Fix PaymentMethodTab wrong propType

### DIFF
--- a/assets/js/base/components/payment-methods/payment-method-tab.js
+++ b/assets/js/base/components/payment-methods/payment-method-tab.js
@@ -54,7 +54,7 @@ const PaymentMethodTab = ( { children, allowsSaving } ) => {
 };
 
 PaymentMethodTab.propTypes = {
-	allowsSaving: PropTypes.string,
+	allowsSaving: PropTypes.bool,
 	children: PropTypes.node,
 };
 


### PR DESCRIPTION
In #3226 I added propTypes to the `PaymentMethodTab` component, but by mistake I defined `allowsSaving` as a string instead of a bool and that was printing some errors in the console. This PR fixes its definition.

### How to test the changes in this Pull Request:

With a user that has saved payment methods, go to the Checkout block and verify there are no errors related to the `allowsSaving` propType in the browser console.
