### PR TITLE
Enable defaults for new import rules and configure

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,7 @@ module.exports = {
 			'requireindex',
 		],
 		'import/resolver': {
-			Node: {},
+			node: {},
 			webpack: {},
 		},
 	},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,17 +19,44 @@ module.exports = {
 	},
 	settings: {
 		jsdoc: { mode: 'typescript' },
+		// List of modules that are externals in our webpack config.
+		// This helps the `import/no-extraneous-dependencies` and
+		//`import/no-unresolved` rules account for them.
+		'import/core-modules': [
+			'@woocommerce/block-data',
+			'@woocommerce/blocks-checkout',
+			'@woocommerce/settings',
+			'@woocommerce/shared-context',
+			'@woocommerce/shared-hocs',
+			'@woocommerce/knobs',
+			'@wordpress/a11y',
+			'@wordpress/api-fetch',
+			'@wordpress/block-editor',
+			'@wordpress/compose',
+			'@wordpress/data',
+			'@wordpress/escape-html',
+			'@wordpress/hooks',
+			'@wordpress/keycodes',
+			'@wordpress/url',
+			'babel-jest',
+			'dotenv',
+			'jest-environment-puppeteer',
+			'lodash/kebabCase',
+			'lodash',
+			'prop-types',
+			'react',
+			'requireindex',
+		],
+		'import/resolver': {
+			Node: {},
+			webpack: {},
+		},
 	},
 	rules: {
 		'woocommerce/feature-flag': 'off',
 		'react-hooks/exhaustive-deps': 'error',
 		'react/jsx-fragments': [ 'error', 'syntax' ],
 		'@wordpress/no-global-active-element': 'warn',
-		// @todo Remove temporary conversion of eslint rules to warn instead of error.
-		//       These are new rules surfacing as a result of a eslint plugin update and the intent
-		//       is to update them in their own individual prs to make for easier review.
-		'import/no-extraneous-dependencies': 'warn',
-		'import/no-unresolved': 'warn',
 	},
 	overrides: [
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -8374,6 +8374,12 @@
 			"integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
 			"dev": true
 		},
+		"array-find": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+			"integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+			"dev": true
+		},
 		"array-flatten": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -13698,6 +13704,55 @@
 			"requires": {
 				"debug": "^2.6.9",
 				"resolve": "^1.13.1"
+			}
+		},
+		"eslint-import-resolver-webpack": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.0.tgz",
+			"integrity": "sha512-hZWGcmjaJZK/WSCYGI/y4+FMGQZT+cwW/1E/P4rDwFj2PbanlQHISViw4ccDJ+2wxAqjgwBfxwy3seABbVKDEw==",
+			"dev": true,
+			"requires": {
+				"array-find": "^1.0.0",
+				"debug": "^2.6.9",
+				"enhanced-resolve": "^0.9.1",
+				"find-root": "^1.1.0",
+				"has": "^1.0.3",
+				"interpret": "^1.2.0",
+				"lodash": "^4.17.15",
+				"node-libs-browser": "^1.0.0 || ^2.0.0",
+				"resolve": "^1.13.1",
+				"semver": "^5.7.1"
+			},
+			"dependencies": {
+				"enhanced-resolve": {
+					"version": "0.9.1",
+					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+					"integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"memory-fs": "^0.2.0",
+						"tapable": "^0.1.8"
+					}
+				},
+				"interpret": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+					"integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+					"dev": true
+				},
+				"memory-fs": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+					"integrity": "sha1-8rslNovBIeORwlIN6Slpyu4KApA=",
+					"dev": true
+				},
+				"tapable": {
+					"version": "0.1.10",
+					"resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+					"integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
+					"dev": true
+				}
 			}
 		},
 		"eslint-module-utils": {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
 		"cross-env": "6.0.3",
 		"cssnano": "4.1.10",
 		"deep-freeze": "0.0.1",
+		"eslint-import-resolver-webpack": "^0.13.0",
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",
 		"eslint-plugin-you-dont-need-lodash-underscore": "6.10.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
 		"cross-env": "6.0.3",
 		"cssnano": "4.1.10",
 		"deep-freeze": "0.0.1",
+		"eslint-import-resolver-node": "^0.3.4",
 		"eslint-import-resolver-webpack": "^0.13.0",
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
 		"cross-env": "6.0.3",
 		"cssnano": "4.1.10",
 		"deep-freeze": "0.0.1",
-		"eslint-import-resolver-node": "^0.3.4",
 		"eslint-import-resolver-webpack": "^0.13.0",
 		"eslint-plugin-import": "^2.22.1",
 		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",


### PR DESCRIPTION
Fixes: #3753 

In this pull request, the `import/no-unresolved` and `import/no-extraneous-dependencies` rules defaults are enabled and configuration for adding exceptions for both webpack config resolution and externals or indirect dependencies are added.

With our webpack configuration, there are a number of aliases and externals we define that aren't resolved with the default rule configuration, so the changes here make sure _known_ exceptions are accounted for.

## To test

If GitHub workflow checks pass without error, this can be merged.
