### PR TITLE
Subscriptions Shipping Packages Support

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/package.js
@@ -47,7 +47,11 @@ const Package = ( {
 								className="wc-block-components-shipping-rates-control__package-item"
 							>
 								<Label
-									label={ `${ name } ×${ quantity }` }
+									label={
+										quantity === 1
+											? name
+											: `${ name } ×${ quantity }`
+									}
 									screenReaderLabel={ sprintf(
 										// translators: %1$s name of the product (ie: Sunglasses), %2$d number of units in the current cart package
 										_n(

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/packages.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/packages.js
@@ -65,7 +65,10 @@ Packages.propTypes = {
 					quantity: PropTypes.number,
 				} )
 			).isRequired,
-			package_id: PropTypes.number,
+			package_id: PropTypes.oneOfType( [
+				PropTypes.string,
+				PropTypes.number,
+			] ),
 			name: PropTypes.string,
 			destination: PropTypes.object,
 			shipping_rates: PropTypes.arrayOf( PropTypes.object ),

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/style.scss
@@ -32,4 +32,13 @@
 	.wc-blocks-components-panel__content {
 		padding-bottom: 0;
 	}
+	.wc-block-components-radio-control__option-layout {
+		padding-bottom: 0;
+	}
+	.wc-block-components-radio-control__option:last-child {
+		margin-bottom: $gap-small;
+	}
+	.wc-block-components-radio-control__option::after {
+		border-bottom: 0;
+	}
 }

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -15,7 +15,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 	 * @return string
 	 */
 	public function get_path() {
-		return '/cart/select-shipping-rate/(?P<package_id>[\d]+)';
+		return '/cart/select-shipping-rate/(?P<package_id>[\w-]+)';
 	}
 
 	/**
@@ -32,7 +32,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 				'args'                => [
 					'package_id' => array(
 						'description' => __( 'The ID of the package being shipped.', 'woo-gutenberg-products-block' ),
-						'type'        => 'integer',
+						'type'        => 'string',
 						'required'    => true,
 					),
 					'rate_id'    => [
@@ -58,7 +58,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_shipping_disabled', __( 'Shipping is disabled.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
-		if ( ! isset( $request['package_id'] ) || ! is_numeric( $request['package_id'] ) ) {
+		if ( ! isset( $request['package_id'] ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_missing_package_id', __( 'Invalid Package ID.', 'woo-gutenberg-products-block' ), 400 );
 		}
 
@@ -66,7 +66,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 		$cart       = $controller->get_cart_instance();
 
 		if ( $cart->needs_shipping() ) {
-			$package_id = absint( $request['package_id'] );
+			$package_id = wc_clean( wp_unslash( $request['package_id'] ) );
 			$rate_id    = wc_clean( wp_unslash( $request['rate_id'] ) );
 
 			try {

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -198,23 +198,6 @@ abstract class AbstractSchema {
 	}
 
 	/**
-	 * Apply a schema get_item_response callback to an array of items and return the result.
-	 *
-	 * @param AbstractSchema $schema Schema class instance.
-	 * @param array          $items Array of items.
-	 * @return array Array of values from the callback function.
-	 */
-	protected function get_item_responses_from_schema( AbstractSchema $schema, $items ) {
-		$items = array_filter( $items );
-
-		if ( empty( $items ) ) {
-			return [];
-		}
-
-		return array_values( array_map( [ $schema, 'get_item_response' ], $items ) );
-	}
-
-	/**
 	 * Returns consistent currency schema used across endpoints for prices.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -198,6 +198,23 @@ abstract class AbstractSchema {
 	}
 
 	/**
+	 * Apply a schema get_item_response callback to an array of items and return the result.
+	 *
+	 * @param AbstractSchema $schema Schema class instance.
+	 * @param array          $items Array of items.
+	 * @return array Array of values from the callback function.
+	 */
+	protected function get_item_responses_from_schema( AbstractSchema $schema, $items ) {
+		$items = array_filter( $items );
+
+		if ( empty( $items ) ) {
+			return [];
+		}
+
+		return array_values( array_map( [ $schema, 'get_item_response' ], $items ) );
+	}
+
+	/**
 	 * Returns consistent currency schema used across endpoints for prices.
 	 *
 	 * @return array

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -271,6 +271,43 @@ class CartShippingRateSchema extends AbstractSchema {
 	}
 
 	/**
+	 * Gets and formats the destination address of a package.
+	 *
+	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @return object
+	 */
+	protected function prepare_package_destination_response( $package ) {
+		return (object) $this->prepare_html_response(
+			[
+				'address_1' => $package['destination']['address_1'],
+				'address_2' => $package['destination']['address_2'],
+				'city'      => $package['destination']['city'],
+				'state'     => $package['destination']['state'],
+				'postcode'  => $package['destination']['postcode'],
+				'country'   => $package['destination']['country'],
+			]
+		);
+	}
+
+	/**
+	 * Gets items from a package and creates an array of strings containing product names and quantities.
+	 *
+	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @return array
+	 */
+	protected function prepare_package_items_response( $package ) {
+		$items = array();
+		foreach ( $package['contents'] as $item_id => $values ) {
+			$items[] = [
+				'key'      => $item_id,
+				'name'     => $values['data']->get_name(),
+				'quantity' => $values['quantity'],
+			];
+		}
+		return $items;
+	}
+
+	/**
 	 * Prepare an array of rates from a package for the response.
 	 *
 	 * @param array $package Shipping package complete with rates from WooCommerce.

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -32,7 +32,7 @@ class CartShippingRateSchema extends AbstractSchema {
 		return [
 			'package_id'     => [
 				'description' => __( 'The ID of the package the shipping rates belong to.', 'woo-gutenberg-products-block' ),
-				'type'        => 'integer',
+				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
@@ -231,43 +231,6 @@ class CartShippingRateSchema extends AbstractSchema {
 			'items'          => $this->prepare_package_items_response( $package ),
 			'shipping_rates' => $this->prepare_package_shipping_rates_response( $package ),
 		];
-	}
-
-	/**
-	 * Gets and formats the destination address of a package.
-	 *
-	 * @param array $package Shipping package complete with rates from WooCommerce.
-	 * @return object
-	 */
-	protected function prepare_package_destination_response( $package ) {
-		return (object) $this->prepare_html_response(
-			[
-				'address_1' => $package['destination']['address_1'],
-				'address_2' => $package['destination']['address_2'],
-				'city'      => $package['destination']['city'],
-				'state'     => $package['destination']['state'],
-				'postcode'  => $package['destination']['postcode'],
-				'country'   => $package['destination']['country'],
-			]
-		);
-	}
-
-	/**
-	 * Gets items from a package and creates an array of strings containing product names and quantities.
-	 *
-	 * @param array $package Shipping package complete with rates from WooCommerce.
-	 * @return array
-	 */
-	protected function prepare_package_items_response( $package ) {
-		$items = array();
-		foreach ( $package['contents'] as $item_id => $values ) {
-			$items[] = [
-				'key'      => $item_id,
-				'name'     => $values['data']->get_name(),
-				'quantity' => $values['quantity'],
-			];
-		}
-		return $items;
 	}
 
 	/**

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -459,7 +459,6 @@ class CartController {
 	 * Get shipping packages from the cart with calculated shipping rates.
 	 *
 	 * @todo this can be refactored once https://github.com/woocommerce/woocommerce/pull/26101 lands.
-	 *
 	 * @param bool $calculate_rates Should rates for the packages also be returned.
 	 * @return array
 	 */
@@ -471,7 +470,7 @@ class CartController {
 			return [];
 		}
 
-		$packages = $cart->get_shipping_packages();
+		$packages = apply_filters( '__experimental_woocommerce_store_api_cart_shipping_packages', $cart->get_shipping_packages() );
 
 		// Add extra package data to array.
 		if ( count( $packages ) ) {
@@ -515,7 +514,7 @@ class CartController {
 	/**
 	 * Selects a shipping rate.
 	 *
-	 * @param int    $package_id ID of the package to choose a rate for.
+	 * @param string $package_id ID of the package to choose a rate for.
 	 * @param string $rate_id ID of the rate being chosen.
 	 */
 	public function select_shipping_rate( $package_id, $rate_id ) {

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -76,7 +76,7 @@ class Cart extends TestCase {
 		$this->assertArrayHasKey( '/wc/store/cart/apply-coupon', $routes );
 		$this->assertArrayHasKey( '/wc/store/cart/remove-coupon', $routes );
 		$this->assertArrayHasKey( '/wc/store/cart/update-customer', $routes );
-		$this->assertArrayHasKey( '/wc/store/cart/select-shipping-rate/(?P<package_id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wc/store/cart/select-shipping-rate/(?P<package_id>[\w-]+)', $routes );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds integration points and schema changes to support subscriptions recurring cart shipping methods implemented in https://github.com/woocommerce/woocommerce-subscriptions/pull/3949

There are 2 experimental filters in this PR:

1. `__experimental_woocommerce_store_api_cart_recalculate_totals` to force recalculation so subscriptions populates it's cart(s)
2. `__experimental_woocommerce_store_api_cart_shipping_packages` to allow subscriptions to populate the packages from it's recurring carts.

I am not 100% happy with how this is implemented but this is as far as I can get without changing approach. cc @senadir 

As discussed, the alternative to this would be to instead allow subscriptions to return these packages in it's own API data set, and then allow it to render the shipping options itself. There would be more work involved in this but it would avoid the need for `__experimental_woocommerce_store_api_cart_shipping_packages`.

This is not complete, but I am marking for review to gain feedback.

### Screenshots

![Screenshot 2021-01-12 at 16 16 26](https://user-images.githubusercontent.com/90977/104341348-9a72d300-54f1-11eb-8dbd-30b2e9d531e8.png)

