### PR TITLE
Escape basename paths with spaces correctly while running E2E tests.

### DIFF
--- a/bin/wp-env-pre-config.sh
+++ b/bin/wp-env-pre-config.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-npm run wp-env run tests-cli './wp-content/plugins/$(basename `pwd`)/bin/wp-env-config.sh'
+BASENAME=$(basename "`pwd`")
+npm run wp-env run tests-cli './wp-content/plugins/'$BASENAME'/bin/wp-env-config.sh'


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The `sh` syntax used for basename extraction was causing the wrong path to be selected in the case when the path contained spaces.

For example, the default path for sites set up with [Local](https://localwp.com/) has "Local Sites" as the main folder. This caused the the `$(basename 'pwd')` to yield `Local` and not the plugin directory.


<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:
 Run e2e tests as usual

1. for a path that has no spaces
2. for a path that has spaces

The expected behaviour is that the tests are executed correctly. This change does not affect tests results is only addresses if the tests can be run at all on some setups.

<!-- If you can, add the appropriate labels -->
