### PR TITLE
Move "no rates found" logic to package level

### DIFF
--- a/packages/checkout/shipping/shipping-rates-control/shipping-rates-control.js
+++ b/packages/checkout/shipping/shipping-rates-control/shipping-rates-control.js
@@ -50,14 +50,7 @@ const ShippingRatesControl = ( {
 		}
 		const packageCount = getShippingRatesPackageCount( shippingRates );
 		const shippingOptions = getShippingRatesRateCount( shippingRates );
-		if ( shippingOptions === 0 ) {
-			speak(
-				__(
-					'No shipping options were found.',
-					'woo-gutenberg-products-block'
-				)
-			);
-		} else if ( packageCount === 1 ) {
+		if ( packageCount === 1 ) {
 			speak(
 				sprintf(
 					// translators: %d number of shipping options found.
@@ -127,13 +120,13 @@ const ShippingRatesControl = ( {
  *
  * @param {Object} props Incoming props.
  * @param {Array} props.packages Array of packages.
- * @param {React.ReactElement} props.noResultsMessage Rendered when there are no packages.
+ * @param {React.ReactElement} props.noResultsMessage Rendered when there are no rates in a package.
  * @param {boolean} props.collapsible If the package should be rendered as a
  * collapsible panel.
  * @param {boolean} props.collapse If the panel should be collapsed by default,
  * only works if collapsible is true.
  * @param {boolean} props.showItems If we should items below the package name.
- * @return {React.ReactElement|Array} Rendered components.
+ * @return {React.ReactElement|Array|null} Rendered components.
  */
 const Packages = ( {
 	packages,
@@ -142,8 +135,9 @@ const Packages = ( {
 	collapsible,
 	noResultsMessage,
 } ) => {
+	// If there are no packages, return nothing.
 	if ( ! packages.length ) {
-		return noResultsMessage;
+		return null;
 	}
 
 	return packages.map( ( { package_id: packageId, ...packageData } ) => (
@@ -154,6 +148,7 @@ const Packages = ( {
 			collapsible={ collapsible }
 			collapse={ collapse }
 			showItems={ showItems }
+			noResultsMessage={ noResultsMessage }
 		/>
 	) );
 };

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -64,17 +64,15 @@ class CartSelectShippingRate extends AbstractCartRoute {
 
 		$controller = new CartController();
 		$cart       = $controller->get_cart_instance();
+		$package_id = wc_clean( wp_unslash( $request['package_id'] ) );
+		$rate_id    = wc_clean( wp_unslash( $request['rate_id'] ) );
 
-		if ( $cart->needs_shipping() ) {
-			$package_id = wc_clean( wp_unslash( $request['package_id'] ) );
-			$rate_id    = wc_clean( wp_unslash( $request['rate_id'] ) );
-
-			try {
-				$controller->select_shipping_rate( $package_id, $rate_id );
-			} catch ( \WC_Rest_Exception $e ) {
-				throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
-			}
+		try {
+			$controller->select_shipping_rate( $package_id, $rate_id );
+		} catch ( \WC_Rest_Exception $e ) {
+			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
 		}
+
 		$cart->calculate_shipping();
 		$cart->calculate_totals();
 


### PR DESCRIPTION
Two changes for compatibility with subscriptions.

1. Allow rates to be selected via the API even if shipping is not needed for the cart. Reason: Subscriptions has recurring carts which may need shipping, even if the main cart does not.
2. Move the "no rates found" notice logic to cart level. This ensures that we only see a notice when a package has no rates, not when there are no packages.

![cart](https://user-images.githubusercontent.com/90977/106290497-737f0580-6242-11eb-92a3-99e453394e75.png)

Fixes #3728

### How to test the changes in this Pull Request:

Requires the feature branch: https://github.com/woocommerce/woocommerce-subscriptions/tree/feature/checkout-block-simple-multiple-subscriptions

See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3728