### PR TITLE
Fix direct call to setAttribute in EditProductSearch body

### DIFF
--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { InspectorControls, PlainText } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -39,11 +40,13 @@ const Edit = ( {
 		className
 	);
 
-	if ( ! formId ) {
-		setAttributes( {
-			formId: `wc-block-product-search-${ instanceId }`,
-		} );
-	}
+	useEffect( () => {
+		if ( ! formId ) {
+			setAttributes( {
+				formId: `wc-block-product-search-${ instanceId }`,
+			} );
+		}
+	}, [ formId, setAttributes, instanceId ] );
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Product Search called `setAttribute` directly on body, while this might work, it would cause other issues down the road and emits a console error.
All state changes should be called in an event callback or inside useEffect.

<!-- Reference any related issues or PRs here -->
Fixes #3486

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


### How to test the changes in this Pull Request:

1. Insert Product Search
2. You would not see any issues


### Changelog

> Fix bug inside Product Search in the editor.
