### PR TITLE
Change delimiter used for spltChunks from tilde to hyphens

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -64,6 +64,11 @@ const getCoreConfig = ( options = {} ) => {
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksJsonp',
 		},
+		optimization: {
+			splitChunks: {
+				automaticNameDelimiter: '--',
+			},
+		},
 		module: {
 			rules: [
 				{
@@ -215,6 +220,11 @@ const getFrontConfig = ( options = {} ) => {
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksJsonp',
 		},
+		optimization: {
+			splitChunks: {
+				automaticNameDelimiter: '--',
+			},
+		},
 		module: {
 			rules: [
 				{
@@ -307,6 +317,11 @@ const getPaymentsConfig = ( options = {} ) => {
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksPaymentMethodExtensionJsonp',
+		},
+		optimization: {
+			splitChunks: {
+				automaticNameDelimiter: '--',
+			},
 		},
 		module: {
 			rules: [

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -133,6 +133,7 @@ const getMainConfig = ( options = {} ) => {
 		optimization: {
 			splitChunks: {
 				minSize: 0,
+				automaticNameDelimiter: '--',
 				cacheGroups: {
 					commons: {
 						test: /[\\/]node_modules[\\/]/,
@@ -410,6 +411,7 @@ const getStylingConfig = ( options = {} ) => {
 		optimization: {
 			splitChunks: {
 				minSize: 0,
+				automaticNameDelimiter: '--',
 				cacheGroups: {
 					editor: {
 						// Capture all `editor` stylesheets and editor-components stylesheets.


### PR DESCRIPTION
#3338 reported a conflict with a deployment system due to our built file and directory names containing the tilde character (`~`).

Whilst I couldn't find docs or other examples of this problem, switching our uses seems to have minimal impact. @nerrad pointed out `splitChunks.automaticNameDelimiter` documented [here](https://webpack.js.org/plugins/split-chunks-plugin/).

I opted to use a hyphen, but 2 to ensure there are no chance of conflicts with existing files (`--`).

Fixes #3338

### Screenshots

This is how the built files will look. Functionality is unchanged.

![webpack-configs js — woocommerce-gutenberg-products-block 2020-11-03 14-39-44](https://user-images.githubusercontent.com/90977/97999276-05fa3f00-1de3-11eb-8725-dc9c33c07ca1.png)

### How to test the changes in this Pull Request:

- Complete a build and smoke test block inserter - atomic blocks would be affected if this broke anything.
- Confirm `--` usage in built files.
