### PR TITLE
Stop hidden products from being linked in cart and checkout blocks 

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -18,6 +18,7 @@ import Dinero from 'dinero.js';
 const OrderSummaryItem = ( { cartItem } ) => {
 	const {
 		images,
+		catalog_visibility: catalogVisibility = '',
 		low_stock_remaining: lowStockRemaining = null,
 		show_backorder_badge: showBackorderBadge = false,
 		name,
@@ -37,6 +38,8 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		.multiply( quantity )
 		.convertPrecision( currency.minorUnit )
 		.getAmount();
+	const shouldLinkToProduct =
+		catalogVisibility !== 'hidden' && catalogVisibility !== 'search';
 
 	return (
 		<div className="wc-block-components-order-summary-item">
@@ -55,7 +58,11 @@ const OrderSummaryItem = ( { cartItem } ) => {
 			</div>
 			<div className="wc-block-components-order-summary-item__description">
 				<div className="wc-block-components-order-summary-item__header">
-					<ProductName permalink={ permalink } name={ name } />
+					<ProductName
+						hasLink={ shouldLinkToProduct }
+						permalink={ permalink }
+						name={ name }
+					/>
 					<ProductPrice
 						currency={ currency }
 						price={ linePrice }

--- a/assets/js/base/components/cart-checkout/product-name/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/index.js
@@ -9,8 +9,13 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import './style.scss';
 
-const ProductName = ( { name, permalink, disabled = false } ) => {
-	return (
+const ProductName = ( {
+	name,
+	permalink,
+	disabled = false,
+	hasLink = true,
+} ) => {
+	return hasLink ? (
 		// we use tabIndex -1 to prevent the link from being focused, pointer-events
 		// disabled click events, so we get an almost disabled link.
 		<a
@@ -20,6 +25,10 @@ const ProductName = ( { name, permalink, disabled = false } ) => {
 		>
 			{ decodeEntities( name ) }
 		</a>
+	) : (
+		<span className="wc-block-components-product-name">
+			{ decodeEntities( name ) }
+		</span>
 	);
 };
 

--- a/assets/js/base/components/cart-checkout/product-name/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/index.js
@@ -9,26 +9,15 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import './style.scss';
 
-const ProductName = ( {
-	name,
-	permalink,
-	disabled = false,
-	hasLink = true,
-} ) => {
-	return hasLink ? (
-		// we use tabIndex -1 to prevent the link from being focused, pointer-events
-		// disabled click events, so we get an almost disabled link.
-		<a
-			className="wc-block-components-product-name"
-			href={ permalink }
-			tabIndex={ disabled ? -1 : 0 }
-		>
-			{ decodeEntities( name ) }
-		</a>
-	) : (
+const ProductName = ( { name, permalink, disabled = false } ) => {
+	return disabled ? (
 		<span className="wc-block-components-product-name">
 			{ decodeEntities( name ) }
 		</span>
+	) : (
+		<a className="wc-block-components-product-name" href={ permalink }>
+			{ decodeEntities( name ) }
+		</a>
 	);
 };
 

--- a/assets/js/base/components/cart-checkout/product-name/stories/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/stories/index.js
@@ -14,11 +14,11 @@ export default {
 };
 
 export const Default = () => {
-	const hasLink = boolean( 'hasLink', true );
+	const disabled = boolean( 'disabled', false );
 
 	return (
 		<ProductName
-			hasLink={ hasLink }
+			disabled={ disabled }
 			name={ 'Test product' }
 			permalink={ '/' }
 		/>

--- a/assets/js/base/components/cart-checkout/product-name/stories/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/stories/index.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { boolean } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import ProductName from '../';
+
+export default {
+	title: 'WooCommerce Blocks/@base-components/cart-checkout/ProductName',
+	component: ProductName,
+};
+
+export const Default = () => {
+	const hasLink = boolean( 'hasLink', true );
+
+	return (
+		<ProductName
+			hasLink={ hasLink }
+			name={ 'Test product' }
+			permalink={ '/' }
+		/>
+	);
+};

--- a/assets/js/base/components/cart-checkout/product-name/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/product-name/test/__snapshots__/index.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProductName should not render a link if hasLink is false 1`] = `
+<span
+  className="wc-block-components-product-name"
+>
+  Test product
+</span>
+`;
+
+exports[`ProductName should render a link if hasLink is not defined 1`] = `
+<a
+  className="wc-block-components-product-name"
+  tabIndex={0}
+>
+  Test product
+</a>
+`;
+
+exports[`ProductName should render a link if hasLink is true 1`] = `
+<a
+  className="wc-block-components-product-name"
+  tabIndex={0}
+>
+  Test product
+</a>
+`;

--- a/assets/js/base/components/cart-checkout/product-name/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/product-name/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProductName should not render a link if hasLink is false 1`] = `
+exports[`ProductName should not render a link if disabled is true 1`] = `
 <span
   className="wc-block-components-product-name"
 >
@@ -8,19 +8,17 @@ exports[`ProductName should not render a link if hasLink is false 1`] = `
 </span>
 `;
 
-exports[`ProductName should render a link if hasLink is not defined 1`] = `
+exports[`ProductName should render a link if disabled is false 1`] = `
 <a
   className="wc-block-components-product-name"
-  tabIndex={0}
 >
   Test product
 </a>
 `;
 
-exports[`ProductName should render a link if hasLink is true 1`] = `
+exports[`ProductName should render a link if disabled is not defined 1`] = `
 <a
   className="wc-block-components-product-name"
-  tabIndex={0}
 >
   Test product
 </a>

--- a/assets/js/base/components/cart-checkout/product-name/test/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/test/index.js
@@ -9,23 +9,23 @@ import TestRenderer from 'react-test-renderer';
 import ProductName from '..';
 
 describe( 'ProductName', () => {
-	test( 'should not render a link if hasLink is false', () => {
+	test( 'should not render a link if disabled is true', () => {
 		const component = TestRenderer.create(
-			<ProductName hasLink={ false } name={ 'Test product' } />
+			<ProductName disabled={ true } name={ 'Test product' } />
 		);
 
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
-	test( 'should render a link if hasLink is true', () => {
+	test( 'should render a link if disabled is false', () => {
 		const component = TestRenderer.create(
-			<ProductName hasLink={ true } name={ 'Test product' } />
+			<ProductName disabled={ false } name={ 'Test product' } />
 		);
 
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
 
-	test( 'should render a link if hasLink is not defined', () => {
+	test( 'should render a link if disabled is not defined', () => {
 		const component = TestRenderer.create(
 			<ProductName name={ 'Test product' } />
 		);

--- a/assets/js/base/components/cart-checkout/product-name/test/index.js
+++ b/assets/js/base/components/cart-checkout/product-name/test/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import TestRenderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import ProductName from '..';
+
+describe( 'ProductName', () => {
+	test( 'should not render a link if hasLink is false', () => {
+		const component = TestRenderer.create(
+			<ProductName hasLink={ false } name={ 'Test product' } />
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a link if hasLink is true', () => {
+		const component = TestRenderer.create(
+			<ProductName hasLink={ true } name={ 'Test product' } />
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	test( 'should render a link if hasLink is not defined', () => {
+		const component = TestRenderer.create(
+			<ProductName name={ 'Test product' } />
+		);
+
+		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+} );

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -43,6 +43,7 @@ const getAmountFromRawPrice = ( priceObject, currency ) => {
 const CartLineItemRow = ( { lineItem = {} } ) => {
 	const {
 		name = '',
+		catalog_visibility: catalogVisibility = '',
 		short_description: shortDescription = '',
 		description: fullDescription = '',
 		low_stock_remaining: lowStockRemaining = null,
@@ -90,6 +91,8 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 	} ).multiply( quantity );
 	const saleAmount = regularAmount.subtract( purchaseAmount );
 	const firstImage = images.length ? images[ 0 ] : {};
+	const shouldLinkToProduct =
+		catalogVisibility !== 'hidden' && catalogVisibility !== 'search';
 
 	return (
 		<tr
@@ -103,15 +106,20 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 				aria-hidden={ ! firstImage.alt }
 			>
 				{ /* We don't need to make it focusable, because product name has the same link. */ }
-				<a href={ permalink } tabIndex={ -1 }>
+				{ shouldLinkToProduct ? (
+					<a href={ permalink } tabIndex={ -1 }>
+						<ProductImage image={ firstImage } />
+					</a>
+				) : (
 					<ProductImage image={ firstImage } />
-				</a>
+				) }
 			</td>
 			<td className="wc-block-cart-item__product">
 				<ProductName
 					permalink={ permalink }
 					name={ name }
 					disabled={ isPendingDelete }
+					hasLink={ shouldLinkToProduct }
 				/>
 				{ showBackorderBadge ? (
 					<ProductBackorderBadge />

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -91,8 +91,8 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 	} ).multiply( quantity );
 	const saleAmount = regularAmount.subtract( purchaseAmount );
 	const firstImage = images.length ? images[ 0 ] : {};
-	const shouldLinkToProduct =
-		catalogVisibility !== 'hidden' && catalogVisibility !== 'search';
+	const isProductHiddenFromCatalog =
+		catalogVisibility === 'hidden' || catalogVisibility === 'search';
 
 	return (
 		<tr
@@ -106,20 +106,19 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 				aria-hidden={ ! firstImage.alt }
 			>
 				{ /* We don't need to make it focusable, because product name has the same link. */ }
-				{ shouldLinkToProduct ? (
+				{ isProductHiddenFromCatalog ? (
+					<ProductImage image={ firstImage } />
+				) : (
 					<a href={ permalink } tabIndex={ -1 }>
 						<ProductImage image={ firstImage } />
 					</a>
-				) : (
-					<ProductImage image={ firstImage } />
 				) }
 			</td>
 			<td className="wc-block-cart-item__product">
 				<ProductName
 					permalink={ permalink }
 					name={ name }
-					disabled={ isPendingDelete }
-					hasLink={ shouldLinkToProduct }
+					disabled={ isPendingDelete || isProductHiddenFromCatalog }
 				/>
 				{ showBackorderBadge ? (
 					<ProductBackorderBadge />

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -260,6 +260,12 @@ class CartItemSchema extends ProductSchema {
 					]
 				),
 			],
+			'catalog_visibility'   => [
+				'description' => __( 'Whether the product is visible in the catalog', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
 			self::EXTENDING_KEY    => $this->get_extended_schema( self::IDENTIFIER ),
 		];
 	}
@@ -299,6 +305,7 @@ class CartItemSchema extends ProductSchema {
 					'line_total_tax'    => $this->prepare_money_response( $cart_item['line_tax'], wc_get_price_decimals() ),
 				]
 			),
+			'catalog_visibility'   => $product->get_catalog_visibility(),
 			self::EXTENDING_KEY    => $this->get_extended_data( self::IDENTIFIER, $cart_item ),
 		];
 	}

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -244,6 +244,7 @@ class CartItems extends TestCase {
 		$this->assertArrayHasKey( 'backorders_allowed', $data );
 		$this->assertArrayHasKey( 'show_backorder_badge', $data );
 		$this->assertArrayHasKey( 'short_description', $data );
+		$this->assertArrayHasKey( 'catalog_visibility', $data );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3370 

### Screenshots

<img width="339" alt="Screenshot 2020-11-17 at 16 30 11" src="https://user-images.githubusercontent.com/5656702/99417840-4af99780-28f2-11eb-991e-6f4c7f890b77.png">

<img width="528" alt="Screenshot 2020-11-17 at 16 32 14" src="https://user-images.githubusercontent.com/5656702/99418009-75e3eb80-28f2-11eb-83ad-cd894e6ee31f.png">

The "T-shirt with Logo" product is hidden from the catalogue, and therefore its name or image does not link to the product page.
### How to test the changes in this Pull Request:

1. Create a page that contains the checkout and cart blocks.
2. Find a product in the dashboard and set its catalogue visibility to hidden.
3. Add that product to your cart.
4. Visit the page with the checkout and cart blocks and ensure the name of the hidden product does not link to the product page in the checkout sidebar and in the line items in the cart.
5. Repeat steps 2-4 with the catalogue visibility set to "Search results only".
