### PR TITLE
Fix select inputs when dark mode is enabled in Twenty Twenty-One

### DIFF
--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -118,3 +118,18 @@
 		display: none;
 	}
 }
+
+// This class is set on the body by Twenty Twenty-One when dark mode is active.
+.is-dark-theme {
+	// If the theme is in dark mode, as well as the block, then this selector will match.
+	.has-dark-controls {
+		.components-custom-select-control__item {
+			color: $input-text-dark;
+		}
+	}
+
+	// If the theme is in dark mode, but the block isn't, then this selector will match.
+	.components-custom-select-control__item {
+		color: $input-text-active;
+	}
+}

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -119,17 +119,18 @@
 	}
 }
 
-// This class is set on the body by Twenty Twenty-One when dark mode is active.
-.is-dark-theme {
-	// If the theme is in dark mode, as well as the block, then this selector will match.
-	.has-dark-controls {
-		.components-custom-select-control__item {
-			color: $input-text-dark;
+.theme-twentytwentyone {
+	&.is-dark-theme {
+		// If the theme is in dark mode, as well as the block, then this selector will match.
+		.has-dark-controls {
+			.components-custom-select-control__item {
+				color: $input-text-dark;
+			}
 		}
-	}
 
-	// If the theme is in dark mode, but the block isn't, then this selector will match.
-	.components-custom-select-control__item {
-		color: $input-text-active;
+		// If the theme is in dark mode, but the block isn't, then this selector will match.
+		.components-custom-select-control__item {
+			color: $input-text-active;
+		}
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
### Description

This PR adds a new rule to` assets/js/base/components/select/style.scss` for when the class `is-dark-theme` exists (it is put on the body by Twenty Twenty-One theme).

This PR is required because without it, when the theme is set to dark mode (irrespective of the browser/OS dark mode preference) the text in the select is barely visible. 

<!-- Reference any related issues or PRs here -->
Fixes #3518 

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
#### Before
![imatge](https://user-images.githubusercontent.com/3616980/101373657-7f3af500-38ad-11eb-8efa-9447964c7dd7.png)

#### After when block has dark mode inputs enabled
<img width="307" alt="Screenshot 2020-12-15 at 18 37 09" src="https://user-images.githubusercontent.com/5656702/102257264-6dd49700-3f04-11eb-9c1e-40be5d774e4f.png">

#### After when block doesn't have dark mode inputs enabled.
<img width="307" alt="Screenshot 2020-12-15 at 18 37 09" src="https://user-images.githubusercontent.com/5656702/102257369-8e045600-3f04-11eb-8354-0338606459eb.png">


### How to test the changes in this Pull Request:

1. Install and activate Twenty Twenty One.
2. Go to Customize > Colors & Dark mode and check the Dark mode support checkbox.
3. `npm run build`.
5. Add a checkout block to a page, ensure items are in your basket.
6. Visit the page, enable dark mode (bottom right of screen), and open the country dropdown.
7. Ensure text is readable.
8. Change checkout block settings to enable dark mode inputs.
9. Check again and ensure the colour of the text has changed to white on black and that it is is still readable.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fixed text visibility in select inputs when using Twenty Twenty-One theme's dark mode.
