### PR TITLE
Allow shoppers to sign-up for an account from the Checkout block

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -23,10 +23,7 @@ import {
 	Main,
 } from '@woocommerce/base-components/sidebar-layout';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import {
-	CHECKOUT_ALLOWS_GUEST,
-	isExperimentalBuild,
-} from '@woocommerce/block-settings';
+import { CHECKOUT_ALLOWS_GUEST } from '@woocommerce/block-settings';
 import { compareWithWooVersion, getSetting } from '@woocommerce/settings';
 
 /**
@@ -87,10 +84,8 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	// Checkout signup is feature gated to WooCommerce 4.7 and newer;
 	// uses updated my-account/lost-password screen from 4.7+ for
 	// setting initial password.
-	// Also currently gated to dev builds only.
 	const allowCreateAccount =
 		attributes.allowCreateAccount &&
-		isExperimentalBuild() &&
 		compareWithWooVersion( '4.7.0', '<=' );
 
 	useEffect( () => {

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -85,8 +85,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	// uses updated my-account/lost-password screen from 4.7+ for
 	// setting initial password.
 	const allowCreateAccount =
-		attributes.allowCreateAccount &&
-		compareWithWooVersion( '4.7.0', '<=' );
+		attributes.allowCreateAccount && compareWithWooVersion( '4.7.0', '<=' );
 
 	useEffect( () => {
 		if ( hasErrorsToDisplay ) {

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -57,8 +57,8 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 	// Checkout signup is feature gated to WooCommerce 4.7 and newer;
 	// uses updated my-account/lost-password screen from 4.7+ for
 	// setting initial password.
-	// Also implicitly gated to feature plugin, because Checkout 
-	// block is gated to plugin.
+	// Also implicitly gated to feature plugin, because Checkout
+	// block is gated to plugin
 	const showCreateAccountOption = compareWithWooVersion( '4.7.0', '<=' );
 	return (
 		<InspectorControls>

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -17,7 +17,6 @@ import {
 	PRIVACY_URL,
 	TERMS_URL,
 	CHECKOUT_PAGE_ID,
-	isExperimentalBuild,
 } from '@woocommerce/block-settings';
 import { compareWithWooVersion, getAdminLink } from '@woocommerce/settings';
 import { createInterpolateElement } from 'wordpress-element';
@@ -58,9 +57,9 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 	// Checkout signup is feature gated to WooCommerce 4.7 and newer;
 	// uses updated my-account/lost-password screen from 4.7+ for
 	// setting initial password.
-	// Also currently gated to dev builds only.
-	const showCreateAccountOption =
-		isExperimentalBuild() && compareWithWooVersion( '4.7.0', '<=' );
+	// Also implicitly gated to feature plugin, because Checkout 
+	// block is gated to plugin.
+	const showCreateAccountOption = compareWithWooVersion( '4.7.0', '<=' );
 	return (
 		<InspectorControls>
 			{ currentPostId !== CHECKOUT_PAGE_ID && (

--- a/assets/js/blocks/cart-checkout/checkout/form/address-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/address-step.js
@@ -93,6 +93,7 @@ AddressStep.propTypes = {
 	showApartmentField: PropTypes.bool.isRequired,
 	showCompanyField: PropTypes.bool.isRequired,
 	showPhoneField: PropTypes.bool.isRequired,
+	allowCreateAccount: PropTypes.bool.isRequired,
 };
 
 export default AddressStep;

--- a/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
@@ -5,10 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { DebouncedValidatedTextInput } from '@woocommerce/base-components/text-input';
 import { useCheckoutContext } from '@woocommerce/base-context';
-import {
-	CHECKOUT_ALLOWS_GUEST,
-	isExperimentalBuild,
-} from '@woocommerce/block-settings';
+import { CHECKOUT_ALLOWS_GUEST } from '@woocommerce/block-settings';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 
 /**
@@ -27,11 +24,9 @@ const ContactFieldsStep = ( {
 		setShouldCreateAccount,
 	} = useCheckoutContext();
 
-	// "Create Account" checkbox is gated to dev builds only.
 	const createAccountUI = ! customerId &&
 		allowCreateAccount &&
-		CHECKOUT_ALLOWS_GUEST &&
-		isExperimentalBuild() && (
+		CHECKOUT_ALLOWS_GUEST &&(
 			<CheckboxControl
 				className="wc-block-checkout__create-account"
 				label={ __(

--- a/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
@@ -26,7 +26,7 @@ const ContactFieldsStep = ( {
 
 	const createAccountUI = ! customerId &&
 		allowCreateAccount &&
-		CHECKOUT_ALLOWS_GUEST &&(
+		CHECKOUT_ALLOWS_GUEST && (
 			<CheckboxControl
 				className="wc-block-checkout__create-account"
 				label={ __(

--- a/assets/js/blocks/cart-checkout/checkout/form/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/index.js
@@ -49,6 +49,7 @@ CheckoutForm.propTypes = {
 	showCompanyField: PropTypes.bool.isRequired,
 	showOrderNotes: PropTypes.bool.isRequired,
 	showPhoneField: PropTypes.bool.isRequired,
+	allowCreateAccount: PropTypes.bool.isRequired,
 };
 
 export default CheckoutForm;

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -35,15 +35,16 @@ class CreateAccount {
 		// Checkout signup is feature gated to WooCommerce 4.7 and newer;
 		// uses updated my-account/lost-password screen from 4.7+ for
 		// setting initial password.
-		// Also currently gated to dev builds only.
-		return Package::is_experimental_build();
+		// This service is feature gated to plugin only, to match the
+		// availability of the Checkout block (feature plugin only).
+		return Package::is_feature_plugin_build() && defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '>=' );
 	}
 
 	/**
 	 * Init - register handlers for WooCommerce core email hooks.
 	 */
 	public function init() {
-		if ( ! self::is_feature_enabled() || defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '<' ) ) {
+		if ( ! self::is_feature_enabled() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #3286

This PR removes the `isExperimental` feature flag for the checkout signup feature, so it can be launched to stores using WooCommerce Blocks feature plugin. 🎉 

The feature gating is implemented as follows:

- The Checkout block is currently feature gated to feature plugin only. 
   - The Checkout block editor option `allowCreateAccount` is only displayed if store is running WooCommerce 4.7 or newer.
- The service class implements back-end parts of the flow - creating the account, new account email, and a set password flow.
   - All functionality in this class is gated to feature plugin only AND WooCommerce 4.7 or newer.
- The Checkout API also will only invoke create account if store is running WooCommerce 4.7 or newer.

To summarise:

If a store is running WooCommerce Blocks plugin, and WooCommerce 4.7 or newer, all features will be available:

- Merchant can allow customers to sign up at checkout (block setting).
- Checkout API will create accounts when requested.
- New accounts created via checkout block will use the improved new-account email and set password flow.
  - Note: new accounts via other means will continue to use existing email & flow.

If the store is running an older version of WooCommerce, or the blocks plugin is not active, then no features should be available:

- No block option to allow signups.
- Checkout API should ignore any request to create account.
- Existing core new-account email & password handling.

### Screenshots
See related previous PRs for details of what's changed and how the feature works.

#2851

#3236

woocommerce/woocommerce#27898

### How to test the changes in this Pull Request:
- Test using a release build of the plugin. Previously this feature was only available in dev builds.
- Confirm that feature is still working correctly in dev build.
- Confirm that checkout signup is available and works correctly with blocks plugin + woo 4.7+.
- Confirm that checkout signup is not available and doesn't cause any issues with woo version older than 4.7.0.

Note: When we next **update the package included in WooCommerce Core, we'll need to confirm that checkout signup is not available** (unless recent blocks plugin is active). 

### Changelog

> Feature: Allow shoppers to sign-up for an account from the Checkout block. #2851 #3236 #3331
