### PR TITLE
Change register_endpoint_data to use an array of params instead of individual params. 

### DIFF
--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -181,7 +181,7 @@ class ExtendRestApi {
 		return [
 			/* translators: %s: extension namespace */
 			'description' => sprintf( __( 'Extension data registered by %s', 'woo-gutenberg-products-block' ), $namespace ),
-			'type'        => 'object',
+			'type'        => [ 'object', 'null' ],
 			'context'     => [ 'view', 'edit' ],
 			'readonly'    => true,
 			'properties'  => $schema,

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -44,36 +44,40 @@ class ExtendRestApi {
 	/**
 	 * An endpoint that validates registration method call
 	 *
-	 * @param string   $endpoint The endpoint to extend.
-	 * @param string   $namespace Plugin namespace.
-	 * @param callable $schema_callback Callback executed to add schema data.
-	 * @param callable $data_callback Callback executed to add endpoint data.
+	 * @param array $args {
+	 *     An array of elements that make up a post to update or insert.
+	 *
+	 *     @type string   $endpoint The endpoint to extend.
+	 *     @type string   $namespace Plugin namespace.
+	 *     @type callable $schema_callback Callback executed to add schema data.
+	 *     @type callable $data_callback Callback executed to add endpoint data.
+	 * }
 	 *
 	 * @throws Exception On failure to register.
 	 * @return boolean True on success.
 	 */
-	public function register_endpoint_data( $endpoint, $namespace, $schema_callback, $data_callback ) {
-		if ( ! is_string( $namespace ) ) {
+	public function register_endpoint_data( $args ) {
+		if ( ! is_string( $args['namespace'] ) ) {
 			$this->throw_exception( 'You must provide a plugin namespace when extending a Store REST endpoint.' );
 		}
 
-		if ( ! is_string( $endpoint ) || ! in_array( $endpoint, $this->endpoints, true ) ) {
+		if ( ! is_string( $args['endpoint'] ) || ! in_array( $args['endpoint'], $this->endpoints, true ) ) {
 			$this->throw_exception(
-				sprintf( 'You must provide a valid Store REST endpoint to extend, valid endpoints are: %1$s. You provided %2$s.', implode( ', ', $this->endpoints ), $endpoint )
+				sprintf( 'You must provide a valid Store REST endpoint to extend, valid endpoints are: %1$s. You provided %2$s.', implode( ', ', $this->endpoints ), $args['endpoint'] )
 			);
 		}
 
-		if ( ! is_callable( $schema_callback ) ) {
+		if ( ! is_callable( $args['schema_callback'] ) ) {
 			$this->throw_exception( '$schema_callback must be a callable function.' );
 		}
 
-		if ( ! is_callable( $data_callback ) ) {
+		if ( ! is_callable( $args['data_callback'] ) ) {
 			$this->throw_exception( '$data_callback must be a callable function.' );
 		}
 
-		$this->extend_data[ $endpoint ][ $namespace ] = [
-			'schema_callback' => $schema_callback,
-			'data_callback'   => $data_callback,
+		$this->extend_data[ $args['endpoint'] ][ $args['namespace'] ] = [
+			'schema_callback' => $args['schema_callback'],
+			'data_callback'   => $args['data_callback'],
 		];
 
 		return true;


### PR DESCRIPTION
This is a quick refactor that changes how `ExtendRestApi::register_endpoint_data` works.
Instead of passing parameters directly, we now pass an array of functions.

### Before:
```php
$extend_instance->register_endpoint_data(
	array(
		CartSchema::IDENTIFIER,
		'subscriptions',
		 'my_schema_function',
		'my_data_function',
	)
);
```

### After:
```php
$extend_instance->register_endpoint_data(
	array(
		'endpoint'        => CartSchema::IDENTIFIER,
		'namespace'       => 'subscriptions',
		'schema_callback' => 'my_schema_function',
		'data_callback'   => 'my_data_function',
	)
);
```

### Testing instructions 

- Add this code
```php
<?PHP
use Automattic\WooCommerce\Blocks\Package;
use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;

add_action(
	'init',
	function() {
		$extend_instance = Package::container()->get( ExtendRestApi::class );
		$extend_instance->register_endpoint_data(
			array(
				'endpoint'        => CartSchema::IDENTIFIER,
				'namespace'       => 'subscriptions',
				'schema_callback' => function () {
					return array(
						'key' => array(
							'description' => 'Subscription key',
							'type'        => 'string',
						),
					);
				},
				'data_callback'   => function () {
					return array( 'key' => 'hey' );
				},
			)
		);
	}
);
```

- On Cart block, open the network tab.
- Change the quantity of some item or shipping.
- inspect the response of the new API call.
- You should see a top-level `extensions -> subscriptions -> key -> hey`