### PR TITLE
Support a plain js config argument to payment method registration APIs

### DIFF
--- a/assets/js/base/components/payment-methods/test/payment-methods.js
+++ b/assets/js/base/components/payment-methods/test/payment-methods.js
@@ -26,18 +26,15 @@ jest.mock( '../saved-payment-method-options', () => ( { onChange } ) => (
 
 const registerMockPaymentMethods = () => {
 	[ 'cheque' ].forEach( ( name ) => {
-		registerPaymentMethod(
-			( Config ) =>
-				new Config( {
-					name,
-					label: name,
-					content: <div>A payment method</div>,
-					edit: <div>A payment method</div>,
-					icons: null,
-					canMakePayment: () => true,
-					ariaLabel: name,
-				} )
-		);
+		registerPaymentMethod( {
+			name,
+			label: name,
+			content: <div>A payment method</div>,
+			edit: <div>A payment method</div>,
+			icons: null,
+			canMakePayment: () => true,
+			ariaLabel: name,
+		} );
 	} );
 };
 

--- a/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -53,60 +53,52 @@ jest.mock( '@woocommerce/settings', () => {
 
 const registerMockPaymentMethods = () => {
 	[ 'cheque', 'bacs' ].forEach( ( name ) => {
-		registerPaymentMethod(
-			( Config ) =>
-				new Config( {
-					name,
-					label: name,
-					content: <div>A payment method</div>,
-					edit: <div>A payment method</div>,
-					icons: null,
-					canMakePayment: () => true,
-					ariaLabel: name,
-				} )
-		);
+		registerPaymentMethod( {
+			name,
+			label: name,
+			content: <div>A payment method</div>,
+			edit: <div>A payment method</div>,
+			icons: null,
+			canMakePayment: () => true,
+			ariaLabel: name,
+		} );
 	} );
 	[ 'stripe' ].forEach( ( name ) => {
-		registerPaymentMethod(
-			( Config ) =>
-				new Config( {
-					name,
-					label: name,
-					content: <div>A payment method</div>,
-					edit: <div>A payment method</div>,
-					icons: null,
-					canMakePayment: () => true,
-					supports: {
-						savePaymentInfo: true,
-					},
-					ariaLabel: name,
-				} )
-		);
+		registerPaymentMethod( {
+			name,
+			label: name,
+			content: <div>A payment method</div>,
+			edit: <div>A payment method</div>,
+			icons: null,
+			canMakePayment: () => true,
+			supports: {
+				savePaymentInfo: true,
+			},
+			ariaLabel: name,
+		} );
 	} );
 	[ 'express-payment' ].forEach( ( name ) => {
-		registerExpressPaymentMethod( ( Config ) => {
-			const Content = ( {
-				onClose = () => void null,
-				onClick = () => void null,
-			} ) => {
-				return (
-					<>
-						<button onClick={ onClick }>
-							{ name + ' express payment method' }
-						</button>
-						<button onClick={ onClose }>
-							{ name + ' express payment method close' }
-						</button>
-					</>
-				);
-			};
-			return new Config( {
-				name,
-				content: <Content />,
-				edit: <div>An express payment method</div>,
-				canMakePayment: () => true,
-				paymentMethodId: name,
-			} );
+		const Content = ( {
+			onClose = () => void null,
+			onClick = () => void null,
+		} ) => {
+			return (
+				<>
+					<button onClick={ onClick }>
+						{ name + ' express payment method' }
+					</button>
+					<button onClick={ onClose }>
+						{ name + ' express payment method close' }
+					</button>
+				</>
+			);
+		};
+		registerExpressPaymentMethod( {
+			name,
+			content: <Content />,
+			edit: <div>An express payment method</div>,
+			canMakePayment: () => true,
+			paymentMethodId: name,
 		} );
 	} );
 };

--- a/assets/js/blocks-registry/payment-methods/assertions.js
+++ b/assets/js/blocks-registry/payment-methods/assertions.js
@@ -50,11 +50,3 @@ export const assertConfigHasProperties = (
 		throw new TypeError( message + missingProperties.join( ', ' ) );
 	}
 };
-
-export const assertValidPaymentMethodCreator = ( creator, configName ) => {
-	if ( typeof creator !== 'function' ) {
-		throw new TypeError(
-			`A payment method must be registered with a function that creates and returns a ${ configName } instance`
-		);
-	}
-};

--- a/assets/js/blocks-registry/payment-methods/registry.js
+++ b/assets/js/blocks-registry/payment-methods/registry.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertValidPaymentMethodCreator } from './assertions';
 import { default as PaymentMethodConfig } from './payment-method-config';
 import { default as ExpressPaymentMethodConfig } from './express-payment-method-config';
 
@@ -22,14 +21,15 @@ export const registerPaymentMethod = ( options ) => {
 	}
 };
 
-export const registerExpressPaymentMethod = ( expressPaymentMethodCreator ) => {
-	assertValidPaymentMethodCreator(
-		expressPaymentMethodCreator,
-		'ExpressPaymentMethodConfig'
-	);
-	const paymentMethodConfig = expressPaymentMethodCreator(
-		ExpressPaymentMethodConfig
-	);
+export const registerExpressPaymentMethod = ( options ) => {
+	let paymentMethodConfig;
+	if ( typeof options === 'function' ) {
+		// Legacy fallback for previous API, where client passes a function:
+		// registerExpressPaymentMethod( ( Config ) => new Config( options ) );
+		paymentMethodConfig = options( ExpressPaymentMethodConfig );
+	} else {
+		paymentMethodConfig = new ExpressPaymentMethodConfig( options );
+	}
 	if ( paymentMethodConfig instanceof ExpressPaymentMethodConfig ) {
 		expressPaymentMethods[ paymentMethodConfig.name ] = paymentMethodConfig;
 	}

--- a/assets/js/blocks-registry/payment-methods/registry.js
+++ b/assets/js/blocks-registry/payment-methods/registry.js
@@ -31,6 +31,11 @@ export const registerPaymentMethod = ( options ) => {
 	}
 };
 
+/**
+ * Register an express payment method.
+ *
+ * @param {ExpressPaymentMethodRegistrationOptions} options  Configuration options for the payment method.
+ */
 export const registerExpressPaymentMethod = ( options ) => {
 	let paymentMethodConfig;
 	if ( typeof options === 'function' ) {

--- a/assets/js/blocks-registry/payment-methods/registry.js
+++ b/assets/js/blocks-registry/payment-methods/registry.js
@@ -4,6 +4,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import { default as PaymentMethodConfig } from './payment-method-config';
@@ -15,7 +20,7 @@ const expressPaymentMethods = {};
 /**
  * Register a regular payment method.
  *
- * @param {PaymentMethodRegistrationOptions} options  Configuration options for the payment method.
+ * @param {PaymentMethodRegistrationOptions} options Configuration options for the payment method.
  */
 export const registerPaymentMethod = ( options ) => {
 	let paymentMethodConfig;
@@ -23,6 +28,12 @@ export const registerPaymentMethod = ( options ) => {
 		// Legacy fallback for previous API, where client passes a function:
 		// registerPaymentMethod( ( Config ) => new Config( options ) );
 		paymentMethodConfig = options( PaymentMethodConfig );
+		deprecated( 'Passing a callback to registerPaymentMethod()', {
+			alternative: 'a config options object',
+			plugin: 'woocommerce-gutenberg-products-block',
+			link:
+				'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3404',
+		} );
 	} else {
 		paymentMethodConfig = new PaymentMethodConfig( options );
 	}
@@ -34,7 +45,7 @@ export const registerPaymentMethod = ( options ) => {
 /**
  * Register an express payment method.
  *
- * @param {ExpressPaymentMethodRegistrationOptions} options  Configuration options for the payment method.
+ * @param {ExpressPaymentMethodRegistrationOptions} options Configuration options for the payment method.
  */
 export const registerExpressPaymentMethod = ( options ) => {
 	let paymentMethodConfig;
@@ -42,6 +53,12 @@ export const registerExpressPaymentMethod = ( options ) => {
 		// Legacy fallback for previous API, where client passes a function:
 		// registerExpressPaymentMethod( ( Config ) => new Config( options ) );
 		paymentMethodConfig = options( ExpressPaymentMethodConfig );
+		deprecated( 'Passing a callback to registerExpressPaymentMethod()', {
+			alternative: 'a config options object',
+			plugin: 'woocommerce-gutenberg-products-block',
+			link:
+				'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3404',
+		} );
 	} else {
 		paymentMethodConfig = new ExpressPaymentMethodConfig( options );
 	}

--- a/assets/js/blocks-registry/payment-methods/registry.js
+++ b/assets/js/blocks-registry/payment-methods/registry.js
@@ -1,4 +1,9 @@
 /**
+ * @typedef {import('@woocommerce/type-defs/payments').PaymentMethodRegistrationOptions} PaymentMethodRegistrationOptions
+ * @typedef {import('@woocommerce/type-defs/payments').ExpressPaymentMethodRegistrationOptions} ExpressPaymentMethodRegistrationOptions
+ */
+
+/**
  * Internal dependencies
  */
 import { default as PaymentMethodConfig } from './payment-method-config';
@@ -7,6 +12,11 @@ import { default as ExpressPaymentMethodConfig } from './express-payment-method-
 const paymentMethods = {};
 const expressPaymentMethods = {};
 
+/**
+ * Register a regular payment method.
+ *
+ * @param {PaymentMethodRegistrationOptions} options  Configuration options for the payment method.
+ */
 export const registerPaymentMethod = ( options ) => {
 	let paymentMethodConfig;
 	if ( typeof options === 'function' ) {

--- a/assets/js/blocks-registry/payment-methods/registry.js
+++ b/assets/js/blocks-registry/payment-methods/registry.js
@@ -8,12 +8,15 @@ import { default as ExpressPaymentMethodConfig } from './express-payment-method-
 const paymentMethods = {};
 const expressPaymentMethods = {};
 
-export const registerPaymentMethod = ( paymentMethodCreator ) => {
-	assertValidPaymentMethodCreator(
-		paymentMethodCreator,
-		'PaymentMethodConfig'
-	);
-	const paymentMethodConfig = paymentMethodCreator( PaymentMethodConfig );
+export const registerPaymentMethod = ( options ) => {
+	let paymentMethodConfig;
+	if ( typeof options === 'function' ) {
+		// Legacy fallback for previous API, where client passes a function:
+		// registerPaymentMethod( ( Config ) => new Config( options ) );
+		paymentMethodConfig = options( PaymentMethodConfig );
+	} else {
+		paymentMethodConfig = new PaymentMethodConfig( options );
+	}
 	if ( paymentMethodConfig instanceof PaymentMethodConfig ) {
 		paymentMethods[ paymentMethodConfig.name ] = paymentMethodConfig;
 	}

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -47,7 +47,6 @@ const bankTransferPaymentMethod = {
 	label: <Label />,
 	content: <Content />,
 	edit: <Content />,
-	icons: null,
 	canMakePayment: () => true,
 	ariaLabel: label,
 };

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -52,4 +52,4 @@ const bankTransferPaymentMethod = {
 	ariaLabel: label,
 };
 
-registerPaymentMethod( ( Config ) => new Config( bankTransferPaymentMethod ) );
+registerPaymentMethod( bankTransferPaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -44,7 +44,6 @@ const offlineChequePaymentMethod = {
 	label: <Label />,
 	content: <Content />,
 	edit: <Content />,
-	icons: null,
 	canMakePayment: () => true,
 	ariaLabel: label,
 };

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -49,4 +49,4 @@ const offlineChequePaymentMethod = {
 	ariaLabel: label,
 };
 
-registerPaymentMethod( ( Config ) => new Config( offlineChequePaymentMethod ) );
+registerPaymentMethod( offlineChequePaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/cod/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cod/index.js
@@ -77,7 +77,6 @@ const cashOnDeliveryPaymentMethod = {
 	label: <Label />,
 	content: <Content />,
 	edit: <Content />,
-	icons: null,
 	canMakePayment,
 	ariaLabel: label,
 };

--- a/assets/js/payment-method-extensions/payment-methods/cod/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cod/index.js
@@ -82,6 +82,4 @@ const cashOnDeliveryPaymentMethod = {
 	ariaLabel: label,
 };
 
-registerPaymentMethod(
-	( Config ) => new Config( cashOnDeliveryPaymentMethod )
-);
+registerPaymentMethod( cashOnDeliveryPaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -48,4 +48,4 @@ const paypalPaymentMethod = {
 	),
 };
 
-registerPaymentMethod( ( Config ) => new Config( paypalPaymentMethod ) );
+registerPaymentMethod( paypalPaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -40,7 +40,6 @@ const paypalPaymentMethod = {
 	),
 	content: <Content />,
 	edit: <Content />,
-	icons: null,
 	canMakePayment: () => true,
 	ariaLabel: decodeEntities(
 		settings.title ||

--- a/assets/js/payment-method-extensions/payment-methods/stripe/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/index.js
@@ -10,7 +10,7 @@ import {
  * Internal dependencies
  */
 import stripeCcPaymentMethod from './credit-card';
-import PaymentRequestPaymentMethod from './payment-request';
+import paymentRequestPaymentMethod from './payment-request';
 import { getStripeServerData } from './stripe-utils';
 
 // Register Stripe Credit Card.
@@ -18,5 +18,5 @@ registerPaymentMethod( stripeCcPaymentMethod );
 
 // Register Stripe Payment Request (Apple/Chrome Pay) if enabled.
 if ( getStripeServerData().allowPaymentRequest ) {
-	registerExpressPaymentMethod( PaymentRequestPaymentMethod );
+	registerExpressPaymentMethod( paymentRequestPaymentMethod );
 }

--- a/assets/js/payment-method-extensions/payment-methods/stripe/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/index.js
@@ -14,7 +14,7 @@ import PaymentRequestPaymentMethod from './payment-request';
 import { getStripeServerData } from './stripe-utils';
 
 // Register Stripe Credit Card.
-registerPaymentMethod( ( Config ) => new Config( stripeCcPaymentMethod ) );
+registerPaymentMethod( stripeCcPaymentMethod );
 
 // Register Stripe Payment Request (Apple/Chrome Pay) if enabled.
 if ( getStripeServerData().allowPaymentRequest ) {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/index.js
@@ -18,7 +18,5 @@ registerPaymentMethod( stripeCcPaymentMethod );
 
 // Register Stripe Payment Request (Apple/Chrome Pay) if enabled.
 if ( getStripeServerData().allowPaymentRequest ) {
-	registerExpressPaymentMethod(
-		( Config ) => new Config( PaymentRequestPaymentMethod )
-	);
+	registerExpressPaymentMethod( PaymentRequestPaymentMethod );
 }

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -52,7 +52,7 @@ function paymentRequestAvailable( currencyCode ) {
 	} );
 }
 
-const PaymentRequestPaymentMethod = {
+const paymentRequestPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
 	content: <PaymentRequestExpress stripe={ componentStripePromise } />,
 	edit: <ApplePayPreview />,
@@ -64,4 +64,4 @@ const PaymentRequestPaymentMethod = {
 	paymentMethodId: 'stripe',
 };
 
-export default PaymentRequestPaymentMethod;
+export default paymentRequestPaymentMethod;

--- a/assets/js/type-defs/payments.js
+++ b/assets/js/type-defs/payments.js
@@ -5,4 +5,28 @@
  * @property {string} value Value for the payment data item.
  */
 
+/**
+ * @typedef {Object} ExpressPaymentMethodRegistrationOptions
+ *
+ * @property {string} name              A unique string to identify the payment method client side.
+ * @property {Object} content           A react node for your payment method UI.
+ * @property {Object} edit              A react node to display a preview of your payment method in the editor.
+ * @property {Function} canMakePayment  A callback to determine whether the payment method should be shown in the checkout.
+ * @property {string} [paymentMethodId] A unique string to represent the payment method server side. If not provided, defaults to name.
+ */
+
+/**
+ * @typedef {Object} PaymentMethodRegistrationOptions
+ *
+ * @property {string} name                    A unique string to identify the payment method client side.
+ * @property {Object} content                 A react node for your payment method UI.
+ * @property {Object} edit                    A react node to display a preview of your payment method in the editor.
+ * @property {Array} [icons]                  Array of card types (brands) supported by the payment method. (See stripe/credit-card for example.)
+ * @property {Function} canMakePayment        A callback to determine whether the payment method should be shown in the checkout.
+ * @property {string} [paymentMethodId]       A unique string to represent the payment method server side. If not provided, defaults to name.
+ * @property {Object} label                   A react node that will be used as a label for the payment method in the checkout.
+ * @property {string} ariaLabel               An accessibility label. Screen readers will output this label when the payment method is selected.
+ * @property {string} [placeOrderButtonLabel] Optionally customise the label text for the checkout submit (`Place Order`) button.
+ */
+
 export {};

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -8,7 +8,7 @@ The checkout block has an API interface for payment methods to integrate that co
 
 - [Client Side integration](#client-side-integration)
   - [Express payment methods - `registerExpressPaymentMethod( options )`](#express-payment-methods---registerexpresspaymentmethod-paymentmethodcreator-)
-  - [Payment Methods - `registerPaymentMethod( paymentMethodCreator )`](#payment-methods---registerpaymentmethod-paymentmethodcreator-)
+  - [Payment Methods - `registerPaymentMethod( options )`](#payment-methods---registerpaymentmethod-paymentmethodcreator-)
   - [Props Fed to Payment Method Nodes](#props-fed-to-payment-method-nodes)
 - [Server Side Integration](#server-side-integration)
   - [Processing Payment](#processing-payment)
@@ -20,7 +20,7 @@ The client side integration consists of an API for registering both _express_ pa
 
 In both cases, the client side integration is done using registration methods exposed on the `blocks-registry` API. You can access this via the `wc` global in a WooCommerce environment (`wc.wcBlocksRegistry`). You'll see that we also Webpack configured in the blocks repository to expose this API on `@woocommerce/blocks-registry` which you can implement in your own build process as well.
 
-### Express payment methods - `registerExpressPaymentMethod( paymentMethodCreator )`
+### Express payment methods - `registerExpressPaymentMethod( options )`
 
 ![Express Payment Area](https://user-images.githubusercontent.com/1429108/79565636-17fed500-807f-11ea-8e5d-9af32e43b71d.png)
 
@@ -38,12 +38,10 @@ _wc global_
 const { registerExpressPaymentMethod } = wc.wcBlocksRegistry;
 ```
 
-The registry function expects a function that will receive an `ExpressPaymentMethodConfig` creator as an argument and is expected to return a valid `ExpressPaymentMethodConfig` instance. As a very basic example, something like this:
+The registry function expects a javascript object with options specific to the payment method:
 
 ```js
-registerExpressPaymentMethod(
-	( ExpressPaymentMethodConfig ) => new ExpressPaymentMethodConfig( options )
-);
+registerExpressPaymentMethod( options );
 ```
 
 The options you feed the configuration instance should be an object in this shape:

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -7,7 +7,7 @@ The checkout block has an API interface for payment methods to integrate that co
 ## Table of Contents <!-- omit in toc -->
 
 - [Client Side integration](#client-side-integration)
-  - [Express payment methods - `registerExpressPaymentMethod( paymentMethodCreator )`](#express-payment-methods---registerexpresspaymentmethod-paymentmethodcreator-)
+  - [Express payment methods - `registerExpressPaymentMethod( options )`](#express-payment-methods---registerexpresspaymentmethod-paymentmethodcreator-)
   - [Payment Methods - `registerPaymentMethod( paymentMethodCreator )`](#payment-methods---registerpaymentmethod-paymentmethodcreator-)
   - [Props Fed to Payment Method Nodes](#props-fed-to-payment-method-nodes)
 - [Server Side Integration](#server-side-integration)
@@ -66,7 +66,7 @@ Here's some more details on the configuration options:
 -   `canMakePayment` (required): A callback to determine whether the payment method should be available as an option for the shopper. The function will be passed an object containing data about the current order. Return a boolean value - true if payment method is available for use. If your gateway needs to perform async initialisation to determine availability, you can return a promise (resolving to boolean). This allows a payment method to be hidden based on the cart, e.g. if the cart has physical/shippable products (example: `Cash on delivery`); or for payment methods to control whether they are available depending on other conditions. Keep in mind this function could be invoked multiple times in the lifecycle of the checkout and thus any expensive logic in the callback provided on this property should be memoized.
 -   `paymentMethodId`: This is the only optional configuration object. The value of this property is what will accompany the checkout processing request to the server and used to identify what payment method gateway class to load for processing the payment (if the shopper selected the gateway). So for instance if this is `stripe`, then `WC_Gateway_Stripe::process_payment` will be invoked for processing the payment.
 
-### Payment Methods - `registerPaymentMethod( paymentMethodCreator )`
+### Payment Methods - `registerPaymentMethod( options )`
 
 ![Payment Method Area](https://user-images.githubusercontent.com/1429108/79565774-5d230700-807f-11ea-9335-0111ec306a47.png)
 
@@ -84,19 +84,17 @@ _wc global_
 const { registerPaymentMethod } = wc.wcBlocksRegistry;
 ```
 
-The registry function expects a function that will receive an `PaymentMethodConfig` creator as an argument and is expected to return a valid `PaymentMethodConfig` instance. As a very basic example, something like this:
+The registry function expects a javascript object with options specific to the payment method:
 
 ```js
-registerPaymentMethod(
-	( PaymentMethodConfig ) => new PaymentMethodConfig( options )
-);
+registerPaymentMethod( options );
 ```
 
 The options you feed the configuration instance are the same as those for express payment methods with the following additions:
 
 -   `label`: This should be a react node that will be used to output the label for the tab in the payment methods are. For example it might be `<strong>Credit/Debit Cart</strong>` or you might output images.
 -   `ariaLabel`: This is the label that will be read out via screen-readers when the payment method is selected.
-- `placeOrderButtonLabel`: This is an optional label which will change the default "Place Order" button text to something else when the payment method is selected.
+-   `placeOrderButtonLabel`: This is an optional label which will change the default "Place Order" button text to something else when the payment method is selected.
 
 ### Props Fed to Payment Method Nodes
 

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -38,7 +38,7 @@ _wc global_
 const { registerExpressPaymentMethod } = wc.wcBlocksRegistry;
 ```
 
-The registry function expects a javascript object with options specific to the payment method:
+The registry function expects a JavaScript object with options specific to the payment method:
 
 ```js
 registerExpressPaymentMethod( options );
@@ -82,7 +82,7 @@ _wc global_
 const { registerPaymentMethod } = wc.wcBlocksRegistry;
 ```
 
-The registry function expects a javascript object with options specific to the payment method:
+The registry function expects a JavaScript object with options specific to the payment method:
 
 ```js
 registerPaymentMethod( options );

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -44,7 +44,7 @@ The registry function expects a JavaScript object with options specific to the p
 registerExpressPaymentMethod( options );
 ```
 
-The options you feed the configuration instance should be an object in this shape:
+The options you feed the configuration instance should be an object in this shape (see `ExpressPaymentMethodRegistrationOptions` typedef):
 
 ```js
 const options = {
@@ -82,7 +82,7 @@ _wc global_
 const { registerPaymentMethod } = wc.wcBlocksRegistry;
 ```
 
-The registry function expects a JavaScript object with options specific to the payment method:
+The registry function expects a JavaScript object with options specific to the payment method (see `PaymentMethodRegistrationOptions` typedef):
 
 ```js
 registerPaymentMethod( options );


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #3064

This PR updates the two APIs for registering payment methods so they are simpler. They now both receive an `options` JS object. Previously was a callback which exposed internal details of how payment methods are handled.

The new interfaces are:

- `registerPaymentMethod( options )`
- `registerExpressPaymentMethod( options )`

The existing callback API is still supported if a function is passed.

All payment methods in this code base have been updated to the new simpler API. Docs have also been updated.

This PR also includes JSDoc typedefs for the `options` objects. This should help us catch any payment methods passing incorrect info, and when we support new fields to options.

#### Deprecating the old API - help!
In the issue it's suggested that we deprecate the old callback-style API. I don't know how we should do this – how do we deprecate JS APIs?

Perhaps we can add a `warn_deprecated_api()` routine that logs to console, possibly with an extra conditional (e.g. `SCRIPT_DEBUG` ?), and call this in the deprecated/legacy code path.

Update: using [`@wordpress/deprecated`](https://developer.wordpress.org/block-editor/packages/packages-deprecated/).

#### API docs
I've manually updated the markdown doc for now. Long term it might be a good idea to start documenting our JS APIs using code docs, for example using [JSDoc](https://jsdoc.app/) or some other tech. Then we can use this to automatically generate consistently formatted API docs, and also keep track of changes over different releases. 

@nerrad - keen for your thoughts on this. If there's interest I'm happy to take a look in the next cooldown.

I haven't looked to see what other projects are doing (e.g. Gutenberg, WooCommerce, wc-admin, Jetpack), maybe there's a convention we can adopt.

Update: using a JSDoc typedef now.

### How to test the changes in this Pull Request:
1. Check out this branch and build. 
2. Test all payment methods work correctly - e.g. complete an order with each payment method.

Note I haven't tested the following payment methods myself, would appreciate extra testing of the following. Please comment in your review which payment methods you tested – thanks!

- [ ] Stripe Payment Request - Chrome/Google Pay
- [ ] Stripe Payment Request - Apple Pay
- [ ] PayPal

Bonus points: 

- Test a 3rd-party payment method from another extension (e.g. WC Pay) - using new or old API.
- Hack a payment method in blocks code base to use callback-style registration and ensure fallback works correctly.

### Changelog

> Dev: Payment method registration APIs now receive a plain JavaScript object argument (previously expected a callback function).

#### Developer Note

##### Payment method registration APIs receive JS options arg (was callback)
In WooCommerce Blocks `{version}` the APIs for registering a payment method have changed.

The affected JavaScript functions are:

- `registerPaymentMethod( options )`
- `registerExpressPaymentMethod( options )`

Previously these APIs received a callback function, for example:

```js
const bankTransferPaymentMethod = {
	name: PAYMENT_METHOD_NAME,
	label: <Label />,
	content: <Content />,
	edit: <Content />,
	icons: null,
	canMakePayment: () => true,
	ariaLabel: label,
};
// OLD API
registerPaymentMethod( ( Config ) => new Config( bankTransferPaymentMethod ) );
```

Now you can simply pass the options object directly: 

```js
// New API
registerPaymentMethod( bankTransferPaymentMethod );
```

All payment methods (gateway extensions) should update to the new API as soon as possible. The previous callback-based API is supported as a fallback, and will be deprecated in a future release.