### PR TITLE
use consistent product name `WooCommerce Blocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This is the feature plugin for WooCommerce + Gutenberg. This plugin serves as a 
 
 Use this plugin if you want access to the bleeding edge of available blocks for WooCommerce. However, stable blocks are bundled into WooCommerce, and can be added from the "WooCommerce" section in the block inserter.
 
+- [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
+- [User documentation](https://docs.woocommerce.com/document/woocommerce-blocks/)
+
 ## Table of Contents <!-- omit in toc -->
 
 - [Documentation](#documentation)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WooCommerce Product Blocks <!-- omit in toc -->
+# WooCommerce Blocks <!-- omit in toc -->
 
 [![Latest Tag](https://img.shields.io/github/tag/woocommerce/woocommerce-gutenberg-products-block.svg?style=flat&label=Latest%20Tag)](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases)
 [![Travis](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block.svg?branch=trunk)](https://travis-ci.com/woocommerce/woocommerce-gutenberg-products-block)
@@ -69,6 +69,6 @@ Other useful docs to explore:
 -   [`apiFetch`](https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-api-fetch/)
 -   [`@wordpress/editor`](https://github.com/WordPress/gutenberg/blob/master/packages/editor/README.md)
 
-## Vision for the Feature
+## Long-term vision
 
-Users should be able to insert a variety of products from their store (specific products, products in a category, with assorted layouts and visual styles, etc.) into their post content using a simple and powerful visual editor.
+WooCommerce Blocks are the easiest, most flexible way to build your store user interface and showcase your products.

--- a/readme.txt
+++ b/readme.txt
@@ -55,7 +55,7 @@ Visit the [WooCommerce server requirements documentation](https://docs.woocommer
 
 Automatic installation is the easiest option as WordPress handles the file transfers itself and you don’t need to leave your web browser. To do an automatic install of this plugin, log in to your WordPress dashboard, navigate to the Plugins menu and click Add New.
 
-In the search field type “WooCommerce Gutenberg Products Block” and click Search Plugins. Once you’ve found this plugin you can view details about it such as the point release, rating and description. Most importantly of course, you can install it by simply clicking “Install Now”.
+In the search field type “WooCommerce Blocks” and click Search Plugins. Once you’ve found this plugin you can view details about it such as the point release, rating and description. Most importantly of course, you can install it by simply clicking “Install Now”.
 
 = Manual installation =
 
@@ -67,7 +67,7 @@ WooCommerce comes with some sample data you can use to populate the products and
 
 = Where can I report bugs or contribute to the project? =
 
-Bugs should be reported in the [WooCommerce Gutenberg Products Block GitHub repository](https://github.com/woocommerce/woocommerce-gutenberg-products-block/).
+Bugs should be reported in the [WooCommerce Blocks GitHub repository](https://github.com/woocommerce/woocommerce-gutenberg-products-block/).
 
 = This is awesome! Can I contribute? =
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -48,7 +48,7 @@ function wc_dir() {
  * Install WC Blocks
  */
 function wc_blocks_install() {
-	echo esc_html( 'Loading WooCommerce Gutenberg Products Block plugin' . PHP_EOL );
+	echo esc_html( 'Loading WooCommerce Blocks plugin' . PHP_EOL );
 	require dirname( __DIR__ ) . '/woocommerce-gutenberg-products-block.php';
 }
 


### PR DESCRIPTION
Fixes #3066

This PR refreshes various references to `WooCommerce Gutenberg Products Block` (product name in older iterations) to the correct product name `WooCommerce Blocks`. 

Also refreshes the vision sentence in the readme - cc @garymurray - let's get this right, I've done an initial draft. We might consider using this for the org tagline too.

<img width="590" alt="Screen Shot 2020-12-18 at 9 56 36 AM" src="https://user-images.githubusercontent.com/4167300/102542886-53263c00-4117-11eb-9199-7612ff9addef.png">

Note there are still some things we could tidy up in WCCOM and docs, to really make the messaging consistent around why this plugin exists and when to use it (and the fact that most of the blocks are in core). 

Also I haven't changed any slugs. We could consider changing the WCCOM url slug and the github repo slug, I suggest doing these individually as follow up (with care!).

### How to test the changes in this Pull Request:

1. Review the docs changes.


