### PR TITLE
Expose store/cart via ExtendRestApi to extensions

### DIFF
--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartItemSchema;
+use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
 use Throwable;
 use Exception;
 
@@ -31,7 +32,7 @@ class ExtendRestApi {
 	 *
 	 * @var array
 	 */
-	private $endpoints = [ CartItemSchema::IDENTIFIER ];
+	private $endpoints = [ CartItemSchema::IDENTIFIER, CartSchema::IDENTIFIER ];
 
 	/**
 	 * Data to be extended

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -288,6 +288,7 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->error_schema->get_properties() ),
 				],
 			],
+			self::EXTENDING_KEY       => $this->get_extended_schema( self::IDENTIFIER ),
 		];
 	}
 
@@ -338,6 +339,7 @@ class CartSchema extends AbstractSchema {
 				]
 			),
 			'errors'                  => $cart_errors,
+			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
 		];
 	}
 


### PR DESCRIPTION
Closes #3409

This PR exposes `store/cart` endpoint to be extensible, we need it so we can add Future Subscriptions data to it (a prerequisite for #3441).

### Testing steps
1. Add this code
```php
<?PHP
use Automattic\WooCommerce\Blocks\Package;
use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;

add_action(
	'init',
	function() {
		$extend_instance = Package::container()->get( ExtendRestApi::class );

		$extend_instance->register_endpoint_data(
			CartSchema::IDENTIFIER,
			'subscriptions',
			function () {
				return array(
					'key' => array(
						'description' => 'Subscription key',
						'type'        => 'string',
					),
				);
			},
			function () {
				return array( 'key' => 'hey' );
			}
		);
	}
);
```
2. Inspect the `cart` endpoint response (trigger a change in cart like quantity or shipping or coupons).
3. You should see `extensions => subscriptions => key => hey`. 