### PR TITLE
SearchListControl styles cleanup

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -48,8 +48,10 @@
 	}
 }
 
-// Adds border to placeholder lists, so they can be distinguished from the white background.
-.components-placeholder .woocommerce-search-list__list {
+// This border has been upstreamed to WooCommerce Admin, so it can be removed
+// from here once @woocommerce/components gets updated.
+// https://github.com/woocommerce/woocommerce-admin/pull/5809
+.woocommerce-search-list__list {
 	border: 1px solid $gray-200;
 }
 

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -50,7 +50,7 @@
 
 // This border has been upstreamed to WooCommerce Admin, so it can be removed
 // from here once @woocommerce/components gets updated.
-// https://github.com/woocommerce/woocommerce-admin/pull/5809
+// https://github.com/woocommerce/woocommerce-admin/pull/5901
 .woocommerce-search-list__list {
 	border: 1px solid $gray-200;
 }

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -54,12 +54,3 @@
 .woocommerce-search-list__list {
 	border: 1px solid $gray-200;
 }
-
-// Work-around to make the SearchList component work fine with the last versions of @wordpress/components.
-// Ideally it should be possible to remove this once this issue is fixed in WC Admin:
-// https://github.com/woocommerce/woocommerce-admin/issues/4349
-.components-placeholder .woocommerce-search-list__list .woocommerce-search-list__item {
-	border-radius: 0;
-	height: auto;
-	text-align: left;
-}


### PR DESCRIPTION
Small PR that removes a very old CSS selector which was no longer necessary and adds a comment to another selector which we will be able to remove when updating `@woocommerce/components`. Notice I didn't prefix it with `// @todo` because I included it in a meta issue about all the tasks we will need to do when updating `@woocommerce/components` (#3603).

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/103219728-d23d2080-491e-11eb-9bfb-70ab4eb372ba.png)

![imatge](https://user-images.githubusercontent.com/3616980/103221258-7aa0b400-4922-11eb-9e09-170c4bd68e9e.png)

Note there is an issue in the second screenshot: `Display products matching` should have top margin. It's not there because [this selector](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/0cffa3e2eca9fa757597a504085e352acb9e0ecf/assets/js/editor-components/product-attribute-term-control/style.scss#L13) is not working with recent WP versions, instead of fixing it downstream, I [upstreamed the fix](https://github.com/woocommerce/woocommerce-admin/pull/5901/files#r545244002), but until we update `@woocommerce/components`, it will not be fixed in WC Blocks. In parallel, we can't remove the broken selector yet, because it _does_ work in WP 5.4.

### How to test the changes in this Pull Request:

1. Add a Products by Attribute block in a page or post.
2. Select some attributes and verify there are no visual regressions.
3. Extra points if you test it in WP 5.4 + WC 4.3 (our oldest supported versions). :slightly_smiling_face: 