### PR TITLE
Switch to Fragment Short Syntax (`<>`)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,5 +20,6 @@ module.exports = {
 	rules: {
 		'woocommerce/feature-flag': 'off',
 		'react-hooks/exhaustive-deps': 'error',
+		'react/jsx-fragments': [ 'error', 'syntax' ],
 	},
 };

--- a/assets/js/base/components/block-error-boundary/index.js
+++ b/assets/js/base/components/block-error-boundary/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { Component, Fragment } from 'react';
+import { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -20,10 +20,10 @@ class BlockErrorBoundary extends Component {
 		) {
 			return {
 				errorMessage: (
-					<Fragment>
+					<>
 						<strong>{ error.status }</strong>:&nbsp;
 						{ error.statusText }
-					</Fragment>
+					</>
 				),
 				hasError: true,
 			};

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -110,7 +110,7 @@ const CheckboxList = ( {
 		const optionCount = options.length;
 		const shouldTruncateOptions = optionCount > limit + 5;
 		return (
-			<Fragment>
+			<>
 				{ options.map( ( option, index ) => (
 					<Fragment key={ option.value }>
 						<li
@@ -138,7 +138,7 @@ const CheckboxList = ( {
 					</Fragment>
 				) ) }
 				{ shouldTruncateOptions && renderedShowLess }
-			</Fragment>
+			</>
 		);
 	}, [
 		options,

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	Fragment,
 	useState,
 	useEffect,
 	useCallback,
@@ -305,7 +304,7 @@ const PriceSlider = ( {
 			</div>
 			<div className="wc-block-price-filter__controls wc-block-components-price-slider__controls">
 				{ showInputFields && (
-					<Fragment>
+					<>
 						<FormattedMonetaryAmount
 							currency={ currency }
 							displayType="input"
@@ -342,7 +341,7 @@ const PriceSlider = ( {
 							disabled={ isLoading || ! hasValidConstraints }
 							value={ maxPriceInput }
 						/>
-					</Fragment>
+					</>
 				) }
 				{ ! showInputFields &&
 					! isLoading &&

--- a/assets/js/base/hocs/with-scroll-to-top/index.js
+++ b/assets/js/base/hocs/with-scroll-to-top/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Component, createRef, Fragment } from 'react';
+import { Component, createRef } from 'react';
 
 /**
  * Internal dependencies
@@ -54,7 +54,7 @@ const withScrollToTop = ( OriginalComponent ) => {
 
 		render() {
 			return (
-				<Fragment>
+				<>
 					<div
 						className="with-scroll-to-top__scroll-point"
 						ref={ this.scrollPointRef }
@@ -64,7 +64,7 @@ const withScrollToTop = ( OriginalComponent ) => {
 						{ ...this.props }
 						scrollToTop={ this.scrollToTop }
 					/>
-				</Fragment>
+				</>
 			);
 		}
 	}

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useQueryStateByKey } from '@woocommerce/base-hooks';
-import { useMemo, Fragment } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
@@ -91,14 +91,14 @@ const ActiveFiltersBlock = ( {
 	} );
 
 	return (
-		<Fragment>
+		<>
 			{ ! isEditor && blockAttributes.heading && (
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
 			<div className="wc-block-active-filters">
 				<ul className={ listClasses }>
 					{ isEditor ? (
-						<Fragment>
+						<>
 							{ renderRemovableListItem( {
 								type: __(
 									'Size',
@@ -121,12 +121,12 @@ const ActiveFiltersBlock = ( {
 								),
 								displayStyle: blockAttributes.displayStyle,
 							} ) }
-						</Fragment>
+						</>
 					) : (
-						<Fragment>
+						<>
 							{ activePriceFilters }
 							{ activeAttributeFilters }
-						</Fragment>
+						</>
 					) }
 				</ul>
 				<button
@@ -149,7 +149,7 @@ const ActiveFiltersBlock = ( {
 					/>
 				</button>
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -11,13 +11,7 @@ import {
 	usePrevious,
 	useShallowEqual,
 } from '@woocommerce/base-hooks';
-import {
-	useCallback,
-	Fragment,
-	useEffect,
-	useState,
-	useMemo,
-} from '@wordpress/element';
+import { useCallback, useEffect, useState, useMemo } from '@wordpress/element';
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
 import DropdownSelector from '@woocommerce/base-components/dropdown-selector';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
@@ -332,7 +326,7 @@ const AttributeFilterBlock = ( {
 	const isDisabled = ! blockAttributes.isPreview && filteredCountsLoading;
 
 	return (
-		<Fragment>
+		<>
 			{ ! isEditor && blockAttributes.heading && (
 				<TagName>{ blockAttributes.heading }</TagName>
 			) }
@@ -366,7 +360,7 @@ const AttributeFilterBlock = ( {
 					/>
 				) }
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Fragment, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import {
 	Placeholder,
@@ -377,7 +377,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	return Object.keys( ATTRIBUTES ).length === 0 ? (
 		noAttributesPlaceholder()
 	) : (
-		<Fragment>
+		<>
 			{ getBlockControls() }
 			{ getInspectorControls() }
 			{ isEditing ? (
@@ -396,7 +396,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 					</Disabled>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/attribute-filter/label.js
+++ b/assets/js/blocks/attribute-filter/label.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import Label from '@woocommerce/base-components/label';
 
 /**
@@ -14,7 +13,7 @@ import Label from '@woocommerce/base-components/label';
  */
 const AttributeFilterLabel = ( { name, count } ) => {
 	return (
-		<Fragment>
+		<>
 			{ name }
 			{ Number.isFinite( count ) && (
 				<Label
@@ -35,7 +34,7 @@ const AttributeFilterLabel = ( { name, count } ) => {
 					} }
 				/>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -27,7 +27,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import classnames from 'classnames';
-import { Fragment } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import PropTypes from 'prop-types';
 import { MIN_HEIGHT } from '@woocommerce/block-settings';
@@ -158,7 +157,7 @@ const FeaturedCategory = ( {
 					] }
 				>
 					{ !! url && (
-						<Fragment>
+						<>
 							<RangeControl
 								label={ __(
 									'Background Opacity',
@@ -182,7 +181,7 @@ const FeaturedCategory = ( {
 									}
 								/>
 							) }
-						</Fragment>
+						</>
 					) }
 				</PanelColorSettings>
 			</InspectorControls>
@@ -374,11 +373,11 @@ const FeaturedCategory = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls() }
 			{ getInspectorControls() }
 			{ category ? renderCategory() : renderNoCategory() }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -28,7 +28,7 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import classnames from 'classnames';
-import { Fragment, Component } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
@@ -97,7 +97,7 @@ const FeaturedProduct = ( {
 		};
 
 		return (
-			<Fragment>
+			<>
 				{ getBlockControls() }
 				<Placeholder
 					icon={ <Icon srcElement={ star } /> }
@@ -130,7 +130,7 @@ const FeaturedProduct = ( {
 						</Button>
 					</div>
 				</Placeholder>
-			</Fragment>
+			</>
 		);
 	};
 
@@ -233,7 +233,7 @@ const FeaturedProduct = ( {
 					] }
 				>
 					{ !! url && (
-						<Fragment>
+						<>
 							<RangeControl
 								label={ __(
 									'Background Opacity',
@@ -257,7 +257,7 @@ const FeaturedProduct = ( {
 									}
 								/>
 							) }
-						</Fragment>
+						</>
 					) }
 				</PanelColorSettings>
 			</InspectorControls>
@@ -421,11 +421,11 @@ const FeaturedProduct = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls() }
 			{ getInspectorControls() }
 			{ product ? renderProduct() : renderNoProduct() }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -14,7 +14,7 @@ import {
 	withSpokenMessages,
 	ToggleControl,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { MAX_COLUMNS, MIN_COLUMNS } from '@woocommerce/block-settings';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
@@ -162,7 +162,7 @@ class ProductsBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar
 						controls={ [
@@ -187,7 +187,7 @@ class ProductsBlock extends Component {
 						/>
 					</Disabled>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -7,7 +7,7 @@ import {
 	useCollectionData,
 	usePrevious,
 } from '@woocommerce/base-hooks';
-import { Fragment, useCallback, useState, useEffect } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
 import PriceSlider from '@woocommerce/base-components/price-slider';
 import { useDebouncedCallback } from 'use-debounce';
 import PropTypes from 'prop-types';
@@ -149,7 +149,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 	const TagName = `h${ attributes.headingLevel }`;
 
 	return (
-		<Fragment>
+		<>
 			{ ! isEditor && attributes.heading && (
 				<TagName>{ attributes.heading }</TagName>
 			) }
@@ -167,7 +167,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 					isLoading={ isLoading }
 				/>
 			</div>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Placeholder,
@@ -152,7 +151,7 @@ export default function ( { attributes, setAttributes } ) {
 	);
 
 	return (
-		<Fragment>
+		<>
 			{ PRODUCT_COUNT === 0 ? (
 				noProductsPlaceholder()
 			) : (
@@ -170,6 +169,6 @@ export default function ( { attributes, setAttributes } ) {
 					</Disabled>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 }

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ServerSideRender } from '@wordpress/editor';
@@ -82,7 +82,7 @@ class ProductBestSellersBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -90,7 +90,7 @@ class ProductBestSellersBlock extends Component {
 						attributes={ attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ServerSideRender } from '@wordpress/editor';
 import PropTypes from 'prop-types';
@@ -180,14 +179,14 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	};
 
 	return (
-		<Fragment>
+		<>
 			{ getInspectorControls() }
 			<ServerSideRender
 				block={ name }
 				attributes={ attributes }
 				EmptyResponsePlaceholder={ EmptyPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -12,7 +12,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
@@ -279,7 +279,7 @@ class ProductByCategoryBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar
 						controls={ [
@@ -297,7 +297,7 @@ class ProductByCategoryBlock extends Component {
 				</BlockControls>
 				{ this.getInspectorControls() }
 				{ isEditing ? this.renderEditMode() : this.renderViewMode() }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ServerSideRender } from '@wordpress/editor';
@@ -82,7 +82,7 @@ class ProductNewestBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -90,7 +90,7 @@ class ProductNewestBlock extends Component {
 						attributes={ attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody, Placeholder } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ServerSideRender } from '@wordpress/editor';
@@ -107,7 +107,7 @@ class ProductOnSaleBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -116,7 +116,7 @@ class ProductOnSaleBlock extends Component {
 						EmptyResponsePlaceholder={ EmptyPlaceholder }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -12,7 +12,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { HAS_TAGS } from '@woocommerce/block-settings';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
@@ -260,51 +260,42 @@ class ProductsByTagBlock extends Component {
 			return gridBlockPreview;
 		}
 
-		return (
-			<Fragment>
-				{ HAS_TAGS ? (
-					<Fragment>
-						<BlockControls>
-							<Toolbar
-								controls={ [
-									{
-										icon: 'edit',
-										title: __( 'Edit' ),
-										onClick: () =>
-											isEditing
-												? this.stopEditing()
-												: this.startEditing(),
-										isActive: isEditing,
-									},
-								] }
-							/>
-						</BlockControls>
-						{ this.getInspectorControls() }
-						{ isEditing
-							? this.renderEditMode()
-							: this.renderViewMode() }
-					</Fragment>
-				) : (
-					<Placeholder
-						icon={
-							<Icon
-								icon={ more }
-								className="block-editor-block-icon"
-							/>
-						}
-						label={ __(
-							'Products by Tag',
-							'woo-gutenberg-products-block'
-						) }
-						className="wc-block-products-grid wc-block-product-tag"
-					>
-						{ __(
-							"This block displays products from selected tags. In order to preview this you'll first need to create a product and assign it some tags.",
-							'woo-gutenberg-products-block'
-						) }
-					</Placeholder>
+		return HAS_TAGS ? (
+			<>
+				<BlockControls>
+					<Toolbar
+						controls={ [
+							{
+								icon: 'edit',
+								title: __( 'Edit' ),
+								onClick: () =>
+									isEditing
+										? this.stopEditing()
+										: this.startEditing(),
+								isActive: isEditing,
+							},
+						] }
+					/>
+				</BlockControls>
+				{ this.getInspectorControls() }
+				{ isEditing ? this.renderEditMode() : this.renderViewMode() }
+			</>
+		) : (
+			<Placeholder
+				icon={
+					<Icon icon={ more } className="block-editor-block-icon" />
+				}
+				label={ __(
+					'Products by Tag',
+					'woo-gutenberg-products-block'
 				) }
-			</Fragment>
+				className="wc-block-products-grid wc-block-product-tag"
+			>
+				{ __(
+					"This block displays products from selected tags. In order to preview this you'll first need to create a product and assign it some tags.",
+					'woo-gutenberg-products-block'
+				) }
+			</Placeholder>
 		);
 	}
 }

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ServerSideRender } from '@wordpress/editor';
@@ -82,7 +82,7 @@ class ProductTopRatedBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -90,7 +90,7 @@ class ProductTopRatedBlock extends Component {
 						attributes={ attributes }
 					/>
 				</Disabled>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -12,7 +12,7 @@ import {
 	Toolbar,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { Icon, tags } from '@woocommerce/icons';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
@@ -162,7 +162,7 @@ class ProductsByAttributeBlock extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<Toolbar
 						controls={ [
@@ -187,7 +187,7 @@ class ProductsByAttributeBlock extends Component {
 						/>
 					</Disabled>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/blocks/reviews/all-reviews/edit.js
+++ b/assets/js/blocks/reviews/all-reviews/edit.js
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { Icon, discussion } from '@woocommerce/icons';
 
@@ -62,7 +61,7 @@ const AllReviewsEditor = ( { attributes, setAttributes } ) => {
 	};
 
 	return (
-		<Fragment>
+		<>
 			{ getInspectorControls() }
 			<EditorContainerBlock
 				attributes={ attributes }
@@ -75,7 +74,7 @@ const AllReviewsEditor = ( { attributes, setAttributes } ) => {
 				name={ __( 'All Reviews', 'woo-gutenberg-products-block' ) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { REVIEW_RATINGS_ENABLED } from '@woocommerce/block-settings';
 import LoadMoreButton from '@woocommerce/base-components/load-more-button';
@@ -36,7 +35,7 @@ const FrontendBlock = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ attributes.showOrderby !== 'false' && REVIEW_RATINGS_ENABLED && (
 				<ReviewSortSelect
 					defaultValue={ orderby }
@@ -54,7 +53,7 @@ const FrontendBlock = ( {
 						) }
 					/>
 				) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -11,7 +11,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/components';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
 import { Icon, review } from '@woocommerce/icons';
@@ -175,7 +174,7 @@ const ReviewsByCategoryEditor = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls( editMode, setAttributes ) }
 			{ getInspectorControls() }
 			<EditorContainerBlock
@@ -192,7 +191,7 @@ const ReviewsByCategoryEditor = ( {
 				) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -10,7 +10,6 @@ import {
 	withSpokenMessages,
 } from '@wordpress/components';
 import { SearchListItem } from '@woocommerce/components';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import ProductControl from '@woocommerce/editor-components/product-control';
 import { Icon, comment } from '@woocommerce/icons';
@@ -164,7 +163,7 @@ const ReviewsByProductEditor = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ getBlockControls( editMode, setAttributes ) }
 			{ getInspectorControls() }
 			<EditorContainerBlock
@@ -181,7 +180,7 @@ const ReviewsByProductEditor = ( {
 				) }
 				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/editor-components/error-placeholder/index.js
+++ b/assets/js/editor-components/error-placeholder/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { Icon, notice } from '@woocommerce/icons';
 import classNames from 'classnames';
@@ -25,7 +24,7 @@ const ErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 	>
 		<ErrorMessage error={ error } />
 		{ onRetry && (
-			<Fragment>
+			<>
 				{ isLoading ? (
 					<Spinner />
 				) : (
@@ -33,7 +32,7 @@ const ErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 						{ __( 'Retry', 'woo-gutenberg-products-block' ) }
 					</Button>
 				) }
-			</Fragment>
+			</>
 		) }
 	</Placeholder>
 );

--- a/assets/js/editor-components/grid-content-control/index.js
+++ b/assets/js/editor-components/grid-content-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { ToggleControl } from '@wordpress/components';
 
@@ -16,7 +15,7 @@ import { ToggleControl } from '@wordpress/components';
 const GridContentControl = ( { onChange, settings } ) => {
 	const { button, price, rating, title } = settings;
 	return (
-		<Fragment>
+		<>
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
 				help={
@@ -84,7 +83,7 @@ const GridContentControl = ( { onChange, settings } ) => {
 				checked={ button }
 				onChange={ () => onChange( { ...settings, button: ! button } ) }
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/editor-components/grid-layout-control/index.js
+++ b/assets/js/editor-components/grid-layout-control/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { clamp, isNaN } from 'lodash';
-import { Fragment } from '@wordpress/element';
 import PropTypes from 'prop-types';
 import { RangeControl, ToggleControl } from '@wordpress/components';
 import {
@@ -29,7 +28,7 @@ const GridLayoutControl = ( {
 	alignButtons,
 } ) => {
 	return (
-		<Fragment>
+		<>
 			<RangeControl
 				label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
 				value={ columns }
@@ -75,7 +74,7 @@ const GridLayoutControl = ( {
 					setAttributes( { alignButtons: ! alignButtons } )
 				}
 			/>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -134,7 +133,7 @@ const ProductAttributeTermControl = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			<SearchListControl
 				className="woocommerce-product-attributes"
 				list={ currentList }
@@ -184,7 +183,7 @@ const ProductAttributeTermControl = ( {
 					/>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -132,7 +131,7 @@ const ProductCategoryControl = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			<SearchListControl
 				className="woocommerce-product-categories"
 				list={ categories }
@@ -183,7 +182,7 @@ const ProductCategoryControl = ( {
 					/>
 				</div>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { debounce, find } from 'lodash';
 import PropTypes from 'prop-types';
 import { SearchListControl, SearchListItem } from '@woocommerce/components';
@@ -124,7 +124,7 @@ class ProductTagControl extends Component {
 		};
 
 		return (
-			<Fragment>
+			<>
 				<SearchListControl
 					className="woocommerce-product-tags"
 					list={ list }
@@ -175,7 +175,7 @@ class ProductTagControl extends Component {
 						/>
 					</div>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/js/editor-components/view-switcher/index.js
+++ b/assets/js/editor-components/view-switcher/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { ButtonGroup, Button } from '@wordpress/components';
-import { useState, Fragment } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
 
 /**
@@ -26,7 +26,7 @@ const ViewSwitcher = ( {
 	const htmlId = 'wc-block-view-switch-control-' + instanceId;
 
 	return (
-		<Fragment>
+		<>
 			<div className={ classes }>
 				<label
 					htmlFor={ htmlId }
@@ -57,7 +57,7 @@ const ViewSwitcher = ( {
 				</ButtonGroup>
 			</div>
 			{ render( currentView ) }
-		</Fragment>
+		</>
 	);
 };
 


### PR DESCRIPTION
This PR replaces usage of `<Fragment>` with the shorthand `<>`—this also allows us to remove some imports. 

[Fragment documentation can be found here](https://reactjs.org/docs/fragments.html). Our only remaining use of Fragment is as a fallback for the `Label` component, and where a `key` prop is needed.

I have enabled the eslint rule `react/jsx-fragments` which will catch usage of Fragment, **however**, this only catches `React.Fragment`, not the fragments imported from the `@wordpress/elements` package. I'm not sure if this is fixable or not.

I think this change can be left out of the changelog. `('<>')/`

Closes #1761

### How to test the changes in this Pull Request:

Given we've been rolling out shorthand `<>` in recent updates, I don't envision this having negative impact anywhere, and since the updated components are used in Blocks covered by e2e I think we're safe. That said, some smoke testing of updated components could be helpful. I tested a few of them (Product Tag Block since that change was a little larger) in particular. In all cases you should only need insert the block and check the console for errors.

The following Blocks are affected:

- Active Filters
- Price Slider
- Filter By Attribute
- Featured Cateogry
- Featured Product
- Handpicked products
- Best Sellers
- New Products
- Product categories
- Products by Category
- Onsale products
- Products by Tag