### PR TITLE
Add FeatureGating parameter to Package in tests

### DIFF
--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -13,6 +13,7 @@ use \WC_Helper_Shipping;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 
 /**
@@ -34,7 +35,7 @@ class Cart extends TestCase {
 
 		$this->products = [];
 
-		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '', new FeatureGating( 2 ) ) );
 
 		// Create some test products.
 		$this->products[0] = ProductHelper::create_simple_product( false );

--- a/tests/php/StoreApi/Routes/CartCoupons.php
+++ b/tests/php/StoreApi/Routes/CartCoupons.php
@@ -12,6 +12,7 @@ use \WC_Helper_Coupon as CouponHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 /**
  * Cart Coupons Controller Tests.
@@ -28,7 +29,7 @@ class CartCoupons extends TestCase {
 
 		wp_set_current_user( 0 );
 
-		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '', new FeatureGating( 2 ) ) );
 
 		$this->product = ProductHelper::create_simple_product( false );
 		$this->coupon  = CouponHelper::create_coupon();

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -11,6 +11,7 @@ use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 /**
  * Cart Controller Tests.
@@ -27,7 +28,7 @@ class CartItems extends TestCase {
 
 		parent::setUp();
 
-		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '', new FeatureGating( 2 ) ) );
 
 		wp_set_current_user( 0 );
 

--- a/tests/php/StoreApi/Routes/ProductAttributeTerms.php
+++ b/tests/php/StoreApi/Routes/ProductAttributeTerms.php
@@ -11,6 +11,7 @@ use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 /**
  * Product Attributes Controller Tests.
@@ -26,7 +27,7 @@ class ProductAttributeTerms extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
-		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '', new FeatureGating() ) );
 
 		$this->attributes    = [];
 		$this->attributes[0] = ProductHelper::create_attribute( 'color', [ 'red', 'green', 'blue' ] );

--- a/tests/php/StoreApi/Routes/ProductAttributes.php
+++ b/tests/php/StoreApi/Routes/ProductAttributes.php
@@ -11,6 +11,7 @@ use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 /**
  * Product Attributes Controller Tests.
@@ -26,7 +27,7 @@ class ProductAttributes extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
-		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '', new FeatureGating() ) );
 
 		$color_attribute = ProductHelper::create_attribute( 'color', [ 'red', 'green', 'blue' ] );
 		$size_attribute  = ProductHelper::create_attribute( 'size', [ 'small', 'medium', 'large' ] );

--- a/tests/php/StoreApi/Routes/ProductCollectionData.php
+++ b/tests/php/StoreApi/Routes/ProductCollectionData.php
@@ -11,6 +11,7 @@ use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 /**
  * Controller Tests.
@@ -26,7 +27,7 @@ class ProductCollectionData extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
-		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '', new FeatureGating() ) );
 
 		$this->products    = [];
 		$this->products[0] = ProductHelper::create_simple_product( false );

--- a/tests/php/StoreApi/Routes/Products.php
+++ b/tests/php/StoreApi/Routes/Products.php
@@ -11,6 +11,7 @@ use \WC_Helper_Product as ProductHelper;
 use Automattic\WooCommerce\Blocks\Tests\Helpers\ValidateSchema;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 /**
  * Products Controller Tests.
  */
@@ -26,7 +27,7 @@ class Products extends TestCase {
 		parent::setUp();
 
 		wp_set_current_user( 0 );
-		$this->mock_extend = new ExtendRestApi( new Package( '', '' ) );
+		$this->mock_extend = new ExtendRestApi( new Package( '', '', new FeatureGating() ) );
 
 		$this->products    = [];
 		$this->products[0] = ProductHelper::create_simple_product( true );


### PR DESCRIPTION
Tests are failing in `trunk` after #3343 was merged because it was not updated with the changes from #3305. This PR updates all tests so any call to `Package` has the `FeatureGating` parameter.

### How to test the changes in this Pull Request:

1. Run `npm run phpunit` or verify that Travis tests pass.
