### PR TITLE
Fix notice close button color in Twenty Twenty One dark mode

### DIFF
--- a/assets/js/base/components/store-notices-container/style.scss
+++ b/assets/js/base/components/store-notices-container/style.scss
@@ -11,9 +11,9 @@
 			margin: 0 0 0 auto;
 			border: 0;
 			outline: 0;
-			color: #fff;
+			color: currentColor;
 			svg {
-				fill: #fff;
+				fill: currentColor;
 				vertical-align: text-top;
 			}
 		}


### PR DESCRIPTION
The Notice close button was forced to be white, but that might not look right in themes that change the background of notices, like Twenty Twenty One in dark mode. This PR changes the CSS to use `currentColor`, so the close button always has the color from the text.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/100433135-ec26e180-309a-11eb-8609-1be88c19819a.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/100433112-e204e300-309a-11eb-87c8-e624ec3a4d21.png)

### How to test the changes in this Pull Request:

1. Install and activate Twenty Twenty One.
2. Go to Customize > Colors & Dark mode and check the Dark mode support checkbox.
3. In the frontend, make sure the dark mode is enabled and go to a page with the Checkout block.
4. Try submitting the form leaving one of the required inputs empty so the error notice appears.
5. Verify the close button is visible.

### Changelog

> Fix notice close button color in Twenty Twenty One dark mode.