### PR TITLE
Add circular dependency check and fix it

### DIFF
--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -6,13 +6,13 @@ on:
   pull_request:
 
 jobs:
-  
+
   Setup:
     runs-on: ubuntu-latest
     name: Setup
     steps:
       - uses: actions/checkout@v2
-      
+
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -25,17 +25,17 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-  
+
       - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-  
+
       - name: Npm install and build
         run: |
           npm ci
           FORCE_REDUCED_MOTION=true npm run build:e2e-test
-          
+
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -46,24 +46,24 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-  
+
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
           coverage: none
           tools: composer
-  
+
       - name: Composer install
         run: |
           composer install
-  
+
   PHPUnitTests:
     name: PHP Unit Tests
     needs: Setup
 
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -91,18 +91,18 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
 
       - name: Run PHP Unit tests
         run: |
           npm run phpunit
-          
+
   JSUnitTests:
     name: JS Unit Tests
     needs: Setup
 
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -131,13 +131,13 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
 
       - name: Run JavaScript Unit tests
         run: |
           npm run test
-    
-    
+
+
   JSE2ETestsWP56Gutenberg:
     name: JavaScipt E2E Tests (WP 5.6 with Gutenberg plugin)
     needs: Setup
@@ -170,7 +170,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -201,7 +201,7 @@ jobs:
           npm run wp-env start
           npm run wp-env clean all
           npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
-          npm run test:e2e   
+          npm run test:e2e
 
   JSE2ETestsWP56:
     name: JavaScipt E2E Tests (WP 5.6)
@@ -235,7 +235,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -301,7 +301,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -367,7 +367,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |

--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -91,8 +91,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3 > blocks.ini
-          echo 'woocommerce_blocks_env = tests' >> blocks.ini
+          echo -e 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
 
       - name: Run PHP Unit tests
         run: |
@@ -132,8 +131,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3 > blocks.ini
-          echo 'woocommerce_blocks_env = tests' >> blocks.ini
+          echo -e 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
 
       - name: Run JavaScript Unit tests
         run: |
@@ -172,8 +170,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3 > blocks.ini
-          echo 'woocommerce_blocks_env = tests' >> blocks.ini
+          echo -e 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -238,8 +235,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3 > blocks.ini
-          echo 'woocommerce_blocks_env = tests' >> blocks.ini
+          echo -e 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -305,8 +301,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3 > blocks.ini
-          echo 'woocommerce_blocks_env = tests' >> blocks.ini
+          echo -e 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -372,8 +367,7 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3 > blocks.ini
-          echo 'woocommerce_blocks_env = tests' >> blocks.ini
+          echo -e 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |

--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -91,7 +91,8 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3 > blocks.ini
+          echo 'woocommerce_blocks_env = tests' >> blocks.ini
 
       - name: Run PHP Unit tests
         run: |
@@ -131,7 +132,8 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3 > blocks.ini
+          echo 'woocommerce_blocks_env = tests' >> blocks.ini
 
       - name: Run JavaScript Unit tests
         run: |
@@ -170,7 +172,8 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3 > blocks.ini
+          echo 'woocommerce_blocks_env = tests' >> blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -235,7 +238,8 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3 > blocks.ini
+          echo 'woocommerce_blocks_env = tests' >> blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -301,7 +305,8 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3 > blocks.ini
+          echo 'woocommerce_blocks_env = tests' >> blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -367,7 +372,8 @@ jobs:
 
       - name: blocks.ini setup
         run: |
