### PR TITLE
add circular dependency plugin

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -12,6 +12,7 @@ const WebpackRTLPlugin = require( 'webpack-rtl-plugin' );
 const chalk = require( 'chalk' );
 const { kebabCase } = require( 'lodash' );
 const CreateFileWebpack = require( 'create-file-webpack' );
+const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
 
 /**
  * Internal dependencies
@@ -104,6 +105,11 @@ const getCoreConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
+			new CircularDependencyPlugin( {
+				exclude: /a\.js|node_modules/,
+				failOnError: true,
+				cwd: process.cwd(),
+			} ),
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Core', options.fileSuffix )
 			),
@@ -196,6 +202,11 @@ const getMainConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
+			new CircularDependencyPlugin( {
+				exclude: /a\.js|node_modules/,
+				failOnError: true,
+				cwd: process.cwd(),
+			} ),
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Main', options.fileSuffix )
 			),
@@ -296,6 +307,11 @@ const getFrontConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
+			new CircularDependencyPlugin( {
+				exclude: /a\.js|node_modules/,
+				failOnError: true,
+				cwd: process.cwd(),
+			} ),
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Frontend', options.fileSuffix )
 			),

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -107,7 +107,7 @@ const getCoreConfig = ( options = {} ) => {
 		plugins: [
 			new CircularDependencyPlugin( {
 				exclude: /a\.js|node_modules/,
-				failOnError: true,
+				failOnError: 'warn',
 				cwd: process.cwd(),
 			} ),
 			new ProgressBarPlugin(
@@ -204,7 +204,7 @@ const getMainConfig = ( options = {} ) => {
 		plugins: [
 			new CircularDependencyPlugin( {
 				exclude: /a\.js|node_modules/,
-				failOnError: true,
+				failOnError: 'warn',
 				cwd: process.cwd(),
 			} ),
 			new ProgressBarPlugin(
@@ -309,7 +309,7 @@ const getFrontConfig = ( options = {} ) => {
 		plugins: [
 			new CircularDependencyPlugin( {
 				exclude: /a\.js|node_modules/,
-				failOnError: true,
+				failOnError: 'warn',
 				cwd: process.cwd(),
 			} ),
 			new ProgressBarPlugin(

--- a/package-lock.json
+++ b/package-lock.json
@@ -10653,6 +10653,16 @@
 			"dev": true,
 			"optional": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"bl": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -11817,6 +11827,12 @@
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"circular-dependency-plugin": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
+			"integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
+			"dev": true
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -15818,6 +15834,13 @@
 					}
 				}
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"filelist": {
 			"version": "1.0.1",
@@ -35452,6 +35475,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
+						"bindings": "^1.5.0",
 						"nan": "^2.12.1"
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"babel-plugin-transform-react-remove-prop-types": "0.4.24",
 		"babel-plugin-transform-runtime": "6.23.0",
 		"chalk": "4.1.0",
+		"circular-dependency-plugin": "^5.2.2",
 		"commander": "6.2.1",
 		"core-js": "3.8.2",
 		"create-file-webpack": "1.0.2",


### PR DESCRIPTION
This plugins watch our files for any circular dependencies issues and log them to the console.

Plugin repo: https://github.com/aackerman/circular-dependency-plugin

### How to test:
- Running `npm start` should produce some errors, they're non-blocking so you should use blocks fine.