### PR TITLE
Add puppeteer directly to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
 		"prettier": "npm:wp-prettier@2.0.5",
 		"progress-bar-webpack-plugin": "2.1.0",
 		"promptly": "3.2.0",
+		"puppeteer": "npm:puppeteer-core@3.0.0",
 		"react-test-renderer": "17.0.1",
 		"request-promise": "4.2.6",
 		"rimraf": "3.0.2",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2806

By adding the puppeteer core package directly we should avoid problems with Renovate that generates packages updates that are not passing tests - and because of that, they are not auto merged.