### PR TITLE
Create IE11 SCSS mixin

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -145,6 +145,13 @@ $fontSizes: (
 	}
 }
 
+// Wraps the content with a media query specially targeting IE11.
+@mixin ie11() {
+	@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+		@content;
+	}
+}
+
 // Converts a px unit to em.
 @function em($size, $base: 16px) {
 	@return $size / $base * 1em;

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -56,7 +56,7 @@
 
 // Hack to hide the check mark in IE11
 // See comment: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2320/#issuecomment-621936576
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+@include ie11() {
 	.wc-block-components-checkbox__mark {
 		display: none;
 	}

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -212,7 +212,7 @@
 	}
 }
 
-@mixin ie {
+@mixin ie-fixes() {
 	.wc-block-components-price-slider__range-input-wrapper {
 		background: transparent;
 		box-shadow: none;
@@ -263,27 +263,31 @@
 		}
 	}
 
-	&.is-loading,
-	&.is-disabled {
-		.wc-block-components-price-slider__range-input-wrapper {
-			@include placeholder();
-			box-shadow: none;
+	.wc-block-components-price-slider {
+		&.is-loading,
+		&.is-disabled {
+			.wc-block-components-price-slider__range-input-wrapper {
+				@include placeholder();
+				box-shadow: none;
+			}
 		}
-	}
 
-	&.is-disabled:not(.is-loading) {
-		.wc-block-components-price-slider__range-input-wrapper {
-			animation: none;
+		&.is-disabled:not(.is-loading) {
+			.wc-block-components-price-slider__range-input-wrapper {
+				animation: none;
+			}
 		}
 	}
 }
 
 /* IE 11 will not support multi-range slider due to poor pointer-events support on the thumb. Reverts to 2 sliders. */
-@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-	@include ie;
+@include ie11() {
+	@include ie-fixes();
 }
+
+// Targets Edge <= 18.
 @supports (-ms-ime-align:auto) {
-	@include ie;
+	@include ie-fixes();
 }
 
 .theme-twentytwentyone {
@@ -335,7 +339,7 @@
 		}
 	}
 
-	@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+	@include ie11() {
 		.wc-block-components-price-slider__range-input-wrapper {
 			border: 0;
 			height: auto;


### PR DESCRIPTION
While working on #3444 I thought it would be nice having an IE11 SCSS mixin so we don't need to repeat the hacky-media query all over the code base.

### Screenshots

_Filter products by price in IE11_
<img src="https://user-images.githubusercontent.com/3616980/100432348-c64d0d00-3099-11eb-8663-cf1660ce0d4b.png" alt="" width="273" />

_Checkboxes in IE11_
<img src="https://user-images.githubusercontent.com/3616980/100432572-12984d00-309a-11eb-8f64-cf2b61127c46.png" alt="" width="273" />

### How to test the changes in this Pull Request:

1. With IE11, check that there are no visual regressions in the Filter products by price block and the checkboxes of the Checkout block (they should look like in the screenshots above).
