### PR TITLE
Move error to admin notice

### DIFF
--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -89,8 +89,15 @@ class Api {
 		if ( in_array( $handle, $dependencies, true ) ) {
 			if ( $this->package->feature()->is_development_environment() ) {
 				$dependencies = array_diff( $dependencies, [ $handle ] );
-				// phpcs:ignore
-				trigger_error( sprintf( 'Script with handle %s had a dependency on itself which has been removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ), E_USER_WARNING );
+					add_action(
+						'admin_notices',
+						function() use ( $handle ) {
+								echo '<div class="error"><p>';
+								// Translators: %s file handle name.
+								printf( esc_html__( 'Script with handle %s had a dependency on itself which has been removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', 'woo-gutenberg-products-block' ), esc_html( $handle ) );
+								echo '</p></div>';
+						}
+					);
 			} else {
 				throw new Exception( sprintf( 'Script with handle %s had a dependency on itself. This is an indicator that your JS code has a circular dependency that can cause bugs.', $handle ) );
 			}


### PR DESCRIPTION
This moves the circular dependency warning to an admin notice.

A warning took a lot of screen, modified headers, and broke down POST requests.

### How to test:
- run `npm start` to generate the circular dependency.
- On cart, checkout, or any frontend page, you shouldn't see any error.
- in admin, you should see the error notice.
- run `npm run build` the error is now gone.