### PR TITLE
Align Place Order button to the right

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -141,7 +141,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 						allowCreateAccount={ allowCreateAccount }
 					/>
 					<div className="wc-block-checkout__actions">
-						<PlaceOrderButton />
 						{ attributes.showReturnToCart && (
 							<ReturnToCartButton
 								link={ getSetting(
@@ -150,6 +149,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 								) }
 							/>
 						) }
+						<PlaceOrderButton />
 					</div>
 					{ attributes.showPolicyLinks && <Policies /> }
 				</Main>

--- a/assets/js/blocks/cart-checkout/checkout/form/order-notes/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/form/order-notes/style.scss
@@ -1,6 +1,16 @@
 .wc-block-checkout__add-note {
-	padding: $gap $gap 0 9px;
-	margin-bottom: $gap;
+	margin: em($gap-large) 0 em($gap-large) 9px;
+}
+
+.is-mobile,
+.is-small,
+.is-medium {
+	.wc-block-checkout__add-note {
+		@include with-translucent-border(1px 0);
+		margin-bottom: em($gap);
+		margin-top: em($gap);
+		padding: em($gap) 0;
+	}
 }
 
 .wc-block-checkout__add-note .wc-block-components-textarea {

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -16,7 +16,6 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	flex-direction: row-reverse;
 	margin-left: 9px;
 
 	.wc-block-components-checkout-place-order-button {

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -14,15 +14,15 @@
 
 .wc-block-checkout__actions {
 	display: flex;
-	flex-direction: column;
-	margin: 0 0 $gap-large*2;
-	padding-left: 9px;
+	justify-content: space-between;
+	align-items: center;
+	flex-direction: row-reverse;
+	margin-left: 9px;
 
 	.wc-block-components-checkout-place-order-button {
 		width: 50%;
 		padding: 1em;
 		height: auto;
-		margin-bottom: 44px;
 
 		.wc-block-components-button__text {
 			line-height: 24px;
@@ -147,10 +147,8 @@
 
 .is-large {
 	.wc-block-checkout__actions {
-		padding-right: 36px;
+		@include with-translucent-border(1px 0 0);
+		margin-right: $gap-large;
+		padding-top: em($gap-large);
 	}
-}
-
-.wc-block-checkout__actions {
-	margin-top: $gap;
 }


### PR DESCRIPTION
Fixes #3795.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/106997175-b54c0680-6782-11eb-8eda-0e5188948689.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/107060924-d7bc3f00-67d7-11eb-8fcd-34670bcec285.png)

### How to test the changes in this Pull Request:

1. Go to the Checkout block and verify the Place Order button is aligned to the right and looks correct.
2. In mobile, verify it takes the entire width.
3. Optionally, test some other themes in addition to Storefront.

### Changelog

> Align place order button to the right of the block.