### PR TITLE
Update minimum required WP version to 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ We release a new version of WooCommerce Blocks onto WordPress.org every few week
 >
 > We **recommend** you always keep WordPress and WooCommerce core up to date in order to ensure your store is running with the most recent fixes and enhancements to help your store be successful.
 
-1. Make sure you have WordPress 5.3+ and WooCommerce 4.0+
+1. Make sure you have WordPress 5.4+ and WooCommerce 4.3+
 2. The plugin version is available on WordPress.org. [Download the plugin version here.](https://wordpress.org/plugins/woo-gutenberg-products-block/)
 3. Activate the plugin.
 
 ## Installing the development version
 
-1. Make sure you have WordPress 5.3+ and WooCommerce 4.0+
+1. Make sure you have WordPress 5.4+ and WooCommerce 4.3+
 2. Get a copy of this plugin using the green "Clone or download" button on the right.
 3. `npm install` to install the dependencies.
 4. `composer install` to install core dependencies.

--- a/assets/js/filters/block-list-block.js
+++ b/assets/js/filters/block-list-block.js
@@ -3,7 +3,6 @@
  */
 import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { compareWithWpVersion } from '@woocommerce/settings';
 import { getBlockType } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
 
@@ -88,10 +87,8 @@ const withDefaultAttributes = createHigherOrderComponent(
  * as defining `attributes` during block registration, you must also declare an
  * array called `defaults`. Defaults should be omitted from `attributes`.
  */
-if ( compareWithWpVersion( '5.3', '<=' ) ) {
-	addFilter(
-		'editor.BlockListBlock',
-		'woocommerce-blocks/block-list-block',
-		withDefaultAttributes
-	);
-}
+addFilter(
+	'editor.BlockListBlock',
+	'woocommerce-blocks/block-list-block',
+	withDefaultAttributes
+);

--- a/docs/testing/cart-checkout/cross-browser.md
+++ b/docs/testing/cart-checkout/cross-browser.md
@@ -3,7 +3,7 @@
 The main goal of this is to test in a variety of themes, browsers, platforms, and setups, this is a list of things you can test with, with sane expectations.
 
 The baseline for testing is:
-- WordPress 5.3 and up.
-- WooCommerce 4.0 and up
+- WordPress 5.4 and up.
+- WooCommerce 4.2 and up
 - All Browsers supported by [those two versions](https://make.wordpress.org/core/handbook/best-practices/browser-support/) so this includes Internet Explorer 11, and latest two versions of each browser.
 - Storefront, TwentyTwenty, and TwentyNineteen themes, we use storefront as a basis for development and push fixes to it regularly, so make sure you run the latest version.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Blocks ===
 Contributors: automattic, woocommerce, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia, aljullu, mikejolley, nerrad, joshuawold, assassinateur, haszari
 Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
-Requires at least: 5.3
+Requires at least: 5.4
 Tested up to: 5.6
 Requires PHP: 7.0
 Stable tag: 4.0.0
@@ -44,7 +44,7 @@ Use this plugin if you want access to the bleeding edge of available blocks for 
 
 = Minimum Requirements =
 
-* WordPress 5.3 or greater
+* WordPress 5.4 or greater
 * WooCommerce 4.3 or greater
 * PHP version 7.0 or greater (PHP 7.4 or greater is recommended)
 * MySQL version 5.6 or greater

--- a/src/Library.php
+++ b/src/Library.php
@@ -57,19 +57,14 @@ class Library {
 			'ReviewsByCategory',
 			'ProductSearch',
 			'ProductTag',
+			'AllProducts',
+			'PriceFilter',
+			'AttributeFilter',
+			'ActiveFilters',
 		];
-		// Note: as a part of refactoring dynamic block registration, this will be moved
-		// to block level config.
-		if ( version_compare( $wp_version, '5.3', '>=' ) ) {
-			$blocks[] = 'AllProducts';
-			$blocks[] = 'PriceFilter';
-			$blocks[] = 'AttributeFilter';
-			$blocks[] = 'ActiveFilters';
-
-			if ( Package::feature()->is_feature_plugin_build() ) {
-				$blocks[] = 'Checkout';
-				$blocks[] = 'Cart';
-			}
+		if ( Package::feature()->is_feature_plugin_build() ) {
+			$blocks[] = 'Checkout';
+			$blocks[] = 'Cart';
 		}
 		if ( Package::feature()->is_experimental_build() ) {
 			$blocks[] = 'SingleProduct';

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * Requires at least: 5.3
+ * Requires at least: 5.4
  * Requires PHP: 7.0
  * WC requires at least: 4.3
  * WC tested up to: 4.8
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$minimum_wp_version = '5.3';
+$minimum_wp_version = '5.4';
 
 if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
 	define( 'WC_BLOCKS_IS_FEATURE_PLUGIN', true );


### PR DESCRIPTION
Fixes #3516.

This PR updates the minimum WP required version to 5.4 in all relevant files and removes a couple of checks which are no longer needed.

### How to test the changes in this Pull Request:

Changes are quite safe, so the only think that it might make sense testing is that blocks that were only available on WP>=5.3 are still available:

1. Open the inserter when creating/editing a post or page and verify All Products, Price Filter, Attribute Filter, Active Filters, Checkout and Cart blocks are available.

### Changelog

> Bumped the minimum WP required version to 5.4.