### PR TITLE
WIP/Experiment: Add a hook which allows extensions to inform about changes to available payment gateways

### DIFF
--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -47,10 +47,28 @@ final class PaymentMethodRegistry {
 		 */
 		do_action( 'woocommerce_blocks_payment_method_type_registration', $this );
 
+		add_action( '__experimental_woocommerce_blocks_available_gateways_maybe_changed', array( $this, 'unregister_all_gateways_except' ) );
+
 		$registered_payment_method_types = $this->get_all_registered();
 
 		foreach ( $registered_payment_method_types as $registered_type ) {
 			$registered_type->initialize();
+		}
+	}
+
+	/**
+	 * This method will take an array of WC_Payment_Gateways and unregister every gateway that is not in the array.
+	 * Extensions can do the action __experimental_woocommerce_blocks_available_gateways_maybe_changed to tell this
+	 * plugin that available gateways may have changed, and that we should process this.
+	 *
+	 * @param \WC_Payment_Gateway $available_gateways The list of available payment gateways.
+	 */
+	public function unregister_all_gateways_except( $available_gateways ) {
+		$available_gateway_names = wc_list_pluck( $available_gateways, 'id' );
+		foreach ( $this->registered_payment_methods as $registered_payment_method ) {
+			if ( ! in_array( $registered_payment_method->get_name(), $available_gateway_names, true ) ) {
+				$this->unregister( $registered_payment_method->get_name() );
+			}
 		}
 	}
 


### PR DESCRIPTION
This hook can be used by extensions to inform our API that the available payment gateways have changed, and maybe Blocks needs to unregister payment gateways.

The use by the extension would be something like:

`do_action( '__experimental_woocommerce_blocks_available_gateways_maybe_changed', $available_gateways );`

I wanted to prevent us from even registering unavailable payment methods, but we cannot do this because we register payment method integrations very early in the request pipeline and at this point extensions may not have finished processing their data, setting up their carts etc. I planned to filter the available payment methods using the `woocommerce_available_payment_gateways` filter here https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/96ef975f8cdc0cf6af07eff2e0ae284b39aa0ec7/src/Payments/Api.php#L106 to prevent ones that are removed by this filter even being registered. 

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3252
Related to #3686
Supersedes PR #3500
<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->
Right now I have not added docs for this hook as it is a POC and would like feedback on this approach.

### How to test the changes in this Pull Request:

1. Add `do_action( '__experimental_woocommerce_blocks_available_gateways_maybe_changed', $available_gateways );` just before the return here: https://github.com/woocommerce/woocommerce-subscriptions/blob/c81f04b4b47d53dad02f48b1813e5aafceb91041/includes/gateways/class-wc-subscriptions-payment-gateways.php#L100
1. Enable some payment gateways that we know subscriptions does not support. Cheque and BACS for example, but ensure you have Stripe enabled.
2. Add a subscription product to the cart.
3. Visit the checkout block and check BACS and Cheque do not show up as payment options.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.
