### PR TITLE
Fix isDefault on Buttons and switch Toolbar with ToolbarGroup

### DIFF
--- a/assets/js/atomic/blocks/product-elements/shared/with-product-selector.js
+++ b/assets/js/atomic/blocks/product-elements/shared/with-product-selector.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import ProductControl from '@woocommerce/editor-components/product-control';
-import { Placeholder, Button, Toolbar } from '@wordpress/components';
+import { Placeholder, Button, ToolbarGroup } from '@wordpress/components';
 import { BlockControls } from '@wordpress/block-editor';
 import TextToolbarButton from '@woocommerce/editor-components/text-toolbar-button';
 import { useProductDataContext } from '@woocommerce/shared-context';
@@ -68,7 +68,7 @@ const withProductSelector = ( selectorArgs ) => ( OriginalComponent ) => {
 				) : (
 					<>
 						<BlockControls>
-							<Toolbar>
+							<ToolbarGroup>
 								<TextToolbarButton
 									onClick={ () => setIsEditing( true ) }
 								>
@@ -77,7 +77,7 @@ const withProductSelector = ( selectorArgs ) => ( OriginalComponent ) => {
 										'woo-gutenberg-products-block'
 									) }
 								</TextToolbarButton>
-							</Toolbar>
+							</ToolbarGroup>
 						</BlockControls>
 						<OriginalComponent { ...props } />
 					</>

--- a/assets/js/atomic/blocks/product-elements/shared/with-product-selector.js
+++ b/assets/js/atomic/blocks/product-elements/shared/with-product-selector.js
@@ -55,7 +55,7 @@ const withProductSelector = ( selectorArgs ) => ( OriginalComponent ) => {
 								} }
 							/>
 							<Button
