### PR TITLE
Change payment processing for subscriptions

### DIFF
--- a/assets/js/base/components/payment-methods/payment-method-options.js
+++ b/assets/js/base/components/payment-methods/payment-method-options.js
@@ -71,6 +71,9 @@ const PaymentMethodOptions = () => {
 					content: (
 						<PaymentMethodTab
 							allowsSaving={ supports.savePaymentInfo }
+							displaySavePaymentMethodCheckbox={
+								supports.displaySavePaymentMethodCheckbox
+							}
 						>
 							{ cloneElement( component, {
 								activePaymentMethod,

--- a/assets/js/base/components/payment-methods/payment-method-options.js
+++ b/assets/js/base/components/payment-methods/payment-method-options.js
@@ -70,8 +70,7 @@ const PaymentMethodOptions = () => {
 					ariaLabel,
 					content: (
 						<PaymentMethodTab
-							allowsSaving={ supports.savePaymentInfo }
-							requiresSaving={ supports.requiresSaving }
+							showSaveOption={ supports.showSaveOption }
 						>
 							{ cloneElement( component, {
 								activePaymentMethod,

--- a/assets/js/base/components/payment-methods/payment-method-options.js
+++ b/assets/js/base/components/payment-methods/payment-method-options.js
@@ -71,9 +71,7 @@ const PaymentMethodOptions = () => {
 					content: (
 						<PaymentMethodTab
 							allowsSaving={ supports.savePaymentInfo }
-							displaySavePaymentMethodCheckbox={
-								supports.displaySavePaymentMethodCheckbox
-							}
+							requiresSaving={ supports.requiresSaving }
 						>
 							{ cloneElement( component, {
 								activePaymentMethod,

--- a/assets/js/base/components/payment-methods/payment-method-tab.js
+++ b/assets/js/base/components/payment-methods/payment-method-tab.js
@@ -55,8 +55,7 @@ const PaymentMethodTab = ( { children, showSaveOption } ) => {
 };
 
 PaymentMethodTab.propTypes = {
-	allowsSaving: PropTypes.bool,
-	requiresSaving: PropTypes.bool,
+	showSaveOption: PropTypes.bool,
 	children: PropTypes.node,
 };
 

--- a/assets/js/base/components/payment-methods/payment-method-tab.js
+++ b/assets/js/base/components/payment-methods/payment-method-tab.js
@@ -21,17 +21,13 @@ import PaymentMethodErrorBoundary from './payment-method-error-boundary';
  * @param {Object}  props              Incoming props for the component.
  * @param {boolean} props.allowsSaving Whether that payment method allows saving
  *                                     the data for future purchases.
- * @param {boolean} props.displaySavePaymentMethodCheckbox Whether the payment method should display the option to save
+ * @param {boolean} props.requiresSaving Whether the payment method should display the option to save
  * 														   the details entered by the customer.
  * @param {Object}  props.children     Content of the payment method tab.
  *
  * @return {*} The rendered component.
  */
-const PaymentMethodTab = ( {
-	children,
-	allowsSaving,
-	displaySavePaymentMethodCheckbox,
-} ) => {
+const PaymentMethodTab = ( { children, allowsSaving, requiresSaving } ) => {
 	const { isEditor } = useEditorContext();
 	const {
 		shouldSavePayment,
@@ -42,28 +38,26 @@ const PaymentMethodTab = ( {
 	return (
 		<PaymentMethodErrorBoundary isEditor={ isEditor }>
 			{ children }
-			{ customerId > 0 &&
-				allowsSaving &&
-				displaySavePaymentMethodCheckbox && (
-					<CheckboxControl
-						className="wc-block-components-payment-methods__save-card-info"
-						label={ __(
-							'Save payment information to my account for future purchases.',
-							'woo-gutenberg-products-block'
-						) }
-						checked={ shouldSavePayment }
-						onChange={ () =>
-							setShouldSavePayment( ! shouldSavePayment )
-						}
-					/>
-				) }
+			{ customerId > 0 && allowsSaving && ! requiresSaving && (
+				<CheckboxControl
+					className="wc-block-components-payment-methods__save-card-info"
+					label={ __(
+						'Save payment information to my account for future purchases.',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ shouldSavePayment }
+					onChange={ () =>
+						setShouldSavePayment( ! shouldSavePayment )
+					}
+				/>
+			) }
 		</PaymentMethodErrorBoundary>
 	);
 };
 
 PaymentMethodTab.propTypes = {
 	allowsSaving: PropTypes.bool,
-	displaySavePaymentMethodCheckbox: PropTypes.bool,
+	requiresSaving: PropTypes.bool,
 	children: PropTypes.node,
 };
 

--- a/assets/js/base/components/payment-methods/payment-method-tab.js
+++ b/assets/js/base/components/payment-methods/payment-method-tab.js
@@ -18,16 +18,15 @@ import PaymentMethodErrorBoundary from './payment-method-error-boundary';
 /**
  * Component used to render the contents of a payment method tab.
  *
- * @param {Object}  props              Incoming props for the component.
- * @param {boolean} props.allowsSaving Whether that payment method allows saving
- *                                     the data for future purchases.
- * @param {boolean} props.requiresSaving Whether the payment method should display the option to save
- * 														   the details entered by the customer.
- * @param {Object}  props.children     Content of the payment method tab.
+ * @param {Object}  props                Incoming props for the component.
+ * @param {boolean} props.showSaveOption Whether that payment method allows saving
+ *                                       the data for future purchases and should
+ *                                       display the checkbox to do so.
+ * @param {Object}  props.children       Content of the payment method tab.
  *
  * @return {*} The rendered component.
  */
-const PaymentMethodTab = ( { children, allowsSaving, requiresSaving } ) => {
+const PaymentMethodTab = ( { children, showSaveOption } ) => {
 	const { isEditor } = useEditorContext();
 	const {
 		shouldSavePayment,
@@ -38,7 +37,7 @@ const PaymentMethodTab = ( { children, allowsSaving, requiresSaving } ) => {
 	return (
 		<PaymentMethodErrorBoundary isEditor={ isEditor }>
 			{ children }
-			{ customerId > 0 && allowsSaving && ! requiresSaving && (
+			{ customerId > 0 && showSaveOption && (
 				<CheckboxControl
 					className="wc-block-components-payment-methods__save-card-info"
 					label={ __(

--- a/assets/js/base/components/payment-methods/payment-method-tab.js
+++ b/assets/js/base/components/payment-methods/payment-method-tab.js
@@ -21,11 +21,17 @@ import PaymentMethodErrorBoundary from './payment-method-error-boundary';
  * @param {Object}  props              Incoming props for the component.
  * @param {boolean} props.allowsSaving Whether that payment method allows saving
  *                                     the data for future purchases.
+ * @param {boolean} props.displaySavePaymentMethodCheckbox Whether the payment method should display the option to save
+ * 														   the details entered by the customer.
  * @param {Object}  props.children     Content of the payment method tab.
  *
  * @return {*} The rendered component.
  */
-const PaymentMethodTab = ( { children, allowsSaving } ) => {
+const PaymentMethodTab = ( {
+	children,
+	allowsSaving,
+	displaySavePaymentMethodCheckbox,
+} ) => {
 	const { isEditor } = useEditorContext();
 	const {
 		shouldSavePayment,
@@ -36,25 +42,28 @@ const PaymentMethodTab = ( { children, allowsSaving } ) => {
 	return (
 		<PaymentMethodErrorBoundary isEditor={ isEditor }>
 			{ children }
-			{ customerId > 0 && allowsSaving && (
-				<CheckboxControl
-					className="wc-block-components-payment-methods__save-card-info"
-					label={ __(
-						'Save payment information to my account for future purchases.',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ shouldSavePayment }
-					onChange={ () =>
-						setShouldSavePayment( ! shouldSavePayment )
-					}
-				/>
-			) }
+			{ customerId > 0 &&
+				allowsSaving &&
+				displaySavePaymentMethodCheckbox && (
+					<CheckboxControl
+						className="wc-block-components-payment-methods__save-card-info"
+						label={ __(
+							'Save payment information to my account for future purchases.',
+							'woo-gutenberg-products-block'
+						) }
+						checked={ shouldSavePayment }
+						onChange={ () =>
+							setShouldSavePayment( ! shouldSavePayment )
+						}
+					/>
+				) }
 		</PaymentMethodErrorBoundary>
 	);
 };
 
 PaymentMethodTab.propTypes = {
 	allowsSaving: PropTypes.bool,
+	displaySavePaymentMethodCheckbox: PropTypes.bool,
 	children: PropTypes.node,
 };
 

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -95,7 +95,7 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 				const isAvailable = gateway in availablePaymentMethods;
 				return (
 					isAvailable &&
-					availablePaymentMethods[ gateway ].supports?.savePaymentInfo
+					availablePaymentMethods[ gateway ].supports?.showSavedCards
 				);
 			}
 		);

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -91,13 +91,7 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 	const enabledCustomerPaymentMethods = {};
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(
-			( { method: { gateway } } ) => {
-				const isAvailable = gateway in availablePaymentMethods;
-				return (
-					isAvailable &&
-					availablePaymentMethods[ gateway ].supports?.savePaymentInfo
-				);
-			}
+			( { method: { gateway } } ) => gateway in availablePaymentMethods
 		);
 		if ( methods.length ) {
 			enabledCustomerPaymentMethods[ type ] = methods;

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.js
@@ -91,7 +91,13 @@ const getCustomerPaymentMethods = ( availablePaymentMethods = {} ) => {
 	const enabledCustomerPaymentMethods = {};
 	paymentMethodKeys.forEach( ( type ) => {
 		const methods = customerPaymentMethods[ type ].filter(
-			( { method: { gateway } } ) => gateway in availablePaymentMethods
+			( { method: { gateway } } ) => {
+				const isAvailable = gateway in availablePaymentMethods;
+				return (
+					isAvailable &&
+					availablePaymentMethods[ gateway ].supports?.savePaymentInfo
+				);
+			}
 		);
 		if ( methods.length ) {
 			enabledCustomerPaymentMethods[ type ] = methods;

--- a/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -72,7 +72,8 @@ const registerMockPaymentMethods = () => {
 			icons: null,
 			canMakePayment: () => true,
 			supports: {
-				savePaymentInfo: true,
+				showSavedCards: true,
+				showSaveOption: true,
 			},
 			ariaLabel: name,
 		} );

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -22,8 +22,7 @@ export default class PaymentMethodConfig {
 		this.paymentMethodId = config.paymentMethodId || this.name;
 		this.supports = {
 			savePaymentInfo: config?.supports?.savePaymentInfo || false,
-			displaySavePaymentMethodCheckbox:
-				config?.supports?.displaySavePaymentMethodCheckbox || false,
+			requiresSaving: config?.supports?.requiresSaving || false,
 		};
 	}
 
@@ -90,13 +89,11 @@ export default class PaymentMethodConfig {
 		}
 		if (
 			config.supports &&
-			typeof config.supports.displaySavePaymentMethodCheckbox !==
-				'undefined' &&
-			typeof config.supports.displaySavePaymentMethodCheckbox !==
-				'boolean'
+			typeof config.supports.requiresSaving !== 'undefined' &&
+			typeof config.supports.requiresSaving !== 'boolean'
 		) {
 			throw new TypeError(
-				'If the payment method includes the `supports.displaySavePaymentMethodCheckbox` property, it must be a boolean'
+				'If the payment method includes the `supports.requiresSaving` property, it must be a boolean'
 			);
 		}
 	};

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -21,8 +21,11 @@ export default class PaymentMethodConfig {
 		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
 		this.supports = {
-			savePaymentInfo: config?.supports?.savePaymentInfo || false,
-			requiresSaving: config?.supports?.requiresSaving || false,
+			showSavedCards:
+				config?.supports?.showSavedCards ||
+				config?.supports?.savePaymentInfo || // Kept for backward compatibility if methods still pas this when registering.
+				false,
+			showSaveOption: config?.supports?.showSaveOption || false,
 		};
 	}
 
@@ -80,20 +83,20 @@ export default class PaymentMethodConfig {
 		}
 		if (
 			config.supports &&
-			typeof config.supports.savePaymentInfo !== 'undefined' &&
-			typeof config.supports.savePaymentInfo !== 'boolean'
+			typeof config.supports.showSavedCards !== 'undefined' &&
+			typeof config.supports.showSavedCards !== 'boolean'
 		) {
 			throw new TypeError(
-				'If the payment method includes the `supports.savePaymentInfo` property, it must be a boolean'
+				'If the payment method includes the `supports.showSavedCards` property, it must be a boolean'
 			);
 		}
 		if (
 			config.supports &&
-			typeof config.supports.requiresSaving !== 'undefined' &&
-			typeof config.supports.requiresSaving !== 'boolean'
+			typeof config.supports.showSaveOption !== 'undefined' &&
+			typeof config.supports.showSaveOption !== 'boolean'
 		) {
 			throw new TypeError(
-				'If the payment method includes the `supports.requiresSaving` property, it must be a boolean'
+				'If the payment method includes the `supports.showSaveOption` property, it must be a boolean'
 			);
 		}
 	};

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -100,7 +100,8 @@ export default class PaymentMethodConfig {
 				{
 					alternative: 'Pass showSavedCards and showSaveOption',
 					plugin: 'woocommerce-gutenberg-products-block',
-					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686'
+					link:
+						'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686',
 				}
 			);
 		}

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import {
@@ -88,6 +93,14 @@ export default class PaymentMethodConfig {
 		) {
 			throw new TypeError(
 				'If the payment method includes the `supports.showSavedCards` property, it must be a boolean'
+			);
+		}
+		if (
+			config.supports &&
+			typeof config.supports.savePaymentInfo !== 'undefined'
+		) {
+			deprecated(
+				'Passing savePaymentInfo when registering a payment method is deprecated, instead you should pass showSavedCards and showSaveOption'
 			);
 		}
 		if (

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -22,6 +22,8 @@ export default class PaymentMethodConfig {
 		this.paymentMethodId = config.paymentMethodId || this.name;
 		this.supports = {
 			savePaymentInfo: config?.supports?.savePaymentInfo || false,
+			displaySavePaymentMethodCheckbox:
+				config?.supports?.displaySavePaymentMethodCheckbox || false,
 		};
 	}
 
@@ -84,6 +86,17 @@ export default class PaymentMethodConfig {
 		) {
 			throw new TypeError(
 				'If the payment method includes the `supports.savePaymentInfo` property, it must be a boolean'
+			);
+		}
+		if (
+			config.supports &&
+			typeof config.supports.displaySavePaymentMethodCheckbox !==
+				'undefined' &&
+			typeof config.supports.displaySavePaymentMethodCheckbox !==
+				'boolean'
+		) {
+			throw new TypeError(
+				'If the payment method includes the `supports.displaySavePaymentMethodCheckbox` property, it must be a boolean'
 			);
 		}
 	};

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -87,26 +87,21 @@ export default class PaymentMethodConfig {
 			);
 		}
 		if (
-			config.supports &&
-			typeof config.supports.showSavedCards !== 'undefined' &&
-			typeof config.supports.showSavedCards !== 'boolean'
+			typeof config.supports?.showSavedCards !== 'undefined' &&
+			typeof config.supports?.showSavedCards !== 'boolean'
 		) {
 			throw new TypeError(
 				'If the payment method includes the `supports.showSavedCards` property, it must be a boolean'
 			);
 		}
-		if (
-			config.supports &&
-			typeof config.supports.savePaymentInfo !== 'undefined'
-		) {
+		if ( typeof config.supports?.savePaymentInfo !== 'undefined' ) {
 			deprecated(
 				'Passing savePaymentInfo when registering a payment method is deprecated, instead you should pass showSavedCards and showSaveOption'
 			);
 		}
 		if (
-			config.supports &&
-			typeof config.supports.showSaveOption !== 'undefined' &&
-			typeof config.supports.showSaveOption !== 'boolean'
+			typeof config.supports?.showSaveOption !== 'undefined' &&
+			typeof config.supports?.showSaveOption !== 'boolean'
 		) {
 			throw new TypeError(
 				'If the payment method includes the `supports.showSaveOption` property, it must be a boolean'

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -96,7 +96,12 @@ export default class PaymentMethodConfig {
 		}
 		if ( typeof config.supports?.savePaymentInfo !== 'undefined' ) {
 			deprecated(
-				'Passing savePaymentInfo when registering a payment method is deprecated, instead you should pass showSavedCards and showSaveOption'
+				'Passing savePaymentInfo when registering a payment method.',
+				{
+					alternative: 'Pass showSavedCards and showSaveOption',
+					plugin: 'woocommerce-gutenberg-products-block',
+					link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686'
+				}
 			);
 		}
 		if (

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -28,7 +28,7 @@ export default class PaymentMethodConfig {
 		this.supports = {
 			showSavedCards:
 				config?.supports?.showSavedCards ||
-				config?.supports?.savePaymentInfo || // Kept for backward compatibility if methods still pas this when registering.
+				config?.supports?.savePaymentInfo || // Kept for backward compatibility if methods still pass this when registering.
 				false,
 			showSaveOption: config?.supports?.showSaveOption || false,
 		};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -57,8 +57,7 @@ const stripeCcPaymentMethod = {
 	),
 	supports: {
 		savePaymentInfo: getStripeServerData().allowSavedCards,
-		displaySavePaymentMethodCheckbox: getStripeServerData()
-			.displaySavePaymentMethodCheckbox,
+		requiresSaving: getStripeServerData().requiresSaving,
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -57,6 +57,8 @@ const stripeCcPaymentMethod = {
 	),
 	supports: {
 		savePaymentInfo: getStripeServerData().allowSavedCards,
+		displaySavePaymentMethodCheckbox: getStripeServerData()
+			.displaySavePaymentMethodCheckbox,
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -56,8 +56,8 @@ const stripeCcPaymentMethod = {
 		'woo-gutenberg-products-block'
 	),
 	supports: {
-		savePaymentInfo: getStripeServerData().allowSavedCards,
-		requiresSaving: getStripeServerData().requiresSaving,
+		showSavedCards: getStripeServerData().showSavedCards,
+		showSaveOption: getStripeServerData().showSaveOption,
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
@@ -297,8 +297,10 @@
  *                                                              inline cc
  *                                                              form or separate inputs.
  * @property {{[k:string]:CreditCardIcon}} icons                Contains supported cc icons.
- * @property {boolean}                     allowSavedCards      Used to indicate whether saved cards
+ * @property {boolean}                     showSavedCards       Used to indicate whether saved cards
  *                                                              can be used.
+ * @property {boolean}                     showSaveOption       Used to indicate whether the option to
+ *                                                              save card can be displayed.
  * @property {boolean}                     allowPaymentRequest  True if merchant has enabled payment
  *                                                              request (Chrome/Apple Pay).
  */

--- a/docs/blocks/feature-flags-and-experimental-interfaces.md
+++ b/docs/blocks/feature-flags-and-experimental-interfaces.md
@@ -52,6 +52,7 @@ We also have individual features or code blocks behind a feature flag, this is a
 
 ## Usages of `__experimental` prefix
 
+-   `__experimental_woocommerce_blocks_checkout_update_order_meta` hook when the draft order has been created or updated from the cart and is now ready for extensions to modify the metadata ([experimental hook](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686/files#diff-af2c90fa556cc086b780c8fad99b68373d87fd6007e6e2ff1b4c68ebe9ccb551R377-R393)).
 -   `__experimental_woocommerce_blocks_checkout_order_processed` hook when order has completed processing and is ready for payment ([experimental hook](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/accd1bbf402e043b9fc322f118ab614ba7437c92/src/StoreApi/Routes/Checkout.php#L237)).
 -   `__experimentalDeRegisterPaymentMethod` function used to deregister a payment method, only used in tests ([experimental function](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/b07883b8b76feeb439d655b255507b24fc59e091/assets/js/blocks-registry/payment-methods/registry.js#L70)).
 -   `__experimentalDeRegisterExpressPaymentMethod` function used to deregister an express payment method, only used in tests ([experimental function](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/b07883b8b76feeb439d655b255507b24fc59e091/assets/js/blocks-registry/payment-methods/registry.js#L74)).

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -93,6 +93,9 @@ The options you feed the configuration instance are the same as those for expres
 -   `label`: This should be a react node that will be used to output the label for the tab in the payment methods are. For example it might be `<strong>Credit/Debit Cart</strong>` or you might output images.
 -   `ariaLabel`: This is the label that will be read out via screen-readers when the payment method is selected.
 -   `placeOrderButtonLabel`: This is an optional label which will change the default "Place Order" button text to something else when the payment method is selected.
+-   `supports`: This is an object containing information about what features your payment method supports. The following keys are valid here:
+    - `showSavedCards`: This value will determine whether saved cards associated with your payment method are shown to the customer.
+    - `showSaveOption`: This value will control whether to show the checkbox which allows customers to save their payment method for future payments.
 
 ### Props Fed to Payment Method Nodes
 

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -81,21 +81,21 @@ final class Stripe extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'stripeTotalLabel'                 => $this->get_total_label(),
-			'publicKey'                        => $this->get_publishable_key(),
-			'allowPrepaidCard'                 => $this->get_allow_prepaid_card(),
-			'title'                            => $this->get_title(),
-			'button'                           => [
+			'stripeTotalLabel'    => $this->get_total_label(),
+			'publicKey'           => $this->get_publishable_key(),
+			'allowPrepaidCard'    => $this->get_allow_prepaid_card(),
+			'title'               => $this->get_title(),
+			'button'              => [
 				'type'   => $this->get_button_type(),
 				'theme'  => $this->get_button_theme(),
 				'height' => $this->get_button_height(),
 				'locale' => $this->get_button_locale(),
 			],
-			'inline_cc_form'                   => $this->get_inline_cc_form(),
-			'icons'                            => $this->get_icons(),
-			'allowSavedCards'                  => $this->get_allow_saved_cards(),
-			'allowPaymentRequest'              => $this->get_allow_payment_request(),
-			'displaySavePaymentMethodCheckbox' => $this->get_display_save_payment_method_checkbox(),
+			'inline_cc_form'      => $this->get_inline_cc_form(),
+			'icons'               => $this->get_icons(),
+			'allowSavedCards'     => $this->get_allow_saved_cards(),
+			'allowPaymentRequest' => $this->get_allow_payment_request(),
+			'requiresSaving'      => $this->get_requires_saving(),
 		];
 	}
 
@@ -109,17 +109,18 @@ final class Stripe extends AbstractPaymentMethodType {
 	}
 
 	/**
-	 * Determine if the save payment method checkbox should be displayed.
+	 * Determine if the payment method requires saving. If saved_cards is set to yes and filters hide the save
+	 * payment method checkbox, we can assume that this method requires saving.
 	 *
 	 * @return bool True if the save payment checkbox should be displayed to the user.
 	 */
-	private function get_display_save_payment_method_checkbox() {
+	private function get_requires_saving() {
 		$saved_cards = $this->get_allow_saved_cards();
 		// This assumes that Stripe supports `tokenization` - currently this is true, based on
 		// https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95 .
 		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and
 		// https://github.com/woocommerce/woocommerce/wiki/Payment-Token-API .
-		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $saved_cards, FILTER_VALIDATE_BOOLEAN ) );
+		return ! apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $saved_cards, FILTER_VALIDATE_BOOLEAN ) );
 	}
 
 	/**

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -93,9 +93,9 @@ final class Stripe extends AbstractPaymentMethodType {
 			],
 			'inline_cc_form'      => $this->get_inline_cc_form(),
 			'icons'               => $this->get_icons(),
-			'allowSavedCards'     => $this->get_allow_saved_cards(),
+			'showSavedCards'      => $this->get_show_saved_cards(),
 			'allowPaymentRequest' => $this->get_allow_payment_request(),
-			'requiresSaving'      => $this->get_requires_saving(),
+			'showSaveOption'      => $this->get_show_save_option(),
 		];
 	}
 

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -104,23 +104,22 @@ final class Stripe extends AbstractPaymentMethodType {
 	 *
 	 * @return bool True if merchant allows shopper to save card (payment method) during checkout).
 	 */
-	private function get_allow_saved_cards() {
+	private function get_show_saved_cards() {
 		return isset( $this->settings['saved_cards'] ) ? 'yes' === $this->settings['saved_cards'] : false;
 	}
 
 	/**
-	 * Determine if the payment method requires saving. If saved_cards is set to yes and filters hide the save
-	 * payment method checkbox, we can assume that this method requires saving.
+	 * Determine if the checkbox to enable the user to save their payment method should be shown.
 	 *
 	 * @return bool True if the save payment checkbox should be displayed to the user.
 	 */
-	private function get_requires_saving() {
-		$saved_cards = $this->get_allow_saved_cards();
+	private function get_show_save_option() {
+		$saved_cards = $this->get_show_saved_cards();
 		// This assumes that Stripe supports `tokenization` - currently this is true, based on
 		// https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95 .
 		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and
 		// https://github.com/woocommerce/woocommerce/wiki/Payment-Token-API .
-		return ! apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $saved_cards, FILTER_VALIDATE_BOOLEAN ) );
+		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $saved_cards, FILTER_VALIDATE_BOOLEAN ) );
 	}
 
 	/**

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -104,7 +104,16 @@ final class Stripe extends AbstractPaymentMethodType {
 	 * @return bool True if merchant allows shopper to save card (payment method) during checkout).
 	 */
 	private function get_allow_saved_cards() {
-		$saved_cards = isset( $this->settings['saved_cards'] ) ? $this->settings['saved_cards'] : false;
+		return isset( $this->settings['saved_cards'] ) ? 'yes' === $this->settings['saved_cards'] : false;
+	}
+
+	/**
+	 * Determine if the save payment method checkbox should be displayed.
+	 *
+	 * @return bool True if the save payment checkbox should be displayed to the user.
+	 */
+	private function get_display_save_payment_method_checkbox() {
+		$saved_cards = $this->get_allow_saved_cards();
 		// This assumes that Stripe supports `tokenization` - currently this is true, based on
 		// https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95 .
 		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -81,20 +81,21 @@ final class Stripe extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'stripeTotalLabel'    => $this->get_total_label(),
-			'publicKey'           => $this->get_publishable_key(),
-			'allowPrepaidCard'    => $this->get_allow_prepaid_card(),
-			'title'               => $this->get_title(),
-			'button'              => [
+			'stripeTotalLabel'                 => $this->get_total_label(),
+			'publicKey'                        => $this->get_publishable_key(),
+			'allowPrepaidCard'                 => $this->get_allow_prepaid_card(),
+			'title'                            => $this->get_title(),
+			'button'                           => [
 				'type'   => $this->get_button_type(),
 				'theme'  => $this->get_button_theme(),
 				'height' => $this->get_button_height(),
 				'locale' => $this->get_button_locale(),
 			],
-			'inline_cc_form'      => $this->get_inline_cc_form(),
-			'icons'               => $this->get_icons(),
-			'allowSavedCards'     => $this->get_allow_saved_cards(),
-			'allowPaymentRequest' => $this->get_allow_payment_request(),
+			'inline_cc_form'                   => $this->get_inline_cc_form(),
+			'icons'                            => $this->get_icons(),
+			'allowSavedCards'                  => $this->get_allow_saved_cards(),
+			'allowPaymentRequest'              => $this->get_allow_payment_request(),
+			'displaySavePaymentMethodCheckbox' => $this->get_display_save_payment_method_checkbox(),
 		];
 	}
 

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -419,7 +419,7 @@ class Checkout extends AbstractRoute {
 		if ( isset( $request['customer_note'] ) ) {
 			$this->order->set_customer_note( $request['customer_note'] );
 		}
-		$this->order->set_payment_method( $this->order->needs_payment() ? $this->get_request_payment_method( $request ) : '' );
+		$this->order->set_payment_method( $this->order->needs_payment() ? $this->get_request_payment_method( $request ) : $this->safely_get_request_payment_method( $request ) );
 		$this->order->save();
 	}
 
@@ -522,6 +522,20 @@ class Checkout extends AbstractRoute {
 		}
 
 		return $available_gateways[ $payment_method_id ];
+	}
+
+	/**
+	 * Gets the chosen payment method from the request, or an empty string if one is not present.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return \WC_Payment_Gateway|string
+	 */
+	private function safely_get_request_payment_method( WP_REST_Request $request ) {
+		try {
+			return $this->get_request_payment_method( $request );
+		} catch ( Exception $e ) {
+			return '';
+		}
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -356,6 +356,8 @@ class Checkout extends AbstractRoute {
 			$order_controller->update_order_from_cart( $this->order );
 		}
 
+		do_action( '__experimental_woocommerce_blocks_checkout_update_order_meta', $this->order );
+
 		// Confirm order is valid before proceeding further.
 		if ( ! $this->order instanceof WC_Order ) {
 			throw new RouteException(

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -355,6 +355,21 @@ class Checkout extends AbstractRoute {
 			$order_controller->update_order_from_cart( $this->order );
 		}
 
+		/**
+		 * WooCommerce Blocks Checkout Update Order Meta (experimental).
+		 *
+		 * This hook gives extensions the chance to add or update meta data on the $order.
+		 *
+		 * This is similar to existing core hook woocommerce_checkout_update_order_meta.
+		 * We're using a new action:
+		 * - To keep the interface focused (only pass $order, not passing request data).
+		 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686
+		 * @internal This Hook is experimental and may change or be removed.
+		 *
+		 * @param WC_Order $order Order object.
+		 */
 		do_action( '__experimental_woocommerce_blocks_checkout_update_order_meta', $this->order );
 
 		// Confirm order is valid before proceeding further.

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -421,7 +421,7 @@ class Checkout extends AbstractRoute {
 		if ( isset( $request['customer_note'] ) ) {
 			$this->order->set_customer_note( $request['customer_note'] );
 		}
-		$this->order->set_payment_method( $this->order->needs_payment() ? $this->get_request_payment_method( $request ) : $this->safely_get_request_payment_method( $request ) );
+		$this->order->set_payment_method( $this->order->needs_payment() ? $this->get_request_payment_method( $request ) : '' );
 		$this->order->save();
 	}
 
@@ -524,20 +524,6 @@ class Checkout extends AbstractRoute {
 		}
 
 		return $available_gateways[ $payment_method_id ];
-	}
-
-	/**
-	 * Gets the chosen payment method from the request, or an empty string if one is not present.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 * @return \WC_Payment_Gateway|string
-	 */
-	private function safely_get_request_payment_method( WP_REST_Request $request ) {
-		try {
-			return $this->get_request_payment_method( $request );
-		} catch ( Exception $e ) {
-			return '';
-		}
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -230,7 +230,6 @@ class Checkout extends AbstractRoute {
 		 *
 		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
 		 * @internal This Hook is experimental and may change or be removed.
-		 * @since 3.8.0
 		 *
 		 * @param WC_Order $order Order object.
 		 */


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Saved payment methods are now correctly displayed - previously they were hidden based on whether or not the 'Save payment method' checkbox was visible, by running the `wc_stripe_display_save_payment_method_checkbox` filter.

The checkbox display was ultimately decided by the Stripe extension, which set the checkbox to not display if a subscription product was in the cart. The logic was because the payment method should always be saved when buying a subscription, so displaying the checkbox was unnecessary.

To fix this I have changed the naming of some props used when registering payment methods:
- Previously, we used `savePaymentInfo` to inform the UI whether we should show saved cards **and** the checkbox. 
- I have now changed this to `showSavedCards` and `showSaveOption` to give more granular control over the UI to the payment methods. In our Stripe integration, we set `showSavedCards` based on the value of the `saved_cards` option in the Stripe extension, and we set `showSaveOption` based on the result of the `wc_stripe_display_save_payment_method_checkbox` filter.
- Change `get_allow_saved_cards` method in the `Stripe` class to be named `get_show_saved_cards` and return whether the `saved_cards` option is enabled, without running the checkbox filter mentioned above.
- Add a method to the Stripe class `get_show_save_option` which will return the result of `get_show_saved_cards` filtered through `wc_stripe_display_save_payment_method_checkbox`
- Change the `PaymentMethodTab` component to accept a boolean `showSaveOption` prop. It is this prop that determines if the checkbox should be displayed or not.
- Update the payment method registration code to reflect the new names of these props.
- Update the payment method config and validation to reflect the new names of these props. I also included a shim to set `supports.showSavedCards` to the same value as `supports.savePaymentInfo` for backward compatibility. If any payment methods are registering and still using `savePaymentInfo` then a deprecation notice will be emitted using `@wordpress/deprecated`.
- Updated test files to reflect the new names of these props.

I have also modified the Checkout API so that it will fire a new action `__experimental_woocommerce_blocks_checkout_update_order_meta` which is handled in Subscriptions - this is required as extensions should be given the chance to update the metadata for the orders.

<!-- Reference any related issues or PRs here -->
Fixes #3616
Fixes #3620 
Fixes #3271 
Related PR in subs: 3963-gh-woocommerce/woocommerce-subscriptions

### How to test the changes in this Pull Request

1. Check out this branch and `add/actions-hooks-for-update-meta-from-blocks` on `woocommerce-subscriptions`
1. Enable a payment gateway that supports subs and blocks, for example Stripe 💳
2. Add a non-subscription product to your cart. 
3. Go to the checkout block and when using the Stripe payment method verify that the `Save payment method` checkbox shows.
4. Empty your cart.
4. Create a subscription product that has multiple variations so that you may up/down/crossgrade between them. 
3. Add a subscription for this product to your cart and check out using the checkout block, and ensure any saved cards show as options.
4. Ensure the checkout block asks you for payment, or allows you to use an existing method if you have one saved.
5. Ensure the subscription is created correctly with the correct variation, renewal dates, and price. Also ensure the payment method used to create the subscription was recorded.
6. Go to My account -> Subscription -> and begin the process to up/down/crossgrade the subscription.
7. Go to the checkout block and ensure you are not asked for payment. The payment method should already be saved on the subscription. (If you have prorate upgrades and downgrades turned on you may actually be asked for payment here)
8. Check out, and ensure the checkout completes and you can see the order summary showing your subscription on the client.
9. Visit the subscription in the admin dashboard and ensure it has the correct details for the order you just created.
10. Ensure there is a singular additional order in the Orders list for the *grade we just performed.