### PR TITLE
Update ESLint workflow to only add comment on error.

### DIFF
--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -35,6 +35,8 @@ jobs:
         npm install
     - name: Lint JavaScript
       uses: bradennapier/eslint-plus-action@v3.4.2
+      with:
+        issueSummaryOnlyOnEvent: true
     - name: Lint CSS
       run: npm run lint:css
 


### PR DESCRIPTION
We don't need a comment in the PR if there are no eslint errors so this config change implements that.

When all checks are green, I'll go ahead and merge.