### PR TITLE
Hide unsupported payment methods in checkout if the cart contains a subscription

### DIFF
--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -21,7 +21,10 @@ export default class PaymentMethodConfig {
 		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
 		this.supports = {
+			// Supply a default for `savePaymentInfo`.
 			savePaymentInfo: config?.supports?.savePaymentInfo || false,
+			// Pass through any `supports` feature string (open-ended API).
+			...config?.supports,
 		};
 	}
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -57,7 +57,11 @@ const stripeCcPaymentMethod = {
 	),
 	supports: {
 		savePaymentInfo: getStripeServerData().allowSavedCards,
-		...getStripeServerData().supports,
+		// Copy all server-provided `supports` features into JS config.
+		...getStripeServerData().supports.reduce( ( features, featureKey ) => {
+			features[ featureKey ] = true;
+			return features;
+		}, {} ),
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -57,6 +57,7 @@ const stripeCcPaymentMethod = {
 	),
 	supports: {
 		savePaymentInfo: getStripeServerData().allowSavedCards,
+		...getStripeServerData().supports,
 	},
 };
 

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -86,10 +86,6 @@ class Api {
 		if ( ! $this->asset_registry->exists( 'paymentGatewaySortOrder' ) ) {
 			$payment_gateways = WC()->payment_gateways->payment_gateways();
 			$enabled_gateways = array_filter( $payment_gateways, array( $this, 'is_payment_gateway_enabled' ) );
-			$enabled_gateways = array_filter(
-				(array) apply_filters( 'woocommerce_available_payment_gateways', $enabled_gateways ),
-				array( $this, 'filter_valid_gateway_class' )
-			);
 			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $enabled_gateways ) );
 		}
 
@@ -100,16 +96,6 @@ class Api {
 				$this->asset_registry->add( $asset_data_key, $asset_data_value );
 			}
 		}
