### PR TITLE
Validate order items on post, not on draft order creation

### DIFF
--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -195,6 +195,14 @@ class Checkout extends AbstractRoute {
 	 */
 	protected function get_route_post_response( WP_REST_Request $request ) {
 		/**
+		 * Validate items etc are allowed in the order before the order is processed. This will fix violations and tell
+		 * the customer.
+		 */
+		$cart_controller = new CartController();
+		$cart_controller->validate_cart_items();
+		$cart_controller->validate_cart_coupons();
+
+		/**
 		 * Obtain Draft Order and process request data.
 		 *
 		 * Note: Customer data is persisted from the request first so that OrderController::update_addresses_from_cart
@@ -340,14 +348,9 @@ class Checkout extends AbstractRoute {
 	 * @throws RouteException On error.
 	 */
 	private function create_or_update_draft_order() {
-		$cart_controller  = new CartController();
 		$order_controller = new OrderController();
 		$reserve_stock    = new ReserveStock();
 		$this->order      = $this->get_draft_order_id() ? wc_get_order( $this->get_draft_order_id() ) : null;
-
-		// Validate items etc are allowed in the order before it gets created.
-		$cart_controller->validate_cart_items();
-		$cart_controller->validate_cart_coupons();
 
 		if ( ! $this->is_valid_draft_order( $this->order ) ) {
 			$this->order = $order_controller->create_order_from_cart();


### PR DESCRIPTION
If coupons become invalid between applying to a cart and checking out, right now the coupons will be removed/invalidated without informing the user. This is because the check is ran when the draft order is created on page load. Any errors are not surfaced at this point by the API.

To resolve this, we simply defer the validation until the user attempts to checkout. Instead of the order going through, a proper error is returned from the API as the invalid coupons are removed.

Fixes #3447

### Screenshots

This is an example notice from the API:

![Screenshot 2021-02-08 at 11 42 08](https://user-images.githubusercontent.com/90977/107215319-0ff39580-6a03-11eb-80a8-d33060f78a3a.png)

### How to test the changes in this Pull Request:

There are 4 test cases in #3447.

### Changelog

> If coupons become invalid between applying to a cart and checking out, show the user a notice when the order is placed.
