### PR TITLE
disable automated `lockFileMaintenance`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
 	"extends": [ "config:base" ],
-	"lockFileMaintenance": { "enabled": true },
+	"lockFileMaintenance": { "enabled": false },
 	"ignoreDeps": [ "husky" ],
 	"schedule": [ "before 3am on wednesday" ],
 	"composer": {


### PR DESCRIPTION
This PR disables the [`lockFileMaintenance` option](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) in RenovateBot. At present we are manually refreshing lockfile for every renovate PR, to work around a platform issue†, so it's unhelpful getting a prompt from Renovate to nudge the lock file!

† My understanding is this (this is super hazy, please correct this!): 

- Renovate generates the lock file on linux platform.
- We all typically work on macOS.
- Some of our packages (puppeteer related) depend on the host OS.
- So we are regenerating lockfile on macOS manually so the exact packages match the typical dev OS.

### How to test the changes in this Pull Request:
1. Consider the change.
2. Merge this PR.
3. PRs like this should stop happening: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3506