-								isDefault
+								isSecondary
 								disabled={ ! productId }
 								onClick={ () => {
 									setIsEditing( false );

--- a/assets/js/base/components/payment-methods/no-payment-methods/index.js
+++ b/assets/js/base/components/payment-methods/no-payment-methods/index.js
@@ -43,7 +43,7 @@ const NoPaymentMethodsPlaceholder = () => {
 				) }
 			</span>
 			<Button
-				isDefault
+				isSecondary
 				href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=checkout` }
 				target="_blank"
 				rel="noopener noreferrer"

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -10,7 +10,7 @@ import {
 	PanelBody,
 	ToggleControl,
 	Button,
-	Toolbar,
+	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { Icon, server, external } from '@woocommerce/icons';
@@ -48,7 +48,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 	const getBlockControls = () => {
 		return (
 			<BlockControls>
-				<Toolbar
+				<ToolbarGroup
 					controls={ [
 						{
 							icon: 'edit',

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -238,7 +238,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			</p>
 			<Button
 				className="wc-block-attribute-filter__add-attribute-button"
-				isDefault
+				isSecondary
 				href={ getAdminLink(
 					'edit.php?post_type=product&page=product_attributes'
 				) }

--- a/assets/js/blocks/cart-checkout/checkout/form/no-shipping-placeholder/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/no-shipping-placeholder/index.js
@@ -25,7 +25,7 @@ const NoShippingPlaceholder = () => {
 				) }
 			</span>
 			<Button
-				isDefault
+				isSecondary
 				href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=shipping` }
 				target="_blank"
 				rel="noopener noreferrer"

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -22,7 +22,7 @@ import {
 	ResizableBox,
 	Spinner,
 	ToggleControl,
-	Toolbar,
+	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
 import classnames from 'classnames';
@@ -93,7 +93,7 @@ const FeaturedCategory = ( {
 					} }
 				/>
 				<MediaUploadCheck>
-					<Toolbar>
+					<ToolbarGroup>
 						<MediaUpload
 							onSelect={ ( media ) => {
 								setAttributes( {
@@ -113,7 +113,7 @@ const FeaturedCategory = ( {
 								/>
 							) }
 						/>
-					</Toolbar>
+					</ToolbarGroup>
 				</MediaUploadCheck>
 			</BlockControls>
 		);

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -23,7 +23,7 @@ import {
 	ResizableBox,
 	Spinner,
 	ToggleControl,
-	Toolbar,
+	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
 import classnames from 'classnames';
@@ -146,7 +146,7 @@ const FeaturedProduct = ( {
 					} }
 				/>
 				<MediaUploadCheck>
-					<Toolbar>
+					<ToolbarGroup>
 						<MediaUpload
 							onSelect={ ( media ) => {
 								setAttributes( {
@@ -166,9 +166,9 @@ const FeaturedProduct = ( {
 								/>
 							) }
 						/>
-					</Toolbar>
+					</ToolbarGroup>
 				</MediaUploadCheck>
-				<Toolbar
+				<ToolbarGroup
 					controls={ [
 						{
 							icon: 'edit',

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -10,7 +10,7 @@ import {
 	PanelBody,
 	Placeholder,
 	RangeControl,
-	Toolbar,
+	ToolbarGroup,
 	withSpokenMessages,
 	ToggleControl,
 } from '@wordpress/components';
@@ -164,7 +164,7 @@ class ProductsBlock extends Component {
 		return (
 			<>
 				<BlockControls>
-					<Toolbar
+					<ToolbarGroup
 						controls={ [
 							{
 								icon: 'edit',

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -133,7 +133,7 @@ export default function ( { attributes, setAttributes } ) {
 			</p>
 			<Button
 				className="wc-block-price-slider__add-product-button"
-				isDefault
+				isSecondary
 				href={ getAdminLink( 'post-new.php?post_type=product' ) }
 			>
 				{ __( 'Add new product', 'woo-gutenberg-products-block' ) +

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -9,7 +9,7 @@ import {
 	Disabled,
 	PanelBody,
 	Placeholder,
-	Toolbar,
+	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
@@ -281,7 +281,7 @@ class ProductByCategoryBlock extends Component {
 		return (
 			<>
 				<BlockControls>
-					<Toolbar
+					<ToolbarGroup
 						controls={ [
 							{
 								icon: 'edit',

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -9,7 +9,7 @@ import {
 	Disabled,
 	PanelBody,
 	Placeholder,
-	Toolbar,
+	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
@@ -263,7 +263,7 @@ class ProductsByTagBlock extends Component {
 		return HAS_TAGS ? (
 			<>
 				<BlockControls>
-					<Toolbar
+					<ToolbarGroup
 						controls={ [
 							{
 								icon: 'edit',

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -9,7 +9,7 @@ import {
 	Disabled,
 	PanelBody,
 	Placeholder,
-	Toolbar,
+	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
 import { Component } from '@wordpress/element';
@@ -164,7 +164,7 @@ class ProductsByAttributeBlock extends Component {
 		return (
 			<>
 				<BlockControls>
-					<Toolbar
+					<ToolbarGroup
 						controls={ [
 							{
 								icon: 'edit',

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -14,7 +14,7 @@ import {
 	withSpokenMessages,
 	Placeholder,
 	Button,
-	Toolbar,
+	ToolbarGroup,
 	Disabled,
 	Tip,
 } from '@wordpress/components';
@@ -139,7 +139,7 @@ class Editor extends Component {
 
 		return (
 			<BlockControls>
-				<Toolbar
+				<ToolbarGroup
 					controls={ [
 						{
 							icon: 'edit',

--- a/assets/js/blocks/products/utils.js
+++ b/assets/js/blocks/products/utils.js
@@ -33,7 +33,7 @@ export const renderNoProductsPlaceholder = ( blockTitle, blockIcon ) => (
 		</p>
 		<Button
 			className="wc-block-products__add-product-button"
-			isDefault
+			isSecondary
 			href={ ADMIN_URL + 'post-new.php?post_type=product' }
 		>
 			{ __( 'Add new product', 'woo-gutenberg-products-block' ) + ' ' }

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -6,7 +6,7 @@ import { createInterpolateElement } from 'wordpress-element';
 import {
 	Notice,
 	ToggleControl,
-	Toolbar,
+	ToolbarGroup,
 	RangeControl,
 	SelectControl,
 } from '@wordpress/components';
@@ -20,7 +20,7 @@ import ToggleButtonControl from '@woocommerce/editor-components/toggle-button-co
 
 export const getBlockControls = ( editMode, setAttributes ) => (
 	<BlockControls>
-		<Toolbar
+		<ToolbarGroup
 			controls={ [
 				{
 					icon: 'edit',

--- a/assets/js/blocks/single-product/edit/editor-block-controls.js
+++ b/assets/js/blocks/single-product/edit/editor-block-controls.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls } from '@wordpress/block-editor';
-import { Toolbar } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 
 /**
  * Adds controls to the editor toolbar.
@@ -15,7 +15,7 @@ import { Toolbar } from '@wordpress/components';
 const EditorBlockControls = ( { isEditing, setIsEditing } ) => {
 	return (
 		<BlockControls>
-			<Toolbar
+			<ToolbarGroup
 				controls={ [
 					{
 						icon: 'edit',

--- a/assets/js/blocks/single-product/edit/index.js
+++ b/assets/js/blocks/single-product/edit/index.js
@@ -85,7 +85,7 @@ const Editor = ( {
 								setAttributes={ setAttributes }
 							/>
 							<Button
-								isDefault
+								isSecondary
 								onClick={ () => {
 									setIsEditing( false );
 								} }

--- a/assets/js/editor-components/error-placeholder/index.js
+++ b/assets/js/editor-components/error-placeholder/index.js
@@ -28,7 +28,7 @@ const ErrorPlaceholder = ( { className, error, isLoading, onRetry } ) => (
 				{ isLoading ? (
 					<Spinner />
 				) : (
-					<Button isDefault onClick={ onRetry }>
+					<Button isSecondary onClick={ onRetry }>
 						{ __( 'Retry', 'woo-gutenberg-products-block' ) }
 					</Button>
 				) }

--- a/assets/js/editor-components/heading-toolbar/index.js
+++ b/assets/js/editor-components/heading-toolbar/index.js
@@ -4,7 +4,7 @@
 import { range } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { Toolbar } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -38,7 +38,7 @@ class HeadingToolbar extends Component {
 		} = this.props;
 
 		return (
-			<Toolbar
+			<ToolbarGroup
 				isCollapsed={ isCollapsed }
 				icon={ <HeadingLevelIcon level={ selectedLevel } /> }
 				controls={ range( minLevel, maxLevel ).map( ( index ) =>

--- a/assets/js/editor-components/toggle-button-control/index.js
+++ b/assets/js/editor-components/toggle-button-control/index.js
@@ -68,7 +68,7 @@ class ToggleButtonControl extends Component {
 							buttonArgs.isPrimary = true;
 							buttonArgs[ 'aria-pressed' ] = true;
 						} else {
-							buttonArgs.isDefault = true;
+							buttonArgs.isSecondary = true;
 							buttonArgs[ 'aria-pressed' ] = false;
 						}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes all `isDefault` and `Toolbar` warnings, I did a regex global replace for Toolbar and manually searched and replaced isDefault, it touches a lot of files but everything should be caught by our E2E.
<!-- Reference any related issues or PRs here -->
Fixes #3487
Fixes #3485
Fixes #3481
Fixes #3479
Fixes #3475
Fixes #3510
Fixes #3438


### How to test the changes in this Pull Request:
Smoke test the following blocks
- any atomic block settings.
- attributes filter
- featured category
- featured product
- handpicked products
- product category
- product tag
- products by attribute
- all products
- all reviews
- single product

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix console warnings in WordPress 5.6
