### PR TITLE
Implement a dynamic SlotFill Component for cart item row additions.

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -160,7 +160,6 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 					) }
 				/>
 
-				{ /* My Upgrade/Downgrade/CrossGrade badges go here */ }
 				<ExperimentalCartItemDynamicMeta
 					slotName={ name }
 					extensions={ extensions }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -160,10 +160,7 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 					) }
 				/>
 
-				<ExperimentalCartItemDynamicMeta
-					slotName={ name }
-					extensions={ extensions }
-				/>
+				<ExperimentalCartItemDynamicMeta extensions={ extensions } />
 
 				<ProductMetadata
 					shortDescription={ shortDescription }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -17,7 +17,7 @@ import {
 } from '@woocommerce/base-components/cart-checkout';
 import {
 	ExperimentalCartItemDynamicMeta,
-	getCurrency
+	getCurrency,
 } from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
 
@@ -160,8 +160,11 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 					) }
 				/>
 
-				{ /* My Upgrade/Downgrade/CrossGrade badges go here */}
-				<ExperimentalCartItemDynamicMeta slotName={name} extensions={ extensions }/>
+				{ /* My Upgrade/Downgrade/CrossGrade badges go here */ }
+				<ExperimentalCartItemDynamicMeta
+					slotName={ name }
+					extensions={ extensions }
+				/>
 
 				<ProductMetadata
 					shortDescription={ shortDescription }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -15,7 +15,10 @@ import {
 	ProductMetadata,
 	ProductSaleBadge,
 } from '@woocommerce/base-components/cart-checkout';
