### PR TITLE
Fix account creation bugs

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	HAS_DARK_EDITOR_STYLE_SUPPORT,
-	CHECKOUT_ALLOWS_SIGNUP,
-} from '@woocommerce/block-settings';
+import { HAS_DARK_EDITOR_STYLE_SUPPORT } from '@woocommerce/block-settings';
 
 const blockAttributes = {
 	isPreview: {
@@ -22,7 +19,7 @@ const blockAttributes = {
 	},
 	allowCreateAccount: {
 		type: 'boolean',
-		default: CHECKOUT_ALLOWS_SIGNUP,
+		default: false,
 	},
 	showApartmentField: {
 		type: 'boolean',

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -23,7 +23,10 @@ import {
 	Main,
 } from '@woocommerce/base-components/sidebar-layout';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import { CHECKOUT_ALLOWS_GUEST } from '@woocommerce/block-settings';
+import {
+	CHECKOUT_ALLOWS_GUEST,
+	CHECKOUT_ALLOWS_SIGNUP,
+} from '@woocommerce/block-settings';
 import { compareWithWooVersion, getSetting } from '@woocommerce/settings';
 
 /**
@@ -102,7 +105,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		! isEditor &&
 		! customerId &&
 		! CHECKOUT_ALLOWS_GUEST &&
-		! allowCreateAccount
+		! ( allowCreateAccount && CHECKOUT_ALLOWS_SIGNUP )
 	) {
 		return (
 			<>

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -17,6 +17,7 @@ import {
 	PRIVACY_URL,
 	TERMS_URL,
 	CHECKOUT_PAGE_ID,
+	CHECKOUT_ALLOWS_SIGNUP,
 } from '@woocommerce/block-settings';
 import { compareWithWooVersion, getAdminLink } from '@woocommerce/settings';
 import { createInterpolateElement } from 'wordpress-element';
@@ -59,7 +60,8 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 	// setting initial password.
 	// Also implicitly gated to feature plugin, because Checkout
 	// block is gated to plugin
-	const showCreateAccountOption = compareWithWooVersion( '4.7.0', '<=' );
+	const showCreateAccountOption =
+		CHECKOUT_ALLOWS_SIGNUP && compareWithWooVersion( '4.7.0', '<=' );
 	return (
 		<InspectorControls>
 			{ currentPostId !== CHECKOUT_PAGE_ID && (

--- a/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
@@ -5,7 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { DebouncedValidatedTextInput } from '@woocommerce/base-components/text-input';
 import { useCheckoutContext } from '@woocommerce/base-context';
-import { CHECKOUT_ALLOWS_GUEST } from '@woocommerce/block-settings';
+import {
+	CHECKOUT_ALLOWS_GUEST,
+	CHECKOUT_ALLOWS_SIGNUP,
+} from '@woocommerce/block-settings';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 
 /**
@@ -26,7 +29,8 @@ const ContactFieldsStep = ( {
 
 	const createAccountUI = ! customerId &&
 		allowCreateAccount &&
-		CHECKOUT_ALLOWS_GUEST && (
+		CHECKOUT_ALLOWS_GUEST &&
+		CHECKOUT_ALLOWS_SIGNUP && (
 			<CheckboxControl
 				className="wc-block-checkout__create-account"
 				label={ __(

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -123,17 +123,6 @@ class Assets {
 	}
 
 	/**
-	 * Check whether store is configured to allow shoppers to sign up for
-	 * an account at checkout.
-	 * Inspired by WC_Checkout::is_registration_enabled().
-	 *
-	 * @return Boolean True if store is configured to allow signup.
-	 */
-	public static function is_checkout_signup_allowed() {
-		return apply_filters( 'woocommerce_checkout_registration_enabled', 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout' ) );
-	}
-
-	/**
 	 * Returns block-related data for enqueued wc-block-settings script.
 	 *
 	 * This is used to map site settings & data into JS-accessible variables.
@@ -153,6 +142,7 @@ class Assets {
 			'privacy'  => wc_privacy_policy_page_id(),
 			'terms'    => wc_terms_and_conditions_page_id(),
 		];
+		$checkout       = WC()->checkout();
 
 		// Global settings used in each block.
 		return array_merge(
@@ -198,8 +188,14 @@ class Assets {
 					'privacy'  => self::format_page_resource( $page_ids['privacy'] ),
 					'terms'    => self::format_page_resource( $page_ids['terms'] ),
 				],
-				'checkoutAllowsGuest'           => filter_var( get_option( 'woocommerce_enable_guest_checkout' ), FILTER_VALIDATE_BOOLEAN ),
-				'checkoutAllowsSignup'          => self::is_checkout_signup_allowed(),
+				'checkoutAllowsGuest'           => $checkout instanceof \WC_Checkout && false === filter_var(
+					$checkout->is_registration_required(),
+					FILTER_VALIDATE_BOOLEAN
+				),
+				'checkoutAllowsSignup'          => $checkout instanceof \WC_Checkout && filter_var(
+					$checkout->is_registration_enabled(),
+					FILTER_VALIDATE_BOOLEAN
+				),
 				'baseLocation'                  => wc_get_base_location(),
 				'woocommerceBlocksPhase'        => WOOCOMMERCE_BLOCKS_PHASE,
 				'hasDarkEditorStyleSupport'     => current_theme_supports( 'dark-editor-style' ),

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -123,6 +123,17 @@ class Assets {
 	}
 
 	/**
+	 * Check whether store is configured to allow shoppers to sign up for
+	 * an account at checkout.
+	 * Inspired by WC_Checkout::is_registration_enabled().
+	 *
+	 * @return Boolean True if store is configured to allow signup.
+	 */
+	public static function is_checkout_signup_allowed() {
+		return apply_filters( 'woocommerce_checkout_registration_enabled', 'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout' ) );
+	}
+
+	/**
 	 * Returns block-related data for enqueued wc-block-settings script.
 	 *
 	 * This is used to map site settings & data into JS-accessible variables.
@@ -188,7 +199,7 @@ class Assets {
 					'terms'    => self::format_page_resource( $page_ids['terms'] ),
 				],
 				'checkoutAllowsGuest'           => filter_var( get_option( 'woocommerce_enable_guest_checkout' ), FILTER_VALIDATE_BOOLEAN ),
-				'checkoutAllowsSignup'          => filter_var( get_option( 'woocommerce_enable_signup_and_login_from_checkout' ), FILTER_VALIDATE_BOOLEAN ),
+				'checkoutAllowsSignup'          => self::is_checkout_signup_allowed(),
 				'baseLocation'                  => wc_get_base_location(),
 				'woocommerceBlocksPhase'        => WOOCOMMERCE_BLOCKS_PHASE,
 				'hasDarkEditorStyleSupport'     => current_theme_supports( 'dark-editor-style' ),

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -139,17 +139,23 @@ class CreateAccount {
 		}
 
 		// From here we know that the shopper is not logged in.
+		// check for whether account creation is enabled at the global level.
+		$checkout = WC()->checkout();
 
-		if ( false === filter_var( get_option( 'woocommerce_enable_guest_checkout' ), FILTER_VALIDATE_BOOLEAN ) ) {
+		if ( $checkout instanceof \WC_Checkout && false === filter_var(
+			$checkout->is_registration_required(),
+			FILTER_VALIDATE_BOOLEAN
+		) ) {
 			// Store requires an account for all checkouts (purchases).
 			// Create an account independent of shopper option in $request.
 			// Note - checkbox is not displayed to shopper in this case.
 			return true;
 		}
 
-		// check for whether account creation is enabled at the global level.
-		$checkout = WC()->checkout();
-		if ( $checkout instanceof \WC_Checkout && false === filter_var( $checkout->is_registration_enabled(), FILTER_VALIDATE_BOOLEAN ) ) {
+		if ( $checkout instanceof \WC_Checkout && false === filter_var(
+			$checkout->is_registration_enabled(),
+			FILTER_VALIDATE_BOOLEAN
+		) ) {
 			// Registration is not enabled for the store, so return false.
 			return false;
 		}

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -146,16 +146,16 @@ class CreateAccount {
 			return false;
 		}
 
+		if ( false === filter_var( $checkout->is_registration_enabled(), FILTER_VALIDATE_BOOLEAN ) ) {
+			// Registration is not enabled for the store, so return false.
+			return false;
+		}
+
 		if ( true === filter_var( $checkout->is_registration_required(), FILTER_VALIDATE_BOOLEAN ) ) {
 			// Store requires an account for all checkouts (purchases).
 			// Create an account independent of shopper option in $request.
 			// Note - checkbox is not displayed to shopper in this case.
 			return true;
-		}
-
-		if ( false === filter_var( $checkout->is_registration_enabled(), FILTER_VALIDATE_BOOLEAN ) ) {
-			// Registration is not enabled for the store, so return false.
-			return false;
 		}
 
 		// From here we know that the store allows guest checkout;

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -142,7 +142,7 @@ class CreateAccount {
 		// check for whether account creation is enabled at the global level.
 		$checkout = WC()->checkout();
 
-		if ( $checkout instanceof \WC_Checkout && false === filter_var(
+		if ( $checkout instanceof \WC_Checkout && true === filter_var(
 			$checkout->is_registration_required(),
 			FILTER_VALIDATE_BOOLEAN
 		) ) {

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -141,21 +141,19 @@ class CreateAccount {
 		// From here we know that the shopper is not logged in.
 		// check for whether account creation is enabled at the global level.
 		$checkout = WC()->checkout();
+		if ( ! $checkout instanceof \WC_Checkout ) {
+			// If checkout class is not available, we have major problems, don't create account.
+			return false;
+		}
 
-		if ( $checkout instanceof \WC_Checkout && false === filter_var(
-			$checkout->is_registration_required(),
-			FILTER_VALIDATE_BOOLEAN
-		) ) {
+		if ( false === filter_var( $checkout->is_registration_required(), FILTER_VALIDATE_BOOLEAN ) ) {
 			// Store requires an account for all checkouts (purchases).
 			// Create an account independent of shopper option in $request.
 			// Note - checkbox is not displayed to shopper in this case.
 			return true;
 		}
 
-		if ( $checkout instanceof \WC_Checkout && false === filter_var(
-			$checkout->is_registration_enabled(),
-			FILTER_VALIDATE_BOOLEAN
-		) ) {
+		if ( false === filter_var( $checkout->is_registration_enabled(), FILTER_VALIDATE_BOOLEAN ) ) {
 			// Registration is not enabled for the store, so return false.
 			return false;
 		}

--- a/src/Domain/Services/CreateAccount.php
+++ b/src/Domain/Services/CreateAccount.php
@@ -147,6 +147,13 @@ class CreateAccount {
 			return true;
 		}
 
+		// check for whether account creation is enabled at the global level.
+		$checkout = WC()->checkout();
+		if ( $checkout instanceof \WC_Checkout && false === filter_var( $checkout->is_registration_enabled(), FILTER_VALIDATE_BOOLEAN ) ) {
+			// Registration is not enabled for the store, so return false.
+			return false;
+		}
+
 		// From here we know that the store allows guest checkout;
 		// shopper can choose whether they sign up (`should_create_account`).
 

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -189,7 +189,7 @@ class CreateAccount extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a user is not created if not requested (and the site allows guest checkout).
+	 * Test cases where a user should not be created (no signup should occur).
 	 */
 	public function test_no_account_created() {
 		$site_user_counts = count_users();

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -204,6 +204,7 @@ class CreateAccount extends WP_UnitTestCase {
 			],
 		);
 
+
 		// test with explicitly turning off global registration
 		$this->execute_create_customer_from_order(
 			'maryjones@testperson.net',
@@ -213,6 +214,18 @@ class CreateAccount extends WP_UnitTestCase {
 				'can_register' => 'no',
 				'should_create_account' => 'yes',
 				'enable_guest_checkout' => 'yes',
+			],
+		);
+
+		// test with guest checkout off and global registration off.
+		$this->execute_create_customer_from_order(
+			'maryjones@testperson.net',
+			'Mary',
+			'Jones',
+			[
+				'can_register' => 'no',
+				'should_create_account' => 'yes',
+				'enable_guest_checkout' => 'no',
 			],
 		);
 

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -15,6 +15,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\CreateAccount as TestedCreateA
  * that woocommerce_blocks_phase===3, i.e. dev build. Tests will fail
  * with other builds (release feature plugin, woo core package).
  * Related: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3211
+ * @group TESTS
  *
  * @since $VID:$
  */
@@ -37,13 +38,13 @@ class CreateAccount extends WP_UnitTestCase {
 
 		$tmp_enable_guest_checkout = get_option( 'woocommerce_enable_guest_checkout' );
 		$tmp_can_register = get_option('woocommerce_enable_signup_and_login_from_checkout');
-		$enable_guest_checkout = array_key_exists( 'enable_guest_checkout', $options ) ? $options['enable_guest_checkout'] : false;
+		$enable_guest_checkout = array_key_exists( 'enable_guest_checkout', $options ) ? $options['enable_guest_checkout'] : 'no';
 		$can_register = array_key_exists( 'can_register', $options ) ? $options['can_register'] : 'yes';
 		update_option( 'woocommerce_enable_guest_checkout', $enable_guest_checkout );
 		update_option( 'woocommerce_enable_signup_and_login_from_checkout', $can_register );
 
 		$test_request = new \WP_REST_Request();
-		$should_create_account = array_key_exists( 'should_create_account', $options ) ? $options['should_create_account'] : false;
+		$should_create_account = array_key_exists( 'should_create_account', $options ) ? $options['should_create_account'] : 'no';
 		$test_request->set_param( 'should_create_account', $should_create_account );
 		$test_request->set_param( 'billing_address', [
 			'email'      => $email,
@@ -102,8 +103,8 @@ class CreateAccount extends WP_UnitTestCase {
 				'Mary',
 				'Jones',
 				[
-					'should_create_account' => true,
-					'enable_guest_checkout' => true,
+					'should_create_account' => 'yes',
+					'enable_guest_checkout' => 'yes',
 				],
 			],
 			// User requested an account + site doesn't allow guest.
@@ -112,8 +113,8 @@ class CreateAccount extends WP_UnitTestCase {
 				'Mary',
 				'Jones',
 				[
-					'should_create_account' => true,
-					'enable_guest_checkout' => false,
+					'should_create_account' => 'yes',
+					'enable_guest_checkout' => 'no',
 				],
 			],
 			// User requested an account; name fields are not required.
@@ -122,8 +123,8 @@ class CreateAccount extends WP_UnitTestCase {
 				'',
 				'',
 				[
-					'should_create_account' => true,
-					'enable_guest_checkout' => true,
+					'should_create_account' => 'yes',
+					'enable_guest_checkout' => 'yes',
 				],
 			],
 			// Store does not allow guest - signup is required (automatic).
@@ -132,8 +133,8 @@ class CreateAccount extends WP_UnitTestCase {
 				'Henry',
 				'Kissinger',
 				[
-					'should_create_account' => false,
-					'enable_guest_checkout' => false,
+					'should_create_account' => 'no',
+					'enable_guest_checkout' => 'no',
 				],
 			],
 		];
@@ -154,8 +155,8 @@ class CreateAccount extends WP_UnitTestCase {
 			'Mary',
 			'Jones',
 			[
-				'should_create_account' => true,
-				'enable_guest_checkout' => true,
+				'should_create_account' => 'yes',
+				'enable_guest_checkout' => 'yes',
 			],
 		);
 	}
@@ -173,8 +174,8 @@ class CreateAccount extends WP_UnitTestCase {
 			'Mary',
 			'Jones',
 			[
-				'should_create_account' => true,
-				'enable_guest_checkout' => true,
+				'should_create_account' => 'yes',
+				'enable_guest_checkout' => 'yes',
 			],
 		);
 	}
@@ -199,22 +200,22 @@ class CreateAccount extends WP_UnitTestCase {
 			'Mary',
 			'Jones',
 			[
-				'should_create_account' => false,
-				'enable_guest_checkout' => true,
+				'should_create_account' => 'no',
+				'enable_guest_checkout' => 'yes',
 			],
 		);
 
 		// test with explicitly turning off global registration
-		$this->execute_create_customer_from_order(
-			'maryjones@testperson.net',
-			'Mary',
-			'Jones',
-			[
-				'can_register' => false,
-				'should_create_account' => false,
-				'enable_guest_checkout' => true,
-			],
-		);
+		// $this->execute_create_customer_from_order(
+		// 	'maryjones@testperson.net',
+		// 	'Mary',
+		// 	'Jones',
+		// 	[
+		// 		'can_register' => 'no',
+		// 		'should_create_account' => 'yes',
+		// 		'enable_guest_checkout' => 'yes',
+		// 	],
+		// );
 
 		$site_user_counts_after = count_users();
 

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -36,8 +36,11 @@ class CreateAccount extends WP_UnitTestCase {
 		/// -- Test-specific setup start.
 
 		$tmp_enable_guest_checkout = get_option( 'woocommerce_enable_guest_checkout' );
+		$tmp_can_register = get_option('woocommerce_enable_signup_and_login_from_checkout');
 		$enable_guest_checkout = array_key_exists( 'enable_guest_checkout', $options ) ? $options['enable_guest_checkout'] : false;
+		$can_register = array_key_exists( 'can_register', $options ) ? $options['can_register'] : 'yes';
 		update_option( 'woocommerce_enable_guest_checkout', $enable_guest_checkout );
+		update_option( 'woocommerce_enable_signup_and_login_from_checkout', $can_register );
 
 		$test_request = new \WP_REST_Request();
 		$should_create_account = array_key_exists( 'should_create_account', $options ) ? $options['should_create_account'] : false;
@@ -57,6 +60,7 @@ class CreateAccount extends WP_UnitTestCase {
 
 		/// -- Undo test-specific setup; restore previous state.
 		update_option( 'woocommerce_enable_guest_checkout', $tmp_enable_guest_checkout );
+		update_option( 'woocommerce_enable_signup_and_login_from_checkout', $tmp_can_register );
 
 		return [
 			'user_id' => $user_id,
@@ -190,11 +194,23 @@ class CreateAccount extends WP_UnitTestCase {
 	public function test_no_account_requested() {
 		$site_user_counts = count_users();
 
-		$result = $this->execute_create_customer_from_order(
+		$this->execute_create_customer_from_order(
 			'maryjones@testperson.net',
 			'Mary',
 			'Jones',
 			[
+				'should_create_account' => false,
+				'enable_guest_checkout' => true,
+			],
+		);
+
+		// test with explicitly turning off global registration
+		$this->execute_create_customer_from_order(
+			'maryjones@testperson.net',
+			'Mary',
+			'Jones',
+			[
+				'can_register' => false,
 				'should_create_account' => false,
 				'enable_guest_checkout' => true,
 			],

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -15,7 +15,6 @@ use Automattic\WooCommerce\Blocks\Domain\Services\CreateAccount as TestedCreateA
  * that woocommerce_blocks_phase===3, i.e. dev build. Tests will fail
  * with other builds (release feature plugin, woo core package).
  * Related: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3211
- * @group TESTS
  *
  * @since $VID:$
  */
@@ -206,16 +205,16 @@ class CreateAccount extends WP_UnitTestCase {
 		);
 
 		// test with explicitly turning off global registration
-		// $this->execute_create_customer_from_order(
-		// 	'maryjones@testperson.net',
-		// 	'Mary',
-		// 	'Jones',
-		// 	[
-		// 		'can_register' => 'no',
-		// 		'should_create_account' => 'yes',
-		// 		'enable_guest_checkout' => 'yes',
-		// 	],
-		// );
+		$this->execute_create_customer_from_order(
+			'maryjones@testperson.net',
+			'Mary',
+			'Jones',
+			[
+				'can_register' => 'no',
+				'should_create_account' => 'yes',
+				'enable_guest_checkout' => 'yes',
+			],
+		);
 
 		$site_user_counts_after = count_users();
 

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -191,7 +191,7 @@ class CreateAccount extends WP_UnitTestCase {
 	/**
 	 * Test that a user is not created if not requested (and the site allows guest checkout).
 	 */
-	public function test_no_account_requested() {
+	public function test_no_account_created() {
 		$site_user_counts = count_users();
 
 		$this->execute_create_customer_from_order(


### PR DESCRIPTION
Fixes #3362

This PR ensures that the checkout block signup flow and API correctly checks store options/settings for whether checkout signup is allowed.

In WooCommerce there are two ways a merchant can enable or disable creating accounts as part of checkout processing:

- `woocommerce_enable_signup_and_login_from_checkout` option, aka `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout`
- `woocommerce_checkout_registration_enabled` hook

These are now consulted in both the checkout processing (Store API / `CreateAccount` service class) and the rendering of the checkout block. 

- If checkout signup is disabled, Store API will not create an account under any circumstances.
- If checkout signup is disabled, Checkout block will not render a `Create an account?` checkbox, i.e. won't offer this to shopper.

This PR also includes fixes for the relevant PHPUnit tests. These tests have been updated to use correct option values (`yes no` vs `true false`), alongside updating the tests to include `woocommerce_enable_signup_and_login_from_checkout` option.

### How to test the changes in this Pull Request:
All tests require:

- Checkout block published in woo checkout page.
- Items added to cart.
- Anon / incognito user session.

#### Test 1: Store API will only create an account if store options allow it
1. Render checkout block with `Create an account?` checkbox. We're going to use a stale copy of the page to submit a checkout API request with `should_create_account=true`.
   - Ensure `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout` is checked (temporarily enable).
   - Edit checkout page, ensure `Allow shoppers to sign up for a user account during checkout` is enabled, publish. 
2. In another browser/window, view checkout page (with items in cart, as anon user/logged out). Should see `Create an account` checkbox.
3. Complete checkout form and check `Create an account`. **Do not submit** (yet).
4. As admin, disable `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout` and save settings.
5. Submit checkout (with `should_create_account=true`). 
6. Ensure no account is created for the customer, and the order is processed correctly.

As an alternative to (1), could also hack the JS AJAX request to always send `should_create_account=true`, or use other approaches to call the API with that value set.

#### Test 2: Checkout block will only offer to create an account if store options allow it
1. As admin, disable `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout` and save settings.
2. View checkout page and ensure there is no `Create an account` checkbox.
3. Repeat the above test with different block settings and ensure no checkbox is displayed unless store option is enabled. E.g. allow checkout signup in settings, enable block `Allow shoppers to sign up for a user account during checkout` setting, publish, change store setting and refresh page.

##### Other possible tests
- Repeat similar tests with a custom plugin implementing `woocommerce_checkout_registration_enabled` hook to disable checkout signup.
- Test various combinations of store settings (e.g. guest checkout `Allow customers to place orders without an account`) and ensure that accounts are created when appropriate. See below for the various permutations of options & expected behaviour.

  - allow_guest=yes | allow_signup=yes
    - enable block option, checkout sign up works
    - disable block option, no checkout sign up available
  - allow_guest=yes | allow_signup=no
    - can't create an account by passing `should_create_account` API params
    - block option not available in editor
  - allow_guest=no  | allow_signup=no
    - block shows login prompt
    - can't purchase without logging in
  - allow_guest=no  | allow_signup=yes
    - block shows no option to sign up
    - successful orders sign up automatically (unless logged in already)
- Test with WooCommerce < v4.7 and ensure that checkout block signup feature is not available, and there is no way to sign up using checkout block.

### Changelog

> Checkout block: Signup now fully supports existing checkout signup store option and related hook. #3371
