### PR TITLE
Convert saved payment methods token to a string

### DIFF
--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -47,7 +47,7 @@ const getCcOrEcheckPaymentMethodOption = (
 			setActivePaymentMethod( method.gateway );
 			setPaymentStatus().success( {
 				payment_method: method.gateway,
-				[ savedTokenKey ]: token,
+				[ savedTokenKey ]: token + '',
 				isSavedToken: true,
 			} );
 		},
@@ -81,7 +81,7 @@ const getDefaultPaymentMethodOptions = (
 			setActivePaymentMethod( method.gateway );
 			setPaymentStatus().success( {
 				payment_method: method.gateway,
-				[ savedTokenKey ]: token,
+				[ savedTokenKey ]: token + '',
 				isSavedToken: true,
 			} );
 		},

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -89,7 +89,7 @@ class Checkout extends AbstractRoute {
 										'type' => 'string',
 									],
 									'value' => [
-										'type' => [ 'string', 'boolean' ],
+										'type' => [ 'string', 'boolean', 'integer' ],
 									],
 								],
 							],

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -89,7 +89,7 @@ class Checkout extends AbstractRoute {
 										'type' => 'string',
 									],
 									'value' => [
-										'type' => [ 'string', 'boolean', 'integer' ],
+										'type' => [ 'string', 'boolean' ],
 									],
 								],
 							],


### PR DESCRIPTION
Fixes #3618.

Even though the issue has been there forever, it wasn't reproducible until validation was added to the Checkout route (#3552), so #3618 can be considered a regression from 4.0 → 4.1.

The issue is caused because when making a payment with a Stripe saved credit card, the value of `wc-stripe-payment-token` was set to an integer, but we are [only accepting strings and bools](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/StoreApi/Routes/Checkout.php#L92). This PR forces saved payment method tokens to be converted to strings.

![imatge](https://user-images.githubusercontent.com/3616980/103531720-37969180-4e8a-11eb-8688-7da1560f46bc.png)

### How to test the changes in this Pull Request:

I wasn't able to reproduce #3618 in a local install, but I could reproduce it in an ephemeral site.

1. Make sure you have WC Blocks >=4.1.0 installed and WooCommerce Stripe Payment Gateway enabled.
2. With a new user, go to My Account > Payment Methods and add a new payment method.
3. Add a product to your cart and go to the checkout page.
4. Fill the details but keep the payment method as the saved card you added in step 2.
5. Try to make the purchase and verify the error from #3618 doesn't appear anymore.

### Changelog

> Fix an error that was blocking checkout with some user saved payment methods.