### PR TITLE
Prevent checkout completing if any items are out of stock

### DIFF
--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -153,14 +153,20 @@ class OrderController {
 			);
 		}
 
-		// Ensure all items in cart are still in stock.
-		$cart_stock_check_result = wc()->cart->check_cart_item_stock();
-		if ( $cart_stock_check_result instanceof \WP_Error ) {
-			throw new RouteException(
-				'woocommerce_rest_checkout_items_out_of_stock_error',
-				implode( ', ', $cart_stock_check_result->get_error_messages() ),
-				400
-			);
+		// Ensure all items on draft order are still in stock.
+		foreach ( $order->get_items() as $item ) {
+			$product = wc_get_product( $item->get_data()['product_id'] );
+			if ( ! $product->is_in_stock() ) {
+				throw new RouteException(
+					'woocommerce_rest_checkout_item_out_of_stock_error',
+					sprintf(
+						// Translators: %s Out of stock item name.
+						__( 'Sorry, "%s" is not in stock. Please edit your basket and try again. We apologise for any inconvenience caused.', 'woo-gutenberg-products-block' ),
+						$product->get_name()
+					),
+					400
+				);
+			}
 		}
 	}
 

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -152,6 +152,16 @@ class OrderController {
 				]
 			);
 		}
+
+		// Ensure all items in cart are still in stock.
+		$cart_stock_check_result = wc()->cart->check_cart_item_stock();
+		if ( $cart_stock_check_result instanceof \WP_Error ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_items_out_of_stock_error',
+				implode( ', ', $cart_stock_check_result->get_error_messages() ),
+				400
+			);
+		}
 	}
 
 	/**

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -154,13 +154,19 @@ class OrderController {
 		}
 
 		// Ensure all items on draft order are still in stock.
-		$out_of_stock_products = [];
 		foreach ( $order->get_items() as $item ) {
 			$product = wc_get_product( $item->get_data()['product_id'] );
 
 			if ( ! $product->is_in_stock() ) {
-				$out_of_stock_products[] = $product->get_name();
-				continue;
+				throw new RouteException(
+					'woocommerce_rest_checkout_item_out_of_stock_error',
+					sprintf(
+					// Translators: %s Out of stock product.
+						__( 'Sorry, "%s" is not in stock. Please edit your basket and try again. We apologise for any inconvenience caused.', 'woo-gutenberg-products-block' ),
+						$product->get_name()
+					),
+					400
+				);
 			}
 
 			if ( $product->managing_stock() && ! $product->backorders_allowed() ) {
@@ -168,21 +174,17 @@ class OrderController {
 				$qty_on_order  = $item->get_quantity();
 
 				if ( $qty_remaining < $qty_on_order ) {
-					$out_of_stock_products[] = $product->get_name();
+					throw new RouteException(
+						'woocommerce_rest_checkout_item_out_of_stock_error',
+						sprintf(
+						// Translators: %s Not enough stock product.
+							__( 'Sorry, we do not have enough "%s" left in stock. Please edit your basket and try again. We apologise for any inconvenience caused.', 'woo-gutenberg-products-block' ),
+							$product->get_name()
+						),
+						400
+					);
 				}
 			}
-		}
-
-		if ( count( $out_of_stock_products ) > 0 ) {
-			throw new RouteException(
-				'woocommerce_rest_checkout_item_out_of_stock_error',
-				sprintf(
-					// Translators: %s Out of stock product.
-					__( 'Sorry, "%s" is not in stock. Please edit your basket and try again. We apologise for any inconvenience caused.', 'woo-gutenberg-products-block' ),
-					$out_of_stock_products[0]
-				),
-				400
-			);
 		}
 	}
 

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -177,13 +177,9 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_checkout_item_out_of_stock_error',
 				sprintf(
-					// Translators: %s Sorry "item name(s)" is/are out of stock.
-					__( '%s Please edit your basket and try again. We apologise for any inconvenience caused.', 'woo-gutenberg-products-block' ),
-					sprintf(
-						// Translators: %s Out of stock item names.
-						_n( 'Sorry, "%s" is not in stock.', 'Sorry, "%s" are not in stock.', count( $out_of_stock_products ), 'woo-gutenberg-products-block' ),
-						implode( ', ', $out_of_stock_products )
-					)
+					// Translators: %s Out of stock product.
+					__( 'Sorry, "%s" is not in stock. Please edit your basket and try again. We apologise for any inconvenience caused.', 'woo-gutenberg-products-block' ),
+					$out_of_stock_products[0]
 				),
 				400
 			);

--- a/tests/php/StoreApi/Utilities/OrderController.php
+++ b/tests/php/StoreApi/Utilities/OrderController.php
@@ -15,13 +15,28 @@ class OrderControllerTests extends TestCase {
 
 	public function test_validate_order_before_payment() {
 		$class = new OrderController();
-		$product = ProductHelper::create_simple_product();
+
+		// This product will simply be in/out of stock.
+		$unmanaged_product = ProductHelper::create_simple_product();
+
+		//This product will have exact levels of stock known.
+		$managed_product = ProductHelper::create_simple_product();
+		$managed_product->set_manage_stock( true );
+		$managed_product->set_stock_quantity( 2 );
+
 		wc()->cart->empty_cart();
-		wc()->cart->add_to_cart( $product->get_id() );
+		wc()->cart->add_to_cart( $unmanaged_product->get_id() );
+		wc()->cart->add_to_cart( $managed_product->get_id(), 2 );
 		$order = $class->create_order_from_cart();
-		$product->set_stock_status( 'outofstock' );
-		$product->save_meta_data();
-		$product->save();
+
+		$unmanaged_product->set_stock_status( 'outofstock' );
+		$unmanaged_product->save_meta_data();
+		$unmanaged_product->save();
+
+		$managed_product->set_stock_quantity( 1 );
+		$managed_product->save_meta_data();
+		$managed_product->save();
+
 		$this->expectException( RouteException::class );
 		$class->validate_order_before_payment( $order );
 	}

--- a/tests/php/StoreApi/Utilities/OrderController.php
+++ b/tests/php/StoreApi/Utilities/OrderController.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * OrderController Tests.
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;
+
+use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\OrderController;
+use PHPUnit\Framework\TestCase;
+use \WC_Helper_Order as OrderHelper;
+use \WC_Helper_Product as ProductHelper;
+
+class OrderControllerTests extends TestCase {
+
+	public function test_validate_order_before_payment() {
+		$class = new OrderController();
+		$product = ProductHelper::create_simple_product();
+		$product->set_manage_stock( true );
+
+		wc_update_product_stock( $product, 1 );
+		wc()->cart->empty_cart();
+		wc()->cart->add_to_cart( $product->get_id() );
+		wc_update_product_stock( $product, 0 );
+		$order = OrderHelper::create_order( 1, $product ); // Note this adds 4 to the order.
+
+		$product->set_stock_status( 'outofstock' );
+		$product->save_meta_data();
+		$product->save();
+
+		var_dump( wc()->cart->get_cart_contents() );
+		var_dump(wc_get_product(216)->get_stock_status());
+		$this->expectException( RouteException::class );
+
+		$class->validate_order_before_payment( $order );
+	}
+
+}

--- a/tests/php/StoreApi/Utilities/OrderController.php
+++ b/tests/php/StoreApi/Utilities/OrderController.php
@@ -16,6 +16,7 @@ class OrderControllerTests extends TestCase {
 	public function test_validate_order_before_payment() {
 		$class = new OrderController();
 		$product = ProductHelper::create_simple_product();
+		wc()->cart->empty_cart();
 		wc()->cart->add_to_cart( $product->get_id() );
 		$order = $class->create_order_from_cart();
 		$product->set_stock_status( 'outofstock' );

--- a/tests/php/StoreApi/Utilities/OrderController.php
+++ b/tests/php/StoreApi/Utilities/OrderController.php
@@ -16,22 +16,12 @@ class OrderControllerTests extends TestCase {
 	public function test_validate_order_before_payment() {
 		$class = new OrderController();
 		$product = ProductHelper::create_simple_product();
-		$product->set_manage_stock( true );
-
-		wc_update_product_stock( $product, 1 );
-		wc()->cart->empty_cart();
 		wc()->cart->add_to_cart( $product->get_id() );
-		wc_update_product_stock( $product, 0 );
-		$order = OrderHelper::create_order( 1, $product ); // Note this adds 4 to the order.
-
+		$order = $class->create_order_from_cart();
 		$product->set_stock_status( 'outofstock' );
 		$product->save_meta_data();
 		$product->save();
-
-		var_dump( wc()->cart->get_cart_contents() );
-		var_dump(wc_get_product(216)->get_stock_status());
 		$this->expectException( RouteException::class );
-
 		$class->validate_order_before_payment( $order );
 	}
 

--- a/tests/php/StoreApi/Utilities/OrderController.php
+++ b/tests/php/StoreApi/Utilities/OrderController.php
@@ -30,11 +30,9 @@ class OrderControllerTests extends TestCase {
 		$order = $class->create_order_from_cart();
 
 		$unmanaged_product->set_stock_status( 'outofstock' );
-		$unmanaged_product->save_meta_data();
 		$unmanaged_product->save();
 
 		$managed_product->set_stock_quantity( 1 );
-		$managed_product->save_meta_data();
 		$managed_product->save();
 
 		$this->expectException( RouteException::class );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will stop a checkout completing when an item on the order is out of stock. If this happens, an error will be shown to the user and the checkout will not complete.

<!-- Reference any related issues or PRs here -->
Fixes #3412 

Related to PR #3454 

### Screenshots

<img width="623" alt="Screenshot 2020-11-26 at 12 26 03" src="https://user-images.githubusercontent.com/5656702/100350910-90008680-2fe2-11eb-9c28-7e544f8a57ce.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Add one (or more) products to the cart.
2. Ensure "Allow customers to create an account during checkout" is enabled in the WooCommerce settings and in the block specific settings too.
3. Load the checkout block and fill in all required fields. Tick create account too.
4. Make some/all (try with different combinations of which products are in and out of stock if possible) of the products out of stock.
* *Try with an item whose stock is managed at product level, and set the current stock level higher than one. Add more than one of the product to the cart, load the checkout block, then set the stock level to below the number in the cart.*
5. Try to complete the checkout process.
6. Ensure checkout does not complete and you see an appropriate error message.
7. Check that the customer's account was created and that the order did not complete.

### Automated tests
1. Please run `npm run phpunit` and verify all tests are passing. One test was added in this PR to ensure an exception is thrown during the checkout process.