### PR TITLE
Fix React hook dependency warnings in filter an All Products blocks

### DIFF
--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -16,7 +16,7 @@ import './style.scss';
  *
  * @param {Object} props Incoming props for the component.
  * @param {string} props.className CSS class used.
- * @param {function():any} props.onChange Function called when inputs change.
+ * @param {function(string):any} props.onChange Function called when inputs change.
  * @param {Array} props.options Options for list.
  * @param {Array} props.checked Which items are checked.
  * @param {boolean} props.isLoading If loading or not.

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -142,6 +142,7 @@ const CheckboxList = ( {
 		);
 	}, [
 		options,
+		onChange,
 		checked,
 		showExpanded,
 		limit,

--- a/assets/js/base/components/price-slider/constrain-range-slider-values.js
+++ b/assets/js/base/components/price-slider/constrain-range-slider-values.js
@@ -2,8 +2,8 @@
  * Validate a min and max value for a range slider against defined constraints (min, max, step).
  *
  * @param {Array} values Array containing min and max values.
- * @param {number} min Min allowed value for the sliders.
- * @param {number} max Max allowed value for the sliders.
+ * @param {number|null} min Min allowed value for the sliders.
+ * @param {number|null} max Max allowed value for the sliders.
  * @param {number} step Step value for the sliders.
  * @param {boolean} isMin Whether we're currently interacting with the min range slider or not, so we update the correct values.
  * @return {Array} Validated and updated min/max values that fit within the range slider constraints.

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -112,7 +112,6 @@ const PriceSlider = ( {
 		minConstraint,
 		maxConstraint,
 		hasValidConstraints,
-		stepValue,
 	] );
 
 	/**
@@ -186,7 +185,14 @@ const PriceSlider = ( {
 				parseInt( values[ 1 ], 10 ),
 			] );
 		},
-		[ minPrice, maxPrice, minConstraint, maxConstraint, stepValue ]
+		[
+			onChange,
+			minPrice,
+			maxPrice,
+			minConstraint,
+			maxConstraint,
+			stepValue,
+		]
 	);
 
 	/**
@@ -221,14 +227,7 @@ const PriceSlider = ( {
 				parseInt( values[ 1 ], 10 ),
 			] );
 		},
-		[
-			minConstraint,
-			maxConstraint,
-			stepValue,
-			minPriceInput,
-			maxPriceInput,
-			currency,
-		]
+		[ onChange, stepValue, minPriceInput, maxPriceInput ]
 	);
 
 	const classes = classnames(

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -70,7 +70,7 @@ const generateQuery = ( { sortValue, currentPage, attributes } ) => {
 const extractPaginationAndSortAttributes = ( query ) => {
 	/* eslint-disable-next-line no-unused-vars, camelcase */
 	const { order, orderby, page, per_page, ...totalQuery } = query;
-	return totalQuery;
+	return totalQuery || {};
 };
 
 const announceLoadingCompletion = ( totalProducts ) => {
@@ -136,21 +136,25 @@ const ProductList = ( {
 		{ totalQuery, totalProducts },
 		areQueryTotalsDifferent
 	);
-	const isPreviousTotalQueryEqual =
-		typeof previousQueryTotals === 'object' &&
-		isEqual( totalQuery, previousQueryTotals.totalQuery );
-	useEffect( () => {
-		// If query state (excluding pagination/sorting attributes) changed,
-		// reset pagination to the first page.
-		if ( ! isPreviousTotalQueryEqual ) {
-			onPageChange( 1 );
 
-			// Make sure there was a previous query, so we don't announce it on page load.
-			if ( previousQueryTotals ) {
-				announceLoadingCompletion( totalProducts );
-			}
+	// If query state (excluding pagination/sorting attributes) changed,
+	// reset pagination to the first page.
+	useEffect( () => {
+		if ( isEqual( totalQuery, previousQueryTotals?.totalQuery ) ) {
+			return;
 		}
-	}, [ queryState ] );
+		onPageChange( 1 );
+
+		// Make sure there was a previous query, so we don't announce it on page load.
+		if ( previousQueryTotals?.totalQuery ) {
+			announceLoadingCompletion( totalProducts );
+		}
+	}, [
+		previousQueryTotals?.totalQuery,
+		totalProducts,
+		onPageChange,
+		totalQuery,
+	] );
 
 	const onPaginationChange = ( newPage ) => {
 		scrollToTop( { focusableSelector: 'a, button' } );
@@ -175,7 +179,9 @@ const ProductList = ( {
 	const { contentVisibility } = attributes;
 	const perPage = attributes.columns * attributes.rows;
 	const totalPages =
-		! Number.isFinite( totalProducts ) && isPreviousTotalQueryEqual
+		! Number.isFinite( totalProducts ) &&
+		Number.isFinite( previousQueryTotals?.totalProducts ) &&
+		isEqual( totalQuery, previousQueryTotals?.totalQuery )
 			? Math.ceil( previousQueryTotals.totalProducts / perPage )
 			: Math.ceil( totalProducts / perPage );
 	const listProducts = products.length

--- a/assets/js/base/components/product-list/index.js
+++ b/assets/js/base/components/product-list/index.js
@@ -96,6 +96,11 @@ const announceLoadingCompletion = ( totalProducts ) => {
 	}
 };
 
+const areQueryTotalsDifferent = (
+	{ totalQuery: nextQuery, totalProducts: nextProducts },
+	{ totalQuery: currentQuery } = {}
+) => ! isEqual( nextQuery, currentQuery ) && Number.isFinite( nextProducts );
+
 const ProductList = ( {
 	attributes,
 	currentPage,
@@ -129,12 +134,7 @@ const ProductList = ( {
 	// the total number of products is a finite number.
 	const previousQueryTotals = usePrevious(
 		{ totalQuery, totalProducts },
-		(
-			{ totalQuery: nextQuery, totalProducts: nextProducts },
-			{ totalQuery: currentQuery } = {}
-		) =>
-			! isEqual( nextQuery, currentQuery ) &&
-			Number.isFinite( nextProducts )
+		areQueryTotalsDifferent
 	);
 	const isPreviousTotalQueryEqual =
 		typeof previousQueryTotals === 'object' &&

--- a/assets/js/base/hooks/use-previous.js
+++ b/assets/js/base/hooks/use-previous.js
@@ -20,7 +20,7 @@ export const usePrevious = ( value, validation ) => {
 		) {
 			ref.current = value;
 		}
-	}, [ value, ref.current ] );
+	}, [ value, validation ] );
 
 	return ref.current;
 };

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -5,6 +5,8 @@ import { QUERY_STATE_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef, useEffect, useCallback } from '@wordpress/element';
 import { useQueryStateContext } from '@woocommerce/base-context';
+import { usePrevious } from '@woocommerce/base-hooks';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 import { assign } from 'lodash';
 
 /**
@@ -43,7 +45,7 @@ export const useQueryStateByContext = ( context ) => {
 		( value ) => {
 			setValueForQueryContext( context, value );
 		},
-		[ context ]
+		[ context, setValueForQueryContext ]
 	);
 
 	return [ queryState, setQueryState ];
@@ -81,7 +83,7 @@ export const useQueryStateByKey = ( queryKey, defaultValue, context ) => {
 		( value ) => {
 			setQueryValue( context, queryKey, value );
 		},
-		[ context, queryKey ]
+		[ context, queryKey, setQueryValue ]
 	);
 
 	return [ queryValue, setQueryValueByKey ];
@@ -117,15 +119,31 @@ export const useSynchronizedQueryState = ( synchronizedQuery, context ) => {
 	const queryStateContext = useQueryStateContext();
 	context = context || queryStateContext;
 	const [ queryState, setQueryState ] = useQueryStateByContext( context );
+	const currentQueryState = useShallowEqual( queryState );
 	const currentSynchronizedQuery = useShallowEqual( synchronizedQuery );
+	const previousSynchronizedQuery = usePrevious( currentSynchronizedQuery );
 	// used to ensure we allow initial synchronization to occur before
 	// returning non-synced state.
 	const isInitialized = useRef( false );
 	// update queryState anytime incoming synchronizedQuery changes
 	useEffect( () => {
-		setQueryState( assign( {}, queryState, currentSynchronizedQuery ) );
-		isInitialized.current = true;
-	}, [ currentSynchronizedQuery ] );
+		if (
+			! isShallowEqual(
+				previousSynchronizedQuery,
+				currentSynchronizedQuery
+			)
+		) {
+			setQueryState(
+				assign( {}, currentQueryState, currentSynchronizedQuery )
+			);
+			isInitialized.current = true;
+		}
+	}, [
+		currentQueryState,
+		currentSynchronizedQuery,
+		previousSynchronizedQuery,
+		setQueryState,
+	] );
 	return isInitialized.current
 		? [ queryState, setQueryState ]
 		: [ synchronizedQuery, setQueryState ];

--- a/assets/js/base/hooks/use-query-state.js
+++ b/assets/js/base/hooks/use-query-state.js
@@ -56,11 +56,11 @@ export const useQueryStateByContext = ( context ) => {
  * "Query State" is a wp.data store that keeps track of an arbitrary object of
  * query keys and their values.
  *
- * @param {*}      queryKey     The specific query key to retrieve the value for.
- * @param {*}      defaultValue Default value if query does not exist.
- * @param {string} [context]    What context to retrieve the query state for. If
- *                              not provided will attempt to use what is provided
- *                              by query state context.
+ * @param {*}      queryKey       The specific query key to retrieve the value for.
+ * @param {*}      [defaultValue] Default value if query does not exist.
+ * @param {string} [context]      What context to retrieve the query state for. If
+ *                                not provided will attempt to use what is provided
+ *                                by query state context.
  *
  * @return {*}  Whatever value is set at the query state index using the
  *              provided context and query key.

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -47,7 +47,13 @@ const ActiveFiltersBlock = ( {
 			},
 			displayStyle: blockAttributes.displayStyle,
 		} );
-	}, [ minPrice, maxPrice, formatPriceRange ] );
+	}, [
+		minPrice,
+		maxPrice,
+		blockAttributes.displayStyle,
+		setMinPrice,
+		setMaxPrice,
+	] );
 
 	const activeAttributeFilters = useMemo( () => {
 		return productAttributes.map( ( attribute ) => {
@@ -64,7 +70,7 @@ const ActiveFiltersBlock = ( {
 				/>
 			);
 		} );
-	}, [ productAttributes ] );
+	}, [ productAttributes, blockAttributes.displayStyle ] );
 
 	const hasFilters = () => {
 		return (

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Fragment, useState, useCallback } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import {
 	Placeholder,
@@ -258,7 +258,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		</Placeholder>
 	);
 
-	const onDone = useCallback( () => {
+	const onDone = () => {
 		setIsEditing( false );
 		debouncedSpeak(
 			__(
@@ -266,37 +266,34 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 				'woo-gutenberg-products-block'
 			)
 		);
-	}, [] );
+	};
 
-	const onChange = useCallback(
-		( selected ) => {
-			if ( ! selected || ! selected.length ) {
-				return;
-			}
+	const onChange = ( selected ) => {
+		if ( ! selected || ! selected.length ) {
+			return;
+		}
 
-			const selectedId = selected[ 0 ].id;
-			const productAttribute = find( ATTRIBUTES, [
-				'attribute_id',
-				selectedId.toString(),
-			] );
+		const selectedId = selected[ 0 ].id;
+		const productAttribute = find( ATTRIBUTES, [
+			'attribute_id',
+			selectedId.toString(),
+		] );
 
-			if ( ! productAttribute || attributeId === selectedId ) {
-				return;
-			}
+		if ( ! productAttribute || attributeId === selectedId ) {
+			return;
+		}
 
-			const attributeName = productAttribute.attribute_label;
+		const attributeName = productAttribute.attribute_label;
 
-			setAttributes( {
-				attributeId: selectedId,
-				heading: sprintf(
-					// Translators: %s attribute name.
-					__( 'Filter by %s', 'woo-gutenberg-products-block' ),
-					attributeName
-				),
-			} );
-		},
-		[ attributeId ]
-	);
+		setAttributes( {
+			attributeId: selectedId,
+			heading: sprintf(
+				// Translators: %s attribute name.
+				__( 'Filter by %s', 'woo-gutenberg-products-block' ),
+				attributeName
+			),
+		} );
+	};
 
 	const renderAttributeControl = () => {
 		const messages = {

--- a/assets/js/blocks/price-filter/use-price-constraints.js
+++ b/assets/js/blocks/price-filter/use-price-constraints.js
@@ -28,8 +28,9 @@ export const usePriceConstraint = ( price, minorUnit, direction ) => {
 			: Math.floor( parseFloat( price, 10 ) / step ) * step;
 	}
 
-	const previousConstraint = usePrevious( currentConstraint, ( val ) =>
-		Number.isFinite( val )
+	const previousConstraint = usePrevious(
+		currentConstraint,
+		Number.isFinite
 	);
 	return Number.isFinite( currentConstraint )
 		? currentConstraint


### PR DESCRIPTION
Part of #3204.

This PR handles the React hook dependency warnings produced by ESLint in the filter and All Products blocks. Some fixes were trivial while some others needed bigger refactors. Adding new dependencies to effects/memos/callbacks might have caused them to do unnecessary recalculations, when that was evident, I tried to prevent it either wrapping some dependencies with `useShallowEqual()` or refactoring it completely. However, I might have missed some and for sure there are many more optimizations to do.

### How to test the changes in this Pull Request:
The scope of changes in this PR is limited to the filter and All Products blocks, so those are the ones that need to be tested.

1. Create a page with the Filter products by price, Filter products by attribute, Active filters and All Products blocks.
2. Verify you can switch pages in the product list.
3. Verify you can change the sorting order and it sets the page back to 1.
4. Verify that when you activate a filter, the pagination goes back to 1.
5. Try setting several filters at the same time, removing them, clearing them all at once, etc.
6. Summarizing, try to break the blocks. :slightly_smiling_face: 
In the process I found a couple of bugs (#3282 and #3283), but I could reproduce them in `trunk` too, so I filled issues in GH.
9. Repeat the process above but first edit the filter blocks so they have the 'Filter button' visible.
![imatge](https://user-images.githubusercontent.com/3616980/96000715-7f7fbc80-0e37-11eb-9af5-df795cbe0254.png)
10. Extra testing modifying other attributes of the blocks would be great.