### PR TITLE
Remove customer saved payment methods from context if they are not enabled.

### DIFF
--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -121,11 +121,6 @@ const SavedPaymentMethodOptions = ( { onChange } ) => {
 			.flatMap( ( type ) => {
 				const typeMethods = customerPaymentMethods[ type ];
 				return typeMethods.map( ( paymentMethod ) => {
-					const method =
-						standardMethods[ paymentMethod.method.gateway ];
-					if ( ! method?.supports?.savePaymentInfo ) {
-						return null;
-					}
 					const option =
 						type === 'cc' || type === 'echeck'
 							? getCcOrEcheckPaymentMethodOption(

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -94,7 +94,7 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 	const enabledCustomerPaymentMethods = {};
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(
-			( { method : { gateway } } ) => {
+			( { method: { gateway } } ) => {
 				const isAvailable = gateway in availablePaymentMethods;
 				return isAvailable && availablePaymentMethods[ gateway ].supports?.savePaymentInfo;
 			}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -81,11 +81,11 @@ export const usePaymentMethodDataContext = () => {
  * Gets the payment methods saved for the current user after filtering out
  * disabled ones.
  *
- * @param {Object[]} availablePaymentMethods List of available payment methods.
+ * @param {Object} availablePaymentMethods List of available payment methods.
  * @return {Object} Object containing the payment methods saved for a specific
  *                  user which are available.
  */
-const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
+const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 	const customerPaymentMethods = getSetting( 'customerPaymentMethods', {} );
 	const paymentMethodKeys = Object.keys( customerPaymentMethods );
 	if ( paymentMethodKeys.length === 0 ) {
@@ -94,18 +94,9 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 	const enabledCustomerPaymentMethods = {};
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(
-			( paymentMethod ) => {
-				const { gateway } = paymentMethod.method;
-				const isGatewayAvailable = Object.keys(
-					availablePaymentMethods
-				).includes( gateway );
-				if ( ! isGatewayAvailable ) {
-					return false;
-				}
-				const supportsSavedPayments =
-					availablePaymentMethods[ gateway ].supports
-						?.savePaymentInfo;
-				return supportsSavedPayments;
+			( { method : { gateway } } ) => {
+				const isAvailable = gateway in availablePaymentMethods;
+				return isAvailable && availablePaymentMethods[ gateway ].supports?.savePaymentInfo;
 			}
 		);
 		if ( methods.length ) {
@@ -190,7 +181,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		}
 		if (
 			! paymentMethodsInitialized ||
-			paymentData.paymentMethods.length === 0
+			Object.keys( paymentData.paymentMethods ).length === 0
 		) {
 			return {};
 		}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -81,11 +81,11 @@ export const usePaymentMethodDataContext = () => {
  * Gets the payment methods saved for the current user after filtering out
  * disabled ones.
  *
- * @param {Object} availablePaymentMethods List of available payment methods.
+ * @param {Object[]} availablePaymentMethods List of available payment methods.
  * @return {Object} Object containing the payment methods saved for a specific
  *                  user which are available.
  */
-const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
+const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 	const customerPaymentMethods = getSetting( 'customerPaymentMethods', {} );
 	const paymentMethodKeys = Object.keys( customerPaymentMethods );
 	if ( paymentMethodKeys.length === 0 ) {
@@ -95,8 +95,10 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(
 			( { method: { gateway } } ) => {
-				const isAvailable = gateway in availablePaymentMethods;
-				return isAvailable && availablePaymentMethods[ gateway ].supports?.savePaymentInfo;
+				const isAvailable =
+					gateway in availablePaymentMethods;
+				return isAvailable &&
+					availablePaymentMethods[ gateway ].supports?.savePaymentInfo;
 			}
 		);
 		if ( methods.length ) {
@@ -181,7 +183,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		}
 		if (
 			! paymentMethodsInitialized ||
-			Object.keys( paymentData.paymentMethods ).length === 0
+			paymentData.paymentMethods.length === 0
 		) {
 			return {};
 		}

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -95,9 +95,13 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(
 			( paymentMethod ) => {
-				return Object.keys( availablePaymentMethods ).includes(
-					paymentMethod.method.gateway
-				);
+				const { gateway } = paymentMethod.method;
+				const gatewayAvailable = Object.keys( availablePaymentMethods ).includes( gateway );
+				if ( ! gatewayAvailable ) {
+					return false;
+				}
+				const supportsSavedPayments = availablePaymentMethods[gateway].supports?.savePaymentInfo;
+				return supportsSavedPayments;
 			}
 		);
 		if ( methods.length ) {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -96,10 +96,10 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 		const methods = customerPaymentMethods[ type ].filter(
 			( paymentMethod ) => {
 				const { gateway } = paymentMethod.method;
-				const gatewayAvailable = Object.keys(
+				const isGatewayAvailable = Object.keys(
 					availablePaymentMethods
 				).includes( gateway );
-				if ( ! gatewayAvailable ) {
+				if ( ! isGatewayAvailable ) {
 					return false;
 				}
 				const supportsSavedPayments =

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -95,10 +95,11 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(
 			( { method: { gateway } } ) => {
-				const isAvailable =
-					gateway in availablePaymentMethods;
-				return isAvailable &&
-					availablePaymentMethods[ gateway ].supports?.savePaymentInfo;
+				const isAvailable = gateway in availablePaymentMethods;
+				return (
+					isAvailable &&
+					availablePaymentMethods[ gateway ].supports?.savePaymentInfo
+				);
 			}
 		);
 		if ( methods.length ) {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -96,11 +96,15 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
 		const methods = customerPaymentMethods[ type ].filter(
 			( paymentMethod ) => {
 				const { gateway } = paymentMethod.method;
-				const gatewayAvailable = Object.keys( availablePaymentMethods ).includes( gateway );
+				const gatewayAvailable = Object.keys(
+					availablePaymentMethods
+				).includes( gateway );
 				if ( ! gatewayAvailable ) {
 					return false;
 				}
-				const supportsSavedPayments = availablePaymentMethods[gateway].supports?.savePaymentInfo;
+				const supportsSavedPayments =
+					availablePaymentMethods[ gateway ].supports
+						?.savePaymentInfo;
 				return supportsSavedPayments;
 			}
 		);


### PR DESCRIPTION
### Info

If a user has a saved payment method for a gateway but the option to use saved payment methods is disabled the context still includes the saved methods. This can happen if the merchant has disabled that option after it was initially available. Currently, it is up to the consumer of the context to do the check. IMO this should be the task of the context. This PR adds the check if saved payment methods are allowed to the `paymentMethodDataContext`. This way no saved methods are propagated unless their gateway is enabled and it has the usage of saved payment methods options enabled.

This PR also removes the check that is no longer necessary after the context change.

### Testing
This is related to https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3439. That PR relies heavily on the idea of saved payment methods for the UI configuration. Different views are presented depending if the saved methods are present or not.

For this PR a valid test would be to check if the saved payment methods in checkout still work as they did.
Saved not saved, disabled, and enabled in different configurations.


