### PR TITLE
Correctly process $0 checkouts

### DIFF
--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -41,6 +41,7 @@ class DraftOrders {
 			add_filter( 'wc_order_statuses', [ $this, 'register_draft_order_status' ] );
 			add_filter( 'woocommerce_register_shop_order_post_statuses', [ $this, 'register_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment', [ $this, 'append_draft_order_post_status' ] );
+			add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', [ $this, 'append_draft_order_post_status' ] );
 			add_action( 'woocommerce_cleanup_draft_orders', [ $this, 'delete_expired_draft_orders' ] );
 			add_action( 'admin_init', [ $this, 'install' ] );
 		} else {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3229

We didn't add draft order to `woocommerce_valid_order_statuses_for_payment_complete` which is used when checking an order status before processing it, this one is invoked as part of `payment_complete` which we only call when processing empty orders.
When processing a paid order, we use `woocommerce_valid_order_statuses_for_payment` which we already integrated with.
This caused empty orders ($0) to never get processed and will always stay as a draft.


### How to test the changes in this Pull Request:

1. Add a $0 product to your cart and checkout.
2. Notice the order ID, check the order in the backend, it should be processing.
3. Checkout the product again, it should create a new order, not the previous one.


## Dev notes
> Any stores offering products that can result in free orders (where the order total equals 0) should update to this version of the WooCommerce Blocks plugin. There was a significant bug affecting order loss for orders made with the checkout block that totalled 0.
