### PR TITLE
Fix Fees not visible in Cart & Checkout blocks when order doesn't need shipping

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/fees/index.js
+++ b/assets/js/base/components/cart-checkout/totals/fees/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
-import { useShippingDataContext } from '@woocommerce/base-context';
 import PropTypes from 'prop-types';
 
 /**
@@ -12,10 +11,6 @@ import PropTypes from 'prop-types';
 import TotalsItem from '../item';
 
 const TotalsFees = ( { currency, values } ) => {
-	const { needsShipping } = useShippingDataContext();
-	if ( ! needsShipping ) {
-		return null;
-	}
 	const { total_fees: totalFees, total_fees_tax: totalFeesTax } = values;
 	const feesValue = parseInt( totalFees, 10 );
 


### PR DESCRIPTION
Fixes #3517.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/101480959-af899e80-3954-11eb-90fc-bf5da63dedc4.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/101481086-e8297800-3954-11eb-99f4-f0f6bb4de213.png)

### How to test the changes in this Pull Request:

1. Add this PHP code snippet to any PHP file (for example, `woocommerce-gutenberg-products-block.php`):
```PHP
add_action( 'woocommerce_cart_calculate_fees', 'add_fee', 10 );
function add_fee( $cart ) {
	$cart->add_fee( __( 'Fee', 'woo-gutenberg-products-block' ), 100, true );
}
```
2. Add a product that doesn't need shipping to your cart and go to the Cart and Checkout blocks.
3. Verify 'Fees' is listed in the sidebar.
