### PR TITLE
Fix data type used for paymentData.paymentMethods handling.

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -88,9 +88,6 @@ export const usePaymentMethodDataContext = () => {
 const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 	const customerPaymentMethods = getSetting( 'customerPaymentMethods', {} );
 	const paymentMethodKeys = Object.keys( customerPaymentMethods );
-	if ( paymentMethodKeys.length === 0 ) {
-		return {};
-	}
 	const enabledCustomerPaymentMethods = {};
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -81,11 +81,11 @@ export const usePaymentMethodDataContext = () => {
  * Gets the payment methods saved for the current user after filtering out
  * disabled ones.
  *
- * @param {Object[]} availablePaymentMethods List of available payment methods.
+ * @param {Object} availablePaymentMethods List of available payment methods.
  * @return {Object} Object containing the payment methods saved for a specific
  *                  user which are available.
  */
-const getCustomerPaymentMethods = ( availablePaymentMethods = [] ) => {
+const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 	const customerPaymentMethods = getSetting( 'customerPaymentMethods', {} );
 	const paymentMethodKeys = Object.keys( customerPaymentMethods );
 	if ( paymentMethodKeys.length === 0 ) {
@@ -184,7 +184,7 @@ export const PaymentMethodDataProvider = ( { children } ) => {
 		}
 		if (
 			! paymentMethodsInitialized ||
-			paymentData.paymentMethods.length === 0
+			Object.keys( paymentData.paymentMethods ).length === 0
 		) {
 			return {};
 		}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adjusts the `paymentData.paymentMethods` assumed type in `getCustomerPaymentMethods` it is an `Object` not an `Array`. Besides the parameter and documentation the code was adjusted to reflect the correct type.

<!-- Reference any related issues or PRs here -->
Fixes #3574 

### How to test the changes in this Pull Request:

Check that saved payment methods still work. Two cases:
1. User has saved payment methods
2. User has no saved payment methods

In general, this error was not causing issues since there was a proper check later in the code ( now removed since it is no longer necessary ), but this could potentially cause issues in the future if used improperly.

Props to @mikejolley for the comment in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3551#discussion_r545888046 that led to this PR.

<!-- If you can, add the appropriate labels -->
