### PR TITLE
Add missing wrapper from FeaturedCategory & FeatureProduct blocks

### DIFF
--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -56,15 +56,15 @@ class FeaturedCategory extends AbstractDynamicBlock {
 			wc_format_content( $category->description )
 		);
 
-		$output = sprintf( '<div class="%1$s" style="%2$s">', esc_attr( $this->get_classes( $attributes ) ), esc_attr( $this->get_styles( $attributes, $category ) ) );
-
+		$output  = sprintf( '<div class="%1$s" style="%2$s">', esc_attr( $this->get_classes( $attributes ) ), esc_attr( $this->get_styles( $attributes, $category ) ) );
+		$output .= '<div class="wc-block-featured-category__wrapper">';
 		$output .= $title;
 		if ( $attributes['showDesc'] ) {
 			$output .= $desc_str;
 		}
 		$output .= '<div class="wc-block-featured-category__link">' . $content . '</div>';
 		$output .= '</div>';
-
+		$output .= '</div>';
 		return $output;
 	}
 

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -69,8 +69,8 @@ class FeaturedProduct extends AbstractDynamicBlock {
 			$product->get_price_html()
 		);
 
-		$output = sprintf( '<div class="%1$s" style="%2$s">', esc_attr( $this->get_classes( $attributes ) ), esc_attr( $this->get_styles( $attributes, $product ) ) );
-
+		$output  = sprintf( '<div class="%1$s" style="%2$s">', esc_attr( $this->get_classes( $attributes ) ), esc_attr( $this->get_styles( $attributes, $product ) ) );
+		$output .= '<div class="wc-block-featured-product__wrapper">';
 		$output .= $title;
 		if ( $attributes['showDesc'] ) {
 			$output .= $desc_str;
@@ -79,6 +79,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 			$output .= $price_str;
 		}
 		$output .= '<div class="wc-block-featured-product__link">' . $content . '</div>';
+		$output .= '</div>';
 		$output .= '</div>';
 
 		return $output;


### PR DESCRIPTION
In the rendered blocks we now have a div around the inner elements.
-  `div.wc-block-featured-category__wrapper`  for FeaturedCategory
-  `div.wc-block-featured-product__wrapper`  for FeaturedProduct

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2046 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


### Screenshots
Before: 
<img width="859" alt="Screenshot 2021-01-27 at 11 22 53" src="https://user-images.githubusercontent.com/1628454/105977816-1c3a3300-6092-11eb-9ebd-a88cae5b0868.png">

After:
<img width="869" alt="Screenshot 2021-01-27 at 11 22 03" src="https://user-images.githubusercontent.com/1628454/105977844-23f9d780-6092-11eb-8c51-3023ad5e4b6e.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Add a Featured Category and Featured Product blocks on a page
2. Inspect the markup
3. Notice the inner elements (title, text, button) are wrapped with a `<div class="wc-block-featured-X__wrapper"></div>`

### Changelog

> Fix - Added missing wrapper div within FeaturedCategory and FeatureProduct blocks
