### PR TITLE
Introduce payment gateway feature check for cart content.

### DIFF
--- a/assets/js/base/components/payment-methods/test/payment-methods.js
+++ b/assets/js/base/components/payment-methods/test/payment-methods.js
@@ -34,6 +34,9 @@ const registerMockPaymentMethods = () => {
 			icons: null,
 			canMakePayment: () => true,
 			ariaLabel: name,
+			supports: {
+				features: [ 'products' ],
+			}
 		} );
 	} );
 };

--- a/assets/js/base/components/payment-methods/test/payment-methods.js
+++ b/assets/js/base/components/payment-methods/test/payment-methods.js
@@ -36,7 +36,7 @@ const registerMockPaymentMethods = () => {
 			ariaLabel: name,
 			supports: {
 				features: [ 'products' ],
-			}
+			},
 		} );
 	} );
 };

--- a/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -106,7 +106,7 @@ const registerMockPaymentMethods = () => {
 			paymentMethodId: name,
 			supports: {
 				features: [ 'products' ],
-			}
+			},
 		} );
 	} );
 };

--- a/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -60,6 +60,9 @@ const registerMockPaymentMethods = () => {
 			edit: <div>A payment method</div>,
 			icons: null,
 			canMakePayment: () => true,
+			supports: {
+				features: [ 'products' ],
+			},
 			ariaLabel: name,
 		} );
 	} );
@@ -74,6 +77,7 @@ const registerMockPaymentMethods = () => {
 			supports: {
 				showSavedCards: true,
 				showSaveOption: true,
+				features: [ 'products' ],
 			},
 			ariaLabel: name,
 		} );
@@ -100,6 +104,9 @@ const registerMockPaymentMethods = () => {
 			edit: <div>An express payment method</div>,
 			canMakePayment: () => true,
 			paymentMethodId: name,
+			supports: {
+				features: [ 'products' ],
+			}
 		} );
 	} );
 };

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -54,7 +54,11 @@ const usePaymentMethodRegistration = (
 	const { selectedRates, shippingAddress } = useShippingDataContext();
 	const selectedShippingMethods = useShallowEqual( selectedRates );
 	const paymentMethodsOrder = useShallowEqual( paymentMethodsSortOrder );
-	const { cartTotals, cartNeedsShipping } = useStoreCart();
+	const {
+		cartTotals,
+		cartNeedsShipping,
+		paymentRequirements,
+	} = useStoreCart();
 	const canPayArgument = useRef( {
 		cartTotals,
 		cartNeedsShipping,
@@ -91,6 +95,17 @@ const usePaymentMethodRegistration = (
 			const paymentMethodName = paymentMethodsOrder[ i ];
 			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
 			if ( ! paymentMethod ) {
+				continue;
+			}
+			// Filter out payment methods by supported features and cart requirement.
+			const requirements = paymentRequirements || [];
+			const features = paymentMethod?.supports?.features || [];
+			if (
+				requirements.length > 0 &&
+				! requirements.every( ( requirement ) =>
+					features.includes( requirement )
+				)
+			) {
 				continue;
 			}
 
@@ -137,6 +152,7 @@ const usePaymentMethodRegistration = (
 		noticeContext,
 		paymentMethodsOrder,
 		registeredPaymentMethods,
+		paymentRequirements,
 	] );
 
 	// Determine which payment methods are available initially and whenever
@@ -144,7 +160,12 @@ const usePaymentMethodRegistration = (
 	// Some payment methods (e.g. COD) can be disabled for specific shipping methods.
 	useEffect( () => {
 		refreshCanMakePayments();
-	}, [ refreshCanMakePayments, cartTotals, selectedShippingMethods ] );
+	}, [
+		refreshCanMakePayments,
+		cartTotals,
+		selectedShippingMethods,
+		paymentRequirements,
+	] );
 
 	return isInitialized;
 };

--- a/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/use-payment-method-registration.js
@@ -64,6 +64,7 @@ const usePaymentMethodRegistration = (
 		cartNeedsShipping,
 		shippingAddress,
 		selectedShippingMethods,
+		paymentRequirements,
 	} );
 	const { addErrorNotice } = useStoreNotices();
 
