### PR TITLE
Update usage of legacy packages (inc. ServerSideRender)

### DIFF
--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Fragment } from 'react';
 import { InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
 import { Icon, list } from '@woocommerce/icons';

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody, Placeholder } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Component, Fragment } from '@wordpress/element';
 import { Disabled, PanelBody } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import { ServerSideRender } from '@wordpress/editor';
+import ServerSideRender from '@wordpress/server-side-render';
 import {
 	Button,
 	Disabled,

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -6,12 +6,11 @@ const path = require( 'path' );
 const NODE_ENV = process.env.NODE_ENV || 'development';
 const FORCE_MAP = process.env.FORCE_MAP || false;
 
-// Some packages are not available in legacy versions of WordPress, so we don't
-// want to extract them.
+// If a package is not available, or missing functionality, in an old but __supported__ version of WordPress, it should be listed here.
+// Some packages are not available in legacy versions of WordPress, so we don't want to extract them.
 const requiredPackagesInWPLegacy = [
-	'@wordpress/compose', // WP 5.3 version doesn't include `useResizeObserver`.
-	'@wordpress/primitives', // Not included in WP 5.3.
-	'@wordpress/warning', // Not included in WP 5.3.
+	// The package included in WP 5.4 version doesn't include `useResizeObserver`. This can be removed when we support 5.5+.
+	'@wordpress/compose',
 ];
 
 const wcDepMap = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5709,7 +5709,6 @@
 			"version": "3.20.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.20.0.tgz",
 			"integrity": "sha512-VQtdH8QH7pUlYoc2k7GQsT5KXp/ouyQp/hDGZKW4ir9fhGV1QZd/B9ptEitqeXdvXzY6lsEBzHXAJipz3WJ8ng==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/i18n": "^3.16.0",
@@ -5720,7 +5719,6 @@
 					"version": "3.16.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.16.0.tgz",
 					"integrity": "sha512-ZyRWplETgD90caVaBuGBFcnYVpcogji1g9Ctbb5AO2bGFeHpmPpjvWm0NE64iQTtLFEJoaCiq6oqUvAOPIQJpw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"gettext-parser": "^1.3.1",
@@ -5733,8 +5731,7 @@
 				"lodash": {
 					"version": "4.17.20",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-					"dev": true
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 				}
 			}
 		},
@@ -8053,14 +8050,13 @@
 			}
 		},
 		"@wordpress/server-side-render": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.19.2.tgz",
-			"integrity": "sha512-aXOdLCyl05LKI2bqDVIfO32YbOTzx3Zljl2RzSiuayXx7eksuTi6UIMSMW9ifzUVJabq9XHG90nl4Ko0NEiS5w==",
-			"dev": true,
+			"version": "1.19.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.19.3.tgz",
+			"integrity": "sha512-qF/rJk1u6qh1wlpgUoUn40b5uT6erNUlZYVY0sSa6z1BB/99jaYE6bdlmi1SYkXCOoh2vfs9bn/R5v848Mk2yA==",
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"@wordpress/api-fetch": "^3.20.0",
-				"@wordpress/components": "^11.1.2",
+				"@wordpress/components": "^11.1.3",
 				"@wordpress/data": "^4.25.0",
 				"@wordpress/deprecated": "^2.10.0",
 				"@wordpress/element": "^2.18.0",
