### PR TITLE
Ensure correct alignment of checkout notice's dismiss button

### DIFF
--- a/assets/js/base/components/store-notices-container/style.scss
+++ b/assets/js/base/components/store-notices-container/style.scss
@@ -8,7 +8,7 @@
 		.components-notice__dismiss {
 			background: transparent none;
 			padding: 0;
-			margin: 0 0 0 0.5em;
+			margin: 0 0 0 auto;
 			border: 0;
 			outline: 0;
 			color: #fff;


### PR DESCRIPTION
The change in this PR ensures the dismiss icon in notices will always be as far over to the right of the parent container as possible. Previously, it sat just alongside the text in the Storefront theme. Some themes override the position of the cross, so please test in Storefront where the original issue was, but bonus points for testing in other themes too.


<!-- Reference any related issues or PRs here -->
Fixes #3116 

### Screenshots

#### Before
<img width="832" alt="Screenshot 2020-11-24 at 09 57 57" src="https://user-images.githubusercontent.com/5656702/100078538-8ab50780-2e3b-11eb-99c9-961cd7b83f51.png">


#### After
<img width="829" alt="Screenshot 2020-11-24 at 09 58 35" src="https://user-images.githubusercontent.com/5656702/100078634-a15b5e80-2e3b-11eb-9103-dc754d3568f8.png">


### How to test the changes in this Pull Request:

1.  Enable Storefront theme
2. Add an item to the cart and go to the checkout block
3. Leave a required field on the checkout form blank and attempt checkout
4. Ensure the error notice's dismiss button is aligned to the right
