### PR TITLE
CartItems must extend AbastractCartRoute otherwise the cart is not loaded from the session

### DIFF
--- a/src/StoreApi/Routes/CartItems.php
+++ b/src/StoreApi/Routes/CartItems.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
-class CartItems extends AbstractRoute {
+class CartItems extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *


### PR DESCRIPTION
_edited by @senadir_ 

`store/cart/items` endpoint returns an error because cart is not loaded at that point.
This issue happens because `AbstractCartRoute` loads the cart before returning, `CartItems` didn't extend so the cart was never loaded.

### Testing instructions

1- Add items to your cart.
2- From your browser console, ping `store/cart/items` 
```js
await (await fetch("https://EXAMPLE/wp-json/wc/store/cart/items")).json()
```
3- You should see a result of the current cart items.

### Changelog

> Fix - Make sure cart is initialized before the CartItems route is used in the Store API.