### PR TITLE
Hide spinner on cart block's "Proceed to Checkout" link when page unloads

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/checkout-button/index.js
+++ b/assets/js/blocks/cart-checkout/cart/checkout-button/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
 import Button from '@woocommerce/base-components/button';
 import { CHECKOUT_URL } from '@woocommerce/block-settings';
@@ -40,6 +40,30 @@ const CheckoutButton = ( { link } ) => {
 	] = usePositionRelativeToViewport();
 	const [ showSpinner, setShowSpinner ] = useState( false );
 	const { paymentMethods } = usePaymentMethods();
+
+	useEffect( () => {
+		//add a listener for when the page is unloaded (specifically needed for Safari)
+		//to remove the spinner on the checkout button, so the saved page snapshot does not
+		// contain the spinner class. See https://archive.is/lOEW0 for why this is needed.
+
+		if (
+			! window ||
+			typeof window.addEventListener !== 'function' ||
+			typeof window.removeEventListener !== 'function'
+		) {
+			return;
+		}
+
+		const hideSpinner = () => {
+			setShowSpinner( false );
+		};
+
+		window.addEventListener( 'beforeunload', hideSpinner );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', hideSpinner );
+		};
+	}, [] );
 
 	const submitContainerContents = (
 		<>

--- a/assets/js/blocks/cart-checkout/cart/checkout-button/index.js
+++ b/assets/js/blocks/cart-checkout/cart/checkout-button/index.js
@@ -42,8 +42,8 @@ const CheckoutButton = ( { link } ) => {
 	const { paymentMethods } = usePaymentMethods();
 
 	useEffect( () => {
-		//add a listener for when the page is unloaded (specifically needed for Safari)
-		//to remove the spinner on the checkout button, so the saved page snapshot does not
+		// Add a listener for when the page is unloaded (specifically needed for Safari)
+		// to remove the spinner on the checkout button, so the saved page snapshot does not
 		// contain the spinner class. See https://archive.is/lOEW0 for why this is needed.
 
 		if (


### PR DESCRIPTION
This is required because of a feature of Safari where the page state is saved, including all class names, when a transition occurs. Navigating back to this page using the back button restores the page to that cached state, so in the case of the **Cart -> Checkout -> Back to cart** the spinner class remains on the "Proceed to Checkout" link on the cart block. Resetting the state so as to remove the class just before the page gets cached stops this from happening.

Fixes #3196

### How to test the changes in this Pull Request:

*Please test in Safari especially*
1. Add an item to the cart.
2. Visit a page with the cart block on.
3. Press the "Proceed to checkout" link.
4. A spinner should appear on the link.
5. When on the checkout page, use the browser's back button to get back to the page with the cart block.
6. When back on the cart block, ensure the "Proceed to checkout" link does not contain a spinner.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix an issue where the proceed to cart button would show a spinner in Safari when navigating back to the page using the browser's back button.
