### PR TITLE
Improve Package Handling in CartShippingRateSchema

### DIFF
--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -224,7 +224,41 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $package ) {
-		// Add product names and quantities.
+		return [
+			'package_id'     => $package['package_id'],
+			'name'           => $package['package_name'],
+			'destination'    => $this->prepare_package_destination_response( $package ),
+			'items'          => $this->prepare_package_items_response( $package ),
+			'shipping_rates' => $this->prepare_package_shipping_rates_response( $package ),
+		];
+	}
+
+	/**
+	 * Gets and formats the destination address of a package.
+	 *
+	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @return object
+	 */
+	protected function prepare_package_destination_response( $package ) {
+		return (object) $this->prepare_html_response(
+			[
+				'address_1' => $package['destination']['address_1'],
+				'address_2' => $package['destination']['address_2'],
+				'city'      => $package['destination']['city'],
+				'state'     => $package['destination']['state'],
+				'postcode'  => $package['destination']['postcode'],
+				'country'   => $package['destination']['country'],
+			]
+		);
+	}
+
+	/**
+	 * Gets items from a package and creates an array of strings containing product names and quantities.
+	 *
+	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @return array
+	 */
+	protected function prepare_package_items_response( $package ) {
 		$items = array();
 		foreach ( $package['contents'] as $item_id => $values ) {
 			$items[] = [
@@ -233,38 +267,7 @@ class CartShippingRateSchema extends AbstractSchema {
 				'quantity' => $values['quantity'],
 			];
 		}
-
-		// Generate package name.
-		$package_number       = absint( $package['package_id'] ) + 1;
-		$package_display_name = apply_filters(
-			'woocommerce_shipping_package_name',
-			$package_number > 1 ?
-				sprintf(
-					/* translators: %d: shipping package number */
-					_x( 'Shipping %d', 'shipping packages', 'woo-gutenberg-products-block' ),
-					$package_number
-				) :
-				_x( 'Shipping', 'shipping packages', 'woo-gutenberg-products-block' ),
-			$package['package_id'],
-			$package
-		);
-
-		return [
-			'package_id'     => $package['package_id'],
-			'name'           => $package_display_name,
-			'destination'    => (object) $this->prepare_html_response(
-				[
-					'address_1' => $package['destination']['address_1'],
-					'address_2' => $package['destination']['address_2'],
-					'city'      => $package['destination']['city'],
-					'state'     => $package['destination']['state'],
-					'postcode'  => $package['destination']['postcode'],
-					'country'   => $package['destination']['country'],
-				]
-			),
-			'items'          => $items,
-			'shipping_rates' => $this->prepare_rates_response( $package ),
-		];
+		return $items;
 	}
 
 	/**
@@ -273,7 +276,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @param array $package Shipping package complete with rates from WooCommerce.
 	 * @return array
 	 */
-	protected function prepare_rates_response( $package ) {
+	protected function prepare_package_shipping_rates_response( $package ) {
 		$rates          = $package['rates'];
 		$selected_rates = wc()->session->get( 'chosen_shipping_methods', array() );
 		$selected_rate  = isset( $chosen_shipping_methods[ $package['package_id'] ] ) ? $chosen_shipping_methods[ $package['package_id'] ] : '';

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -279,7 +279,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	protected function prepare_package_shipping_rates_response( $package ) {
 		$rates          = $package['rates'];
 		$selected_rates = wc()->session->get( 'chosen_shipping_methods', array() );
-		$selected_rate  = isset( $chosen_shipping_methods[ $package['package_id'] ] ) ? $chosen_shipping_methods[ $package['package_id'] ] : '';
+		$selected_rate  = isset( $selected_rates[ $package['package_id'] ] ) ? $selected_rates[ $package['package_id'] ] : '';
 
 		if ( empty( $selected_rate ) && ! empty( $package['rates'] ) ) {
 			$selected_rate = wc_get_chosen_shipping_method_for_package( $package['package_id'], $package );


### PR DESCRIPTION
This is another small refactor (and fix) split from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3672/files

- Splits up the methods which format package data in the shipping rate response
- Fixes an incorrectly named variable in prepare_package_shipping_rates_response
- Create the package name in the cart controller instead of in the API endpoint

### How to test the changes in this Pull Request:

1. Get a cart response from the API
2. Check shipping packages are returned correctly

This does not impact functionality, but there is a fix.

<!-- If you can, add the appropriate labels -->

### Changelog

> Store API - Fix selected rate in cart shipping rates response.
