### PR TITLE
Get the latest stable version of WooCommerce for PHPUnit testing

### DIFF
--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -150,7 +150,7 @@ install_db() {
 
 install_woocommerce() {
 	# get built plugin from .org
-	download https://downloads.wordpress.org/plugin/woocommerce.zip "$TMPDIR/woocommerce.zip"
+	download https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip "$TMPDIR/woocommerce.zip"
 	unzip -q $TMPDIR/woocommerce.zip -d "$WP_CORE_DIR/wp-content/plugins"
 
 	# Script Variables


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The current docker container that runs the PHP Unit tests gets the latest release of WooCommerce from wordpress.org - as of today (2020-12-23), the URL https://downloads.wordpress.org/plugin/woocommerce.zip downloads version `4.9.0-beta.1` - this is causing our PHP Unit tests to fail.

This PR will pull the `latest-stable` version of WooCommerce from .org to run our unit tests against.

### How to test the changes in this Pull Request:

1. Clean your docker containers and images so that any ones relating to the PHP Unit tests for WooCommerce Blocks are gone. If you don't mind re-downloading all images again you may use `docker image prune -a`
2. Run `composer install` and `npm run phpunit`
3. Verify unit tests are passing
4. (Optional) make a code change so that a PHP unit test will fail and re-run `npm run phpunit`
5. Verify unit tests fail.
