### PR TITLE
Force node 12 for action

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -7,6 +7,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - uses: actions/setup-node@v2-beta
+              with:
+                node-version: '12'
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 1


### PR DESCRIPTION
Currently our repository doesn't support node 14.x and this branch of node recently became LTS so GitHub actions now default to that version. This is an attempt to force a specific version of node for the action.

## To test

I _think_ this should be verified by the `bundlesize` action running in the pull request. But it's possible I might need to have the workflow in trunk first so we'll see on the first execution in this pr.
