### PR TITLE
Rename version compare functions to isWpVersion and isWcVersion and add docblocks

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -27,7 +27,7 @@ import {
 	CHECKOUT_ALLOWS_GUEST,
 	CHECKOUT_ALLOWS_SIGNUP,
 } from '@woocommerce/block-settings';
-import { compareWithWooVersion, getSetting } from '@woocommerce/settings';
+import { isWcVersion, getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -88,7 +88,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	// uses updated my-account/lost-password screen from 4.7+ for
 	// setting initial password.
 	const allowCreateAccount =
-		attributes.allowCreateAccount && compareWithWooVersion( '4.7.0', '<=' );
+		attributes.allowCreateAccount && isWcVersion( '4.7.0', '>=' );
 
 	useEffect( () => {
 		if ( hasErrorsToDisplay ) {

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -19,7 +19,7 @@ import {
 	CHECKOUT_PAGE_ID,
 	CHECKOUT_ALLOWS_SIGNUP,
 } from '@woocommerce/block-settings';
-import { compareWithWooVersion, getAdminLink } from '@woocommerce/settings';
+import { isWcVersion, getAdminLink } from '@woocommerce/settings';
 import { createInterpolateElement } from 'wordpress-element';
 import { useRef } from '@wordpress/element';
 import {
@@ -61,7 +61,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 	// Also implicitly gated to feature plugin, because Checkout
 	// block is gated to plugin
 	const showCreateAccountOption =
-		CHECKOUT_ALLOWS_SIGNUP && compareWithWooVersion( '4.7.0', '<=' );
+		CHECKOUT_ALLOWS_SIGNUP && isWcVersion( '4.7.0', '>=' );
 	return (
 		<InspectorControls>
 			{ currentPostId !== CHECKOUT_PAGE_ID && (

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -42,6 +42,17 @@ const compareVersionSettingIgnorePrerelease = (
 	return compareVersions.compare( version, replacement, operator );
 };
 
+/**
+ * Compare the provided `version` param with the current WP version using the
+ * `operator`.
+ *
+ * For example `compareWithWpVersion( '5.6', '<=' )` returns true if `5.6` is
+ * smaller or equal than the site WP version.
+ *
+ * @param {string} version Version to use to compare against the current wpVersion.
+ * @param {string} operator Operator to use in the comparison.
+ */
+
 export const compareWithWpVersion = ( version, operator ) => {
 	return compareVersionSettingIgnorePrerelease(
 		version,
@@ -50,6 +61,16 @@ export const compareWithWpVersion = ( version, operator ) => {
 	);
 };
 
+/**
+ * Compare the provided `version` param with the current WC version using the
+ * `operator`.
+ *
+ * For example `compareWithWooVersion( '4.9.0', '<=' )` returns true if `4.9` is
+ * smaller or equal than the site WC version.
+ *
+ * @param {string} version Version to use to compare against the current wcVersion.
+ * @param {string} operator Operator to use in the comparison.
+ */
 export const compareWithWooVersion = ( version, operator ) => {
 	return compareVersionSettingIgnorePrerelease(
 		version,

--- a/assets/js/settings/shared/index.js
+++ b/assets/js/settings/shared/index.js
@@ -23,13 +23,13 @@ import '../../filters/exclude-draft-status-from-analytics';
  * For the purpose of these comparisons all pre-release versions are normalized
  * to `rc`.
  *
- * @param {string} version Version to compare.
  * @param {string} setting Setting name (e.g. wpVersion or wcVersion).
+ * @param {string} version Version to compare.
  * @param {string} operator Comparison operator.
  */
 const compareVersionSettingIgnorePrerelease = (
-	version,
 	setting,
+	version,
 	operator
 ) => {
 	let replacement = getSetting( setting, '' ).replace(
@@ -39,42 +39,41 @@ const compareVersionSettingIgnorePrerelease = (
 	replacement = replacement.endsWith( '.' )
 		? replacement.substring( 0, replacement.length - 1 )
 		: replacement;
-	return compareVersions.compare( version, replacement, operator );
+	return compareVersions.compare( replacement, version, operator );
 };
 
 /**
- * Compare the provided `version` param with the current WP version using the
+ * Compare the current WP version with the provided `version` param using the
  * `operator`.
  *
- * For example `compareWithWpVersion( '5.6', '<=' )` returns true if `5.6` is
- * smaller or equal than the site WP version.
+ * For example `isWpVersion( '5.6', '<=' )` returns true if the site WP version
+ * is smaller or equal than `5.6` .
  *
  * @param {string} version Version to use to compare against the current wpVersion.
- * @param {string} operator Operator to use in the comparison.
+ * @param {string} [operator='='] Operator to use in the comparison.
  */
-
-export const compareWithWpVersion = ( version, operator ) => {
+export const isWpVersion = ( version, operator = '=' ) => {
 	return compareVersionSettingIgnorePrerelease(
-		version,
 		'wpVersion',
+		version,
 		operator
 	);
 };
 
 /**
- * Compare the provided `version` param with the current WC version using the
+ * Compare the current WC version with the provided `version` param using the
  * `operator`.
  *
- * For example `compareWithWooVersion( '4.9.0', '<=' )` returns true if `4.9` is
- * smaller or equal than the site WC version.
+ * For example `isWcVersion( '4.9.0', '<=' )` returns true if the site WC version
+ * is smaller or equal than `4.9`.
  *
  * @param {string} version Version to use to compare against the current wcVersion.
- * @param {string} operator Operator to use in the comparison.
+ * @param {string} [operator='='] Operator to use in the comparison.
  */
-export const compareWithWooVersion = ( version, operator ) => {
+export const isWcVersion = ( version, operator = '=' ) => {
 	return compareVersionSettingIgnorePrerelease(
-		version,
 		'wcVersion',
+		version,
 		operator
 	);
 };

--- a/assets/js/settings/shared/test/compare-with-wp-version.js
+++ b/assets/js/settings/shared/test/compare-with-wp-version.js
@@ -1,19 +1,19 @@
 /**
  * Internal dependencies
  */
-import { compareWithWpVersion, setSetting } from '..';
+import { isWpVersion, setSetting } from '..';
 
-describe( 'compareWithWpVersion', () => {
+describe( 'isWpVersion', () => {
 	let initial = true;
 	it.each`
 		version               | operator | result
-		${ '5.3-beta1' }      | ${ '>' } | ${ true }
+		${ '5.3-beta1' }      | ${ '<' } | ${ true }
 		${ '5.3' }            | ${ '=' } | ${ true }
-		${ '5.3-beta12-235' } | ${ '>' } | ${ true }
-		${ '5.3-rc1' }        | ${ '<' } | ${ false }
-		${ '5.3-rc12-235' }   | ${ '>' } | ${ true }
-		${ '5.3.1' }          | ${ '<' } | ${ true }
-		${ '5.4-beta1' }      | ${ '<' } | ${ true }
+		${ '5.3-beta12-235' } | ${ '<' } | ${ true }
+		${ '5.3-rc1' }        | ${ '>' } | ${ false }
+		${ '5.3-rc12-235' }   | ${ '<' } | ${ true }
+		${ '5.3.1' }          | ${ '>' } | ${ true }
+		${ '5.4-beta1' }      | ${ '>' } | ${ true }
 	`(
 		'should return $result when $version is the current wpVersion ' +
 			'and `5.3` is the version compared using `$operator`',
@@ -25,7 +25,7 @@ describe( 'compareWithWpVersion', () => {
 				expect( console ).toHaveWarned();
 			}
 			initial = false;
-			expect( compareWithWpVersion( '5.3', operator ) ).toBe( result );
+			expect( isWpVersion( '5.3', operator ) ).toBe( result );
 		}
 	);
 } );


### PR DESCRIPTION
`compareWithWpVersion` and `compareWithWooVersion` are a bit confusing, so this PR renames them to `isWpVersion` and `isWcVersion` and adds a doc block to each function.