### PR TITLE
Change items organisation on smaller viewports.

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -200,6 +200,7 @@ table.wc-block-cart-items {
 				vertical-align: bottom;
 				padding-right: $gap;
 				align-self: end;
+				padding-top: $gap;
 
 				.wc-block-cart-item__remove-link {
 					display: none;
@@ -212,6 +213,8 @@ table.wc-block-cart-items {
 				grid-column: 2 / span 2;
 				grid-row-start: 2;
 				align-self: end;
+				justify-self: end;
+				width: fit-content;
 
 				.wc-block-components-formatted-money-amount {
 					display: inline-block;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -214,7 +214,7 @@ table.wc-block-cart-items {
 				grid-row-start: 2;
 				align-self: end;
 				justify-self: end;
-				width: fit-content;
+				padding-bottom: 0.375em;
 
 				.wc-block-components-formatted-money-amount {
 					display: inline-block;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -195,10 +195,11 @@ table.wc-block-cart-items {
 				padding-bottom: $gap;
 			}
 			.wc-block-cart-item__quantity {
-				grid-column-start: 2;
+				grid-column-start: 1;
 				grid-row-start: 2;
 				vertical-align: bottom;
 				padding-right: $gap;
+				align-self: end;
 
 				.wc-block-cart-item__remove-link {
 					display: none;
@@ -208,9 +209,9 @@ table.wc-block-cart-items {
 				}
 			}
 			.wc-block-cart-item__total {
-				grid-column-start: 3;
+				grid-column: 2 / span 2;
 				grid-row-start: 2;
-				align-self: center;
+				align-self: end;
 
 				.wc-block-components-formatted-money-amount {
 					display: inline-block;


### PR DESCRIPTION
On smaller viewports, the quantity selector and the line item cost were organized on the right side of the view. This caused price values to overflow on smaller viewports or prices with lots of digits:
![image](https://user-images.githubusercontent.com/17271089/96585843-6a47d980-12e0-11eb-87d9-a4ee732bcc9d.png)

To mitigate I have moved the quantity button on the left side and made the price span two last available grid cells.
This way there is a lot more place for the price line. Grid alignment was changed to `end` in order to provide a gap between rows.

I think that the design sits well with how the lines below are structured. If we would something other then more significant changes would be necessary.

<!-- Reference any related issues or PRs here -->
Fixes #3257

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

After the changes, the UI remains consistent when the grid CSS kicks in even for smaller widths then requested in the Issue:
![image](https://user-images.githubusercontent.com/17271089/96587908-3b7f3280-12e3-11eb-8d36-9f680a55a5df.png)

Bigger viewports are consistent:
![image](https://user-images.githubusercontent.com/17271089/96588107-7ed9a100-12e3-11eb-8b10-eaf93bc6f1ab.png)


### How to test the changes in this Pull Request:

1. Add items to cart with a cost that has 3 leading digits.
2. Go to a page with a cart block.
3. Reduce the viewport and check how the price behaves below 320px widht.

<!-- If you can, add the appropriate labels -->

### Changelog

Fix cart item price overflow on smaller viewports.
