### PR TITLE
Create get_item_responses_from_schema abstraction

### DIFF
--- a/src/StoreApi/Schemas/AbstractSchema.php
+++ b/src/StoreApi/Schemas/AbstractSchema.php
@@ -72,7 +72,7 @@ abstract class AbstractSchema {
 	}
 
 	/**
-	 * Returns extended data for a specific endpoint
+	 * Returns extended data for a specific endpoint.
 	 *
 	 * @param string $endpoint The endpoint identifer.
 	 * @param array  ...$passed_args An array of arguments to be passed to callbacks.
@@ -83,7 +83,7 @@ abstract class AbstractSchema {
 	}
 
 	/**
-	 * Returns extended schema for a specific endpoint
+	 * Returns extended schema for a specific endpoint.
 	 *
 	 * @param string $endpoint The endpoint identifer.
 	 * @param array  ...$passed_args An array of arguments to be passed to callbacks.
@@ -98,6 +98,24 @@ abstract class AbstractSchema {
 			'properties'  => $this->extend->get_endpoint_schema( $endpoint, $passed_args ),
 		];
 	}
+
+	/**
+	 * Apply a schema get_item_response callback to an array of items and return the result.
+	 *
+	 * @param AbstractSchema $schema Schema class instance.
+	 * @param array          $items Array of items.
+	 * @return array Array of values from the callback function.
+	 */
+	protected function get_item_responses_from_schema( AbstractSchema $schema, $items ) {
+		$items = array_filter( $items );
+
+		if ( empty( $items ) ) {
+			return [];
+		}
+
+		return array_values( array_map( [ $schema, 'get_item_response' ], $items ) );
+	}
+
 	/**
 	 * Retrieves an array of endpoint arguments from the item schema for the controller.
 	 *

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -303,18 +303,21 @@ class CartSchema extends AbstractSchema {
 		// calculated so we can avoid returning costs and rates prematurely.
 		$has_calculated_shipping = $cart->show_shipping();
 
+		// Get shipping packages to return in the response from the cart.
+		$shipping_packages = $has_calculated_shipping ? $controller->get_shipping_packages() : [];
+
 		return [
-			'coupons'                 => array_values( array_map( [ $this->coupon_schema, 'get_item_response' ], array_filter( $cart->get_applied_coupons() ) ) ),
-			'shipping_rates'          => $has_calculated_shipping ? array_values( array_map( [ $this->shipping_rate_schema, 'get_item_response' ], $controller->get_shipping_packages() ) ) : [],
+			'coupons'                 => $this->get_item_responses_from_schema( $this->coupon_schema, $cart->get_applied_coupons() ),
+			'shipping_rates'          => $this->get_item_responses_from_schema( $this->shipping_rate_schema, $shipping_packages ),
 			'shipping_address'        => $this->shipping_address_schema->get_item_response( wc()->customer ),
 			'billing_address'         => $this->billing_address_schema->get_item_response( wc()->customer ),
-			'items'                   => array_values( array_map( [ $this->item_schema, 'get_item_response' ], array_filter( $cart->get_cart() ) ) ),
+			'items'                   => $this->get_item_responses_from_schema( $this->item_schema, $cart->get_cart() ),
 			'items_count'             => $cart->get_cart_contents_count(),
 			'items_weight'            => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
 			'needs_payment'           => $cart->needs_payment(),
 			'needs_shipping'          => $cart->needs_shipping(),
 			'has_calculated_shipping' => $has_calculated_shipping,
-			'totals'                  => (object) $this->prepare_currency_response(
+			'totals'                  => $this->prepare_currency_response(
 				[
 					'total_items'        => $this->prepare_money_response( $cart->get_subtotal(), wc_get_price_decimals() ),
 					'total_items_tax'    => $this->prepare_money_response( $cart->get_subtotal_tax(), wc_get_price_decimals() ),


### PR DESCRIPTION
This is a small refactor extracted from [this PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3672/files) which creates a `get_item_responses_from_schema` method to avoid repetition—in several places we are mapping a child schema to an array of data in the same way.

### How to test the changes in this Pull Request:

1. GET a cart response from the Store API
2. Check response contains items, coupons, shipping as before.

Functionality is unchanged.