### PR TITLE
Enable 'react-hooks/exhaustive-deps' ESLint flag

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,6 @@ module.exports = {
 	},
 	rules: {
 		'woocommerce/feature-flag': 'off',
+		'react-hooks/exhaustive-deps': 'error',
 	},
 };


### PR DESCRIPTION
Fixes #3204.

Now that #3285 and #3314 have been merged, I think it makes sense enabling the ESLint flag that catches dependency issues so we don't introduce this kind of errors again.

### How to test the changes in this Pull Request:

Run `npm run lint:js` and verify it passes without errors.