### PR TITLE
Panel component: allow all kind of nodes as title

### DIFF
--- a/assets/js/blocks/README.md
+++ b/assets/js/blocks/README.md
@@ -9,7 +9,7 @@ Our blocks are generally made up of up to 4 files:
 |- style.scss
 ```
 
-The only required file is `index.js`, this sets up the block using [`registerBlockType`.](https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/) Each block has edit and save functions.
+The only required file is `index.js`, this sets up the block using [`registerBlockType`](https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-registration/). Each block has edit and save functions.
 
 The scss files are split so that things in `style` are added to the editor _and_ frontend, while styles in `editor` are only added to the editor. Most of our blocks should use core components that won't need CSS though.
 

--- a/packages/checkout/panel/index.js
+++ b/packages/checkout/panel/index.js
@@ -55,7 +55,7 @@ Panel.propTypes = {
 	className: PropTypes.string,
 	hasBorder: PropTypes.bool,
 	initialOpen: PropTypes.bool,
-	title: PropTypes.element,
+	title: PropTypes.node,
 	titleTag: PropTypes.string,
 };
 


### PR DESCRIPTION
Fixes #3744.

### How to test the changes in this Pull Request:

1. Check out this branch in WC Subscriptions: `feature/checkout-block-simple-multiple-subscriptions`.
2. Add a subscription product to your cart and go to the Cart block.
3. Verify the Details panel is rendered and there is no JS error in your browser devtools.

![imatge](https://user-images.githubusercontent.com/3616980/105967878-a67c9a00-6086-11eb-9838-c6a61e2de295.png)
