### PR TITLE
Add the "Fix package lock" script

### DIFF
--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -6,17 +6,17 @@ GREEN_BOLD='\033[1;32m';
 RED_BOLD='\033[1;31m';
 YELLOW_BOLD='\033[1;33m';
 error () {
-	echo -e "\n${RED_BOLD}$1${COLOR_RESET}\n";
+	echo "\n${RED_BOLD}$1${COLOR_RESET}\n";
 	exit 0;
 }
 status () {
-	echo -e "\n${BLUE_BOLD}$1${COLOR_RESET}\n"
+	echo "\n${BLUE_BOLD}$1${COLOR_RESET}\n"
 }
 success () {
-	echo -e "\n${GREEN_BOLD}$1${COLOR_RESET}\n"
+	echo "\n${GREEN_BOLD}$1${COLOR_RESET}\n"
 }
 warning () {
-	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+	echo "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
 }
 
 [[ -z "$1" ]] && {

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -36,7 +36,7 @@ fi
 
 status "Rebasing branch with trunk...";
 
-if ! git rebase -Xours origin/trunk --no-keep-empty
+if ! git rebase origin/trunk
 then
 	error "Unable to rebase branch";
 else

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -6,17 +6,17 @@ GREEN_BOLD='\033[1;32m';
 RED_BOLD='\033[1;31m';
 YELLOW_BOLD='\033[1;33m';
 error () {
-	echo "\n${RED_BOLD}$1${COLOR_RESET}\n";
+	echo -e "\n${RED_BOLD}$1${COLOR_RESET}\n";
 	exit 0;
 }
 status () {
-	echo "\n${BLUE_BOLD}$1${COLOR_RESET}\n"
+	echo -e "\n${BLUE_BOLD}$1${COLOR_RESET}\n"
 }
 success () {
-	echo "\n${GREEN_BOLD}$1${COLOR_RESET}\n"
+	echo -e "\n${GREEN_BOLD}$1${COLOR_RESET}\n"
 }
 warning () {
-	echo "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
 }
 
 [[ -z "$1" ]] && {
@@ -27,7 +27,7 @@ status "Updating trunk...";
 git checkout trunk
 git pull
 
-if git checkout $1
+if ! git checkout $1
 then
 	error "Unable to checkout branch $i";
 else
@@ -37,7 +37,7 @@ fi
 status "Rebasing branch with trunk...";
 git pull
 
-if git rebase -Xours trunk
+if ! git rebase -Xours trunk
 then
 	error "Unable to rebase branch $i";
 else

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -25,9 +25,7 @@ warning () {
 	error "You must specify a branch to fix, for example: npm run fix-package-lock your/branch";
 }
 
-status "Updating trunk...";
-git checkout trunk
-git pull
+git fetch
 
 if ! git checkout $1
 then
@@ -37,9 +35,8 @@ else
 fi
 
 status "Rebasing branch with trunk...";
-git pull
 
-if ! git rebase -Xours trunk
+if ! git rebase -Xours origin/trunk
 then
 	error "Unable to rebase branch";
 else

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -1,22 +1,24 @@
 #!/bin/bash
 
+# Enable nicer messaging for build status.
+BLUE_BOLD='\033[1;34m';
 RED_BOLD='\033[1;31m';
 COLOR_RESET='\033[0m';
 GREEN_BOLD='\033[1;32m';
 RED_BOLD='\033[1;31m';
 YELLOW_BOLD='\033[1;33m';
 error () {
-	echo -e "\n${RED_BOLD}$1${COLOR_RESET}\n";
+	echo -e "${RED_BOLD}$1${COLOR_RESET}\n";
 	exit 0;
 }
 status () {
-	echo -e "\n${BLUE_BOLD}$1${COLOR_RESET}\n"
+	echo -e "${BLUE_BOLD}$1${COLOR_RESET}\n"
 }
 success () {
-	echo -e "\n${GREEN_BOLD}$1${COLOR_RESET}\n"
+	echo -e "${GREEN_BOLD}$1${COLOR_RESET}\n"
 }
 warning () {
-	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+	echo -e "${YELLOW_BOLD}$1${COLOR_RESET}\n"
 }
 
 [[ -z "$1" ]] && {
@@ -29,9 +31,9 @@ git pull
 
 if ! git checkout $1
 then
-	error "Unable to checkout branch $i";
+	error "Unable to checkout branch";
 else
-	success "Checked out branch $i"
+	success "Checked out branch"
 fi
 
 status "Rebasing branch with trunk...";
@@ -39,9 +41,9 @@ git pull
 
 if ! git rebase -Xours trunk
 then
-	error "Unable to rebase branch $i";
+	error "Unable to rebase branch";
 else
-	success "Rebased branch $i with trunk"
+	success "Rebased branch with trunk"
 fi
 
 status "Removing package-lock.json...";

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -38,7 +38,7 @@ status "Rebasing branch with trunk...";
 
 if ! git rebase origin/trunk
 then
-	git checkout origin/trunk -- package-lock.json
+	git rm package-lock.json
 	git add .
 	if ! git rebase --continue
 	then

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -39,6 +39,7 @@ status "Rebasing branch with trunk...";
 if ! git rebase origin/trunk
 then
 	git rm package-lock.json
+	git add .
 	if ! git rebase --continue
 	then
 		git rebase --abort

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -38,7 +38,7 @@ status "Rebasing branch with trunk...";
 
 if ! git rebase origin/trunk
 then
-	git rm package-lock.json
+	git checkout origin/trunk -- package-lock.json
 	git add .
 	if ! git rebase --continue
 	then

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -34,23 +34,6 @@ else
 	success "Checked out branch"
 fi
 
-status "Rebasing branch with trunk...";
-
-if ! git rebase origin/trunk
-then
-	git rm package-lock.json
-	git add .
-	if ! git rebase --continue
-	then
-		git rebase --abort
-		error "Unable to rebase branch";
-	else
-		success "Rebased branch with trunk"
-	fi
-else
-	success "Rebased branch with trunk"
-fi
-
 status "Removing package-lock.json...";
 rm package-lock.json
 

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+RED_BOLD='\033[1;31m';
+COLOR_RESET='\033[0m';
+GREEN_BOLD='\033[1;32m';
+RED_BOLD='\033[1;31m';
+YELLOW_BOLD='\033[1;33m';
+error () {
+	echo -e "\n${RED_BOLD}$1${COLOR_RESET}\n";
+	exit 0;
+}
+status () {
+	echo -e "\n${BLUE_BOLD}$1${COLOR_RESET}\n"
+}
+success () {
+	echo -e "\n${GREEN_BOLD}$1${COLOR_RESET}\n"
+}
+warning () {
+	echo -e "\n${YELLOW_BOLD}$1${COLOR_RESET}\n"
+}
+
+[[ -z "$1" ]] && {
+	error "You must specify a branch to fix, for example: npm run fix-package-lock your/branch";
+}
+
+status "Updating trunk...";
+git checkout trunk
+git pull
+
+if git checkout $1
+then
+	error "Unable to checkout branch $i";
+else
+	success "Checked out branch $i"
+fi
+
+status "Rebasing branch with trunk...";
+git pull
+
+if git rebase -Xours trunk
+then
+	error "Unable to rebase branch $i";
+else
+	success "Rebased branch $i with trunk"
+fi
+
+status "Removing package-lock.json...";
+rm package-lock.json
+
+status "Installing dependencies...";
+npm install
+
+status "Comitting updated package-lock.json...";
+git add package-lock.json
+git commit -m 'update package-lock.json'
+git push -f
+
+success "Done. Package Lock has been updated. 🎉"

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -36,7 +36,7 @@ fi
 
 status "Rebasing branch with trunk...";
 
-if ! git rebase -Xours origin/trunk
+if ! git rebase -Xours origin/trunk --no-keep-empty
 then
 	error "Unable to rebase branch";
 else

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -25,6 +25,33 @@ warning () {
 	error "You must specify a branch to fix, for example: npm run fix-package-lock your/branch";
 }
 
+echo -e "${YELLOW_BOLD} ___ ___ ___
+|   |   |   |
+|___|___|___|
+|   |   |   |
+|___|___|___|
+|   |   |   |
+|___|___|___|
+
+FIX PACKAGE LOCK
+================
+This script will attempt to rebase a Renovate PR and update the package.lock file.
+Usage: npm run fix-package-lock branch/name
+${COLOR_RESET}"
+
+echo -e "${RED_BOLD}BEFORE PROCEEDING\n=================
+You should check the PR on GitHub to see if it already has conflicts with trunk.
+If it does, use the checkbox in the PR to force Renovate to rebase it for you.
+Once the PR has been rebased, you can run this script, and then do a squash merge on GitHub.${COLOR_RESET}"
+
+printf "Ready to proceed? [y/N]: "
+read -r PROCEED
+echo
+
+if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" != "y" ]; then
+	exit
+fi
+
 git fetch
 
 if ! git checkout $1
@@ -38,11 +65,12 @@ status "Removing package-lock.json...";
 rm package-lock.json
 
 status "Installing dependencies...";
+npm cache verify
 npm install
 
 status "Comitting updated package-lock.json...";
 git add package-lock.json
 git commit -m 'update package-lock.json'
-git push -f
+git push --force-with-lease
 
 success "Done. Package Lock has been updated. 🎉"

--- a/bin/fix-package-lock.sh
+++ b/bin/fix-package-lock.sh
@@ -38,7 +38,14 @@ status "Rebasing branch with trunk...";
 
 if ! git rebase origin/trunk
 then
-	error "Unable to rebase branch";
+	git rm package-lock.json
+	if ! git rebase --continue
+	then
+		git rebase --abort
+		error "Unable to rebase branch";
+	else
+		success "Rebased branch with trunk"
+	fi
 else
 	success "Rebased branch with trunk"
 fi

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"explore": "source-map-explorer",
 		"labels:dry": "github-label-sync --labels ./.github/label-sync-config.json --allow-added-labels --dry-run woocommerce/woocommerce-gutenberg-products-block",
 		"labels:sync": "github-label-sync --labels ./.github/label-sync-config.json --allow-added-labels woocommerce/woocommerce-gutenberg-products-block",
+		"fix-package-lock": "sh ./bin/fix-package-lock.sh",
 		"lint": "npm run lint:php && npm run lint:css && npm run lint:js",
 		"lint:ci": "npm run lint:js && npm run lint:css",
 		"lint:css": "stylelint 'assets/**/*.scss'",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"explore": "source-map-explorer",
 		"labels:dry": "github-label-sync --labels ./.github/label-sync-config.json --allow-added-labels --dry-run woocommerce/woocommerce-gutenberg-products-block",
 		"labels:sync": "github-label-sync --labels ./.github/label-sync-config.json --allow-added-labels woocommerce/woocommerce-gutenberg-products-block",
-		"fix-package-lock": "sh ./bin/fix-package-lock.sh",
 		"fix-package-lock": "./bin/fix-package-lock.sh",
 		"lint": "npm run lint:php && npm run lint:css && npm run lint:js",
 		"lint:ci": "npm run lint:js && npm run lint:css",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"labels:dry": "github-label-sync --labels ./.github/label-sync-config.json --allow-added-labels --dry-run woocommerce/woocommerce-gutenberg-products-block",
 		"labels:sync": "github-label-sync --labels ./.github/label-sync-config.json --allow-added-labels woocommerce/woocommerce-gutenberg-products-block",
 		"fix-package-lock": "sh ./bin/fix-package-lock.sh",
+		"fix-package-lock": "./bin/fix-package-lock.sh",
 		"lint": "npm run lint:php && npm run lint:css && npm run lint:js",
 		"lint:ci": "npm run lint:js && npm run lint:css",
 		"lint:css": "stylelint 'assets/**/*.scss'",


### PR DESCRIPTION
Adds the script to fix renovate PRs (update package lock) to our npm scripts. Based on the script from @senadir, but updated to handle conflicts with trunk.

Run with:

```bash
npm run fix-package-lock branch/name
```

If there is a conflict with trunk, it's most likely `package-lock` because of other renovate merges. The script will try to resolve this automatically if it can, otherwise the rebase will abort.

I've tested this on several of the renovate PRs now (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3460).