### PR TITLE
Update WP versions used in Travis e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,13 +93,6 @@ jobs:
               - npm run test
           env:
               - WOOCOMMERCE_BLOCKS_PHASE=3
-        - name: E2E Tests (WP 5.3)
-          script:
-              - npm run test:e2e
-          env:
-              - WP_VERSION=5.3-branch
-              - E2E_TESTS=1
-              - WOOCOMMERCE_BLOCKS_PHASE=3
         - name: E2E Tests (WP 5.4)
           script:
               - npm run test:e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,14 +114,21 @@ jobs:
               - WP_VERSION=5.5-branch
               - E2E_TESTS=1
               - WOOCOMMERCE_BLOCKS_PHASE=3
-        - name: E2E Tests (WP 5.5 with Gutenberg plugin)
+        - name: E2E Tests (WP 5.6)
+          script:
+              - npm run test:e2e
+          env:
+              - WP_VERSION=5.6-branch
+              - E2E_TESTS=1
+              - WOOCOMMERCE_BLOCKS_PHASE=3
+        - name: E2E Tests (WP 5.6 with Gutenberg plugin)
           script:
               - npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
               - npm install @wordpress/e2e-test-utils@latest
               - chmod -R 767 ./
               - npm run test:e2e
           env:
-              - WP_VERSION=5.5-branch
+              - WP_VERSION=5.6-branch
               - E2E_TESTS=1
               - GUTENBERG_LATEST=true
               - WOOCOMMERCE_BLOCKS_PHASE=3

--- a/tests/e2e/specs/backend/all-products.test.js
+++ b/tests/e2e/specs/backend/all-products.test.js
@@ -13,13 +13,6 @@ const block = {
 	class: '.wc-block-all-products',
 };
 
-/**
- * @todo: write helpers to simplify version and feature gating tests.
- */
-if ( process.env.WP_VERSION < 5.3 )
-	// eslint-disable-next-line jest/no-focused-tests
-	test.only( 'skipping all other things', () => {} );
-
 describe( `${ block.name } Block`, () => {
 	beforeAll( async () => {
 		await switchUserToAdmin();

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -23,7 +23,7 @@ const block = {
 	class: '.wc-block-cart',
 };
 
-if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `skipping ${ block.name } tests`, () => {} );
 

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -22,7 +22,7 @@ const block = {
 	class: '.wc-block-checkout',
 };
 
-if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `skipping ${ block.name } tests`, () => {} );
 

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -9,7 +9,7 @@ import {
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
-if ( process.env.WP_VERSION < 5.3 || process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 )
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 )
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( 'skipping all other things', () => {} );
 


### PR DESCRIPTION
Fixes #3534.

This PR removes WP 5.3 from Travis e2e testing and instead adds WP 5.6. I also changed the `with Gutenberg plugin` version to target 5.6 instead of 5.5.

### How to test the changes in this Pull Request:

Verify Travis tests pass.