### PR TITLE
Get extended data before returning cart

### DIFF
--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -303,6 +303,9 @@ class CartSchema extends AbstractSchema {
 		// calculated so we can avoid returning costs and rates prematurely.
 		$has_calculated_shipping = $cart->show_shipping();
 
+		// Get the extended data before returning the cart - this is because the cart may be modified by extensions.
+		$extended_data = $this->get_extended_data( self::IDENTIFIER );
+
 		return [
 			'coupons'                 => array_values( array_map( [ $this->coupon_schema, 'get_item_response' ], array_filter( $cart->get_applied_coupons() ) ) ),
 			'shipping_rates'          => $has_calculated_shipping ? array_values( array_map( [ $this->shipping_rate_schema, 'get_item_response' ], $controller->get_shipping_packages() ) ) : [],
@@ -332,7 +335,7 @@ class CartSchema extends AbstractSchema {
 				]
 			),
 			'errors'                  => $cart_errors,
-			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
+			self::EXTENDING_KEY       => $extended_data,
 		];
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In this PR, I have moved the execution of `$this->get_extended_data( self::IDENTIFIER );` in `CartSchema` so that this happens _before_ the cart is returned.

Previously when this was executed inline, any changes made to the cart by extensions were not reflected. By doing it before the cart is returned, we can ensure we're working with the most up to date cart.

This is related to #3617 and _may_ close it.

### How to test the changes in this Pull Request:

1. Check out `woocommerce-subscriptions` branch `feature/checkout-block-simple-multiple-subscriptions` and this branch in blocks. Ensure subscriptions is active and set up on your test site.
2. Add a subscription product with a trial period, so that the cart value would be £0. Add this to your cart.
2. Optionally visit the shortcode checkout to verify the cart is set up correctly, and your payment method is still required in spite of the cart being £0.
3. Visit the blocks checkout and ensure payment methods are visible. Please note some non-subscriptions compatible payment methods will show. Choose one you know works with subs, for example Stripe.
4. Try checking out. It should work OK. You may also want to check your payment gateway to see if the Setup Intent (as it is called in Stripe) was set up correctly.

<!-- If you can, add the appropriate labels -->

### Changelog

> Ensure extensions can fully modify the cart before it is returned by the API.
