### PR TITLE
Revert test badge name back to Automated Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![View](https://img.shields.io/badge/Project%20Components-brightgreen.svg?style=flat)](https://woocommerce.github.io/woocommerce-gutenberg-products-block)
 ![JavaScript and CSS Linting](https://github.com/woocommerce/woocommerce-gutenberg-products-block/workflows/JavaScript%20and%20CSS%20Linting/badge.svg?branch=trunk)
 ![PHP Coding Standards](https://github.com/woocommerce/woocommerce-gutenberg-products-block/workflows/PHP%20Coding%20Standards/badge.svg?branch=trunk)
-![PHP, JavaScript, and E2E tests](https://github.com/woocommerce/woocommerce-gutenberg-products-block/workflows/PHP,%20JavaScript,%20and%20E2E%20tests/badge.svg?branch=trunk)
+![Automated tests](https://github.com/woocommerce/woocommerce-gutenberg-products-block/workflows/Automated%20tests/badge.svg?branch=trunk)
 
 This is the feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks and updates to existing blocks for WooCommerce, and how WooCommerce might work with the block editor.
 


### PR DESCRIPTION
### Description
This fixes #3293 and an issue that was not noticed in #3585 - because we renamed the automated test workflow, the image path of the badge had to be updated too.

### Testing
To test this please view the README of this branch and check that the badge is showing correctly.