### PR TITLE
Refresh PaymentRequest after cancelling payment to prevent addresses remaining populated on repeat attempts

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
@@ -43,11 +43,8 @@ export const useInitialization = ( {
 	const [ isFinished, setIsFinished ] = useState( false );
 	const [ isProcessing, setIsProcessing ] = useState( false );
 	const [ canMakePayment, setCanMakePayment ] = useState( false );
-
-	const currentPaymentRequest = useRef( paymentRequest );
-	const currentPaymentRequestType = useRef( '' );
+	const [ paymentRequestType, setPaymentRequestType ] = useState( '' );
 	const currentShipping = useRef( shippingData );
-
 	const {
 		paymentRequestEventHandlers,
 		clearPaymentRequestEventHandler,
@@ -56,41 +53,30 @@ export const useInitialization = ( {
 
 	// Update refs when any change.
 	useEffect( () => {
-		currentPaymentRequest.current = paymentRequest;
 		currentShipping.current = shippingData;
-	}, [ paymentRequest, shippingData ] );
+	}, [ shippingData ] );
 
-	// set paymentRequest.
+	// Create the initial paymentRequest object. Note, we can't do anything if stripe isn't available yet or we have zero total.
 	useEffect( () => {
-		// can't do anything if stripe isn't available yet or we have zero total.
 		if ( ! stripe || ! billing.cartTotal.value ) {
 			return;
 		}
-
-		// if payment request hasn't been set yet then set it.
-		if ( ! currentPaymentRequest.current && ! isFinished ) {
-			setPaymentRequest(
-				getPaymentRequest( {
-					total: billing.cartTotal,
-					currencyCode: billing.currency.code.toLowerCase(),
-					countryCode: getSetting( 'baseLocation', {} )?.country,
-					shippingRequired: shippingData.needsShipping,
-					cartTotalItems: billing.cartTotalItems,
-					stripe,
-				} )
-			);
+		if ( isFinished || isProcessing || paymentRequest ) {
+			return;
 		}
-		// otherwise we just update it (but only if payment processing hasn't
-		// already started).
-		if ( ! isProcessing && currentPaymentRequest.current && ! isFinished ) {
-			updatePaymentRequest( {
-				// @ts-ignore
-				paymentRequest: currentPaymentRequest.current,
-				total: billing.cartTotal,
-				currencyCode: billing.currency.code.toLowerCase(),
-				cartTotalItems: billing.cartTotalItems,
-			} );
-		}
+		const pr = getPaymentRequest( {
+			total: billing.cartTotal,
+			currencyCode: billing.currency.code.toLowerCase(),
+			countryCode: getSetting( 'baseLocation', {} )?.country,
+			shippingRequired: shippingData.needsShipping,
+			cartTotalItems: billing.cartTotalItems,
+			stripe,
+		} );
+		canDoPaymentRequest( pr ).then( ( result ) => {
+			setPaymentRequest( pr );
+			setPaymentRequestType( result.requestType || '' );
+			setCanMakePayment( result.canPay );
+		} );
 	}, [
 		billing.cartTotal,
 		billing.currency.code,
@@ -99,28 +85,30 @@ export const useInitialization = ( {
 		stripe,
 		isProcessing,
 		isFinished,
+		paymentRequest,
 	] );
 
-	// whenever paymentRequest changes, then we need to update whether
-	// payment can be made.
-	useEffect( () => {
-		if ( paymentRequest ) {
-			canDoPaymentRequest( paymentRequest ).then( ( result ) => {
-				if ( result.requestType ) {
-					currentPaymentRequestType.current = result.requestType;
-				}
-				setCanMakePayment( result.canPay );
-			} );
-		}
-	}, [ paymentRequest ] );
-
-	// kick off payment processing.
-	const onButtonClick = () => {
+	// When the payment button is clicked, update the request and show it.
+	const onButtonClick = useCallback( () => {
 		setIsProcessing( true );
 		setIsFinished( false );
 		setExpressPaymentError( '' );
+		updatePaymentRequest( {
+			// @ts-ignore
+			paymentRequest,
+			total: billing.cartTotal,
+			currencyCode: billing.currency.code.toLowerCase(),
+			cartTotalItems: billing.cartTotalItems,
+		} );
 		onClick();
-	};
+	}, [
+		onClick,
+		paymentRequest,
+		setExpressPaymentError,
+		billing.cartTotal,
+		billing.currency.code,
+		billing.cartTotalItems,
+	] );
 
 	const abortPayment = useCallback( ( paymentMethod ) => {
 		paymentMethod.complete( 'fail' );
@@ -134,10 +122,15 @@ export const useInitialization = ( {
 		setIsProcessing( false );
 	}, [] );
 
-	// when canMakePayment is true, then we set listeners on payment request for
-	// handling updates.
-	useEffect( () => {
-		const shippingAddressChangeHandler = ( event ) => {
+	const cancelHandler = useCallback( () => {
+		setIsFinished( false );
+		setIsProcessing( false );
+		setPaymentRequest( null );
+		onClose();
+	}, [ onClose ] );
+
+	const shippingAddressChangeHandler = useCallback(
+		( event ) => {
 			const newShippingAddress = normalizeShippingAddressForCheckout(
 				event.shippingAddress
 			);
@@ -163,16 +156,24 @@ export const useInitialization = ( {
 				);
 				setPaymentRequestEventHandler( 'shippingAddressChange', event );
 			}
-		};
-		const shippingOptionChangeHandler = ( event ) => {
+		},
+		[ setPaymentRequestEventHandler ]
+	);
+
+	const shippingOptionChangeHandler = useCallback(
+		( event ) => {
 			currentShipping.current.setSelectedRates(
 				normalizeShippingOptionSelectionsForCheckout(
 					event.shippingOption
 				)
 			);
 			setPaymentRequestEventHandler( 'shippingOptionChange', event );
-		};
-		const sourceHandler = ( paymentMethod ) => {
+		},
+		[ setPaymentRequestEventHandler ]
+	);
+
+	const sourceHandler = useCallback(
+		( paymentMethod ) => {
 			if (
 				// eslint-disable-next-line no-undef
 				! getStripeServerData().allowPrepaidCard &&
@@ -189,18 +190,19 @@ export const useInitialization = ( {
 			setPaymentRequestEventHandler( 'sourceEvent', paymentMethod );
 			// kick off checkout processing step.
 			onSubmit();
-		};
-		const cancelHandler = () => {
-			setIsFinished( true );
-			setIsProcessing( false );
-			onClose();
-		};
+		},
+		[ setPaymentRequestEventHandler, setExpressPaymentError, onSubmit ]
+	);
+
+	// whenever paymentRequest changes, hook in event listeners.
+	useEffect( () => {
 		const noop = { removeAllListeners: () => void null };
 		let shippingAddressChangeEvent = noop,
 			shippingOptionChangeEvent = noop,
 			sourceChangeEvent = noop,
 			cancelChangeEvent = noop;
-		if ( paymentRequest && canMakePayment && isProcessing ) {
+
+		if ( paymentRequest ) {
 			// @ts-ignore
 			shippingAddressChangeEvent = paymentRequest.on(
 				'shippingaddresschange',
@@ -216,6 +218,7 @@ export const useInitialization = ( {
 			// @ts-ignore
 			cancelChangeEvent = paymentRequest.on( 'cancel', cancelHandler );
 		}
+
 		return () => {
 			if ( paymentRequest ) {
 				shippingAddressChangeEvent.removeAllListeners();
@@ -228,11 +231,15 @@ export const useInitialization = ( {
 		paymentRequest,
 		canMakePayment,
 		isProcessing,
-		onClose,
 		setPaymentRequestEventHandler,
 		setExpressPaymentError,
 		onSubmit,
+		cancelHandler,
+		sourceHandler,
+		shippingAddressChangeHandler,
+		shippingOptionChangeHandler,
 	] );
+
 	return {
 		paymentRequest,
 		paymentRequestEventHandlers,
@@ -242,6 +249,6 @@ export const useInitialization = ( {
 		onButtonClick,
 		abortPayment,
 		completePayment,
-		paymentRequestType: currentPaymentRequestType.current,
+		paymentRequestType,
 	};
 };

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
@@ -58,10 +58,13 @@ export const useInitialization = ( {
 
 	// Create the initial paymentRequest object. Note, we can't do anything if stripe isn't available yet or we have zero total.
 	useEffect( () => {
-		if ( ! stripe || ! billing.cartTotal.value ) {
-			return;
-		}
-		if ( isFinished || isProcessing || paymentRequest ) {
+		if (
+			! stripe ||
+			! billing.cartTotal.value ||
+			isFinished ||
+			isProcessing ||
+			paymentRequest
+		) {
 			return;
 		}
 		const pr = getPaymentRequest( {

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/normalize.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/normalize.js
@@ -20,13 +20,17 @@
  * @return {StripePaymentItem[]} An array of PaymentItems
  */
 const normalizeLineItems = ( cartTotalItems, pending = false ) => {
-	return cartTotalItems.map( ( cartTotalItem ) => {
-		return {
-			amount: cartTotalItem.value,
-			label: cartTotalItem.label,
-			pending,
-		};
-	} );
+	return cartTotalItems
+		.map( ( cartTotalItem ) => {
+			return cartTotalItem.value
+				? {
+						amount: cartTotalItem.value,
+						label: cartTotalItem.label,
+						pending,
+				  }
+				: false;
+		} )
+		.filter( Boolean );
 };
 
 /**


### PR DESCRIPTION
Currently when using Stripe and Chrome Pay, a single PaymentRequest object is created when entering the cart and checkout page. From this point on the PaymentRequest is just updated as certain events happen.

The problem we see is that after closing and re-opening the PaymentRequest window, the address gets prepopulated on reattempts. Since the address is prepopulated without an address change event, we cannot capture this and thus show incorrect shipping prices.

To fix this, we need to destroy and recreate the PaymentRequest after the user clicks cancel.

Fixes #3414 

### How to test the changes in this Pull Request:

You need to be using Stripe + Chrome Pay to see this issue, and you need multiple addresses setup in Chrome.

Steps to reproduce the behavior:

- Go to the cart page with items in your cart.
- Click on Pay Now (stripe Chrome pay). The PaymentRequest window is opened.
- In the PaymentRequest window, select a delivery address.
- Cancel the payment.
- Click the Pay Now button again.
- The delivery address area should not have an address selected. This is the fix.

### Changelog

> Refresh PaymentRequest after cancelling payment to prevent addresses remaining populated on repeat attempts
