### PR TITLE
Hide categories with 0 products from the Product Categories block

### DIFF
--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -133,6 +133,16 @@ class ProductCategories extends AbstractDynamicBlock {
 			return [];
 		}
 
+		// This ensures that no categories with a product count of 0 is rendered.
+		if ( ! $attributes['hasEmpty'] ) {
+			$categories = array_filter(
+				$categories,
+				function( $category ) {
+					return 0 !== $category->count;
+				}
+			);
+		}
+
 		return $hierarchical ? $this->build_category_tree( $categories ) : $categories;
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a check so that empty categories are not displayed in the Product Categories list when the "Show empty categories" block setting is false.


<!-- Reference any related issues or PRs here -->
Partially fixes #3564 
A [new issue](https://github.com/woocommerce/woocommerce/issues/28981) has also been submitted to [WooCommerce](https://github.com/woocommerce/woocommerce).  


<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->




### How to test the changes in this Pull Request:

While following the reproduction steps from #3564 we noticed that WooCommerce does not remove from a category a product that has been marked as hidden and assigned to a category in the same Update call. So the block receives the category as one with products. See [WooCommerce Issue](https://github.com/woocommerce/woocommerce/issues/28981) for more details.


In order to test, please follow these steps instead: 

1. Add the Product Categories block to a page
2. Make sure the "Show empty categories" setting is disabled
3. Edit a product and add it to a new category called "Test"
4. Save the product and see that the "Test" category appears in the list with 1 product
5. Edit the product again and set it as hidden.
6. Save the product and see that the "Test" category does not appear in the list.
7. Change the "Show empty categories" block's settings to true
8. Notice that the Test category is listed in the list with 0 products.

### Changelog

> Fix - Ensure empty categories are correctly hidden in the product categories block.

