### PR TITLE
Show the phone number field in the billing section when shipping is disabled in settings

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -66,6 +66,8 @@ const CheckoutContext = createContext( {
 	},
 	hasOrder: false,
 	isCart: false,
+	shouldCreateAccount: false,
+	setShouldCreateAccount: ( value ) => void value,
 } );
 
 /**
@@ -82,11 +84,8 @@ export const useCheckoutContext = () => {
  *
  * @param {Object}  props                     Incoming props for the provider.
  * @param {Object}  props.children            The children being wrapped.
- * @param {string}  props.redirectUrl         Initialize what the checkout will
- *                                            redirect to after successful
- *                                            submit.
- * @param {boolean} props.isCart              If context provider is being used
- *                                            in cart context.
+ * @param {string}  props.redirectUrl         Initialize what the checkout will redirect to after successful submit.
+ * @param {boolean} props.isCart              If context provider is being used in cart context.
  */
 export const CheckoutStateProvider = ( {
 	children,

--- a/assets/js/blocks/cart-checkout/checkout/form/address-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/address-step.js
@@ -5,6 +5,7 @@ import { useMemo } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { useCheckoutAddress } from '@woocommerce/base-hooks';
 import { useShippingDataContext } from '@woocommerce/base-context';
+import { AddressForm } from '@woocommerce/base-components/cart-checkout';
 
 /**
  * Internal dependencies
@@ -12,6 +13,7 @@ import { useShippingDataContext } from '@woocommerce/base-context';
 import BillingFieldsStep from './billing-fields-step';
 import ContactFieldsStep from './contact-fields-step';
 import ShippingFieldsStep from './shipping-fields-step';
+import PhoneNumber from './phone-number';
 import './style.scss';
 
 const AddressStep = ( {
@@ -35,6 +37,7 @@ const AddressStep = ( {
 		showBillingFields,
 	} = useCheckoutAddress();
 	const { needsShipping } = useShippingDataContext();
+
 	const addressFieldsConfig = useMemo( () => {
 		return {
 			company: {
@@ -63,25 +66,44 @@ const AddressStep = ( {
 			/>
 			{ needsShipping && (
 				<ShippingFieldsStep
-					addressFieldsConfig={ addressFieldsConfig }
-					billingFields={ billingFields }
-					defaultAddressFields={ defaultAddressFields }
-					requirePhoneField={ requirePhoneField }
-					setPhone={ setPhone }
-					setShippingAsBilling={ setShippingAsBilling }
-					setShippingFields={ setShippingFields }
 					shippingAsBilling={ shippingAsBilling }
-					shippingFields={ shippingFields }
-					showPhoneField={ showPhoneField }
-				/>
+					setShippingAsBilling={ setShippingAsBilling }
+				>
+					<AddressForm
+						id="shipping"
+						type="shipping"
+						onChange={ setShippingFields }
+						values={ shippingFields }
+						fields={ Object.keys( defaultAddressFields ) }
+						fieldConfig={ addressFieldsConfig }
+					/>
+					{ showPhoneField && (
+						<PhoneNumber
+							isRequired={ requirePhoneField }
+							value={ billingFields.phone }
+							onChange={ setPhone }
+						/>
+					) }
+				</ShippingFieldsStep>
 			) }
 			{ showBillingFields && (
-				<BillingFieldsStep
-					addressFieldsConfig={ addressFieldsConfig }
-					billingFields={ billingFields }
-					defaultAddressFields={ defaultAddressFields }
-					setBillingFields={ setBillingFields }
-				/>
+				<BillingFieldsStep>
+					<AddressForm
+						id="billing"
+						type="billing"
+						onChange={ setBillingFields }
+						values={ billingFields }
+						fields={ Object.keys( defaultAddressFields ) }
+						fieldConfig={ addressFieldsConfig }
+					/>
+					{ showPhoneField && ! needsShipping && (
+						<PhoneNumber
+							isRequired={ requirePhoneField }
+							value={ billingFields.phone }
+							onChange={ setPhone }
+						/>
+					) }
+				</BillingFieldsStep>
 			) }
 		</>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/form/billing-fields-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/billing-fields-step.js
@@ -2,19 +2,11 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	AddressForm,
-	FormStep,
-} from '@woocommerce/base-components/cart-checkout';
+import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
 
-const BillingFieldsStep = ( {
-	addressFieldsConfig,
-	billingFields,
-	defaultAddressFields,
-	setBillingFields,
-} ) => {
+const BillingFieldsStep = ( { children } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 
 	return (
@@ -28,23 +20,13 @@ const BillingFieldsStep = ( {
 				'woo-gutenberg-products-block'
 			) }
 		>
-			<AddressForm
-				id="billing"
-				onChange={ setBillingFields }
-				type="billing"
-				values={ billingFields }
-				fields={ Object.keys( defaultAddressFields ) }
-				fieldConfig={ addressFieldsConfig }
-			/>
+			{ children }
 		</FormStep>
 	);
 };
 
 BillingFieldsStep.propTypes = {
-	addressFieldsConfig: PropTypes.object.isRequired,
-	billingFields: PropTypes.object.isRequired,
-	defaultAddressFields: PropTypes.object.isRequired,
-	setBillingFields: PropTypes.func.isRequired,
+	children: PropTypes.node.isRequired,
 };
 
 export default BillingFieldsStep;

--- a/assets/js/blocks/cart-checkout/checkout/form/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/index.js
@@ -37,7 +37,7 @@ const CheckoutForm = ( {
 			/>
 			<ShippingOptionsStep />
 			<PaymentMethodStep />
-			<OrderNotesStep showOrderNotes={ showOrderNotes } />
+			{ showOrderNotes && <OrderNotesStep /> }
 		</Form>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout/form/order-notes-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/order-notes-step.js
@@ -7,14 +7,13 @@ import {
 	useCheckoutContext,
 	useShippingDataContext,
 } from '@woocommerce/base-context';
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import CheckoutOrderNotes from './order-notes';
 
-const OrderNotesStep = ( { showOrderNotes } ) => {
+const OrderNotesStep = () => {
 	const { needsShipping } = useShippingDataContext();
 	const {
 		isProcessing: checkoutIsProcessing,
@@ -22,10 +21,6 @@ const OrderNotesStep = ( { showOrderNotes } ) => {
 		dispatchActions,
 	} = useCheckoutContext();
 	const { setOrderNotes } = dispatchActions;
-
-	if ( ! showOrderNotes ) {
-		return null;
-	}
 
 	return (
 		<FormStep id="order-notes" showStepNumber={ false }>
@@ -47,10 +42,6 @@ const OrderNotesStep = ( { showOrderNotes } ) => {
 			/>
 		</FormStep>
 	);
-};
-
-OrderNotesStep.propTypes = {
-	showOrderNotes: PropTypes.bool.isRequired,
 };
 
 export default OrderNotesStep;

--- a/assets/js/blocks/cart-checkout/checkout/form/phone-number/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/phone-number/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { DebouncedValidatedTextInput } from '@woocommerce/base-components/text-input';
+
+/**
+ * Renders a phone number input.
+ *
+ * @param {Object} props Component props.
+ * @param {boolean} props.isRequired Is the phone number required or optional.
+ * @param {Function} props.onChange Event fired when the input changes.
+ * @param {string} props.value Value of the input.
+ * @return {*} The component.
+ */
+const PhoneNumber = ( { isRequired = false, value = '', onChange } ) => {
+	return (
+		<DebouncedValidatedTextInput
+			id="phone"
+			type="tel"
+			autoComplete="tel"
+			required={ isRequired }
+			label={
+				isRequired
+					? __( 'Phone', 'woo-gutenberg-products-block' )
+					: __( 'Phone (optional)', 'woo-gutenberg-products-block' )
+			}
+			value={ value }
+			onChange={ onChange }
+		/>
+	);
+};
+
+export default PhoneNumber;

--- a/assets/js/blocks/cart-checkout/checkout/form/shipping-fields-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/shipping-fields-step.js
@@ -2,26 +2,15 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	AddressForm,
-	FormStep,
-} from '@woocommerce/base-components/cart-checkout';
-import { DebouncedValidatedTextInput } from '@woocommerce/base-components/text-input';
+import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 import { useCheckoutContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
 
 const ShippingFieldsStep = ( {
-	addressFieldsConfig,
-	defaultAddressFields,
-	billingFields,
-	setPhone,
 	shippingAsBilling,
-	shippingFields,
-	showPhoneField,
-	setShippingFields,
 	setShippingAsBilling,
-	requirePhoneField,
+	children,
 } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 
@@ -36,31 +25,7 @@ const ShippingFieldsStep = ( {
 				'woo-gutenberg-products-block'
 			) }
 		>
-			<AddressForm
-				id="shipping"
-				onChange={ setShippingFields }
-				values={ shippingFields }
-				fields={ Object.keys( defaultAddressFields ) }
-				fieldConfig={ addressFieldsConfig }
-			/>
-			{ showPhoneField && (
-				<DebouncedValidatedTextInput
-					id="phone"
-					type="tel"
-					label={
-						requirePhoneField
-							? __( 'Phone', 'woo-gutenberg-products-block' )
-							: __(
-									'Phone (optional)',
-									'woo-gutenberg-products-block'
-							  )
-					}
-					value={ billingFields.phone }
-					autoComplete="tel"
-					onChange={ setPhone }
-					required={ requirePhoneField }
-				/>
-			) }
+			{ children }
 			<CheckboxControl
 				className="wc-block-checkout__use-address-for-billing"
 				label={ __(
@@ -75,16 +40,9 @@ const ShippingFieldsStep = ( {
 };
 
 ShippingFieldsStep.propTypes = {
-	addressFieldsConfig: PropTypes.object.isRequired,
-	billingFields: PropTypes.object.isRequired,
-	defaultAddressFields: PropTypes.object.isRequired,
-	requirePhoneField: PropTypes.bool.isRequired,
-	setPhone: PropTypes.func.isRequired,
 	shippingAsBilling: PropTypes.bool.isRequired,
 	setShippingAsBilling: PropTypes.func.isRequired,
-	setShippingFields: PropTypes.func.isRequired,
-	shippingFields: PropTypes.object.isRequired,
-	showPhoneField: PropTypes.bool.isRequired,
+	children: PropTypes.node.isRequired,
 };
 
 export default ShippingFieldsStep;

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -19,37 +19,26 @@
  * @typedef {Object} ShippingDataContext
  *
  * @property {ShippingErrorStatus}  shippingErrorStatus         The current shipping error status.
- * @property {Function}             dispatchErrorStatus         A function for dispatching a
- *                                                              shipping rate error status.
- * @property {ShippingErrorTypes}   shippingErrorTypes          The error type constants for the
- *                                                              shipping rate error status.
+ * @property {Function}             dispatchErrorStatus         A function for dispatching a shipping rate error status.
+ * @property {ShippingErrorTypes}   shippingErrorTypes          The error type constants for the shipping rate error
+ *                                                              status.
  * @property {CartShippingOption[]} shippingRates               An array of available shipping rates.
- * @property {Function}             setShippingRates            Used to set the available shipping
- *                                                              rates.
- * @property {boolean}              shippingRatesLoading        Whether or not the shipping rates
- *                                                              are being loaded.
- * @property {string[]}             selectedRates               The ids of the rates that are
- *                                                              selected.
- * @property {Function}             setSelectedRates            Function for setting the selected
- *                                                              rates.
+ * @property {Function}             setShippingRates            Used to set the available shipping rates.
+ * @property {boolean}              shippingRatesLoading        Whether or not the shipping rates are being loaded.
+ * @property {string[]}             selectedRates               The ids of the rates that are selected.
+ * @property {Function}             setSelectedRates            Function for setting the selected rates.
  * @property {boolean}              isSelectingRate             True when rate is being selected.
  * @property {CartShippingAddress}  shippingAddress             The current set address for shipping.
- * @property {Function}             setShippingAddress          Function for setting the shipping
- *                                                              address.
- * @property {function()}           onShippingRateSuccess       Used to register a callback to be
- *                                                              invoked when shipping rates are
- *                                                              retrieved.
- * @property {function()}           onShippingRateSelectSuccess Used to register a callback to be
- *                                                              invoked when shipping rate is
- *                                                              selected.
- * @property {function()}           onShippingRateSelectFail    Used to register a callback to be
- *                                                              invoked when shipping rate is
- *                                                              selected unsuccessfully
- * @property {function()}           onShippingRateFail          Used to register a callback to be
- *                                                              invoked when there is an error with
- *                                                              retrieving shipping rates.
- * @property {boolean}              needsShipping               True if the cart has items requiring
- *                                                              shipping.
+ * @property {Function}             setShippingAddress          Function for setting the shipping address.
+ * @property {function()}           onShippingRateSuccess       Used to register a callback to be invoked when shipping
+ *                                                              rates are retrieved.
+ * @property {function()}           onShippingRateSelectSuccess Used to register a callback to be invoked when shipping
+ *                                                              rate is selected.
+ * @property {function()}           onShippingRateSelectFail    Used to register a callback to be invoked when shipping
+ *                                                              rate is selected unsuccessfully
+ * @property {function()}           onShippingRateFail          Used to register a callback to be invoked when there is
+ *                                                              an error with retrieving shipping rates.
+ * @property {boolean}              needsShipping               True if the cart has items requiring shipping.
  */
 
 /**
@@ -66,27 +55,23 @@
  *
  * @property {string} NONE            No shipping error.
  * @property {string} INVALID_ADDRESS Error due to an invalid address for calculating shipping.
- * @property {string} UNKNOWN         When an unknown error has occurred in calculating/retrieving
- *                                    shipping rates.
+ * @property {string} UNKNOWN         When an unknown error has occurred in calculating/retrieving shipping rates.
  */
 
 /**
  * @typedef {Object} PaymentMethodCurrentStatus
  *
- * This contains status information for the current active payment method in
- * the checkout.
+ * This contains status information for the current active payment method in the checkout.
  *
  * @property {boolean} isPristine   If true then the payment method state in checkout is pristine.
- * @property {boolean} isStarted    If true then the payment method has been initialized and has
- *                                  started.
+ * @property {boolean} isStarted    If true then the payment method has been initialized and has started.
  * @property {boolean} isProcessing If true then the payment method is processing payment.
- * @property {boolean} isFinished   If true then the payment method is in a finished state (which
- *                                  may mean it's status is either error, failed, or success).
+ * @property {boolean} isFinished   If true then the payment method is in a finished state (which may mean it's status
+ *                                  is either error, failed, or success).
  * @property {boolean} hasError     If true then the payment method is in an error state.
- * @property {boolean} hasFailed    If true then the payment method has failed (usually indicates a
- *                                  problem with the  payment method used, not logic error)
- * @property {boolean} isSuccessful If true then the payment method has  completed it's processing
- *                                  successfully.
+ * @property {boolean} hasFailed    If true then the payment method has failed (usually indicates a problem with the
+ *                                  payment method used, not logic error)
+ * @property {boolean} isSuccessful If true then the payment method has  completed it's processing successfully.
  */
 
 /**
@@ -98,8 +83,7 @@
  * @property {string}  expires    Short form of expiry for payment method.
  * @property {boolean} is_default Whether it is the default payment method of the customer or not.
  * @property {number}  tokenId    The id of the saved payment method.
- * @property {Object}  actions    Varies, actions that can be done to interact with the payment
- *                                method.
+ * @property {Object}  actions    Varies, actions that can be done to interact with the payment method.
  */
 
 /**
@@ -111,8 +95,8 @@
 /**
  * A Saved Customer Payment methods object
  *
- * This is an object where the keys are payment gateway slugs and the values are an array of
- * CustomerPaymentMethod objects.
+ * This is an object where the keys are payment gateway slugs and the values are an array of CustomerPaymentMethod
+ * objects.
  *
  * @typedef {Object} SavedCustomerPaymentMethods
  * @property {any} any Various payment methods
@@ -136,122 +120,90 @@
 /**
  * @typedef {Object} PaymentMethodDataContext
  *
- * @property {PaymentStatusDispatch}       setPaymentStatus                 Sets the payment status
- *                                                                          for the payment method.
- * @property {PaymentMethodCurrentStatus}  currentStatus                    The current payment
- *                                                                          status.
- * @property {Object}                      paymentStatuses                  An object of payment
- *                                                                          status constants.
- * @property {Object}                      paymentMethodData                Arbitrary data to be
- *                                                                          passed along for
- *                                                                          processing by the
- *                                                                          payment method on the
- *                                                                          server.
- * @property {string}                      errorMessage                     An error message
- *                                                                          provided by the payment
- *                                                                          method if there is an
- *                                                                          error.
- * @property {string}                      activePaymentMethod              The active payment
- *                                                                          method slug.
- * @property {function(string)}            setActivePaymentMethod           A function for setting
- *                                                                          the active payment
+ * @property {PaymentStatusDispatch}       setPaymentStatus                 Sets the payment status for the payment
  *                                                                          method.
- * @property {SavedCustomerPaymentMethods} customerPaymentMethods           Returns the customer
- *                                                                          payment for the customer
- *                                                                          if it exists.
- * @property {Object}                      paymentMethods                   Registered payment
- *                                                                          methods.
- * @property {Object}                      expressPaymentMethods            Registered express
- *                                                                          payment methods.
- * @property {boolean}                     paymentMethodsInitialized        True when all registered
- *                                                                          payment methods have
- *                                                                          been initialized.
- * @property {boolean}                     expressPaymentMethodsInitialized True when all registered
- *                                                                          express payment methods
+ * @property {PaymentMethodCurrentStatus}  currentStatus                    The current payment status.
+ * @property {Object}                      paymentStatuses                  An object of payment status constants.
+ * @property {Object}                      paymentMethodData                Arbitrary data to be passed along for
+ *                                                                          processing by the payment method on the
+ *                                                                          server.
+ * @property {string}                      errorMessage                     An error message provided by the payment
+ *                                                                          method if there is an error.
+ * @property {string}                      activePaymentMethod              The active payment method slug.
+ * @property {function(string)}            setActivePaymentMethod           A function for setting the active payment
+ *                                                                          method.
+ * @property {SavedCustomerPaymentMethods} customerPaymentMethods           Returns the customer payment for the
+ *                                                                          customer if it exists.
+ * @property {Object}                      paymentMethods                   Registered payment methods.
+ * @property {Object}                      expressPaymentMethods            Registered express payment methods.
+ * @property {boolean}                     paymentMethodsInitialized        True when all registered payment methods
  *                                                                          have been initialized.
- * @property {function(function())}        onPaymentProcessing              Event registration
- *                                                                          callback for registering
- *                                                                          observers for the
- *                                                                          payment processing
- *                                                                          event.
- * @property {function(string)}            setExpressPaymentError           A function used by
- *                                                                          express payment methods
- *                                                                          to indicate an error
- *                                                                          for checkout to handle.
- *                                                                          It receives an error
- *                                                                          message string. Does not
- *                                                                          change payment status.
- * @property {function(boolean):void}      setShouldSavePayment             A function used to set
- *                                                                          the shouldSavePayment
+ * @property {boolean}                     expressPaymentMethodsInitialized True when all registered express payment
+ *                                                                          methods have been initialized.
+ * @property {function(function())}        onPaymentProcessing              Event registration callback for registering
+ *                                                                          observers for the payment processing event.
+ * @property {function(string)}            setExpressPaymentError           A function used by express payment methods
+ *                                                                          to indicate an error for checkout to handle.
+ *                                                                          It receives an error message string.
+ *                                                                          Does not change payment status.
+ * @property {function(boolean):void}      setShouldSavePayment             A function used to set the shouldSavePayment
  *                                                                          value.
- * @property {boolean}                     shouldSavePayment                True means that
- *                                                                          the configured payment
- *                                                                          method option is saved
- *                                                                          for the customer.
+ * @property {boolean}                     shouldSavePayment                True means that the configured payment
+ *                                                                          method option is saved for the customer.
  */
 
 /**
  * @typedef {Object} CheckoutDataContext
  *
- * @property {function()}                   onSubmit                   The callback to register with
- *                                                                     the checkout submit button.
- * @property {boolean}                      isComplete                 True when checkout is complete
- *                                                                     and ready for redirect.
- * @property {boolean}                      isBeforeProcessing         True during any observers
- *                                                                     executing logic before
- *                                                                     checkout processing (eg.
- *                                                                     validation).
- * @property {boolean}                      isAfterProcessing          True when checkout status is
- *                                                                     AFTER_PROCESSING.
- * @property {boolean}                      isIdle                     True when the checkout state
- *                                                                     has changed and checkout has
- *                                                                     no activity.
- * @property {boolean}                      isProcessing               True when checkout has been
- *                                                                     submitted and is being
- *                                                                     processed. Note, payment
- *                                                                     related processing happens
- *                                                                     during this state. When
- *                                                                     payment status is success,
- *                                                                     processing happens on the
- *                                                                     server.
- * @property {boolean}                      isCalculating              True when something in the
- *                                                                     checkout is resulting in
- *                                                                     totals being calculated.
- * @property {boolean}                      hasError                   True when the checkout is in
- *                                                                     an error state. Whatever
- *                                                                     caused the error
- *                                                                     (validation/payment method)
- *                                                                     will likely have triggered a
- *                                                                     notice.
- * @property {string}                       redirectUrl                This is the url that checkout
- *                                                                     will redirect to when it's
- *                                                                     ready.
- * @property {function(function(),number=)} onCheckoutAfterProcessingWithSuccess Used to register a
- *                                                                     callback that will fire after
- *                                                                     checkout has been processed
- *                                                                     and there are no errors.
- * @property {function(function(),number=)} onCheckoutAfterProcessingWithError Used to register a
- *                                                                     callback that will fire when
- *                                                                     the checkout has been
- *                                                                     processed and has an error.
- * @property {function(function(),number=)} onCheckoutBeforeProcessing Used to register a callback
- *                                                                     that will fire when the
- *                                                                     checkout has been submitted
- *                                                                     before being sent off to the
- *                                                                     server.
- * @property {CheckoutDispatchActions}      dispatchActions            Various actions that can be
- *                                                                     dispatched for the checkout
- *                                                                     context data.
- * @property {number}                       orderId                    This is the ID for the draft
- *                                                                     order if one exists.
- * @property {number}                       orderNotes                 Order notes introduced by the
- *                                                                     user in the checkout form.
- * @property {boolean}                      hasOrder                   True when the checkout has a
- *                                                                     draft order from the API.
- * @property {boolean}                      isCart                     When true, means the provider
- *                                                                     is providing data for the cart.
- * @property {number}                       customerId                 This is the ID of the customer
- *                                                                     the draft order belongs to.
+ * @property {function()}                   onSubmit                             The callback to register with the
+ *                                                                               checkout submit button.
+ * @property {boolean}                      isComplete                           True when checkout is complete and
+ *                                                                               ready for redirect.
+ * @property {boolean}                      isBeforeProcessing                   True during any observers executing
+ *                                                                               logic before checkout processing
+ *                                                                               (eg. validation).
+ * @property {boolean}                      isAfterProcessing                    True when checkout status is
+ *                                                                               AFTER_PROCESSING.
+ * @property {boolean}                      isIdle                               True when the checkout state has
+ *                                                                               changed and checkout has no activity.
+ * @property {boolean}                      isProcessing                         True when checkout has been submitted
+ *                                                                               and is being processed. Note, payment
+ *                                                                               related processing happens during this
+ *                                                                               state. When payment status is success,
+ *                                                                               processing happens on the server.
+ * @property {boolean}                      isCalculating                        True when something in the checkout is
+ *                                                                               resulting in totals being calculated.
+ * @property {boolean}                      hasError                             True when the checkout is in an error
+ *                                                                               state. Whatever caused the error
+ *                                                                               (validation/payment method) will likely
+ *                                                                               have triggered a notice.
+ * @property {string}                       redirectUrl                          This is the url that checkout will
+ *                                                                               redirect to when it's ready.
+ * @property {function(function(),number=)} onCheckoutAfterProcessingWithSuccess Used to register a callback that will
+ *                                                                               fire after checkout has been processed
+ *                                                                               and there are no errors.
+ * @property {function(function(),number=)} onCheckoutAfterProcessingWithError   Used to register a callback that will
+ *                                                                               fire when the checkout has been
+ *                                                                               processed and has an error.
+ * @property {function(function(),number=)} onCheckoutBeforeProcessing           Used to register a callback that will
+ *                                                                               fire when the checkout has been
+ *                                                                               submitted before being sent off to the
+ *                                                                               server.
+ * @property {CheckoutDispatchActions}      dispatchActions                      Various actions that can be dispatched
+ *                                                                               for the checkout context data.
+ * @property {number}                       orderId                              This is the ID for the draft order if
+ *                                                                               one exists.
+ * @property {number}                       orderNotes                           Order notes introduced by the user in
+ *                                                                               the checkout form.
+ * @property {boolean}                      hasOrder                             True when the checkout has a draft
+ *                                                                               order from the API.
+ * @property {boolean}                      isCart                               When true, means the provider is
+ *                                                                               providing data for the cart.
+ * @property {number}                       customerId                           This is the ID of the customer the
+ *                                                                               draft order belongs to.
+ * @property {boolean}                      shouldCreateAccount                  Should a user account be created?
+ * @property {function()}                   setShouldCreateAccount               Function to update the
+ *                                                                               shouldCreateAccount property.
  */
 
 /**
@@ -268,44 +220,44 @@
  * @property {Object}                         product              The product object to add to the cart.
  * @property {string}                         productType          The name of the product type.
  * @property {boolean}                        productIsPurchasable True if the product can be purchased.
- * @property {boolean}                        productHasOptions    True if the product has additonal options and thus needs a cart form.
+ * @property {boolean}                        productHasOptions    True if the product has additional options and thus
+ *                                                                 needs a cart form.
  * @property {boolean}                        supportsFormElements True if the product type supports form elements.
- * @property {boolean}                        showFormElements     True if showing a full add to cart form (enabled and supported).
+ * @property {boolean}                        showFormElements     True if showing a full add to cart form (enabled and
+ *                                                                 supported).
  * @property {number}                         quantity             Stores the quantity being added to the cart.
  * @property {number}                         minQuantity          Min quantity that can be added to the cart.
  * @property {number}                         maxQuantity          Max quantity than can be added to the cart.
  * @property {Object}                         requestParams        List of params to send to the API.
- * @property {boolean}                        isIdle               True when the form state has changed and has no activity.
+ * @property {boolean}                        isIdle               True when the form state has changed and has no
+ *                                                                 activity.
  * @property {boolean}                        isDisabled           True when the form cannot be submitted.
- * @property {boolean}                        isProcessing         True when the form has been submitted and is being processed.
- * @property {boolean}                        isBeforeProcessing   True during any observers executing logic before form processing (eg. validation).
+ * @property {boolean}                        isProcessing         True when the form has been submitted and is being
+ *                                                                 processed.
+ * @property {boolean}                        isBeforeProcessing   True during any observers executing logic before form
+ *                                                                 processing (eg. validation).
  * @property {boolean}                        isAfterProcessing    True when form status is AFTER_PROCESSING.
- * @property {boolean}                        hasError             True when the form is in an error state. Whatever caused the error (validation/payment method) will likely have triggered a notice.
+ * @property {boolean}                        hasError             True when the form is in an error state. Whatever
+ *                                                                 caused the error (validation/payment method) will
+ *                                                                 likely have triggered a notice.
  * @property {AddToCartFormEventRegistration} eventRegistration    Event emitters that can be subscribed to.
- * @property {AddToCartFormDispatchActions}   dispatchActions      Various actions that can be dispatched for the add to cart form context data.
+ * @property {AddToCartFormDispatchActions}   dispatchActions      Various actions that can be dispatched for the add to
+ *                                                                 cart form context data.
  */
 
 /**
  * @typedef {Object} ValidationContext
  *
- * @property {function(string):Object}  getValidationError       Return validation error for the
- *                                                               given property.
- * @property {function(Object)}         setValidationErrors      Receive an object of properties and
- *                                                               error messages as strings and adds
- *                                                               to the validation error state.
- * @property {function(string)}         clearValidationError     Clears a validation error for the
- *                                                               given property name.
- * @property {function()}               clearAllValidationErrors Clears all validation errors
- *                                                               currently in state.
+ * @property {function(string):Object}  getValidationError       Return validation error for the given property.
+ * @property {function(Object)}         setValidationErrors      Receive an object of properties and  error messages as
+ *                                                               strings and adds to the validation error state.
+ * @property {function(string)}         clearValidationError     Clears a validation error for the given property name.
+ * @property {function()}               clearAllValidationErrors Clears all validation errors currently in state.
  * @property {function(string)}         getValidationErrorId     Returns the css id for the
- *                                                               validation error using the given
- *                                                               inputId string.
- * @property {function(string)}         hideValidationError      Sets the hidden prop of a specific
- *                                                               error to true.
- * @property {function(string)}         showValidationError      Sets the hidden prop of a specific
- *                                                               error to false.
- * @property {function()}               showAllValidationErrors  Sets the hidden prop of all
- *                                                               errors to false.
+ *                                                               validation error using the given inputId string.
+ * @property {function(string)}         hideValidationError      Sets the hidden prop of a specific error to true.
+ * @property {function(string)}         showValidationError      Sets the hidden prop of a specific error to false.
+ * @property {function()}               showAllValidationErrors  Sets the hidden prop of all errors to false.
  * @property {boolean}                  hasValidationErrors      True if there is at least one error.
  */
 
@@ -320,19 +272,13 @@
 /**
  * @typedef NoticeContext
  *
- * @property {Array<StoreNoticeObject>}              notices              An array of notice
- *                                                                        objects.
- * @property {function(string,string,any):undefined} createNotice         Creates a notice for the
- *                                                                        given arguments.
- * @property {function(string, any):undefined}       createSnackbarNotice Creates a snackbar notice
- *                                                                        type.
- * @property {function(string,string=):undefined}    removeNotice         Removes a notice with the
- *                                                                        given id and context
- * @property {string}                                context              The current context
- *                                                                        identifier for the notice
+ * @property {Array<StoreNoticeObject>}              notices              An array of notice objects.
+ * @property {function(string,string,any):undefined} createNotice         Creates a notice for the given arguments.
+ * @property {function(string, any):undefined}       createSnackbarNotice Creates a snackbar notice type.
+ * @property {function(string,string=):undefined}    removeNotice         Removes a notice with the given id and context
+ * @property {string}                                context              The current context identifier for the notice
  *                                                                        provider
- * @property {function(boolean):void}                setIsSuppressed      Consumers can use this
- *                                                                        setter to suppress
+ * @property {function(boolean):void}                setIsSuppressed      Consumers can use this setter to suppress
  */
 
 /**

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -202,7 +202,7 @@
  * @property {number}                       customerId                           This is the ID of the customer the
  *                                                                               draft order belongs to.
  * @property {boolean}                      shouldCreateAccount                  Should a user account be created?
- * @property {function()}                   setShouldCreateAccount               Function to update the
+ * @property {function(boolean)}            setShouldCreateAccount               Function to update the
  *                                                                               shouldCreateAccount property.
  */
 


### PR DESCRIPTION
Moves the rendering of address fields to a single file so that PhoneNumber (new component) can be rendered in _either_ billing or shipping, depending on visibility, without duplication.

I was going to update context to handle this (hence why I cleaned up some missing docblocks) however, it made more sense to handle this within the address-step component and simply pass around the attributes as before.

Fixes #3231
Fixes #3346 

### How to test the changes in this Pull Request:

Ensure the phone number field is enabled in block settings, then test 2 cases:

1. With shipping enabled, ensure phone number displays beneath the shipping step
2. With shipping disabled (you can delete all rates and zones to edit general settings), ensure phone number displays beneath the billing step.

In both scenarios the values should change and be saved as billing information.

### Changelog

> Show the phone number field in the billing section when shipping is disabled in settings
