### PR TITLE
Print wordpress version in e2e tests.

### DIFF
--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -14,6 +14,7 @@ fi
 
 ## set permalinks for easier wp-json
 wp rewrite structure '/%postname%/'
+wp core version --extra
 wp plugin list
 
 exit $EXIT_CODE


### PR DESCRIPTION
### Print WordPress core information when executing E2E tests.

This affects output inside Travis log. With this change we can check which version of WordPress was exactly used for tests.

This uses:
https://developer.wordpress.org/cli/commands/core/version/ 