### PR TITLE
Fix PHP 8 error when argument is not invocable in AssetsDataRegistry::add_data

### DIFF
--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -258,7 +258,7 @@ class AssetDataRegistry {
 			}
 			return;
 		}
-		if ( \method_exists( $data, '__invoke' ) ) {
+		if ( \is_callable( $data ) ) {
 			$this->lazy_data[ $key ] = $data;
 			return;
 		}

--- a/src/Registry/AbstractDependencyType.php
+++ b/src/Registry/AbstractDependencyType.php
@@ -38,7 +38,7 @@ abstract class AbstractDependencyType {
 	 */
 	protected function resolve_value( Container $container ) {
 		$callback = $this->callable_or_value;
-		return \method_exists( $callback, '__invoke' )
+		return \is_callable( $callback )
 			? $callback( $container )
 			: $callback;
 	}


### PR DESCRIPTION
After installing PHP8, I noticed the following error when trying to create a new page:

> Fatal error: Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, array given in /srv/www/woo/public_html/wp-content/plugins/woo-blocks/src/Assets/AssetDataRegistry.php:

This is because PHP 8 is more strict on the type passed into `method_exists`. 

The solution is to ensure that we use `is_callable` as the check instead. `method_exists` was also used in `AbstractDependencyType` so I replaced it there as well.

## To Test

Currently this is covered by phpunit tests for `AssetDataRegistry` and `AbstractDependencyType` and I did a review of our code and we don't actually have any data lazy loaded (or using factory for the container) via this mechanism yet (that I could find) so user impact is nil.