### PR TITLE
Add missing experimental functions to the feature flags page

### DIFF
--- a/assets/js/data/collections/actions.js
+++ b/assets/js/data/collections/actions.js
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-import { apiFetch, select } from '@wordpress/data-controls';
-
-/**
  * Internal dependencies
  */
 import { ACTION_TYPES as types } from './action-types';
-import { STORE_KEY as SCHEMA_STORE_KEY } from '../schema/constants';
 
 let Headers = window.Headers || null;
 Headers = Headers
@@ -60,50 +54,6 @@ export function receiveCollection(
 		ids,
 		response,
 	};
-}
-
-export function* __experimentalPersistItemToCollection(
-	namespace,
-	resourceName,
-	currentCollection,
-	data = {}
-) {
-	const newCollection = [ ...currentCollection ];
-	const route = yield select(
-		SCHEMA_STORE_KEY,
-		'getRoute',
-		namespace,
-		resourceName
-	);
-	if ( ! route ) {
-		return;
-	}
-
-	try {
-		const item = yield apiFetch( {
-			path: route,
-			method: 'POST',
-			data,
-			cache: 'no-store',
-		} );
-
-		if ( item ) {
-			newCollection.push( item );
-			yield receiveCollection(
-				namespace,
-				resourceName,
-				'',
-				[],
-				{
-					items: newCollection,
-					headers: Headers,
-				},
-				true
-			);
-		}
-	} catch ( error ) {
-		yield receiveCollectionError( namespace, resourceName, '', [], error );
-	}
 }
 
 export function receiveCollectionError(

--- a/docs/blocks/feature-flags-and-experimental-interfaces.md
+++ b/docs/blocks/feature-flags-and-experimental-interfaces.md
@@ -53,3 +53,5 @@ We also have individual features or code blocks behind a feature flag, this is a
 ## Usages of `__experimental` prefix
 
 -   `__experimental_woocommerce_blocks_checkout_order_processed` hook when order has completed processing and is ready for payment ([experimental hook](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/accd1bbf402e043b9fc322f118ab614ba7437c92/src/StoreApi/Routes/Checkout.php#L237)).
+-   `__experimentalDeRegisterPaymentMethod` function used to deregister a payment method, only used in tests ([experimental function](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/b07883b8b76feeb439d655b255507b24fc59e091/assets/js/blocks-registry/payment-methods/registry.js#L70)).
+-   `__experimentalDeRegisterExpressPaymentMethod` function used to deregister an express payment method, only used in tests ([experimental function](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/b07883b8b76feeb439d655b255507b24fc59e091/assets/js/blocks-registry/payment-methods/registry.js#L74)).


### PR DESCRIPTION
This PR:
* adds `__experimentalDeRegisterPaymentMethod` and `__experimentalDeRegisterExpressPaymentMethod` to the feature flags documentation page.
* removes `__experimentalPersistItemToCollection`, which was introduced in #1102 but if I'm not wrong it's no longer used.

### How to test the changes in this Pull Request:

It's as documentation change and removing dead code, so I don't think there is a need for testing instructions. However, I played a bit with the All Products block & filters to ensure they didn't call the removed function.
