### PR TITLE
Hide All Products Block from Widget Areas

### DIFF
--- a/src/Library.php
+++ b/src/Library.php
@@ -40,7 +40,8 @@ class Library {
 	 * Register blocks, hooking up assets and render functions as needed.
 	 */
 	public static function register_blocks() {
-		global $wp_version;
+		global $wp_version, $pagenow;
+
 		$blocks = [
 			'AllReviews',
 			'FeaturedCategory',
@@ -68,6 +69,18 @@ class Library {
 		}
 		if ( Package::feature()->is_experimental_build() ) {
 			$blocks[] = 'SingleProduct';
+		}
+		/**
+		 * This disables specific blocks in Widget Areas by not registering them.
+		 */
+		if ( 'themes.php' === $pagenow ) {
+			$blocks_to_unset = [
+				'AllProducts',
+				'PriceFilter',
+				'AttributeFilter',
+				'ActiveFilters',
+			];
+			$blocks          = array_diff( $blocks, $blocks_to_unset );
 		}
 		foreach ( $blocks as $class ) {
 			$class    = __NAMESPACE__ . '\\BlockTypes\\' . $class;


### PR DESCRIPTION
This PR offers a simplistic solution to hiding certain blocks in the new Widget Areas that are part of the Gutenberg Feature Plugin, and coming in WordPress <del>5.7</del> <ins>5.8</ins>.

The new widget functionality does allow legacy widgets to be removed via the `widgets_to_exclude_from_legacy_widget_block ` filter, but does not have a filter for blocks. This probably makes sense because blocks are the future, and widgets are legacy.

Originally I thought we'd be able to utilise the `allowed_block_types` filter, however on inspection this filter is only part of the editor for post types, [ran here](https://github.com/WordPress/WordPress/blob/b3b8942dfcb451eddb5559b63c1043fce5d9449e/wp-admin/edit-form-blocks.php#L161).

The new widget areas page has no such filter,[ the page content being generated from here](https://github.com/WordPress/gutenberg/blob/b529dd7a45cd8a3b4ecd2c7921795b6c6db88d5e/lib/widgets-page.php#L13). There is also no block level 'supports' flag we can use either.

So instead, we need to determine if we're on the widgets screen in WP Admin and remove the blocks that way. Blocks are registered on `init` which is too early for `get_current_screen`, but we do have access to the `$pagenow` global. If `$pagenow` is themes (where the widgets page is registered) we simply do not register the blocks that do not support widgets.

Fixes #3727
Fixes #3726
Closes #3724

### How to test the changes in this Pull Request:

1. Ensure Gutenberg feature plugin is enabled and you can see the new Widget Areas screen under Appearance > Widgets.
2. Go to the screen and try to insert "All Products", "Price Filter", "Attribute Filter", and "Active Filter" blocks. You shouldn't be able to see them in the inspector!
3. Edit a page and try to insert "All Products", "Price Filter", "Attribute Filter", and "Active Filter" blocks. It should work as expected.

<!-- If you can, add the appropriate labels -->

### Changelog

> Hide the All Products Block from the new Gutenberg Widget Areas until full support is achieved.
