### PR TITLE
Ensure new payment methods are only displayed when no saved payment method is selected

### DIFF
--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -11,10 +11,10 @@ import classNames from 'classnames';
  * specified via props.
  *
  * @param {Object} props Incoming props for the component.
- * @param {string} props.label Label content.
- * @param {string} props.screenReaderLabel Content for screen readers.
- * @param {string} props.wrapperElement What element is used to wrap the label.
- * @param {Object} props.wrapperProps Props passed into wrapper element.
+ * @param {string} [props.label] Label content.
+ * @param {string} [props.screenReaderLabel] Content for screen readers.
+ * @param {string} [props.wrapperElement] What element is used to wrap the label.
+ * @param {Object} [props.wrapperProps] Props passed into wrapper element.
  */
 const Label = ( {
 	label,

--- a/assets/js/base/components/label/index.js
+++ b/assets/js/base/components/label/index.js
@@ -20,7 +20,7 @@ const Label = ( {
 	label,
 	screenReaderLabel,
 	wrapperElement,
-	wrapperProps,
+	wrapperProps = {},
 } ) => {
 	let Wrapper;
 
@@ -62,10 +62,6 @@ Label.propTypes = {
 	screenReaderLabel: PropTypes.node,
 	wrapperElement: PropTypes.elementType,
 	wrapperProps: PropTypes.object,
-};
-
-Label.defaultProps = {
-	wrapperProps: {},
 };
 
 export default Label;

--- a/assets/js/base/components/payment-methods/payment-methods.js
+++ b/assets/js/base/components/payment-methods/payment-methods.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { usePaymentMethods } from '@woocommerce/base-hooks';
-import { usePaymentMethodDataContext } from '@woocommerce/base-context';
+import { useCallback, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,23 +17,25 @@ import SavedPaymentMethodOptions from './saved-payment-method-options';
  * @return {*} The rendered component.
  */
 const PaymentMethods = () => {
-	const {
-		customerPaymentMethods = {},
-		paymentMethodData,
-	} = usePaymentMethodDataContext();
 	const { isInitialized, paymentMethods } = usePaymentMethods();
+	const [ showNewPaymentMethods, setShowNewPaymentMethods ] = useState(
+		true
+	);
+	const onChange = useCallback(
+		( token ) => {
+			setShowNewPaymentMethods( token === '0' );
+		},
+		[ setShowNewPaymentMethods ]
+	);
 
 	if ( isInitialized && Object.keys( paymentMethods ).length === 0 ) {
 		return <NoPaymentMethods />;
 	}
 
-	return Object.keys( customerPaymentMethods ).length > 0 &&
-		paymentMethodData.isSavedToken ? (
-		<SavedPaymentMethodOptions />
-	) : (
+	return (
 		<>
-			<SavedPaymentMethodOptions />
-			<PaymentMethodOptions />
+			<SavedPaymentMethodOptions onChange={ onChange } />
+			{ showNewPaymentMethods && <PaymentMethodOptions /> }
 		</>
 	);
 };

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -9,6 +9,7 @@ import {
 } from '@woocommerce/base-context';
 import RadioControl from '@woocommerce/base-components/radio-control';
 import { getPaymentMethods } from '@woocommerce/blocks-registry';
+import PropTypes from 'prop-types';
 
 /**
  * @typedef {import('@woocommerce/type-defs/contexts').CustomerPaymentMethod} CustomerPaymentMethod
@@ -170,6 +171,10 @@ const SavedPaymentMethodOptions = ( { onChange } ) => {
 			options={ [ ...currentOptions.current, newPaymentMethodOption ] }
 		/>
 	) : null;
+};
+
+SavedPaymentMethodOptions.propTypes = {
+	onChange: PropTypes.func.isRequired,
 };
 
 export default SavedPaymentMethodOptions;

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -102,6 +102,18 @@ const SavedPaymentMethodOptions = ( { onChange } ) => {
 	 * @property  {Array}  current  The current options on the type.
 	 */
 	const currentOptions = useRef( [] );
+
+	const updateToken = useCallback(
+		( token ) => {
+			if ( token === '0' ) {
+				setPaymentStatus().started();
+			}
+			setSelectedToken( token );
+			onChange( token );
+		},
+		[ onChange, setSelectedToken, setPaymentStatus ]
+	);
+
 	useEffect( () => {
 		const types = Object.keys( customerPaymentMethods );
 		const options = types
@@ -126,7 +138,7 @@ const SavedPaymentMethodOptions = ( { onChange } ) => {
 									setPaymentStatus
 							  );
 					if ( paymentMethod.is_default && selectedToken === '' ) {
-						setSelectedToken( paymentMethod.tokenId + '' );
+						updateToken( paymentMethod.tokenId + '' );
 						option.onChange( paymentMethod.tokenId );
 					}
 					return option;
@@ -136,27 +148,12 @@ const SavedPaymentMethodOptions = ( { onChange } ) => {
 		currentOptions.current = options;
 	}, [
 		customerPaymentMethods,
+		updateToken,
 		selectedToken,
 		setActivePaymentMethod,
 		setPaymentStatus,
 		standardMethods,
 	] );
-
-	const updateToken = useCallback(
-		( token ) => {
-			if ( token === '0' ) {
-				setPaymentStatus().started();
-			}
-			setSelectedToken( token );
-		},
-		[ setSelectedToken, setPaymentStatus ]
-	);
-	useEffect( () => {
-		if ( selectedToken && currentOptions.current.length > 0 ) {
-			updateToken( selectedToken );
-			onChange( selectedToken );
-		}
-	}, [ onChange, selectedToken, updateToken ] );
 
 	// In the editor, show `Use a new payment method` option as selected.
 	const selectedOption = isEditor ? '0' : selectedToken + '';
@@ -169,10 +166,7 @@ const SavedPaymentMethodOptions = ( { onChange } ) => {
 		<RadioControl
 			id={ 'wc-payment-method-saved-tokens' }
 			selected={ selectedOption }
-			onChange={ ( token ) => {
-				updateToken( token );
-				onChange( token );
-			} }
+			onChange={ updateToken }
 			options={ [ ...currentOptions.current, newPaymentMethodOption ] }
 		/>
 	) : null;

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -87,7 +87,7 @@ const getDefaultPaymentMethodOptions = (
 	};
 };
 
-const SavedPaymentMethodOptions = () => {
+const SavedPaymentMethodOptions = ( { onChange } ) => {
 	const { isEditor } = useEditorContext();
 	const {
 		setPaymentStatus,
@@ -154,8 +154,9 @@ const SavedPaymentMethodOptions = () => {
 	useEffect( () => {
 		if ( selectedToken && currentOptions.current.length > 0 ) {
 			updateToken( selectedToken );
+			onChange( selectedToken );
 		}
-	}, [ selectedToken, updateToken ] );
+	}, [ onChange, selectedToken, updateToken ] );
 
 	// In the editor, show `Use a new payment method` option as selected.
 	const selectedOption = isEditor ? '0' : selectedToken + '';
@@ -168,7 +169,10 @@ const SavedPaymentMethodOptions = () => {
 		<RadioControl
 			id={ 'wc-payment-method-saved-tokens' }
 			selected={ selectedOption }
-			onChange={ updateToken }
+			onChange={ ( token ) => {
+				updateToken( token );
+				onChange( token );
+			} }
 			options={ [ ...currentOptions.current, newPaymentMethodOption ] }
 		/>
 	) : null;

--- a/assets/js/base/components/payment-methods/test/payment-methods.js
+++ b/assets/js/base/components/payment-methods/test/payment-methods.js
@@ -13,9 +13,6 @@ import { PaymentMethodDataProvider } from '@woocommerce/base-context';
  */
 import PaymentMethods from '../payment-methods';
 
-jest.mock( '../no-payment-methods', () => () => (
-	<span>No payment methods</span>
-) );
 jest.mock( '../payment-method-options', () => () => (
 	<span>Payment method options</span>
 ) );
@@ -59,7 +56,9 @@ describe( 'PaymentMethods', () => {
 		);
 
 		await waitFor( () => {
-			const noPaymentMethods = screen.queryByText( /No payment methods/ );
+			const noPaymentMethods = screen.queryByText(
+				/no payment methods available/
+			);
 			expect( noPaymentMethods ).not.toBeNull();
 		} );
 	} );

--- a/assets/js/base/components/payment-methods/test/payment-methods.js
+++ b/assets/js/base/components/payment-methods/test/payment-methods.js
@@ -1,0 +1,103 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import * as mockBaseHooks from '@woocommerce/base-hooks';
+
+/**
+ * Internal dependencies
+ */
+import PaymentMethods from '../payment-methods';
+
+jest.mock( '../no-payment-methods', () => () => (
+	<span>No payment methods</span>
+) );
+jest.mock( '../payment-method-options', () => () => (
+	<span>Payment method options</span>
+) );
+jest.mock( '../saved-payment-method-options', () => ( { onChange } ) => (
+	<>
+		<span>Saved payment method options</span>
+		<button onClick={ () => onChange( '1' ) }>Select saved</button>
+		<button onClick={ () => onChange( '0' ) }>Select not saved</button>
+	</>
+) );
+
+jest.mock( '@woocommerce/base-hooks', () => ( {
+	...jest.requireActual( '@woocommerce/base-hooks' ),
+	usePaymentMethods: jest.fn(),
+} ) );
+
+describe( 'PaymentMethods', () => {
+	afterEach( () => {
+		mockBaseHooks.usePaymentMethods.mockReset();
+	} );
+
+	test( 'should show no payment methods component when there are no payment methods', async () => {
+		mockBaseHooks.usePaymentMethods.mockImplementation( () => ( {
+			isInitialized: true,
+			paymentMethods: {},
+		} ) );
+		render( <PaymentMethods /> );
+
+		await waitFor( () => {
+			const noPaymentMethods = screen.queryByText( /No payment methods/ );
+			expect( noPaymentMethods ).not.toBeNull();
+		} );
+	} );
+
+	test( 'should hide/show PaymentMethodOptions when a saved payment method is checked/unchecked', async () => {
+		mockBaseHooks.usePaymentMethods.mockImplementation( () => ( {
+			isInitialized: true,
+			paymentMethods: {
+				cheque: {
+					name: 'cheque',
+					label: 'Cheque',
+					content: <div>Cheque payment method</div>,
+					edit: <div>Cheque payment method</div>,
+					icons: null,
+					canMakePayment: () => true,
+					ariaLabel: 'Cheque',
+				},
+			},
+		} ) );
+		render( <PaymentMethods /> );
+
+		await waitFor( () => {
+			const savedPaymentMethodOptions = screen.queryByText(
+				/Saved payment method options/
+			);
+			const paymentMethodOptions = screen.queryByText(
+				/Payment method options/
+			);
+			expect( savedPaymentMethodOptions ).not.toBeNull();
+			expect( paymentMethodOptions ).not.toBeNull();
+		} );
+
+		fireEvent.click( screen.getByText( 'Select saved' ) );
+
+		await waitFor( () => {
+			const savedPaymentMethodOptions = screen.queryByText(
+				/Saved payment method options/
+			);
+			const paymentMethodOptions = screen.queryByText(
+				/Payment method options/
+			);
+			expect( savedPaymentMethodOptions ).not.toBeNull();
+			expect( paymentMethodOptions ).toBeNull();
+		} );
+
+		fireEvent.click( screen.getByText( 'Select not saved' ) );
+
+		await waitFor( () => {
+			const savedPaymentMethodOptions = screen.queryByText(
+				/Saved payment method options/
+			);
+			const paymentMethodOptions = screen.queryByText(
+				/Payment method options/
+			);
+			expect( savedPaymentMethodOptions ).not.toBeNull();
+			expect( paymentMethodOptions ).not.toBeNull();
+		} );
+	} );
+} );

--- a/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -192,7 +192,7 @@ describe( 'Testing Payment Method Data Context Provider', () => {
 			return (
 				<>
 					<CheckoutExpressPayment />
-					<SavedPaymentMethodOptions />
+					<SavedPaymentMethodOptions onChange={ () => void null } />
 					{ 'Active Payment Method: ' + activePaymentMethod }
 					{ paymentMethodData[ 'wc-stripe-payment-token' ] && (
 						<span>Stripe token</span>


### PR DESCRIPTION
Fixes #3234.

The issue was probably introduced in #3135.

This PR adds back a state to `PaymentMethods`, but instead of saving the token, it just saves a boolean (`showNewPaymentMethods`).

This PR also removes an unnecessary `useEffect()` from `SavedPaymentMethodOptions`.

### How to test the changes in this Pull Request:

1. Make sure you are logged in on an account with saved payment methods.
2. Add products to the cart.
3. Checkout with the checkout block.
4. Select express payment method and then cancel to close the modal.
5. Scroll down and verify the payment methods tabs are not displayed. (Only the radios should be visible)

### Changelog

> Fixed a regression that was displaying payment method tabs when an express payment method was cancelled and the previously selected option was a saved payment method.