### PR TITLE
Try using new lines instead of html break tags for stale automation

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -16,7 +16,7 @@ jobs:
         days-before-close: 20
         remove-stale-when-updated: true
         exempt-issue-labels: 'priority: critical,priority: high'
-        stale-issue-message: "This issue has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface issues for review. If you are the author of the issue there's no need to comment as it will be looked at. <br><br>###### Internal: After 10 days with no activity this issue will be automatically be closed."
-        stale-pr-message: "This PR has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface pull requests that have slipped through review. <br><br>###### If deemed still relevant, the pr can be kept active by ensuring it's up to date with the main branch and removing the stale label - otherwise it will automatically be closed after 10 days."
+        stale-issue-message: "This issue has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface issues for review. If you are the author of the issue there's no need to comment as it will be looked at. \n\n###### Internal: After 10 days with no activity this issue will be automatically be closed."
+        stale-pr-message: "This PR has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface pull requests that have slipped through review. \n\n###### If deemed still relevant, the pr can be kept active by ensuring it's up to date with the main branch and removing the stale label - otherwise it will automatically be closed after 10 days."
         stale-issue-label: 'stale'
         stale-pr-label: 'stale'


### PR DESCRIPTION
The Stale automation messaging is still not parsing the markdown header for the comments it adds to issues and I think it's because of the usage of `<br>` which results in the markdown not being on it's own line for parsing. I'm not sure if new lines are parsed correctly by the engine but if they are, then this change should fix things.