### PR TITLE
Fix checkbox and textarea styles in Twenty Twenty One when it has dark controls

### DIFF
--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -63,12 +63,15 @@
 }
 
 .theme-twentytwentyone {
-	.wc-block-components-checkbox__input[type="checkbox"] {
+	.wc-block-components-checkbox__input[type="checkbox"],
+	.has-dark-controls .wc-block-components-checkbox__input[type="checkbox"] {
+		background-color: #fff;
 		border-color: var(--form--border-color);
 		position: relative;
 	}
 
-	.wc-block-components-checkbox__input[type="checkbox"]:checked {
+	.wc-block-components-checkbox__input[type="checkbox"]:checked,
+	.has-dark-controls .wc-block-components-checkbox__input[type="checkbox"]:checked {
 		background-color: #fff;
 		border-color: var(--form--border-color);
 	}

--- a/assets/js/base/components/textarea/style.scss
+++ b/assets/js/base/components/textarea/style.scss
@@ -20,3 +20,10 @@
 		}
 	}
 }
+
+.theme-twentytwentyone {
+	.has-dark-controls .wc-block-components-textarea {
+		background-color: $input-background-dark;
+		color: $input-text-dark;
+	}
+}


### PR DESCRIPTION
Checkbox and textarea styles were not correctly applied in Twenty Twenty One when the Checkout block used dark controls.

### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/100010302-5a844f00-2dd0-11eb-953e-2b33e5cb202f.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/100010281-535d4100-2dd0-11eb-9242-5b70b8624893.png)

### How to test the changes in this Pull Request:

1. Create a page with the Checkout block and enable the Twenty Twenty One theme. Make sure your store has at least two shipping options for the same zone.
2. In the customizer, go to Colors & Dark Mode and chose a dark background color.
3. In the frontend, add products to your Cart and go to the page with the Checkout block.
4. Verify the order notes checkbox and text area look fine (see screenshots above).