-import { getCurrency } from '@woocommerce/blocks-checkout';
+import {
+	ExperimentalCartItemDynamicMeta,
+	getCurrency
+} from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
 
 /**
@@ -71,8 +74,8 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 				sale_price: '0',
 			},
 		},
+		extensions = {},
 	} = lineItem;
-
 	const {
 		quantity,
 		changeQuantity,
@@ -156,6 +159,9 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 						currency
 					) }
 				/>
+
+				{ /* My Upgrade/Downgrade/CrossGrade badges go here */}
+				<ExperimentalCartItemDynamicMeta slotName={name} extensions={ extensions }/>
 
 				<ProductMetadata
 					shortDescription={ shortDescription }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -150,6 +150,7 @@ const Cart = ( { attributes } ) => {
 					values={ cartTotals }
 				/>
 				<ExperimentalOrderMeta.Slot />
+				<ExperimentalOrderMeta.Slot />
 				<div className="wc-block-cart__payment-options">
 					{ cartNeedsPayment && <CartExpressPayment /> }
 					<CheckoutButton

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -150,7 +150,6 @@ const Cart = ( { attributes } ) => {
 					values={ cartTotals }
 				/>
 				<ExperimentalOrderMeta.Slot />
-				<ExperimentalOrderMeta.Slot />
 				<div className="wc-block-cart__payment-options">
 					{ cartNeedsPayment && <CartExpressPayment /> }
 					<CheckoutButton

--- a/packages/checkout/cart-item-dynamic-meta/index.js
+++ b/packages/checkout/cart-item-dynamic-meta/index.js
@@ -1,0 +1,90 @@
+/**
+ * External dependencies
+ */
+import { createSlotFill } from 'wordpress-components';
+import { Children, cloneElement, useEffect } from '@wordpress/element';
+import classnames from 'classnames';
+import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import BlockErrorBoundary from '../error-boundary';
+const components = [];
+
+function CartItemDynamicMeta( { FillComponent } ) {
+	useEffect(() => {
+		console.log( 'create CartItemDynamicMeta' );
+		return () => {
+			console.log( 'destroy CartItemDynamicMeta' );
+		};
+	  }, []);
+	return (
+		<FillComponent>
+			{ ( fillProps ) => {
+				console.log( 'fill', fillProps );
+				return Children.map( components, ( fill ) => {
+					return (
+						<BlockErrorBoundary
+							renderError={
+								CURRENT_USER_IS_ADMIN ? null : () => null
+							}
+						>
+							{ cloneElement( fill, fillProps ) }
+						</BlockErrorBoundary>
+					);
+				} );
+			} }
+		</FillComponent>
+	);
+}
+
+function SlotProvider( { SlotComponent, className, extensions } ) {
+	console.log('slot');
+	return (
+		<SlotComponent
+			bubblesVirtually
+			className={ classnames(
+				className,
+				'wc-block-components-cart-item-dynamic-meta'
+			) }
+			fillProps={ extensions }
+		/>
+	);
+}
+
+export function ExperimentalCartItemMeta( { children } ) {
+	useEffect(() => {
+		if ( Array.isArray( children ) ) {
+			components.push( ...children );
+		} else {
+			components.push( children );
+		}
+		console.log( 'create' );
+		return () => {
+			components.length = 0;
+			console.log( 'destroy' );
+		};
+	  }, []);
+	return null;
+}
+
+const ExperimentalCartItemDynamicMeta = ( { slotName, extensions, className = '' } ) => {
+	if ( slotName === '' ) {
+		return null;
+	}
+	console.log( {slotName, extensions});
+	const { Fill, Slot } = createSlotFill( slotName );
+
+	return (
+		<>
+			<CartItemDynamicMeta FillComponent={ Fill }/>
+			<SlotProvider 
+				className={ className }
+				SlotComponent={ Slot }
+				extensions={ extensions }/>
+		</>
+	)
+}
+
+export default ExperimentalCartItemDynamicMeta;

--- a/packages/checkout/cart-item-dynamic-meta/index.js
+++ b/packages/checkout/cart-item-dynamic-meta/index.js
@@ -2,73 +2,82 @@
  * External dependencies
  */
 import { createSlotFill } from 'wordpress-components';
-import { Children, cloneElement, useEffect } from '@wordpress/element';
+import {
+	Children,
+	cloneElement,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import classnames from 'classnames';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/block-settings';
-
+import { uniqueId } from 'lodash';
 /**
  * Internal dependencies
  */
 import BlockErrorBoundary from '../error-boundary';
-const components = [];
+import ProductBadge from '../../../assets/js/base/components/cart-checkout/product-badge';
 
-function CartItemDynamicMeta( { FillComponent } ) {
-	useEffect( () => {
-		console.log( 'create CartItemDynamicMeta' );
-		return () => {
-			console.log( 'destroy CartItemDynamicMeta' );
-		};
-	}, [] );
-	return (
-		<FillComponent>
-			{ ( fillProps ) => {
-				console.log( 'fill', fillProps );
-				return Children.map( components, ( fill ) => {
-					return (
-						<BlockErrorBoundary
-							renderError={
-								CURRENT_USER_IS_ADMIN ? null : () => null
-							}
-						>
-							{ cloneElement( fill, fillProps ) }
-						</BlockErrorBoundary>
-					);
-				} );
-			} }
-		</FillComponent>
-	);
+const componentsRegistry = {};
+
+function getAllComponentsFromRegistry() {
+	return Object.values( componentsRegistry ).flat();
 }
 
-function SlotProvider( { SlotComponent, className, extensions } ) {
-	console.log( 'slot' );
-	return (
-		<SlotComponent
-			bubblesVirtually
-			className={ classnames(
-				className,
-				'wc-block-components-cart-item-dynamic-meta'
-			) }
-			fillProps={ extensions }
-		/>
-	);
-}
-
-export function ExperimentalCartItemMeta( { children } ) {
+/**
+ * Component responsible for registering the 3rd party integration components.
+ * 
+ * @param {Array[Object]|Object} children Items to render inside the slot.
+ */
+const ExperimentalCartItemMeta = ( { children } ) => {
+	const [ id ] = useState( uniqueId( 'cart-item-meta-' ) );
 	useEffect( () => {
 		if ( Array.isArray( children ) ) {
-			components.push( ...children );
+			componentsRegistry[ id ] = children;
 		} else {
-			components.push( children );
+			componentsRegistry[ id ] = [ children ];
 		}
-		console.log( 'create' );
 		return () => {
-			components.length = 0;
-			console.log( 'destroy' );
+			componentsRegistry[ id ].length = 0;
 		};
 	}, [] );
 	return null;
-}
+};
 
+/**
+ * This component is used as a child of ExperimentalCartItemMeta.
+ * It is the only component type that will be allowed to render.
+ * 
+ * It functions using a badgeCallback that receives all the remaining props.
+ * The callback needs to return an object that has className to style the badge
+ * and the text that will be used to display the text inside the badge.
+ * 
+ */
+const BadgeGenerator = ( { badgeCallback, ...props } ) => {
+	if ( ! ( typeof badgeCallback === 'function' ) ) {
+		return null;
+	}
+	const badgeParameters = badgeCallback( props );
+	if ( badgeParameters === null ) {
+		return null;
+	}
+	return (
+		<ProductBadge className={ badgeParameters?.className }>
+			{ badgeParameters?.text }
+		</ProductBadge>
+	);
+};
+
+ExperimentalCartItemMeta.BadgeGenerator = BadgeGenerator;
+
+/**
+ * This component is a slotFill generator. It generate both the Slot and the Fill component and renders them.
+ * Fill component is automatically populated with the components in the registry.
+ * Each instance of ExperimentalCartItemDynamicMeta will receive all of the components currently registered
+ * inside the componentsRegistry. Each instance will pass to the components distinct set of props. This allows
+ * to components to render different information for each ExperimentalCartItemDynamicMeta instance.
+ * This pattern allows dynamic instantiation of multiple dynamic slot fills.
+ *  
+ */
 const ExperimentalCartItemDynamicMeta = ( {
 	slotName,
 	extensions,
@@ -77,19 +86,51 @@ const ExperimentalCartItemDynamicMeta = ( {
 	if ( slotName === '' ) {
 		return null;
 	}
-	console.log( { slotName, extensions } );
 	const { Fill, Slot } = createSlotFill( slotName );
-
 	return (
-		<>
-			<CartItemDynamicMeta FillComponent={ Fill } />
-			<SlotProvider
-				className={ className }
-				SlotComponent={ Slot }
-				extensions={ extensions }
-			/>
-		</>
+		<div
+			className={ classnames(
+				className,
+				'wc-block-components-cart-item-dynamic-meta'
+			) }
+		>
+			{ /*<CartItemDynamicMeta FillComponent={ Fill } /> */ }
+			<Slot fillProps={ extensions } />
+			<Fill>
+				{ ( fillProps ) => {
+					return Children.map(
+						getAllComponentsFromRegistry(),
+						( fill ) => {
+							/**
+							 * If we disable this check we open the Slot for any component type not just
+							 * the Badge we are generating in BadgeGenerator.
+							 */
+							if (
+								! (
+									fill.type ===
+									ExperimentalCartItemMeta.BadgeGenerator
+								)
+							) {
+								return null; // Fail silently.
+							}
+							return (
+								<BlockErrorBoundary
+									renderError={
+										CURRENT_USER_IS_ADMIN
+											? null
+											: () => null
+									}
+								>
+									{ cloneElement( fill, fillProps ) }
+								</BlockErrorBoundary>
+							);
+						}
+					);
+				} }
+			</Fill>
+		</div>
 	);
 };
 
+export { ExperimentalCartItemMeta };
 export default ExperimentalCartItemDynamicMeta;

--- a/packages/checkout/cart-item-dynamic-meta/index.js
+++ b/packages/checkout/cart-item-dynamic-meta/index.js
@@ -29,14 +29,16 @@ function getAllComponentsFromRegistry() {
  * @param {Array[Object]|Object} children Items to render inside the slot.
  */
 const ExperimentalCartItemMeta = ( { children } ) => {
+	console.log( children )
 	const [ id ] = useState( uniqueId( 'cart-item-meta-' ) );
 	useEffect( () => {
 		if ( Array.isArray( children ) ) {
-			componentsRegistry[ id ] = children;
+			componentsRegistry[ id ] = [ ...children ];
 		} else {
 			componentsRegistry[ id ] = [ children ];
 		}
 		return () => {
+			console.log( componentsRegistry );
 			componentsRegistry[ id ].length = 0;
 		};
 	}, [ id, children ] );

--- a/packages/checkout/cart-item-dynamic-meta/index.js
+++ b/packages/checkout/cart-item-dynamic-meta/index.js
@@ -13,12 +13,12 @@ import BlockErrorBoundary from '../error-boundary';
 const components = [];
 
 function CartItemDynamicMeta( { FillComponent } ) {
-	useEffect(() => {
+	useEffect( () => {
 		console.log( 'create CartItemDynamicMeta' );
 		return () => {
 			console.log( 'destroy CartItemDynamicMeta' );
 		};
-	  }, []);
+	}, [] );
 	return (
 		<FillComponent>
 			{ ( fillProps ) => {
@@ -40,7 +40,7 @@ function CartItemDynamicMeta( { FillComponent } ) {
 }
 
 function SlotProvider( { SlotComponent, className, extensions } ) {
-	console.log('slot');
+	console.log( 'slot' );
 	return (
 		<SlotComponent
 			bubblesVirtually
@@ -54,7 +54,7 @@ function SlotProvider( { SlotComponent, className, extensions } ) {
 }
 
 export function ExperimentalCartItemMeta( { children } ) {
-	useEffect(() => {
+	useEffect( () => {
 		if ( Array.isArray( children ) ) {
 			components.push( ...children );
 		} else {
@@ -65,26 +65,31 @@ export function ExperimentalCartItemMeta( { children } ) {
 			components.length = 0;
 			console.log( 'destroy' );
 		};
-	  }, []);
+	}, [] );
 	return null;
 }
 
-const ExperimentalCartItemDynamicMeta = ( { slotName, extensions, className = '' } ) => {
+const ExperimentalCartItemDynamicMeta = ( {
+	slotName,
+	extensions,
+	className = '',
+} ) => {
 	if ( slotName === '' ) {
 		return null;
 	}
-	console.log( {slotName, extensions});
+	console.log( { slotName, extensions } );
 	const { Fill, Slot } = createSlotFill( slotName );
 
 	return (
 		<>
-			<CartItemDynamicMeta FillComponent={ Fill }/>
-			<SlotProvider 
+			<CartItemDynamicMeta FillComponent={ Fill } />
+			<SlotProvider
 				className={ className }
 				SlotComponent={ Slot }
-				extensions={ extensions }/>
+				extensions={ extensions }
+			/>
 		</>
-	)
-}
+	);
+};
 
 export default ExperimentalCartItemDynamicMeta;

--- a/packages/checkout/cart-item-dynamic-meta/index.js
+++ b/packages/checkout/cart-item-dynamic-meta/index.js
@@ -25,7 +25,7 @@ function getAllComponentsFromRegistry() {
 
 /**
  * Component responsible for registering the 3rd party integration components.
- * 
+ *
  * @param {Array[Object]|Object} children Items to render inside the slot.
  */
 const ExperimentalCartItemMeta = ( { children } ) => {
@@ -39,18 +39,18 @@ const ExperimentalCartItemMeta = ( { children } ) => {
 		return () => {
 			componentsRegistry[ id ].length = 0;
 		};
-	}, [] );
+	}, [ id, children ] );
 	return null;
 };
 
 /**
  * This component is used as a child of ExperimentalCartItemMeta.
  * It is the only component type that will be allowed to render.
- * 
+ *
  * It functions using a badgeCallback that receives all the remaining props.
  * The callback needs to return an object that has className to style the badge
  * and the text that will be used to display the text inside the badge.
- * 
+ *
  */
 const BadgeGenerator = ( { badgeCallback, ...props } ) => {
 	if ( ! ( typeof badgeCallback === 'function' ) ) {
@@ -76,17 +76,11 @@ ExperimentalCartItemMeta.BadgeGenerator = BadgeGenerator;
  * inside the componentsRegistry. Each instance will pass to the components distinct set of props. This allows
  * to components to render different information for each ExperimentalCartItemDynamicMeta instance.
  * This pattern allows dynamic instantiation of multiple dynamic slot fills.
- *  
+ *
  */
-const ExperimentalCartItemDynamicMeta = ( {
-	slotName,
-	extensions,
-	className = '',
-} ) => {
-	if ( slotName === '' ) {
-		return null;
-	}
-	const { Fill, Slot } = createSlotFill( slotName );
+const ExperimentalCartItemDynamicMeta = ( { extensions, className = '' } ) => {
+	const [ id ] = useState( uniqueId( 'cart-item-meta-' ) );
+	const { Fill, Slot } = createSlotFill( id );
 	return (
 		<div
 			className={ classnames(

--- a/packages/checkout/index.js
+++ b/packages/checkout/index.js
@@ -3,6 +3,8 @@ export * from './utils';
 export * from './shipping';
 export { default as ExperimentalOrderMeta } from './order-meta';
 export { default as ExperimentalOrderShippingPackages } from './order-shipping-packages';
+export { default as ExperimentalCartItemDynamicMeta } from './cart-item-dynamic-meta';
+export { ExperimentalCartItemMeta } from './cart-item-dynamic-meta';
 export { default as Panel } from './panel';
 export { SlotFillProvider } from 'wordpress-components';
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR implements a dynamic SlotFill generator for cart items. It can be placed in multiple locations at the same time.
This makes it usable as a SlotFill that can be placed on each cart line. It has a component that aggregates the fills. Its behavior is modeled after the standard Fill component. In this implementation, it only accepts the `BadgeGenerator` that was created for the purpose of the design. With a simple change, we can open the Slots for components of any type or we can extend the list of allowed components. It should also be also possible to implement a filter functionality for the admin UI that would allow limiting the badge display only to a selected group. 

<!-- Reference any related issues or PRs here -->
Fixes #3619 
This can be tested using https://github.com/woocommerce/woocommerce-subscriptions/tree/update/wc-blocks-issue-3619 to work. Using that code the following badge feature is implemented:
![image](https://user-images.githubusercontent.com/17271089/106900497-e252d780-66f6-11eb-8f63-a2265467d6b0.png)

This should also easily solve the Resubscribe display issue.
