### PR TITLE
Fix PHP8 Unsupported Types with Operators warnings for PHP8

### DIFF
--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -129,7 +129,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			]
 		);
 
-		if ( ! is_array( $terms ) || empty( $categories ) ) {
+		if ( ! is_array( $categories ) || empty( $categories ) ) {
 			return [];
 		}
 

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -57,7 +57,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		$uid        = uniqid( 'product-categories-' );
 		$categories = $this->get_categories( $attributes );
 
-		if ( ! $categories ) {
+		if ( empty( $categories ) ) {
 			return '';
 		}
 
@@ -129,7 +129,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			]
 		);
 
-		if ( ! $categories ) {
+		if ( ! is_array( $terms ) || empty( $categories ) ) {
 			return [];
 		}
 

--- a/src/StoreApi/Routes/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/AbstractTermsRoute.php
@@ -104,7 +104,7 @@ abstract class AbstractTermsRoute extends AbstractRoute {
 	 */
 	protected function get_terms_response( $taxonomy, $request ) {
 		$page          = (int) $request['page'];
-		$per_page      = $request['per_page'] ? $request['per_page'] : 0;
+		$per_page      = $request['per_page'] ? (int) $request['per_page'] : 0;
 		$prepared_args = array(
 			'taxonomy'   => $taxonomy,
 			'exclude'    => $request['exclude'],

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -65,7 +65,7 @@ class CartItemsByKey extends AbstractRoute {
 		$controller = new CartController();
 		$cart_item  = $controller->get_cart_item( $request['key'] );
 
-		if ( ! $cart_item ) {
+		if ( empty( $cart_item ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
@@ -105,7 +105,7 @@ class CartItemsByKey extends AbstractRoute {
 		$cart       = $controller->get_cart_instance();
 		$cart_item  = $controller->get_cart_item( $request['key'] );
 
-		if ( ! $cart_item ) {
+		if ( empty( $cart_item ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );
 		}
 

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -52,7 +52,7 @@ class CartRemoveItem extends AbstractCartRoute {
 		$cart       = $controller->get_cart_instance();
 		$cart_item  = $controller->get_cart_item( $request['key'] );
 
-		if ( ! $cart_item ) {
+		if ( empty( $cart_item ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item no longer exists or is invalid.', 'woo-gutenberg-products-block' ), 409 );
 		}
 

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -280,7 +280,7 @@ class Checkout extends AbstractRoute {
 	protected function get_draft_order_object( $order_id ) {
 		$draft_order_object = $order_id ? wc_get_order( $order_id ) : false;
 
-		if ( ! $draft_order_object ) {
+		if ( ! $draft_order_object instanceof \WC_Order ) {
 			return false;
 		}
 

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -147,7 +147,7 @@ class Checkout extends AbstractRoute {
 		$order_controller = new OrderController();
 		$order_object     = $this->get_draft_order_object( $this->get_draft_order_id() );
 
-		if ( ! $order_object ) {
+		if ( ! $order_object instanceof \WC_Order ) {
 			throw new RouteException(
 				'woocommerce_rest_checkout_invalid_order',
 				__( 'This session has no orders pending payment.', 'woo-gutenberg-products-block' ),
@@ -315,7 +315,7 @@ class Checkout extends AbstractRoute {
 		$cart_controller->validate_cart_items();
 		$cart_controller->validate_cart_coupons();
 
-		if ( ! $order_object ) {
+		if ( ! $order_object instanceof \WC_Order ) {
 			$order_object = $order_controller->create_order_from_cart();
 			$created      = true;
 		} else {

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -110,7 +110,7 @@ class CartController {
 	public function set_cart_item_quantity( $item_id, $quantity = 1 ) {
 		$cart_item = $this->get_cart_item( $item_id );
 
-		if ( ! $cart_item ) {
+		if ( empty( $cart_item ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );
 		}
 


### PR DESCRIPTION
Exakat scan audit of blocks caught 8 instances in the WooCommerce Blocks code base that triggered "PHP 8 Unsupported Types with Operators" rule failures. In this pull request I fixed 7 of them, the last one for [this code](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/src/StoreApi/Routes/AbstractTermsRoute.php#L134) is a false positive. I did tighten up the types in 476049f but that still wasn't enough to fix the rule fail for the calculation happening. I'm confident enough in the code that is present currently to ignore the false positive.

<img width="1193" alt="Image 2020-11-06 at 5 24 22 PM" src="https://user-images.githubusercontent.com/1429108/98422111-da808a00-2058-11eb-88b0-8a9968c74198.png">


## To Test

This impacts a few areas that will need tested:

**Commits d460aac and 7698570**
Impact: Various cart endpoints

- With the cart block, try increasing and decreasing quantity of products in the cart and verify that totals update etc. Verify there are no console errors or errors with the block.
- With the cart block try removing an item from the cart, verify totals update etc and there are no errors.
- In the All Products block, try adding products to the cart, verify there are no errors.

**Commit 2762798**
Impact: Checkout

- With the checkout block, loading the block and submitting a payment (doesn't matter what payment method) should give the expected results without any errors (in console or UI). Also verify that the order persists to the backend as expected after order is complete.

**Commit 476049f**
Impact: Attribute Filter Block

- Verify the attribute filter block returns expected terms for various settings and that there are no errors.
- Verify that pagination for results on filtered products works as expected.

**Commit a34611d**
Impact: Product Categories Block

- Verify that the block in the editor and in the frontend works as expected with no errors. Any problems should surface fairly quickly.