### PR TITLE
Fix Gutenberg e2e tests failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,17 +142,4 @@ jobs:
               local_dir: storybook/dist
               on:
                   branch: trunk
-    # @TODO: Investigate why is WP 5.4 + GB e2e test failing and don't allow it to fail.
-    allow_failures:
-      - name: E2E Tests (WP 5.5 with Gutenberg plugin)
-        script:
-          - npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
-          - npm install @wordpress/e2e-test-utils@latest
-          - chmod -R 767 ./
-          - npm run test:e2e
-        env:
-          - WP_VERSION=5.5
-          - E2E_TESTS=1
-          - GUTENBERG_LATEST=true
-          - WOOCOMMERCE_BLOCKS_PHASE=3
 

--- a/tests/e2e/specs/backend/all-products.test.js
+++ b/tests/e2e/specs/backend/all-products.test.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import {
-	insertBlock,
 	getAllBlocks,
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {
 	name: 'All Products',
@@ -29,7 +30,7 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'can only be inserted once', async () => {
-		await insertBlock( block.name );
+		await insertBlockDontWaitForInsertClose( block.name );
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );
 

--- a/tests/e2e/specs/backend/all-products.test.js
+++ b/tests/e2e/specs/backend/all-products.test.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	getAllBlocks,
-	switchUserToAdmin,
-} from '@wordpress/e2e-test-utils';
+import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -4,7 +4,6 @@
 import {
 	clickButton,
 	getAllBlocks,
-	insertBlock,
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
@@ -13,14 +12,15 @@ import {
 	visitBlockPage,
 } from '@woocommerce/blocks-test-utils';
 
+import {
+	insertBlockDontWaitForInsertClose,
+	closeInserter
+} from '../../utils.js';
+
 const block = {
 	name: 'Cart',
 	slug: 'woocommerce/cart',
 	class: '.wc-block-cart',
-};
-
-const closeInserter = async () => {
-	await page.click( '.edit-post-header [aria-label="Add block"]' );
 };
 
 if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
@@ -34,7 +34,7 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'can only be inserted once', async () => {
-		await insertBlock( block.name );
+		await insertBlockDontWaitForInsertClose( block.name );
 		await closeInserter();
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -14,7 +14,7 @@ import {
 
 import {
 	insertBlockDontWaitForInsertClose,
-	closeInserter
+	closeInserter,
 } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -13,7 +13,7 @@ import {
 
 import {
 	insertBlockDontWaitForInsertClose,
-	closeInserter
+	closeInserter,
 } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	insertBlock,
 	getAllBlocks,
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
@@ -12,14 +11,15 @@ import {
 	visitBlockPage,
 } from '@woocommerce/blocks-test-utils';
 
+import {
+	insertBlockDontWaitForInsertClose,
+	closeInserter
+} from '../../utils.js';
+
 const block = {
 	name: 'Checkout',
 	slug: 'woocommerce/checkout',
 	class: '.wc-block-checkout',
-};
-
-const closeInserter = async () => {
-	await page.click( '.edit-post-header [aria-label="Add block"]' );
 };
 
 if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
@@ -33,7 +33,7 @@ describe( `${ block.name } Block`, () => {
 	} );
 
 	it( 'can only be inserted once', async () => {
-		await insertBlock( block.name );
+		await insertBlockDontWaitForInsertClose( block.name );
 		await closeInserter();
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { searchForBlock } from '@wordpress/e2e-test-utils';
+
+/**
+ * Opens the inserter, searches for the given term, then selects the first
+ * result that appears.
+ *
+ * @param {string} searchTerm The text to search the inserter for.
+ */
+export async function insertBlockDontWaitForInsertClose( searchTerm ) {
+	await searchForBlock( searchTerm );
+	const insertButton = (
+		await page.$x( `//button//span[contains(text(), '${ searchTerm }')]` )
+	 )[ 0 ];
+	await insertButton.click();
+}
+
+export const closeInserter = async () => {
+	await page.click( '.edit-post-header [aria-label="Add block"]' );
+};


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

There was a recent change in how the blocks insert mechanism works. It now works as a popover: https://github.com/WordPress/gutenberg/pull/24429

 This means that inserting a block should close the modal and put the focus on the newly added block. Since the automatic close action is part of the new behavior the `insertBlock` puppeteer command was also updated. It now expects that the blocks selection panel becomes closed and focus is shifted:
https://github.com/WordPress/gutenberg/blob/master/packages/e2e-test-utils/src/inserter.js#L135

We have three instances of a test where we test that the block can be added just once on the page. Since the second add operation is not possible the block selector will not be closed and the focus will not be shifted. This means that we can't use `insertBlock` for our tests. A new utility function was created that tries to add the block but does not wait for the closing. 


<!-- Reference any related issues or PRs here -->
Fixes #2993 

<!-- Don't forget to update the title with something descriptive. -->

### How to test the changes in this Pull Request:

1. This fixes E2E tests triggered by Travis so the tests should be green.

<!-- If you can, add the appropriate labels -->

