### PR TITLE
Add 'hidden' class name when using the 'hidden' attribute

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/shared/quantity-input.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/shared/quantity-input.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Quantity Input Component.
  *
  * @param {Object}         props          Incoming props for component
@@ -11,7 +16,10 @@
 const QuantityInput = ( { disabled, min, max, value, onChange } ) => {
 	return (
 		<input
-			className="wc-block-components-product-add-to-cart-quantity"
+			className={ classnames(
+				'wc-block-components-product-add-to-cart-quantity',
+				{ hidden: max === 1 }
+			) }
 			type="number"
 			value={ value }
 			min={ min }

--- a/assets/js/base/components/panel/index.js
+++ b/assets/js/base/components/panel/index.js
@@ -42,7 +42,9 @@ const Panel = ( {
 				</button>
 			</TitleTag>
 			<div
-				className="wc-blocks-components-panel__content"
+				className={ classNames( 'wc-blocks-components-panel__content', {
+					hidden: ! isOpen,
+				} ) }
 				hidden={ ! isOpen }
 			>
 				{ children }


### PR DESCRIPTION
Some themes might add custom styles which override the browser styles for the `hidden` attribute. For example, the Artisan theme has a `div { display: block; }` rule, that made the `hidden` elements to be displayed anyway. This PR adds the `hidden` class to those elements in order to fix it.

Some more context in p9h1Lv-1KE-p2#comment-6046.

### How to test the changes in this Pull Request:

0. Install [Artisan](https://woocommerce.com/products/artisan/) theme.
2. Go to the Cart or Checkout blocks and verify you can expand/contract the Coupon Code panel.

_Before:_
![Peek 2020-12-18 12-20](https://user-images.githubusercontent.com/3616980/102610456-84116b80-412d-11eb-8ee1-58de094147ca.gif)

_After:_
![Peek 2020-12-18 12-35](https://user-images.githubusercontent.com/3616980/102610463-85db2f00-412d-11eb-8bc5-b9777c84cc71.gif)

3. Edit a product and in the Inventory tab check the option so it can only be sold individually.
4. Create a post or page with the Add to cart atomic block.
5. In the frontend, visit that page and verify there is no number input.

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/102610793-13b71a00-412e-11eb-8f7d-6b688ebb880b.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/102610886-3d704100-412e-11eb-8faa-3dfbe4c075bd.png)

### Changelog

> Fixed Coupon Code panel not expanding/contracting in some themes.