### PR TITLE
add sourceMap: true option in various style related webpack loaders

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -464,11 +464,23 @@ const getStylingConfig = ( options = {} ) => {
 					test: /\/node_modules\/.*?style\.s?css$/,
 					use: [
 						MiniCssExtractPlugin.loader,
-						{ loader: 'css-loader', options: { importLoaders: 1 } },
-						'postcss-loader',
+						{
+							loader: 'css-loader',
+							options: {
+								importLoaders: 1,
+								sourceMap: true,
+							},
+						},
+						{
+							loader: 'postcss-loader',
+							options: {
+								sourceMap: true,
+							},
+						},
 						{
 							loader: 'sass-loader',
-							query: {
+							options: {
+								sourceMap: true,
 								includePaths: [ 'node_modules' ],
 								data: [
 									'colors',
@@ -492,11 +504,23 @@ const getStylingConfig = ( options = {} ) => {
 					exclude: /node_modules/,
 					use: [
 						MiniCssExtractPlugin.loader,
-						{ loader: 'css-loader', options: { importLoaders: 1 } },
-						'postcss-loader',
+						{
+							loader: 'css-loader',
+							options: {
+								importLoaders: 1,
+								sourceMap: true,
+							},
+						},
+						{
+							loader: 'postcss-loader',
+							options: {
+								sourceMap: true,
+							},
+						},
 						{
 							loader: 'sass-loader',
-							query: {
+							options: {
+								sourceMap: true,
 								includePaths: [ 'assets/css/abstracts' ],
 								data: [
 									'_colors',


### PR DESCRIPTION
Related #2200 

This PR adds `sourceMap: true` config option to all our style-related webpack config. This goes some way to fixing our sourcemap problems; the previous sourcemaps were empty. 

However it's not a complete solution to #2200 - there's still an issue linking the generated css file to the source map. I don't know how to solve this, we could try not using `MiniCssExtractPlugin` in dev build maybe. Note I also tried adding `devtool: 'source-map'` to our webpack config, this didn't make any difference.

Raising this PR for review anyway, I think this is worth merging as it's a step forward 🤷 