### PR TITLE
Prevent checkout step heading text overlapping actual heading on small viewports

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -57,7 +57,6 @@
 
 .wc-block-components-checkout-step__heading-content {
 	@include font-size(smaller);
-	position: relative;
 
 	a {
 		font-weight: bold;

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -12,6 +12,16 @@
 	.is-large & {
 		padding-right: $gap-large;
 	}
+
+	.wc-block-components-checkout-step__heading::after {
+		content: "";
+		border-left: 1px solid;
+		opacity: 0.3;
+		position: absolute;
+		left: -$gap-larger/2;
+		top: 2.5em;
+		bottom: em($gap) * -1;
+	}
 }
 
 .wc-block-components-checkout-step__container {
@@ -33,6 +43,8 @@
 	flex-wrap: wrap;
 	margin: em($gap-small) 0 em($gap);
 	position: relative;
+	align-items: center;
+	gap: em($gap);
 }
 
 .wc-block-components-checkout-step:first-child .wc-block-components-checkout-step__heading {
@@ -45,8 +57,7 @@
 
 .wc-block-components-checkout-step__heading-content {
 	@include font-size(smaller);
-	position: absolute;
-	right: 0;
+	position: relative;
 
 	a {
 		font-weight: bold;


### PR DESCRIPTION
This change stops the `wc-block-components-checkout-step__heading-content` class being positioned absolutely, which caused it to overlap the checkout step title on smaller viewports. The heading content now drops below the heading when the text will overlap. It also adds the same grey line to the left of the heading content as on the checkout step description.

Fixes #3082

⚠️ Because Safari does not support the CSS property `gap` the text sits very close to the heading. There is not an easy way to set the margins on this text without specifically targeting Safari, however `gap` will be supported in the next version of Safari according to https://caniuse.com/flexbox-gap

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/5656702/99527687-1b4f9b80-2995-11eb-8972-092e522f6190.png)

#### After
<img width="336" alt="Screenshot 2020-11-18 at 11 56 56" src="https://user-images.githubusercontent.com/5656702/99527717-2dc9d500-2995-11eb-9dec-694e65ade2e3.png">

#### In Safari
<img width="357" alt="Screenshot 2020-11-18 at 12 05 09" src="https://user-images.githubusercontent.com/5656702/99528517-51414f80-2996-11eb-895b-6d56f6552024.png">

### How to test the changes in this Pull Request:

1. Ensure the Allow customers to log into an existing account during checkout option is enabled in **WooCommerce -> Settings -> Accounts & Privacy**.
2. Log out of the site and add a product to your cart.
3. Go to a page with the checkout block on and reduce the viewport so far that the "Already have an account? Log in" text is about to overlap.
4. Ensure the text drops to below the header and does not overlap with the section heading.

<!-- If you can, add the appropriate labels -->