-          echo 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
+          echo 'woocommerce_blocks_phase = 3 > blocks.ini
+          echo 'woocommerce_blocks_env = tests' >> blocks.ini
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -117,9 +117,10 @@ const getCoreConfig = ( options = {} ) => {
 				// file name
 				fileName: 'blocks.ini',
 				// content of the file
-				content: `woocommerce_blocks_phase = ${
-					process.env.WOOCOMMERCE_BLOCKS_PHASE || 3
-				}`,
+				content: `
+woocommerce_blocks_phase = ${ process.env.WOOCOMMERCE_BLOCKS_PHASE || 3 }
+${ NODE_ENV === 'development' ? 'woocommerce_blocks_env = development' : '' }
+`.trim(),
 			} ),
 		],
 		resolve,

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -119,7 +119,7 @@ const getCoreConfig = ( options = {} ) => {
 				// content of the file
 				content: `
 woocommerce_blocks_phase = ${ process.env.WOOCOMMERCE_BLOCKS_PHASE || 3 }
-${ NODE_ENV === 'development' ? 'woocommerce_blocks_env = development' : '' }
+woocommerce_blocks_env = ${ NODE_ENV }
 `.trim(),
 			} ),
 		],

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -87,7 +87,7 @@ class Api {
 		}
 
 		if ( in_array( $handle, $dependencies, true ) ) {
-			if ( Package::feature()->is_development_environment() ) {
+			if ( $this->package->feature()->is_development_environment() ) {
 				$dependencies = array_diff( $dependencies, [ $handle ] );
 				// phpcs:ignore
 				trigger_error( sprintf( 'Script with handle %s had a dependency on itself which has been removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ), E_USER_WARNING );

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -84,6 +84,14 @@ class Api {
 			$version = $this->get_file_version( $relative_src );
 		}
 
+		if ( in_array( $handle, $dependencies, true ) ) {
+			$dependencies = array_diff( $dependencies, [ $handle ] );
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				// phpcs:ignore
+				trigger_error( sprintf( 'Script with handle %s had a dependency on itself which we removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ), E_USER_WARNING );
+			}
+		}
+
 		wp_register_script( $handle, $src, apply_filters( 'woocommerce_blocks_register_script_dependencies', $dependencies, $handle ), $version, true );
 
 		if ( $has_i18n && function_exists( 'wp_set_script_translations' ) ) {

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -88,7 +88,7 @@ class Api {
 
 		if ( in_array( $handle, $dependencies, true ) ) {
 			if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-				throw new Exception( sprintf( 'Script with handle %s had a dependency on itself which we removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ) );
+				throw new Exception( sprintf( 'Script with handle %s had a dependency on itself. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ) );
 			}
 		}
 

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -87,7 +87,11 @@ class Api {
 		}
 
 		if ( in_array( $handle, $dependencies, true ) ) {
-			if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			if ( Package::feature()->is_development_environment() ) {
+				$dependencies = array_diff( $dependencies, [ $handle ] );
+				// phpcs:ignore
+				trigger_error( sprintf( 'Script with handle %s had a dependency on itself which has been removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ), E_USER_WARNING );
+			} else {
 				throw new Exception( sprintf( 'Script with handle %s had a dependency on itself. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ) );
 			}
 		}

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -2,7 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
-
+use Exception;
 /**
  * The Api class provides an interface to various asset registration helpers.
  *
@@ -69,6 +69,8 @@ class Api {
 	 * @param bool   $has_i18n      Optional. Whether to add a script
 	 *                              translation call to this file. Default:
 	 *                              true.
+	 *
+	 * @throws Exception If the registered script has a dependency on itself.
 	 */
 	public function register_script( $handle, $relative_src, $dependencies = [], $has_i18n = true ) {
 		$src        = $this->get_asset_url( $relative_src );
@@ -85,10 +87,8 @@ class Api {
 		}
 
 		if ( in_array( $handle, $dependencies, true ) ) {
-			$dependencies = array_diff( $dependencies, [ $handle ] );
-			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-				// phpcs:ignore
-				trigger_error( sprintf( 'Script with handle %s had a dependency on itself which we removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ), E_USER_WARNING );
+			if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+				throw new Exception( sprintf( 'Script with handle %s had a dependency on itself which we removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ) );
 			}
 		}
 

--- a/src/Domain/Services/FeatureGating.php
+++ b/src/Domain/Services/FeatureGating.php
@@ -20,19 +20,33 @@ class FeatureGating {
 	const CORE_FLAG           = 1;
 
 	/**
+	 * Current environment
+	 *
+	 * @var string
+	 */
+	private $environment;
+
+	const PRODUCTION_ENVIRONMENT  = 'production';
+	const DEVELOPMENT_ENVIRONMENT = 'development';
+	const TEST_ENVIRONMENT        = 'test';
+
+	/**
 	 * Constructor
 	 *
-	 * @param int $flag Hardcoded flag value. Useful for tests.
+	 * @param int    $flag        Hardcoded flag value. Useful for tests.
+	 * @param string $environment Hardcoded environment value. Useful for tests.
 	 */
-	public function __construct( $flag = 0 ) {
-		$this->flag = $flag;
-		$this->init();
+	public function __construct( $flag = 0, $environment = 'unset' ) {
+		$this->flag        = $flag;
+		$this->environment = $environment;
+		$this->load_flag();
+		$this->load_environment();
 	}
 
 	/**
 	 * Set correct flag.
 	 */
-	public function init() {
+	public function load_flag() {
 		if ( 0 === $this->flag ) {
 			$default_flag = defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ? self::FEATURE_PLUGIN_FLAG : self::CORE_FLAG;
 
@@ -42,6 +56,21 @@ class FeatureGating {
 				$this->flag    = is_array( $woo_options ) && in_array( intval( $woo_options['woocommerce_blocks_phase'] ), $allowed_flags, true ) ? $woo_options['woocommerce_blocks_phase'] : $default_flag;
 			} else {
 				$this->flag = $default_flag;
+			}
+		}
+	}
+
+		/**
+		 * Set correct environment.
+		 */
+	public function load_environment() {
+		if ( 'unset' === $this->environment ) {
+			if ( file_exists( __DIR__ . '/../../../blocks.ini' ) ) {
+				$allowed_environments = [ self::PRODUCTION_ENVIRONMENT, self::DEVELOPMENT_ENVIRONMENT, self::TEST_ENVIRONMENT ];
+				$woo_options          = parse_ini_file( __DIR__ . '/../../../blocks.ini' );
+				$this->environment    = is_array( $woo_options ) && in_array( $woo_options['woocommerce_blocks_env'], $allowed_environments, true ) ? $woo_options['woocommerce_blocks_env'] : self::PRODUCTION_ENVIRONMENT;
+			} else {
+				$this->environment = self::PRODUCTION_ENVIRONMENT;
 			}
 		}
 	}
@@ -71,5 +100,41 @@ class FeatureGating {
 	 */
 	public function is_feature_plugin_build() {
 		return $this->flag >= self::FEATURE_PLUGIN_FLAG;
+	}
+
+		/**
+		 * Returns the current environment value.
+		 *
+		 * @return string
+		 */
+	public function get_environment() {
+		return $this->environment;
+	}
+
+	/**
+	 * Checks if we're executing the code in an development environment.
+	 *
+	 * @return boolean
+	 */
+	public function is_development_environment() {
+		return self::DEVELOPMENT_ENVIRONMENT === $this->environment;
+	}
+
+	/**
+	 * Checks if we're executing the code in a production environment.
+	 *
+	 * @return boolean
+	 */
+	public function is_production_environment() {
+		return self::PRODUCTION_ENVIRONMENT === $this->environment;
+	}
+
+	/**
+	 * Checks if we're executing the code in a test environment.
+	 *
+	 * @return boolean
+	 */
+	public function is_test_environment() {
+		return self::TEST_ENVIRONMENT === $this->environment;
 	}
 }


### PR DESCRIPTION
This PR adds a check around our enqueue call, it checks if the current script being registered has a dependency on its own.
When this happens and left unfixed, PHP will emit a `maximum function nesting level of '256' reached aborting` error and the script won't load.
This PR will throw an exception.

```
Script with handle %s had a dependency on itself. This is an indicator that your JS code has a circular dependency that can cause bugs.
```


### How to test

- Check out this branch https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3671
- check that Cart block is not loading, with a nesting level warning below.
- cherry-pick this PR into that branch `git cherry-pick 2450048`
- Refresh the page, a more descriptive error is shown.