### PR TITLE
Catch errors during cart validation

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -231,15 +231,13 @@ const CheckoutProcessor = () => {
 						id: 'checkout',
 					} );
 
-					if ( Array.isArray( response.additional_errors ) ) {
-						response.additional_errors.forEach(
-							( additionalError ) => {
-								addErrorNotice( additionalError.message, {
-									id: additionalError.error_code,
-								} );
-							}
-						);
-					}
+					response.additional_errors?.forEach?.(
+						( additionalError ) => {
+							addErrorNotice( additionalError.message, {
+								id: additionalError.error_code,
+							} );
+						}
+					);
 
 					dispatchActions.setHasError();
 					dispatchActions.setAfterProcessing( response );

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -230,6 +230,17 @@ const CheckoutProcessor = () => {
 					addErrorNotice( formatStoreApiErrorMessage( response ), {
 						id: 'checkout',
 					} );
+
+					if ( Array.isArray( response.additional_errors ) ) {
+						response.additional_errors.forEach(
+							( additionalError ) => {
+								addErrorNotice( additionalError.message, {
+									id: additionalError.error_code,
+								} );
+							}
+						);
+					}
+
 					dispatchActions.setHasError();
 					dispatchActions.setAfterProcessing( response );
 					setIsProcessingOrder( false );

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\AbstractSchema;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\StockAvailabilityException;
 
 /**
  * AbstractRoute class.
@@ -72,6 +73,8 @@ abstract class AbstractRoute implements RouteInterface {
 			}
 		} catch ( RouteException $error ) {
 			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
+		} catch ( StockAvailabilityException $error ) {
+			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getError(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
 			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
 		}

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -2,7 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\AbstractSchema;
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\StockAvailabilityException;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\InvalidStockLevelsInCartException;
 use WP_Error;
 
 /**
@@ -74,7 +74,7 @@ abstract class AbstractRoute implements RouteInterface {
 			}
 		} catch ( RouteException $error ) {
 			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
-		} catch ( StockAvailabilityException $error ) {
+		} catch ( InvalidStockLevelsInCartException $error ) {
 			$response = $this->get_route_error_response_from_object( $error->getError(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
 			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -210,7 +210,9 @@ abstract class AbstractRoute implements RouteInterface {
 	}
 
 	/**
-	 * Get route response when something went wrong and the supplied error is a WP_Error. This happens when
+	 * Get route response when something went wrong and the supplied error is a WP_Error. This currently only happens
+	 * when an item in the cart is out of stock, partially out of stock, can only be bought individually, or when the
+	 * item is not purchasable.
 	 *
 	 * @param WP_Error $error_object The WP_Error object containing the error.
 	 * @param int      $http_status_code HTTP status. Defaults to 500.

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\AbstractSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\StockAvailabilityException;
+use WP_Error;
 
 /**
  * AbstractRoute class.
@@ -74,7 +75,7 @@ abstract class AbstractRoute implements RouteInterface {
 		} catch ( RouteException $error ) {
 			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( StockAvailabilityException $error ) {
-			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getError(), $error->getCode(), $error->getAdditionalData() );
+			$response = $this->get_route_error_response_from_object( $error->getError(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
 			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
 		}
@@ -206,6 +207,19 @@ abstract class AbstractRoute implements RouteInterface {
 	 */
 	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
 		return new \WP_Error( $error_code, $error_message, array_merge( $additional_data, [ 'status' => $http_status_code ] ) );
+	}
+
+	/**
+	 * Get route response when something went wrong and the supplied error is a WP_Error. This happens when
+	 *
+	 * @param WP_Error $error_object The WP_Error object containing the error.
+	 * @param int      $http_status_code HTTP status. Defaults to 500.
+	 * @param array    $additional_data  Extra data (key value pairs) to expose in the error response.
+	 * @return WP_Error WP Error object.
+	 */
+	protected function get_route_error_response_from_object( $error_object, $http_status_code = 500, $additional_data = [] ) {
+		$error_object->add_data( array_merge( $additional_data, [ 'status' => $http_status_code ] ) );
+		return $error_object;
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -1,7 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\StockAvailabilityException;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\InvalidStockLevelsInCartException;
 use \Exception;
 use \WP_Error;
 use \WP_REST_Server;
@@ -191,8 +191,10 @@ class Checkout extends AbstractRoute {
 	 * 5. Process Payment
 	 *
 	 * @throws RouteException On error.
-	 * @throws StockAvailabilityException On error.
+	 * @throws InvalidStockLevelsInCartException On error.
+	 *
 	 * @param WP_REST_Request $request Request object.
+	 *
 	 * @return WP_REST_Response
 	 */
 	protected function get_route_post_response( WP_REST_Request $request ) {

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -262,59 +262,58 @@ class Checkout extends AbstractRoute {
 	/**
 	 * Get route response when something went wrong.
 	 *
-	 * @param string          $error_code String based error code.
-	 * @param string|WP_Error $error_message User facing error message.
-	 * @param int             $http_status_code HTTP status. Defaults to 500.
-	 * @param array           $additional_data  Extra data (key value pairs) to expose in the error response.
+	 * @param string $error_code String based error code.
+	 * @param string $error_message User facing error message.
+	 * @param int    $http_status_code HTTP status. Defaults to 500.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
 	 * @return WP_Error WP Error object.
 	 */
 	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
+		$error_from_message = new WP_Error(
+			$error_code,
+			$error_message
+		);
 		switch ( $http_status_code ) {
-			case 400:
-				if ( is_wp_error( $error_message ) ) {
-					return $error_message;
-				}
-				return new WP_Error(
-					$error_code,
-					$error_message,
-					array_merge(
-						$additional_data,
-						[
-							'status' => $http_status_code,
-						]
-					)
-				);
 			case 409:
-				// If there was a conflict, return the cart so the client can resolve it.
-				$controller = new CartController();
-				$cart       = $controller->get_cart_instance();
-
-				if ( is_wp_error( $error_message ) ) {
-					$error_message->add_data(
-						array_merge(
-							$error_message->error_data,
-							[
-								'status' => $http_status_code,
-								'cart'   => wc()->api->get_endpoint_data( '/wc/store/cart' ),
-							]
-						)
-					);
-					return $error_message;
-				}
-
-				return new WP_Error(
-					$error_code,
-					$error_message,
-					array_merge(
-						$additional_data,
-						[
-							'status' => $http_status_code,
-							'cart'   => wc()->api->get_endpoint_data( '/wc/store/cart' ),
-						]
-					)
-				);
+				// 409 is when there was a conflict, so we return the cart so the client can resolve it.
+				return $this->add_data_to_error_object( $error_from_message, $additional_data, $http_status_code, true );
 		}
-		return new WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );
+		return $this->add_data_to_error_object( $error_from_message, $additional_data, $http_status_code );
+	}
+
+	/**
+	 * Get route response when something went wrong.
+	 *
+	 * @param WP_Error $error_object User facing error message.
+	 * @param int      $http_status_code HTTP status. Defaults to 500.
+	 * @param array    $additional_data  Extra data (key value pairs) to expose in the error response.
+	 * @return WP_Error WP Error object.
+	 */
+	protected function get_route_error_response_from_object( $error_object, $http_status_code = 500, $additional_data = [] ) {
+		switch ( $http_status_code ) {
+			case 409:
+				// 409 is when there was a conflict, so we return the cart so the client can resolve it.
+				return $this->add_data_to_error_object( $error_object, $additional_data, $http_status_code, true );
+		}
+		return $this->add_data_to_error_object( $error_object, $additional_data, $http_status_code );
+	}
+
+	/**
+	 * Adds additional data to the WP_Error object.
+	 *
+	 * @param WP_Error $error The error object to add the cart to.
+	 * @param array    $data The data to add to the error object.
+	 * @param int      $http_status_code The HTTP status code this error should return.
+	 * @param bool     $include_cart Whether the cart should be included in the error data.
+	 * @returns WP_Error The WP_Error with the cart added.
+	 */
+	private function add_data_to_error_object( $error, $data, $http_status_code, bool $include_cart = false ) {
+		$data = array_merge( $data, [ 'status' => $http_status_code ] );
+		if ( $include_cart ) {
+			$data = array_merge( $data, [ 'cart' => wc()->api->get_endpoint_data( '/wc/store/cart' ) ] );
+		}
+		$error->add_data( $data );
+		return $error;
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\StockAvailabilityException;
 use \Exception;
 use \WP_Error;
 use \WP_REST_Server;
@@ -190,6 +191,7 @@ class Checkout extends AbstractRoute {
 	 * 5. Process Payment
 	 *
 	 * @throws RouteException On error.
+	 * @throws StockAvailabilityException On error.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
@@ -260,15 +262,18 @@ class Checkout extends AbstractRoute {
 	/**
 	 * Get route response when something went wrong.
 	 *
-	 * @param string $error_code String based error code.
-	 * @param string $error_message User facing error message.
-	 * @param int    $http_status_code HTTP status. Defaults to 500.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 * @param string          $error_code String based error code.
+	 * @param string|WP_Error $error_message User facing error message.
+	 * @param int             $http_status_code HTTP status. Defaults to 500.
+	 * @param array           $additional_data  Extra data (key value pairs) to expose in the error response.
 	 * @return WP_Error WP Error object.
 	 */
 	protected function get_route_error_response( $error_code, $error_message, $http_status_code = 500, $additional_data = [] ) {
 		switch ( $http_status_code ) {
 			case 400:
+				if ( is_wp_error( $error_message ) ) {
+					return $error_message;
+				}
 				return new WP_Error(
 					$error_code,
 					$error_message,
@@ -283,6 +288,19 @@ class Checkout extends AbstractRoute {
 				// If there was a conflict, return the cart so the client can resolve it.
 				$controller = new CartController();
 				$cart       = $controller->get_cart_instance();
+
+				if ( is_wp_error( $error_message ) ) {
+					$error_message->add_data(
+						array_merge(
+							$error_message->error_data,
+							[
+								'status' => $http_status_code,
+								'cart'   => wc()->api->get_endpoint_data( '/wc/store/cart' ),
+							]
+						)
+					);
+					return $error_message;
+				}
 
 				return new WP_Error(
 					$error_code,

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -395,7 +395,12 @@ class CartSchema extends AbstractSchema {
 	 */
 	protected function get_cart_errors( $cart ) {
 		$controller    = new CartController();
-		$item_errors   = $controller->get_cart_item_errors();
+		$item_errors   = array_filter(
+			[ $controller->get_cart_item_errors() ],
+			function( \WP_Error  $error ) {
+				return $error->has_errors();
+			}
+		);
 		$coupon_errors = $controller->get_cart_coupon_errors();
 
 		return array_values( array_map( [ $this->error_schema, 'get_item_response' ], array_merge( $item_errors, $coupon_errors ) ) );

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use WP_Error;
 
 
 /**
@@ -396,8 +397,8 @@ class CartSchema extends AbstractSchema {
 	protected function get_cart_errors( $cart ) {
 		$controller    = new CartController();
 		$item_errors   = array_filter(
-			[ $controller->get_cart_item_errors() ],
-			function( \WP_Error  $error ) {
+			$controller->get_cart_item_errors(),
+			function ( WP_Error $error ) {
 				return $error->has_errors();
 			}
 		);

--- a/src/StoreApi/Schemas/ErrorSchema.php
+++ b/src/StoreApi/Schemas/ErrorSchema.php
@@ -45,7 +45,7 @@ class ErrorSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Convert a WooCommerce product into an object suitable for the response.
+	 * Convert a WP_Error into an object suitable for the response.
 	 *
 	 * @param \WP_Error $error Error object.
 	 * @return array

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -260,95 +260,85 @@ class CartController {
 			}
 		}
 
-		if (
-			count(
-				array_merge(
-					$out_of_stock_products,
-					$partial_out_of_stock_products,
-					$not_purchasable_products,
-					$too_many_in_cart_products
-				)
-			) > 0 ) {
+		$error = new WP_Error();
 
-			$error = new WP_Error();
-
-			if ( count( $out_of_stock_products ) > 0 ) {
-				// translators: %s: product names.
-				$singular_error = __(
-					'%s is out of stock and cannot be purchased. It has been removed from your cart.',
-					'woo-gutenberg-products-block'
-				);
-				// translators: %s: product names.
-				$plural_error = __(
-					'%s are out of stock and cannot be purchased. They have been removed from your cart.',
-					'woo-gutenberg-products-block'
-				);
-
-				$error->add(
-					409,
-					$this->add_product_names_to_message( $singular_error, $plural_error, $out_of_stock_products )
-				);
-			}
-
-			if ( count( $not_purchasable_products ) > 0 ) {
-				// translators: %s: product names.
-				$singular_error = __(
-					'%s cannot be purchased. It has been removed from your cart.',
-					'woo-gutenberg-products-block'
-				);
-				// translators: %s: product names.
-				$plural_error = __(
-					'%s cannot be purchased. They have been removed from your cart.',
-					'woo-gutenberg-products-block'
-				);
-
-				$error->add(
-					409,
-					$this->add_product_names_to_message( $singular_error, $plural_error, $not_purchasable_products )
-				);
-			}
-
-			if ( count( $too_many_in_cart_products ) > 0 ) {
-				// translators: %s: product names.
-				$singular_error = __(
-					'There are too many %s in the cart. Only 1 can be purchased. The quantity in your cart has been reduced.',
-					'woo-gutenberg-products-block'
-				);
-				// translators: %s: product names.
-				$plural_error = __(
-					'There are too many %s in the cart. Only 1 of each can be purchased. The quantities in your cart have been reduced.',
-					'woo-gutenberg-products-block'
-				);
-
-				$error->add(
-					409,
-					$this->add_product_names_to_message( $singular_error, $plural_error, $too_many_in_cart_products )
-				);
-			}
-
-			if ( count( $partial_out_of_stock_products ) > 0 ) {
-				// translators: %s: product names.
-				$singular_error = __(
-					'There is not enough %s in stock. The quantity in your cart has been reduced.',
-					'woo-gutenberg-products-block'
-				);
-				// translators: %s: product names.
-				$plural_error = __(
-					'There are not enough %s in stock. The quantities in your cart have been reduced.',
-					'woo-gutenberg-products-block'
-				);
-
-				$error->add(
-					409,
-					$this->add_product_names_to_message( $singular_error, $plural_error, $partial_out_of_stock_products )
-				);
-			}
-
-			throw new InvalidStockLevelsInCartException(
-				'woocommerce_stock_availability_error',
-				$error
+		if ( count( $out_of_stock_products ) > 0 ) {
+			// translators: %s: product names.
+			$singular_error = __(
+				'%s is out of stock and cannot be purchased. It has been removed from your cart.',
+				'woo-gutenberg-products-block'
+			);
+			// translators: %s: product names.
+			$plural_error = __(
+				'%s are out of stock and cannot be purchased. They have been removed from your cart.',
+				'woo-gutenberg-products-block'
 			);
 
+			$error->add(
+				409,
+				$this->add_product_names_to_message( $singular_error, $plural_error, $out_of_stock_products )
+			);
+		}
+
+		if ( count( $not_purchasable_products ) > 0 ) {
+			// translators: %s: product names.
+			$singular_error = __(
+				'%s cannot be purchased. It has been removed from your cart.',
+				'woo-gutenberg-products-block'
+			);
+			// translators: %s: product names.
+			$plural_error = __(
+				'%s cannot be purchased. They have been removed from your cart.',
+				'woo-gutenberg-products-block'
+			);
+
+			$error->add(
+				409,
+				$this->add_product_names_to_message( $singular_error, $plural_error, $not_purchasable_products )
+			);
+		}
+
+		if ( count( $too_many_in_cart_products ) > 0 ) {
+			// translators: %s: product names.
+			$singular_error = __(
+				'There are too many %s in the cart. Only 1 can be purchased. The quantity in your cart has been reduced.',
+				'woo-gutenberg-products-block'
+			);
+			// translators: %s: product names.
+			$plural_error = __(
+				'There are too many %s in the cart. Only 1 of each can be purchased. The quantities in your cart have been reduced.',
+				'woo-gutenberg-products-block'
+			);
+
+			$error->add(
+				409,
+				$this->add_product_names_to_message( $singular_error, $plural_error, $too_many_in_cart_products )
+			);
+		}
+
+		if ( count( $partial_out_of_stock_products ) > 0 ) {
+			// translators: %s: product names.
+			$singular_error = __(
+				'There is not enough %s in stock. The quantity in your cart has been reduced.',
+				'woo-gutenberg-products-block'
+			);
+			// translators: %s: product names.
+			$plural_error = __(
+				'There are not enough %s in stock. The quantities in your cart have been reduced.',
+				'woo-gutenberg-products-block'
+			);
+
+			$error->add(
+				409,
+				$this->add_product_names_to_message( $singular_error, $plural_error, $partial_out_of_stock_products )
+			);
+
+			if ( $error->has_errors() ) {
+				throw new InvalidStockLevelsInCartException(
+					'woocommerce_stock_availability_error',
+					$error
+				);
+			}
 		}
 
 		// Before running the woocommerce_check_cart_items hook, unhook validation from the core cart.

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -461,13 +461,7 @@ class CartController {
 				$this->validate_cart_item( $cart_item );
 			} catch ( RouteException $error ) {
 				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
-			} catch ( NotPurchasableException $error ) {
-				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
-			} catch ( OutOfStockException $error ) {
-				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
-			} catch ( PartialOutOfStockException $error ) {
-				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
-			} catch ( TooManyInCartException $error ) {
+			} catch ( StockAvailabilityException $error ) {
 				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 			}
 		}

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -3,7 +3,9 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\NoticeHandler;
+use Automattic\WooCommerce\Blocks\Utils\ArrayUtils;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
+use WP_Error;
 
 /**
  * Woo Cart Controller class.
@@ -213,17 +215,144 @@ class CartController {
 		do_action( 'wooocommerce_store_api_validate_add_to_cart', $product, $request );
 	}
 
+	// phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber -- this method _does_ throw a RouteException
+	// in convert_notices_to_exceptions.
 	/**
 	 * Validate all items in the cart and check for errors.
 	 *
-	 * @throws RouteException Exception if invalid data is detected.
+	 * @throws StockAvailabilityException Exception if invalid data is detected due to insufficient stock levels.
+	 * @throws RouteException Exception if invalid data is detected but not due to insufficient stock levels.
 	 */
 	public function validate_cart_items() {
 		$cart       = $this->get_cart_instance();
 		$cart_items = $this->get_cart_items();
 
+		$out_of_stock_products         = [];
+		$too_many_in_cart_products     = [];
+		$partial_out_of_stock_products = [];
+		$not_purchasable_products      = [];
+
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
-			$this->validate_cart_item( $cart_item );
+			try {
+				$this->validate_cart_item( $cart_item );
+			} catch ( TooManyInCartException $error ) {
+				$too_many_in_cart_products[] = $error;
+			} catch ( NotPurchasableException $error ) {
+				$not_purchasable_products[] = $error;
+			} catch ( PartialOutOfStockException $error ) {
+				$partial_out_of_stock_products[] = $error;
+			} catch ( OutOfStockException $error ) {
+				$out_of_stock_products[] = $error;
+			}
+		}
+
+		if (
+			count(
+				array_merge(
+					$out_of_stock_products,
+					$partial_out_of_stock_products,
+					$not_purchasable_products,
+					$too_many_in_cart_products
+				)
+			) > 0 ) {
+
+			$error = new WP_Error();
+
+			if ( count( $out_of_stock_products ) > 0 ) {
+				$out_of_stock_product_names = array_map(
+					function( $product ) {
+						return $product->getProductName();
+					},
+					$out_of_stock_products
+				);
+
+				$error->add(
+					409,
+					sprintf(
+						/* translators: %s: product names  */
+						_n(
+							'"%s" is out of stock and cannot be purchased.',
+							'"%s" are out of stock and cannot be purchased.',
+							count( $out_of_stock_products ),
+							'woo-gutenberg-products-block'
+						),
+						ArrayUtils::natural_language_join( $out_of_stock_product_names )
+					)
+				);
+			}
+
+			if ( count( $not_purchasable_products ) > 0 ) {
+				$not_purchasable_product_names = array_map(
+					function( $product ) {
+						return $product->getProductName();
+					},
+					$not_purchasable_products
+				);
+
+				$error->add(
+					409,
+					sprintf(
+						/* translators: %s: product names  */
+						'"%s" cannot be purchased.',
+						ArrayUtils::natural_language_join( $not_purchasable_product_names )
+					)
+				);
+			}
+
+			if ( count( $too_many_in_cart_products ) > 0 ) {
+				$too_many_in_cart_product_names = array_map(
+					function( $product ) {
+						return $product->getProductName();
+					},
+					$too_many_in_cart_products
+				);
+
+				$error->add(
+					409,
+					sprintf(
+					/* translators: %s: product names  */
+						_n(
+							'There are too many "%s" in the cart. Only 1 can be purchased. The quantity in your cart has been adjusted.',
+							'There are too many "%s" in the cart. Only 1 of each can be purchased. The quantities in your cart have been adjusted',
+							count( $too_many_in_cart_products ),
+							'woo-gutenberg-products-block'
+						),
+						ArrayUtils::natural_language_join( $too_many_in_cart_product_names )
+					)
+				);
+			}
+
+			if ( count( $partial_out_of_stock_products ) > 0 ) {
+				$partial_out_of_stock_product_names = array_map(
+					function( $product ) {
+						return $product->getProductName();
+					},
+					$partial_out_of_stock_products
+				);
+
+				$error->add(
+					$partial_out_of_stock_products[0]->getErrorCode(),
+					sprintf(
+						/* translators: %s: product names  */
+						_n(
+							'There is not enough "%s" in stock. Its quantity in your cart has been reduced.',
+							'There are not enough "%s" in stock. Their quantities in your cart have been reduced..',
+							count( $partial_out_of_stock_products ),
+							'woo-gutenberg-products-block'
+						),
+						ArrayUtils::natural_language_join( $partial_out_of_stock_product_names )
+					)
+				);
+			}
+
+			// Calculate totals here because we didn't do it in validate_item.
+			WC()->cart->calculate_totals();
+
+			throw new StockAvailabilityException(
+				'woocommerce_stock_availability_error',
+				$error
+			);
+
 		}
 
 		// Before running the woocommerce_check_cart_items hook, unhook validation from the core cart.
@@ -240,12 +369,16 @@ class CartController {
 		do_action( 'woocommerce_check_cart_items' );
 		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_cart_item_error' );
 	}
+	// phpcs:enable
 
 	/**
 	 * Validates an existing cart item and returns any errors.
 	 *
-	 * @throws RouteException Exception if invalid data is detected.
-	 *
+	 * @throws TooManyInCartException Exception if more than one product that can only be purchased individually is in
+	 * the cart.
+	 * @throws PartialOutOfStockException Exception if an item has a quantity greater than what is available in stock.
+	 * @throws OutOfStockException Exception thrown when an item is entirely out of stock.
+	 * @throws NotPurchasableException Exception thrown when an item is not purchasable.
 	 * @param array $cart_item Cart item array.
 	 */
 	public function validate_cart_item( $cart_item ) {
@@ -256,30 +389,25 @@ class CartController {
 		}
 
 		if ( ! $product->is_purchasable() ) {
-			$this->throw_default_product_exception( $product );
+			throw new NotPurchasableException(
+				'woocommerce_rest_cart_product_not_purchasable',
+				$product->get_name()
+			);
 		}
 
 		if ( $product->is_sold_individually() && $cart_item['quantity'] > 1 ) {
-			throw new RouteException(
+			WC()->cart->set_quantity( $cart_item['key'], 1, false );
+			throw new TooManyInCartException(
 				'woocommerce_rest_cart_product_sold_individually',
-				sprintf(
-					/* translators: %s: product name */
-					__( 'There are too many &quot;%s&quot; in the cart. Only 1 can be purchased.', 'woo-gutenberg-products-block' ),
-					$product->get_name()
-				),
-				400
+				$product->get_name()
 			);
 		}
 
 		if ( ! $product->is_in_stock() ) {
-			throw new RouteException(
+			WC()->cart->remove_cart_item( $cart_item['key'] );
+			throw new OutOfStockException(
 				'woocommerce_rest_cart_product_no_stock',
-				sprintf(
-					/* translators: %s: product name */
-					__( '&quot;%s&quot; is out of stock and cannot be purchased.', 'woo-gutenberg-products-block' ),
-					$product->get_name()
-				),
-				400
+				$product->get_name()
 			);
 		}
 
@@ -288,20 +416,11 @@ class CartController {
 			$qty_in_cart   = $this->get_product_quantity_in_cart( $product );
 
 			if ( $qty_remaining < $qty_in_cart ) {
-				throw new RouteException(
-					'woocommerce_rest_cart_product_no_stock',
-					sprintf(
-						/* translators: 1: quantity in stock, 2: product name  */
-						_n(
-							'There is only %1$s unit of &quot;%2$s&quot; in stock.',
-							'There are only %1$s units of &quot;%2$s&quot; in stock.',
-							$qty_remaining,
-							'woo-gutenberg-products-block'
-						),
-						wc_format_stock_quantity_for_display( $qty_remaining, $product ),
-						$product->get_name()
-					),
-					400
+
+				WC()->cart->set_quantity( $cart_item['key'], $qty_remaining, false );
+				throw new PartialOutOfStockException(
+					'woocommerce_rest_cart_product_partially_no_stock',
+					$product->get_name()
 				);
 			}
 		}

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -474,6 +474,8 @@ class CartController {
 				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
 			} catch ( PartialOutOfStockException $error ) {
 				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+			} catch ( TooManyInCartException $error ) {
+				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
 			}
 		}
 

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -271,8 +271,8 @@ class CartController {
 					sprintf(
 						/* translators: %s: product names  */
 						_n(
-							'"%s" is out of stock and cannot be purchased.',
-							'"%s" are out of stock and cannot be purchased.',
+							'"%s" is out of stock and cannot be purchased. It has been removed from your cart.',
+							'"%s" are out of stock and cannot be purchased. They have been removed from your cart.',
 							count( $out_of_stock_products ),
 							'woo-gutenberg-products-block'
 						),
@@ -293,7 +293,12 @@ class CartController {
 					409,
 					sprintf(
 						/* translators: %s: product names  */
-						'"%s" cannot be purchased.',
+						_n(
+							'"%s" cannot be purchased. It has been removed from your cart.',
+							'"%s" cannot be purchased. They have been removed from your cart.',
+							count( $too_many_in_cart_products ),
+							'woo-gutenberg-products-block'
+						),
 						ArrayUtils::natural_language_join( $not_purchasable_product_names )
 					)
 				);
@@ -312,8 +317,8 @@ class CartController {
 					sprintf(
 					/* translators: %s: product names  */
 						_n(
-							'There are too many "%s" in the cart. Only 1 can be purchased. The quantity in your cart has been adjusted.',
-							'There are too many "%s" in the cart. Only 1 of each can be purchased. The quantities in your cart have been adjusted',
+							'There are too many "%s" in the cart. Only 1 can be purchased. The quantity in your cart has been reduced.',
+							'There are too many "%s" in the cart. Only 1 of each can be purchased. The quantities in your cart have been reduced',
 							count( $too_many_in_cart_products ),
 							'woo-gutenberg-products-block'
 						),
@@ -335,8 +340,8 @@ class CartController {
 					sprintf(
 						/* translators: %s: product names  */
 						_n(
-							'There is not enough "%s" in stock. Its quantity in your cart has been reduced.',
-							'There are not enough "%s" in stock. Their quantities in your cart have been reduced..',
+							'There is not enough "%s" in stock. The quantity in your cart has been reduced.',
+							'There are not enough "%s" in stock. The quantities in your cart have been reduced.',
 							count( $partial_out_of_stock_products ),
 							'woo-gutenberg-products-block'
 						),

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -344,9 +344,6 @@ class CartController {
 				);
 			}
 
-			// Calculate totals here because we didn't do it in validate_item.
-			WC()->cart->calculate_totals();
-
 			throw new InvalidStockLevelsInCartException(
 				'woocommerce_stock_availability_error',
 				$error

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -344,6 +344,12 @@ class CartController {
 				$this->validate_cart_item( $cart_item );
 			} catch ( RouteException $error ) {
 				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+			} catch ( NotPurchasableException $error ) {
+				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+			} catch ( OutOfStockException $error ) {
+				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+			} catch ( PartialOutOfStockException $error ) {
+				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
 			}
 		}
 

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -235,7 +235,7 @@ class CartController {
 	/**
 	 * Validate all items in the cart and check for errors.
 	 *
-	 * @throws StockAvailabilityException Exception if invalid data is detected due to insufficient stock levels.
+	 * @throws InvalidStockLevelsInCartException Exception if invalid data is detected due to insufficient stock levels.
 	 */
 	public function validate_cart_items() {
 		$cart       = $this->get_cart_instance();
@@ -347,7 +347,7 @@ class CartController {
 			// Calculate totals here because we didn't do it in validate_item.
 			WC()->cart->calculate_totals();
 
-			throw new StockAvailabilityException(
+			throw new InvalidStockLevelsInCartException(
 				'woocommerce_stock_availability_error',
 				$error
 			);

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -467,15 +467,15 @@ class CartController {
 			try {
 				$this->validate_cart_item( $cart_item );
 			} catch ( RouteException $error ) {
-				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 			} catch ( NotPurchasableException $error ) {
-				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 			} catch ( OutOfStockException $error ) {
-				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 			} catch ( PartialOutOfStockException $error ) {
-				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 			} catch ( TooManyInCartException $error ) {
-				$errors[] = new \WP_Error( $error->getErrorCode(), $error->getMessage() );
+				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 			}
 		}
 

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -334,16 +334,8 @@ class CartController {
 		$error = new WP_Error();
 
 		if ( count( $out_of_stock_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'%s is out of stock and cannot be purchased. It has been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'%s are out of stock and cannot be purchased. They have been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'out_of_stock', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'out_of_stock', 'plural' );
 
 			$error->add(
 				409,
@@ -352,16 +344,8 @@ class CartController {
 		}
 
 		if ( count( $not_purchasable_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'%s cannot be purchased. It has been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'%s cannot be purchased. They have been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'not_purchasable', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'not_purchasable', 'plural' );
 
 			$error->add(
 				409,
@@ -370,16 +354,8 @@ class CartController {
 		}
 
 		if ( count( $too_many_in_cart_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'There are too many %s in the cart. Only 1 can be purchased. The quantity in your cart has been reduced.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'There are too many %s in the cart. Only 1 of each can be purchased. The quantities in your cart have been reduced.',
-				'woo-gutenberg-products-block'
-			);
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'too_many_in_cart', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'too_many_in_cart', 'plural' );
 
 			$error->add(
 				409,
@@ -388,16 +364,8 @@ class CartController {
 		}
 
 		if ( count( $partial_out_of_stock_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'There is not enough %s in stock. The quantity in your cart has been reduced.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'There are not enough %s in stock. The quantities in your cart have been reduced.',
-				'woo-gutenberg-products-block'
-			);
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'partial_out_of_stock', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'partial_out_of_stock', 'plural' );
 
 			$error->add(
 				409,

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -452,12 +452,17 @@ class CartController {
 			);
 		}
 
-		return [
-			$too_many_in_cart_error,
-			$partial_out_of_stock_error,
-			$out_of_stock_error,
-			$not_purchasable_error,
-		];
+		return array_filter(
+			[
+				$too_many_in_cart_error,
+				$partial_out_of_stock_error,
+				$out_of_stock_error,
+				$not_purchasable_error,
+			],
+			function( $error ) {
+				return $error->has_errors();
+			}
+		);
 	}
 
 	/**

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -485,7 +485,6 @@ class CartController {
 		}
 
 		if ( $product->is_sold_individually() && $cart_item['quantity'] > 1 ) {
-			WC()->cart->set_quantity( $cart_item['key'], 1, false );
 			throw new TooManyInCartException(
 				'woocommerce_rest_cart_product_sold_individually',
 				$product->get_name()
@@ -493,7 +492,6 @@ class CartController {
 		}
 
 		if ( ! $product->is_in_stock() ) {
-			WC()->cart->remove_cart_item( $cart_item['key'] );
 			throw new OutOfStockException(
 				'woocommerce_rest_cart_product_no_stock',
 				$product->get_name()
@@ -505,8 +503,6 @@ class CartController {
 			$qty_in_cart   = $this->get_product_quantity_in_cart( $product );
 
 			if ( $qty_remaining < $qty_in_cart ) {
-
-				WC()->cart->set_quantity( $cart_item['key'], $qty_remaining, false );
 				throw new PartialOutOfStockException(
 					'woocommerce_rest_cart_product_partially_no_stock',
 					$product->get_name()

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -543,10 +543,10 @@ class CartController {
 		$errors     = [];
 		$cart_items = $this->get_cart_items();
 
-		$too_many_in_cart_products     = [];
-		$not_purchasable_products      = [];
-		$partial_out_of_stock_products = [];
-		$out_of_stock_products         = [];
+		$too_many_in_cart_exceptions     = [];
+		$not_purchasable_exceptions      = [];
+		$partial_out_of_stock_exceptions = [];
+		$out_of_stock_exceptions         = [];
 
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
 			try {
@@ -554,13 +554,13 @@ class CartController {
 			} catch ( RouteException $error ) {
 				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 			} catch ( TooManyInCartException $error ) {
-				$too_many_in_cart_products[] = $error;
+				$too_many_in_cart_exceptions[] = $error;
 			} catch ( NotPurchasableException $error ) {
-				$not_purchasable_products[] = $error;
+				$not_purchasable_exceptions[] = $error;
 			} catch ( PartialOutOfStockException $error ) {
-				$partial_out_of_stock_products[] = $error;
+				$partial_out_of_stock_exceptions[] = $error;
 			} catch ( OutOfStockException $error ) {
-				$out_of_stock_products[] = $error;
+				$out_of_stock_exceptions[] = $error;
 			}
 		}
 
@@ -568,7 +568,7 @@ class CartController {
 			return $errors;
 		}
 
-		return $this->stock_exceptions_to_wp_errors( $too_many_in_cart_products, $not_purchasable_products, $partial_out_of_stock_products, $out_of_stock_products );
+		return $this->stock_exceptions_to_wp_errors( $too_many_in_cart_exceptions, $not_purchasable_exceptions, $partial_out_of_stock_exceptions, $out_of_stock_exceptions );
 	}
 
 	/**

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -233,6 +233,77 @@ class CartController {
 	}
 
 	/**
+	 * Takes a string describing the type of stock extension, whether there is a single product or multiple products
+	 * causing this exception and returns an appropriate error message.
+	 *
+	 * @param string $exception_type     The type of exception encountered.
+	 * @param string $singular_or_plural Whether to get the error message for a single product or multiple.
+	 *
+	 * @return string
+	 */
+	private function get_error_message_for_stock_exception_type( $exception_type, $singular_or_plural ) {
+		$stock_error_messages = [
+			'out_of_stock'         => [
+				// translators: %s: product name.
+				'singular' => __(
+					'%s is out of stock and cannot be purchased. Please remove it from your cart.',
+					'woo-gutenberg-products-block'
+				),
+				// translators: %s: product names.
+				'plural'   => __(
+					'%s are out of stock and cannot be purchased. Please remove them from your cart.',
+					'woo-gutenberg-products-block'
+				),
+			],
+			'not_purchasable'      => [
+				// translators: %s: product name.
+				'singular' => __(
+					'%s cannot be purchased.  Please remove it from your cart.',
+					'woo-gutenberg-products-block'
+				),
+				// translators: %s: product names.
+				'plural'   => __(
+					'%s cannot be purchased. Please remove them from your cart.',
+					'woo-gutenberg-products-block'
+				),
+			],
+			'too_many_in_cart'     => [
+				// translators: %s: product names.
+				'singular' => __(
+					'There are too many %s in the cart. Only 1 can be purchased. Please reduce the quantity in your cart.',
+					'woo-gutenberg-products-block'
+				),
+				// translators: %s: product names.
+				'plural'   => __(
+					'There are too many %s in the cart. Only 1 of each can be purchased. Please reduce the quantities in your cart.',
+					'woo-gutenberg-products-block'
+				),
+			],
+			'partial_out_of_stock' => [
+				// translators: %s: product names.
+				'singular' => __(
+					'There is not enough %s in stock. Please reduce the quantity in your cart.',
+					'woo-gutenberg-products-block'
+				),
+				// translators: %s: product names.
+				'plural'   => __(
+					'There are not enough %s in stock. Please reduce the quantities in your cart.',
+					'woo-gutenberg-products-block'
+				),
+			],
+		];
+
+		if (
+			isset( $stock_error_messages[ $exception_type ] ) &&
+			isset( $stock_error_messages[ $exception_type ][ $singular_or_plural ] )
+		) {
+			return $stock_error_messages[ $exception_type ][ $singular_or_plural ];
+		}
+
+		return __( 'There was an error with an item in your cart.', 'woo-gutenberg-products-block' );
+	}
+
+	/**
 	 * Validate all items in the cart and check for errors.
 	 *
 	 * @throws InvalidStockLevelsInCartException Exception if invalid data is detected due to insufficient stock levels.

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -551,20 +551,24 @@ class CartController {
 		foreach ( $cart_items as $cart_item_key => $cart_item ) {
 			try {
 				$this->validate_cart_item( $cart_item );
-				} catch ( RouteException $error ) {
-					$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
-				} catch ( TooManyInCartException $error ) {
-					$too_many_in_cart_products[] = $error;
-				} catch ( NotPurchasableException $error ) {
-					$not_purchasable_products[] = $error;
-				} catch ( PartialOutOfStockException $error ) {
-					$partial_out_of_stock_products[] = $error;
-				} catch ( OutOfStockException $error ) {
-					$out_of_stock_products[] = $error;
-				}
+			} catch ( RouteException $error ) {
+				$errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
+			} catch ( TooManyInCartException $error ) {
+				$too_many_in_cart_products[] = $error;
+			} catch ( NotPurchasableException $error ) {
+				$not_purchasable_products[] = $error;
+			} catch ( PartialOutOfStockException $error ) {
+				$partial_out_of_stock_products[] = $error;
+			} catch ( OutOfStockException $error ) {
+				$out_of_stock_products[] = $error;
+			}
 		}
 
-		return $this->stock_exceptions_to_wp_error( $too_many_in_cart_products, $not_purchasable_products, $partial_out_of_stock_products, $out_of_stock_products );
+		if ( count( $errors ) > 0 ) {
+			return $errors;
+		}
+
+		return $this->stock_exceptions_to_wp_errors( $too_many_in_cart_products, $not_purchasable_products, $partial_out_of_stock_products, $out_of_stock_products );
 	}
 
 	/**

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -417,7 +417,7 @@ class CartController {
 			$plural_error   = $this->get_error_message_for_stock_exception_type( 'out_of_stock', 'plural' );
 
 			$out_of_stock_error->add(
-				'woocommerce-blocks-product-out_of_stock',
+				'woocommerce-blocks-product-out-of-stock',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $out_of_stock_products )
 			);
 		}
@@ -447,7 +447,7 @@ class CartController {
 			$plural_error   = $this->get_error_message_for_stock_exception_type( 'partial_out_of_stock', 'plural' );
 
 			$partial_out_of_stock_error->add(
-				'woocommerce-blocks-product-partially-out_of_stock',
+				'woocommerce-blocks-product-partially-out-of-stock',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $partial_out_of_stock_products )
 			);
 		}

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -398,89 +398,66 @@ class CartController {
 	/**
 	 * This method will take arrays of exceptions relating to stock, and will convert them to a WP_Error object.
 	 *
-	 * @param $too_many_in_cart_products TooManyInCartException[] Array of TooManyInCartExceptions
-	 * @param $not_purchasable_products NotPurchasableException[] Array of NotPurchasableExceptions
-	 * @param $partial_out_of_stock_products PartialOutOfStockException[] Array of PartialOutOfStockExceptions
-	 * @param $out_of_stock_products OutOfStockException[] Array of OutOfStockExceptions
+	 * @param TooManyInCartException[]     $too_many_in_cart_products         Array of TooManyInCartExceptions.
+	 * @param NotPurchasableException[]    $not_purchasable_products         Array of NotPurchasableExceptions.
+	 * @param PartialOutOfStockException[] $partial_out_of_stock_products Array of PartialOutOfStockExceptions.
+	 * @param OutOfStockException[]        $out_of_stock_products                Array of OutOfStockExceptions.
 	 *
-	 * @return WP_Error The WP_Error object returned. Will have errors if any exceptions were in the args. It will be empty if they do not.
+	 * @return WP_Error[] The WP_Error object returned. Will have errors if any exceptions were in the args. It will be empty if they do not.
 	 */
-	private function stock_exceptions_to_wp_error( $too_many_in_cart_products, $not_purchasable_products, $partial_out_of_stock_products, $out_of_stock_products ) {
-		$error = new WP_Error();
+	private function stock_exceptions_to_wp_errors( $too_many_in_cart_products, $not_purchasable_products, $partial_out_of_stock_products, $out_of_stock_products ) {
+		$too_many_in_cart_error     = new WP_Error();
+		$out_of_stock_error         = new WP_Error();
+		$partial_out_of_stock_error = new WP_Error();
+		$not_purchasable_error      = new WP_Error();
 
 		if ( count( $out_of_stock_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'%s is out of stock and cannot be purchased. It has been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'%s are out of stock and cannot be purchased. They have been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
 
-			$error->add(
-				409,
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'out_of_stock', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'out_of_stock', 'plural' );
+
+			$out_of_stock_error->add(
+				'woocommerce-blocks-product-out_of_stock',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $out_of_stock_products )
 			);
 		}
 
 		if ( count( $not_purchasable_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'%s cannot be purchased. It has been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'%s cannot be purchased. They have been removed from your cart.',
-				'woo-gutenberg-products-block'
-			);
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'not_purchasable', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'not_purchasable', 'plural' );
 
-			$error->add(
-				409,
+			$not_purchasable_error->add(
+				'woocommerce-blocks-product-not-purchasable',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $not_purchasable_products )
 			);
 		}
 
 		if ( count( $too_many_in_cart_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'There are too many %s in the cart. Only 1 can be purchased. The quantity in your cart has been reduced.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'There are too many %s in the cart. Only 1 of each can be purchased. The quantities in your cart have been reduced.',
-				'woo-gutenberg-products-block'
-			);
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'too_many_in_cart', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'too_many_in_cart', 'plural' );
 
-			$error->add(
-				409,
+			$too_many_in_cart_error->add(
+				'woocommerce-blocks-too-many-of-product-in-cart',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $too_many_in_cart_products )
 			);
 		}
 
 		if ( count( $partial_out_of_stock_products ) > 0 ) {
-			// translators: %s: product names.
-			$singular_error = __(
-				'There is not enough %s in stock. The quantity in your cart has been reduced.',
-				'woo-gutenberg-products-block'
-			);
-			// translators: %s: product names.
-			$plural_error = __(
-				'There are not enough %s in stock. The quantities in your cart have been reduced.',
-				'woo-gutenberg-products-block'
-			);
+			$singular_error = $this->get_error_message_for_stock_exception_type( 'partial_out_of_stock', 'singular' );
+			$plural_error   = $this->get_error_message_for_stock_exception_type( 'partial_out_of_stock', 'plural' );
 
-			$error->add(
-				409,
+			$partial_out_of_stock_error->add(
+				'woocommerce-blocks-product-partially-out_of_stock',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $partial_out_of_stock_products )
 			);
 		}
 
-		return $error;
+		return [
+			$too_many_in_cart_error,
+			$partial_out_of_stock_error,
+			$out_of_stock_error,
+			$not_purchasable_error,
+		];
 	}
 
 	/**

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -537,7 +537,7 @@ class CartController {
 	/**
 	 * Validate all items in the cart and get a list of errors.
 	 *
-	 * @throws RouteException Exception if invalid data is detected.
+	 * @return WP_Error[] An array of WP_Errors describing the cart's error state.
 	 */
 	public function get_cart_item_errors() {
 		$errors     = [];

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -332,13 +332,13 @@ class CartController {
 				409,
 				$this->add_product_names_to_message( $singular_error, $plural_error, $partial_out_of_stock_products )
 			);
+		}
 
-			if ( $error->has_errors() ) {
-				throw new InvalidStockLevelsInCartException(
-					'woocommerce_stock_availability_error',
-					$error
-				);
-			}
+		if ( $error->has_errors() ) {
+			throw new InvalidStockLevelsInCartException(
+				'woocommerce_stock_availability_error',
+				$error
+			);
 		}
 
 		// Before running the woocommerce_check_cart_items hook, unhook validation from the core cart.

--- a/src/StoreApi/Utilities/InvalidStockLevelsInCartException.php
+++ b/src/StoreApi/Utilities/InvalidStockLevelsInCartException.php
@@ -1,0 +1,75 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
+
+use WP_Error;
+
+/**
+ * InvalidStockLevelsInCartException class.
+ *
+ * @internal This API is used internally by Blocks, this exception is thrown if any items are out of stock
+ * after each product on a draft order has been stock checked.
+ */
+class InvalidStockLevelsInCartException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	public $error_code;
+
+	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
+	 * All errors to display to the user.
+	 *
+	 * @var WP_Error
+	 */
+	public $error;
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string   $error_code      Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param WP_Error $error           The WP_Error object containing all errors relating to stock availability.
+	 * @param array    $additional_data Extra data (key value pairs) to expose in the error response.
+	 */
+	public function __construct( $error_code, $error, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->error           = $error;
+		$this->additional_data = array_filter( (array) $additional_data );
+		parent::__construct( '', 409 );
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns the list of messages.
+	 *
+	 * @return WP_Error
+	 */
+	public function getError() {
+		return $this->error;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
+	}
+
+}

--- a/src/StoreApi/Utilities/NotPurchasableException.php
+++ b/src/StoreApi/Utilities/NotPurchasableException.php
@@ -7,67 +7,6 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
  * @internal This API is used internally by Blocks, this exception is thrown when an item in the cart is not able to be
  * purchased.
  */
-class NotPurchasableException extends \Exception {
-	/**
-	 * Sanitized error code.
-	 *
-	 * @var string
-	 */
-	public $error_code;
-
-	/**
-	 * The name of the product that can only be purchased individually.
-	 *
-	 * @var string
-	 */
-	public $product_name;
-
-	/**
-	 * Additional error data.
-	 *
-	 * @var array
-	 */
-	public $additional_data = [];
-
-	/**
-	 * Setup exception.
-	 *
-	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
-	 * @param string $product_name     The name of the product that can only be purchased individually.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
-	 */
-	public function __construct( $error_code, $product_name, $additional_data = [] ) {
-		$this->error_code      = $error_code;
-		$this->product_name    = $product_name;
-		$this->additional_data = array_filter( (array) $additional_data );
-		parent::__construct();
-	}
-
-	/**
-	 * Returns the error code.
-	 *
-	 * @return string
-	 */
-	public function getErrorCode() {
-		return $this->error_code;
-	}
-
-	/**
-	 * Returns additional error data.
-	 *
-	 * @return array
-	 */
-	public function getAdditionalData() {
-		return $this->additional_data;
-	}
-
-	/**
-	 * Returns the product name.
-	 *
-	 * @return string
-	 */
-	public function getProductName() {
-		return $this->product_name;
-	}
+class NotPurchasableException extends StockAvailabilityException {
 
 }

--- a/src/StoreApi/Utilities/NotPurchasableException.php
+++ b/src/StoreApi/Utilities/NotPurchasableException.php
@@ -1,0 +1,73 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
+
+/**
+ * NotPurchasableException class.
+ *
+ * @internal This API is used internally by Blocks, this exception is thrown when an item in the cart is not able to be
+ * purchased.
+ */
+class NotPurchasableException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	public $error_code;
+
+	/**
+	 * The name of the product that can only be purchased individually.
+	 *
+	 * @var string
+	 */
+	public $product_name;
+
+	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param string $product_name     The name of the product that can only be purchased individually.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 */
+	public function __construct( $error_code, $product_name, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->product_name    = $product_name;
+		$this->additional_data = array_filter( (array) $additional_data );
+		parent::__construct();
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
+	}
+
+	/**
+	 * Returns the product name.
+	 *
+	 * @return string
+	 */
+	public function getProductName() {
+		return $this->product_name;
+	}
+
+}

--- a/src/StoreApi/Utilities/OutOfStockException.php
+++ b/src/StoreApi/Utilities/OutOfStockException.php
@@ -7,67 +7,6 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
  * @internal This API is used internally by Blocks, this exception is thrown when an item in a draft order is out
  * of stock completely.
  */
-class OutOfStockException extends \Exception {
-	/**
-	 * Sanitized error code.
-	 *
-	 * @var string
-	 */
-	public $error_code;
-
-	/**
-	 * The name of the product that is out of stock.
-	 *
-	 * @var string
-	 */
-	public $product_name;
-
-	/**
-	 * Additional error data.
-	 *
-	 * @var array
-	 */
-	public $additional_data = [];
-
-	/**
-	 * Setup exception.
-	 *
-	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
-	 * @param string $product_name     The name of the product that is out of stock.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
-	 */
-	public function __construct( $error_code, $product_name, $additional_data = [] ) {
-		$this->error_code      = $error_code;
-		$this->product_name    = $product_name;
-		$this->additional_data = array_filter( (array) $additional_data );
-		parent::__construct();
-	}
-
-	/**
-	 * Returns the error code.
-	 *
-	 * @return string
-	 */
-	public function getErrorCode() {
-		return $this->error_code;
-	}
-
-	/**
-	 * Returns additional error data.
-	 *
-	 * @return array
-	 */
-	public function getAdditionalData() {
-		return $this->additional_data;
-	}
-
-	/**
-	 * Returns the product name.
-	 *
-	 * @return string
-	 */
-	public function getProductName() {
-		return $this->product_name;
-	}
+class OutOfStockException extends StockAvailabilityException {
 
 }

--- a/src/StoreApi/Utilities/OutOfStockException.php
+++ b/src/StoreApi/Utilities/OutOfStockException.php
@@ -1,0 +1,73 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
+
+/**
+ * OutOfStockException class.
+ *
+ * @internal This API is used internally by Blocks, this exception is thrown when an item in a draft order is out
+ * of stock completely.
+ */
+class OutOfStockException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	public $error_code;
+
+	/**
+	 * The name of the product that is out of stock.
+	 *
+	 * @var string
+	 */
+	public $product_name;
+
+	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param string $product_name     The name of the product that is out of stock.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 */
+	public function __construct( $error_code, $product_name, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->product_name    = $product_name;
+		$this->additional_data = array_filter( (array) $additional_data );
+		parent::__construct();
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
+	}
+
+	/**
+	 * Returns the product name.
+	 *
+	 * @return string
+	 */
+	public function getProductName() {
+		return $this->product_name;
+	}
+
+}

--- a/src/StoreApi/Utilities/PartialOutOfStockException.php
+++ b/src/StoreApi/Utilities/PartialOutOfStockException.php
@@ -7,67 +7,6 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
  * @internal This API is used internally by Blocks, this exception is thrown when an item in a draft order has a
  * quantity greater than what is available in stock.
  */
-class PartialOutOfStockException extends \Exception {
-	/**
-	 * Sanitized error code.
-	 *
-	 * @var string
-	 */
-	public $error_code;
-
-	/**
-	 * The name of the product that is partially out of stock.
-	 *
-	 * @var string
-	 */
-	public $product_name;
-
-	/**
-	 * Additional error data.
-	 *
-	 * @var array
-	 */
-	public $additional_data = [];
-
-	/**
-	 * Setup exception.
-	 *
-	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
-	 * @param string $product_name     The name of the product that is partially out of stock.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
-	 */
-	public function __construct( $error_code, $product_name, $additional_data = [] ) {
-		$this->error_code      = $error_code;
-		$this->product_name    = $product_name;
-		$this->additional_data = array_filter( (array) $additional_data );
-		parent::__construct();
-	}
-
-	/**
-	 * Returns the error code.
-	 *
-	 * @return string
-	 */
-	public function getErrorCode() {
-		return $this->error_code;
-	}
-
-	/**
-	 * Returns additional error data.
-	 *
-	 * @return array
-	 */
-	public function getAdditionalData() {
-		return $this->additional_data;
-	}
-
-	/**
-	 * Returns the product name.
-	 *
-	 * @return string
-	 */
-	public function getProductName() {
-		return $this->product_name;
-	}
+class PartialOutOfStockException extends StockAvailabilityException {
 
 }

--- a/src/StoreApi/Utilities/PartialOutOfStockException.php
+++ b/src/StoreApi/Utilities/PartialOutOfStockException.php
@@ -1,0 +1,73 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
+
+/**
+ * PartialOutOfStockException class.
+ *
+ * @internal This API is used internally by Blocks, this exception is thrown when an item in a draft order has a
+ * quantity greater than what is available in stock.
+ */
+class PartialOutOfStockException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	public $error_code;
+
+	/**
+	 * The name of the product that is partially out of stock.
+	 *
+	 * @var string
+	 */
+	public $product_name;
+
+	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param string $product_name     The name of the product that is partially out of stock.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 */
+	public function __construct( $error_code, $product_name, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->product_name    = $product_name;
+		$this->additional_data = array_filter( (array) $additional_data );
+		parent::__construct();
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
+	}
+
+	/**
+	 * Returns the product name.
+	 *
+	 * @return string
+	 */
+	public function getProductName() {
+		return $this->product_name;
+	}
+
+}

--- a/src/StoreApi/Utilities/StockAvailabilityException.php
+++ b/src/StoreApi/Utilities/StockAvailabilityException.php
@@ -1,0 +1,75 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
+
+use WP_Error;
+
+/**
+ * StockAvailabilityException class.
+ *
+ * @internal This API is used internally by Blocks, this exception is thrown if any items are out of stock
+ * after each product on a draft order has been stock checked.
+ */
+class StockAvailabilityException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	public $error_code;
+
+	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
+	 * All errors to display to the user.
+	 *
+	 * @var WP_Error
+	 */
+	public $error;
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string   $error_code      Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param WP_Error $error           The WP_Error object containing all errors relating to stock availability.
+	 * @param array    $additional_data Extra data (key value pairs) to expose in the error response.
+	 */
+	public function __construct( $error_code, $error, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->error           = $error;
+		$this->additional_data = array_filter( (array) $additional_data );
+		parent::__construct( '', 409 );
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns the list of messages.
+	 *
+	 * @return WP_Error
+	 */
+	public function getError() {
+		return $this->error;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
+	}
+
+}

--- a/src/StoreApi/Utilities/StockAvailabilityException.php
+++ b/src/StoreApi/Utilities/StockAvailabilityException.php
@@ -1,13 +1,11 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
 
-use WP_Error;
-
 /**
  * StockAvailabilityException class.
  *
- * @internal This API is used internally by Blocks, this exception is thrown if any items are out of stock
- * after each product on a draft order has been stock checked.
+ * @internal This API is used internally by Blocks, this exception is thrown when more than one of a product that
+ * can only be purchased individually is in a cart.
  */
 class StockAvailabilityException extends \Exception {
 	/**
@@ -18,6 +16,13 @@ class StockAvailabilityException extends \Exception {
 	public $error_code;
 
 	/**
+	 * The name of the product that can only be purchased individually.
+	 *
+	 * @var string
+	 */
+	public $product_name;
+
+	/**
 	 * Additional error data.
 	 *
 	 * @var array
@@ -25,24 +30,17 @@ class StockAvailabilityException extends \Exception {
 	public $additional_data = [];
 
 	/**
-	 * All errors to display to the user.
-	 *
-	 * @var WP_Error
-	 */
-	public $error;
-
-	/**
 	 * Setup exception.
 	 *
-	 * @param string   $error_code      Machine-readable error code, e.g `woocommerce_invalid_product_id`.
-	 * @param WP_Error $error           The WP_Error object containing all errors relating to stock availability.
-	 * @param array    $additional_data Extra data (key value pairs) to expose in the error response.
+	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param string $product_name     The name of the product that can only be purchased individually.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
 	 */
-	public function __construct( $error_code, $error, $additional_data = [] ) {
+	public function __construct( $error_code, $product_name, $additional_data = [] ) {
 		$this->error_code      = $error_code;
-		$this->error           = $error;
+		$this->product_name    = $product_name;
 		$this->additional_data = array_filter( (array) $additional_data );
-		parent::__construct( '', 409 );
+		parent::__construct();
 	}
 
 	/**
@@ -55,21 +53,21 @@ class StockAvailabilityException extends \Exception {
 	}
 
 	/**
-	 * Returns the list of messages.
-	 *
-	 * @return WP_Error
-	 */
-	public function getError() {
-		return $this->error;
-	}
-
-	/**
 	 * Returns additional error data.
 	 *
 	 * @return array
 	 */
 	public function getAdditionalData() {
 		return $this->additional_data;
+	}
+
+	/**
+	 * Returns the product name.
+	 *
+	 * @return string
+	 */
+	public function getProductName() {
+		return $this->product_name;
 	}
 
 }

--- a/src/StoreApi/Utilities/TooManyInCartException.php
+++ b/src/StoreApi/Utilities/TooManyInCartException.php
@@ -7,67 +7,6 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
  * @internal This API is used internally by Blocks, this exception is thrown when more than one of a product that
  * can only be purchased individually is in a cart.
  */
-class TooManyInCartException extends \Exception {
-	/**
-	 * Sanitized error code.
-	 *
-	 * @var string
-	 */
-	public $error_code;
-
-	/**
-	 * The name of the product that can only be purchased individually.
-	 *
-	 * @var string
-	 */
-	public $product_name;
-
-	/**
-	 * Additional error data.
-	 *
-	 * @var array
-	 */
-	public $additional_data = [];
-
-	/**
-	 * Setup exception.
-	 *
-	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
-	 * @param string $product_name     The name of the product that can only be purchased individually.
-	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
-	 */
-	public function __construct( $error_code, $product_name, $additional_data = [] ) {
-		$this->error_code      = $error_code;
-		$this->product_name    = $product_name;
-		$this->additional_data = array_filter( (array) $additional_data );
-		parent::__construct();
-	}
-
-	/**
-	 * Returns the error code.
-	 *
-	 * @return string
-	 */
-	public function getErrorCode() {
-		return $this->error_code;
-	}
-
-	/**
-	 * Returns additional error data.
-	 *
-	 * @return array
-	 */
-	public function getAdditionalData() {
-		return $this->additional_data;
-	}
-
-	/**
-	 * Returns the product name.
-	 *
-	 * @return string
-	 */
-	public function getProductName() {
-		return $this->product_name;
-	}
+class TooManyInCartException extends StockAvailabilityException {
 
 }

--- a/src/StoreApi/Utilities/TooManyInCartException.php
+++ b/src/StoreApi/Utilities/TooManyInCartException.php
@@ -1,0 +1,73 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
+
+/**
+ * TooManyInCartException class.
+ *
+ * @internal This API is used internally by Blocks, this exception is thrown when more than one of a product that
+ * can only be purchased individually is in a cart.
+ */
+class TooManyInCartException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	public $error_code;
+
+	/**
+	 * The name of the product that can only be purchased individually.
+	 *
+	 * @var string
+	 */
+	public $product_name;
+
+	/**
+	 * Additional error data.
+	 *
+	 * @var array
+	 */
+	public $additional_data = [];
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $error_code       Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param string $product_name     The name of the product that can only be purchased individually.
+	 * @param array  $additional_data  Extra data (key value pairs) to expose in the error response.
+	 */
+	public function __construct( $error_code, $product_name, $additional_data = [] ) {
+		$this->error_code      = $error_code;
+		$this->product_name    = $product_name;
+		$this->additional_data = array_filter( (array) $additional_data );
+		parent::__construct();
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns additional error data.
+	 *
+	 * @return array
+	 */
+	public function getAdditionalData() {
+		return $this->additional_data;
+	}
+
+	/**
+	 * Returns the product name.
+	 *
+	 * @return string
+	 */
+	public function getProductName() {
+		return $this->product_name;
+	}
+
+}

--- a/src/Utils/ArrayUtils.php
+++ b/src/Utils/ArrayUtils.php
@@ -1,0 +1,27 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+/**
+ * ArrayUtils class used for custom functions to operate on arrays
+ */
+class ArrayUtils {
+	/**
+	 * Join a string with a natural language conjunction at the end.
+	 *
+	 * @param array $array  The array to join together with the natural language conjunction.
+	 *
+	 * @return string a string containing a list of items and a natural language conjuction.
+	 */
+	public static function natural_language_join( $array ) {
+		$last = array_pop( $array );
+		if ( $array ) {
+			return sprintf(
+			// translators: 1: The first n-1 items of a list 2: the last item in the list.
+				__( '%1$s, and %2$s', 'woo-gutenberg-products-block' ),
+				implode( ', ', $array ),
+				$last
+			);
+		}
+		return $last;
+	}
+}

--- a/src/Utils/ArrayUtils.php
+++ b/src/Utils/ArrayUtils.php
@@ -9,15 +9,24 @@ class ArrayUtils {
 	 * Join a string with a natural language conjunction at the end.
 	 *
 	 * @param array $array  The array to join together with the natural language conjunction.
+	 * @param bool  $enclose_items_with_quotes Whether each item in the array should be enclosed within quotation marks.
 	 *
 	 * @return string a string containing a list of items and a natural language conjuction.
 	 */
-	public static function natural_language_join( $array ) {
+	public static function natural_language_join( $array, $enclose_items_with_quotes = false ) {
+		if ( true === $enclose_items_with_quotes ) {
+			$array = array_map(
+				function( $item ) {
+					return '"' . $item . '"';
+				},
+				$array
+			);
+		}
 		$last = array_pop( $array );
 		if ( $array ) {
 			return sprintf(
 			// translators: 1: The first n-1 items of a list 2: the last item in the list.
-				__( '%1$s, and %2$s', 'woo-gutenberg-products-block' ),
+				__( '%1$s and %2$s', 'woo-gutenberg-products-block' ),
 				implode( ', ', $array ),
 				$last
 			);

--- a/tests/php/StoreApi/Utilities/CartController.php
+++ b/tests/php/StoreApi/Utilities/CartController.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * OrderController Tests.
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;
+
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use PHPUnit\Framework\TestCase;
+use \WC_Helper_Product as ProductHelper;
+
+class OrderControllerTests extends TestCase {
+
+	public function test_get_cart_item_errors()    {
+		$class = new CartController();
+
+		// This product will simply be in/out of stock.
+		$out_of_stock_product = ProductHelper::create_simple_product();
+		$out_of_stock_product_key = wc()->cart->add_to_cart( $out_of_stock_product->get_id(), 2 );
+		$out_of_stock_in_cart = wc()->cart->get_cart_item( $out_of_stock_product_key )['data'];
+
+		// This product will have exact levels of stock known
+		$partially_out_of_stock_product = ProductHelper::create_simple_product();
+		$partially_out_of_stock_key = wc()->cart->add_to_cart( $partially_out_of_stock_product->get_id(), 4 );
+		$partially_out_of_stock_in_cart = wc()->cart->get_cart_item( $partially_out_of_stock_key )['data'];
+
+		// This product will have exact levels of stock known
+		$too_many_in_cart_product = ProductHelper::create_simple_product();
+		$too_many_in_cart_product_key = wc()->cart->add_to_cart( $too_many_in_cart_product->get_id(), 4 );
+		$too_many_in_cart_in_cart = wc()->cart->get_cart_item( $too_many_in_cart_product_key )['data'];
+
+		$out_of_stock_in_cart->set_stock_status( 'outofstock' );
+		$partially_out_of_stock_in_cart->set_manage_stock( true );
+		$partially_out_of_stock_in_cart->set_stock_quantity( 2 );
+		$too_many_in_cart_in_cart->set_sold_individually( true );
+
+		// This product will not be purchasable
+		$not_purchasable_product = ProductHelper::create_simple_product();
+		wc()->cart->add_to_cart( $not_purchasable_product->get_id(), 2 );
+
+		// This function will force the $product->is_pruchasable() function to return false for our $not_purchasable_product
+		add_filter( 'woocommerce_is_purchasable', function( $is_purchasable, $product ) use ( $not_purchasable_product ) {
+			if ( $product->get_id() === $not_purchasable_product->get_id() ) {
+				return false;
+			}
+			return true;
+		}, 10, 2 );
+
+		$errors = array_map(
+			function( $error ) {
+				return $error->get_error_code();
+			},
+			$class->get_cart_item_errors()
+		);
+
+		$expected_errors = [
+			'woocommerce-blocks-product-partially-out-of-stock',
+			'woocommerce-blocks-product-out-of-stock',
+			'woocommerce-blocks-product-not-purchasable',
+			'woocommerce-blocks-too-many-of-product-in-cart',
+		];
+
+		foreach( $expected_errors as $expected_error ) {
+			$this->assertContains( $expected_error, $errors );
+		}
+
+	}
+
+}

--- a/tests/php/StoreApi/Utilities/CartController.php
+++ b/tests/php/StoreApi/Utilities/CartController.php
@@ -38,7 +38,7 @@ class OrderControllerTests extends TestCase {
 		$not_purchasable_product = ProductHelper::create_simple_product();
 		wc()->cart->add_to_cart( $not_purchasable_product->get_id(), 2 );
 
-		// This function will force the $product->is_pruchasable() function to return false for our $not_purchasable_product
+		// This function will force the $product->is_purchasable() function to return false for our $not_purchasable_product
 		add_filter( 'woocommerce_is_purchasable', function( $is_purchasable, $product ) use ( $not_purchasable_product ) {
 			if ( $product->get_id() === $not_purchasable_product->get_id() ) {
 				return false;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR extends the work done in #3656 - there was a bug found where the errors would not display properly in the cart block so this was reverted from trunk for the release. This PR includes those changes, but makes further changes to the way we handle the different types of out of stock error and refactors the way the errors are generated so that they can work in both the cart and checkout blocks.

This PR adds some new exceptions that can be thrown when validating the cart contents. These exceptions all relate to different types of "out of stock"

##### Thrown in `validate_cart_item`
- `PartialOutOfStockException` - Thrown when there _are_ items in stock, but not enough to satisfy the customer's order. The quantity in cart will be reduced to the in-stock amount.
- `TooManyInCartException` - Thrown when products can only be purchased individually but there is more than one in the cart. The quantity in cart will be reduced to 1.
- `OutOfStockException` - Thrown when the product is completely out of stock. The item is removed from cart.
- `NotPurchasableException` - Thrown when the product is not able to be purchased (doesn't exist, doesn't have a price etc.)
##### Thrown in `validate_cart_items`
- `StockValidationException` - Thrown as a "general" exception from `validate_cart_items` when one/some/all of the above exceptions are thrown in `validate_cart_item`. This Exception contains a `WP_Error` object that in turn contains all of the errors thrown by each execution of`validate_cart_item`. This `WP_Error` is then converted into a response and sent to the client so that the individual error notices might be displayed.

It also introduces the following code changes:

1. `get_error_message_for_stock_exception_type` function in the `CartController` which will return an appropriate error message based on the type of `StockAvailabilityException` and whether a single product or multiple products are causing the exception.
2. `stock_exceptions_to_wp_errors` in `CartController` - this takes all of the exceptions generated when checking the cart items' validities and turns them into `WP_Error`s
3. Add `get_route_error_response_from_object` to `AbstractRoute` - this will create an error response when the error is already a `WP_Error`.
4. Clean up code in `Routes/Checkout` and abstract adding the cart to the response to its own function so we don't repeat code
5. Creation of a `natural_language_join` function in the `ArrayUtils` class - used to join an array with a (translatable) natural language conjunction between the second to last and last item.

<!-- Reference any related issues or PRs here -->
Fixes #3699
Fixes #3412

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

### Cart Before
![image](https://user-images.githubusercontent.com/5656702/107668386-88b75380-6c88-11eb-8964-b94a5c3dfe74.png)

### Cart After
![image](https://user-images.githubusercontent.com/5656702/107668235-5c9bd280-6c88-11eb-96f5-c82088ae7b33.png)


### Checkout Before
<img width="700" alt="Screenshot 2021-01-06 at 16 06 36" src="https://user-images.githubusercontent.com/5656702/103790580-4c655780-5039-11eb-96c1-ac78055f18f2.png">

### Checkout After
<img width="700" alt="Screenshot 2021-01-06 at 14 45 04" src="https://user-images.githubusercontent.com/5656702/103781101-c8f23900-502d-11eb-94bb-998d73373663.png">

### How to test the changes in this Pull Request:

1. **In an incognito window** Add several products to your cart. Add these in differing quantities. Several of these added products need to have a quantity of 3+ in the cart.
2. Open the checkout page and ensure all the products are showing. **Do different combinations of the following steps in a different session to the one where you've added the items, and also without refreshing the checkout page. This is necessary because we can't be logged in as admin when testing step 3 below.**
3. Delete one or more of the products from the back end.
4. Set one or more of the products to "Manage stock?" true, and edit the in-stock amount of one or more of the products ensuring it is below the quantity that is in the cart, but above 0.
5. Set one or more of the products to "Sold individually"
6. Set one or more of the products to be entirely out of stock.
7. Try to check out and ensure you see the correct error messages for the products whose stock you've changed/reduced.
8. Try a few different scenarios with stock levels, number of products affected, number of products in cart etc. 

### Changelog

> Improve error displayed to customers when an item's stock status changes during checkout.
