### PR TITLE
E2E WC Core Terms Consistency

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -171,7 +171,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				>
 					<ToggleControl
 						label={ __(
-							'Allow shopper to sign up for a user account during checkout',
+							'Allow shoppers to sign up for a user account during checkout',
 							'woo-gutenberg-products-block'
 						) }
 						checked={ allowCreateAccount }
@@ -194,7 +194,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 				</p>
 				<ToggleControl
 					label={ __(
-						'Allow customers to optionally add order notes',
+						'Allow shoppers to optionally add order notes',
 						'woo-gutenberg-products-block'
 					) }
 					checked={ showOrderNotes }

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -102,7 +102,7 @@ describe( `${ block.name } Block`, () => {
 			it( 'visibility can be toggled', async () => {
 				const selector = `${ block.class } .wc-block-checkout__add-note`;
 				const toggleLabel = await findLabelWithText(
-					'Allow customers to optionally add order notes'
+					'Allow shoppers to optionally add order notes'
 				);
 				await expect( toggleLabel ).toToggleElement( selector );
 			} );


### PR DESCRIPTION
fixes 3309

WC Core and blocks use sentences having the exact same sense but with different words, this PR fixes it.

<!-- Reference any related issues or PRs here -->
Fixes #3309

Related to https://github.com/woocommerce/woocommerce/pull/28055

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Changelog

> E2E terms consistency update