@@ -73,12 +74,14 @@ const usePaymentMethodRegistration = (
 			cartNeedsShipping,
 			shippingAddress,
 			selectedShippingMethods,
+			paymentRequirements,
 		};
 	}, [
 		cartTotals,
 		cartNeedsShipping,
 		shippingAddress,
 		selectedShippingMethods,
+		paymentRequirements,
 	] );
 
 	const refreshCanMakePayments = useCallback( async () => {
@@ -95,17 +98,6 @@ const usePaymentMethodRegistration = (
 			const paymentMethodName = paymentMethodsOrder[ i ];
 			const paymentMethod = registeredPaymentMethods[ paymentMethodName ];
 			if ( ! paymentMethod ) {
-				continue;
-			}
-			// Filter out payment methods by supported features and cart requirement.
-			const requirements = paymentRequirements || [];
-			const features = paymentMethod?.supports?.features || [];
-			if (
-				requirements.length > 0 &&
-				! requirements.every( ( requirement ) =>
-					features.includes( requirement )
-				)
-			) {
 				continue;
 			}
 
@@ -152,7 +144,6 @@ const usePaymentMethodRegistration = (
 		noticeContext,
 		paymentMethodsOrder,
 		registeredPaymentMethods,
-		paymentRequirements,
 	] );
 
 	// Determine which payment methods are available initially and whenever

--- a/assets/js/base/hooks/cart/test/use-store-cart.js
+++ b/assets/js/base/hooks/cart/test/use-store-cart.js
@@ -108,6 +108,7 @@ describe( 'useStoreCart', () => {
 		shippingRatesLoading: false,
 		cartHasCalculatedShipping: true,
 		receiveCart: undefined,
+		paymentRequirements: [],
 	};
 
 	const getWrappedComponents = ( Component ) => (

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -51,6 +51,7 @@ export const defaultCartData = {
 	shippingRates: [],
 	shippingRatesLoading: false,
 	cartHasCalculatedShipping: false,
+	paymentRequirements: [],
 	receiveCart: () => {},
 };
 
@@ -97,6 +98,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 					shippingRatesLoading: false,
 					cartHasCalculatedShipping:
 						previewCart.has_calculated_shipping,
+					paymentRequirements: previewCart.paymentRequirements,
 					receiveCart:
 						typeof previewCart?.receiveCart === 'function'
 							? previewCart.receiveCart
@@ -135,6 +137,7 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 				shippingRates: cartData.shippingRates || [],
 				shippingRatesLoading,
 				cartHasCalculatedShipping: cartData.hasCalculatedShipping,
+				paymentRequirements: cartData.paymentRequirements || [],
 				receiveCart,
 			};
 		},

--- a/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
@@ -36,6 +36,11 @@ export default class ExpressPaymentMethodConfig {
 				'The paymentMethodId property for the payment method must be a string or undefined (in which case it will be the value of the name property).'
 			);
 		}
+		if ( ! Array.isArray( config.supports?.features ) ) {
+			throw new Error(
+				'The features property for the payment method must be an array or null.'
+			);
+		}
 		assertValidElement( config.content, 'content' );
 		assertValidElement( config.edit, 'edit' );
 		if ( typeof config.canMakePayment !== 'function' ) {

--- a/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import { assertConfigHasProperties, assertValidElement } from './assertions';
+import { canMakePaymentWithFeaturesCheck } from './payment-method-config-helper';
 
 export default class ExpressPaymentMethodConfig {
 	constructor( config ) {
@@ -10,11 +11,14 @@ export default class ExpressPaymentMethodConfig {
 		this.name = config.name;
 		this.content = config.content;
 		this.edit = config.edit;
-		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
 		this.supports = {
 			features: config?.supports?.features || [],
 		};
+		this.canMakePayment = canMakePaymentWithFeaturesCheck(
+			config.canMakePayment,
+			this.supports.features
+		);
 	}
 
 	static assertValidConfig = ( config ) => {

--- a/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
@@ -12,6 +12,9 @@ export default class ExpressPaymentMethodConfig {
 		this.edit = config.edit;
 		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
+		this.supports = {
+			features: config?.supports?.features || [],
+		};
 	}
 
 	static assertValidConfig = ( config ) => {

--- a/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/express-payment-method-config.js
@@ -38,7 +38,7 @@ export default class ExpressPaymentMethodConfig {
 		}
 		if ( ! Array.isArray( config.supports?.features ) ) {
 			throw new Error(
-				'The features property for the payment method must be an array or null.'
+				'The features property for the payment method must be an array.'
 			);
 		}
 		assertValidElement( config.content, 'content' );

--- a/assets/js/blocks-registry/payment-methods/payment-method-config-helper.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config-helper.js
@@ -1,0 +1,10 @@
+// Filter out payment methods by supported features and cart requirement.
+export const canMakePaymentWithFeaturesCheck = ( canMakePayment, features ) => (
+	canPayArgument
+) => {
+	const requirements = canPayArgument.paymentRequirements || [];
+	const featuresSupportRequirements = requirements.every( ( requirement ) =>
+		features.includes( requirement )
+	);
+	return featuresSupportRequirements && canMakePayment( canPayArgument );
+};

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -113,7 +113,7 @@ export default class PaymentMethodConfig {
 		}
 		if ( ! Array.isArray( config.supports?.features ) ) {
 			throw new Error(
-				'The features property for the payment method must be an array or null.'
+				'The features property for the payment method must be an array.'
 			);
 		}
 		if (

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -12,6 +12,8 @@ import {
 	assertValidElementOrString,
 } from './assertions';
 
+import { canMakePaymentWithFeaturesCheck } from './payment-method-config-helper';
+
 export default class PaymentMethodConfig {
 	constructor( config ) {
 		// validate config
@@ -23,7 +25,6 @@ export default class PaymentMethodConfig {
 		this.content = config.content;
 		this.icons = config.icons;
 		this.edit = config.edit;
-		this.canMakePayment = config.canMakePayment;
 		this.paymentMethodId = config.paymentMethodId || this.name;
 		this.supports = {
 			showSavedCards:
@@ -33,6 +34,10 @@ export default class PaymentMethodConfig {
 			showSaveOption: config?.supports?.showSaveOption || false,
 			features: config?.supports?.features || [],
 		};
+		this.canMakePayment = canMakePaymentWithFeaturesCheck(
+			config.canMakePayment,
+			this.supports.features
+		);
 	}
 
 	static assertValidConfig = ( config ) => {

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -31,6 +31,7 @@ export default class PaymentMethodConfig {
 				config?.supports?.savePaymentInfo || // Kept for backward compatibility if methods still pass this when registering.
 				false,
 			showSaveOption: config?.supports?.showSaveOption || false,
+			features: config?.supports?.features || [],
 		};
 	}
 

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -111,6 +111,11 @@ export default class PaymentMethodConfig {
 				}
 			);
 		}
+		if ( ! Array.isArray( config.supports?.features ) ) {
+			throw new Error(
+				'The features property for the payment method must be an array or null.'
+			);
+		}
 		if (
 			typeof config.supports?.showSaveOption !== 'undefined' &&
 			typeof config.supports?.showSaveOption !== 'boolean'

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -58,8 +58,8 @@ const bankTransferPaymentMethod = {
 	canMakePayment: () => true,
 	ariaLabel: label,
 	supports: {
-		features: getSupportedFeatures()
-	}
+		features: getSupportedFeatures(),
+	},
 };
 
 registerPaymentMethod( bankTransferPaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -39,14 +39,6 @@ const Label = ( props ) => {
 	return <PaymentMethodLabel text={ label } />;
 };
 
-const getSupportedFeatures = () => {
-	const features = settings?.supports ?? [];
-	return features.reduce( ( supported, supportedKey ) => {
-		supported[ supportedKey ] = true;
-		return supported;
-	}, {} );
-};
-
 /**
  * Bank transfer (BACS) payment method config object.
  */
@@ -58,7 +50,7 @@ const bankTransferPaymentMethod = {
 	canMakePayment: () => true,
 	ariaLabel: label,
 	supports: {
-		features: getSupportedFeatures(),
+		features: settings?.supports ?? [],
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -39,6 +39,14 @@ const Label = ( props ) => {
 	return <PaymentMethodLabel text={ label } />;
 };
 
+const getSupportedFeatures = () => {
+	const features = settings?.supports ?? [];
+	return features.reduce( ( supported, supportedKey ) => {
+		supported[ supportedKey ] = true;
+		return supported;
+	}, {} );
+};
+
 /**
  * Bank transfer (BACS) payment method config object.
  */
@@ -49,6 +57,9 @@ const bankTransferPaymentMethod = {
 	edit: <Content />,
 	canMakePayment: () => true,
 	ariaLabel: label,
+	supports: {
+		features: getSupportedFeatures()
+	}
 };
 
 registerPaymentMethod( bankTransferPaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -46,6 +46,9 @@ const offlineChequePaymentMethod = {
 	edit: <Content />,
 	canMakePayment: () => true,
 	ariaLabel: label,
+	supports: {
+		features: settings?.supports ?? [],
+	},
 };
 
 registerPaymentMethod( offlineChequePaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/cod/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cod/index.js
@@ -79,6 +79,9 @@ const cashOnDeliveryPaymentMethod = {
 	edit: <Content />,
 	canMakePayment,
 	ariaLabel: label,
+	supports: {
+		features: settings?.supports ?? [],
+	},
 };
 
 registerPaymentMethod( cashOnDeliveryPaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -45,6 +45,9 @@ const paypalPaymentMethod = {
 		settings.title ||
 			__( 'Payment via PayPal', 'woo-gutenberg-products-block' )
 	),
+	supports: {
+		features: settings.supports ?? [],
+	},
 };
 
 registerPaymentMethod( paypalPaymentMethod );

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -43,14 +43,6 @@ const StripeLabel = ( props ) => {
 	return <PaymentMethodLabel text={ labelText } />;
 };
 
-const getSupportedFeatures = () => {
-	const features = getStripeServerData()?.supports ?? [];
-	return features.reduce( ( supported, supportedKey ) => {
-		supported[ supportedKey ] = true;
-		return supported;
-	}, {} );
-};
-
 const cardIcons = getStripeCreditCardIcons();
 const stripeCcPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
@@ -66,7 +58,7 @@ const stripeCcPaymentMethod = {
 	supports: {
 		showSavedCards: getStripeServerData().showSavedCards,
 		showSaveOption: getStripeServerData().showSaveOption,
-		features: getSupportedFeatures(),
+		features: getStripeServerData()?.supports ?? [],
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -44,7 +44,7 @@ const StripeLabel = ( props ) => {
 };
 
 const getSupportedFeatures = () => {
-	const features = getStripeServerData().supports ?? [];
+	const features = getStripeServerData()?.supports ?? [];
 	return features.reduce( ( supported, supportedKey ) => {
 		supported[ supportedKey ] = true;
 		return supported;
@@ -66,7 +66,7 @@ const stripeCcPaymentMethod = {
 	supports: {
 		showSavedCards: getStripeServerData().showSavedCards,
 		showSaveOption: getStripeServerData().showSaveOption,
-		...getSupportedFeatures(),
+		features: getSupportedFeatures(),
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/index.js
@@ -43,6 +43,14 @@ const StripeLabel = ( props ) => {
 	return <PaymentMethodLabel text={ labelText } />;
 };
 
+const getSupportedFeatures = () => {
+	const features = getStripeServerData().supports ?? [];
+	return features.reduce( ( supported, supportedKey ) => {
+		supported[ supportedKey ] = true;
+		return supported;
+	}, {} );
+};
+
 const cardIcons = getStripeCreditCardIcons();
 const stripeCcPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
@@ -58,6 +66,7 @@ const stripeCcPaymentMethod = {
 	supports: {
 		showSavedCards: getStripeServerData().showSavedCards,
 		showSaveOption: getStripeServerData().showSaveOption,
+		...getSupportedFeatures(),
 	},
 };
 

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/index.js
@@ -9,7 +9,7 @@ import { getSetting } from '@woocommerce/settings';
 import { PAYMENT_METHOD_NAME } from './constants';
 import { PaymentRequestExpress } from './payment-request-express';
 import { applePayImage } from './apple-pay-preview';
-import { loadStripe } from '../stripe-utils';
+import { getStripeServerData, loadStripe } from '../stripe-utils';
 
 const ApplePayPreview = () => <img src={ applePayImage } alt="" />;
 
@@ -68,6 +68,9 @@ const paymentRequestPaymentMethod = {
 			totalPrice: parseInt( cartData?.cartTotals?.total_price || 0, 10 ),
 		} ),
 	paymentMethodId: 'stripe',
+	supports: {
+		features: getStripeServerData()?.supports ?? [],
+	},
 };
 
 export default paymentRequestPaymentMethod;

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/type-defs.js
@@ -303,6 +303,7 @@
  *                                                              save card can be displayed.
  * @property {boolean}                     allowPaymentRequest  True if merchant has enabled payment
  *                                                              request (Chrome/Apple Pay).
+ * @property {Object}                      supports             List of features supported by the payment gateway
  */
 /* eslint-enable jsdoc/valid-types */
 

--- a/assets/js/type-defs/hooks.js
+++ b/assets/js/type-defs/hooks.js
@@ -40,6 +40,7 @@
  *                                                      shipping rates are
  *                                                      being loaded.
  * @property {boolean}             cartHasCalculatedShipping Whether or not the cart has calculated shipping yet.
+ * @property {Array}               paymentRequirements  List of features required from payment gateways.
  * @property {function(Object):any} receiveCart         Dispatcher to receive
  *                                                      updated cart.
  */

--- a/assets/js/type-defs/payments.js
+++ b/assets/js/type-defs/payments.js
@@ -13,6 +13,7 @@
  * @property {Object} edit              A react node to display a preview of your payment method in the editor.
  * @property {Function} canMakePayment  A callback to determine whether the payment method should be shown in the checkout.
  * @property {string} [paymentMethodId] A unique string to represent the payment method server side. If not provided, defaults to name.
+ * @property {Object} supports          Object that describes various features provided by the payment method.
  */
 
 /**
@@ -27,6 +28,7 @@
  * @property {Object} label                   A react node that will be used as a label for the payment method in the checkout.
  * @property {string} ariaLabel               An accessibility label. Screen readers will output this label when the payment method is selected.
  * @property {string} [placeOrderButtonLabel] Optionally customise the label text for the checkout submit (`Place Order`) button.
+ * @property {Object} supports                Object that describes various features provided by the payment method.
  */
 
 export {};

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -52,7 +52,10 @@ const options = {
 	content: <div>A react node</div>,
 	edit: <div> A react node </div>,
 	canMakePayment: () => true,
-	paymentMethodId: 'new_payment_method',
+  paymentMethodId: 'new_payment_method',
+  supports = {
+      features: [],
+  }
 };
 ```
 
@@ -63,6 +66,7 @@ Here's some more details on the configuration options:
 -   `edit` (required): This should be a react node that will be output in the express payment method area when the block is rendered in the editor. It will be cloned in the rendering process. When cloned, this react node will receive props from the payment method interface to checkout (but they will contain preview data).
 -   `canMakePayment` (required): A callback to determine whether the payment method should be available as an option for the shopper. The function will be passed an object containing data about the current order. Return a boolean value - true if payment method is available for use. If your gateway needs to perform async initialisation to determine availability, you can return a promise (resolving to boolean). This allows a payment method to be hidden based on the cart, e.g. if the cart has physical/shippable products (example: `Cash on delivery`); or for payment methods to control whether they are available depending on other conditions. Keep in mind this function could be invoked multiple times in the lifecycle of the checkout and thus any expensive logic in the callback provided on this property should be memoized.
 -   `paymentMethodId`: This is the only optional configuration object. The value of this property is what will accompany the checkout processing request to the server and used to identify what payment method gateway class to load for processing the payment (if the shopper selected the gateway). So for instance if this is `stripe`, then `WC_Gateway_Stripe::process_payment` will be invoked for processing the payment.
+-   `supports:features`: This is an array of payment features supported by the gateway. It is used to crosscheck if the payment method can be used for the content of the cart. By default payment methods should support at least `products` feature.
 
 ### Payment Methods - `registerPaymentMethod( options )`
 

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -71,6 +71,15 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	}
 
 	/**
+	 * Returns an array of supported features.
+	 *
+	 * @return string[]
+	 */
+	public function get_supported_features() {
+		return [];
+	}
+
+	/**
 	 * An array of key, value pairs of data made available to payment methods
 	 * client side.
 	 *

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -76,7 +76,7 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	 * @return string[]
 	 */
 	public function get_supported_features() {
-		return [ 'products' ];
+		return array( 'supports' => array( 'products' ) );
 	}
 
 	/**

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -76,7 +76,7 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	 * @return string[]
 	 */
 	public function get_supported_features() {
-		return array( 'supports' => array( 'products' ) );
+		return array( 'products' );
 	}
 
 	/**

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -76,7 +76,7 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	 * @return string[]
 	 */
 	public function get_supported_features() {
-		return array( 'products' );
+		return [ 'products' ];
 	}
 
 	/**

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -76,7 +76,7 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	 * @return string[]
 	 */
 	public function get_supported_features() {
-		return [];
+		return [ 'products' ];
 	}
 
 	/**

--- a/src/Payments/Integrations/BankTransfer.php
+++ b/src/Payments/Integrations/BankTransfer.php
@@ -70,6 +70,7 @@ final class BankTransfer extends AbstractPaymentMethodType {
 		return [
 			'title'       => $this->get_setting( 'title' ),
 			'description' => $this->get_setting( 'description' ),
+			'supports'    => $this->get_supported_features(),
 		];
 	}
 }

--- a/src/Payments/Integrations/CashOnDelivery.php
+++ b/src/Payments/Integrations/CashOnDelivery.php
@@ -95,6 +95,7 @@ final class CashOnDelivery extends AbstractPaymentMethodType {
 			'description'              => $this->get_setting( 'description' ),
 			'enableForVirtual'         => $this->get_enable_for_virtual(),
 			'enableForShippingMethods' => $this->get_enable_for_methods(),
+			'supports'                 => $this->get_supported_features(),
 		];
 	}
 }

--- a/src/Payments/Integrations/Cheque.php
+++ b/src/Payments/Integrations/Cheque.php
@@ -73,6 +73,7 @@ final class Cheque extends AbstractPaymentMethodType {
 		return [
 			'title'       => $this->get_setting( 'title' ),
 			'description' => $this->get_setting( 'description' ),
+			'supports'    => $this->get_supported_features(),
 		];
 	}
 }

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -71,7 +71,7 @@ final class PayPal extends AbstractPaymentMethodType {
 		return [
 			'title'       => $this->get_setting( 'title' ),
 			'description' => $this->get_setting( 'description' ),
-			'supports'    => apply_filters( '__experimental_woocommerce_blocks_payment_gateway_features_list', $this->get_supported_features(), $this->get_name() ),
+			'supports'    => $this->get_supported_features(),
 		];
 	}
 
@@ -81,7 +81,8 @@ final class PayPal extends AbstractPaymentMethodType {
 	 * @return string[]
 	 */
 	public function get_supported_features() {
-		$gateway = new WC_Gateway_Paypal();
-		return array_filter( $gateway->supports, array( $gateway, 'supports' ) );
+		$gateway  = new WC_Gateway_Paypal();
+		$features = array_filter( $gateway->supports, array( $gateway, 'supports' ) );
+		return apply_filters( '__experimental_woocommerce_blocks_payment_gateway_features_list', $features, $this->get_name() );
 	}
 }

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -1,9 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
-use Exception;
-use WC_Stripe_Payment_Request;
-use WC_Stripe_Helper;
+use WC_Gateway_Paypal;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 
 /**
@@ -74,5 +72,15 @@ final class PayPal extends AbstractPaymentMethodType {
 			'title'       => $this->get_setting( 'title' ),
 			'description' => $this->get_setting( 'description' ),
 		];
+	}
+
+	/**
+	 * Returns an array of supported features.
+	 *
+	 * @return string[]
+	 */
+	public function get_supported_features() {
+		$gateway = new WC_Gateway_Paypal();
+		return array_filter( $gateway->supports, array( $gateway, 'supports' ) );
 	}
 }

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -71,6 +71,7 @@ final class PayPal extends AbstractPaymentMethodType {
 		return [
 			'title'       => $this->get_setting( 'title' ),
 			'description' => $this->get_setting( 'description' ),
+			'supports'    => apply_filters( 'woocommerce_blocks_payment_gateway_features_list', $this->get_supported_features(), $this->get_name() ),
 		];
 	}
 

--- a/src/Payments/Integrations/PayPal.php
+++ b/src/Payments/Integrations/PayPal.php
@@ -71,7 +71,7 @@ final class PayPal extends AbstractPaymentMethodType {
 		return [
 			'title'       => $this->get_setting( 'title' ),
 			'description' => $this->get_setting( 'description' ),
-			'supports'    => apply_filters( 'woocommerce_blocks_payment_gateway_features_list', $this->get_supported_features(), $this->get_name() ),
+			'supports'    => apply_filters( '__experimental_woocommerce_blocks_payment_gateway_features_list', $this->get_supported_features(), $this->get_name() ),
 		];
 	}
 

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 use Exception;
 use WC_Stripe_Payment_Request;
 use WC_Stripe_Helper;
+use WC_Gateway_Stripe;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\Payments\PaymentContext;
 use Automattic\WooCommerce\Blocks\Payments\PaymentResult;
@@ -332,5 +333,15 @@ final class Stripe extends AbstractPaymentMethodType {
 			$order->set_payment_method_title( 'Chrome Payment Request (Stripe)' );
 			$order->save();
 		}
+	}
+
+	/**
+	 * Returns an array of supported features.
+	 *
+	 * @return string[]
+	 */
+	public function get_supported_features() {
+		$gateway = new WC_Gateway_Stripe();
+		return array_filter( $gateway->supports, array( $gateway, 'supports' ) );
 	}
 }

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -97,6 +97,7 @@ final class Stripe extends AbstractPaymentMethodType {
 			'showSavedCards'      => $this->get_show_saved_cards(),
 			'allowPaymentRequest' => $this->get_allow_payment_request(),
 			'showSaveOption'      => $this->get_show_save_option(),
+			'supports'            => $this->get_supported_features(),
 		];
 	}
 

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -342,6 +342,8 @@ final class Stripe extends AbstractPaymentMethodType {
 	 */
 	public function get_supported_features() {
 		$gateway = new WC_Gateway_Stripe();
-		return array_filter( $gateway->supports, array( $gateway, 'supports' ) );
+		return array(
+			'supports' => array_filter( $gateway->supports, array( $gateway, 'supports' ) ),
+		);
 	}
 }

--- a/src/Payments/Integrations/Stripe.php
+++ b/src/Payments/Integrations/Stripe.php
@@ -342,8 +342,6 @@ final class Stripe extends AbstractPaymentMethodType {
 	 */
 	public function get_supported_features() {
 		$gateway = new WC_Gateway_Stripe();
-		return array(
-			'supports' => array_filter( $gateway->supports, array( $gateway, 'supports' ) ),
-		);
+		return array_filter( $gateway->supports, array( $gateway, 'supports' ) );
 	}
 }

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -153,11 +153,7 @@ final class PaymentMethodRegistry {
 		$payment_methods = $this->get_all_active_registered();
 
 		foreach ( $payment_methods as $payment_method ) {
-			$script_data[ $payment_method->get_name() . '_data' ] =
-				array_merge(
-					$payment_method->get_payment_method_data(),
-					array( 'supports' => apply_filters( 'woocommerce_blocks_payment_gateway_features_list', $payment_method->get_supported_features(), $payment_method->get_name() ) )
-				);
+			$script_data[ $payment_method->get_name() . '_data' ] = $payment_method->get_payment_method_data();
 		}
 
 		return array_filter( $script_data );

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -153,7 +153,8 @@ final class PaymentMethodRegistry {
 		$payment_methods = $this->get_all_active_registered();
 
 		foreach ( $payment_methods as $payment_method ) {
-			$script_data[ $payment_method->get_name() . '_data' ] = $payment_method->get_payment_method_data();
+			$script_data[ $payment_method->get_name() . '_data' ] =
+				array_merge( $payment_method->get_payment_method_data(), $payment_method->get_supported_features() );
 		}
 
 		return array_filter( $script_data );

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -154,7 +154,10 @@ final class PaymentMethodRegistry {
 
 		foreach ( $payment_methods as $payment_method ) {
 			$script_data[ $payment_method->get_name() . '_data' ] =
-				array_merge( $payment_method->get_payment_method_data(), $payment_method->get_supported_features() );
+				array_merge(
+					$payment_method->get_payment_method_data(),
+					array( 'supports' => apply_filters( 'woocommerce_blocks_payment_gateway_features_list', $payment_method->get_supported_features(), $payment_method->get_name() ) )
+				);
 		}
 
 		return array_filter( $script_data );

--- a/src/Payments/PaymentMethodTypeInterface.php
+++ b/src/Payments/PaymentMethodTypeInterface.php
@@ -45,4 +45,11 @@ interface PaymentMethodTypeInterface {
 	 * @return array
 	 */
 	public function get_payment_method_data();
+
+	/**
+	 * Get array of supported features.
+	 *
+	 * @return string[]
+	 */
+	public function get_supported_features();
 }

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -362,7 +362,7 @@ class CartSchema extends AbstractSchema {
 				]
 			),
 			'errors'                  => $cart_errors,
-			'payment_requirements'    => apply_filters( 'woocommerce_blocks_store_api_cart_payment_requirements', array( 'products' ) ),
+			'payment_requirements'    => $this->extend->get_payment_requirements(),
 			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
 		];
 	}

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -302,6 +302,12 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->error_schema->get_properties() ),
 				],
 			],
+			'payment_requirements'    => [
+				'description' => __( 'List of required payment gateway features to process the order.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
 			self::EXTENDING_KEY       => $this->get_extended_schema( self::IDENTIFIER ),
 		];
 	}
@@ -356,6 +362,7 @@ class CartSchema extends AbstractSchema {
 				]
 			),
 			'errors'                  => $cart_errors,
+			'payment_requirements'    => apply_filters( 'woocommerce_blocks_store_api_cart_payment_requirements', array( 'products' ), $cart ),
 			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
 		];
 	}

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -362,7 +362,7 @@ class CartSchema extends AbstractSchema {
 				]
 			),
 			'errors'                  => $cart_errors,
-			'payment_requirements'    => apply_filters( 'woocommerce_blocks_store_api_cart_payment_requirements', array( 'products' ), $cart ),
+			'payment_requirements'    => apply_filters( 'woocommerce_blocks_store_api_cart_payment_requirements', array( 'products' ) ),
 			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
 		];
 	}


### PR DESCRIPTION
This PR implements a payment gateways capability check for the content in the cart. This means that a payment gateway will not be shown in the available payments methods list ( at checkout ) if not all of the required features are provided by that payment gateway. 

It consists of three parts:

1. Required features integration.
2. Payment gateway features list
3. Glue code that compares required features to features provided by the payment gateways. 

### Required features integration.

### 2 Payment gateway features list
Each payment gateway needs to advertise what type of payment operations it supports.

### 3 Glue code that compares required features to features provided by the payment gateways. 
Before the Checkout block displays the available payments methods the `usePaymentMethodRegistration` check which payment methods are valid for this cart setup. This PR adds additional features. It crosschecks what is required by the cart and what is required by 

<!-- Reference any related issues or PRs here -->
Fixes #3252

TODO:
- [x] Move features check to can make payment function.
- [x] Prepare subscriptions PR that injects subscription requirements to carts with subscription type items. 3966-gh-woocommerce/woocommerce-subscriptions
- [x] Make sure that all payment gateways we integrate are supported.
- [x] _experimental for filters.

## WIP

### How to test the changes in this Pull Request:

1. Use 3966-gh-woocommerce/woocommerce-subscriptions
2. Setup payment methods that do not support subscriptions and payment methods that do
3. add non-subscription product to the cart
4. View the checkout block - all payment methods should be there
5. Add subscription product to the cart
6. View the checkout block - only payment methods that support subscriptions should be available
7. Enable manual payments for renewal
8. View the checkout block - all payments should be visible, no matter if subscription items are in the cart or not.
9. Also check with express payments.

<!-- If you can, add the appropriate labels -->

### Changelog

Update - Filter payment methods by features required by the content of the cart.