### PR TITLE
refactor and reorder checkout processing

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -216,10 +216,10 @@ const CheckoutProcessor = () => {
 					setIsProcessingOrder( false );
 				} );
 			} )
-			.catch( ( fetchResponse ) => {
-				fetchResponse.json().then( function ( response ) {
+			.catch( ( errorResponse ) => {
+				errorResponse.json().then( function ( response ) {
 					// Update nonce.
-					triggerFetch.setNonce( fetchResponse.headers );
+					triggerFetch.setNonce( errorResponse.headers );
 
 					// If updated cart state was returned, also update that.
 					if ( response.data?.cart ) {

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -216,8 +216,11 @@ const CheckoutProcessor = () => {
 					setIsProcessingOrder( false );
 				} );
 			} )
-			.catch( ( error ) => {
-				error.json().then( function ( response ) {
+			.catch( ( fetchResponse ) => {
+				fetchResponse.json().then( function ( response ) {
+					// Update nonce.
+					triggerFetch.setNonce( fetchResponse.headers );
+
 					// If updated cart state was returned, also update that.
 					if ( response.data?.cart ) {
 						receiveCart( response.data.cart );

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -85,23 +85,15 @@ abstract class AbstractRoute implements RouteInterface {
 	}
 
 	/**
-	 * Converts an error to a response object.
-	 *
-	 * Based on WP_REST_Server (wp-includes/rest-api/class-wp-rest-server.php).
+	 * Converts an error to a response object. Based on \WP_REST_Server.
 	 *
 	 * @param WP_Error $error WP_Error instance.
 	 * @return WP_REST_Response List of associative arrays with code and message keys.
 	 */
 	protected function error_to_response( $error ) {
 		$error_data = $error->get_error_data();
-
-		if ( is_array( $error_data ) && isset( $error_data['status'] ) ) {
-			$status = $error_data['status'];
-		} else {
-			$status = 500;
-		}
-
-		$errors = array();
+		$status     = isset( $error_data, $error_data['status'] ) ? $error_data['status'] : 500;
+		$errors     = [];
 
 		foreach ( (array) $error->errors as $code => $messages ) {
 			foreach ( (array) $messages as $message ) {
@@ -113,10 +105,9 @@ abstract class AbstractRoute implements RouteInterface {
 			}
 		}
 
-		$data = $errors[0];
-		if ( count( $errors ) > 1 ) {
-			// Remove the primary error.
-			array_shift( $errors );
+		$data = array_shift( $errors );
+
+		if ( count( $errors ) ) {
 			$data['additional_errors'] = $errors;
 		}
 

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -80,16 +80,6 @@ abstract class AbstractRoute implements RouteInterface {
 			$response = $this->error_to_response( $response );
 		}
 
-		return $this->add_response_headers( $response );
-	}
-
-	/**
-	 * Add Store API headers to a response object.
-	 *
-	 * @param \WP_REST_Response $response Response object.
-	 * @return \WP_REST_Response
-	 */
-	protected function add_response_headers( $response ) {
 		$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
 		return $response;
 	}

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -81,6 +81,7 @@ abstract class AbstractRoute implements RouteInterface {
 		}
 
 		$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$response->header( 'X-WC-Store-API-User', get_current_user_id() );
 		return $response;
 	}
 

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -250,7 +250,7 @@ class Checkout extends AbstractRoute {
 	 * @return \WP_Error WP Error object.
 	 */
 	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
-		// Always return the user ID. Checkout may create an account and log user in
+		// Return user ID with all errors. Checkout may create an account and log user in
 		// (CreateAccount service). If there is an error elsewhere in checkout processing,
 		// return the user id so the checkout UX can update where needed.
 		// For example: out of stock, or coupon fails validation.

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -342,7 +342,6 @@ class Checkout extends AbstractRoute {
 		$cart_controller  = new CartController();
 		$order_controller = new OrderController();
 		$reserve_stock    = \class_exists( '\Automattic\WooCommerce\Checkout\Helpers\ReserveStock' ) ? new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() : new ReserveStock();
-		$created          = false;
 		$this->order      = $this->get_draft_order_id() ? wc_get_order( $this->get_draft_order_id() ) : null;
 
 		// Validate items etc are allowed in the order before it gets created.
@@ -351,7 +350,6 @@ class Checkout extends AbstractRoute {
 
 		if ( ! $this->is_valid_draft_order( $this->order ) ) {
 			$this->order = $order_controller->create_order_from_cart();
-			$created     = true;
 		} else {
 			$order_controller->update_order_from_cart( $this->order );
 		}

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -111,11 +111,11 @@ class Checkout extends AbstractRoute {
 	/**
 	 * Prepare a single item for response. Handles setting the status based on the payment result.
 	 *
-	 * @param mixed            $item Item to format to schema.
-	 * @param \WP_REST_Request $request Request object.
-	 * @return \WP_REST_Response $response Response data.
+	 * @param mixed           $item Item to format to schema.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
 	 */
-	public function prepare_item_for_response( $item, \WP_REST_Request $request ) {
+	public function prepare_item_for_response( $item, WP_REST_Request $request ) {
 		$response = parent::prepare_item_for_response( $item, $request );
 
 		if ( isset( $item->payment_result ) && $item->payment_result instanceof PaymentResult ) {

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -183,9 +183,7 @@ class Checkout extends AbstractRoute {
 	/**
 	 * Update and process an order.
 	 *
-	 * Logic runs in this order:
-	 *
-	 * 1. Obtain Draft Order. Note: Customer data is updated first for OrderController::update_addresses_from_cart.
+	 * 1. Obtain Draft Order.
 	 * 2. Process Request
 	 * 3. Process Customer
 	 * 4. Validate Order

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -466,7 +466,7 @@ class Checkout extends AbstractRoute {
 			 *
 			 * @hook woocommerce_rest_checkout_process_payment_with_context
 			 *
-			 * @throws \Exception If there is an error taking payment, an Exception object can be thrown
+			 * @throws Exception If there is an error taking payment, an Exception object can be thrown
 			 *                                     with an error message.
 			 *
 			 * @param PaymentContext $context Holds context for the payment, including order ID and payment method.
@@ -479,7 +479,7 @@ class Checkout extends AbstractRoute {
 			}
 
 			return $result;
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 400 );
 		}
 	}
@@ -578,10 +578,7 @@ class Checkout extends AbstractRoute {
 					case 'registration-error-email-exists':
 						throw new RouteException(
 							'registration-error-email-exists',
-							apply_filters(
-								'woocommerce_registration_error_email_exists',
-								__( 'An account is already registered with your email address. Please log in.', 'woo-gutenberg-products-block' )
-							),
+							__( 'An account is already registered with your email address. Please log in before proceeding.', 'woo-gutenberg-products-block' ),
 							400
 						);
 				}

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -42,7 +42,7 @@ class Checkout extends AbstractRoute {
 	 * Enforce nonces for all checkout endpoints.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @return WP_Error| WP_REST_Response
+	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_response( WP_REST_Request $request ) {
 		$this->maybe_load_cart();

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -257,12 +257,6 @@ class Checkout extends AbstractRoute {
 	 * @return \WP_Error WP Error object.
 	 */
 	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
-		// Return user ID with all errors. Checkout may create an account and log user in
-		// (CreateAccount service). If there is an error elsewhere in checkout processing,
-		// return the user id so the checkout UX can update where needed.
-		// For example: out of stock, or coupon fails validation.
-		$user_id = get_current_user_id();
-
 		switch ( $http_status_code ) {
 			case 409:
 				// If there was a conflict, return the cart so the client can resolve it.
@@ -275,21 +269,13 @@ class Checkout extends AbstractRoute {
 					array_merge(
 						$additional_data,
 						[
-							'status'  => $http_status_code,
-							'cart'    => wc()->api->get_endpoint_data( '/wc/store/cart' ),
-							'user_id' => $user_id,
+							'status' => $http_status_code,
+							'cart'   => wc()->api->get_endpoint_data( '/wc/store/cart' ),
 						]
 					)
 				);
 		}
-		return new \WP_Error(
-			$error_code,
-			$error_message,
-			[
-				'status'  => $http_status_code,
-				'user_id' => $user_id,
-			]
-		);
+		return new \WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -179,20 +179,28 @@ class Checkout extends AbstractRoute {
 		// Update order with customer details, and sign up a user account as necessary.
 		$this->process_customer( $order, $request );
 
-		/*
-		* Fire woocommerce_blocks_checkout_order_processed, should work the same way as woocommerce_checkout_order_processed
-		* But we're opting for a new action because the original ones attaches POST data.
-		* NOTE: this hook is still experimental, and might change or get removed.
-		* @todo: Document and stabilize __experimental_woocommerce_blocks_checkout_order_processed
-		*/
-		do_action( '__experimental_woocommerce_blocks_checkout_order_processed', $order );
-
 		// --
 		// 4. Validate Order
 
 		// Check order is still valid.
 		$order_controller = new OrderController();
 		$order_controller->validate_order_before_payment( $order );
+
+		/*
+		* Action: woocommerce_blocks_checkout_order_processed (experimental).
+		* This hook informs extensions that $order has completed processing and is ready
+		* for payment.
+		*
+		* This is similar to existing core hook woocommerce_checkout_order_processed.
+		* We're using a new action:
+		* - To keep the interface focused (only pass $order, not passing request data).
+		* - This also explicitly indicates these orders are from checkout block/StoreAPI.
+		*
+		* Status: experimental; may change or be removed.
+		* Introduced: WooCommerce Blocks 3.8.0.
+		* https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
+		*/
+		do_action( '__experimental_woocommerce_blocks_checkout_order_processed', $order );
 
 		// --
 		// 5. Process Payment

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -587,9 +587,10 @@ class Checkout extends AbstractRoute {
 	/**
 	 * Order processing relating to customer account.
 	 *
-	 * - Creates a customer account as needed (based on request & store settings).
-	 *   - If so, updates the order with the new customer ID.
-	 * - Updates the order with user details (e.g. address).
+	 * Creates a customer account as needed (based on request & store settings) and  updates the order with the new customer ID.
+	 * Updates the order with user details (e.g. address).
+	 *
+	 * @todo OrderController (and CartController) should be injected into Checkout Route Class.
 	 *
 	 * @param \WC_Order        $order   Order object.
 	 * @param \WP_REST_Request $request Request object.

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -542,6 +542,9 @@ class Checkout extends AbstractRoute {
 	 * Creates a customer account as needed (based on request & store settings) and  updates the order with the new customer ID.
 	 * Updates the order with user details (e.g. address).
 	 *
+	 * @internal CreateAccount class includes feature gating logic (i.e. this may not create an account depending on build).
+	 * @internal Checkout signup is feature gated to WooCommerce 4.7 and newer; Because it requires updated my-account/lost-password screen in 4.7+ for setting initial password.
+
 	 * @todo OrderController (and CartController) should be injected into Checkout Route Class.
 	 *
 	 * @throws RouteException API error object with error details.
@@ -550,13 +553,7 @@ class Checkout extends AbstractRoute {
 	private function process_customer( WP_REST_Request $request ) {
 		$order_controller = new OrderController();
 
-		// Create a new user account as necessary.
-		// Note - CreateAccount class includes feature gating logic (i.e. this
-		// may not create an account depending on build).
 		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '4.7', '>=' ) ) {
-			// Checkout signup is feature gated to WooCommerce 4.7 and newer;
-			// Because it requires updated my-account/lost-password screen in 4.7+
-			// for setting initial password.
 			try {
 				$create_account = Package::container()->get( CreateAccount::class );
 				$create_account->from_order_request( $request );

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -189,22 +189,24 @@ class Checkout extends AbstractRoute {
 		$order_controller = new OrderController();
 		$order_controller->validate_order_before_payment( $order );
 
-		/*
-		* Action: woocommerce_blocks_checkout_order_processed (experimental).
-		* This hook informs extensions that $order has completed processing and is ready
-		* for payment.
-		*
-		* This is similar to existing core hook woocommerce_checkout_order_processed.
-		* We're using a new action:
-		* - To keep the interface focused (only pass $order, not passing request data).
-		* - This also explicitly indicates these orders are from checkout block/StoreAPI.
-		*
-		* Status: experimental; may change or be removed.
-		* Introduced: WooCommerce Blocks 3.8.0.
-		* https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
-		*/
 		// Save the order so the param and database match (extensions may access DB).
 		$order->save();
+
+		/**
+		 * WooCommerce Blocks Checkout Order Processed (experimental).
+		 *
+		 * This hook informs extensions that $order has completed processing and is ready for payment.
+		 *
+		 * This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:
+		 * - To keep the interface focused (only pass $order, not passing request data).
+		 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
+		 * @internal This Hook is experimental and may change or be removed.
+		 * @since 3.8.0
+		 *
+		 * @param \WC_Order  $order Order object.
+		 */
 		do_action( '__experimental_woocommerce_blocks_checkout_order_processed', $order );
 
 		// --

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -200,6 +200,8 @@ class Checkout extends AbstractRoute {
 		* Introduced: WooCommerce Blocks 3.8.0.
 		* https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
 		*/
+		// Save the order so the param and database match (extensions may access DB).
+		$order->save();
 		do_action( '__experimental_woocommerce_blocks_checkout_order_processed', $order );
 
 		// --

--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -104,6 +104,7 @@ class CheckoutSchema extends AbstractSchema {
 				'description' => __( 'The ID of the payment method being used to process the payment.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
+				'enum'        => wc()->payment_gateways->get_payment_gateway_ids(),
 			],
 			'create_account'   => [
 				'description' => __( 'Whether to create a new user account as part of order processing.', 'woo-gutenberg-products-block' ),


### PR DESCRIPTION
Fixes #3363

Related: #3260 #3423  https://github.com/woocommerce/woocommerce-subscriptions/pull/3825

This PR revamps `POST /checkout` processing in the Store API to address various issues and inconsistencies. 

The overall order of processing is as follows (more detail tbc):

1. Obtain Draft Order
1. Process Request
1. Process Customer
1. Validate Order
1. Process Payment

The following expectations apply to order status:

- Order should be `checkout-draft` status until payment is attempted.
- Order should only be `pending` once initial validation and processing has been attempted; it should be set to `pending` when it is _ready_ for payment processing.

The following expectations apply to checkout signup (aka create account):

- Customer accounts can be created as a side-effect of order processing; a checkout request can fail, yet still sign up the shopper and log them in.
- If an account is created:
  - Customer should be logged in immediately.
  - Customer id should be returned with response (even if it's an error) so client can update user-related UI. 
  - Any open / existing draft orders for the session should be updated with customer id.
  - Store API nonce should be refreshed and returned with response.
- If account creation fails:
  - Order should not proceed to payment; error should be returned, order should remain at `checkout-draft`. 

Note - not all the above account create items are implemented, though there is related work in #3429. (This might be handled as follow up once the key checkout processing is fully tested.)

#### Details about specific flows
##### Order date should match when order was "placed"

The order date is when draft order was created. If order sits around for a while, this could be misleading (e.g. up to a day out).

I'm wondering if we should reset the date when the order goes `pending`. We can probably log an issue and handle as follow up (not a blocker to this PR IMO). 

##### Returning customer id and updated nonce with error responses
We need to return the customer ID (and a new nonce) when customer account is created, in particular when there's an error (e.g. #3429). This PR implements this, and handling of the nonce client side. 

This is a basic fix for #3429 – this flow now works, but there's more UX polish to add (inform user that they have an account, remove `Create account` checkbox, etc). We can handle this as follow up in #3429.

##### Require an account to checkout
This is handled as before in `CreateAccount` with `$checkout->is_registration_required()` which checks well-known core options and filters.

### How to test the changes in this Pull Request:
Test all purchase / checkout flows, with and without user account, with various settings and errors, with all payment methods (!).

Please consider the following variations and test a good range of combinations:

- Order fail due to bad coupon.
- Order fail due to no stock.
- Order fail due to server-side payment error. (May be simplest to hack this in PHP, e.g. force a fail in BACS/COD.)
- Guest/anon orders or logged in.
- Various account settings: allow guest | require account, allow signup (x shopper `Create an account`=yes/no).

Since this is a revamp of checkout processing, I'd appreciate some extra care & time testing! Reviewers please leave a summary of the use-cases you tested. And please add ideas for variations that I've missed (and test 'em!).

### Changelog

> Fix: Fixed a bug in Checkout block (Store API) causing checkout to fail when using an invalid coupon and creating an account.
> Dev: Refactored and reordered Store API checkout processing to handle various edge cases and better support future extensibility.
