### PR TITLE
Add an interim filter for cart item and expose prepare_money_response

### DIFF
--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -230,7 +230,7 @@ abstract class AbstractSchema {
 	 * @param int          $rounding_mode Defaults to the PHP_ROUND_HALF_UP constant.
 	 * @return string      The new amount.
 	 */
-	protected function prepare_money_response( $amount, $decimals = 2, $rounding_mode = PHP_ROUND_HALF_UP ) {
+	public function prepare_money_response( $amount, $decimals = 2, $rounding_mode = PHP_ROUND_HALF_UP ) {
 		return (string) intval(
 			round(
 				( (float) wc_format_decimal( $amount ) ) * ( 10 ** $decimals ),

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -278,7 +278,7 @@ class CartItemSchema extends ProductSchema {
 	public function get_item_response( $cart_item ) {
 		$product = $cart_item['data'];
 
-		return [
+		$item_data = [
 			'key'                  => $cart_item['key'],
 			'id'                   => $product->get_id(),
 			'quantity'             => wc_stock_amount( $cart_item['quantity'] ),
@@ -305,6 +305,9 @@ class CartItemSchema extends ProductSchema {
 				]
 			),
 		];
+
+		// This filter will be delete an replaced by a proper register mechanism, don't use it.
+		return apply_filters( '__internal_woocommerce_blocks_cart_item', $item_data, $cart_item, $product, $this );
 	}
 
 	/**


### PR DESCRIPTION
## This PR does two things

### Add interim hook
In order to add subscription data to our endpoints, we need to provide some sort of a hook place, we discussed the approach we're going to take in this issue https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3244, but in order to not limit myself and overengineer it beforehand, I went ahead and created this interim filter that will be deleted once I implement what's discussed in that issue.

### Turn prepare_money_response to public
This function is used to format any monetary value, but it's protected, so third party code can't use it.
It's part of `AbstractSchema` and is only relevant when returning money in REST.
I temporarily turned it to public and will create an issue to decide if we want to keep it public or move it to a utility class.

## Why two changes in a single PR

Ideally, I would split those into two PRs, but to facilitate testing https://github.com/woocommerce/woocommerce-subscriptions/pull/3839 and because they're not permanent changes, I decided to keep them in a single PR. They're both needed for that PR.