-	}
-
-	/**
-	 * Callback used to filter out invalid results of woocommerce_available_payment_gateways.
-	 *
-	 * @param object $gateway Potential payment gateway object.
-	 * @return bool True if the arg is a valid payment gateway.
-	 */
-	private function filter_valid_gateway_class( $gateway ) {
-		return $gateway && $gateway instanceof \WC_Payment_Gateway;
 	}
 
 	/**

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -86,6 +86,10 @@ class Api {
 		if ( ! $this->asset_registry->exists( 'paymentGatewaySortOrder' ) ) {
 			$payment_gateways = WC()->payment_gateways->payment_gateways();
 			$enabled_gateways = array_filter( $payment_gateways, array( $this, 'is_payment_gateway_enabled' ) );
+			$enabled_gateways = array_filter(
+				(array) apply_filters( 'woocommerce_available_payment_gateways', $enabled_gateways ),
+				array( $this, 'filter_valid_gateway_class' )
+			);
 			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $enabled_gateways ) );
 		}
 
@@ -96,6 +100,16 @@ class Api {
 				$this->asset_registry->add( $asset_data_key, $asset_data_value );
 			}
 		}
+	}
+
+	/**
+	 * Callback used to filter out invalid results of woocommerce_available_payment_gateways.
+	 *
+	 * @param object $gateway Potential payment gateway object.
+	 * @return bool True if the arg is a valid payment gateway.
+	 */
+	private function filter_valid_gateway_class( $gateway ) {
+		return $gateway && $gateway instanceof \WC_Payment_Gateway;
 	}
 
 	/**

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 use Exception;
 use WC_Stripe_Payment_Request;
 use WC_Stripe_Helper;
+use WC_Gateway_Stripe;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\Payments\PaymentContext;
 use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
@@ -94,6 +95,7 @@ final class Stripe extends AbstractPaymentMethodType {
 			'icons'               => $this->get_icons(),
 			'allowSavedCards'     => $this->get_allow_saved_cards(),
 			'allowPaymentRequest' => $this->get_allow_payment_request(),
+			'supports'            => $this->get_supported_features(),
 		];
 	}
 
@@ -109,6 +111,18 @@ final class Stripe extends AbstractPaymentMethodType {
 		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and
 		// https://github.com/woocommerce/woocommerce/wiki/Payment-Token-API .
 		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $saved_cards, FILTER_VALIDATE_BOOLEAN ) );
+	}
+
+	/**
+	 * Returns a list of features supported by Stripe.
+	 *
+	 * @return Array Array of supported features as strings.
+	 */
+	private function get_supported_features() {
+		$gateway = new WC_Gateway_Stripe();
+		// We may need to support filtering via `woocommerce_payment_gateway_supports`,
+		// e.g. loop over each pass through `WC_Payment_Gateway::supports( .. )`.
+		return $gateway->supports;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3252

**Work In Progress** This is a proof-of-concept. Will likely need refinement and feedback before merging, or may be closed in favour of an alternative approach.

### Problem/goal
Only certain payment methods are supported for orders with subscriptions. This PR implements one way of hiding unsupported payment methods.

### Overview of the approach
- Payment gateways in Woo have a [`supports` array of strings](https://github.com/woocommerce/woocommerce/blob/master/includes/abstracts/abstract-wc-payment-gateway.php#L417) to indicate feature support.
- This is a core extensibility API. Extensions can declare and check for support for any feature (string) they wish; there is no predetermined list of capabilities.
- In this PR, the `supports` array is exposed to the client via the payment method data JSON blob, and then merged into the client-side config object for the payment gateway.
  - Note: this is only implemented for Stripe CC for now.
- The Store API `cart-items` endpoint now allows extensions to add data about cart items. WooCommerce Subscriptions use this [to add info about any subscriptions associated with a cart item - `items[].extensions.subscriptions`](https://github.com/woocommerce/woocommerce-subscriptions/pull/3839).
- When payment methods are refreshed in the checkout (or cart), this PR adds a new check. If there are any subscriptions in the cart, and the payment method doesn't support subscriptions, it's excluded (hidden).

#### Potential enhancements, improvements
1. The logic to detect subscriptions, and filter payment methods, is "hard-coded" in WooCommerce Blocks. There's no extensibility API (yet); Woo Blocks has specific knowledge about how `gateway.supports.subscriptions` and `cartItems.extensions.subscriptions relate.
2. There are possibly more use-cases supported in Woo Subscriptions that are not supported here. For example, [`multiple_subscriptions`](https://github.com/woocommerce/woocommerce-subscriptions/blob/trunk/includes/gateways/class-wc-subscriptions-payment-gateways.php#L91) or the merchant overriding settings to [`_accept_manual_renewals`](https://github.com/woocommerce/woocommerce-subscriptions/blob/trunk/includes/gateways/class-wc-subscriptions-payment-gateways.php#L83).

Next step for 1 & 2 is to explore extensibility APIs so this logic can be delegated to extensions (e.g. Woo Subscriptions in this case). Also confirm if this is a common enough need that it warrants extensibility; do we want to open this up, how much.

3. Gateway `supports` is [filterable - `woocommerce_payment_gateway_supports`](https://github.com/woocommerce/woocommerce/blob/master/includes/abstracts/abstract-wc-payment-gateway.php#L418). We're currently ignoring this. 

If `woocommerce_payment_gateway_supports` is regularly used/essential, we could loop through all `supports` values when generating the `supports` array for JS.

4. Implement this in more payment methods (PayPal, explore implications for WCPay). We should be able to export `supports` as JSON automatically for all payment gateways.

### Alternatives
1. Implement a more generic `order_type` (or `order_tags`?) field in Store API, as an extensibility point. This would allow Woo Subs to extend the API to capture info like "this cart contains `subscriptions`" (or `multiple_subscriptions` etc). Then generically consult this and `supports` automatically. This was [proposed by @nerrad in issue](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3252#issuecomment-738248611).
2. Implement a filter-style API in JS, similar to the previous approach. Extensions would be able to disable payment methods, based on cart contents. E.g. `shouldAllowPayment( paymentGateway, cartItems )` or `shouldAllowPayment( paymentGatewaySupports, cartItems )`.

I didn't prototype (1) above because it felt too limited for the Woo Subs use case. Subscriptions has more logic in `get_available_payment_gateways`, though some of this may not be relevant to checkout. Also we have already extended the API to add subs data, so it didn't feel right to add another extensibility point to allow extension to summarise that same data (to add `subscriptions` and/or `multiple_subscriptions`).

(2) feels too flexible for the initial iteration. We may iterate towards something like this; ideally we can limit the extensibility API so it's robust, simple to use, and doesn't allow abuse (e.g. hide other payment methods, conflicts between extensions).

### How to test the changes in this Pull Request:
1. Clone this branch and build.
2. Clone feature branch from WooCommerce Subscriptions [`feature/checkout-block-simple-multiple-subscriptions`](https://github.com/woocommerce/woocommerce-subscriptions/tree/feature/checkout-block-simple-multiple-subscriptions), build.
3. Ensure both extensions are active, checkout block is on checkout page, and store has a subscription product.
4. Add normal products to cart.
1. View cart with a range of payment methods enabled, ensure they all work correctly.
1. Add a subscription to cart.
1. View cart with a range of payment methods enabled, ensure they all work correctly - should only see Stripe CC if a subscription product is in the cart.

### Changelog

> TBC
