### PR TITLE
respect merchant setting for Stripe CC `title`

### DIFF
--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -36,11 +36,11 @@ const StripeComponent = ( props ) => {
 const StripeLabel = ( props ) => {
 	const { PaymentMethodLabel } = props.components;
 
-	return (
-		<PaymentMethodLabel
-			text={ __( 'Credit / Debit Card', 'woo-gutenberg-products-block' ) }
-		/>
-	);
+	const labelText = getStripeServerData().title
+		? getStripeServerData().title
+		: __( 'Credit / Debit Card', 'woo-gutenberg-products-block' );
+
+	return <PaymentMethodLabel text={ labelText } />;
 };
 
 const cardIcons = getStripeCreditCardIcons();

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -84,6 +84,7 @@ final class Stripe extends AbstractPaymentMethodType {
 			'stripeTotalLabel'    => $this->get_total_label(),
 			'publicKey'           => $this->get_publishable_key(),
 			'allowPrepaidCard'    => $this->get_allow_prepaid_card(),
+			'title'               => $this->get_title(),
 			'button'              => [
 				'type'   => $this->get_button_type(),
 				'theme'  => $this->get_button_theme(),
@@ -138,6 +139,15 @@ final class Stripe extends AbstractPaymentMethodType {
 	 */
 	private function get_allow_prepaid_card() {
 		return apply_filters( 'wc_stripe_allow_prepaid_card', true );
+	}
+
+	/**
+	 * Returns the title string to use in the UI (customisable via admin settings screen).
+	 *
+	 * @return string Title / label string
+	 */
+	private function get_title() {
+		return isset( $this->settings['title'] ) ? $this->settings['title'] : __( 'Credit / Debit Card', 'woo-gutenberg-products-block' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2919 

This PR exposes the `title` setting to the client and uses it for the tab label. This respects the customisation option already available in legacy checkout (and other payment methods in blocks too).

### Screenshots
Here I've gone with `Stripes Timez`…

<img width="644" alt="Screen Shot 2020-12-18 at 12 55 14 PM" src="https://user-images.githubusercontent.com/4167300/102557536-482bd580-4130-11eb-9b90-937efd227d75.png">

### How to test the changes in this Pull Request:
1. Set up Stripe CC and checkout block.
2. View front end, add stuff to cart, view checkout.
3. Stripe should work correctly.
4. Customise title in `WooCommerce > Settings > Payments > Stripe` and save.
5. View checkout again, should use custom title in checkout block. In general should work similar to shortcode checkout.

### Changelog

> Fix: Checkout Block – Support customised `title` setting for Stripe Credit Card payment method.
