### PR TITLE
Simplify emitEventWithAbort logic

### DIFF
--- a/assets/js/base/context/shared/event-emit/emitters.js
+++ b/assets/js/base/context/shared/event-emit/emitters.js
@@ -58,22 +58,18 @@ export const emitEvent = async ( observers, eventType, data ) => {
  */
 export const emitEventWithAbort = async ( observers, eventType, data ) => {
 	const observersByType = getObserversByPriority( observers, eventType );
-	let emitterResponse = true;
 	for ( const observer of observersByType ) {
 		try {
 			const response = await Promise.resolve( observer.callback( data ) );
-			if (
-				typeof response === 'object' &&
-				typeof response.type === 'undefined'
-			) {
+			if ( typeof response !== 'object' ) {
+				continue;
+			}
+			if ( typeof response.type === 'undefined' ) {
 				throw new Error(
 					'If you want to abort event emitter processing, your observer must return an object with a type property'
 				);
 			}
-			emitterResponse = typeof response === 'object' ? response : true;
-			if ( emitterResponse !== true ) {
-				return emitterResponse;
-			}
+			return response;
 		} catch ( e ) {
 			// We don't handle thrown errors but just console.log for troubleshooting.
 			// eslint-disable-next-line no-console
@@ -81,5 +77,5 @@ export const emitEventWithAbort = async ( observers, eventType, data ) => {
 			return { type: 'error' };
 		}
 	}
-	return emitterResponse;
+	return true;
 };


### PR DESCRIPTION
Small PR that refactors `emitEventWithAbort`, it should work equivalently but with fewer lines of code.

### How to test the changes in this Pull Request:

Fortunately, event emitters have good test coverage, so if the refactor produced any output difference, it will probably be caught by tests.

Steps to test it manually:
1. Place an order using the Stripe payment gateway with the card number `4000000000000101` (it will fail with an invalid CVC error).
2. Verify the order isn't processed and an error is displayed in the frontend.