### PR TITLE
Expose `discount_type` in Store API coupon endpoints

### DIFF
--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -24,8 +24,8 @@ class CartCouponSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'code'   => [
-				'description' => __( 'The coupons unique code.', 'woo-gutenberg-products-block' ),
+			'code'          => [
+				'description' => __( 'The coupon\'s unique code.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'arg_options' => [
@@ -33,7 +33,15 @@ class CartCouponSchema extends AbstractSchema {
 					'validate_callback' => [ $this, 'coupon_exists' ],
 				],
 			],
-			'totals' => [
+			'discount_type' => [
+				'description' => __( 'The discount type for the coupon (e.g. percentage or fixed amount)', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'arg_options' => [
+					'validate_callback' => [ $this, 'coupon_exists' ],
+				],
+			],
+			'totals'        => [
 				'description' => __( 'Total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -71,7 +79,7 @@ class CartCouponSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Convert a WooCommerce cart item to an object suitable for the response.
+	 * Generate a response from passed coupon code.
 	 *
 	 * @param string $coupon_code Coupon code from the cart.
 	 * @return array
@@ -81,9 +89,11 @@ class CartCouponSchema extends AbstractSchema {
 		$cart                 = $controller->get_cart_instance();
 		$total_discounts      = $cart->get_coupon_discount_totals();
 		$total_discount_taxes = $cart->get_coupon_discount_tax_totals();
+		$coupon               = new \WC_Coupon( $coupon_code );
 		return [
-			'code'   => $coupon_code,
-			'totals' => (object) array_merge(
+			'code'          => $coupon_code,
+			'discount_type' => $coupon->get_discount_type(),
+			'totals'        => (object) array_merge(
 				$this->get_store_currency_response(),
 				[
 					'total_discount'     => $this->prepare_money_response( isset( $total_discounts[ $coupon_code ] ) ? $total_discounts[ $coupon_code ] : 0, wc_get_price_decimals() ),

--- a/src/StoreApi/Schemas/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/CartCouponSchema.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  * @since 2.5.0
+ * @since $VID:$ Coupon type (`discount_type`) added.
  */
 class CartCouponSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/docs/cart-coupons.md
+++ b/src/StoreApi/docs/cart-coupons.md
@@ -24,6 +24,7 @@ curl "https://example-store.com/wp-json/wc/store/cart/coupons"
 [
 	{
 		"code": "20off",
+		"type": "fixed_cart",
 		"totals": {
 			"currency_code": "GBP",
 			"currency_symbol": "£",
@@ -71,7 +72,8 @@ curl "https://example-store.com/wp-json/wc/store/cart/coupons/20off"
 
 ```json
 {
-	"code": "20off",
+	"code": "halfprice",
+	"type": "percent",
 	"totals": {
 		"currency_code": "GBP",
 		"currency_symbol": "£",
@@ -80,8 +82,8 @@ curl "https://example-store.com/wp-json/wc/store/cart/coupons/20off"
 		"currency_thousand_separator": ",",
 		"currency_prefix": "£",
 		"currency_suffix": "",
-		"total_discount": "1667",
-		"total_discount_tax": "333"
+		"total_discount": "9950",
+		"total_discount_tax": "0"
 	}
 }
 ```
@@ -107,6 +109,7 @@ curl --request POST https://example-store.com/wp-json/wc/store/cart/coupons?code
 ```json
 {
 	"code": "20off",
+	"type": "percent",
 	"totals": {
 		"currency_code": "GBP",
 		"currency_symbol": "£",


### PR DESCRIPTION
Fixes #3274

### Screenshots

Example after `POST`ing two coupons in cart, `POST /wc/store/cart/apply-coupon`

<img width="472" alt="Screen Shot 2020-11-13 at 2 26 13 PM" src="https://user-images.githubusercontent.com/4167300/99016528-3056b400-25bc-11eb-90be-e109bae08b23.png">

### How to test the changes in this Pull Request:
1. Test cart & checkout with & without various coupons. Check network requests inspector in dev tools and confirm coupon type is present and correct. 

### Changelog

> Store API: Add `discount_type` field to coupon-related requests.
