### PR TITLE
Use em for coupon code button height

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -10,7 +10,7 @@
 	}
 
 	.wc-block-components-totals-coupon__button {
-		height: 48px;
+		height: em(48px);
 		flex-shrink: 0;
 		margin-left: $gap-smaller;
 		padding-left: $gap-large;


### PR DESCRIPTION
Part of #3228.

Small PR that changes the coupon code button height to use `em` instead of `px`.

### Screenshots

_Before:_

<img src="https://user-images.githubusercontent.com/3616980/102773451-8c65e280-4389-11eb-9f78-9a333d3499ab.png" alt="" width="252" />

_After:_

<img src="https://user-images.githubusercontent.com/3616980/102773485-9be52b80-4389-11eb-9d0d-17f055814f60.png" alt="" width="248" />


### How to test the changes in this Pull Request:

1. Set your browser font size to something smaller than 16px.
2. Open the Cart block and expand the Coupon Code panel.
3. Verify the button has the same height as the input text on the left.

### Changelog

> Fix coupon code button height not adapting to the font size.
