### PR TITLE
Fix:3501 Omit keys in `customerPaymentMethods` that have an empty list as a value.

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -93,13 +93,13 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 	}
 	const enabledCustomerPaymentMethods = {};
 	paymentMethodKeys.forEach( ( type ) => {
-		const methods = customerPaymentMethods[
-			type
-		].filter( ( paymentMethod ) => {
-			return Object.keys( availablePaymentMethods ).includes(
-				paymentMethod.method.gateway
-			);
-		} );
+		const methods = customerPaymentMethods[ type ].filter(
+			( paymentMethod ) => {
+				return Object.keys( availablePaymentMethods ).includes(
+					paymentMethod.method.gateway
+				);
+			}
+		);
 		if ( methods.length ) {
 			enabledCustomerPaymentMethods[ type ] = methods;
 		}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -93,13 +93,16 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 	}
 	const enabledCustomerPaymentMethods = {};
 	paymentMethodKeys.forEach( ( type ) => {
-		enabledCustomerPaymentMethods[ type ] = customerPaymentMethods[
+		const methods = customerPaymentMethods[
 			type
 		].filter( ( paymentMethod ) => {
 			return Object.keys( availablePaymentMethods ).includes(
 				paymentMethod.method.gateway
 			);
 		} );
+		if ( methods.length ) {
+			enabledCustomerPaymentMethods[ type ] = methods;
+		}
 	} );
 	return enabledCustomerPaymentMethods;
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

When there are stored payment methods for a gateway that got disabled the `PaymentMethodDataContext` was still adding a key entry to the value returned by `customerPaymentMethods`. 
This caused wrong behaviour for code constructs similar to this:
```js
const customerHasSavedCards = Object.keys( customerPaymentMethods ).length > 0;
```
The fix is to simply not add entries to the object when the value is an empty array.

<!-- Reference any related issues or PRs here -->
Fixes #3501 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

1. Follow the instructions from #3501, this time the object should be empty:
```js
{}
```

<!-- If you can, add the appropriate labels -->