@@ -8070,10 +8066,9 @@
 			},
 			"dependencies": {
 				"@wordpress/components": {
-					"version": "11.1.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-11.1.2.tgz",
-					"integrity": "sha512-Brgrhn+eYBeAxPxh0p6m6XS3dc5TKqWUvySTrbIqsufX5KReOrL5eVkTZFo0F/lWAWQV5luMPNWcbamjQipB4Q==",
-					"dev": true,
+					"version": "11.1.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-11.1.3.tgz",
+					"integrity": "sha512-J598iMZfDUWWJq7v1kYBeELBqPW9ZkyO+wzX6OnbnIh88KCiQbA2eMCHlzgB3rll9VxrRY1ew5FkmLgx9vRjYg==",
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"@emotion/core": "^10.0.22",
@@ -8117,7 +8112,6 @@
 					"version": "3.22.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.22.0.tgz",
 					"integrity": "sha512-y+CbfHLUveOHFPJyHFaYuJ3xE9AJGOVSnZOq4sxFNOI7XKxEkwUl+2LV9yEShXyDtBRDPx5nlIzU4uPdYJQtjg==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"@wordpress/element": "^2.18.0",
@@ -8134,7 +8128,6 @@
 					"version": "3.12.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.12.0.tgz",
 					"integrity": "sha512-sVLSWS3ViLTz4JVM9mmWXKcIrtzkkd+hqDoVyLGZRIBZAK1Fp5c/uDmTCUf7arYW856g8vftWy35r9GC+f6D+A==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"moment": "^2.22.1",
@@ -8145,7 +8138,6 @@
 					"version": "2.10.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.10.0.tgz",
 					"integrity": "sha512-eyHZMRtq7XItAep7vpeqaLQbF5Guud49UiO0ib5UBT97hrORtd6hM+rlqlFOB3ENvs42XPDCV9jR+jwYJPU9DQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"@wordpress/hooks": "^2.10.0"
@@ -8155,7 +8147,6 @@
 					"version": "2.18.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.18.0.tgz",
 					"integrity": "sha512-aR1gOXFxIDcrLCSANe5PwOwYH40n29LzjqBascNkFo6f0LBekCZPbI3Bqq4EtoH/zjq2RKAO9PVPlQRDoQUlmA==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"@types/react": "^16.9.0",
@@ -8170,7 +8161,6 @@
 					"version": "3.16.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.16.0.tgz",
 					"integrity": "sha512-ZyRWplETgD90caVaBuGBFcnYVpcogji1g9Ctbb5AO2bGFeHpmPpjvWm0NE64iQTtLFEJoaCiq6oqUvAOPIQJpw==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"gettext-parser": "^1.3.1",
@@ -8184,7 +8174,6 @@
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
 					"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2"
 					}
@@ -8193,7 +8182,6 @@
 					"version": "2.16.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.16.0.tgz",
 					"integrity": "sha512-8CfxB+9f08FXMUsaO625abmbx2ZinFUz6upzXbe0Da8W3oy7+/TZz6EWsMVBEWz+alSR3Z2FUZ7xUuopHZFcow==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.11.2",
 						"@wordpress/i18n": "^3.16.0",
@@ -8204,7 +8192,6 @@
 					"version": "5.4.7",
 					"resolved": "https://registry.npmjs.org/downshift/-/downshift-5.4.7.tgz",
 					"integrity": "sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==",
-					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.10.2",
 						"compute-scroll-into-view": "^1.0.14",
@@ -8215,14 +8202,12 @@
 				"lodash": {
 					"version": "4.17.20",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-					"dev": true
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 				},
 				"uuid": {
 					"version": "7.0.3",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-					"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-					"dev": true
+					"integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
 				}
 			}
 		},
@@ -8267,7 +8252,6 @@
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.19.0.tgz",
 			"integrity": "sha512-RizWbBxYmWBlNd+q89r3N6Y2XO8eCG3VncnXDgbGnhV4e+2z9fjzp1/9C/SORftEn+ix/qBKbqygmkmBqb+wuw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.11.2",
 				"lodash": "^4.17.19",
@@ -8278,8 +8262,7 @@
 				"lodash": {
 					"version": "4.17.20",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-					"dev": true
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 				}
 			}
 		},
@@ -10111,8 +10094,7 @@
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"dev": true
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
 		},
 		"batch-processor": {
 			"version": "1.0.0",
@@ -17251,8 +17233,7 @@
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"dev": true
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -29299,8 +29280,7 @@
 		"qs": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
-			"dev": true
+			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
 		},
 		"query-string": {
 			"version": "4.3.4",
@@ -30100,7 +30080,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.2.0.tgz",
 			"integrity": "sha512-hpLZ8RyS3oGVyTOe/HjoqVoCOSkeJvrCoEB3bJsY7t9uh7kpQDV6kgvdlECEafYpxe3RzMrKLVcmWRbPU7CuAw==",
-			"dev": true,
 			"requires": {
 				"whatwg-url-without-unicode": "8.0.0-3"
 			}
@@ -35611,8 +35590,7 @@
 		"webidl-conversions": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-			"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-			"dev": true
+			"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
 		},
 		"webpack": {
 			"version": "4.44.2",
@@ -36382,7 +36360,6 @@
 			"version": "8.0.0-3",
 			"resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
 			"integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
-			"dev": true,
 			"requires": {
 				"buffer": "^5.4.3",
 				"punycode": "^2.1.1",
@@ -36393,7 +36370,6 @@
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.3.1",
 						"ieee754": "^1.1.13"

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
 		"@wordpress/deprecated": "2.9.0",
 		"@wordpress/notices": "2.9.1",
 		"@wordpress/plugins": "^2.23.0",
+		"@wordpress/server-side-render": "^1.19.3",
 		"@wordpress/wordcount": "2.11.0",
 		"classnames": "2.2.6",
 		"compare-versions": "3.6.0",


### PR DESCRIPTION
This PR updates our imports of `ServerSideRender ` to the correct package, `@wordpress/server-side-render`. This PR also removes our workarounds for:

- `@wordpress/primitives`
- `@wordpress/warning`

`@wordpress/compose` is needed until the min version is 5.5. I added a note to the docblock about this.

Fixes #3515
Fixes #3513

### How to test the changes in this Pull Request:

This affects all SSR blocks but I don't think this is high risk. If build complets, check that SSR blocks still function in the editor and frontend. And example of an SSR block is `Products by Tag`.

In the page source, you should see the external JS for server-side-render being included.

I believe e2e tests would flag anything when ran on WP 5.4.

### Changelog

> Removed compatibility with packages in WordPress 5.3. 
