### PR TITLE
Don't add the hidden class name to elements with the hidden attribute

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/shared/quantity-input.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/shared/quantity-input.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * Quantity Input Component.
  *
  * @param {Object}         props          Incoming props for component
@@ -16,10 +11,7 @@ import classnames from 'classnames';
 const QuantityInput = ( { disabled, min, max, value, onChange } ) => {
 	return (
 		<input
-			className={ classnames(
-				'wc-block-components-product-add-to-cart-quantity',
-				{ hidden: max === 1 }
-			) }
+			className="wc-block-components-product-add-to-cart-quantity"
 			type="number"
 			value={ value }
 			min={ min }

--- a/assets/js/base/components/panel/index.js
+++ b/assets/js/base/components/panel/index.js
@@ -42,9 +42,7 @@ const Panel = ( {
 				</button>
 			</TitleTag>
 			<div
-				className={ classNames( 'wc-blocks-components-panel__content', {
-					hidden: ! isOpen,
-				} ) }
+				className="wc-blocks-components-panel__content"
 				hidden={ ! isOpen }
 			>
 				{ children }

--- a/assets/js/base/components/panel/style.scss
+++ b/assets/js/base/components/panel/style.scss
@@ -41,6 +41,12 @@
 .wc-blocks-components-panel__content {
 	padding-bottom: em($gap);
 	overflow: auto;
+
+	// Ensures the panel contents are not visible for any theme that tweaked the
+	// `display` property of div elements.
+	&[hidden] {
+		display: none;
+	}
 }
 
 .theme-twentytwenty .wc-blocks-components-panel__button,

--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -59,6 +59,10 @@ WooCommerce Blocks uses HTML elements according to their semantic meaning, not t
 
 In these cases, Blocks include some CSS resets to undo most default styles introduced by themes. A `<button>` that is displayed as a text link will probably have resets for the background, border, etc. That will solve most conflicts out-of-the-box but in some occasions those CSS resets might not have effect if the theme has a specific CSS selector with higher specificity. When that happens, we really encourage theme developers to decrease their selectors specificity so Blocks styles have preference, if that's not possible, themes can write CSS resets on top.
 
+### Hidden elements
+
+WC Blocks use the [`hidden` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) in order to hide some elements from the UI so they are not displayed in screens neither read by assistive technologies. If your theme has some generic styles that tweak the CSS display property of a specific tag (ie: `div { display: block; }`). Make sure you account for the hidden case: `div[hidden] { display: none; }`.
+
 ### Legacy classes from WooCommerce (.price, .star-rating, .button...)
 
 WooCommerce Blocks avoids using legacy unprefixed classes as much as possible. However, you might find some of them that have been added for backwards compatibility. We still encourage themes to use the prefixed classes when possible, this avoids conflicts with other plugins, the editor, etc.

--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -61,7 +61,7 @@ In these cases, Blocks include some CSS resets to undo most default styles intro
 
 ### Hidden elements
 
-WC Blocks use the [`hidden` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) in order to hide some elements from the UI so they are not displayed in screens neither read by assistive technologies. If your theme has some generic styles that tweak the CSS display property of a specific tag (ie: `div { display: block; }`). Make sure you account for the hidden case: `div[hidden] { display: none; }`.
+WC Blocks use the [`hidden` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden) to hide some elements from the UI so they are not displayed in screens neither read by assistive technologies. If your theme has some generic styles that tweak the CSS display property of blocks elements (ie: `div { display: block; }`), make sure you correctly handle the hidden attribute: `div[hidden] { display: none; }`.
 
 ### Legacy classes from WooCommerce (.price, .star-rating, .button...)
 


### PR DESCRIPTION
Follow-up of #3569 given @haszari's feedback.

This PR:
* 333c871ac294dfae72b7e5a11949692e15a4925e: reverts the changes from #3569, which were adding a `hidden` class to elements with the `[hidden]` attribute.
* eeb5674dd8b24c416fb1c92596662aaee1c4b83d: adds a `.wc-blocks-components-panel__content[hidden] { display: none; }` rule in order to keep the fix introduced in #3569. In future occasions, we might not need to do that, but I think it doesn't harm us and it's ok to add this extra protection for a component that is shared across blocks like the Panel.
* 54d2037cad51d683d9a45b69d832d827e8c7aac9: adds some docs to the theming section so themes are aware about the `hidden` HTML attribute.

### How to test the changes in this Pull Request:

Verify there are no regressions in these steps from #3569:

> 0. Install [Artisan](https://woocommerce.com/products/artisan/) theme.
> 1. Go to the Cart or Checkout blocks and verify you can expand/contract the Coupon Code panel.

I intentionally didn't add the hidden styles to the Add to Cart element block so we can re-evaluate what solution we apply in that case before it's released.
