### PR TITLE
Remove unused imports from Cheque.php

### DIFF
--- a/src/Payments/Integrations/Cheque.php
+++ b/src/Payments/Integrations/Cheque.php
@@ -2,8 +2,6 @@
 namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
 
 use Exception;
-use WC_Stripe_Payment_Request;
-use WC_Stripe_Helper;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 
 /**


### PR DESCRIPTION
This PR removes unused imports from Cheque.php

### Testing
I don't think this would break anything.
- Make sure Cheque payment load find.