### PR TITLE
sync shipping with billing when shipping is disabled

### DIFF
--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -113,7 +113,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 			const billingAddress = decodeAddress( cartData.billingAddress );
 			const shippingAddress = cartData.needsShipping
 				? decodeAddress( cartData.shippingAddress )
-				: defaultShippingAddress;
+				: billingAddress;
 			return {
 				cartCoupons: cartData.coupons,
 				cartItems: cartData.items || [],

--- a/assets/js/base/hooks/checkout/use-checkout-address.js
+++ b/assets/js/base/hooks/checkout/use-checkout-address.js
@@ -60,6 +60,20 @@ export const useCheckoutAddress = () => {
 		[ shippingAsBilling, setShippingAddress, setBillingData ]
 	);
 
+	/**
+	 * Sets billing address data, and also shipping if shipping is disabled.
+	 */
+	const setBillingFields = useCallback(
+		( value ) => {
+			setBillingData( value );
+
+			if ( ! needsShipping ) {
+				setShippingAddress( value );
+			}
+		},
+		[ needsShipping, setShippingAddress, setBillingData ]
+	);
+
 	// When the "Use same address" checkbox is toggled we need to update the current billing address to reflect this;
 	// that is either setting the billing address to the shipping address, or restoring the billing address to it's
 	// previous state.
@@ -79,8 +93,14 @@ export const useCheckoutAddress = () => {
 		}
 	}, [ shippingAsBilling, setBillingData, shippingAddress, billingData ] );
 
-	const setEmail = ( value ) => void setBillingData( { email: value } );
-	const setPhone = ( value ) => void setBillingData( { phone: value } );
+	const setEmail = ( value ) =>
+		void setBillingData( {
+			email: value,
+		} );
+	const setPhone = ( value ) =>
+		void setBillingData( {
+			phone: value,
+		} );
 
 	// Note that currentShippingAsBilling is returned rather than the current state of shippingAsBilling--this is so that
 	// the billing fields are not rendered before sync (billing field values are debounced and would be outdated)
@@ -89,7 +109,7 @@ export const useCheckoutAddress = () => {
 		shippingFields: shippingAddress,
 		setShippingFields,
 		billingFields: billingData,
-		setBillingFields: setBillingData,
+		setBillingFields,
 		setEmail,
 		setPhone,
 		shippingAsBilling,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR syncs shipping with billing when shipping is disabled.
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3592


### How to test the changes in this Pull Request:

1. Disable Shipping and try to checkout.
2. You should not see a validation issue.
3. Your shipping address should be the same as the billing address on the backend.
4. After you already did a successful checkout, try doing another one with shipping disabled.
5. You should see no error, the order should have your billing address as a shipping address.
