### PR TITLE
Improve deploy script to properly account for releases not deployed to wp.org

### DIFF
--- a/bin/github-deploy.sh
+++ b/bin/github-deploy.sh
@@ -175,6 +175,9 @@ if [ "$(echo "${DO_WP_DEPLOY:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]; then
 	else
 		hub release create -m $VERSION -m "Release of version $VERSION. See readme.txt for details." -t $BRANCH "v${VERSION}"
 	fi
+else
+	git tag "v${VERSION}"
+	git push origin "v${VERSION}"
 fi
 
 git checkout $CURRENTBRANCH


### PR DESCRIPTION
I noticed when doing the 3.8.1 patch release that the `npm run deploy` script is not properly accounting for patch releases that are _not_ deployed to WordPress.org. In that scenario, we don't want to do a GitHub release because that triggers the `wp.org` workflow but we still want to push a git tag. 

This pull request fixes that (and was already tested in the `release/3.8.1` branch for the 3.8.1 release).