### PR TITLE
Migrate WordPress PHP unit (integration) tests to GitHub actions (and remove travis)

### DIFF
--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          coverage: none
+          tools: composer, cs2pr
+
       - name: Install devtools for nodegit (dep) build 🤨
         run: |
           sudo apt-get update

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -5,19 +5,19 @@ on:
 
 jobs:
   PHP_Tests:
-    name: 'PHP WP Tests'
+    name: PHP WP Tests
     runs-on: ubuntu-latest
 
-  steps:
-    - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-    - name: 'Install Node.js'
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
 
-    - name: 'Build WooCommerce Blocks'
-      run: |
-        npm ci
-        composer install
-        npm run build
+      - name: Build WooCommerce Blocks
+        run: |
+          npm ci
+          composer install
+          npm run build

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -7,12 +7,15 @@ jobs:
   PHP_Tests:
     name: 'PHP WP Tests'
     runs-on: ubuntu-latest
+
   steps:
     - uses: actions/checkout@v2
+
     - name: 'Install Node.js'
       uses: actions/setup-node@v1
       with:
         node-version: 14.x
+
     - name: 'Build WooCommerce Blocks'
       run: |
         npm ci

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           php-version: 7.4
           coverage: none
-          tools: composer, cs2pr
+          tools: composer
 
       - name: Install devtools for nodegit (dep) build 🤨
         run: |

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -1,0 +1,20 @@
+name: PHP WordPress Integration (Unit) Tests
+
+on:
+  pull_request:
+
+jobs:
+  PHP_Tests:
+    name: 'PHP WP Tests'
+    runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v2
+    - name: 'Install Node.js'
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - name: 'Build WooCommerce Blocks'
+      run: |
+        npm ci
+        composer install
+        npm run build

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           node-version: 14.x
 
+      - name: Install devtools for nodegit (dep) build 🤨
+        run: |
+          sudo apt-get update
+          sudo apt-get --assume-yes install libkrb5-dev
 
       - name: Build WooCommerce Blocks
         run: |

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -11,19 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
@@ -32,6 +19,4 @@ jobs:
 
       - name: Build WooCommerce Blocks
         run: |
-          npm ci
-          # composer install
-          # npm run build
+          npm install

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -1,11 +1,11 @@
-name: PHP WordPress Integration (Unit) Tests
+name: PHP Tests
 
 on:
   pull_request:
 
 jobs:
   PHP_Tests:
-    name: PHP WP Tests
+    name: PHP Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -19,4 +19,4 @@ jobs:
 
       - name: Build WooCommerce Blocks
         run: |
-          npm install
+          npm install --verbose

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -11,13 +11,27 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
 
+
       - name: Build WooCommerce Blocks
         run: |
-          npm install
-          composer install
-          npm run build
+          npm ci
+          # composer install
+          # npm run build

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -23,4 +23,11 @@ jobs:
 
       - name: Build WooCommerce Blocks
         run: |
-          npm install --verbose
+          npm install
+          composer install
+          npm run build
+
+      - name: Run PHP tests
+        run: |
+          npm run phpunit
+

--- a/.github/workflows/php-wp-unit-tests.yml
+++ b/.github/workflows/php-wp-unit-tests.yml
@@ -18,6 +18,6 @@ jobs:
 
       - name: Build WooCommerce Blocks
         run: |
-          npm ci
+          npm install
           composer install
           npm run build

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"package-plugin:dev": "rimraf woocommerce-gutenberg-products-block.zip && ./bin/build-plugin-zip.sh -d",
 		"package-plugin:zip-only": "rimraf woocommerce-gutenberg-products-block.zip && ./bin/build-plugin-zip.sh -z",
 		"package-plugin:deploy": "npm run build:deploy && npm run package-plugin:zip-only",
-		"phpunit": "docker-compose up -d db && docker-compose up -d --build wordpress-unit-tests && docker exec -it --workdir /var/www/html/wp-content/plugins/woocommerce-gutenberg-products-block wordpress_test php ./vendor/bin/phpunit",
+		"phpunit": "docker-compose up -d db && docker-compose up -d --build wordpress-unit-tests && docker exec --workdir /var/www/html/wp-content/plugins/woocommerce-gutenberg-products-block wordpress_test php ./vendor/bin/phpunit",
 		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"release": "sh ./bin/wordpress-deploy.sh",
 		"start": "rimraf build/* && cross-env BABEL_ENV=default webpack --watch --info-verbosity none",

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -85,7 +85,7 @@ class CreateAccount extends WP_UnitTestCase {
 		$test_user = $this->factory()->user->get_object_by_id( $result['user_id'] );
 		$test_order = $result['order'];
 
-		$this->assertEquals( get_current_user_id(), $result['user_id'] );
+		$this->assertEquals( get_current_user_id(), $result['user_id']+1 );
 
 		$this->assertEquals( $test_user->first_name, $first_name );
 		$this->assertEquals( $test_user->last_name, $last_name );

--- a/tests/php/Domain/Services/CreateAccount.php
+++ b/tests/php/Domain/Services/CreateAccount.php
@@ -85,7 +85,7 @@ class CreateAccount extends WP_UnitTestCase {
 		$test_user = $this->factory()->user->get_object_by_id( $result['user_id'] );
 		$test_order = $result['order'];
 
-		$this->assertEquals( get_current_user_id(), $result['user_id']+1 );
+		$this->assertEquals( get_current_user_id(), $result['user_id'] );
 
 		$this->assertEquals( $test_user->first_name, $first_name );
 		$this->assertEquals( $test_user->last_name, $last_name );


### PR DESCRIPTION
_In progress_

Related #3542

This PR implements a GitHub action workflow for running our PHP tests. The goal is to run our PHP tests on all commits to PRs as a check.

There's a bit more to do before merge:

- Implement PHP tests for different versions of PHP. We had this in Travis, so we should replicate same conditions (or revisit if this is out of date). 
- Review and implement other conditions - specifically `WP_VERSION`, `WOOCOMMERCE_BLOCKS_PHASE`, not sure what `PHP_UNIT` is doing.
- Remove the Travis config (i.e. migrate from Travis to GitHub Actions).

And some other things to consider:

- Should we share / cache state to speed these up? 
- Can we share state with other actions?
- What platform do we want to run on - debian, ubuntu, macOS etc?
- Is the workaround installing build deps for `nodegit` providing value, or could we address that more elegantly?

### How to test the changes in this Pull Request:
1. Scroll down to view the checks for this PR, see the new one: **`PHP Tests`**.
2. Push some code to this branch that breaks a PHP test 😈 
3. See the test fail 💇‍♂️ 
4. (Revert your changes.)
