### PR TITLE
GitHub Stale Action: Tweak message for stale activity and bump close boundary

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,11 +12,11 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 90
-        days-before-close: 21
+        days-before-stale: 60
+        days-before-close: 20
         remove-stale-when-updated: true
         exempt-issue-labels: 'priority: critical,priority: high'
-        stale-issue-message: 'This issue has been marked as `stale` because it has not seen any activity within the past 90 days. Our team uses this tool to help surface issues for review. If you are the author of the issue there's no need to comment as it will be looked at. <br><br>######Internal: After 10 days with no activity this issue will be automatically be closed.'
-        stale-pr-message: 'This PR has been marked as `stale` because it has not seen any activity within the past 90 days. Our team uses this tool to help surface pull requests that have slipped through review. If deemed still relevant, the pr can be kept active by ensuring it's up to date with the main branch and removing the stale label - otherwise it will automatically be closed after 10 days.'
+        stale-issue-message: 'This issue has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface issues for review. If you are the author of the issue there's no need to comment as it will be looked at. <br><br>######Internal: After 10 days with no activity this issue will be automatically be closed.'
+        stale-pr-message: 'This PR has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface pull requests that have slipped through review. <br><br>######If deemed still relevant, the pr can be kept active by ensuring it's up to date with the main branch and removing the stale label - otherwise it will automatically be closed after 10 days.'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,11 +12,11 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 60
-        days-before-close: 10
+        days-before-stale: 90
+        days-before-close: 21
         remove-stale-when-updated: true
         exempt-issue-labels: 'priority: critical,priority: high'
-        stale-issue-message: 'This issue has been marked as `stale` because it has not seen any activity within the past 60 days. Remove the `stale` label or post a comment, otherwise it will be closed in 10 days.'
-        stale-pr-message: 'This PR has been marked as `stale` because it has not seen any activity within the past 60 days. Is it still relevant? Please remove the `stale` label or post a comment, otherwise it will be closed in 10 days.'
+        stale-issue-message: 'This issue has been marked as `stale` because it has not seen any activity within the past 90 days. Our team uses this tool to help surface issues for review. If you are the author of the issue there's no need to comment as it will be looked at. <br><br>######Internal: After 10 days with no activity this issue will be automatically be closed.'
+        stale-pr-message: 'This PR has been marked as `stale` because it has not seen any activity within the past 90 days. Our team uses this tool to help surface pull requests that have slipped through review. If deemed still relevant, the pr can be kept active by ensuring it's up to date with the main branch and removing the stale label - otherwise it will automatically be closed after 10 days.'
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'


### PR DESCRIPTION
The new stale label action workflow works great but I think it could use a couple tweaks:

- I've temporarily bumped the close trigger threshold to 20 days from 10. This gives some extra allowance for the lack of triaging that will happen over the holidays. I intentionally left the messaging around when things are closed because it will be bumped back to 10 after the holidays.
- I noticed that some non team authors of issues are alarmed with the automation and add a spurious comment just to keep their issue open (which means the stale label gets removed and it likely won't surface in the triaging). So I've tweaked the wording of the messages a bit to hopefully help reduce the unnecessary commenting so that there's time for it to get through triage.