### PR TITLE
Update Cart and Checkout sidebar design

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/index.js
+++ b/assets/js/base/components/cart-checkout/order-summary/index.js
@@ -23,6 +23,7 @@ const OrderSummary = ( { cartItems = [] } ) => {
 		<Panel
 			className="wc-block-components-order-summary"
 			initialOpen={ isLarge }
+			hasBorder={ true }
 			title={
 				<span className="wc-block-components-order-summary__button-text">
 					{ __( 'Order summary', 'woo-gutenberg-products-block' ) }

--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -1,10 +1,3 @@
-.wc-block-components-order-summary {
-	.wc-blocks-components-panel__button {
-		margin-top: 0;
-		padding-top: 0;
-	}
-}
-
 .wc-block-components-order-summary__content {
 	display: table;
 	width: 100%;
@@ -17,6 +10,10 @@
 	padding-bottom: 1px;
 	padding-top: $gap;
 	width: 100%;
+
+	&:first-child {
+		padding-top: 0;
+	}
 
 	&:last-child {
 		> div {

--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -62,7 +62,7 @@
 	justify-content: center;
 	min-width: 20px;
 	right: 0;
-	top: $gap;
+	top: 0;
 	transform: translate(50%, -50%);
 	white-space: nowrap;
 	z-index: 1;

--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -70,6 +70,7 @@
 
 .wc-block-components-order-summary-item__description {
 	padding-left: $gap-large;
+	padding-right: $gap-small;
 	padding-bottom: $gap;
 
 	p,

--- a/assets/js/base/components/cart-checkout/product-details/style.scss
+++ b/assets/js/base/components/cart-checkout/product-details/style.scss
@@ -7,6 +7,10 @@
 	&:last-of-type {
 		margin-bottom: 0;
 	}
+
+	li {
+		margin-left: 0;
+	}
 }
 
 .wc-block-components-product-details__name,

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.js
@@ -26,9 +26,9 @@ import {
  * @param {Array} props.shippingRates Array of packages containing shipping rates.
  * @param {boolean} props.shippingRatesLoading True when rates are being loaded.
  * @param {string} props.className Class name for package rates.
- * @param {boolean} props.collapsible If true, when multiple packages are rendered they can be toggled open and closed.
+ * @param {boolean} [props.collapsible] If true, when multiple packages are rendered they can be toggled open and closed.
  * @param {React.ReactElement} props.noResultsMessage Rendered when there are no packages.
- * @param {Function} props.renderOption Function to render a shipping rate.
+ * @param {Function} [props.renderOption] Function to render a shipping rate.
  */
 const ShippingRatesControl = ( {
 	shippingRates,
@@ -103,6 +103,7 @@ const ShippingRatesControl = ( {
 				<Packages
 					packages={ shippingRates }
 					noResultsMessage={ noResultsMessage }
+					renderOption={ renderOption }
 				/>
 			</ExperimentalOrderShippingPackages>
 		</LoadingMask>
@@ -120,6 +121,7 @@ const ShippingRatesControl = ( {
  * @param {boolean} props.collapse If the panel should be collapsed by default,
  * only works if collapsible is true.
  * @param {boolean} props.showItems If we should items below the package name.
+ * @param {Function} [props.renderOption] Function to render a shipping rate.
  * @return {React.ReactElement|Array|null} Rendered components.
  */
 const Packages = ( {
@@ -128,6 +130,7 @@ const Packages = ( {
 	showItems,
 	collapsible,
 	noResultsMessage,
+	renderOption,
 } ) => {
 	// If there are no packages, return nothing.
 	if ( ! packages.length ) {
@@ -143,6 +146,7 @@ const Packages = ( {
 			collapse={ collapse }
 			showItems={ showItems }
 			noResultsMessage={ noResultsMessage }
+			renderOption={ renderOption }
 		/>
 	) );
 };

--- a/assets/js/base/components/cart-checkout/totals/coupon/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.js
@@ -59,7 +59,6 @@ const TotalsCoupon = ( {
 					htmlFor={ textInputId }
 				/>
 			}
-			titleTag="h2"
 		>
 			<LoadingMask
 				screenReaderLabel={ __(

--- a/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/style.scss
@@ -5,7 +5,7 @@
 	}
 
 	.wc-block-components-totals-item__label {
-		font-weight: normal;
+		font-weight: 700;
 	}
 
 	.wc-block-components-totals-footer-item-tax {

--- a/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -18,7 +18,7 @@
 	}
 
 	.wc-block-components-shipping-rates-control__no-results-notice {
-		margin-bottom: em($gap-small);
+		margin: 0 0 em($gap-small);
 	}
 
 	.wc-block-components-totals-shipping__change-address-button {

--- a/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -31,3 +31,8 @@
 		}
 	}
 }
+
+// Extra classes for specificity.
+.theme-twentytwentyone.theme-twentytwentyone.theme-twentytwentyone .wc-block-components-totals-shipping__change-address-button {
+	@include link-button();
+}

--- a/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -1,6 +1,4 @@
 .wc-block-components-totals-shipping {
-	@include with-translucent-border(1px 0 0);
-
 	// Added extra label for specificity.
 	fieldset.wc-block-components-totals-shipping__fieldset {
 		background-color: transparent;
@@ -19,13 +17,6 @@
 		}
 	}
 
-	.wc-block-components-radio-control__option,
-	.wc-block-components-radio-control__option-layout {
-		&:last-child::after {
-			display: none;
-		}
-	}
-
 	.wc-block-components-shipping-rates-control__no-results-notice {
 		margin-bottom: em($gap-small);
 	}
@@ -38,9 +29,5 @@
 		&:active {
 			opacity: 0.8;
 		}
-	}
-
-	.wc-blocks-components-panel:last-child::after {
-		border-bottom-width: 0;
 	}
 }

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -184,13 +184,25 @@
 	}
 }
 
-.wc-block-components-radio-control__option-checked.wc-block-components-radio-control__option-checked {
-	font-weight: bold;
+.wc-block-components-radio-control-accordion-option {
+	// We need to add the first-child and last-child pseudoclasses for specificity.
+	.wc-block-components-radio-control__option,
+	.wc-block-components-radio-control__option:first-child,
+	.wc-block-components-radio-control__option:last-child {
+		margin: 0;
+		padding-bottom: em($gap);
+		padding-top: em($gap);
+	}
+
+	.wc-block-components-radio-control__option-checked {
+		font-weight: bold;
+	}
 }
 
 .wc-block-checkout__payment-method {
 	.wc-block-components-radio-control__option {
 		padding-left: 56px;
+
 		&::after {
 			content: none;
 		}
@@ -239,7 +251,7 @@
 }
 
 .wc-block-components-radio-control-accordion-content {
-	padding: 8px 16px 16px 16px;
+	padding: 0 $gap em($gap) $gap;
 }
 
 .wc-block-checkout__order-notes {

--- a/assets/js/base/components/payment-methods/style.scss
+++ b/assets/js/base/components/payment-methods/style.scss
@@ -184,21 +184,6 @@
 	}
 }
 
-.wc-block-components-radio-control-accordion-option {
-	// We need to add the first-child and last-child pseudoclasses for specificity.
-	.wc-block-components-radio-control__option,
-	.wc-block-components-radio-control__option:first-child,
-	.wc-block-components-radio-control__option:last-child {
-		margin: 0;
-		padding-bottom: em($gap);
-		padding-top: em($gap);
-	}
-
-	.wc-block-components-radio-control__option-checked {
-		font-weight: bold;
-	}
-}
-
 .wc-block-checkout__payment-method {
 	.wc-block-components-radio-control__option {
 		padding-left: 56px;
@@ -210,6 +195,19 @@
 		.wc-block-components-radio-control__input {
 			left: 16px;
 		}
+	}
+
+	// We need to add the first-child and last-child pseudoclasses for specificity.
+	.wc-block-components-radio-control__option,
+	.wc-block-components-radio-control__option:first-child,
+	.wc-block-components-radio-control__option:last-child {
+		margin: 0;
+		padding-bottom: em($gap);
+		padding-top: em($gap);
+	}
+
+	.wc-block-components-radio-control__option-checked {
+		font-weight: bold;
 	}
 
 	.wc-block-components-radio-control__option:last-child,

--- a/assets/js/base/components/radio-control/style.scss
+++ b/assets/js/base/components/radio-control/style.scss
@@ -1,12 +1,19 @@
 .wc-block-components-radio-control__option {
 	@include reset-typography();
-	@include with-translucent-border( 0 0 1px );
 	display: block;
-	padding: em($gap) 0 em($gap) em($gap-largest);
+	margin: em($gap) 0;
+	padding: 0 0 0 em($gap-largest);
+	position: relative;
+
+	&:first-child {
+		margin-top: 0;
+	}
+	&:last-child {
+		margin-bottom: 0;
+	}
 }
 
 .wc-block-components-radio-control__option-layout {
-	@include with-translucent-border( 0 0 1px );
 	display: table;
 	width: 100%;
 }

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -121,6 +121,12 @@
 }
 
 .theme-twentytwentyone {
+	// Extra classes for specificity.
+	&.theme-twentytwentyone.theme-twentytwentyone .components-custom-select-control__button {
+		background-color: #fff;
+		color: $input-text-active;
+	}
+
 	&.is-dark-theme {
 		// If the theme is in dark mode, as well as the block, then this selector will match.
 		.has-dark-controls {

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -18,11 +18,9 @@
 	padding-left: percentage($gap-large / 1060px);
 	width: 35%;
 
-	.wc-blocks-components-panel {
-		> h2 {
-			@include font-size(large);
-			@include reset-box();
-		}
+	.wc-blocks-components-panel > h2 {
+		@include font-size(regular);
+		@include reset-box();
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.js
@@ -105,63 +105,74 @@ const Cart = ( { attributes } ) => {
 	} );
 
 	return (
-		<SidebarLayout className={ cartClassName }>
-			<Main className="wc-block-cart__main">
-				<CartLineItemsTitle itemCount={ cartItemsCount } />
-				<CartLineItemsTable
-					lineItems={ cartItems }
-					isLoading={ cartIsLoading }
-				/>
-			</Main>
-			<Sidebar className="wc-block-cart__sidebar">
-				<Title headingLevel="2" className="wc-block-cart__totals-title">
-					{ __( 'Cart totals', 'woo-gutenberg-products-block' ) }
-				</Title>
-				<Subtotal currency={ totalsCurrency } values={ cartTotals } />
-				<TotalsFees currency={ totalsCurrency } cartFees={ cartFees } />
-				<TotalsDiscount
-					cartCoupons={ appliedCoupons }
-					currency={ totalsCurrency }
-					isRemovingCoupon={ isRemovingCoupon }
-					removeCoupon={ removeCoupon }
-					values={ cartTotals }
-				/>
-				{ cartNeedsShipping && (
-					<TotalsShipping
-						showCalculator={ isShippingCalculatorEnabled }
-						showRateSelector={ true }
-						values={ cartTotals }
-						currency={ totalsCurrency }
+		<>
+			<CartLineItemsTitle itemCount={ cartItemsCount } />
+			<SidebarLayout className={ cartClassName }>
+				<Main className="wc-block-cart__main">
+					<CartLineItemsTable
+						lineItems={ cartItems }
+						isLoading={ cartIsLoading }
 					/>
-				) }
-				{ ! DISPLAY_CART_PRICES_INCLUDING_TAX && (
-					<TotalsTaxes
+				</Main>
+				<Sidebar className="wc-block-cart__sidebar">
+					<Title
+						headingLevel="2"
+						className="wc-block-cart__totals-title"
+					>
+						{ __( 'Cart totals', 'woo-gutenberg-products-block' ) }
+					</Title>
+					<Subtotal
 						currency={ totalsCurrency }
 						values={ cartTotals }
 					/>
-				) }
-				{ COUPONS_ENABLED && (
-					<TotalsCoupon
-						onSubmit={ applyCoupon }
-						isLoading={ isApplyingCoupon }
+					<TotalsFees
+						currency={ totalsCurrency }
+						cartFees={ cartFees }
 					/>
-				) }
-				<TotalsFooterItem
-					currency={ totalsCurrency }
-					values={ cartTotals }
-				/>
-				<ExperimentalOrderMeta.Slot />
-				<div className="wc-block-cart__payment-options">
-					{ cartNeedsPayment && <CartExpressPayment /> }
-					<CheckoutButton
-						link={ getSetting(
-							'page-' + attributes?.checkoutPageId,
-							false
-						) }
+					<TotalsDiscount
+						cartCoupons={ appliedCoupons }
+						currency={ totalsCurrency }
+						isRemovingCoupon={ isRemovingCoupon }
+						removeCoupon={ removeCoupon }
+						values={ cartTotals }
 					/>
-				</div>
-			</Sidebar>
-		</SidebarLayout>
+					{ cartNeedsShipping && (
+						<TotalsShipping
+							showCalculator={ isShippingCalculatorEnabled }
+							showRateSelector={ true }
+							values={ cartTotals }
+							currency={ totalsCurrency }
+						/>
+					) }
+					{ ! DISPLAY_CART_PRICES_INCLUDING_TAX && (
+						<TotalsTaxes
+							currency={ totalsCurrency }
+							values={ cartTotals }
+						/>
+					) }
+					{ COUPONS_ENABLED && (
+						<TotalsCoupon
+							onSubmit={ applyCoupon }
+							isLoading={ isApplyingCoupon }
+						/>
+					) }
+					<TotalsFooterItem
+						currency={ totalsCurrency }
+						values={ cartTotals }
+					/>
+					<ExperimentalOrderMeta.Slot />
+					<div className="wc-block-cart__payment-options">
+						{ cartNeedsPayment && <CartExpressPayment /> }
+						<CheckoutButton
+							link={ getSetting(
+								'page-' + attributes?.checkoutPageId,
+								false
+							) }
+						/>
+					</div>
+				</Sidebar>
+			</SidebarLayout>
+		</>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -89,6 +89,10 @@ table.wc-block-cart-items {
 	}
 }
 
+.wc-block-cart .wc-block-components-shipping-rates-control__package {
+	@include with-translucent-border(1px 0 0);
+}
+
 // Loading placeholder state.
 .wc-block-cart--is-loading {
 	th span,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -241,8 +241,18 @@ table.wc-block-cart-items {
 		left: 0;
 	}
 
+	.wc-block-cart__totals-title {
+		@include with-translucent-border(0 0 1px);
+		@include text-heading();
+		@include font-size(smaller);
+		display: block;
+		font-weight: 600;
+		padding: 0.25rem 0;
+		text-align: right;
+		text-transform: uppercase;
+	}
+
 	.wc-block-components-sidebar {
-		> .wc-block-cart__totals-title,
 		.wc-block-components-shipping-calculator,
 		.wc-block-components-shipping-rates-control__package:not(.wc-blocks-components-panel) {
 			padding-left: $gap;

--- a/assets/js/blocks/cart-checkout/checkout/form/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/form/style.scss
@@ -8,21 +8,14 @@
 }
 
 .wc-block-checkout__shipping-option {
-	.wc-block-components-shipping-rates-control__package:not(:first-of-type) {
-		margin-top: $gap-larger;
-	}
-
 	.wc-block-components-radio-control__option {
 		@include with-translucent-border( 0 0 1px );
 		margin: 0;
 		padding: em($gap-small) 0 em($gap-small) em($gap-largest);
+	}
 
-		&:first-child {
-			// We can't remove the top padding because the radio input is vertically
-			// centered, so we apply a negative top margin which undoes the top
-			// padding.
-			margin-top: em(-$gap-small);
-		}
+	.wc-block-components-shipping-rates-control__no-results-notice {
+		margin: em($gap-small) 0;
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/checkout/form/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/form/style.scss
@@ -11,6 +11,19 @@
 	.wc-block-components-shipping-rates-control__package:not(:first-of-type) {
 		margin-top: $gap-larger;
 	}
+
+	.wc-block-components-radio-control__option {
+		@include with-translucent-border( 0 0 1px );
+		margin: 0;
+		padding: em($gap-small) 0 em($gap-small) em($gap-largest);
+
+		&:first-child {
+			// We can't remove the top padding because the radio input is vertically
+			// centered, so we apply a negative top margin which undoes the top
+			// padding.
+			margin-top: em(-$gap-small);
+		}
+	}
 }
 
 .is-small,

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -5,7 +5,6 @@
 .wc-block-checkout__sidebar {
 	.wc-block-components-product-name {
 		color: inherit;
-		padding-right: $gap-small;
 		flex-grow: 1;
 		// Required by IE11.
 		flex-basis: 0;

--- a/packages/checkout/panel/style.scss
+++ b/packages/checkout/panel/style.scss
@@ -40,7 +40,6 @@
 
 .wc-blocks-components-panel__content {
 	padding-bottom: em($gap);
-	overflow: auto;
 
 	// Ensures the panel contents are not visible for any theme that tweaked the
 	// `display` property of div elements.

--- a/packages/checkout/panel/style.scss
+++ b/packages/checkout/panel/style.scss
@@ -48,6 +48,12 @@
 	}
 }
 
+// Extra classes for specificity.
+.theme-twentytwentyone.theme-twentytwentyone.theme-twentytwentyone .wc-blocks-components-panel__button {
+	background-color: inherit;
+	color: inherit;
+}
+
 .theme-twentytwenty .wc-blocks-components-panel__button,
 .theme-twentyseventeen .wc-blocks-components-panel__button {
 	background: transparent;

--- a/packages/checkout/shipping/shipping-rates-control/package.js
+++ b/packages/checkout/shipping/shipping-rates-control/package.js
@@ -90,7 +90,6 @@ const Package = ( {
 		return (
 			<Panel
 				className="wc-block-components-shipping-rates-control__package"
-				hasBorder={ true }
 				initialOpen={ ! collapse }
 				title={ header }
 			>

--- a/packages/checkout/shipping/shipping-rates-control/style.scss
+++ b/packages/checkout/shipping/shipping-rates-control/style.scss
@@ -1,6 +1,28 @@
 .wc-block-components-shipping-rates-control__package {
+	@include with-translucent-border(1px 0 0);
+
+	.wc-blocks-components-panel__button {
+		margin-bottom: 0;
+		margin-top: 0;
+		padding-bottom: em($gap-small);
+		padding-top: em($gap-small);
+	}
+
 	.wc-block-components-shipping-rates-control__package-title {
+		@include text-heading();
+		font-weight: bold;
 		margin: 0;
+	}
+
+	// Remove panel padding. In the next ruleset we are already adding a margin
+	// to the last option, so it works when it's inside a panel and when it's
+	// rendered directly.
+	.wc-blocks-components-panel__content {
+		padding-bottom: 0;
+	}
+
+	.wc-block-components-radio-control__option:last-child {
+		margin-bottom: em($gap);
 	}
 }
 
@@ -25,11 +47,5 @@
 }
 
 .wc-block-checkout__shipping-option .wc-block-components-shipping-rates-control__no-results-notice {
-	margin-bottom: 0;
-}
-
-.wc-block-components-shipping-rates-control {
-	.wc-blocks-components-panel__content {
-		padding-bottom: 0;
-	}
+	margin: em($gap) 0 0;
 }

--- a/packages/checkout/shipping/shipping-rates-control/style.scss
+++ b/packages/checkout/shipping/shipping-rates-control/style.scss
@@ -1,6 +1,4 @@
 .wc-block-components-shipping-rates-control__package {
-	@include with-translucent-border(1px 0 0);
-
 	.wc-blocks-components-panel__button {
 		margin-bottom: 0;
 		margin-top: 0;
@@ -14,15 +12,19 @@
 		margin: 0;
 	}
 
-	// Remove panel padding. In the next ruleset we are already adding a margin
-	// to the last option, so it works when it's inside a panel and when it's
-	// rendered directly.
+	// Remove panel padding because we are adding bottom padding to `.wc-block-components-radio-control`
+	// and `.wc-block-components-radio-control__option-layout` in the next ruleset.
 	.wc-blocks-components-panel__content {
 		padding-bottom: 0;
 	}
 
-	.wc-block-components-radio-control__option:last-child {
-		margin-bottom: em($gap);
+	.wc-block-components-radio-control,
+	.wc-block-components-radio-control__option-layout {
+		padding-bottom: em($gap);
+	}
+
+	.wc-block-components-radio-control .wc-block-components-radio-control__option-layout {
+		padding-bottom: 0;
 	}
 }
 
@@ -44,8 +46,4 @@
 .wc-block-components-shipping-rates-control__package-item:not(:last-child)::after {
 	content: ", ";
 	white-space: pre;
-}
-
-.wc-block-checkout__shipping-option .wc-block-components-shipping-rates-control__no-results-notice {
-	margin: em($gap) 0 0;
 }

--- a/packages/checkout/totals/item/style.scss
+++ b/packages/checkout/totals/item/style.scss
@@ -11,10 +11,10 @@
 
 .wc-block-components-totals-item__label {
 	flex-grow: 1;
-	font-weight: bold;
 }
 
 .wc-block-components-totals-item__value {
+	font-weight: bold;
 	white-space: nowrap;
 }
 

--- a/packages/checkout/totals/item/style.scss
+++ b/packages/checkout/totals/item/style.scss
@@ -1,12 +1,8 @@
 .wc-block-components-totals-item {
 	display: flex;
 	flex-wrap: wrap;
-	padding: em($gap-small) 0;
+	margin: em($gap-small) 0;
 	width: 100%;
-
-	&:not(:first-of-type):not(:last-of-type) {
-		@include with-translucent-border(1px 0 0);
-	}
 }
 
 .wc-block-components-totals-item__label {

--- a/packages/checkout/totals/taxes/index.js
+++ b/packages/checkout/totals/taxes/index.js
@@ -13,7 +13,6 @@ import {
  * Internal dependencies
  */
 import TotalsItem from '../item';
-import './style.scss';
 
 const TotalsTaxes = ( { currency, values, className } ) => {
 	const { total_tax: totalTax, tax_lines: taxLines } = values;

--- a/packages/checkout/totals/taxes/style.scss
+++ b/packages/checkout/totals/taxes/style.scss
@@ -1,3 +1,0 @@
-.wc-block-components-totals-taxes {
-	@include with-translucent-border(1px 0 0);
-}


### PR DESCRIPTION
Fixes #3632.

This PR updates the Cart and Checkout sidebar so it matches the newest designs, that required making some changes to the Shipping rates control and payment methods too.

I tried to keep commits organized so every code change is explained by its commit description, but if something is still not clear, I can give a more verbose explanation. :slightly_smiling_face: 

### Screenshots

_Cart sidebar with no shipping options:_
![imatge](https://user-images.githubusercontent.com/3616980/107000287-e975f600-6787-11eb-92b4-c39ce463c593.png)

_Cart sidebar with 2 shipping rates:_
![imatge](https://user-images.githubusercontent.com/3616980/107000346-04486a80-6788-11eb-9ffc-9459050dd7f2.png)

_Checkout sidebar:_
![imatge](https://user-images.githubusercontent.com/3616980/107001503-07445a80-678a-11eb-9ebc-88964604c09b.png)

_Checkout shipping options & payment methods:_
![imatge](https://user-images.githubusercontent.com/3616980/107000430-25a95680-6788-11eb-963d-ecd6607e7cb4.png)

### How to test the changes in this Pull Request:

Go to the Cart and Checkout block and verify designs look good. Some ideas of things to try:
* Test in a situation where there are +1 shipping rate options, only 1 or when there are no available options.
* Test when there is more than one shipping package and when there is only one.
* Test in several themes.
* Test with a different browser font size.
* Verify things look good in the editor as well.
* Test mobile too.

### Changelog

> Improve design of cart and checkout sidebars.