### PR TITLE
Decode fees name so special characters are rendered correctly

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -122,7 +122,7 @@ describe( 'Testing Payment Method Data Context Provider', () => {
 		} );
 		// need to clear the store resolution state between tests.
 		await dispatch( storeKey ).invalidateResolutionForStore();
-		await dispatch( storeKey ).receiveCart( defaultCartState );
+		await dispatch( storeKey ).receiveCart( defaultCartState.cartData );
 	} );
 	afterEach( async () => {
 		resetMockPaymentMethods();

--- a/assets/js/base/hooks/cart/test/use-store-cart.js
+++ b/assets/js/base/hooks/cart/test/use-store-cart.js
@@ -29,6 +29,7 @@ describe( 'useStoreCart', () => {
 	const previewCartData = {
 		cartCoupons: previewCart.coupons,
 		cartItems: previewCart.items,
+		cartFees: previewCart.fees,
 		cartItemsCount: previewCart.items_count,
 		cartItemsWeight: previewCart.items_weight,
 		cartNeedsPayment: previewCart.needs_payment,
@@ -37,7 +38,6 @@ describe( 'useStoreCart', () => {
 		cartIsLoading: false,
 		cartItemErrors: [],
 		cartErrors: [],
-		cartFees: [],
 		billingAddress: {
 			first_name: '',
 			last_name: '',
@@ -75,6 +75,7 @@ describe( 'useStoreCart', () => {
 	const mockCartData = {
 		coupons: [],
 		items: mockCartItems,
+		fees: [],
 		itemsCount: 1,
 		itemsWeight: 10,
 		needsPayment: true,
@@ -83,6 +84,8 @@ describe( 'useStoreCart', () => {
 		shippingAddress: mockShippingAddress,
 		shippingRates: [],
 		hasCalculatedShipping: true,
+		extensions: {},
+		errors: [],
 	};
 	const mockCartTotals = {
 		currency_code: 'USD',

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -118,9 +118,9 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 			const shippingAddress = cartData.needsShipping
 				? decodeValues( cartData.shippingAddress )
 				: billingAddress;
-			const cartFees = Array.isArray( cartData.fees )
-				? cartData.fees.map( ( fee ) => decodeValues( fee ) )
-				: [];
+			const cartFees = cartData.fees.map( ( fee ) =>
+				decodeValues( fee )
+			);
 			return {
 				cartCoupons: cartData.coupons,
 				cartItems: cartData.items || [],

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -27,8 +27,8 @@ const defaultBillingAddress = {
 	phone: '',
 };
 
-const decodeAddress = ( address ) =>
-	mapValues( address, ( value ) => decodeEntities( value ) );
+const decodeValues = ( object ) =>
+	mapValues( object, ( value ) => decodeEntities( value ) );
 
 /**
  * @constant
@@ -113,14 +113,17 @@ export const useStoreCart = ( options = { shouldSelect: true } ) => {
 			);
 			const shippingRatesLoading = store.isCustomerDataUpdating();
 			const { receiveCart } = dispatch( storeKey );
-			const billingAddress = decodeAddress( cartData.billingAddress );
+			const billingAddress = decodeValues( cartData.billingAddress );
 			const shippingAddress = cartData.needsShipping
-				? decodeAddress( cartData.shippingAddress )
+				? decodeValues( cartData.shippingAddress )
 				: billingAddress;
+			const cartFees = Array.isArray( cartData.fees )
+				? cartData.fees.map( ( fee ) => decodeValues( fee ) )
+				: [];
 			return {
 				cartCoupons: cartData.coupons,
 				cartItems: cartData.items || [],
-				cartFees: cartData.fees || [],
+				cartFees,
 				cartItemsCount: cartData.itemsCount,
 				cartItemsWeight: cartData.itemsWeight,
 				cartNeedsPayment: cartData.needsPayment,

--- a/assets/js/base/hooks/cart/use-store-cart.js
+++ b/assets/js/base/hooks/cart/use-store-cart.js
@@ -52,6 +52,7 @@ export const defaultCartData = {
 	shippingRatesLoading: false,
 	cartHasCalculatedShipping: false,
 	receiveCart: () => {},
+	extensions: {},
 };
 
 /**

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -20,7 +20,7 @@ describe( 'Testing cart', () => {
 		} );
 		// need to clear the store resolution state between tests.
 		await dispatch( storeKey ).invalidateResolutionForStore();
-		await dispatch( storeKey ).receiveCart( defaultCartState );
+		await dispatch( storeKey ).receiveCart( defaultCartState.cartData );
 	} );
 	afterEach( () => {
 		fetchMock.resetMocks();
@@ -44,7 +44,9 @@ describe( 'Testing cart', () => {
 	it( 'renders empty cart if there are no items in the cart', async () => {
 		fetchMock.mockResponse( ( req ) => {
 			if ( req.url.match( /wc\/store\/cart/ ) ) {
-				return Promise.resolve( JSON.stringify( defaultCartState ) );
+				return Promise.resolve(
+					JSON.stringify( defaultCartState.cartData )
+				);
 			}
 		} );
 		render(

--- a/assets/js/data/cart/test/reducers.js
+++ b/assets/js/data/cart/test/reducers.js
@@ -14,6 +14,7 @@ describe( 'cartReducer', () => {
 		cartData: {
 			coupons: [],
 			items: [],
+			fees: [],
 			itemsCount: 0,
 			itemsWeight: 0,
 			needsShipping: true,
@@ -34,6 +35,7 @@ describe( 'cartReducer', () => {
 			response: {
 				coupons: [],
 				items: [],
+				fees: [],
 				itemsCount: 0,
 				itemsWeight: 0,
 				needsShipping: true,
@@ -45,6 +47,7 @@ describe( 'cartReducer', () => {
 		expect( newState.cartData ).toEqual( {
 			coupons: [],
 			items: [],
+			fees: [],
 			itemsCount: 0,
 			itemsWeight: 0,
 			needsShipping: true,

--- a/assets/js/data/cart/test/resolvers.js
+++ b/assets/js/data/cart/test/resolvers.js
@@ -20,6 +20,7 @@ describe( 'getCartData', () => {
 				const { value } = fulfillment.next( {
 					coupons: [],
 					items: [],
+					fees: [],
 					itemsCount: 0,
 					itemsWeight: 0,
 					needsShipping: true,
@@ -29,6 +30,7 @@ describe( 'getCartData', () => {
 					receiveCart( {
 						coupons: [],
 						items: [],
+						fees: [],
 						itemsCount: 0,
 						itemsWeight: 0,
 						needsShipping: true,

--- a/assets/js/data/default-states.js
+++ b/assets/js/data/default-states.js
@@ -16,6 +16,7 @@ export const defaultCartState = {
 			country: '',
 		},
 		items: [],
+		fees: [],
 		itemsCount: 0,
 		itemsWeight: 0,
 		needsShipping: true,

--- a/packages/checkout/totals/fees/index.js
+++ b/packages/checkout/totals/fees/index.js
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 import PropTypes from 'prop-types';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -33,8 +32,7 @@ const TotalsFees = ( { currency, cartFees, className } ) => {
 						) }
 						currency={ currency }
 						label={
-							decodeEntities( name ) ||
-							__( 'Fee', 'woo-gutenberg-products-block' )
+							name || __( 'Fee', 'woo-gutenberg-products-block' )
 						}
 						value={
 							DISPLAY_CART_PRICES_INCLUDING_TAX

--- a/packages/checkout/totals/fees/index.js
+++ b/packages/checkout/totals/fees/index.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 import PropTypes from 'prop-types';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -32,7 +33,8 @@ const TotalsFees = ( { currency, cartFees, className } ) => {
 						) }
 						currency={ currency }
 						label={
-							name || __( 'Fee', 'woo-gutenberg-products-block' )
+							decodeEntities( name ) ||
+							__( 'Fee', 'woo-gutenberg-products-block' )
 						}
 						value={
 							DISPLAY_CART_PRICES_INCLUDING_TAX


### PR DESCRIPTION
### Screenshots
_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/105483759-9c375600-5caa-11eb-8681-7ee4c5d86b11.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/105483724-8de93a00-5caa-11eb-92c9-ef6ce3390d63.png)

### How to test the changes in this Pull Request:

1. Add this code snippet to any PHP file (ie: `/woocommerce-gutenberg-products-block.php`):
```PHP
add_action( 'woocommerce_cart_calculate_fees', 'add_fees', 10 );
function add_fees( $cart ) {
	$cart->add_fee( __( 'Fee - Number 1', 'woo-gutenberg-products-block' ), 100, true );
	$cart->add_fee( __( 'Fee - Number 2', 'woo-gutenberg-products-block' ), 100, true );
}
```
2. Add a product to yout cart and visit the Cart or Checkout pages.
3. Verify the dash is rendered correctly.

### Changelog

> Ensure special characters are displayed properly in the Cart sidebar.