### PR TITLE
Improve nonce handling by rejecting stale values

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
 	],
 	globals: {
 		wcStoreApiNonce: 'readonly',
+		wcStoreApiNonceTimestamp: 'readonly',
 		fetchMock: true,
 		jQuery: 'readonly',
 		IntersectionObserver: 'readonly',

--- a/assets/js/middleware/store-api-nonce.js
+++ b/assets/js/middleware/store-api-nonce.js
@@ -63,7 +63,7 @@ const updateNonce = ( nonce, timestamp ) => {
 	}
 
 	currentNonce = nonce;
-	currentTimestamp = timestamp || Date.now();
+	currentTimestamp = timestamp || Date.now() / 1000;
 
 	// Update the persisted values.
 	window.localStorage.setItem(

--- a/assets/js/middleware/store-api-nonce.js
+++ b/assets/js/middleware/store-api-nonce.js
@@ -63,7 +63,7 @@ const updateNonce = ( nonce, timestamp ) => {
 	}
 
 	currentNonce = nonce;
-	currentTimestamp = timestamp || Date.now() / 1000;
+	currentTimestamp = timestamp || Date.now() / 1000; // Convert ms to seconds to match php time()
 
 	// Update the persisted values.
 	window.localStorage.setItem(

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -65,7 +65,7 @@ class Assets {
 			'wc-blocks-middleware',
 			"
 			var wcStoreApiNonce = '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "';
-			var wcStoreApiNonceTimestamp = '" . esc_js( microtime() ) . "';
+			var wcStoreApiNonceTimestamp = '" . esc_js( time() ) . "';
 			",
 			'before'
 		);

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -63,7 +63,10 @@ class Assets {
 		// Inline data.
 		wp_add_inline_script(
 			'wc-blocks-middleware',
-			"var wcStoreApiNonce = '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "';",
+			"
+			var wcStoreApiNonce = '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "';
+			var wcStoreApiNonceTimestamp = '" . esc_js( microtime() ) . "';
+			",
 			'before'
 		);
 

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -81,6 +81,7 @@ abstract class AbstractRoute implements RouteInterface {
 		}
 
 		$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$response->header( 'X-WC-Store-API-Nonce-Timestamp', microtime() );
 		$response->header( 'X-WC-Store-API-User', get_current_user_id() );
 		return $response;
 	}

--- a/src/StoreApi/Routes/AbstractRoute.php
+++ b/src/StoreApi/Routes/AbstractRoute.php
@@ -81,7 +81,7 @@ abstract class AbstractRoute implements RouteInterface {
 		}
 
 		$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
-		$response->header( 'X-WC-Store-API-Nonce-Timestamp', microtime() );
+		$response->header( 'X-WC-Store-API-Nonce-Timestamp', time() );
 		$response->header( 'X-WC-Store-API-User', get_current_user_id() );
 		return $response;
 	}


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3766 fixes the cache issue reported in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3757 by disabling caches.

As an alternative, this PR adds some additional logic to the nonce middleware which allows the nonce to be stored within browser localStorage, and some new logic to detect if a nonce is older or newer than the current.

Fixes #3757
Closes #3766

### How to test the changes in this Pull Request:

1. Start an incognito window.
2. Add some thing to cart from the products block.
3. Go to cart page.
4. Use browser back button back to the page with products block.
5. Add to cart.

If the add to cart worked, this fix is working. Also check browser localStorage and you should see a new field called storeApiNonce.

### Changelog

> Prevent "X-WC-Store-API-Nonce is invalid" error when going back to a page with the products block using the browser back button.
