### PR TITLE
Fix Twenty Twenty One Button and Placeholder Styling

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -18,6 +18,7 @@ $no-stock-color: $alert-red;
 $low-stock-color: $alert-yellow;
 $in-stock-color: $alert-green;
 
+$placeholder-color: var(--global--color-primary, $gray-200);
 $input-border-gray: #8d96a0;
 $input-border-dark: rgba(255, 255, 255, 0.4);
 $input-disabled-dark: rgba(255, 255, 255, 0.3);

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -28,8 +28,8 @@ $fontSizes: (
 	animation: loading-fade 1.2s ease-in-out infinite;
 	background-color: $placeholder-color !important;
 	color: $placeholder-color !important;
-	outline: 0;
-	border: 0;
+	outline: 0 !important;
+	border: 0 !important;
 	box-shadow: none;
 	pointer-events: none;
 	max-width: 100%;

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -26,11 +26,13 @@ $fontSizes: (
 // Adds animation to placeholder section
 @mixin placeholder() {
 	animation: loading-fade 1.2s ease-in-out infinite;
-	background-color: $gray-200 !important;
-	border-color: $gray-200 !important;
-	color: $gray-200 !important;
+	background-color: $placeholder-color !important;
+	color: $placeholder-color !important;
+	outline: 0;
+	border: 0;
 	box-shadow: none;
 	pointer-events: none;
+	max-width: 100%;
 
 	// Forces direct descendants to keep layout but lose visibility.
 	> * {

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -19,6 +19,7 @@
 		.wc-block-grid__products {
 			list-style: none;
 			margin: 0 (-$gap/2) $gap;
+			padding: 0;
 
 			.wc-block-grid__product {
 				margin: 0 0 $gap-large 0;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -46,38 +46,56 @@
 		margin-right: 0.5em;
 	}
 }
-.wc-block-grid__product-add-to-cart {
+.wc-block-grid__product-add-to-cart.wp-block-button {
 	word-break: break-word;
 	white-space: normal;
-	a,
-	button {
+	.wp-block-button__link {
 		word-break: break-word;
 		white-space: normal;
 		margin: 0 auto !important;
 		display: inline-flex;
 		justify-content: center;
+		text-align: center;
+		// Set button font size and padding so it inherits from parent.
+		padding: 0.5em;
+		font-size: 1em;
 
 		&.loading {
 			opacity: 0.25;
 		}
 
-		&::after {
-			margin-left: 0.5em;
-			display: inline-block;
-		}
-
 		&.added::after {
 			font-family: WooCommerce; /* stylelint-disable-line */
 			content: "\e017";
+			margin-left: 0.5em;
+			display: inline-block;
+			width: auto;
+			height: auto;
 		}
 
 		&.loading::after {
 			font-family: WooCommerce; /* stylelint-disable-line */
 			content: "\e031";
 			animation: spin 2s linear infinite;
+			margin-left: 0.5em;
+			display: inline-block;
+			width: auto;
+			height: auto;
 		}
 	}
 }
+// Remove button sugar if unlikely to fit.
+.has-5-columns:not(.alignfull),
+.has-6-columns,
+.has-7-columns,
+.has-8-columns,
+.has-9-columns {
+	.wc-block-grid__product-add-to-cart.wp-block-button .wp-block-button__link::after {
+		content: "";
+		margin: 0;
+	}
+}
+
 .wc-block-grid__product-rating {
 	display: block;
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -57,7 +57,7 @@
 		justify-content: center;
 		text-align: center;
 		// Set button font size and padding so it inherits from parent.
-		padding: 0.5em;
+		padding: 0.5em 1em;
 		font-size: 1em;
 
 		&.loading {

--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -24,3 +24,13 @@
 	min-width: 8em;
 	min-height: 3em;
 }
+
+
+.theme-twentytwentyone {
+	// Prevent buttons appearing disabled in the editor.
+	.editor-styles-wrapper .wc-block-components-product-button .wp-block-button__link {
+		background-color: var(--button--color-background);
+		color: var(--button--color-text);
+		border-color: var(--button--color-background);
+	}
+}

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -74,14 +74,24 @@
 			max-width: 100% / $i;
 		}
 	}
-	&.has-4-columns:not(.alignwide):not(.alignfull),
-	&.has-5-columns:not(.alignfull),
-	&.has-6-columns:not(.alignfull),
-	&.has-7-columns,
-	&.has-8-columns {
+	// Adjust font size as more cols are added.
+	&.has-6-columns .wc-block-grid__product {
+		font-size: 0.5em;
+	}
+	&.has-6-columns.alignfull,
+	&.has-5-columns {
 		.wc-block-grid__product {
-			font-size: 0.8em;
+			font-size: 0.58em;
 		}
+	}
+	&.has-5-columns.alignfull,
+	&.has-4-columns:not(.alignwide):not(.alignfull) {
+		.wc-block-grid__product {
+			font-size: 0.75em;
+		}
+	}
+	&.has-3-columns:not(.alignwide):not(.alignfull) {
+		font-size: 0.92em;
 	}
 }
 


### PR DESCRIPTION
This is part of #3433

Fixes these points from the parent issue:

- Jarring visual difference between "Add to Cart" button and "Read More" or "View Products" buttons in All Products Block.
- Text flow in Add to Cart buttons for Product Grid type blocks (affects frontend as well)

Also:

- Fixes placeholder background color (grey on grey) in Twenty Twenty One
- Updates column based rules so buttons and content shrink as more columns are added
- Removed the checkmarks on cart buttons when more columns are shown

I smoke tested other themes to ensure these styles didn't break anything else.

### Screenshots

These are the updated placeholder styles:

![Edit Page ‹ one wordpress test — WordPress 2020-11-23 13-52-08](https://user-images.githubusercontent.com/90977/99971021-8e418380-2d94-11eb-9c16-6cdc199e3b2b.png)

And this shows the fixed buttons and content sizing:

![2020-11-23 13 51 30](https://user-images.githubusercontent.com/90977/99971043-94376480-2d94-11eb-8e1b-ccc3e7860da3.gif)

### How to test the changes in this Pull Request:

1. View a product block in the editor. Buttons should be consistent. Loading placeholder should match theme.
2. Test various columns. Content should reduce in size to fit better horizonally.
3. Repeat on frontend.

cc @Aljullu 