### PR TITLE
Fix cart block isLarge console error in the editor when running WordPress 5.6 beta

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -239,7 +239,6 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			<Button
 				className="wc-block-attribute-filter__add-attribute-button"
 				isDefault
-				isLarge
 				href={ getAdminLink(
 					'edit.php?post_type=product&page=product_attributes'
 				) }

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -135,7 +135,6 @@ export default function ( { attributes, setAttributes } ) {
 			<Button
 				className="wc-block-price-slider__add-product-button"
 				isDefault
-				isLarge
 				href={ getAdminLink( 'post-new.php?post_type=product' ) }
 			>
 				{ __( 'Add new product', 'woo-gutenberg-products-block' ) +

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -224,7 +224,6 @@ class Editor extends Component {
 						<Button
 							className="wc-block-all-products__done-button"
 							isPrimary
-							isLarge
 							onClick={ onDone }
 						>
 							{ __( 'Done', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/products/utils.js
+++ b/assets/js/blocks/products/utils.js
@@ -34,7 +34,6 @@ export const renderNoProductsPlaceholder = ( blockTitle, blockIcon ) => (
 		<Button
 			className="wc-block-products__add-product-button"
 			isDefault
-			isLarge
 			href={ ADMIN_URL + 'post-new.php?post_type=product' }
 		>
 			{ __( 'Add new product', 'woo-gutenberg-products-block' ) + ' ' }

--- a/assets/js/editor-components/view-switcher/index.js
+++ b/assets/js/editor-components/view-switcher/index.js
@@ -39,7 +39,6 @@ const ViewSwitcher = ( {
 						<Button
 							key={ view.value }
 							isPrimary={ currentView === view.value }
-							isLarge
 							aria-pressed={ currentView === view.value }
 							onMouseDown={ () => {
 								if ( currentView !== view.value ) {


### PR DESCRIPTION
`isLarge` is not longer a supported prop on `@wordpress/components` button (see https://github.com/WordPress/gutenberg/issues/16541). This PR removes usage.

There was only a minor difference between isLarge and regular buttons, and it affected some placeholder states and the view switcher. 

Fixes #3382

### Screenshots

These were the affected buttons in the ViewSwitcher:

![Edit Page ‹ one wordpress test — WordPress 2020-11-16 13-05-25](https://user-images.githubusercontent.com/90977/99255854-7013da80-280c-11eb-8bfa-0a8902382cf4.png)

### How to test the changes in this Pull Request:

1. Open up the cart page in the editor.
2. Check console errors.

No other steps were required to see the error previously.

### Changelog

> Fix cart block isLarge console error in the editor when running WordPress 5.6 beta
