### PR TITLE
Document how to update E2E WP versions.

### DIFF
--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -7,7 +7,7 @@ The Blocks plugin follows the same patterns as Gutenberg, therefore for instruct
 We have two kinds of JavaScript tests:
 
 - JavaScript unit tests - test APIs, hooks, library functionality that we use to build blocks or expose to plugin authors.
-- End-to-end (e2e) tests - test blocks from the user interface. 
+- End-to-end (e2e) tests - test blocks from the user interface.
 
 These tests are all run automatically on open PRs by Travis CI.
 
@@ -34,7 +34,7 @@ Additionally,
 
 End-to-end tests are implemented in `tests/e2e-tests/specs/`.
 
-Since these drive the user interface, they need to run against a test environment - i.e. a web server running WordPress, Woo and blocks plugin, with a known state/configuration. 
+Since these drive the user interface, they need to run against a test environment - i.e. a web server running WordPress, Woo and blocks plugin, with a known state/configuration.
 
 To set up to run e2e tests:
 
@@ -43,7 +43,7 @@ To set up to run e2e tests:
 
 Then, to run the tests:
 
-- `npm run test:e2e` 
+- `npm run test:e2e`
 
 When you're iterating on a new test you'll often run this repeatedly, as you develop, until your test is just right.
 
@@ -52,3 +52,46 @@ When you're done, you may want to shut down the test environment:
 - `npm run wp-env stop` to stop the test environment
 
 **Note:** There are a number of other useful `wp-env` commands. You can find out more in the [wp-env docs](https://github.com/WordPress/gutenberg/blob/master/packages/env/README.md).
+
+### How to update end-to-end tests suites
+
+We follow the same WordPress support policy as WooCommerce, this means we need to support the latest version, and the two previous one (L-2).
+
+For that, we run end-to-end tests against all of those versions, and because we use packages published by Gutenberg, we also run tests against the latest version of Gutenberg plugin.
+
+When a new version of WordPress is released, we drop support for the oldest version we have, so if the latest version is 5.5, we would test against:
+
+- WordPress 5.3
+- WordPress 5.4
+- WordPress 5.5
+- WordPress 5.5 + Gutenberg
+
+When 5.6 is released, we would drop support for 5.3, and update our `./.travis.yml` file.
+
+You need to bump the test version, so
+
+```yml
+- name: E2E Tests (WP 5.3)
+	script:
+			- npm run test:e2e
+	env:
+			- WP_VERSION=5.3
+			- E2E_TESTS=1
+			- WOOCOMMERCE_BLOCKS_PHASE=3
+```
+
+Would become
+
+```yml
+- name: E2E Tests (WP 5.4)
+	script:
+			- npm run test:e2e
+	env:
+			- WP_VERSION=5.4
+			- E2E_TESTS=1
+			- WOOCOMMERCE_BLOCKS_PHASE=3
+```
+
+You also need to check any existing tests that checks the WP version.
+
+In `./tests/e2e/specs`, verify for conditions like `if ( process.env.WP_VERSION < 5.4 )` and remove them if they're not relevant anymore.

--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -55,7 +55,7 @@ When you're done, you may want to shut down the test environment:
 
 ### How to update end-to-end tests suites
 
-We follow the same WordPress support policy as WooCommerce, this means we need to support the latest version, and the two previous one (L-2).
+We follow the same WordPress support policy as WooCommerce, this means we need to support the latest version, and the two previous ones (L-2).
 
 For that, we run end-to-end tests against all of those versions, and because we use packages published by Gutenberg, we also run tests against the latest version of Gutenberg plugin.
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2721

This adds some docs to how we update our E2E WP version numbers.

