### PR TITLE
Remove star-rating class from Product rating block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/block.js
+++ b/assets/js/atomic/blocks/product-elements/rating/block.js
@@ -45,7 +45,6 @@ const Block = ( { className } ) => {
 		<div
 			className={ classnames(
 				className,
-				'star-rating',
 				'wc-block-components-product-rating',
 				{
 					[ `${ parentClassName }__product-rating` ]: parentClassName,


### PR DESCRIPTION
Fixes the issue reported in this comment https://github.com/woocommerce/storefront/pull/1588#issuecomment-763774546.

I think the Product rating styles in the All Products block were not correct, it seems like we were rendering three layers of stars one on top of the other while we should only be rendering two (one for the 'empty stars'  and another one for the 'filled stars').

That's because we added the `star-rating` class to `.wc-block-components-product-rating`. But if we ever wanted it to work, it should have been added to its child: `.wc-block-components-product-rating__stars`.

Given that this is a legacy CSS class and that it was not working properly, I think it's a good opportunity to remove it.

### Screenshots

<img src="https://user-images.githubusercontent.com/3616980/105339599-22856680-5bdd-11eb-947e-f80b22391780.png" alt="Screenshot" width="291" />

### How to test the changes in this Pull Request:

1. Update Storefront to version 3.4.0 or checkout branch `add/star-font` (see related PR: https://github.com/woocommerce/storefront/pull/1588).
2. Verify star icons look good in the All Products block (see screenshot above).
3. It would be nice to test some other themes in order to verify there are no regressions. Some that I tested: Astra, Twenty Nineteen, Twenty Twenty, a Storefront child theme (Arcade), Ocen WP, Orchid Store...

### Changelog

> Legacy `star-rating` class name has been removed from Product rating block (inside All Products block). That element is still selectable with the `.wc-block-components-product-rating` class name.