### PR TITLE
Save order after creating an account

### DIFF
--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -115,15 +115,13 @@ class CreateAccount {
 		}
 
 		$customer_id = $this->create_customer_account(
-			$order->get_billing_email(),
-			$order->get_billing_first_name(),
-			$order->get_billing_last_name()
+			$request['billing_address']['email'],
+			$request['billing_address']['first_name'],
+			$request['billing_address']['last_name']
 		);
-
 		// Log the customer in and associate with the order.
 		wc_set_customer_auth_cookie( $customer_id );
 		$order->set_customer_id( get_current_user_id() );
-		$order->save();
 
 		return $customer_id;
 	}

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -98,18 +98,16 @@ class CreateAccount {
 	}
 
 	/**
-	 * Create a user account for specified order and request (if necessary).
+	 * Create a user account for specified request (if necessary).
 	 * If a new account is created:
-	 * - The order is associated with the account.
 	 * - The user is logged in.
 	 *
-	 * @param \WC_Order        $order   The order currently being processed.
 	 * @param \WP_REST_Request $request The current request object being handled.
 	 *
 	 * @throws Exception On error.
 	 * @return int The new user id, or 0 if no user was created.
 	 */
-	public function from_order_request( \WC_Order $order, \WP_REST_Request $request ) {
+	public function from_order_request( \WP_REST_Request $request ) {
 		if ( ! self::is_feature_enabled() || ! $this->should_create_customer_account( $request ) ) {
 			return 0;
 		}
@@ -121,7 +119,6 @@ class CreateAccount {
 		);
 		// Log the customer in and associate with the order.
 		wc_set_customer_auth_cookie( $customer_id );
-		$order->set_customer_id( get_current_user_id() );
 
 		return $customer_id;
 	}

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -123,6 +123,7 @@ class CreateAccount {
 		// Log the customer in and associate with the order.
 		wc_set_customer_auth_cookie( $customer_id );
 		$order->set_customer_id( get_current_user_id() );
+		$order->save();
 
 		return $customer_id;
 	}

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -158,12 +158,6 @@ class Checkout extends AbstractRoute {
 		// Ensure order still matches cart.
 		$order_controller->update_order_from_cart( $order_object );
 
-		// If any form fields were posted, update the order.
-		$this->update_order_from_request( $order_object, $request );
-
-		// Check order is still valid.
-		$order_controller->validate_order_before_payment( $order_object );
-
 		// Create a new user account as necessary.
 		// Note - CreateAccount class includes feature gating logic (i.e. this
 		// may not create an account depending on build).
@@ -178,6 +172,11 @@ class Checkout extends AbstractRoute {
 				$this->handle_error( $error );
 			}
 		}
+		// If any form fields were posted, update the order.
+		$this->update_order_from_request( $order_object, $request );
+
+		// Check order is still valid.
+		$order_controller->validate_order_before_payment( $order_object );
 
 		// Persist customer address data to account.
 		$order_controller->sync_customer_data_with_order( $order_object );

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -168,7 +168,7 @@ class Checkout extends AbstractRoute {
 			try {
 				$create_account = Package::container()->get( CreateAccount::class );
 				$create_account->from_order_request( $request );
-				$order->set_customer_id( get_current_user_id() );
+				$order_object->set_customer_id( get_current_user_id() );
 			} catch ( Exception $error ) {
 				$this->handle_error( $error );
 			}

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -167,7 +167,8 @@ class Checkout extends AbstractRoute {
 			// for setting initial password.
 			try {
 				$create_account = Package::container()->get( CreateAccount::class );
-				$create_account->from_order_request( $order_object, $request );
+				$create_account->from_order_request( $request );
+				$order->set_customer_id( get_current_user_id() );
 			} catch ( Exception $error ) {
 				$this->handle_error( $error );
 			}

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -52,7 +52,8 @@ class CreateAccount extends WP_UnitTestCase {
 
 		/// -- End test-specific setup.
 
-		$user_id = $this->get_test_instance()->from_order_request( $test_order, $test_request );
+		$user_id = $this->get_test_instance()->from_order_request( $test_request );
+		$test_order->set_customer_id( $user_id );
 
 		/// -- Undo test-specific setup; restore previous state.
 		update_option( 'woocommerce_enable_guest_checkout', $tmp_enable_guest_checkout );

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -42,11 +42,13 @@ class CreateAccount extends WP_UnitTestCase {
 		$test_request = new \WP_REST_Request();
 		$should_create_account = array_key_exists( 'should_create_account', $options ) ? $options['should_create_account'] : false;
 		$test_request->set_param( 'should_create_account', $should_create_account );
+		$test_request->set_param( 'billing_address', [
+			'email'      => $email,
+			'first_name' => $first_name,
+			'last_name'  => $last_name
+		]);
 
 		$test_order = new \WC_Order();
-		$test_order->set_billing_email( $email );
-		$test_order->set_billing_first_name( $first_name );
-		$test_order->set_billing_last_name( $last_name );
 
 		/// -- End test-specific setup.
 


### PR DESCRIPTION
I found this bug while investigating https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3253
The issue was that subscriptions would attempt to create a new order via `new WC_Order( $order_id )`, that order didn't have the customer id in it.

After some digging and asking around, it seems that we need to call `$order->save` after altering the order.

We can use this option (in this PR) by calling `save` after creating the account.

This means we're calling save twice: once in `update_order_from_request` and in here.

I'm not fully sure if save is an expensive method to call, it updates the database directly so it feels expensive, but I don't have any data to prove it.

If it proves to be expensive, we can attempt to create the account before syncing the data.

This means, instead of fetching the email and name from `$order`, we will fetch them from `$request`.

I prefer the second solution, but I'm not sure if it would prove to be problematic, I have a  feeling it won't be problematic because the request will always contain all of the data needed.

### How to test
- It's better to test this in combo with https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238 and https://github.com/woocommerce/woocommerce-subscriptions/pull/3825 to see the subscription creating the account, but that's not straightforward, so we will ensure we have no regression.

- On incognito, checkout and create an account.
- Make sure the account contains the correct data.
