### PR TITLE
Show Express Payment Method Error Notices after Payment Failure

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -250,9 +250,14 @@ export const CheckoutStateProvider = ( {
 						isFailResponse( response )
 					) {
 						if ( response.message ) {
-							const errorOptions = response.messageContext
-								? { context: response.messageContext }
-								: undefined;
+							const errorOptions = {
+								context: response.messageContext
+									? response.messageContext
+									: undefined,
+								id: response.messageId
+									? response.messageId
+									: undefined,
+							};
 							addErrorNotice( response.message, errorOptions );
 						}
 						// irrecoverable error so set complete

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -251,12 +251,8 @@ export const CheckoutStateProvider = ( {
 					) {
 						if ( response.message ) {
 							const errorOptions = {
-								context: response.messageContext
-									? response.messageContext
-									: undefined,
-								id: response.messageId
-									? response.messageId
-									: undefined,
+								id: response?.messageContext,
+								context: response?.messageContext,
 							};
 							addErrorNotice( response.message, errorOptions );
 						}

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
  * Internal dependencies
  */
 import { TYPES, DEFAULT_STATE, STATUS } from './constants';
@@ -54,7 +59,7 @@ export const prepareResponseData = ( data ) => {
 	};
 	if ( Array.isArray( data.payment_details ) ) {
 		data.payment_details.forEach( ( { key, value } ) => {
-			responseData.paymentDetails[ key ] = value;
+			responseData.paymentDetails[ key ] = decodeEntities( value );
 		} );
 	}
 	return responseData;

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -193,16 +193,16 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 
 	const setExpressPaymentError = useCallback(
 		( message ) => {
-			removeNotice(
-				'wc-express-payment-error',
-				noticeContexts.EXPRESS_PAYMENTS
-			);
-
 			if ( message ) {
 				addErrorNotice( message, {
-					context: noticeContexts.EXPRESS_PAYMENTS,
 					id: 'wc-express-payment-error',
+					context: noticeContexts.EXPRESS_PAYMENTS,
 				} );
+			} else {
+				removeNotice(
+					'wc-express-payment-error',
+					noticeContexts.EXPRESS_PAYMENTS
+				);
 			}
 		},
 		[ addErrorNotice, noticeContexts.EXPRESS_PAYMENTS, removeNotice ]

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -193,16 +193,16 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 
 	const setExpressPaymentError = useCallback(
 		( message ) => {
+			removeNotice(
+				'wc-express-payment-error',
+				noticeContexts.EXPRESS_PAYMENTS
+			);
+
 			if ( message ) {
 				addErrorNotice( message, {
 					context: noticeContexts.EXPRESS_PAYMENTS,
 					id: 'wc-express-payment-error',
 				} );
-			} else {
-				removeNotice(
-					'wc-express-payment-error',
-					noticeContexts.EXPRESS_PAYMENTS
-				);
 			}
 		},
 		[ addErrorNotice, noticeContexts.EXPRESS_PAYMENTS, removeNotice ]

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
@@ -166,7 +166,10 @@ export const useCheckoutSubscriptions = ( {
 			const handlers = eventHandlers.current;
 			let response = { type: responseTypes.SUCCESS };
 			if ( handlers.sourceEvent && isProcessing ) {
-				const { paymentStatus, paymentDetails } = checkoutResponse;
+				const {
+					paymentStatus,
+					paymentDetails,
+				} = checkoutResponse.processingResponse;
 				if ( paymentStatus === responseTypes.SUCCESS ) {
 					completePayment( handlers.sourceEvent );
 				}
@@ -174,13 +177,10 @@ export const useCheckoutSubscriptions = ( {
 					paymentStatus === responseTypes.ERROR ||
 					paymentStatus === responseTypes.FAIL
 				) {
-					const paymentResponse = abortPayment(
-						handlers.sourceEvent,
-						paymentDetails?.errorMessage
-					);
+					abortPayment( handlers.sourceEvent );
 					response = {
 						type: responseTypes.ERROR,
-						message: paymentResponse.message,
+						message: paymentDetails?.errorMessage,
 						messageContext: noticeContexts.EXPRESS_PAYMENTS,
 						retry: true,
 					};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
@@ -181,7 +181,6 @@ export const useCheckoutSubscriptions = ( {
 					response = {
 						type: responseTypes.ERROR,
 						message: paymentDetails?.errorMessage,
-						messageId: noticeContexts.EXPRESS_PAYMENTS, // This will allow only 1 express payment error to show at once.
 						messageContext: noticeContexts.EXPRESS_PAYMENTS,
 						retry: true,
 					};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-checkout-subscriptions.js
@@ -181,6 +181,7 @@ export const useCheckoutSubscriptions = ( {
 					response = {
 						type: responseTypes.ERROR,
 						message: paymentDetails?.errorMessage,
+						messageId: noticeContexts.EXPRESS_PAYMENTS, // This will allow only 1 express payment error to show at once.
 						messageContext: noticeContexts.EXPRESS_PAYMENTS,
 						retry: true,
 					};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
@@ -14,8 +14,6 @@ import {
 	getPaymentRequest,
 	updatePaymentRequest,
 	canDoPaymentRequest,
-	getBillingData,
-	getPaymentMethodData,
 	normalizeShippingAddressForCheckout,
 	normalizeShippingOptionSelectionsForCheckout,
 	getStripeServerData,
@@ -124,21 +122,10 @@ export const useInitialization = ( {
 		onClick();
 	};
 
-	const abortPayment = useCallback( ( paymentMethod, message ) => {
-		const response = {
-			fail: {
-				message,
-				billingData: getBillingData( paymentMethod ),
-				paymentMethodData: getPaymentMethodData(
-					paymentMethod,
-					currentPaymentRequestType.current
-				),
-			},
-		};
+	const abortPayment = useCallback( ( paymentMethod ) => {
 		paymentMethod.complete( 'fail' );
 		setIsProcessing( false );
 		setIsFinished( true );
-		return response;
 	}, [] );
 
 	const completePayment = useCallback( ( paymentMethod ) => {

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -258,7 +258,7 @@ final class Stripe extends AbstractPaymentMethodType {
 				'wc_gateway_stripe_process_payment_error',
 				function( $error ) use ( &$result ) {
 					$payment_details                 = $result->payment_details;
-					$payment_details['errorMessage'] = $error->getLocalizedMessage();
+					$payment_details['errorMessage'] = wp_strip_all_tags( $error->getLocalizedMessage() );
 					$result->set_payment_details( $payment_details );
 				}
 			);


### PR DESCRIPTION
This PR fixes the error handling side of Express Payment Methods so that API errors are surfaced in the UI. This also prevents multiple-similar error messages stacking if you try multiple times.

This is part of #3402 — leaving 3402 open so the specific Stripe case can be avoided with validation.

### Screenshots

![Cart – one wordpress test 2020-11-16 16-54-55](https://user-images.githubusercontent.com/90977/99283128-7c0f9480-282c-11eb-9763-00b6a9a71da3.png)

### How to test the changes in this Pull Request:

There are 2 cases in #3402 you can try to get an error message to appear. For the min amount case:

1. Have a cart < 0.30 in total.
2. Try to pay via Chrome Pay (stripe)
3. After inputting card details, the paymentRequest will fail. A notice will be shown (see screenshots).
4. If you repeat this test without dismissing the error message, only one notice should be shown.

### Changelog

> Show Express Payment Method Error Notices after Payment Failure
