### PR TITLE
Respect Enable Taxes setting for checkout block taxe display.

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/totals-footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-footer-item/index.js
@@ -16,6 +16,8 @@ import PropTypes from 'prop-types';
 import TotalsItem from '../totals-item';
 import './style.scss';
 
+const SHOW_TAXES = TAXES_ENABLED && DISPLAY_CART_PRICES_INCLUDING_TAX;
+
 const TotalsFooterItem = ( { currency, values } ) => {
 	const { total_price: totalPrice, total_tax: totalTax } = values;
 
@@ -26,8 +28,7 @@ const TotalsFooterItem = ( { currency, values } ) => {
 			label={ __( 'Total', 'woo-gutenberg-products-block' ) }
 			value={ parseInt( totalPrice, 10 ) }
 			description={
-				TAXES_ENABLED &&
-				DISPLAY_CART_PRICES_INCLUDING_TAX && (
+				SHOW_TAXES && (
 					<p className="wc-block-components-totals-footer-item-tax">
 						{ createInterpolateElement(
 							__(

--- a/assets/js/base/components/cart-checkout/totals/totals-footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/totals-footer-item/index.js
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
+import {
+	TAXES_ENABLED,
+	DISPLAY_CART_PRICES_INCLUDING_TAX,
+} from '@woocommerce/block-settings';
 import { createInterpolateElement } from 'wordpress-element';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import PropTypes from 'prop-types';
@@ -23,6 +26,7 @@ const TotalsFooterItem = ( { currency, values } ) => {
 			label={ __( 'Total', 'woo-gutenberg-products-block' ) }
 			value={ parseInt( totalPrice, 10 ) }
 			description={
+				TAXES_ENABLED &&
 				DISPLAY_CART_PRICES_INCLUDING_TAX && (
 					<p className="wc-block-components-totals-footer-item-tax">
 						{ createInterpolateElement(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The `TotalsItem` component was only checking the `Display prices during cart and checkout` tax sub-setting and was ignoring the main Tax settings switch. This PR adds the missing check.

<!-- Reference any related issues or PRs here -->
Fixes #3195 

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
With the following settings:
![image](https://user-images.githubusercontent.com/17271089/96339839-578e9400-1097-11eb-9828-4fd886e37ffa.png )
![image](https://user-images.githubusercontent.com/17271089/96339852-5f4e3880-1097-11eb-887c-c97fce53b9d7.png)
The tax component is visible - correct behaviour.
![image](https://user-images.githubusercontent.com/17271089/96339858-6aa16400-1097-11eb-9ddc-365de1ee6033.png)

When the `Enable taxes` settings is switched **off** without touching any of the settings in the `Tax` tab the taxes component is no longer visible ( previously it was still visible and that was the error ):
![image](https://user-images.githubusercontent.com/17271089/96339888-a805f180-1097-11eb-978e-5f39bb9b4660.png)


### How to test the changes in this Pull Request:

1. Enable taxes
2. Enable Display prices during cart and checkout ( Tax tab )
3. Add items to the cart.
4. View the checkout block -> tax component should be visible
5. Disable taxes ( don't change anything on the Tax tab )
6. View the checkout block -> tax component should be gone

<!-- If you can, add the appropriate labels -->

### Changelog

Respect the main tax setting for the Checkout Block tax display.
