### PR TITLE
Fix incorrect usage of static method in Stripe payment method integration

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,7 +10,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.6-" />
+	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -246,7 +246,7 @@ final class Stripe extends AbstractPaymentMethodType {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$post_data = $_POST;
 			$_POST     = $context->payment_data;
-			WC_Stripe_Payment_Request::add_order_meta( $context->order->id, $context->payment_data );
+			$this->add_order_meta( $context->order, $data['payment_request_type'] );
 			$_POST = $post_data;
 		}
 
@@ -293,6 +293,24 @@ final class Stripe extends AbstractPaymentMethodType {
 			);
 			$result->set_payment_details( $payment_details );
 			$result->set_status( 'success' );
+		}
+	}
+
+	/**
+	 * Handles adding information about the payment request type used to the order meta.
+	 *
+	 * @param \WC_Order $order The order being processed.
+	 * @param string    $payment_request_type The payment request type used for payment.
+	 */
+	private function add_order_meta( \WC_Order $order, string $payment_request_type ) {
+		if ( 'apple_pay' === $payment_request_type ) {
+			$order->set_payment_method_title( 'Apple Pay (Stripe)' );
+			$order->save();
+		}
+
+		if ( 'payment_request_api' === $payment_request_type ) {
+			$order->set_payment_method_title( 'Chrome Payment Request (Stripe)' );
+			$order->save();
 		}
 	}
 }


### PR DESCRIPTION
While testing some checkout related issues, a fatal error got thrown in my testing environment (with PHP 8.0):

> PHP Fatal error:  Uncaught Error: Non-static method WC_Stripe_Payment_Request::add_order_meta() cannot be called statically in /srv/www/woo/public_html/wp-content/plugins/woo-blocks/src/Payments/Integrations/Stripe.php:249

It turns out, this was never a static method and just _happened_ to work okay in earlier php versions but will result in a fatal in PHP 8 (which is why it never got noticed until now). Obviously if this method was implementing any instance calls it would have surfaced earlier but because it's not, it didn't get surfaced.

I would have like to call the original method from it's instance but the `WC_Stripe_Payment_Request` class is instantiated directly in the Stripe add-on and not assigned to anything. On top of that, it registers filter and action hooks directly so it can't be re-instantiated anywhere.

Thus, in this pull I just reproduced the logic in the Stripe integration class.

I also updated our phpcs compat configuration to check for PHP 7+ because we don't support PHP 5.6 anymore.

## To Test

* [ ] Complete a purchase using any express payment method (Chrome pay or Apple Pay) and ensure the correct payment method used is recorded with the order meta.