### PR TITLE
add fallback screen reader styles

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -52,6 +52,7 @@ $fontSizes: (
 
 // Hide an element from sighted users, but available to screen reader users.
 @mixin visually-hidden() {
+	border: 0;
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
 	height: 1px;
@@ -61,6 +62,29 @@ $fontSizes: (
 	/* Many screen reader and browser combinations announce broken words as they would appear visually. */
 	overflow-wrap: normal !important;
 	word-wrap: normal !important;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+}
+
+@mixin visually-hidden-focus-reveal() {
+	background-color: #fff;
+	border-radius: 3px;
+	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+	clip: auto !important;
+	clip-path: none;
+	color: $input-text-active;
+	display: block;
+	font-size: 0.875rem;
+	font-weight: 700;
+	height: auto;
+	left: 5px;
+	line-height: normal;
+	padding: 15px 23px 14px;
+	text-decoration: none;
+	top: 5px;
+	width: auto;
+	z-index: 100000;
 }
 
 @mixin reset-box() {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -303,3 +303,38 @@
 		}
 	}
 }
+
+// Default screen-reader styles. Included as a fallback for themes that don't have support.
+// These styles are based on the styles included in _underscores theme.
+// https://underscores.me
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important;
+}
+.screen-reader-text:focus {
+	background-color: #fff;
+	border-radius: 3px;
+	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+	clip: auto !important;
+	clip-path: none;
+	color: $input-text-active;
+	display: block;
+	font-size: 0.875rem;
+	font-weight: 700;
+	height: auto;
+	left: 5px;
+	line-height: normal;
+	padding: 15px 23px 14px;
+	text-decoration: none;
+	top: 5px;
+	width: auto;
+	z-index: 100000;
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -305,36 +305,9 @@
 }
 
 // Default screen-reader styles. Included as a fallback for themes that don't have support.
-// These styles are based on the styles included in _underscores theme.
-// https://underscores.me
 .screen-reader-text {
-	border: 0;
-	clip: rect(1px, 1px, 1px, 1px);
-	clip-path: inset(50%);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute !important;
-	width: 1px;
-	word-wrap: normal !important;
+	@include visually-hidden();
 }
 .screen-reader-text:focus {
-	background-color: #fff;
-	border-radius: 3px;
-	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
-	clip: auto !important;
-	clip-path: none;
-	color: $input-text-active;
-	display: block;
-	font-size: 0.875rem;
-	font-weight: 700;
-	height: auto;
-	left: 5px;
-	line-height: normal;
-	padding: 15px 23px 14px;
-	text-decoration: none;
-	top: 5px;
-	width: auto;
-	z-index: 100000;
+	@include visually-hidden-focus-reveal();
 }


### PR DESCRIPTION
Fixes #3265 

This PR adds styling for screen-reader text elements. Usually this is handled by the theme. However if the theme doesn't have support the screen reader text may be rendered inline (which is not intended); these fallback styles ensure screen reader text is hidden by default, and provides `:focus` styles for when the text has focus and is being read.

The specifics of the styles are pasted direct from underscores, with some colours changed. Feedback welcome on how to generalise these so they are a minimal, safe fallback (i.e. should not be opinionated).

#### Accessibility

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

I've tested with Safari VoiceOver but I couldn't focus the element in normal use. Keen for some testing of this with various browsers/platforms and screen reader tech :)

### Screenshots

Focused in chrome and safari:

<img width="519" alt="Chrome" src="https://user-images.githubusercontent.com/4167300/102292375-e477a000-3fa9-11eb-9f68-08928b1a39c0.png">

<img width="445" alt="Safari" src="https://user-images.githubusercontent.com/4167300/102292382-e6d9fa00-3fa9-11eb-81fd-e207535b9499.png">

Notes: 

- I faked `:focus` using browser dev tools.
- When unfocused, screen reader text should not be visible.

For comparison, here's a screenshot of the issue:

<img width="275" alt="Screen Shot 2020-12-16 at 2 27 46 PM" src="https://user-images.githubusercontent.com/4167300/102292889-e9891f00-3faa-11eb-93b1-52b506248965.png">

### How to test the changes in this Pull Request:
1. Install a theme that doesn't provide screen reader styles. I built a new `Bad Theme` using [Underscores](https://underscores.me) and deleted the screen reader styles.
2. Add checkout block to a page and stuff to cart.
3. View checkout on front end - confirm `.screen-reader-text` is hidden by default and is helpful when using a screen reader.
4. Test with other themes to ensure these styles don't conflict or cause issues.

### Changelog

> Fix: Added fallback styling for screen reader text.
