### PR TITLE
Use cart item key instead of name as the React key in Package

### DIFF
--- a/packages/checkout/shipping/shipping-rates-control/package.js
+++ b/packages/checkout/shipping/shipping-rates-control/package.js
@@ -48,7 +48,7 @@ const Package = ( {
 						const quantity = v.quantity;
 						return (
 							<li
-								key={ name }
+								key={ v.key }
 								className="wc-block-components-shipping-rates-control__package-item"
 							>
 								<Label


### PR DESCRIPTION
Fixes #3813.

### How to test the changes in this Pull Request:

1. Add two products (ie: Cap and Beanie with logo) to your Cart.
2. In `wp-admin`, rename Beanie with logo to `Cart`.
3. Go to the Cart and Checkout blocks.
4. Verify there are no errors in the console.

### Changelog

> Fix JS warning if two cart products share the same name.
