### PR TITLE
Fix broken PHPunit tests

### DIFF
--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -338,7 +338,7 @@ class CartSchema extends AbstractSchema {
 			'needs_shipping'          => $cart->needs_shipping(),
 			'has_calculated_shipping' => $has_calculated_shipping,
 			'fees'                    => $this->get_item_responses_from_schema( $this->fee_schema, $cart->get_fees() ),
-			'totals'                  => $this->prepare_currency_response(
+			'totals'                  => (object) $this->prepare_currency_response(
 				[
 					'total_items'        => $this->prepare_money_response( $cart->get_subtotal(), wc_get_price_decimals() ),
 					'total_items_tax'    => $this->prepare_money_response( $cart->get_subtotal_tax(), wc_get_price_decimals() ),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -107,6 +107,7 @@ function wc_install_core() {
 tests_add_filter(
 	'muplugins_loaded',
 	function() {
+		define( 'JETPACK_AUTOLOAD_DEV', true );
 		wc_load_core();
 		// install blocks plugin
 		wc_blocks_install();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3688

On investigating this, it looks like our phpunit tests have been running against the blocks code in WooCommerce core since Jetpack autoloader 2.0 update since we were never accounting for blocks dev build being tested (which requires the `JETPACK_AUTOLOAD_DEV` constant to be defined).

To address this:

- I added a `var_dump` to `CartSchema` in blocks to verify when phpunit tests were run they were executing against Blocks plugin classes. They weren't.
- In 5dc1c4d I defined the `JETPACK_AUTOLOAD_DEV` constant in the tests bootstrap and re-ran the tests, this time the debugging was being hit. So that fixed the incorrect classes being autoloaded. 
- With the fix to the above, this surfaced more errors in failing tests which correspond with what @opr [commented on here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3688#issuecomment-760393523), so I fixed that in c37ada2.

If phpunit tests pass in the Github actions this should be good to go.
