### PR TITLE
Support for multiple fee rows in the cart

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/fees/index.js
+++ b/assets/js/base/components/cart-checkout/totals/fees/index.js
@@ -6,36 +6,41 @@ import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 import PropTypes from 'prop-types';
 import { TotalsItem } from '@woocommerce/blocks-checkout';
 
-const TotalsFees = ( { currency, values } ) => {
-	const { total_fees: totalFees, total_fees_tax: totalFeesTax } = values;
-	const feesValue = parseInt( totalFees, 10 );
-
-	if ( ! feesValue ) {
-		return null;
-	}
-
-	const feesTaxValue = parseInt( totalFeesTax, 10 );
-
+const TotalsFees = ( { currency, cartFees } ) => {
 	return (
-		<TotalsItem
-			className="wc-block-components-totals-fees"
-			currency={ currency }
-			label={ __( 'Fees', 'woo-gutenberg-products-block' ) }
-			value={
-				DISPLAY_CART_PRICES_INCLUDING_TAX
-					? feesValue + feesTaxValue
-					: feesValue
-			}
-		/>
+		<>
+			{ cartFees.map( ( { id, name, totals } ) => {
+				const feesValue = parseInt( totals.total, 10 );
+
+				if ( ! feesValue ) {
+					return null;
+				}
+
+				const feesTaxValue = parseInt( totals.total_tax, 10 );
+
+				return (
+					<TotalsItem
+						key={ id }
+						className="wc-block-components-totals-fees"
+						currency={ currency }
+						label={
+							name || __( 'Fee', 'woo-gutenberg-products-block' )
+						}
+						value={
+							DISPLAY_CART_PRICES_INCLUDING_TAX
+								? feesValue + feesTaxValue
+								: feesValue
+						}
+					/>
+				);
+			} ) }
+		</>
 	);
 };
 
 TotalsFees.propTypes = {
 	currency: PropTypes.object.isRequired,
-	values: PropTypes.shape( {
-		total_fees: PropTypes.string,
-		total_fees_tax: PropTypes.string,
-	} ).isRequired,
+	cartFees: PropTypes.array.isRequired,
 };
 
 export default TotalsFees;

--- a/assets/js/base/components/cart-checkout/totals/fees/stories/index.js
+++ b/assets/js/base/components/cart-checkout/totals/fees/stories/index.js
@@ -17,16 +17,22 @@ export default {
 
 export const Default = () => {
 	const currency = currencyKnob();
-	const totalFees = text( 'Total fees', '1000' );
-	const totalFeesTax = text( 'Total fees tax', '200' );
+	const totalFees = text( 'Total fee', '1000' );
+	const totalFeesTax = text( 'Total fee tax', '200' );
 
 	return (
 		<TotalsFees
 			currency={ currency }
-			values={ {
-				total_fees: totalFees,
-				total_fees_tax: totalFeesTax,
-			} }
+			cartFees={ [
+				{
+					id: 'fee',
+					name: 'Fee',
+					totals: {
+						total: totalFees,
+						total_tax: totalFeesTax,
+					},
+				},
+			] }
 		/>
 	);
 };

--- a/assets/js/base/hooks/cart/test/use-store-cart.js
+++ b/assets/js/base/hooks/cart/test/use-store-cart.js
@@ -37,6 +37,7 @@ describe( 'useStoreCart', () => {
 		cartIsLoading: false,
 		cartItemErrors: [],
 		cartErrors: [],
+		cartFees: [],
 		billingAddress: {
 			first_name: '',
 			last_name: '',
@@ -98,6 +99,7 @@ describe( 'useStoreCart', () => {
 		cartTotals: mockCartTotals,
 		cartIsLoading: mockCartIsLoading,
 		cartErrors: mockCartErrors,
+		cartFees: [],
 		billingAddress: {},
 		shippingAddress: mockShippingAddress,
 		shippingRates: [],

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -37,6 +37,7 @@ const decodeAddress = ( address ) =>
 export const defaultCartData = {
 	cartCoupons: [],
 	cartItems: [],
+	cartFees: [],
 	cartItemsCount: 0,
 	cartItemsWeight: 0,
 	cartNeedsPayment: true,
@@ -80,6 +81,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 				return {
 					cartCoupons: previewCart.coupons,
 					cartItems: previewCart.items,
+					cartFees: previewCart.fees,
 					cartItemsCount: previewCart.items_count,
 					cartItemsWeight: previewCart.items_weight,
 					cartNeedsPayment: previewCart.needs_payment,
@@ -117,6 +119,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 			return {
 				cartCoupons: cartData.coupons,
 				cartItems: cartData.items || [],
+				cartFees: cartData.fees || [],
 				cartItemsCount: cartData.itemsCount,
 				cartItemsWeight: cartData.itemsWeight,
 				cartNeedsPayment: cartData.needsPayment,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -65,6 +65,7 @@ const Cart = ( { attributes } ) => {
 
 	const {
 		cartItems,
+		cartFees,
 		cartTotals,
 		cartIsLoading,
 		cartItemsCount,
@@ -114,7 +115,7 @@ const Cart = ( { attributes } ) => {
 					{ __( 'Cart totals', 'woo-gutenberg-products-block' ) }
 				</Title>
 				<Subtotal currency={ totalsCurrency } values={ cartTotals } />
-				<TotalsFees currency={ totalsCurrency } values={ cartTotals } />
+				<TotalsFees currency={ totalsCurrency } cartFees={ cartFees } />
 				<TotalsDiscount
 					cartCoupons={ appliedCoupons }
 					currency={ totalsCurrency }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -65,6 +65,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 		cartItems,
 		cartTotals,
 		cartCoupons,
+		cartFees,
 		cartNeedsPayment,
 	} = useStoreCart();
 	const {
@@ -157,6 +158,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 						cartCoupons={ cartCoupons }
 						cartItems={ cartItems }
 						cartTotals={ cartTotals }
+						cartFees={ cartFees }
 					/>
 				</Sidebar>
 			</SidebarLayout>

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -23,6 +23,7 @@ import { useStoreCartCoupons } from '@woocommerce/base-hooks';
 const CheckoutSidebar = ( {
 	cartCoupons = [],
 	cartItems = [],
+	cartFees = [],
 	cartTotals = {},
 } ) => {
 	const {
@@ -39,7 +40,7 @@ const CheckoutSidebar = ( {
 		<>
 			<OrderSummary cartItems={ cartItems } />
 			<Subtotal currency={ totalsCurrency } values={ cartTotals } />
-			<TotalsFees currency={ totalsCurrency } values={ cartTotals } />
+			<TotalsFees currency={ totalsCurrency } cartFees={ cartFees } />
 			<TotalsDiscount
 				cartCoupons={ cartCoupons }
 				currency={ totalsCurrency }

--- a/assets/js/previews/cart.js
+++ b/assets/js/previews/cart.js
@@ -156,6 +156,7 @@ export const previewCart = {
 			},
 		},
 	],
+	fees: [],
 	items_count: 3,
 	items_weight: 0,
 	needs_payment: true,

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -12,6 +12,8 @@
  *                                                      to the cart.
  * @property {Array}               cartItems            An array of items in the
  *                                                      cart.
+ * @property {Array}               cartFees             An array of fees in the
+ *                                                      cart.
  * @property {number}              cartItemsCount       The number of items in the
  *                                                      cart.
  * @property {number}              cartItemsWeight      The weight of all items in

--- a/packages/checkout/totals/item/style.scss
+++ b/packages/checkout/totals/item/style.scss
@@ -3,6 +3,10 @@
 	flex-wrap: wrap;
 	padding: em($gap-small) 0;
 	width: 100%;
+
+	&:not(:first-of-type):not(:last-of-type) {
+		@include with-translucent-border(1px 0 0);
+	}
 }
 
 .wc-block-components-totals-item__label {

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -25,6 +25,8 @@ use Automattic\WooCommerce\Blocks\StoreApi\Formatters;
 use Automattic\WooCommerce\Blocks\StoreApi\Formatters\MoneyFormatter;
 use Automattic\WooCommerce\Blocks\StoreApi\Formatters\HtmlFormatter;
 use Automattic\WooCommerce\Blocks\StoreApi\Formatters\CurrencyFormatter;
+use Automattic\WooCommerce\Blocks\StoreApi\RoutesController;
+use Automattic\WooCommerce\Blocks\StoreApi\SchemaController;
 
 /**
  * Takes care of bootstrapping the plugin.
@@ -176,7 +178,7 @@ class Bootstrap {
 		$this->container->register(
 			RestApi::class,
 			function ( Container $container ) {
-				return new RestApi( $container->get( ExtendRestApi::class ) );
+				return new RestApi( $container->get( RoutesController::class ) );
 			}
 		);
 		$this->container->register(
@@ -205,6 +207,18 @@ class Bootstrap {
 				$formatters->register( 'html', HtmlFormatter::class );
 				$formatters->register( 'currency', CurrencyFormatter::class );
 				return $formatters;
+			}
+		);
+		$this->container->register(
+			SchemaController::class,
+			function( Container $container ) {
+				return new SchemaController( $container->get( ExtendRestApi::class ) );
+			}
+		);
+		$this->container->register(
+			RoutesController::class,
+			function( Container $container ) {
+				return new RoutesController( $container->get( SchemaController::class ) );
 			}
 		);
 		$this->container->register(

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -14,19 +14,19 @@ use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
  */
 class RestApi {
 	/**
-	 * Stores Rest Extending instance
+	 * Stores Rest Routes instance
 	 *
-	 * @var ExtendRestApi
+	 * @var RoutesController
 	 */
-	private $extend;
+	private $routes;
 
 	/**
 	 * Constructor
 	 *
-	 * @param ExtendRestApi $extend Rest Extending instance.
+	 * @param RoutesController $routes Rest Routes instance.
 	 */
-	public function __construct( ExtendRestApi $extend ) {
-		$this->extend = $extend;
+	public function __construct( RoutesController $routes ) {
+		$this->routes = $routes;
 		$this->init();
 	}
 
@@ -43,9 +43,7 @@ class RestApi {
 	 * Register REST API routes.
 	 */
 	public function register_rest_routes() {
-		$schemas = new SchemaController( $this->extend );
-		$routes  = new RoutesController( $schemas );
-		$routes->register_routes();
+		$this->routes->register_routes();
 	}
 
 	/**

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -70,6 +70,7 @@ class SchemaController {
 					new Schemas\ImageAttachmentSchema( $this->extend )
 				),
 				new Schemas\CartCouponSchema( $this->extend ),
+				new Schemas\CartFeeSchema( $this->extend ),
 				new Schemas\CartShippingRateSchema( $this->extend ),
 				new Schemas\ShippingAddressSchema( $this->extend ),
 				new Schemas\BillingAddressSchema( $this->extend ),
@@ -80,6 +81,7 @@ class SchemaController {
 				$this->extend,
 				new Schemas\ImageAttachmentSchema( $this->extend )
 			),
+			Schemas\CartFeeSchema::IDENTIFIER          => new Schemas\CartFeeSchema( $this->extend ),
 			Schemas\CheckoutSchema::IDENTIFIER         => new Schemas\CheckoutSchema(
 				$this->extend,
 				new Schemas\BillingAddressSchema( $this->extend ),

--- a/src/StoreApi/Schemas/CartFeeSchema.php
+++ b/src/StoreApi/Schemas/CartFeeSchema.php
@@ -1,0 +1,89 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
+
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
+/**
+ * CartFeeSchema class.
+ *
+ * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
+ */
+class CartFeeSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'cart_fee';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'cart-fee';
+
+	/**
+	 * Cart schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'id'     => [
+				'description' => __( 'Unique identifier for the fee within the cart.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'name'   => [
+				'description' => __( 'Fee name.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'totals' => [
+				'description' => __( 'Fee total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => array_merge(
+					$this->get_store_currency_properties(),
+					[
+						'total'     => [
+							'description' => __( 'Total amount for this fee.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'total_tax' => [
+							'description' => __( 'Total tax amount for this fee.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					]
+				),
+			],
+		];
+	}
+
+	/**
+	 * Convert a WooCommerce cart fee to an object suitable for the response.
+	 *
+	 * @param array $fee Cart fee data.
+	 * @return array
+	 */
+	public function get_item_response( $fee ) {
+		return [
+			'key'    => $fee->id,
+			'name'   => $this->prepare_html_response( $fee->name ),
+			'totals' => (object) $this->prepare_currency_response(
+				[
+					'total'     => $this->prepare_money_response( $fee->total, wc_get_price_decimals() ),
+					'total_tax' => $this->prepare_money_response( $fee->tax, wc_get_price_decimals(), PHP_ROUND_HALF_DOWN ),
+				]
+			),
+		];
+	}
+}

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -41,6 +41,13 @@ class CartSchema extends AbstractSchema {
 	protected $coupon_schema;
 
 	/**
+	 * Fee schema instance.
+	 *
+	 * @var CartFeeSchema
+	 */
+	protected $fee_schema;
+
+	/**
 	 * Shipping rates schema instance.
 	 *
 	 * @var CartShippingRateSchema
@@ -74,6 +81,7 @@ class CartSchema extends AbstractSchema {
 	 * @param ExtendRestApi          $extend Rest Extending instance.
 	 * @param CartItemSchema         $item_schema Item schema instance.
 	 * @param CartCouponSchema       $coupon_schema Coupon schema instance.
+	 * @param CartFeeSchema          $fee_schema Fee schema instance.
 	 * @param CartShippingRateSchema $shipping_rate_schema Shipping rates schema instance.
 	 * @param ShippingAddressSchema  $shipping_address_schema Shipping address schema instance.
 	 * @param BillingAddressSchema   $billing_address_schema Billing address schema instance.
@@ -83,6 +91,7 @@ class CartSchema extends AbstractSchema {
 		ExtendRestApi $extend,
 		CartItemSchema $item_schema,
 		CartCouponSchema $coupon_schema,
+		CartFeeSchema $fee_schema,
 		CartShippingRateSchema $shipping_rate_schema,
 		ShippingAddressSchema $shipping_address_schema,
 		BillingAddressSchema $billing_address_schema,
@@ -90,6 +99,7 @@ class CartSchema extends AbstractSchema {
 	) {
 		$this->item_schema             = $item_schema;
 		$this->coupon_schema           = $coupon_schema;
+		$this->fee_schema              = $fee_schema;
 		$this->shipping_rate_schema    = $shipping_rate_schema;
 		$this->shipping_address_schema = $shipping_address_schema;
 		$this->billing_address_schema  = $billing_address_schema;
@@ -177,6 +187,16 @@ class CartSchema extends AbstractSchema {
 				'type'        => 'boolean',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
+			],
+			'fees'                    => [
+				'description' => __( 'List of cart fees.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->fee_schema->get_properties() ),
+				],
 			],
 			'totals'                  => [
 				'description' => __( 'Cart total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
@@ -317,6 +337,7 @@ class CartSchema extends AbstractSchema {
 			'needs_payment'           => $cart->needs_payment(),
 			'needs_shipping'          => $cart->needs_shipping(),
 			'has_calculated_shipping' => $has_calculated_shipping,
+			'fees'                    => $this->get_item_responses_from_schema( $this->fee_schema, $cart->get_fees() ),
 			'totals'                  => $this->prepare_currency_response(
 				[
 					'total_items'        => $this->prepare_money_response( $cart->get_subtotal(), wc_get_price_decimals() ),

--- a/storybook/__mocks__/woocommerce-base-hooks.js
+++ b/storybook/__mocks__/woocommerce-base-hooks.js
@@ -18,6 +18,7 @@ export const useStoreCart = () => ( {
 	cartTotals: previewCart.totals,
 	cartIsLoading: false,
 	cartErrors: [],
+	cartFees: [],
 	billingAddress: {},
 	shippingAddress: {},
 	shippingRates: previewShippingRates,


### PR DESCRIPTION
Adds fee data to the API response, useStoreCart hook, and cart/checkout blocks.

Note: Fees are added inline and not persisted. Due to this, cart totals must be calculated otherwise those rows will not be returned. This may degrade performance slightly because caching is not supported.

Fixes #3519

### Screenshots

![Screenshot 2021-01-13 at 14 00 44](https://user-images.githubusercontent.com/90977/104461945-e2ecc800-55a7-11eb-9f4b-7044f1fb10b2.png)

### How to test the changes in this Pull Request:

1. Use the code snippet in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3519
2. Go to the cart page and see fee rows.
3. Go to checkout page and see fee rows.
4. Test with and without prices including tax in WC Tax settings.

### Changelog

> Show itemised fee rows in the cart/checkout blocks.
