### PR TITLE
Stop hidden/search-only product names being links in checkout sidebar

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -38,8 +38,8 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		.multiply( quantity )
 		.convertPrecision( currency.minorUnit )
 		.getAmount();
-	const shouldLinkToProduct =
-		catalogVisibility !== 'hidden' && catalogVisibility !== 'search';
+	const isProductHiddenFromCatalog =
+		catalogVisibility === 'hidden' || catalogVisibility === 'search';
 
 	return (
 		<div className="wc-block-components-order-summary-item">
@@ -59,7 +59,7 @@ const OrderSummaryItem = ( { cartItem } ) => {
 			<div className="wc-block-components-order-summary-item__description">
 				<div className="wc-block-components-order-summary-item__header">
 					<ProductName
-						hasLink={ shouldLinkToProduct }
+						disabled={ isProductHiddenFromCatalog }
 						permalink={ permalink }
 						name={ name }
 					/>


### PR DESCRIPTION
The checkout block was still displaying product names as links when the product was hidden from the catalogue. This was accidentally re-introduced when simplifying the logic used to determine whether the name should be a link or not.

This PR simplifies the logic, and passes the correct `disabled` prop to `ProductName`.

<!-- Reference any related issues or PRs here -->
Picked up during testing by @nerrad here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3453

Fixes #3370

Original PR #3415

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Create a page that contains the checkout and cart blocks.
2. Find a product in the dashboard and set its catalogue visibility to hidden.
3. Add that product to your cart.
4. Visit the page with the checkout and cart blocks and ensure the name of the hidden product does not link to the product page in the checkout sidebar and in the line items in the cart.
5. Repeat steps 2-4 with the catalogue visibility set to "Search results only".