### PR TITLE
Introduce ExtendRestApi

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -183,7 +183,7 @@ class Bootstrap {
 		$this->container->register(
 			RestApi::class,
 			function ( Container $container ) {
-				return new RestApi();
+				return new RestApi( $container->get( ExtendRestApi::class ) );
 			}
 		);
 		$this->container->register(

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -18,6 +18,7 @@ use Automattic\WooCommerce\Blocks\Payments\Integrations\BankTransfer;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\CashOnDelivery;
 use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
 use Automattic\WooCommerce\Blocks\Domain\Services\CreateAccount;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Blocks\Domain\Services\Email\CustomerNewAccount;
 
 /**
@@ -78,6 +79,7 @@ class Bootstrap {
 		}
 		$this->container->get( DraftOrders::class )->init();
 		$this->container->get( CreateAccount::class )->init();
+		$this->container->get( ExtendRestApi::class );
 		$this->container->get( PaymentsApi::class );
 		$this->container->get( RestApi::class );
 		Library::init();
@@ -200,6 +202,12 @@ class Bootstrap {
 			CreateAccount::class,
 			function( Container $container ) {
 				return new CreateAccount( $container->get( Package::class ) );
+			}
+		);
+		$this->container->register(
+			ExtendRestApi::class,
+			function( Container $container ) {
+				return new ExtendRestApi( $container->get( Package::class ) );
 			}
 		);
 	}

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -1,0 +1,131 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Domain\Services;
+
+use Exception;
+use Automattic\WooCommerce\Blocks\Domain\Package;
+
+/**
+ * Service class to provide utility functions to extend REST API.
+ */
+class ExtendRestApi {
+	/**
+	 * Holds the Package instance
+	 *
+	 * @var Package
+	 */
+	private $package;
+
+	/**
+	 * Valid endpoints to extend
+	 *
+	 * @var array
+	 */
+	private $endpoints = [ 'item' ];
+
+	/**
+	 * Init - register handlers for internal hooks.
+	 */
+	public function init() {
+
+	}
+	/**
+	 * An endpoint that validates registration method call
+	 *
+	 * @param string   $endpoint The endpoint to extend.
+	 * @param string   $namespace Plugin namespace.
+	 * @param callable $schema_callback Callback executed to add schema data.
+	 * @param callable $data_callback Callback executed to add endpoint data.
+	 */
+	private function validate_endpoint_data( $endpoint, $namespace, $schema_callback, $data_callback ) {
+		if ( ! is_string( $namespace ) ) {
+			$this->throw_exception(
+				'You must provide a plugin namespace when extending a Store REST endpoint.'
+			);
+		}
+
+		if ( ! is_string( $endpoint ) || ! in_array( $endpoint, $this->endpoints, true ) ) {
+			$this->throw_exception(
+				'You must provide a valid Store REST endpoint to extend, valid endpoints are: ' . implode( ', ', $this->endpoints )
+			);
+		}
+
+		if ( ! is_callable( $schema_callback ) ) {
+			$this->throw_exception(
+				'$schema_callback must be a callable function.'
+			);
+		}
+
+		if ( ! is_callable( $data_callback ) ) {
+			$this->throw_exception(
+				'$data_callback must be a callable function.'
+			);
+		}
+	}
+
+	/**
+	 * Extends the items in store/cart endpoint
+	 *
+	 * @param string   $namespace Plugin namespace.
+	 * @param callable $schema_callback Callback executed to add schema data.
+	 * @param callable $data_callback Callback executed to add endpoint data, gets cart item data as param.
+	 */
+	public function register_cart_item_endpoint_data( $namespace, $schema_callback, $data_callback ) {
+		$this->validate_endpoint_data( 'item', $namespace, $schema_callback, $data_callback );
+
+		add_filter( '__internal_extend_cart_item_schema', function( $schema ) use ( $schema_callback, $namespace ) {
+			$schema_data = [];
+
+			try {
+				$schema_data = $schema_callback();
+			} catch ( Exception $e ) {
+				$this->throw_exception( $e );
+				return $schema;
+			}
+
+			if ( ! is_array( $schema_data ) ) {
+				$this->throw_exception(
+					'$schema_callback must return an array.'
+				);
+			}
+
+			return $schema[ $namespace ] = $schema_data;
+		}, 10, 1 );
+
+		add_filter( '__internal_extend_cart_item_data', function( $data, $cart_item ) use ( $data_callback, $namespace ) {
+			$endpoint_data = [];
+
+			try {
+				$endpoint_data = $data_callback( $cart_item );
+			} catch ( Exception $e ) {
+				$this->throw_exception( $e );
+				return $data;
+			}
+
+			if ( ! is_array( $endpoint_data ) ) {
+				$this->throw_exception( '$endpoint_data must return an array.' );
+			}
+
+			return $data[ $namespace ] = $endpoint_data;
+		},
+		10, 2 );
+	}
+
+	/**
+	 * Throws error or silently logs it.
+	 *
+	 * @param string|Exception $exception_or_error Error message or Exception.
+	 */
+	private function throw_exception( $exception_or_error ) {
+		if ( $exception_or_error instanceof Exception ) {
+			$exception = $exception_or_error;
+		} else {
+			$exception = Exception( $exception_or_error );
+		}
+
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			throw $exception;
+		} else {
+			wc_caught_exception( $exception_or_error );
+		}
+	}
+}

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -71,9 +71,10 @@ class ExtendRestApi {
 				}
 
 				if ( ! is_array( $schema_data ) ) {
-					return $this->throw_exception(
+					$this->throw_exception(
 						'$schema_callback must return an array.'
 					);
+					return $schema;
 				}
 
 				$schema[ $namespace ] = $schema_data;
@@ -96,7 +97,8 @@ class ExtendRestApi {
 				}
 
 				if ( ! is_array( $endpoint_data ) ) {
-					return $this->throw_exception( '$endpoint_data must return an array.' );
+					$this->throw_exception( '$endpoint_data must return an array.' );
+					return $data;
 				}
 
 				$data[ $namespace ] = $endpoint_data;

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
-use Exception;
+use Throwable;
 
 /**
  * Service class to provide utility functions to extend REST API.

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -88,7 +88,8 @@ class ExtendRestApi {
 				);
 			}
 
-			return $schema[ $namespace ] = $schema_data;
+			$schema[ $namespace ] = $schema_data;
+			return $schema;
 		}, 10, 1 );
 
 		add_filter( '__internal_extend_cart_item_data', function( $data, $cart_item ) use ( $data_callback, $namespace ) {
@@ -105,7 +106,8 @@ class ExtendRestApi {
 				$this->throw_exception( '$endpoint_data must return an array.' );
 			}
 
-			return $data[ $namespace ] = $endpoint_data;
+			$data[ $namespace ] = $endpoint_data;
+			return $data;
 		},
 		10, 2 );
 	}

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -93,9 +93,9 @@ class ExtendRestApi {
 	 * @throws Exception If a registered callback throws an error, or silently logs it.
 	 */
 	public function get_endpoint_data( $endpoint, array $passed_args = [] ) {
-		$registered_data = [];
+		$registered_data = (object) [];
 		if ( ! isset( $this->extend_data[ $endpoint ] ) ) {
-			return [];
+			return $registered_data;
 		}
 		foreach ( $this->extend_data[ $endpoint ] as $namespace => $callbacks ) {
 			$data = [];

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -100,12 +100,7 @@ class ExtendRestApi {
 			$data = [];
 
 			try {
-				if ( empty( $passed_args ) ) {
-					$data = $callbacks['data_callback']();
-				} else {
-					$passed_args_values = \array_values( $passed_args );
-					$data               = $callbacks['data_callback']( ...$passed_args_values );
-				}
+				$data = $callbacks['data_callback']( ...$passed_args );
 			} catch ( Throwable $e ) {
 				$this->throw_exception( $e );
 				continue;
@@ -139,12 +134,7 @@ class ExtendRestApi {
 			$schema = [];
 
 			try {
-				if ( empty( $passed_args ) ) {
-					$schema = $callbacks['schema_callback']();
-				} else {
-					$passed_args_values = \array_values( $passed_args );
-					$schema             = $callbacks['schema_callback']( ...$passed_args_values );
-				}
+				$schema = $callbacks['schema_callback']( ...$passed_args );
 			} catch ( Throwable $e ) {
 				$this->throw_exception( $e );
 				continue;

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -15,12 +15,6 @@ class ExtendRestApi {
 	private $endpoints = [ 'item' ];
 
 	/**
-	 * Init - register handlers for internal hooks.
-	 */
-	public function init() {
-
-	}
-	/**
 	 * An endpoint that validates registration method call
 	 *
 	 * @param string   $endpoint The endpoint to extend.

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -89,7 +89,7 @@ class ExtendRestApi {
 	public function get_endpoint_data( $endpoint, array $passed_args = [] ) {
 		$registered_data = [];
 		if ( ! isset( $this->extend_data[ $endpoint ] ) ) {
-			return $registered_data;
+			return (object) $registered_data;
 		}
 		foreach ( $this->extend_data[ $endpoint ] as $namespace => $callbacks ) {
 			$data = [];
@@ -121,7 +121,7 @@ class ExtendRestApi {
 	public function get_endpoint_schema( $endpoint, array $passed_args = [] ) {
 		$registered_schema = [];
 		if ( ! isset( $this->extend_data[ $endpoint ] ) ) {
-			return [];
+			return (object) $registered_schema;
 		}
 
 		foreach ( $this->extend_data[ $endpoint ] as $namespace => $callbacks ) {
@@ -142,7 +142,7 @@ class ExtendRestApi {
 
 			$registered_schema[ $namespace ] = $schema;
 		}
-		return $registered_schema;
+		return (object) $registered_schema;
 	}
 
 	/**

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -53,25 +53,26 @@ class ExtendRestApi {
 	public function register_endpoint_data( $endpoint, $namespace, $schema_callback, $data_callback ) {
 		if ( ! is_string( $namespace ) ) {
 			$this->throw_exception(
-				'You must provide a plugin namespace when extending a Store REST endpoint.'
+				__( 'You must provide a plugin namespace when extending a Store REST endpoint.', 'woo-gutenberg-products-block' )
 			);
 		}
 
 		if ( ! is_string( $endpoint ) || ! in_array( $endpoint, $this->endpoints, true ) ) {
 			$this->throw_exception(
-				sprintf( 'You must provide a valid Store REST endpoint to extend, valid endpoints are: %s1. You provided %s2.', implode( ', ', $this->endpoints ), $endpoint )
+				/* translators: 1: a list of endpoints. 2: endpoint provided by user. */
+				sprintf( __( 'You must provide a valid Store REST endpoint to extend, valid endpoints are: %1$s. You provided %2$s.', 'woo-gutenberg-products-block' ), implode( ', ', $this->endpoints ), $endpoint )
 			);
 		}
 
 		if ( ! is_callable( $schema_callback ) ) {
 			$this->throw_exception(
-				'$schema_callback must be a callable function.'
+				__( '$schema_callback must be a callable function.', 'woo-gutenberg-products-block' )
 			);
 		}
 
 		if ( ! is_callable( $data_callback ) ) {
 			$this->throw_exception(
-				'$data_callback must be a callable function.'
+				__( '$data_callback must be a callable function.', 'woo-gutenberg-products-block' )
 			);
 		}
 
@@ -107,7 +108,7 @@ class ExtendRestApi {
 			}
 
 			if ( ! is_array( $data ) ) {
-				$this->throw_exception( '$data_callback must return an array.' );
+				$this->throw_exception( __( '$data_callback must return an array.', 'woo-gutenberg-products-block' ) );
 				continue;
 			}
 
@@ -141,9 +142,11 @@ class ExtendRestApi {
 			}
 
 			if ( ! is_array( $schema ) ) {
-				$this->throw_exception( '$schema_callback must return an array.' );
+				$this->throw_exception( __( '$schema_callback must return an array.', 'woo-gutenberg-products-block' ) );
 				continue;
 			}
+
+			$schema = $this->format_extensions_properties( $namespace, $schema );
 
 			$registered_schema[ $namespace ] = $schema;
 		}
@@ -167,5 +170,24 @@ class ExtendRestApi {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && current_user_can( 'manage_woocommerce' ) ) {
 			throw $exception;
 		}
+	}
+
+	/**
+	 * Format schema for an extension.
+	 *
+	 * @param string $namespace Error message or Exception.
+	 * @param array  $schema An error to throw if we have debug enabled and user is admin.
+	 *
+	 * @return array Formatted schema.
+	 */
+	private function format_extensions_properties( $namespace, $schema ) {
+		return [
+			/* translators: extension namespace */
+			'description' => sprintf( __( 'Extension data registered by %s', 'woo-gutenberg-products-block' ), $namespace ),
+			'type'        => 'object',
+			'context'     => [ 'view', 'edit' ],
+			'readonly'    => true,
+			'properties'  => $schema,
+		];
 	}
 }

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -13,11 +13,17 @@ use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class RestApi {
-
+	/**
+	 * Stores Rest Extending instance
+	 *
+	 * @var ExtendRestApi
+	 */
 	private $extend;
 
 	/**
 	 * Constructor
+	 *
+	 * @param ExtendRestApi $extend Rest Extending instance.
 	 */
 	public function __construct( ExtendRestApi $extend ) {
 		$this->extend = $extend;

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -3,6 +3,8 @@ namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\StoreApi\RoutesController;
 use Automattic\WooCommerce\Blocks\StoreApi\SchemaController;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
 
 /**
  * RestApi class.
@@ -11,10 +13,14 @@ use Automattic\WooCommerce\Blocks\StoreApi\SchemaController;
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class RestApi {
+
+	private $extend;
+
 	/**
 	 * Constructor
 	 */
-	public function __construct() {
+	public function __construct( ExtendRestApi $extend ) {
+		$this->extend = $extend;
 		$this->init();
 	}
 
@@ -30,7 +36,7 @@ class RestApi {
 	 * Register REST API routes.
 	 */
 	public function register_rest_routes() {
-		$schemas = new SchemaController();
+		$schemas = new SchemaController( $this->extend );
 		$routes  = new RoutesController( $schemas );
 		$routes->register_routes();
 	}

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -25,8 +25,8 @@ class SchemaController {
 	/**
 	 * Constructor.
 	 */
-	public function __construct( ExtendRestApi $extend_schema ) {
-		$this->extend = $extend_schema;
+	public function __construct( ExtendRestApi $extend ) {
+		$this->extend = $extend;
 		$this->initialize();
 	}
 

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -45,7 +45,7 @@ class SchemaController {
 	 */
 	protected function initialize() {
 		$this->schemas = [
-			'cart'                    => new Schemas\CartSchema(
+			Schemas\CartSchema::IDENTIFIER             => new Schemas\CartSchema(
 				new Schemas\CartItemSchema(
 					new Schemas\ImageAttachmentSchema()
 				),
@@ -54,26 +54,26 @@ class SchemaController {
 				new Schemas\ShippingAddressSchema(),
 				new Schemas\ErrorSchema()
 			),
-			'cart-coupon'             => new Schemas\CartCouponSchema(),
-			'cart-item'               => new Schemas\CartItemSchema(
+			Schemas\CartCouponSchema::IDENTIFIER       => new Schemas\CartCouponSchema(),
+			Schemas\CartItemSchema::IDENTIFIER         => new Schemas\CartItemSchema(
 				new Schemas\ImageAttachmentSchema()
 			),
-			'checkout'                => new Schemas\CheckoutSchema(
+			Schemas\CheckoutSchema::IDENTIFIER         => new Schemas\CheckoutSchema(
 				new Schemas\BillingAddressSchema(),
 				new Schemas\ShippingAddressSchema()
 			),
-			'product'                 => new Schemas\ProductSchema(
+			Schemas\ProductSchema::IDENTIFIER          => new Schemas\ProductSchema(
 				new Schemas\ImageAttachmentSchema()
 			),
-			'product-attribute'       => new Schemas\ProductAttributeSchema(),
-			'product-category'        => new Schemas\ProductCategorySchema(
+			Schemas\ProductAttributeSchema::IDENTIFIER => new Schemas\ProductAttributeSchema(),
+			Schemas\ProductCategorySchema::IDENTIFIER  => new Schemas\ProductCategorySchema(
 				new Schemas\ImageAttachmentSchema()
 			),
-			'product-collection-data' => new Schemas\ProductCollectionDataSchema(),
-			'product-review'          => new Schemas\ProductReviewSchema(
+			Schemas\ProductCollectionDataSchema::IDENTIFIER => new Schemas\ProductCollectionDataSchema(),
+			Schemas\ProductReviewSchema::IDENTIFIER    => new Schemas\ProductReviewSchema(
 				new Schemas\ImageAttachmentSchema()
 			),
-			'term'                    => new Schemas\TermSchema(),
+			Schemas\TermSchema::IDENTIFIER             => new Schemas\TermSchema(),
 		];
 	}
 }

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -20,10 +20,17 @@ class SchemaController {
 	 */
 	protected $schemas = [];
 
+	/**
+	 * Stores Rest Extending instance
+	 *
+	 * @var ExtendRestApi
+	 */
 	private $extend;
 
 	/**
 	 * Constructor.
+	 *
+	 * @param ExtendRestApi $extend Rest Extending instance.
 	 */
 	public function __construct( ExtendRestApi $extend ) {
 		$this->extend = $extend;

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -3,6 +3,8 @@ namespace Automattic\WooCommerce\Blocks\StoreApi;
 
 use Exception;
 use Schemas\AbstractSchema;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
 
 /**
  * SchemaController class.
@@ -18,10 +20,13 @@ class SchemaController {
 	 */
 	protected $schemas = [];
 
+	private $extend;
+
 	/**
 	 * Constructor.
 	 */
-	public function __construct() {
+	public function __construct( ExtendRestApi $extend_schema ) {
+		$this->extend = $extend_schema;
 		$this->initialize();
 	}
 
@@ -46,34 +51,49 @@ class SchemaController {
 	protected function initialize() {
 		$this->schemas = [
 			Schemas\CartSchema::IDENTIFIER             => new Schemas\CartSchema(
+				$this->extend,
 				new Schemas\CartItemSchema(
-					new Schemas\ImageAttachmentSchema()
+					$this->extend,
+					new Schemas\ImageAttachmentSchema( $this->extend )
 				),
-				new Schemas\CartCouponSchema(),
-				new Schemas\CartShippingRateSchema(),
-				new Schemas\ShippingAddressSchema(),
-				new Schemas\ErrorSchema()
+				new Schemas\CartCouponSchema( $this->extend ),
+				new Schemas\CartShippingRateSchema( $this->extend ),
+				new Schemas\ShippingAddressSchema( $this->extend ),
+				new Schemas\ErrorSchema( $this->extend )
 			),
-			Schemas\CartCouponSchema::IDENTIFIER       => new Schemas\CartCouponSchema(),
+			Schemas\CartCouponSchema::IDENTIFIER       => new Schemas\CartCouponSchema( $this->extend ),
 			Schemas\CartItemSchema::IDENTIFIER         => new Schemas\CartItemSchema(
-				new Schemas\ImageAttachmentSchema()
+				$this->extend,
+				new Schemas\ImageAttachmentSchema( $this->extend )
 			),
 			Schemas\CheckoutSchema::IDENTIFIER         => new Schemas\CheckoutSchema(
-				new Schemas\BillingAddressSchema(),
-				new Schemas\ShippingAddressSchema()
+				$this->extend,
+				new Schemas\BillingAddressSchema( $this->extend ),
+				new Schemas\ShippingAddressSchema(
+					$this->extend
+				)
 			),
 			Schemas\ProductSchema::IDENTIFIER          => new Schemas\ProductSchema(
-				new Schemas\ImageAttachmentSchema()
+				$this->extend,
+				new Schemas\ImageAttachmentSchema(
+					$this->extend
+				)
 			),
-			Schemas\ProductAttributeSchema::IDENTIFIER => new Schemas\ProductAttributeSchema(),
+			Schemas\ProductAttributeSchema::IDENTIFIER => new Schemas\ProductAttributeSchema( $this->extend ),
 			Schemas\ProductCategorySchema::IDENTIFIER  => new Schemas\ProductCategorySchema(
-				new Schemas\ImageAttachmentSchema()
+				$this->extend,
+				new Schemas\ImageAttachmentSchema( $this->extend )
 			),
-			Schemas\ProductCollectionDataSchema::IDENTIFIER => new Schemas\ProductCollectionDataSchema(),
+			Schemas\ProductCollectionDataSchema::IDENTIFIER => new Schemas\ProductCollectionDataSchema(
+				$this->extend
+			),
 			Schemas\ProductReviewSchema::IDENTIFIER    => new Schemas\ProductReviewSchema(
-				new Schemas\ImageAttachmentSchema()
+				$this->extend,
+				new Schemas\ImageAttachmentSchema( $this->extend )
 			),
-			Schemas\TermSchema::IDENTIFIER             => new Schemas\TermSchema(),
+			Schemas\TermSchema::IDENTIFIER             => new Schemas\TermSchema(
+				$this->extend
+			),
 		];
 	}
 }

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -92,7 +92,7 @@ abstract class AbstractSchema {
 	protected function get_extended_schema( $endpoint, ...$passed_args ) {
 		return [
 			'description' => __( 'Extensions data.', 'woo-gutenberg-products-block' ),
-			'type'        => 'object',
+			'type'        => [ 'object' ],
 			'context'     => [ 'view', 'edit' ],
 			'readonly'    => true,
 			'properties'  => $this->extend->get_endpoint_schema( $endpoint, $passed_args ),

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -26,7 +26,12 @@ abstract class AbstractSchema {
 	 */
 	protected $extend;
 
-	public function __construct( ExtendRestAPI $extend ) {
+	/**
+	 * Constructor.
+	 *
+	 * @param ExtendRestApi $extend Rest Extending instance.
+	 */
+	public function __construct( ExtendRestApi $extend ) {
 		$this->extend = $extend;
 	}
 

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 /**
  * AbstractSchema class.
  *
@@ -16,6 +18,13 @@ abstract class AbstractSchema {
 	 * @var string
 	 */
 	protected $title = 'Schema';
+
+	/**
+	 * Rest extend instance
+	 *
+	 * @var ExtendRestApi
+	 */
+	protected $extend;
 
 	/**
 	 * Returns the full item schema.
@@ -46,6 +55,29 @@ abstract class AbstractSchema {
 		return $schema;
 	}
 
+	/**
+	 * Returns extended data for a specific endpoint
+	 *
+	 * @param string $endpoint The endpoint identifer.
+	 * @param array  ...$passed_args An array of arguments to be passed to callbacks.
+	 * @return array the data that will get added.
+	 */
+	protected function get_extended_data( $endpoint, ...$passed_args ) {
+		$this->extend = Package::container()->get( ExtendRestApi::class );
+		return $this->extend->get_endpoint_data( $endpoint, $passed_args );
+	}
+
+	/**
+	 * Returns extended schema for a specific endpoint
+	 *
+	 * @param string $endpoint The endpoint identifer.
+	 * @param array  ...$passed_args An array of arguments to be passed to callbacks.
+	 * @return array the data that will get added.
+	 */
+	protected function get_extended_schema( $endpoint, ...$passed_args ) {
+		$this->extend = Package::container()->get( ExtendRestApi::class );
+		return $this->extend->get_endpoint_schema( $endpoint, $passed_args );
+	}
 	/**
 	 * Retrieves an array of endpoint arguments from the item schema for the controller.
 	 *

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -76,7 +76,7 @@ abstract class AbstractSchema {
 	 *
 	 * @param string $endpoint The endpoint identifer.
 	 * @param array  ...$passed_args An array of arguments to be passed to callbacks.
-	 * @return array the data that will get added.
+	 * @return object the data that will get added.
 	 */
 	protected function get_extended_data( $endpoint, ...$passed_args ) {
 		return $this->extend->get_endpoint_data( $endpoint, $passed_args );

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -26,8 +26,8 @@ abstract class AbstractSchema {
 	 */
 	protected $extend;
 
-	public function __construct( ExtendRestAPI $extend_schema ) {
-		$this->extend = $extend_schema;
+	public function __construct( ExtendRestAPI $extend ) {
+		$this->extend = $extend;
 	}
 
 	/**

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -27,6 +27,13 @@ abstract class AbstractSchema {
 	protected $extend;
 
 	/**
+	 * Extending key that gets added to endpoint.
+	 *
+	 * @var string
+	 */
+	const EXTENDING_KEY = 'extensions';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param ExtendRestApi $extend Rest Extending instance.
@@ -83,7 +90,13 @@ abstract class AbstractSchema {
 	 * @return array the data that will get added.
 	 */
 	protected function get_extended_schema( $endpoint, ...$passed_args ) {
-		return $this->extend->get_endpoint_schema( $endpoint, $passed_args );
+		return [
+			'description' => __( 'Extensions data.', 'woo-gutenberg-products-block' ),
+			'type'        => 'object',
+			'context'     => [ 'view', 'edit' ],
+			'readonly'    => true,
+			'properties'  => $this->extend->get_endpoint_schema( $endpoint, $passed_args ),
+		];
 	}
 	/**
 	 * Retrieves an array of endpoint arguments from the item schema for the controller.

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -26,6 +26,10 @@ abstract class AbstractSchema {
 	 */
 	protected $extend;
 
+	public function __construct( ExtendRestAPI $extend_schema ) {
+		$this->extend = $extend_schema;
+	}
+
 	/**
 	 * Returns the full item schema.
 	 *
@@ -63,7 +67,6 @@ abstract class AbstractSchema {
 	 * @return array the data that will get added.
 	 */
 	protected function get_extended_data( $endpoint, ...$passed_args ) {
-		$this->extend = Package::container()->get( ExtendRestApi::class );
 		return $this->extend->get_endpoint_data( $endpoint, $passed_args );
 	}
 
@@ -75,7 +78,6 @@ abstract class AbstractSchema {
 	 * @return array the data that will get added.
 	 */
 	protected function get_extended_schema( $endpoint, ...$passed_args ) {
-		$this->extend = Package::container()->get( ExtendRestApi::class );
 		return $this->extend->get_endpoint_schema( $endpoint, $passed_args );
 	}
 	/**

--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\RestApi\Routes;
 
+
 /**
  * BillingAddressSchema class.
  *

--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -19,6 +19,13 @@ class BillingAddressSchema extends AbstractSchema {
 	protected $title = 'billing_address';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'billing-address';
+
+	/**
 	 * Term properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -18,6 +18,13 @@ class CartCouponSchema extends AbstractSchema {
 	protected $title = 'cart_coupon';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'cart-coupon';
+
+	/**
 	 * Cart schema properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -2,6 +2,8 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
 
 /**
  * CartCouponSchema class.

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -2,8 +2,6 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
-
 
 /**
  * CartCouponSchema class.

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -1,6 +1,9 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
+
 /**
  * CartItemSchema class.
  *
@@ -21,22 +24,6 @@ class CartItemSchema extends ProductSchema {
 	 * @var string
 	 */
 	const IDENTIFIER = 'cart-item';
-
-	/**
-	 * Image attachment schema instance.
-	 *
-	 * @var ImageAttachmentSchema
-	 */
-	protected $image_attachment_schema;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
-	 */
-	public function __construct( ImageAttachmentSchema $image_attachment_schema ) {
-		$this->image_attachment_schema = $image_attachment_schema;
-	}
 
 	/**
 	 * Cart schema properties.

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -266,6 +266,13 @@ class CartItemSchema extends ProductSchema {
 					]
 				),
 			],
+			'extensions'           => [
+				'description' => __( 'Extra data attached by extensions', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+				'properties'  => apply_filters( '__internal_extend_cart_item_schema', [] ),
+			],
 		];
 	}
 
@@ -304,6 +311,7 @@ class CartItemSchema extends ProductSchema {
 					'line_total_tax'    => $this->prepare_money_response( $cart_item['line_tax'], wc_get_price_decimals() ),
 				]
 			),
+			'extensions'           => apply_filters( '__internal_extend_cart_item_data', [], $cart_item ),
 		];
 	}
 

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -260,13 +260,7 @@ class CartItemSchema extends ProductSchema {
 					]
 				),
 			],
-			'extensions'           => [
-				'description' => __( 'Extra data attached by extensions', 'woo-gutenberg-products-block' ),
-				'type'        => 'array',
-				'context'     => [ 'view' ],
-				'readonly'    => true,
-				'properties'  => $this->get_extended_schema( self::IDENTIFIER ),
-			],
+			self::EXTENDING_KEY    => $this->get_extended_schema( self::IDENTIFIER ),
 		];
 	}
 
@@ -305,7 +299,7 @@ class CartItemSchema extends ProductSchema {
 					'line_total_tax'    => $this->prepare_money_response( $cart_item['line_tax'], wc_get_price_decimals() ),
 				]
 			),
-			'extensions'           => $this->get_extended_data( self::IDENTIFIER, $cart_item, $product ),
+			self::EXTENDING_KEY    => $this->get_extended_data( self::IDENTIFIER, $cart_item ),
 		];
 	}
 

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -16,6 +16,13 @@ class CartItemSchema extends ProductSchema {
 	protected $title = 'cart_item';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'cart-item';
+
+	/**
 	 * Image attachment schema instance.
 	 *
 	 * @var ImageAttachmentSchema
@@ -271,7 +278,7 @@ class CartItemSchema extends ProductSchema {
 				'type'        => 'array',
 				'context'     => [ 'view' ],
 				'readonly'    => true,
-				'properties'  => apply_filters( '__internal_extend_cart_item_schema', [] ),
+				'properties'  => $this->get_extended_schema( self::IDENTIFIER ),
 			],
 		];
 	}
@@ -311,7 +318,7 @@ class CartItemSchema extends ProductSchema {
 					'line_total_tax'    => $this->prepare_money_response( $cart_item['line_tax'], wc_get_price_decimals() ),
 				]
 			),
-			'extensions'           => apply_filters( '__internal_extend_cart_item_data', [], $cart_item ),
+			'extensions'           => $this->get_extended_data( self::IDENTIFIER, [ $cart_item ] ),
 		];
 	}
 

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -318,7 +318,7 @@ class CartItemSchema extends ProductSchema {
 					'line_total_tax'    => $this->prepare_money_response( $cart_item['line_tax'], wc_get_price_decimals() ),
 				]
 			),
-			'extensions'           => $this->get_extended_data( self::IDENTIFIER, [ $cart_item ] ),
+			'extensions'           => $this->get_extended_data( self::IDENTIFIER, $cart_item, $product ),
 		];
 	}
 

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -64,6 +64,7 @@ class CartSchema extends AbstractSchema {
 	/**
 	 * Constructor.
 	 *
+	 * @param ExtendRestApi          $extend Rest Extending instance.
 	 * @param CartItemSchema         $item_schema Item schema instance.
 	 * @param CartCouponSchema       $coupon_schema Coupon schema instance.
 	 * @param CartShippingRateSchema $shipping_rate_schema Shipping rates schema instance.
@@ -71,7 +72,7 @@ class CartSchema extends AbstractSchema {
 	 * @param ErrorSchema            $error_schema Error schema instance.
 	 */
 	public function __construct(
-		ExtendRestAPI $extend,
+		ExtendRestApi $extend,
 		CartItemSchema $item_schema,
 		CartCouponSchema $coupon_schema,
 		CartShippingRateSchema $shipping_rate_schema,

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -18,6 +18,13 @@ class CartSchema extends AbstractSchema {
 	protected $title = 'cart';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'cart';
+
+	/**
 	 * Item schema instance.
 	 *
 	 * @var CartItemSchema

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -71,7 +71,7 @@ class CartSchema extends AbstractSchema {
 	 * @param ErrorSchema            $error_schema Error schema instance.
 	 */
 	public function __construct(
-		ExtendRestAPI $extend_schema,
+		ExtendRestAPI $extend,
 		CartItemSchema $item_schema,
 		CartCouponSchema $coupon_schema,
 		CartShippingRateSchema $shipping_rate_schema,
@@ -83,7 +83,7 @@ class CartSchema extends AbstractSchema {
 		$this->shipping_rate_schema    = $shipping_rate_schema;
 		$this->shipping_address_schema = $shipping_address_schema;
 		$this->error_schema            = $error_schema;
-		parent::__construct( $extend_schema );
+		parent::__construct( $extend );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -2,6 +2,8 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
 
 /**
  * CartSchema class.
@@ -69,6 +71,7 @@ class CartSchema extends AbstractSchema {
 	 * @param ErrorSchema            $error_schema Error schema instance.
 	 */
 	public function __construct(
+		ExtendRestAPI $extend_schema,
 		CartItemSchema $item_schema,
 		CartCouponSchema $coupon_schema,
 		CartShippingRateSchema $shipping_rate_schema,
@@ -80,6 +83,7 @@ class CartSchema extends AbstractSchema {
 		$this->shipping_rate_schema    = $shipping_rate_schema;
 		$this->shipping_address_schema = $shipping_address_schema;
 		$this->error_schema            = $error_schema;
+		parent::__construct( $extend_schema );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -17,6 +17,13 @@ class CartShippingRateSchema extends AbstractSchema {
 	protected $title = 'cart-shipping-rate';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'cart-shipping-rate';
+
+	/**
 	 * Cart schema properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -45,10 +45,10 @@ class CheckoutSchema extends AbstractSchema {
 	 * @param BillingAddressSchema  $billing_address_schema Billing address schema instance.
 	 * @param ShippingAddressSchema $shipping_address_schema Shipping address schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend_schema, BillingAddressSchema $billing_address_schema, ShippingAddressSchema $shipping_address_schema ) {
+	public function __construct( ExtendRestAPI $extend, BillingAddressSchema $billing_address_schema, ShippingAddressSchema $shipping_address_schema ) {
 		$this->billing_address_schema  = $billing_address_schema;
 		$this->shipping_address_schema = $shipping_address_schema;
-		parent::__construct( $extend_schema );
+		parent::__construct( $extend );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -2,6 +2,8 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
 
 /**
  * CheckoutSchema class.
@@ -43,9 +45,10 @@ class CheckoutSchema extends AbstractSchema {
 	 * @param BillingAddressSchema  $billing_address_schema Billing address schema instance.
 	 * @param ShippingAddressSchema $shipping_address_schema Shipping address schema instance.
 	 */
-	public function __construct( BillingAddressSchema $billing_address_schema, ShippingAddressSchema $shipping_address_schema ) {
+	public function __construct( ExtendRestAPI $extend_schema, BillingAddressSchema $billing_address_schema, ShippingAddressSchema $shipping_address_schema ) {
 		$this->billing_address_schema  = $billing_address_schema;
 		$this->shipping_address_schema = $shipping_address_schema;
+		parent::__construct( $extend_schema );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -42,10 +42,11 @@ class CheckoutSchema extends AbstractSchema {
 	/**
 	 * Constructor.
 	 *
+	 * @param ExtendRestApi         $extend Rest Extending instance.
 	 * @param BillingAddressSchema  $billing_address_schema Billing address schema instance.
 	 * @param ShippingAddressSchema $shipping_address_schema Shipping address schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend, BillingAddressSchema $billing_address_schema, ShippingAddressSchema $shipping_address_schema ) {
+	public function __construct( ExtendRestApi $extend, BillingAddressSchema $billing_address_schema, ShippingAddressSchema $shipping_address_schema ) {
 		$this->billing_address_schema  = $billing_address_schema;
 		$this->shipping_address_schema = $shipping_address_schema;
 		parent::__construct( $extend );

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -17,6 +17,13 @@ class CheckoutSchema extends AbstractSchema {
 	protected $title = 'checkout';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'checkout';
+
+	/**
 	 * Billing address schema instance.
 	 *
 	 * @var BillingAddressSchema

--- a/src/StoreApi/Schemas/ErrorSchema.php
+++ b/src/StoreApi/Schemas/ErrorSchema.php
@@ -16,6 +16,13 @@ class ErrorSchema extends AbstractSchema {
 	protected $title = 'error';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'error';
+
+	/**
 	 * Product schema properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/ImageAttachmentSchema.php
@@ -15,6 +15,13 @@ class ImageAttachmentSchema extends AbstractSchema {
 	protected $title = 'image';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'image';
+
+	/**
 	 * Product schema properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/OrderCouponSchema.php
+++ b/src/StoreApi/Schemas/OrderCouponSchema.php
@@ -15,6 +15,13 @@ class OrderCouponSchema extends AbstractSchema {
 	protected $title = 'order_coupon';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order-coupon';
+
+	/**
 	 * Cart schema properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/ProductAttributeSchema.php
+++ b/src/StoreApi/Schemas/ProductAttributeSchema.php
@@ -16,6 +16,13 @@ class ProductAttributeSchema extends AbstractSchema {
 	protected $title = 'product_attribute';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'product-attribute';
+
+	/**
 	 * Term properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -36,9 +36,9 @@ class ProductCategorySchema extends TermSchema {
 	 *
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend_schema, ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestAPI $extend, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
-		parent::__construct( $extend_schema );
+		parent::__construct( $extend );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -1,6 +1,9 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
+
 /**
  * ProductCategorySchema class.
  *
@@ -33,8 +36,9 @@ class ProductCategorySchema extends TermSchema {
 	 *
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestAPI $extend_schema, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
+		parent::__construct( $extend_schema );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -15,6 +15,13 @@ class ProductCategorySchema extends TermSchema {
 	protected $title = 'product-category';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'product-category';
+
+	/**
 	 * Image attachment schema instance.
 	 *
 	 * @var ImageAttachmentSchema

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -34,9 +34,10 @@ class ProductCategorySchema extends TermSchema {
 	/**
 	 * Constructor.
 	 *
+	 * @param ExtendRestApi         $extend Rest Extending instance.
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend, ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestApi $extend, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
 		parent::__construct( $extend );
 	}

--- a/src/StoreApi/Schemas/ProductCollectionDataSchema.php
+++ b/src/StoreApi/Schemas/ProductCollectionDataSchema.php
@@ -16,6 +16,13 @@ class ProductCollectionDataSchema extends AbstractSchema {
 	protected $title = 'product-collection-data';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'product-collection-data';
+
+	/**
 	 * Product collection data schema properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -36,9 +36,9 @@ class ProductReviewSchema extends AbstractSchema {
 	 *
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend_schema, ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestAPI $extend, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
-		parent::__construct( $extend_schema );
+		parent::__construct( $extend );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -1,6 +1,9 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
+
 /**
  * ProductReviewSchema class.
  *
@@ -33,8 +36,9 @@ class ProductReviewSchema extends AbstractSchema {
 	 *
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestAPI $extend_schema, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
+		parent::__construct( $extend_schema );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -34,9 +34,10 @@ class ProductReviewSchema extends AbstractSchema {
 	/**
 	 * Constructor.
 	 *
+	 * @param ExtendRestApi         $extend Rest Extending instance.
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend, ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestApi $extend, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
 		parent::__construct( $extend );
 	}

--- a/src/StoreApi/Schemas/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/ProductReviewSchema.php
@@ -15,6 +15,13 @@ class ProductReviewSchema extends AbstractSchema {
 	protected $title = 'product_review';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'product-review';
+
+	/**
 	 * Image attachment schema instance.
 	 *
 	 * @var ImageAttachmentSchema

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -16,6 +16,13 @@ class ProductSchema extends AbstractSchema {
 	protected $title = 'product';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'product';
+
+	/**
 	 * Image attachment schema instance.
 	 *
 	 * @var ImageAttachmentSchema

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -1,6 +1,9 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
+
 /**
  * ProductSchema class.
  *
@@ -34,8 +37,9 @@ class ProductSchema extends AbstractSchema {
 	 *
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestAPI $extend_schema, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
+		parent::__construct( $extend_schema );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -37,9 +37,9 @@ class ProductSchema extends AbstractSchema {
 	 *
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend_schema, ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestAPI $extend, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
-		parent::__construct( $extend_schema );
+		parent::__construct( $extend );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -35,9 +35,10 @@ class ProductSchema extends AbstractSchema {
 	/**
 	 * Constructor.
 	 *
+	 * @param ExtendRestApi         $extend Rest Extending instance.
 	 * @param ImageAttachmentSchema $image_attachment_schema Image attachment schema instance.
 	 */
-	public function __construct( ExtendRestAPI $extend, ImageAttachmentSchema $image_attachment_schema ) {
+	public function __construct( ExtendRestApi $extend, ImageAttachmentSchema $image_attachment_schema ) {
 		$this->image_attachment_schema = $image_attachment_schema;
 		parent::__construct( $extend );
 	}

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -20,6 +20,13 @@ class ShippingAddressSchema extends AbstractSchema {
 	protected $title = 'shipping_address';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'shipping-address';
+
+	/**
 	 * Term properties.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/TermSchema.php
+++ b/src/StoreApi/Schemas/TermSchema.php
@@ -16,6 +16,13 @@ class TermSchema extends AbstractSchema {
 	protected $title = 'term';
 
 	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'term';
+
+	/**
 	 * Term properties.
 	 *
 	 * @return array

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -11,11 +11,17 @@ use \WC_Helper_Product as ProductHelper;
 use \WC_Helper_Coupon as CouponHelper;
 use \WC_Helper_Shipping;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Package;
+
 
 /**
  * Cart Controller Tests.
  */
 class Cart extends TestCase {
+
+	private $mock_extend;
+
 	/**
 	 * Setup test products data. Called before every test.
 	 */
@@ -27,6 +33,8 @@ class Cart extends TestCase {
 		update_option( 'woocommerce_weight_unit', 'g' );
 
 		$this->products = [];
+
+		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
 
 		// Create some test products.
 		$this->products[0] = ProductHelper::create_simple_product( false );
@@ -350,7 +358,7 @@ class Cart extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'cart' );
 		$cart       = wc()->cart;
 		$response   = $controller->prepare_item_for_response( $cart, new \WP_REST_Request() );
@@ -370,7 +378,7 @@ class Cart extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'cart' );
 		$schema     = $controller->get_item_schema();
 		$cart       = wc()->cart;

--- a/tests/php/StoreApi/Routes/CartCoupons.php
+++ b/tests/php/StoreApi/Routes/CartCoupons.php
@@ -10,11 +10,16 @@ use \WC_REST_Unit_Test_Case as TestCase;
 use \WC_Helper_Product as ProductHelper;
 use \WC_Helper_Coupon as CouponHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
+use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 
 /**
  * Cart Coupons Controller Tests.
  */
 class CartCoupons extends TestCase {
+
+	private $mock_extend;
+
 	/**
 	 * Setup test products data. Called before every test.
 	 */
@@ -22,6 +27,8 @@ class CartCoupons extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
+
+		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
 
 		$this->product = ProductHelper::create_simple_product( false );
 		$this->coupon  = CouponHelper::create_coupon();
@@ -154,7 +161,7 @@ class CartCoupons extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'cart-coupons' );
 
 		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), new \WP_REST_Request() );
@@ -168,7 +175,7 @@ class CartCoupons extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'cart-coupons' );
 		$schema     = $controller->get_item_schema();
 		$response   = $controller->prepare_item_for_response( $this->coupon->get_code(), new \WP_REST_Request() );

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -9,11 +9,16 @@ use \WP_REST_Request;
 use \WC_REST_Unit_Test_Case as TestCase;
 use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Package;
 
 /**
  * Cart Controller Tests.
  */
 class CartItems extends TestCase {
+
+	private $mock_extend;
+
 	/**
 	 * Setup test products data. Called before every test.
 	 */
@@ -21,6 +26,8 @@ class CartItems extends TestCase {
 		global $wpdb;
 
 		parent::setUp();
+
+		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
 
 		wp_set_current_user( 0 );
 
@@ -218,7 +225,7 @@ class CartItems extends TestCase {
 	 * Test conversion of cart item to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'cart-items' );
 		$cart       = wc()->cart->get_cart();
 		$response   = $controller->prepare_item_for_response( current( $cart ), new \WP_REST_Request() );
@@ -245,7 +252,7 @@ class CartItems extends TestCase {
 	 * Tests schema of both products in cart to cover as much schema as possible.
 	 */
 	public function test_schema_matches_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'cart-items' );
 		$schema     = $controller->get_item_schema();
 		$cart       = wc()->cart->get_cart();

--- a/tests/php/StoreApi/Routes/ProductAttributeTerms.php
+++ b/tests/php/StoreApi/Routes/ProductAttributeTerms.php
@@ -9,11 +9,16 @@ use \WP_REST_Request;
 use \WC_REST_Unit_Test_Case as TestCase;
 use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
+use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 
 /**
  * Product Attributes Controller Tests.
  */
 class ProductAttributeTerms extends TestCase {
+
+	private $mock_extend;
+
 	/**
 	 * Setup test products data. Called before every test.
 	 */
@@ -21,6 +26,7 @@ class ProductAttributeTerms extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
 
 		$this->attributes    = [];
 		$this->attributes[0] = ProductHelper::create_attribute( 'color', [ 'red', 'green', 'blue' ] );
@@ -66,7 +72,7 @@ class ProductAttributeTerms extends TestCase {
 	 * Test conversion of product to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schema     = new \Automattic\WooCommerce\Blocks\StoreApi\Schemas\TermSchema();
+		$schema     = new \Automattic\WooCommerce\Blocks\StoreApi\Schemas\TermSchema( $this->mock_extend );
 		$controller = new \Automattic\WooCommerce\Blocks\StoreApi\Routes\ProductAttributeTerms( $schema );
 		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'test', 'pa_size' ), new \WP_REST_Request() );
 		$data       = $response->get_data();
@@ -82,7 +88,7 @@ class ProductAttributeTerms extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-attribute-terms' );
 		$params     = $controller->get_collection_params();
 
@@ -95,7 +101,7 @@ class ProductAttributeTerms extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-attribute-terms' );
 		$schema     = $controller->get_item_schema();
 		$response   = $controller->prepare_item_for_response( get_term_by( 'name', 'test', 'pa_size' ), new \WP_REST_Request() );

--- a/tests/php/StoreApi/Routes/ProductAttributes.php
+++ b/tests/php/StoreApi/Routes/ProductAttributes.php
@@ -9,11 +9,16 @@ use \WP_REST_Request;
 use \WC_REST_Unit_Test_Case as TestCase;
 use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
+use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 
 /**
  * Product Attributes Controller Tests.
  */
 class ProductAttributes extends TestCase {
+
+	private $mock_extend;
+
 	/**
 	 * Setup test products data. Called before every test.
 	 */
@@ -21,6 +26,7 @@ class ProductAttributes extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
 
 		$color_attribute = ProductHelper::create_attribute( 'color', [ 'red', 'green', 'blue' ] );
 		$size_attribute  = ProductHelper::create_attribute( 'size', [ 'small', 'medium', 'large' ] );
@@ -76,7 +82,7 @@ class ProductAttributes extends TestCase {
 	 * Test conversion of product to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-attributes' );
 		$response   = $controller->prepare_item_for_response( $this->attributes[0], new \WP_REST_Request() );
 		$data       = $response->get_data();
@@ -93,7 +99,7 @@ class ProductAttributes extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-attributes' );
 		$schema     = $controller->get_item_schema();
 		$response   = $controller->prepare_item_for_response( $this->attributes[0], new \WP_REST_Request() );

--- a/tests/php/StoreApi/Routes/ProductCollectionData.php
+++ b/tests/php/StoreApi/Routes/ProductCollectionData.php
@@ -9,11 +9,16 @@ use \WP_REST_Request;
 use \WC_REST_Unit_Test_Case as TestCase;
 use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Package;
 
 /**
  * Controller Tests.
  */
 class ProductCollectionData extends TestCase {
+
+	private $mock_extend;
+
 	/**
 	 * Setup test products data. Called before every test.
 	 */
@@ -21,6 +26,7 @@ class ProductCollectionData extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
 
 		$this->products    = [];
 		$this->products[0] = ProductHelper::create_simple_product( false );
@@ -161,7 +167,7 @@ class ProductCollectionData extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-collection-data' );
 		$params     = $controller->get_collection_params();
 
@@ -176,7 +182,7 @@ class ProductCollectionData extends TestCase {
 	public function test_schema_matches_response() {
 		ProductHelper::create_variation_product();
 
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend ) );
 		$controller = $routes->get( 'product-collection-data' );
 		$schema     = $controller->get_item_schema();
 

--- a/tests/php/StoreApi/Routes/Products.php
+++ b/tests/php/StoreApi/Routes/Products.php
@@ -9,11 +9,14 @@ use \WP_REST_Request;
 use \WC_REST_Unit_Test_Case as TestCase;
 use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
-
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Package;
 /**
  * Products Controller Tests.
  */
 class Products extends TestCase {
+
+	private $mock_extend;
 	/**
 	 * Setup test products data. Called before every test.
 	 */
@@ -23,6 +26,7 @@ class Products extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
 
 		$this->products    = [];
 		$this->products[0] = ProductHelper::create_simple_product( true );
@@ -101,7 +105,7 @@ class Products extends TestCase {
 	 * Test conversion of prdouct to rest response.
 	 */
 	public function test_prepare_item_for_response() {
-		$schemas    = new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController();
+		$schemas    = new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController( $this->mock_extend );
 		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( $schemas );
 		$schema     = $schemas->get( 'product' );
 		$controller = $routes->get( 'products' );
@@ -129,7 +133,7 @@ class Products extends TestCase {
 	 * Test collection params getter.
 	 */
 	public function test_get_collection_params() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController($this->mock_extend) );
 		$controller = $routes->get( 'products' );
 		$params     = $controller->get_collection_params();
 
@@ -167,7 +171,7 @@ class Products extends TestCase {
 	 * Test schema matches responses.
 	 */
 	public function test_schema_matches_response() {
-		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController() );
+		$routes     = new \Automattic\WooCommerce\Blocks\StoreApi\RoutesController( new \Automattic\WooCommerce\Blocks\StoreApi\SchemaController($this->mock_extend) );
 		$controller = $routes->get( 'products' );
 		$schema     = $controller->get_item_schema();
 		$response   = $controller->prepare_item_for_response( $this->products[0], new \WP_REST_Request() );


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3244

This PR introduces `ExtendRestApi` a class that 3PD should use to extend the StoreAPI response to add extra data.
The goal of using this instead of filters directly is:
- Protecting the integrity of the original checkout, so that people don't break existing flows.
- Protecting other 3PD from having their code being broken by a rogue plugin.
- Protecting core experience from breaking if a plugin malfunction.
- Ensuring any integration is well validated and has the correct data.

For this, we changed how AbstractSchema work to be aware of `ExtendRestApi`.

### Interface.
3PD should call a `register_endpoint_data` function, that adds correct schema and data to each endpoint.

### Signature 

```php
$ExtendRestApi->register_endpoint_data( string $namespace, string $endpoint, callable $schema_callback, callable $data_callback );
```

$schema_callback is a function that should return an array with metadata of new endpoint being registered:

```php
function mySchemaFunction() {
  return [
		'fee' => [
			'description' => __( 'X Product fees', 'my-plugin' ),
			'type'        => 'integer',
			'context'     => [ 'view', 'edit' ],
			'readonly'    => true,
		],
	];
}
```

$data_callback is a function that should return an array with actual data being registered:

```php
function myDataFunction( $cart_item ) {
	$data = []
	if ( $cart_item['type'] === 'x-product' ) {
		$myXProduct = new MyCustomProduct( $cart_item['item'] );
		$data = [
			'fee' => $myXProduct->get_fee();
		]
	}
  return $data;
} 
```

### Current endpoints that can be extended.
Currently, we only have `cart/items` that can be extended, it passes `$cart_item` to `$data_callback`.

### Code example

```php
use Automattic\WooCommerce\Blocks\Package;
use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartItemSchema;

add_action('init', function() {
	$extend_instance = Package::container()->get( ExtendRestApi::class );

$extend_instance->register_endpoint_data(
		CartItemSchema::IDENTIFIER,
		"subscriptions",
		function () {
			return [
				'key' => [
					'description' => 'Subscription key',
					'type' => 'string',
				]
			];
		},
		function ( $cart_item ) {
			return [
				"key" => $cart_item['key']
			];
		},
	);
});
```

### How to test this change:

- Add the code example above in any plugin (even the main file of this plugin).
- In cart, inspect `store/cart` response.
- Under `items` you should see `extensions` and inside it `subscriptions` containing the data you added.
- Modify the code so that it causes an error, instead of `'key' => $cart_item['key']` try `'key' => new SomeClass`
- Visit cart again, `extensions` shouldn't include `subscriptions` anymore, an error would be logged.
- If you have debug enabled and logged in as an admin, you should an error being thrown.