### PR TITLE
Exclude checkout-draft orders from WC Admin reports and My Account > Orders

### DIFF
--- a/assets/js/settings/shared/exclude-draft-status-from-analytics.js
+++ b/assets/js/settings/shared/exclude-draft-status-from-analytics.js
@@ -5,7 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 
 addFilter(
 	'woocommerce_admin_analytics_settings',
-	'woocommerce-admin',
+	'woocommerce-blocks/exclude-draft-status-from-analytics',
 	( settings ) => {
 		const removeCheckoutDraft = ( optionsGroup ) => {
 			if ( optionsGroup.key === 'customStatuses' ) {

--- a/assets/js/settings/shared/exclude-draft-status-from-analytics.js
+++ b/assets/js/settings/shared/exclude-draft-status-from-analytics.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+addFilter(
+	'woocommerce_admin_analytics_settings',
+	'woocommerce-admin',
+	( settings ) => {
+		const removeCheckoutDraft = ( optionsGroup ) => {
+			if ( optionsGroup.key === 'customStatuses' ) {
+				return {
+					...optionsGroup,
+					options: optionsGroup.options.filter(
+						( option ) => option.value !== 'checkout-draft'
+					),
+				};
+			}
+			return optionsGroup;
+		};
+
+		const actionableStatusesOptions = settings.woocommerce_actionable_order_statuses.options.map(
+			removeCheckoutDraft
+		);
+		const excludedStatusesOptions = settings.woocommerce_excluded_report_order_statuses.options.map(
+			removeCheckoutDraft
+		);
+
+		return {
+			...settings,
+			woocommerce_actionable_order_statuses: {
+				...settings.woocommerce_actionable_order_statuses,
+				options: actionableStatusesOptions,
+			},
+			woocommerce_excluded_report_order_statuses: {
+				...settings.woocommerce_excluded_report_order_statuses,
+				options: excludedStatusesOptions,
+			},
+		};
+	}
+);

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import compareVersions from 'compare-versions';
-import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -11,6 +10,7 @@ import { getSetting } from './get-setting';
 
 export * from './default-constants';
 export { setSetting } from './set-setting';
+import './exclude-draft-status-from-analytics';
 
 /**
  * Note: this attempts to coerce the wpVersion to a semver for comparison
@@ -67,40 +67,3 @@ export { compareVersions, getSetting };
  * @return {string} Full admin URL.
  */
 export const getAdminLink = ( path ) => getSetting( 'adminUrl' ) + path;
-
-addFilter(
-	'woocommerce_admin_analytics_settings',
-	'woocommerce-admin',
-	( settings ) => {
-		const removeCheckoutDraft = ( optionsGroup ) => {
-			if ( optionsGroup.key === 'customStatuses' ) {
-				return {
-					...optionsGroup,
-					options: optionsGroup.options.filter(
-						( option ) => option.value !== 'checkout-draft'
-					),
-				};
-			}
-			return optionsGroup;
-		};
-
-		const actionableStatusesOptions = settings.woocommerce_actionable_order_statuses.options.map(
-			removeCheckoutDraft
-		);
-		const excludedStatusesOptions = settings.woocommerce_excluded_report_order_statuses.options.map(
-			removeCheckoutDraft
-		);
-
-		return {
-			...settings,
-			woocommerce_actionable_order_statuses: {
-				...settings.woocommerce_actionable_order_statuses,
-				options: actionableStatusesOptions,
-			},
-			woocommerce_excluded_report_order_statuses: {
-				...settings.woocommerce_excluded_report_order_statuses,
-				options: excludedStatusesOptions,
-			},
-		};
-	}
-);

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import compareVersions from 'compare-versions';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -66,3 +67,40 @@ export { compareVersions, getSetting };
  * @return {string} Full admin URL.
  */
 export const getAdminLink = ( path ) => getSetting( 'adminUrl' ) + path;
+
+addFilter(
+	'woocommerce_admin_analytics_settings',
+	'woocommerce-admin',
+	( settings ) => {
+		const removeCheckoutDraft = ( optionsGroup ) => {
+			if ( optionsGroup.key === 'customStatuses' ) {
+				return {
+					...optionsGroup,
+					options: optionsGroup.options.filter(
+						( option ) => option.value !== 'checkout-draft'
+					),
+				};
+			}
+			return optionsGroup;
+		};
+
+		const actionableStatusesOptions = settings.woocommerce_actionable_order_statuses.options.map(
+			removeCheckoutDraft
+		);
+		const excludedStatusesOptions = settings.woocommerce_excluded_report_order_statuses.options.map(
+			removeCheckoutDraft
+		);
+
+		return {
+			...settings,
+			woocommerce_actionable_order_statuses: {
+				...settings.woocommerce_actionable_order_statuses,
+				options: actionableStatusesOptions,
+			},
+			woocommerce_excluded_report_order_statuses: {
+				...settings.woocommerce_excluded_report_order_statuses,
+				options: excludedStatusesOptions,
+			},
+		};
+	}
+);

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -43,6 +43,8 @@ class DraftOrders {
 			add_filter( 'woocommerce_analytics_excluded_order_statuses', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', [ $this, 'append_draft_order_post_status' ] );
+			// Hook into the query to retrieve My Account orders so draft status is excluded.
+			add_action( 'woocommerce_my_account_my_orders_query', [ $this, 'delete_draft_order_post_status_from_args' ] );
 			add_action( 'woocommerce_cleanup_draft_orders', [ $this, 'delete_expired_draft_orders' ] );
 			add_action( 'admin_init', [ $this, 'install' ] );
 		} else {
@@ -129,6 +131,31 @@ class DraftOrders {
 			/* translators: %s: number of orders */
 			'label_count'               => _n_noop( 'Drafts <span class="count">(%s)</span>', 'Drafts <span class="count">(%s)</span>', 'woo-gutenberg-products-block' ),
 		];
+	}
+
+	/**
+	 * Remove draft status from the 'status' argument of an $args array.
+	 *
+	 * @param array $args Array of arguments containing statuses in the status key.
+	 * @internal
+	 * @return array
+	 */
+	public function delete_draft_order_post_status_from_args( $args ) {
+		if ( ! array_key_exists( 'status', $args ) ) {
+			$statuses = [];
+			foreach ( wc_get_order_statuses() as $key => $label ) {
+				if ( self::DB_STATUS !== $key ) {
+					$statuses[] = str_replace( 'wc-', '', $key );
+				}
+			}
+			$args['status'] = $statuses;
+		} elseif ( self::DB_STATUS === $args['status'] ) {
+			$args['status'] = '';
+		} elseif ( is_array( $args['status'] ) ) {
+			$args['status'] = array_diff_key( $args['status'], array( self::STATUS => null ) );
+		}
+
+		return $args;
 	}
 
 	/**

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -40,9 +40,6 @@ class DraftOrders {
 		if ( $this->package->feature()->is_feature_plugin_build() ) {
 			add_filter( 'wc_order_statuses', [ $this, 'register_draft_order_status' ] );
 			add_filter( 'woocommerce_register_shop_order_post_statuses', [ $this, 'register_draft_order_post_status' ] );
-			// Hook all WooCommerce order queries to prevent checkout draft orders from being included in results.
-			// These orders are temporary and used internal to the Cart & Checkout blocks, and should not be displayed
-			// along other orders.
 			add_filter( 'woocommerce_order_query_args', [ $this, 'delete_draft_order_post_status_from_args' ] );
 			add_filter( 'woocommerce_analytics_excluded_order_statuses', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment', [ $this, 'append_draft_order_post_status' ] );
@@ -194,7 +191,6 @@ class DraftOrders {
 		$batch_size = 20;
 		$this->ensure_draft_status_registered();
 
-		// Temporarily reinstate checkout draft orders so they are picked up by query for deletion.
 		add_filter( 'woocommerce_order_query_args', [ $this, 'add_draft_order_post_status_to_args' ] );
 		$orders = wc_get_orders(
 			[

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -40,6 +40,7 @@ class DraftOrders {
 		if ( $this->package->feature()->is_feature_plugin_build() ) {
 			add_filter( 'wc_order_statuses', [ $this, 'register_draft_order_status' ] );
 			add_filter( 'woocommerce_register_shop_order_post_statuses', [ $this, 'register_draft_order_post_status' ] );
+			add_filter( 'woocommerce_analytics_excluded_order_statuses', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', [ $this, 'append_draft_order_post_status' ] );
 			add_action( 'woocommerce_cleanup_draft_orders', [ $this, 'delete_expired_draft_orders' ] );

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -40,6 +40,9 @@ class DraftOrders {
 		if ( $this->package->feature()->is_feature_plugin_build() ) {
 			add_filter( 'wc_order_statuses', [ $this, 'register_draft_order_status' ] );
 			add_filter( 'woocommerce_register_shop_order_post_statuses', [ $this, 'register_draft_order_post_status' ] );
+			// Hook all WooCommerce order queries to prevent checkout draft orders from being included in results.
+			// These orders are temporary and used internal to the Cart & Checkout blocks, and should not be displayed
+			// along other orders.
 			add_filter( 'woocommerce_order_query_args', [ $this, 'delete_draft_order_post_status_from_args' ] );
 			add_filter( 'woocommerce_analytics_excluded_order_statuses', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment', [ $this, 'append_draft_order_post_status' ] );
@@ -191,6 +194,7 @@ class DraftOrders {
 		$batch_size = 20;
 		$this->ensure_draft_status_registered();
 
+		// Temporarily reinstate checkout draft orders so they are picked up by query for deletion.
 		add_filter( 'woocommerce_order_query_args', [ $this, 'add_draft_order_post_status_to_args' ] );
 		$orders = wc_get_orders(
 			[

--- a/src/Domain/Services/DraftOrders.php
+++ b/src/Domain/Services/DraftOrders.php
@@ -40,6 +40,7 @@ class DraftOrders {
 		if ( $this->package->feature()->is_feature_plugin_build() ) {
 			add_filter( 'wc_order_statuses', [ $this, 'register_draft_order_status' ] );
 			add_filter( 'woocommerce_register_shop_order_post_statuses', [ $this, 'register_draft_order_post_status' ] );
+			add_filter( 'woocommerce_order_query_args', [ $this, 'delete_draft_order_post_status_from_args' ] );
 			add_filter( 'woocommerce_analytics_excluded_order_statuses', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment', [ $this, 'append_draft_order_post_status' ] );
 			add_filter( 'woocommerce_valid_order_statuses_for_payment_complete', [ $this, 'append_draft_order_post_status' ] );
@@ -132,6 +133,40 @@ class DraftOrders {
 	}
 
 	/**
+	 * Remove draft status from the 'status' argument of an $args array.
+	 *
+	 * @param array $args Array of arguments containing statuses in the status key.
+	 * @internal
+
+	 * @return array
+	 */
+	public function delete_draft_order_post_status_from_args( $args ) {
+		if ( self::DB_STATUS === $args['status'] ) {
+			$args['status'] = '';
+		} elseif ( is_array( $args['status'] ) ) {
+			$args['status'] = array_diff( $args['status'], array( self::DB_STATUS ) );
+		}
+		return $args;
+	}
+
+	/**
+	 * Add draft status to the 'status' argument of an $args array.
+	 *
+	 * @param array $args Array of arguments containing statuses in the status key.
+	 * @internal
+
+	 * @return array
+	 */
+	public function add_draft_order_post_status_to_args( $args ) {
+		if ( '' === $args['status'] ) {
+			$args['status'] = self::DB_STATUS;
+		} elseif ( is_array( $args['status'] ) ) {
+			$args['status'][] = self::DB_STATUS;
+		}
+		return $args;
+	}
+
+	/**
 	 * Append draft status to a list of statuses.
 	 *
 	 * @param array $statuses Array of statuses.
@@ -155,6 +190,8 @@ class DraftOrders {
 		$count      = 0;
 		$batch_size = 20;
 		$this->ensure_draft_status_registered();
+
+		add_filter( 'woocommerce_order_query_args', [ $this, 'add_draft_order_post_status_to_args' ] );
 		$orders = wc_get_orders(
 			[
 				'date_modified' => '<=' . strtotime( '-1 DAY' ),
@@ -163,6 +200,7 @@ class DraftOrders {
 				'type'          => 'shop_order',
 			]
 		);
+		remove_filter( 'woocommerce_order_query_args', [ $this, 'add_draft_order_post_status_to_args' ] );
 
 		// do we bail because the query results are unexpected?
 		try {

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -88,12 +88,14 @@ class DeleteDraftOrders extends TestCase {
 	}
 
 	public function tearDown() {
-		$this->draft_orders_instance = null;
 		// delete all orders
+		add_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
 		$orders = wc_get_orders([]);
+		remove_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
 		foreach( $orders as $order ) {
 			$order->delete( true );
 		}
+		$this->draft_orders_instance = null;
 		remove_all_actions( 'woocommerce_caught_exception' );
 		//restore original logging destination
 		ini_set('error_log', $this->original_logging_destination);

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -88,10 +88,11 @@ class DeleteDraftOrders extends TestCase {
 	}
 
 	public function tearDown() {
-		// delete all orders
+		// Temporarily reinstate checkout draft orders so they are picked up by query for deletion.
 		add_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
 		$orders = wc_get_orders([]);
 		remove_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
+		// Delete all orders.
 		foreach( $orders as $order ) {
 			$order->delete( true );
 		}

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -88,11 +88,10 @@ class DeleteDraftOrders extends TestCase {
 	}
 
 	public function tearDown() {
-		// Temporarily reinstate checkout draft orders so they are picked up by query for deletion.
+		// delete all orders
 		add_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
 		$orders = wc_get_orders([]);
 		remove_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
-		// Delete all orders.
 		foreach( $orders as $order ) {
 			$order->delete( true );
 		}

--- a/tests/php/Domain/Services/DeleteDraftOrders.php
+++ b/tests/php/Domain/Services/DeleteDraftOrders.php
@@ -88,14 +88,12 @@ class DeleteDraftOrders extends TestCase {
 	}
 
 	public function tearDown() {
+		$this->draft_orders_instance = null;
 		// delete all orders
-		add_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
 		$orders = wc_get_orders([]);
-		remove_filter( 'woocommerce_order_query_args', [ $this->draft_orders_instance, 'add_draft_order_post_status_to_args' ] );
 		foreach( $orders as $order ) {
 			$order->delete( true );
 		}
-		$this->draft_orders_instance = null;
 		remove_all_actions( 'woocommerce_caught_exception' );
 		//restore original logging destination
 		ini_set('error_log', $this->original_logging_destination);


### PR DESCRIPTION
Fixes #3301.

This PR:
* Forces `checkout-draft` orders to be excluded when computing WooCommerce Admin reports data.
* Removes the option to enable/disable it from WooCommerce Admin settings, so the checkbox doesn't appear at all in Analytics > Settings.
* Hides draft orders from My Account > Orders.

### How to test the changes in this Pull Request:

1. Make sure your store has at least one completed order and one draft order. You can achieve that adding some products to the cart and navigating to the Cart and Checkout blocks but without completing the order.
2. Go to Analytics > Settings and verify there isn't a `Custom statuses` section or, if it exists, make sure none of the statuses is named `Draft`.
3. Go to the bottom of the page and click on `Delete Previously Imported Data`.
4. Wait until the process finishes and then import all data again.
5. Go to Analytics > Orders.
6. Verify the 'draft' order is not counted in the totals.
7. In the frontend, go to My Account > Orders with the user that made the draft order.
8. Verify the draft order is not listed there.

### Changelog

> Prevent draft orders from being counted in analytics reports and appearing in the My Account page.