### PR TITLE
Prevent inappropriate checkout signup if order fails with coupon error

### DIFF
--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -158,6 +158,12 @@ class Checkout extends AbstractRoute {
 		// Ensure order still matches cart.
 		$order_controller->update_order_from_cart( $order_object );
 
+		// If any form fields were posted, update the order.
+		$this->update_order_from_request( $order_object, $request );
+
+		// Check order is valid, including validating any coupons.
+		$order_controller->validate_order_before_payment( $order_object );
+
 		// Create a new user account as necessary.
 		// Note - CreateAccount class includes feature gating logic (i.e. this
 		// may not create an account depending on build).
@@ -173,11 +179,6 @@ class Checkout extends AbstractRoute {
 				$this->handle_error( $error );
 			}
 		}
-		// If any form fields were posted, update the order.
-		$this->update_order_from_request( $order_object, $request );
-
-		// Check order is still valid.
-		$order_controller->validate_order_before_payment( $order_object );
 
 		// Persist customer address data to account.
 		$order_controller->sync_customer_data_with_order( $order_object );


### PR DESCRIPTION
Fixes #3363

Orders can fail for various reasons, for example if a coupon is rejected. Shoppers can also request an account when submitting an order.

This PR reorders order processing so that accounts are only created if the order succeeds. This prevents accounts getting created for orders that are at `checkout-draft` status.

Specifically, this fixes a use case where a new shopper requests an account and uses an invalid coupon (e.g. after expiry date, or only allowed for specific email addresses). There are possibly other cases affected too.

### How to test the changes in this Pull Request:
1. Make a coupon with an email restriction e.g. `*@legit.com`.
2. In logged-out browser/user, add a product to cart, proceed to checkout.
3. Enter coupon code.
4. Enter an invalid email for coupon e.g. `try@sneaky.com`
5. Check `Create an account?` option and complete checkout fields.
6. Submit order.

expected: checkout fail, no account

actual: checkout fail, account signup

Bonus points: test other ways for the order to fail, e.g. coupon expiry date. Looks like `validate_order_before_payment()` is focused on coupons only.

### Changelog

> Fix – Checkout block: Prevent `Create an account` from creating up a user account if the order fails coupon validation.
