### PR TITLE
Force api call to "store/products" to refresh on browser back button click.

### DIFF
--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -67,6 +67,14 @@ class Products extends AbstractRoute {
 		$response = ( new Pagination() )->add_headers( $response, $request, $query_results['total'], $query_results['pages'] );
 		$response->header( 'Last-Modified', $product_query->get_last_modified() );
 
+		/*
+		 * Setup Cache-Control not to cache this request response.
+		 * This forces the browser to re-do this request when user clicks the navigation back button.
+		 * This in turn allows the code to send an updated store api nonce.
+		 * Without this logged out users could potentially be using stale nonce.
+		 */
+		$response->header( 'Cache-Control', 'no-store, max-age=0' );
+
 		return $response;
 	}
 


### PR DESCRIPTION
This PR sets up the Cache-Control header for the `store/products` route. This is now set up in a way that tells the browser not to use that request from cache. 

Why was it failing in the first place? Long explanation that I have used for myself to understand what is going on.

When a **fresh ( no store session ) logged-out user** navigates to a page with All Products block the site is loaded with a nonce for a logged-out user. This nonce is store as a global JS value. After adding an item to the car ( using the nonce ), WooCommerce creates a session. This changes how the nonce is generated for the user. This is because of the `nonce_user_logged_out` filter added in WooCommerce that modifies the user-id used for the nonce generation. When a sessing is established this filter substitutes, logged-out user-id, with user-id randomly generated when the session was created, and stored in the COOKIE. This means that after the user adds something to the cart he becomes identified as a different user for the purpose of nonce creation and validation. All Products block still works because in the response to `Add to Cart` we are sending and updating this new nonce - so any next requests can still be performed. Now the user navigates to a different page, next he clicks the browser navigation back button. The page with the All Products block is loaded. But this time not entirely from the server - most of the values come from the browser cache. This means that we are using the nonce for the **fresh ( no store session ) logged-out user** stored in global JS value. That is no longer the correct value because the user has a session so the nonce validation will look for a different user.

We could force the reload of the whole page but that would be not optimal. Instead, we can tell the browser no to cache the `store/products` API requests that All Products is doing to get the products. This API request was also cached by the browser. By disabling it we ensure that although the page body is from the cache and initially has the old nonce after the API call finishes the nonce will be updated to the proper one. From my observation, this has a performance impact only for the browser back button use - the user needs to wait for the product's API to respon.

<!-- Reference any related issues or PRs here -->
Fixes #3757

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

Follow the instruction in #3757 and verify that the issue is no longer there.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.
