### PR TITLE
Ensure "Add a note to your order" section is styled correctly when disabled

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/index.js
+++ b/assets/js/base/components/cart-checkout/form-step/index.js
@@ -49,6 +49,7 @@ const FormStep = ( {
 				'wc-block-components-checkout-step',
 				{
 					'wc-block-components-checkout-step--with-step-number': showStepNumber,
+					'wc-block-components-checkout-step--disabled': disabled,
 				}
 			) }
 			id={ id }

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -14,6 +14,10 @@
 	}
 }
 
+.wc-block-components-checkout-step--disabled {
+	opacity: 0.6;
+}
+
 .wc-block-components-checkout-step__container {
 	position: relative;
 }

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -26,10 +26,6 @@
 	padding-bottom: em($gap-large);
 }
 
-.wc-block-components-form .wc-block-components-checkout-step:disabled {
-	opacity: 0.6;
-}
-
 .wc-block-components-checkout-step__heading {
 	display: flex;
 	justify-content: space-between;

--- a/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/form-step/test/__snapshots__/index.js.snap
@@ -231,7 +231,7 @@ exports[`FormStep should render step heading content 1`] = `
 
 exports[`FormStep should set disabled prop to the fieldset element when disabled is true 1`] = `
 <fieldset
-  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number"
+  className="wc-block-components-checkout-step wc-block-components-checkout-step--with-step-number wc-block-components-checkout-step--disabled"
   disabled={true}
 >
   <legend

--- a/assets/js/blocks/cart-checkout/checkout/form/order-notes-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/order-notes-step.js
@@ -23,7 +23,11 @@ const OrderNotesStep = () => {
 	const { setOrderNotes } = dispatchActions;
 
 	return (
-		<FormStep id="order-notes" showStepNumber={ false }>
+		<FormStep
+			id="order-notes"
+			showStepNumber={ false }
+			disabled={ checkoutIsProcessing }
+		>
 			<CheckoutOrderNotes
 				disabled={ checkoutIsProcessing }
 				onChange={ setOrderNotes }


### PR DESCRIPTION
When the checkout form is submitted, the fields in the address fieldset are disabled. They have an opacity set to give a visual indication of this. The "Add a note to your order" section does not have this same visual indication. (Though the form fields within do get the disabled attribute)

Fixes #3426 

### Screenshots
#### Before
<img src="https://user-images.githubusercontent.com/5656702/99548353-7642bc00-29b0-11eb-903a-c9aa5b128a9f.png" width="400">

#### After
<img width="400" alt="Screenshot 2020-11-18 at 15 04 12" src="https://user-images.githubusercontent.com/5656702/99547391-68406b80-29af-11eb-8aae-7275a7fa715c.png">

### How to test the changes in this Pull Request:

1. Add a product to your cart and go to a page with the checkout block
2. Fill in the required form fields. Leave the "Add a note to your order" unticked.
3. Submit the form
4. Ensure the "Add a note to your order" section looks disabled
5. Restart the checkout process and fill in all required form fields.
5. Tick the box next to "Add a note to your order" and (optionally) fill in the textarea with something
6. Submit the form again and ensure the entire "Add a note to your order" section is disabled, including the textarea.
