### PR TITLE
Fixed express payment methods processing not completing when Stripe payment method active.

### DIFF
--- a/assets/js/base/components/payment-methods/payment-method-options.js
+++ b/assets/js/base/components/payment-methods/payment-method-options.js
@@ -26,17 +26,23 @@ import PaymentMethodTab from './payment-method-tab';
  * @return {*} The rendered component.
  */
 const PaymentMethodOptions = () => {
-	const { setActivePaymentMethod } = usePaymentMethodDataContext();
+	const {
+		setActivePaymentMethod,
+		expressPaymentMethods,
+	} = usePaymentMethodDataContext();
 	const { paymentMethods } = usePaymentMethods();
 	const {
 		activePaymentMethod,
 		...paymentMethodInterface
 	} = usePaymentMethodInterface();
+	const expressPaymentMethodActive = Object.keys(
+		expressPaymentMethods
+	).includes( activePaymentMethod );
 	const { noticeContexts } = useEmitResponse();
 	const { removeNotice } = useStoreNotices();
 	const { isEditor } = useEditorContext();
 
-	return (
+	return expressPaymentMethodActive ? null : (
 		<Tabs
 			className="wc-block-components-checkout-payment-methods"
 			onSelect={ ( tabName ) => {


### PR DESCRIPTION
I noticed when testing some express payment method behaviour for other pull requests that given the following conditions, using an express payment method (Stripe payment request API) to make a purchase would fail to complete:

- when checkout is loaded, the Stripe CC payment method is the active payment tab.
- select express payment method to make payment
- submitting the modal would wait for the 30s timeout and then show a fail message

The cause of this can be traced to changes made in #3226 where some improvements (refactoring) were made to the rendering of payment methods and a followup in #3227. Unfortunately, what was not accounted for in that refactor is that any active payment methods will setup their events when they are active and not unset them if an _express payment method_ is triggered. Previous to the changes in #3227, this wasn't an issue because the payment methods registering themselves checked the provided `activePaymentMethod` prop to decide whether or not they would render themselves. While the change in #3227 was great from the standpoint of different tabs selected, it didn't account for if an _express payment method_ is selected.

The fix in this pull request is to simply account for an express payment method being active and using that to control unmounting the registered payment method content (and remounting when not active).

## To test

* [ ] existing automated tests should pass
* [ ] Ensure that you are able to complete a payment using the reproducing steps above.
* [ ] Try setting up the scenario, and then instead of completing the express payment, try canceling the express payment and completing payment with CC.
* [ ] Try cancelling the express payment and then retriggering it again.
* [ ] Try all the above with a logged out and logged in user.