### PR TITLE
Add stories to Cart & Checkout totals components

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/coupon/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/stories/index.js
@@ -13,7 +13,8 @@ import {
 import TotalsCoupon from '../';
 
 export default {
-	title: 'WooCommerce Blocks/@base-components/TotalsCoupon',
+	title:
+		'WooCommerce Blocks/@base-components/cart-checkout/totals/TotalsCoupon',
 	component: TotalsCoupon,
 };
 

--- a/assets/js/base/components/cart-checkout/totals/discount/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { text, boolean } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import TotalsDiscount from '../';
-import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
 
 export default {
 	title:

--- a/assets/js/base/components/cart-checkout/totals/discount/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/stories/index.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { text, boolean } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import TotalsDiscount from '../';
+import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
+
+export default {
+	title:
+		'WooCommerce Blocks/@base-components/cart-checkout/totals/TotalsDiscount',
+	component: TotalsDiscount,
+};
+
+export const Default = () => {
+	const cartCoupons = [ { code: 'COUPON' } ];
+	const currency = currencyKnob();
+	const isRemovingCoupon = boolean( 'Toggle isRemovingCoupon state', false );
+	const totalDiscount = text( 'Total discount', '1000' );
+	const totalDiscountTax = text( 'Total discount tax', '200' );
+
+	return (
+		<TotalsDiscount
+			cartCoupons={ cartCoupons }
+			currency={ currency }
+			isRemovingCoupon={ isRemovingCoupon }
+			removeCoupon={ () => void null }
+			values={ {
+				total_discount: totalDiscount,
+				total_discount_tax: totalDiscountTax,
+			} }
+		/>
+	);
+};

--- a/assets/js/base/components/cart-checkout/totals/fees/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/fees/stories/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import TotalsFees from '../';
+import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
+
+export default {
+	title:
+		'WooCommerce Blocks/@base-components/cart-checkout/totals/TotalsFees',
+	component: TotalsFees,
+};
+
+export const Default = () => {
+	const currency = currencyKnob();
+	const totalFees = text( 'Total fees', '1000' );
+	const totalFeesTax = text( 'Total fees tax', '200' );
+
+	return (
+		<TotalsFees
+			currency={ currency }
+			values={ {
+				total_fees: totalFees,
+				total_fees_tax: totalFeesTax,
+			} }
+		/>
+	);
+};

--- a/assets/js/base/components/cart-checkout/totals/fees/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/fees/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { text } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import TotalsFees from '../';
-import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
 
 export default {
 	title:

--- a/assets/js/base/components/cart-checkout/totals/footer-item/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { text } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import TotalsFooterItem from '../';
-import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
 
 export default {
 	title:

--- a/assets/js/base/components/cart-checkout/totals/footer-item/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/stories/index.js
@@ -17,7 +17,7 @@ export default {
 
 export const Default = () => {
 	const currency = currencyKnob();
-	const totalPrice = text( 'Total price', '1000' );
+	const totalPrice = text( 'Total price', '1200' );
 	const totalTax = text( 'Total tax', '200' );
 
 	return (

--- a/assets/js/base/components/cart-checkout/totals/footer-item/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/stories/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import TotalsFooterItem from '../';
+import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
+
+export default {
+	title:
+		'WooCommerce Blocks/@base-components/cart-checkout/totals/TotalsFooterItem',
+	component: TotalsFooterItem,
+};
+
+export const Default = () => {
+	const currency = currencyKnob();
+	const totalPrice = text( 'Total price', '1000' );
+	const totalTax = text( 'Total tax', '200' );
+
+	return (
+		<TotalsFooterItem
+			currency={ currency }
+			values={ {
+				total_price: totalPrice,
+				total_tax: totalTax,
+			} }
+		/>
+	);
+};

--- a/assets/js/base/components/cart-checkout/totals/item/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/item/stories/index.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import TotalsItem from '../';
+import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
+
+export default {
+	title:
+		'WooCommerce Blocks/@base-components/cart-checkout/totals/TotalsItem',
+	component: TotalsItem,
+};
+
+export const Default = () => {
+	const currency = currencyKnob();
+	const description = text(
+		'Description',
+		'This is the amount that will be charged to your card.'
+	);
+	const label = text( 'Label', 'Amount' );
+	const value = text( 'Value', '1000' );
+
+	return (
+		<TotalsItem
+			currency={ currency }
+			description={ description }
+			label={ label }
+			value={ value }
+		/>
+	);
+};

--- a/assets/js/base/components/cart-checkout/totals/item/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/item/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { text } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import TotalsItem from '../';
-import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
 
 export default {
 	title:

--- a/assets/js/base/components/cart-checkout/totals/shipping/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/shipping/stories/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { boolean, text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import TotalsShipping from '../';
+import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
+
+export default {
+	title:
+		'WooCommerce Blocks/@base-components/cart-checkout/totals/TotalsShipping',
+	component: TotalsShipping,
+};
+
+export const Default = () => {
+	const currency = currencyKnob();
+	const showCalculator = boolean( 'Show calculator', true );
+	const showRateSelector = boolean( 'Show rate selector', true );
+	const totalShipping = text( 'Total shipping', '1000' );
+	const totalShippingTax = text( 'Total shipping tax', '200' );
+
+	return (
+		<TotalsShipping
+			currency={ currency }
+			showCalculator={ showCalculator }
+			showRateSelector={ showRateSelector }
+			values={ {
+				total_shipping: totalShipping,
+				total_shipping_tax: totalShippingTax,
+			} }
+		/>
+	);
+};

--- a/assets/js/base/components/cart-checkout/totals/shipping/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/shipping/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { boolean, text } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import TotalsShipping from '../';
-import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
 
 export default {
 	title:

--- a/assets/js/base/components/cart-checkout/totals/subtotal/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/subtotal/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { text } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import Subtotal from '../';
-import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
 
 export default {
 	title: 'WooCommerce Blocks/@base-components/cart-checkout/totals/Subtotal',

--- a/assets/js/base/components/cart-checkout/totals/subtotal/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/subtotal/stories/index.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import Subtotal from '../';
+import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
+
+export default {
+	title: 'WooCommerce Blocks/@base-components/cart-checkout/totals/Subtotal',
+	component: Subtotal,
+};
+
+export const Default = () => {
+	const currency = currencyKnob();
+	const totalItems = text( 'Total items', '1000' );
+	const totalItemsTax = text( 'Total items tax', '200' );
+
+	return (
+		<Subtotal
+			currency={ currency }
+			values={ {
+				total_items: totalItems,
+				total_items_tax: totalItemsTax,
+			} }
+		/>
+	);
+};

--- a/assets/js/base/components/cart-checkout/totals/taxes/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/taxes/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { text } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import TotalsTaxes from '../';
-import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
 
 export default {
 	title:

--- a/assets/js/base/components/cart-checkout/totals/taxes/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/taxes/stories/index.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import TotalsTaxes from '../';
+import currencyKnob from '../../../../../../../../storybook/currency-knob.js';
+
+export default {
+	title:
+		'WooCommerce Blocks/@base-components/cart-checkout/totals/TotalsTaxes',
+	component: TotalsTaxes,
+};
+
+export const Default = () => {
+	const currency = currencyKnob();
+	const totalTaxes = text( 'Total taxes', '1000' );
+
+	return (
+		<TotalsTaxes
+			currency={ currency }
+			values={ {
+				total_tax: totalTaxes,
+			} }
+		/>
+	);
+};

--- a/assets/js/base/components/product-price/stories/index.js
+++ b/assets/js/base/components/product-price/stories/index.js
@@ -7,43 +7,16 @@ import { number, select } from '@storybook/addon-knobs';
  * Internal dependencies
  */
 import ProductPrice from '../';
+import currencyKnob from '../../../../../../storybook/currency-knob.js';
 
 export default {
 	title: 'WooCommerce Blocks/@base-components/ProductPrice',
 	component: ProductPrice,
 };
 
-const getKnobs = () => {
-	const align = select( 'Align', [ 'left', 'center', 'right' ], 'left' );
-	const currencies = [
-		{
-			label: 'USD',
-			code: 'USD',
-			symbol: '$',
-			thousandSeparator: ',',
-			decimalSeparator: '.',
-			minorUnit: 2,
-			prefix: '$',
-			suffix: '',
-		},
-		{
-			label: 'EUR',
-			code: 'EUR',
-			symbol: '€',
-			thousandSeparator: '.',
-			decimalSeparator: ',',
-			minorUnit: 2,
-			prefix: '',
-			suffix: '€',
-		},
-	];
-	const currency = select( 'Currency', currencies, currencies[ 0 ] );
-
-	return { align, currency };
-};
-
 export const standard = () => {
-	const { align, currency } = getKnobs();
+	const align = select( 'Align', [ 'left', 'center', 'right' ], 'left' );
+	const currency = currencyKnob();
 	const price = number( 'Price', 4000 );
 
 	return (
@@ -52,7 +25,8 @@ export const standard = () => {
 };
 
 export const sale = () => {
-	const { align, currency } = getKnobs();
+	const align = select( 'Align', [ 'left', 'center', 'right' ], 'left' );
+	const currency = currencyKnob();
 	const price = number( 'Price', 3000 );
 	const regularPrice = number( 'Regular price', 4000 );
 
@@ -67,7 +41,8 @@ export const sale = () => {
 };
 
 export const range = () => {
-	const { align, currency } = getKnobs();
+	const align = select( 'Align', [ 'left', 'center', 'right' ], 'left' );
+	const currency = currencyKnob();
 	const minPrice = number( 'Min price', 3000 );
 	const maxPrice = number( 'Max price', 5000 );
 

--- a/assets/js/base/components/product-price/stories/index.js
+++ b/assets/js/base/components/product-price/stories/index.js
@@ -2,12 +2,12 @@
  * External dependencies
  */
 import { number, select } from '@storybook/addon-knobs';
+import { currencyKnob } from '@woocommerce/knobs';
 
 /**
  * Internal dependencies
  */
 import ProductPrice from '../';
-import currencyKnob from '../../../../../../storybook/currency-knob.js';
 
 export default {
 	title: 'WooCommerce Blocks/@base-components/ProductPrice',

--- a/storybook/__mocks__/woocommerce-base-hooks.js
+++ b/storybook/__mocks__/woocommerce-base-hooks.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import {
+	previewCart,
+	previewShippingRates,
+} from '@woocommerce/resource-previews';
+
+export * from '../../assets/js/base/hooks/index.js';
+export const useStoreCart = () => ( {
+	cartCoupons: previewCart.coupons,
+	cartItems: previewCart.items,
+	cartItemsCount: previewCart.items_count,
+	cartItemsWeight: previewCart.items_weight,
+	cartNeedsPayment: previewCart.needs_payment,
+	cartNeedsShipping: previewCart.needs_shipping,
+	cartItemErrors: [],
+	cartTotals: previewCart.totals,
+	cartIsLoading: false,
+	cartErrors: [],
+	billingAddress: {},
+	shippingAddress: {},
+	shippingRates: previewShippingRates,
+	shippingRatesLoading: false,
+	cartHasCalculatedShipping: previewCart.has_calculated_shipping,
+	receiveCart: () => void null,
+} );
+export const useSelectShippingRate = () => ( {
+	selectShippingRate: () => void null,
+	selectedShippingRates: [],
+	isSelectingRate: false,
+} );

--- a/storybook/__mocks__/woocommerce-block-settings.js
+++ b/storybook/__mocks__/woocommerce-block-settings.js
@@ -1,0 +1,3 @@
+export * from '../../assets/js/settings/blocks/index.js';
+export const DISPLAY_CART_PRICES_INCLUDING_TAX = true;
+export const TAXES_ENABLED = true;

--- a/storybook/currency-knob.js
+++ b/storybook/currency-knob.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import { select } from '@storybook/addon-knobs';
+
+const currencyKnob = () => {
+	const currencies = [
+		{
+			label: 'USD',
+			code: 'USD',
+			symbol: '$',
+			thousandSeparator: ',',
+			decimalSeparator: '.',
+			minorUnit: 2,
+			prefix: '$',
+			suffix: '',
+		},
+		{
+			label: 'EUR',
+			code: 'EUR',
+			symbol: '€',
+			thousandSeparator: '.',
+			decimalSeparator: ',',
+			minorUnit: 2,
+			prefix: '',
+			suffix: '€',
+		},
+	];
+	return select( 'Currency', currencies, currencies[ 0 ] );
+};
+
+export default currencyKnob;

--- a/storybook/knobs/currency-knob.js
+++ b/storybook/knobs/currency-knob.js
@@ -3,7 +3,7 @@
  */
 import { select } from '@storybook/addon-knobs';
 
-const currencyKnob = () => {
+export const currencyKnob = () => {
 	const currencies = [
 		{
 			label: 'USD',
@@ -28,5 +28,3 @@ const currencyKnob = () => {
 	];
 	return select( 'Currency', currencies, currencies[ 0 ] );
 };
-
-export default currencyKnob;

--- a/storybook/knobs/index.js
+++ b/storybook/knobs/index.js
@@ -1,0 +1,1 @@
+export * from './currency-knob.js';

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -32,6 +32,12 @@ module.exports = ( { config: storybookConfig } ) => {
 	storybookConfig.resolve.alias = {
 		...storybookConfig.resolve.alias,
 		...aliases,
+		'@woocommerce/block-settings': require.resolve(
+			'./__mocks__/woocommerce-block-settings.js'
+		),
+		'@woocommerce/base-hooks': require.resolve(
+			'./__mocks__/woocommerce-base-hooks.js'
+		),
 	};
 	storybookConfig.module.rules.push(
 		{

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = ( { config: storybookConfig } ) => {
 		'@woocommerce/base-hooks': require.resolve(
 			'./__mocks__/woocommerce-base-hooks.js'
 		),
+		'@woocommerce/storybook': require.resolve( './knobs/index.js' ),
 	};
 	storybookConfig.module.rules.push(
 		{

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
 			],
 			"@woocommerce/icons": [ "assets/js/icons" ],
 			"@woocommerce/resource-previews": [ "assets/js/previews" ],
+			"@woocommerce/knobs": [ "storybook/knobs" ],
 			"@woocommerce/settings": [ "assets/js/settings/shared" ],
 			"@woocommerce/shared-context": [ "assets/js/shared/context" ],
 			"@woocommerce/type-defs/*": [ "assets/js/type-defs/*" ]


### PR DESCRIPTION
This PR:

* Adds stories to all components under `/assets/js/cart-checkout/totals/` which didn't have one yet.
* Adds mocks to some components that were interacting with the backend/API, they are stored in `/storybook/__mocks__/`.
* Adds a `@woocommerce/knobs` alias only available in stories that allows loading knobs that are shared across stories (for now, only `currencyKnob`). They are stored in `/storybook/knobs/`.

### Screenshots
![imatge](https://user-images.githubusercontent.com/3616980/101613551-2d5cb100-3a0c-11eb-8beb-5c8d38c7cf7b.png)

### How to test the changes in this Pull Request:

0. You might need to merge the fix from #3521 in order for the `TotalsFees` story to be visible.
1. Run `npm run storybook`.
2. Check the stories under `@base-components/cart-checkout/totals` and verify they look fine.
3. Try toggling/modifying some of the knobs and verify the components update accordingly.