### PR TITLE
Fix product list images skewed in Widgets editor

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -21,6 +21,7 @@
 	}
 
 	img {
+		height: auto;
 		width: 100%;
 
 		&[hidden] {


### PR DESCRIPTION
Product list styles were relying on themes having something like `img { height: auto; }` so aspect ratio was preserved when there was not enough horizontal space.

While I couldn't find any theme which doesn't have `img { height: auto; }`, in the Widgets editor that ruleset is not available. That causes the product grid blocks to look skewed.

### How to test the changes in this Pull Request:

1. Install Gutenberg `master` and go to Apperance > Widgets.
2. Add a Top Rated Products block into one of the widget areas and verify images have the correct aspect ratio.

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/102205241-3695c400-3ecb-11eb-8f7b-59c988dfcbf7.png) | ![imatge](https://user-images.githubusercontent.com/3616980/102205399-7066ca80-3ecb-11eb-9626-51587dfe29ab.png) |