### PR TITLE
Fix 3D secure payment errors

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -280,7 +280,7 @@ export const CheckoutStateProvider = ( {
 							dispatch( actions.setComplete( response ) );
 						} else {
 							// this will set an error which will end up
-							// triggering the onCheckoutAfterProcessingWithErrors emitter.
+							// triggering the onCheckoutAfterProcessingWithError emitter.
 							// and then setting checkout to IDLE state.
 							dispatch( actions.setHasError( true ) );
 						}

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -292,6 +292,7 @@ export const CheckoutStateProvider = ( {
 		isErrorResponse,
 		isFailResponse,
 		isSuccessResponse,
+		shouldRetry,
 	] );
 
 	const onSubmit = useCallback( () => {

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -10,7 +10,6 @@ import {
 	useEffect,
 	useCallback,
 } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { useStoreNotices, useEmitResponse } from '@woocommerce/base-hooks';
 
 /**
@@ -240,23 +239,11 @@ export const CheckoutStateProvider = ( {
 						// irrecoverable error so set complete
 						if ( ! shouldRetry( response ) ) {
 							dispatch( actions.setComplete( response ) );
-						} else {
-							dispatch( actions.setIdle() );
+							return;
 						}
-					} else {
-						// no error handling in place by anything so let's fall
-						// back to default
-						const message =
-							data.processingResponse?.message ||
-							__(
-								'Something went wrong. Please contact us to get assistance.',
-								'woo-gutenberg-products-block'
-							);
-						addErrorNotice( message, {
-							id: 'checkout',
-						} );
-						dispatch( actions.setIdle() );
 					}
+
+					dispatch( actions.setIdle() );
 				} );
 			} else {
 				emitEventWithAbort(

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -15,6 +15,7 @@ import {
 	useCheckoutNotices,
 	useStoreNotices,
 	useEmitResponse,
+	usePrevious,
 } from '@woocommerce/base-hooks';
 
 /**
@@ -219,7 +220,16 @@ export const CheckoutStateProvider = ( {
 		dispatch,
 	] );
 
+	const previousStatus = usePrevious( checkoutState.status );
+	const previousHasError = usePrevious( checkoutState.hasError );
+
 	useEffect( () => {
+		if (
+			checkoutState.status === previousStatus &&
+			checkoutState.hasError === previousHasError
+		) {
+			return;
+		}
 		if ( checkoutState.status === STATUS.AFTER_PROCESSING ) {
 			const data = {
 				redirectUrl: checkoutState.redirectUrl,
@@ -316,12 +326,15 @@ export const CheckoutStateProvider = ( {
 		checkoutState.customerId,
 		checkoutState.customerNote,
 		checkoutState.processingResponse,
+		previousStatus,
+		previousHasError,
 		dispatchActions,
 		addErrorNotice,
 		isErrorResponse,
 		isFailResponse,
 		isSuccessResponse,
 		shouldRetry,
+		checkoutNotices,
 		paymentNotices,
 		expressPaymentNotices,
 	] );

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -265,8 +265,8 @@ export const CheckoutStateProvider = ( {
 					} else {
 						if (
 							checkoutNotices.length === 0 &&
-							paymentNotices.length === 0 &&
-							expressPaymentNotices.length === 0
+							expressPaymentNotices.length === 0 &&
+							paymentNotices.length === 0
 						) {
 							// no error handling in place by anything so let's fall
 							// back to default
@@ -335,8 +335,8 @@ export const CheckoutStateProvider = ( {
 		isSuccessResponse,
 		shouldRetry,
 		checkoutNotices,
-		paymentNotices,
 		expressPaymentNotices,
+		paymentNotices,
 	] );
 
 	const onSubmit = useCallback( () => {

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -263,11 +263,17 @@ export const CheckoutStateProvider = ( {
 							dispatch( actions.setIdle() );
 						}
 					} else {
-						if (
-							checkoutNotices.length === 0 &&
-							expressPaymentNotices.length === 0 &&
-							paymentNotices.length === 0
-						) {
+						const hasErrorNotices =
+							checkoutNotices.some(
+								( notice ) => notice.status === 'error'
+							) ||
+							expressPaymentNotices.some(
+								( notice ) => notice.status === 'error'
+							) ||
+							paymentNotices.some(
+								( notice ) => notice.status === 'error'
+							);
+						if ( ! hasErrorNotices ) {
 							// no error handling in place by anything so let's fall
 							// back to default
 							const message =

--- a/assets/js/base/hooks/checkout/index.js
+++ b/assets/js/base/hooks/checkout/index.js
@@ -1,4 +1,5 @@
 export * from './use-checkout-redirect-url';
 export * from './use-checkout-address';
+export * from './use-checkout-notices';
 export * from './use-checkout-submit';
 export * from './use-emit-response';

--- a/assets/js/base/hooks/checkout/use-checkout-notices.js
+++ b/assets/js/base/hooks/checkout/use-checkout-notices.js
@@ -4,13 +4,30 @@
 import { useEmitResponse } from '@woocommerce/base-hooks';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * @typedef {import('@woocommerce/type-defs/contexts').StoreNoticeObject} StoreNoticeObject
+ * @typedef {import('@woocommerce/type-defs/hooks').CheckoutNotices} CheckoutNotices
+ */
+
+/**
+ * A hook that returns all notices visible in the Checkout block.
+ *
+ * @return {CheckoutNotices} Notices from the checkout form or payment methods.
+ */
 export const useCheckoutNotices = () => {
 	const { noticeContexts } = useEmitResponse();
 
+	/**
+	 * @type {StoreNoticeObject[]}
+	 */
 	const checkoutNotices = useSelect(
 		( select ) => select( 'core/notices' ).getNotices( 'wc/checkout' ),
 		[]
 	);
+
+	/**
+	 * @type {StoreNoticeObject[]}
+	 */
 	const expressPaymentNotices = useSelect(
 		( select ) =>
 			select( 'core/notices' ).getNotices(
@@ -18,6 +35,10 @@ export const useCheckoutNotices = () => {
 			),
 		[ noticeContexts.EXPRESS_PAYMENTS ]
 	);
+
+	/**
+	 * @type {StoreNoticeObject[]}
+	 */
 	const paymentNotices = useSelect(
 		( select ) =>
 			select( 'core/notices' ).getNotices( noticeContexts.PAYMENTS ),

--- a/assets/js/base/hooks/checkout/use-checkout-notices.js
+++ b/assets/js/base/hooks/checkout/use-checkout-notices.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { useEmitResponse } from '@woocommerce/base-hooks';
+import { useSelect } from '@wordpress/data';
+
+export const useCheckoutNotices = () => {
+	const { noticeContexts } = useEmitResponse();
+
+	const checkoutNotices = useSelect(
+		( select ) => select( 'core/notices' ).getNotices( 'wc/checkout' ),
+		[]
+	);
+	const expressPaymentNotices = useSelect(
+		( select ) =>
+			select( 'core/notices' ).getNotices(
+				noticeContexts.EXPRESS_PAYMENTS
+			),
+		[ noticeContexts.EXPRESS_PAYMENTS ]
+	);
+	const paymentNotices = useSelect(
+		( select ) =>
+			select( 'core/notices' ).getNotices( noticeContexts.PAYMENTS ),
+		[ noticeContexts.PAYMENTS ]
+	);
+
+	return {
+		checkoutNotices,
+		expressPaymentNotices,
+		paymentNotices,
+	};
+};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
@@ -56,7 +56,6 @@ export const useCheckoutSubscriptions = (
 	usePaymentIntents(
 		stripe,
 		onCheckoutAfterProcessingWithSuccess,
-		onCheckoutAfterProcessingWithError,
 		setSourceId,
 		emitResponse
 	);

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
@@ -57,6 +57,7 @@ export const useCheckoutSubscriptions = (
 		stripe,
 		onCheckoutAfterProcessingWithSuccess,
 		onCheckoutAfterProcessingWithError,
+		setSourceId,
 		emitResponse
 	);
 	usePaymentProcessing(

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-checkout-subscriptions.js
@@ -56,6 +56,7 @@ export const useCheckoutSubscriptions = (
 	usePaymentIntents(
 		stripe,
 		onCheckoutAfterProcessingWithSuccess,
+		onCheckoutAfterProcessingWithError,
 		emitResponse
 	);
 	usePaymentProcessing(

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-intents.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/use-payment-intents.js
@@ -71,6 +71,7 @@ export const usePaymentIntents = (
 	stripe,
 	onCheckoutAfterProcessingWithSuccess,
 	onCheckoutAfterProcessingWithError,
+	setSourceId,
 	emitResponse
 ) => {
 	const [ error, setError ] = useState( null );
@@ -95,6 +96,7 @@ export const usePaymentIntents = (
 						retry: response.retry,
 						messageContext: response.messageContext,
 					} );
+					setSourceId( '0' );
 					return { type: response.type, retry: response.retry };
 				}
 
@@ -109,6 +111,7 @@ export const usePaymentIntents = (
 		emitResponse.responseTypes.ERROR,
 		emitResponse.responseTypes.SUCCESS,
 		setError,
+		setSourceId,
 		stripe,
 	] );
 

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -1,6 +1,7 @@
 /**
  * @typedef {import('./cart').CartData} CartData
  * @typedef {import('./cart').CartShippingAddress} CartShippingAddress
+ * @typedef {import('./contexts').StoreNoticeObject} StoreNoticeObject
  */
 
 /**
@@ -73,6 +74,17 @@
  * @property {Function} removeItem             Callback for removing a cart item.
  * @property {Object}   cartItemQuantityErrors An array of errors thrown by
  *                                             the cart.
+ */
+
+/**
+ * @typedef {Object} CheckoutNotices
+ *
+ * @property {StoreNoticeObject[]} checkoutNotices       Array of notices in the
+ *                                                       checkout context.
+ * @property {StoreNoticeObject[]} expressPaymentNotices Array of notices in the
+ *                                                       express payment context.
+ * @property {StoreNoticeObject[]} paymentNotices        Array of notices in the
+ *                                                       payment context.
  */
 
 /**


### PR DESCRIPTION
Fixes #2743.

This PR fixes a couple of issues with 3D secure payment errors:

* After the error, it was not possible to make another payment without making a change in the card number. That was because we were not resetting the source id on error (5095d55ce25ca3361f384cafe94ea4eb70ada00c).
* Two errors were appearing instead of one. That's because the payment method error is created on `onCheckoutAfterProcessingSuccess`, when an error is created at that stage, it then triggers `onCheckoutAfterProcessingError` events. If no error was returned from `onCheckoutAfterProcessingError` events, we were adding a [default one](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/base/context/cart-checkout/checkout-state/index.js#L247-L257). That's why two errors were appearing: the one generated by the payment method in `onCheckoutAfterProcessingSuccess` and the default one generated by Blocks in `onCheckoutAfterProcessingError`.
~For now, I fixed it in Stripe's side saving the error message internally and returning it on `onCheckoutAfterProcessingError` (4a5c04eedcd9f63ab2c4cde2fef6cd95078a71a7), but I feel that's a bit complicated for payment methods. For example, the same issue occurs in WC Payments so we will need to fix it there too. That makes me wonder if we could make the process easier. Maybe removing the default error message that is added on `onCheckoutAfterProcessingError`? Another option would be not to trigger `onCheckoutAfterProcessingError` after an error occurred in `onCheckoutAfterProcessingSuccess`. Thoughts @nerrad?~
Update: we decided to add a check before showing the default error notice. So if there is already an error notice, the default one won't be added in `onCheckoutAfterProcessingError`.
* Fixed missing `useEffect()` dependencies (33280b5fd86272cd52ad810ac4e18539cf5d215b).
* Typo (d97a0fa3b94e464bd8d667e83c3e7f186a5269fc).

### Screenshots

![Peek 2020-10-13 10-22](https://user-images.githubusercontent.com/3616980/95835011-fc2e7000-0d3d-11eb-9153-41501316fa21.gif)

### How to test the changes in this Pull Request:

1. Install Stripe payment gateway and set it up.
2. Add products to the cart and go to a page with the Checkout block.
3. Place an order using Stripe with the card number `4000 0027 6000 3184` (it will open an authentication modal).
4. Click Cancel or fail the authentication.
5. Verify only one error is displayed, inside the payment methods step.
6. Without modifying the payment number, click on Place order again and verify the authentication modal appears again and you can place the order.

Now, let's pretend there is a payment gateway which doesn't add an error message when throwing an error. This way, we will ensure a default error notice is shown.

1. In [`use-payment-intents.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3272/files#diff-f1a85fd67379d04a2efe056f9ff6b51012e543cfd029212c8ccb7c657c17bd60R86-R91), make the following change:
```diff
			if (
				response.type === emitResponse.responseTypes.ERROR &&
				response.retry
			) {
				setSourceId( '0' );
+				return { type: response.type, retry: response.retry };
			}
```
2. Add products to the cart and go to a page with the Checkout block.
3. Place an order using Stripe with the card number `4000 0027 6000 3184` (it will open an authentication modal).
4. Click Cancel or fail the authentication.
5. Verify an error is displayed with a generic text, at the top of the form.

### Changelog

> Fix a couple of issues when a 3D secure payment was aborted: now only one error notice appears and the payment can be retried with the same card number.
