### PR TITLE
Fix color for BlockErrorBoundry

### DIFF
--- a/assets/js/base/components/block-error-boundary/style.scss
+++ b/assets/js/base/components/block-error-boundary/style.scss
@@ -1,15 +1,16 @@
 .wc-block-components-error {
 	display: flex;
-	background-color: #f3f3f4;
-	border-left: 4px solid #6d6d6d;
+	background-color: $gray-100;
+	border-left: 4px solid $gray-300;
 	padding: $gap-larger $gap;
 	align-items: center;
 	justify-content: center;
 	flex-direction: column;
+	color: $gray-700;
 }
 
 .wc-block-components-error__header {
-	@include font-size(larger);
+	@include font-size( larger );
 	font-weight: bold;
 	margin: 0;
 }

--- a/assets/js/base/components/block-error-boundary/style.scss
+++ b/assets/js/base/components/block-error-boundary/style.scss
@@ -10,7 +10,7 @@
 }
 
 .wc-block-components-error__header {
-	@include font-size( larger );
+	@include font-size(larger);
 	font-weight: bold;
 	margin: 0;
 }
@@ -26,7 +26,7 @@
 	font-style: italic;
 }
 
-@include breakpoint( ">480px" ) {
+@include breakpoint(">480px") {
 	.wc-block-components-error {
 		flex-direction: row;
 	}


### PR DESCRIPTION
The new color ensures readability on both light and dark themes.
Also the PR changes the colors used in the component, using colors defined in [WordPress/gutenberg](https://github.com/WordPress/gutenberg/blob/master/packages/base-styles/_colors.scss)
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3668 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
Before:
![imatge](https://user-images.githubusercontent.com/3616980/104204468-9bdac780-542d-11eb-8ed2-5faa0a59a11a.png)
After: 
<img width="804" alt="Screenshot 2021-01-26 at 15 11 02" src="https://user-images.githubusercontent.com/1628454/105855819-ca899e00-5fe8-11eb-9af6-979c41cee253.png">

### How to test the changes in this Pull Request:

1. Chose Storefront and set the background to black and text to white.
2. Force an error to the Cart or Checkout block. Add on line 74 `throw new Error( 'test' );`  in `assets/js/blocks/cart-checkout/cart/block.js`
3. Notice the error text is now visible

### Changelog

> Fix - Set correct text color in BlockErrorBoundry notices.

