### PR TITLE
Improve Stripe (chrome pay) express payment method availability

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.js
@@ -117,10 +117,7 @@ const reducer = (
 		case SET_REGISTERED_EXPRESS_PAYMENT_METHODS:
 			return {
 				...state,
-				expressPaymentMethods: {
-					...state.expressPaymentMethods,
-					...paymentMethods,
-				},
+				expressPaymentMethods: paymentMethods,
 			};
 		case SET_SHOULD_SAVE_PAYMENT_METHOD:
 			return {

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -77,6 +77,7 @@ const usePaymentMethodRegistration = (
 
 	const refreshCanMakePayments = useCallback( async () => {
 		let availablePaymentMethods = {};
+
 		const addAvailablePaymentMethod = ( paymentMethod ) => {
 			availablePaymentMethods = {
 				...availablePaymentMethods,
@@ -137,11 +138,11 @@ const usePaymentMethodRegistration = (
 	] );
 
 	// Determine which payment methods are available initially and whenever
-	// shipping methods change.
+	// shipping methods or cart totals change.
 	// Some payment methods (e.g. COD) can be disabled for specific shipping methods.
 	useEffect( () => {
 		refreshCanMakePayments();
-	}, [ refreshCanMakePayments, selectedShippingMethods ] );
+	}, [ refreshCanMakePayments, cartTotals, selectedShippingMethods ] );
 
 	return isInitialized;
 };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -65,7 +65,7 @@ const PaymentRequestPaymentMethod = {
 	canMakePayment: ( cartData ) =>
 		paymentRequestAvailable( {
 			currencyCode: cartData?.cartTotals?.currency_code?.toLowerCase(),
-			totalPrice: parseInt( cartData?.cartTotals?.total_price, 10 ),
+			totalPrice: parseInt( cartData?.cartTotals?.total_price || 0, 10 ),
 		} ),
 	paymentMethodId: 'stripe',
 };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -21,7 +21,12 @@ let isStripeInitialized = false,
 
 // Initialise stripe API client and determine if payment method can be used
 // in current environment (e.g. geo + shopper has payment settings configured).
-function paymentRequestAvailable( currencyCode ) {
+function paymentRequestAvailable( { currencyCode, totalPrice } ) {
+	// Stripe only supports carts of greater value than 30 cents.
+	if ( totalPrice < 30 ) {
+		return false;
+	}
+
 	// If we've already initialised, return the cached results.
 	if ( isStripeInitialized ) {
 		return canPay;
@@ -38,8 +43,9 @@ function paymentRequestAvailable( currencyCode ) {
 		// Do a test payment to confirm if payment method is available.
 		const paymentRequest = stripe.paymentRequest( {
 			total: {
-				label: 'Test total',
-				amount: 1000,
+				label: 'Total',
+				amount: totalPrice,
+				pending: true,
 			},
 			country: getSetting( 'baseLocation', {} )?.country,
 			currency: currencyCode,
@@ -57,10 +63,10 @@ const PaymentRequestPaymentMethod = {
 	content: <PaymentRequestExpress stripe={ componentStripePromise } />,
 	edit: <ApplePayPreview />,
 	canMakePayment: ( cartData ) =>
-		paymentRequestAvailable(
-			// eslint-disable-next-line camelcase
-			cartData?.cartTotals?.currency_code?.toLowerCase()
-		),
+		paymentRequestAvailable( {
+			currencyCode: cartData?.cartTotals?.currency_code?.toLowerCase(),
+			totalPrice: parseInt( cartData?.cartTotals?.total_price, 10 ),
+		} ),
 	paymentMethodId: 'stripe',
 };
 


### PR DESCRIPTION
This PR will hide/show Stripe in the cart/checkout Express Payment area based on the value of the cart. Transactions lower than 0.30 cents are blocked.

This required a fix to the `SET_REGISTERED_EXPRESS_PAYMENT_METHODS` reducer becaused it merged, rather than replaced, available payment methods.

Fixes #3402

### How to test the changes in this Pull Request:

1. Enable Stripe + Chrome Pay
2. Add an item to the cart costing 0.10
3. No express payment method is visible
4. Increase quantity in cart to 3. Express payment method should then be shown.
5. Reduce the quantity again. The payment method will dissapear.

### Changelog

> Improve Stripe (chrome pay) express payment method availability so it's hidden when the transaction would be too low in value.
