### PR TITLE
Add workflow for linting js and css

### DIFF
--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -30,11 +30,9 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-
-    - name: Npm install and build
+    - name: Npm install
       run: |
         npm install
-        npm run build
     - name: Lint JavaScript
       uses: bradennapier/eslint-plus-action@v3.4.2
     - name: Lint CSS

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -36,10 +36,7 @@ jobs:
         npm install
         npm run build
     - name: Lint JavaScript
-      uses: tinovyatkin/action-eslint@v1
-      with:
-        repo-token: ${{secrets.GITHUB_TOKEN}}
-        check-name: All
+      uses: bradennapier/eslint-plus-action@v3.4.2
     - name: Lint CSS
       run: npm run lint:css
 

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -1,0 +1,42 @@
+name: JavaScript and CSS Linting
+
+on:
+  pull_request:
+  push:
+    branches: [trunk]
+
+jobs:
+  check:
+    name: All
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache node modules
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-node-modules
+      with:
+        # npm cache files are stored in `~/.npm` on Linux/macOS
+        path: ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+
+    - name: Npm install and build
+      run: |
+        npm install
+        npm run build
+    - name: Lint JavaScript
+      run: npm run lint:js
+    - name: Lint CSS
+      run: npm run lint:css
+      

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -39,7 +39,7 @@ jobs:
       uses: tinovyatkin/action-eslint@v1
       with:
         repo-token: ${{secrets.GITHUB_TOKEN}}
-        check-name: JavaScript
+        check-name: All
     - name: Lint CSS
       run: npm run lint:css
 

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -36,7 +36,9 @@ jobs:
         npm install
         npm run build
     - name: Lint JavaScript
-      run: npm run lint:js
+      uses: tinovyatkin/action-eslint@v1
+      with:
+        repo-token: ${{secrets.GITHUB_TOKEN}}
     - name: Lint CSS
       run: npm run lint:css
-      
+

--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -39,6 +39,7 @@ jobs:
       uses: tinovyatkin/action-eslint@v1
       with:
         repo-token: ${{secrets.GITHUB_TOKEN}}
+        check-name: JavaScript
     - name: Lint CSS
       run: npm run lint:css
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,12 +100,6 @@ jobs:
               - npm run test
           env:
               - WOOCOMMERCE_BLOCKS_PHASE=3
-        - name: Javascript/CSS Lint check
-          script:
-              - npm install
-              - npm run lint:ci
-          env:
-              - WOOCOMMERCE_BLOCKS_PHASE=3
         - name: E2E Tests (WP 5.3)
           script:
               - npm run test:e2e

--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -19,8 +19,7 @@ import { useStoreNotices } from './use-store-notices';
 /**
  * Get the quantity of a product in the cart.
  *
- * @param {Object} Array of items.
- * @param cartItems
+ * @param {Object} cartItems Array of items.
  * @param {number} productId  The product id to look for.
  * @return {number} Quantity in the cart.
  */
@@ -35,7 +34,7 @@ const getQuantityFromCartItems = ( cartItems, productId ) => {
  * action for adding a single quantity of the product _to_ the cart.
  *
  *
- * @param {} productId  The product id to be added to the cart.
+ * @param {number} productId  The product id to be added to the cart.
  *
  * @return {StoreCartItemAddToCart} An object exposing data and actions relating
  *                                  to add to cart functionality.

--- a/assets/js/base/hooks/use-store-add-to-cart.js
+++ b/assets/js/base/hooks/use-store-add-to-cart.js
@@ -19,7 +19,8 @@ import { useStoreNotices } from './use-store-notices';
 /**
  * Get the quantity of a product in the cart.
  *
- * @param {Object} cartItems Array of items.
+ * @param {Object} Array of items.
+ * @param cartItems
  * @param {number} productId  The product id to look for.
  * @return {number} Quantity in the cart.
  */
@@ -34,7 +35,7 @@ const getQuantityFromCartItems = ( cartItems, productId ) => {
  * action for adding a single quantity of the product _to_ the cart.
  *
  *
- * @param {number} productId  The product id to be added to the cart.
+ * @param {} productId  The product id to be added to the cart.
  *
  * @return {StoreCartItemAddToCart} An object exposing data and actions relating
  *                                  to add to cart functionality.


### PR DESCRIPTION
WordPress core and the Gutenberg projects are both moving away from travis for automated CI and I like the idea of doing the same for our repo for the following reasons:

- Unified interface (no need to go to another site/service)
- Inline annotations for for linting issues on pull requests.
- GitHub actions have a growing ecosystem and provides opportunities for more automations in the future.
- The future of the Travis service is a bit unknown since they were acquired a couple years ago (there's been little to no investment in new features).

This pull adds a Github workflow for linting js and css (inline annotations not enabled yet on css linting for this workflow).

## To test

The new workflow should run in this pull and I'll experiment with adding deliberate linting issues to see what happens. Also if this works well I'll comment out the js&css linting in the travis build.
