### PR TITLE
Increase width of Cart's product column on <= medium screens

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -190,10 +190,10 @@ table.wc-block-cart-items {
 			}
 			.wc-block-cart-item__product {
 				grid-column-start: 2;
-				grid-column-end: 3;
+				grid-column-end: 4;
 				grid-row-start: 1;
 				justify-self: stretch;
-				padding-bottom: $gap;
+				padding: 0 $gap $gap 0;
 			}
 			.wc-block-cart-item__quantity {
 				grid-column-start: 1;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When viewing the cart block in a way that causes it to be styled with the `is-medium` class or smaller, the product column in the cart block is too narrow.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
#### Before 
![image](https://user-images.githubusercontent.com/5656702/106612341-ee0c9580-6560-11eb-819b-0ab4b8709f0d.png)

#### After
![image](https://user-images.githubusercontent.com/5656702/106612571-201df780-6561-11eb-8cd0-705cf2c7975b.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Activate Twenty Twenty-One
2. Add products with a long name to your cart
3. View the cart block and see that the product column isn't too narrow.
4. Try this in storefront too but resize your window so the cart block displays at medium or smaller.
5. Try this in other themes too