### PR TITLE
Fix nonce issues when adding product to cart from All Products

### DIFF
--- a/assets/js/data/shared-controls.js
+++ b/assets/js/data/shared-controls.js
@@ -55,6 +55,7 @@ export const controls = {
 						} );
 				} )
 				.catch( ( errorResponse ) => {
+					triggerFetch.setNonce( errorResponse.headers );
 					if ( typeof errorResponse.json === 'function' ) {
 						// Parse error response before rejecting it.
 						errorResponse

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
-class CartCoupons extends AbstractRoute {
+class CartCoupons extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/StoreApi/Routes/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/CartCouponsByCode.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
-class CartCouponsByCode extends AbstractRoute {
+class CartCouponsByCode extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
-class CartItemsByKey extends AbstractRoute {
+class CartItemsByKey extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\ProductQuery;
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
-class Products extends AbstractRoute {
+class Products extends AbstractCartRoute {
 	/**
 	 * Get the path of this REST route.
 	 *

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\ProductQuery;
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
-class Products extends AbstractCartRoute {
+class Products extends AbstractRoute {
 	/**
 	 * Get the path of this REST route.
 	 *
@@ -44,6 +44,8 @@ class Products extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
+		// we load so that we have the same session, this is done so that Add to Cart can function.
+		$this->maybe_load_cart();
 		$response      = new \WP_REST_Response();
 		$product_query = new ProductQuery();
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

products endpoint had a different session than cart and checkout, this caused it to return a different nonce from them, causing the Add to cart functionality in all products to not work, ever.
This PR does two things:
- It fixes the different nonce issue by loading cart in Products route, it also extends `AbstractCartRoute` for other cart subroutes that we forget.
- It refreshes the nonce even if an add to cart fails.
<!-- Reference any related issues or PRs here -->
Fixes #3595

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

1. In a private window, go to All Products, try to add to cart, it should work
2. Do it several times with several products.
3. Paginate the block and try to add products again.
4. If you have filters set up, try using filters and then adding to cart.


