### PR TITLE
add missing aria-label for stars image in review-list-item component

### DIFF
--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -124,22 +124,19 @@ function getReviewRating( review ) {
 	const starStyle = {
 		width: ( rating / 5 ) * 100 + '%' /* stylelint-disable-line */,
 	};
+	const ratingText = sprintf(
+		/* Translators: %f is referring to the average rating value */
+		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
+		rating
+	);
 	return (
 		<div className="wc-block-review-list-item__rating wc-block-components-review-list-item__rating">
 			<div
 				className="wc-block-review-list-item__rating__stars wc-block-components-review-list-item__rating__stars"
 				role="img"
+				aria-label={ ratingText }
 			>
-				<span style={ starStyle }>
-					{ sprintf(
-						/* Translators: %f to the average rating for the review. */
-						__(
-							'Rated %f out of 5',
-							'woo-gutenberg-products-block'
-						),
-						rating
-					) }
-				</span>
+				<span style={ starStyle }>{ ratingText }</span>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds an aria-label for the stars image in the review-list-item component for a11y purposes.

<!-- Reference any related issues or PRs here -->
Fixes #1675 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Insert *All reviews* block into a page
2. Use the developer tools to inspect one of the review items in the Reviews list
3. Select the div containing the start image
4. Make sure it has `role="img"` & `aria-label="Rated X out of 5"`
5. Check that the child span has the same text content as the `aria-label` attribute

<!-- If you can, add the appropriate labels -->

### Changelog

> Add missing aria-label for stars image in the review-list-item component.

