### PR TITLE
Fix error with eslint workflow artifact download issues.

### DIFF
--- a/.github/workflows/js-css-linting.yml
+++ b/.github/workflows/js-css-linting.yml
@@ -6,37 +6,74 @@ on:
     branches: [trunk]
 
 jobs:
-  check:
-    name: All
-
+  Setup:
+    name: Setup for Jobs
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+      - name: Install Node Dependencies
+        run: npm install
 
-    - name: Cache node modules
-      uses: actions/cache@v2
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: Npm install
-      run: |
-        npm install
-    - name: Lint JavaScript
-      uses: bradennapier/eslint-plus-action@v3.4.2
-      with:
-        issueSummaryOnlyOnEvent: true
-    - name: Lint CSS
-      run: npm run lint:css
+  JSLintingCheck:
+    name: Lint JavaScript
+    needs: Setup
+    runs-on: ubuntu-latest
 
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+      - name: Install Node Dependencies
+        run: npm install
+      - name: Save Code Linting Report JSON
+        run: npm run lint:js:report
+        # Continue to the next step even if this fails
+        continue-on-error: true
+      - name: Upload ESLint report
+        uses: actions/upload-artifact@v2
+        with:
+          name: eslint_report.json
+          path: eslint_report.json
+      - name: Annotate Code Linting Results
+        uses: ataylorme/eslint-annotate-action@1.1.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          report-json: "eslint_report.json"
+
+  CSSLintingCheck:
+    name: Lint CSS
+    needs: Setup
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+      - name: Install Node Dependencies
+        run: npm install
+      - name: Lint CSS
+        run: npm run lint:css

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ storybook-static/
 blocks.ini
 /wp-content/
 /.wp-env.override.json
+/eslint_report.json

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"lint:css": "stylelint 'assets/**/*.scss'",
 		"lint:css-fix": "stylelint 'assets/**/*.scss' --fix",
 		"lint:js": "wp-scripts lint-js",
+		"lint:js:report": "npm run lint:js -- --output-file eslint_report.json --format json",
 		"lint:js-fix": "eslint assets/js --ext=js,jsx --fix",
 		"lint:php": "composer run-script phpcs ./src",
 		"package-plugin": "rimraf woocommerce-gutenberg-products-block.zip && ./bin/build-plugin-zip.sh",


### PR DESCRIPTION
Recently the ESLint workflow hasn't been working with the following errors in the log:

```
Error: HttpError: Failed to generate URL to download artifact
Error: Failed to generate URL to download artifact
```

I spent some time trying to debug this (including seeing if deleting artifacts would do anything) but was unsuccessful. In the end I ended up switching to use a [different action](https://github.com/ataylorme/eslint-annotate-action) that seems to be more resilient and uses eslint reporting for doing the checks. 

Annotation is still supported.

In the process I cleaned up the workflow a bit with a little bit better naming of steps. 

The only slight downside to this change is that it lints all files not just changed, so that means that there will be a section in the annotations for unchanged files causing linting warnings (which might not be a bad thing because it keeps the warnings from being forgotten).

I tested deliberately causing a eslint fail and this caught it nicely. I then forced a reset of the history for the pull so you won't see that test in the current history. Once Github actions pass this can be merged.