### PR TITLE
Refactor block types to include script registration and integration classes

### DIFF
--- a/docs/contributors/block-assets.md
+++ b/docs/contributors/block-assets.md
@@ -44,13 +44,3 @@ protected function enqueue_data( array $attributes = [] ) {
     $data_registry->add( 'some-asset-data', 'data-value' );
 }
 ```
-
-### AbstractBlock::enqueue_scripts
-
-If extending `AbstractBlock` this method can be overridden. It should register scripts used by the block. This is more commonly used for frontend scripts.
-
-```php
-protected function enqueue_scripts( array $attributes = [] ) {
-    Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
-}
-```

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -48,8 +48,9 @@ class Assets {
 
 		self::register_style( 'wc-block-vendors-style', plugins_url( $asset_api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ), $block_style_dependencies );
 		self::register_style( 'wc-block-editor', plugins_url( $asset_api->get_block_asset_build_path( 'editor', 'css' ), __DIR__ ), array( 'wp-edit-blocks' ) );
-		wp_style_add_data( 'wc-block-editor', 'rtl', 'replace' );
 		self::register_style( 'wc-block-style', plugins_url( $asset_api->get_block_asset_build_path( 'style', 'css' ), __DIR__ ), array( 'wc-block-vendors-style' ) );
+
+		wp_style_add_data( 'wc-block-editor', 'rtl', 'replace' );
 		wp_style_add_data( 'wc-block-style', 'rtl', 'replace' );
 
 		// Shared libraries and components across multiple blocks.
@@ -66,7 +67,6 @@ class Assets {
 			$asset_api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [], false );
 		}
 
-		// Inline data.
 		wp_add_inline_script(
 			'wc-blocks-middleware',
 			"
@@ -75,38 +75,6 @@ class Assets {
 			",
 			'before'
 		);
-
-		// Individual blocks
-		// @todo move script registration to block type classes. This also happens on init.
-		$block_dependencies = array( 'wc-vendors', 'wc-blocks' );
-
-		$asset_api->register_script( 'wc-handpicked-products', $asset_api->get_block_asset_build_path( 'handpicked-products' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-best-sellers', $asset_api->get_block_asset_build_path( 'product-best-sellers' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-category', $asset_api->get_block_asset_build_path( 'product-category' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-new', $asset_api->get_block_asset_build_path( 'product-new' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-on-sale', $asset_api->get_block_asset_build_path( 'product-on-sale' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-top-rated', $asset_api->get_block_asset_build_path( 'product-top-rated' ), $block_dependencies );
-		$asset_api->register_script( 'wc-products-by-attribute', $asset_api->get_block_asset_build_path( 'products-by-attribute' ), $block_dependencies );
-		$asset_api->register_script( 'wc-featured-product', $asset_api->get_block_asset_build_path( 'featured-product' ), $block_dependencies );
-		$asset_api->register_script( 'wc-featured-category', $asset_api->get_block_asset_build_path( 'featured-category' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-categories', $asset_api->get_block_asset_build_path( 'product-categories' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-tag', $asset_api->get_block_asset_build_path( 'product-tag' ), $block_dependencies );
-		$asset_api->register_script( 'wc-all-reviews', $asset_api->get_block_asset_build_path( 'all-reviews' ), $block_dependencies );
-		$asset_api->register_script( 'wc-reviews-by-product', $asset_api->get_block_asset_build_path( 'reviews-by-product' ), $block_dependencies );
-		$asset_api->register_script( 'wc-reviews-by-category', $asset_api->get_block_asset_build_path( 'reviews-by-category' ), $block_dependencies );
-		$asset_api->register_script( 'wc-product-search', $asset_api->get_block_asset_build_path( 'product-search' ), $block_dependencies );
-		$asset_api->register_script( 'wc-all-products', $asset_api->get_block_asset_build_path( 'all-products' ), $block_dependencies );
-		$asset_api->register_script( 'wc-price-filter', $asset_api->get_block_asset_build_path( 'price-filter' ), $block_dependencies );
-		$asset_api->register_script( 'wc-attribute-filter', $asset_api->get_block_asset_build_path( 'attribute-filter' ), $block_dependencies );
-		$asset_api->register_script( 'wc-active-filters', $asset_api->get_block_asset_build_path( 'active-filters' ), $block_dependencies );
-
-		if ( Package::feature()->is_experimental_build() ) {
-			$asset_api->register_script( 'wc-single-product-block', $asset_api->get_block_asset_build_path( 'single-product' ), $block_dependencies );
-		}
-
-		if ( Package::feature()->is_feature_plugin_build() ) {
-			$asset_api->register_script( 'wc-cart-block', $asset_api->get_block_asset_build_path( 'cart' ), $block_dependencies );
-		}
 	}
 
 	/**
@@ -275,12 +243,14 @@ class Assets {
 	 * @since 2.3.0
 	 * @since 2.6.0 Changed $name to $script_name and added $handle argument.
 	 * @since 2.9.0 Made it so scripts are not loaded in admin pages.
+	 * @deprecated 4.5.0 Block types register the scripts themselves.
 	 *
 	 * @param string $script_name  Name of the script used to identify the file inside build folder.
 	 * @param string $handle       Optional. Provided if the handle should be different than the script name. `wc-` prefix automatically added.
 	 * @param array  $dependencies Optional. An array of registered script handles this script depends on. Default empty array.
 	 */
 	public static function register_block_script( $script_name, $handle = '', $dependencies = [] ) {
+		_deprecated_function( 'register_block_script', '4.5.0' );
 		$asset_api = Package::container()->get( AssetApi::class );
 		$asset_api->register_block_script( $script_name, $handle, $dependencies );
 	}

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -52,7 +52,7 @@ class Assets {
 		self::register_style( 'wc-block-style', plugins_url( $asset_api->get_block_asset_build_path( 'style', 'css' ), __DIR__ ), array( 'wc-block-vendors-style' ) );
 		wp_style_add_data( 'wc-block-style', 'rtl', 'replace' );
 
-		// Shared libraries and components across all blocks.
+		// Shared libraries and components across multiple blocks.
 		$asset_api->register_script( 'wc-blocks-middleware', 'build/wc-blocks-middleware.js', [], false );
 		$asset_api->register_script( 'wc-blocks-data-store', 'build/wc-blocks-data.js', [ 'wc-blocks-middleware' ], false );
 		$asset_api->register_script( 'wc-blocks', $asset_api->get_block_asset_build_path( 'blocks' ), [], false );
@@ -60,6 +60,11 @@ class Assets {
 		$asset_api->register_script( 'wc-blocks-registry', 'build/wc-blocks-registry.js', [], false );
 		$asset_api->register_script( 'wc-shared-context', 'build/wc-shared-context.js', [], false );
 		$asset_api->register_script( 'wc-shared-hocs', 'build/wc-shared-hocs.js', [], false );
+		$asset_api->register_script( 'wc-price-format', 'build/price-format.js', [], false );
+
+		if ( Package::feature()->is_feature_plugin_build() ) {
+			$asset_api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [], false );
+		}
 
 		// Inline data.
 		wp_add_inline_script(
@@ -71,7 +76,8 @@ class Assets {
 			'before'
 		);
 
-		// Individual blocks.
+		// Individual blocks
+		// @todo move script registration to block type classes. This also happens on init.
 		$block_dependencies = array( 'wc-vendors', 'wc-blocks' );
 
 		$asset_api->register_script( 'wc-handpicked-products', $asset_api->get_block_asset_build_path( 'handpicked-products' ), $block_dependencies );
@@ -97,11 +103,8 @@ class Assets {
 		if ( Package::feature()->is_experimental_build() ) {
 			$asset_api->register_script( 'wc-single-product-block', $asset_api->get_block_asset_build_path( 'single-product' ), $block_dependencies );
 		}
-		$asset_api->register_script( 'wc-price-format', 'build/price-format.js', [], false );
 
 		if ( Package::feature()->is_feature_plugin_build() ) {
-			$asset_api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [], false );
-			$asset_api->register_script( 'wc-checkout-block', $asset_api->get_block_asset_build_path( 'checkout' ), $block_dependencies );
 			$asset_api->register_script( 'wc-cart-block', $asset_api->get_block_asset_build_path( 'cart' ), $block_dependencies );
 		}
 	}

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -116,12 +116,14 @@ class Api {
 	 * @since 2.5.0
 	 * @since 2.6.0 Changed $name to $script_name and added $handle argument.
 	 * @since 2.9.0 Made it so scripts are not loaded in admin pages.
+	 * @deprecated 4.5.0 Block types register the scripts themselves.
 	 *
 	 * @param string $script_name  Name of the script used to identify the file inside build folder.
 	 * @param string $handle       Optional. Provided if the handle should be different than the script name. `wc-` prefix automatically added.
 	 * @param array  $dependencies Optional. An array of registered script handles this script depends on. Default empty array.
 	 */
 	public function register_block_script( $script_name, $handle = '', $dependencies = [] ) {
+		_deprecated_function( 'register_block_script', '4.5.0' );
 		if ( is_admin() ) {
 			return;
 		}

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -106,7 +106,7 @@ abstract class AbstractBlock {
 			_doing_it_wrong( __METHOD__, esc_html( __( 'Block name is required.', 'woo-gutenberg-products-block' ) ), '4.5.0' );
 			return false;
 		}
-		$this->integration_registry->initialize( $this->block_name );
+		$this->integration_registry->initialize( $this->block_name . '_block' );
 		$this->register_block_type_assets();
 		$this->register_block_type();
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_editor_assets' ] );

--- a/src/BlockTypes/AbstractDynamicBlock.php
+++ b/src/BlockTypes/AbstractDynamicBlock.php
@@ -4,54 +4,13 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 /**
  * AbstractDynamicBlock class.
  */
-abstract class AbstractDynamicBlock {
-
-	/**
-	 * Block namespace.
-	 *
-	 * @var string
-	 */
-	protected $namespace = 'woocommerce';
-
-	/**
-	 * Block namespace.
-	 *
-	 * @var string
-	 */
-	protected $block_name = '';
-
-	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'attributes'      => $this->get_attributes(),
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Include and render a dynamic block.
-	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
-	 */
-	abstract public function render( $attributes = array(), $content = '' );
-
+abstract class AbstractDynamicBlock extends AbstractBlock {
 	/**
 	 * Get block attributes.
 	 *
 	 * @return array
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array();
 	}
 

--- a/src/BlockTypes/AbstractDynamicBlock.php
+++ b/src/BlockTypes/AbstractDynamicBlock.php
@@ -6,6 +6,16 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  */
 abstract class AbstractDynamicBlock extends AbstractBlock {
 	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
 	 * Get block attributes.
 	 *
 	 * @return array

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -58,7 +58,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @param string $content    Block content. Default empty string.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
+	protected function render( $attributes = array(), $content = '' ) {
 		$this->attributes = $this->parse_attributes( $attributes );
 		$this->content    = $content;
 		$this->query_args = $this->parse_query_args();
@@ -308,7 +308,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @param int $id Product ID.
 	 * @return string Rendered product output.
 	 */
-	public function render_product( $id ) {
+	protected function render_product( $id ) {
 		$product = wc_get_product( $id );
 
 		if ( ! $product ) {

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -34,7 +34,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 *
 	 * @return array List of block attributes with type and defaults.
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array(
 			'className'         => $this->get_schema_string(),
 			'columns'           => $this->get_schema_number( wc_get_theme_support( 'product_blocks::default_columns', 3 ) ),

--- a/src/BlockTypes/ActiveFilters.php
+++ b/src/BlockTypes/ActiveFilters.php
@@ -1,43 +1,14 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Assets;
-
 /**
  * ActiveFilters class.
  */
 class ActiveFilters extends AbstractBlock {
-
 	/**
 	 * Block name.
 	 *
 	 * @var string
 	 */
 	protected $block_name = 'active-filters';
-
-	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Register/enqueue scripts used for this block.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( $this->block_name . '-frontend' );
-	}
 }

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -4,41 +4,11 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 /**
  * AllProducts class.
  */
-class AllProducts extends AbstractDynamicBlock {
+class AllProducts extends AbstractBlock {
 	/**
 	 * Block name.
 	 *
 	 * @var string
 	 */
 	protected $block_name = 'all-products';
-
-	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Append frontend scripts when rendering the Product Categories List block.
-	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
-	 * @return string Rendered block type output.
-	 */
-	public function render( $attributes = array(), $content = '' ) {
-		\Automattic\WooCommerce\Blocks\Assets::register_block_script( $this->block_name . '-frontend' );
-
-		return $content;
-	}
 }

--- a/src/BlockTypes/AllReviews.php
+++ b/src/BlockTypes/AllReviews.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Assets;
-
 /**
  * AllReviews class.
  */
@@ -15,28 +13,18 @@ class AllReviews extends AbstractBlock {
 	protected $block_name = 'all-reviews';
 
 	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Register/enqueue scripts used for this block.
+	 * Get the frontend script handle for this block type.
 	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string
 	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( 'reviews-frontend' );
+	protected function get_block_type_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-reviews-frontend',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'reviews-frontend' ),
+			'dependencies' => [],
+		];
+		return $key ? $script[ $key ] : $script;
 	}
 }

--- a/src/BlockTypes/AtomicBlock.php
+++ b/src/BlockTypes/AtomicBlock.php
@@ -10,26 +10,50 @@ class AtomicBlock extends AbstractBlock {
 	/**
 	 * Inject attributes and block name.
 	 *
-	 * @param array|\WP_Block $attributes Block attributes, or an instance of a WP_Block. Defaults to an empty array.
-	 * @param string          $content    Block content. Default empty string.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = [], $content = '' ) {
-		$block_attributes = is_a( $attributes, '\WP_Block' ) ? $attributes->attributes : $attributes;
-		return $this->inject_html_data_attributes( $content, $block_attributes );
+	protected function render( $attributes, $content ) {
+		return $this->inject_html_data_attributes( $content, $attributes );
 	}
 
 	/**
-	 * Registers the block type with WordPress.
+	 * Get the editor script data for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return null
 	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'supports'        => [],
-			)
-		);
+	protected function get_block_type_editor_script( $key = null ) {
+		return null;
+	}
+
+	/**
+	 * Get the editor style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_editor_style() {
+		return null;
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @return null
+	 */
+	protected function get_block_type_style() {
+		return null;
 	}
 
 	/**

--- a/src/BlockTypes/AttributeFilter.php
+++ b/src/BlockTypes/AttributeFilter.php
@@ -1,43 +1,14 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Assets;
-
 /**
  * AttributeFilter class.
  */
 class AttributeFilter extends AbstractBlock {
-
 	/**
 	 * Block name.
 	 *
 	 * @var string
 	 */
 	protected $block_name = 'attribute-filter';
-
-	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Register/enqueue scripts used for this block.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( $this->block_name . '-frontend' );
-	}
 }

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -19,44 +19,72 @@ class Cart extends AbstractBlock {
 	protected $block_name = 'cart';
 
 	/**
-	 * Registers the block type with WordPress.
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
 	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name . '-block',
-				'editor_style'    => 'wc-block-editor',
-				'style'           => [ 'wc-block-style', 'wc-block-vendors-style' ],
-				'script'          => 'wc-' . $this->block_name . '-block-frontend',
-				'supports'        => [],
-			)
-		);
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name ),
+			'dependencies' => [ 'wc-vendors', 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
 	}
 
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string
+	 */
+	protected function get_block_type_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block-frontend',
+			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name . '-frontend' ),
+			'dependencies' => [],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
+	 * Get the frontend style handle for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @return string|array
+	 */
+	protected function get_block_type_style() {
+		return [ 'wc-block-style', 'wc-block-vendors-style' ];
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_assets( array $attributes ) {
+		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
+		parent::enqueue_assets( $attributes );
+		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
+	}
 
 	/**
 	 * Append frontend scripts when rendering the Cart block.
 	 *
-	 * @param array|\WP_Block $attributes Block attributes, or an instance of a WP_Block. Defaults to an empty array.
-	 * @param string          $content    Block content. Default empty string.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		$block_attributes = is_a( $attributes, '\WP_Block' ) ? $attributes->attributes : $attributes;
-
-		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' );
-		$this->enqueue_assets( $block_attributes );
-		do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' );
-
+	protected function render( $attributes, $content ) {
 		// Deregister core cart scripts and styles.
 		wp_deregister_script( 'wc-cart' );
 		wp_deregister_script( 'wc-password-strength-meter' );
 		wp_deregister_script( 'selectWoo' );
 		wp_deregister_style( 'select2' );
 
-		return $this->inject_html_data_attributes( $content . $this->get_skeleton(), $block_attributes );
+		return $this->inject_html_data_attributes( $content . $this->get_skeleton(), $attributes );
 	}
 
 	/**
@@ -67,16 +95,14 @@ class Cart extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
-		$data_registry = Package::container()->get(
-			AssetDataRegistry::class
-		);
+		parent::enqueue_data( $attributes );
 
-		if ( ! $data_registry->exists( 'shippingCountries' ) ) {
-			$data_registry->add( 'shippingCountries', $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() ) );
+		if ( ! $this->asset_data_registry->exists( 'shippingCountries' ) ) {
+			$this->asset_data_registry->add( 'shippingCountries', $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() ) );
 		}
 
-		if ( ! $data_registry->exists( 'shippingStates' ) ) {
-			$data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
+		if ( ! $this->asset_data_registry->exists( 'shippingStates' ) ) {
+			$this->asset_data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
 		}
 
 		if ( ! $data_registry->exists( 'countryLocale' ) ) {
@@ -95,13 +121,13 @@ class Cart extends AbstractBlock {
 
 		$permalink = ! empty( $attributes['checkoutPageId'] ) ? get_permalink( $attributes['checkoutPageId'] ) : false;
 
-		if ( $permalink && ! $data_registry->exists( 'page-' . $attributes['checkoutPageId'] ) ) {
-			$data_registry->add( 'page-' . $attributes['checkoutPageId'], $permalink );
+		if ( $permalink && ! $this->asset_data_registry->exists( 'page-' . $attributes['checkoutPageId'] ) ) {
+			$this->asset_data_registry->add( 'page-' . $attributes['checkoutPageId'], $permalink );
 		}
 
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$this->hydrate_from_api( $data_registry );
+			$this->hydrate_from_api();
 		}
 
 		do_action( 'woocommerce_blocks_cart_enqueue_data' );
@@ -128,24 +154,11 @@ class Cart extends AbstractBlock {
 	}
 
 	/**
-	 * Register/enqueue scripts used for this block.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 *                           Note, this will be empty in the editor context when the block is
-	 *                           not in the post content on editor load.
-	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
-	}
-
-	/**
 	 * Hydrate the cart block with data from the API.
-	 *
-	 * @param AssetDataRegistry $data_registry Data registry instance.
 	 */
-	protected function hydrate_from_api( AssetDataRegistry $data_registry ) {
-		if ( ! $data_registry->exists( 'cartData' ) ) {
-			$data_registry->add( 'cartData', WC()->api->get_endpoint_data( '/wc/store/cart' ) );
+	protected function hydrate_from_api() {
+		if ( ! $this->asset_data_registry->exists( 'cartData' ) ) {
+			$this->asset_data_registry->add( 'cartData', WC()->api->get_endpoint_data( '/wc/store/cart' ) );
 		}
 	}
 

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -105,7 +105,7 @@ class Cart extends AbstractBlock {
 			$this->asset_data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
 		}
 
-		if ( ! $data_registry->exists( 'countryLocale' ) ) {
+		if ( ! $this->asset_data_registry->exists( 'countryLocale' ) ) {
 			// Merge country and state data to work around https://github.com/woocommerce/woocommerce/issues/28944.
 			$country_locale = wc()->countries->get_country_locale();
 			$states         = wc()->countries->get_states();
@@ -116,7 +116,7 @@ class Cart extends AbstractBlock {
 					$country_locale[ $country ]['state']['hidden']   = true;
 				}
 			}
-			$data_registry->add( 'countryLocale', $country_locale );
+			$this->asset_data_registry->add( 'countryLocale', $country_locale );
 		}
 
 		$permalink = ! empty( $attributes['checkoutPageId'] ) ? get_permalink( $attributes['checkoutPageId'] ) : false;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -114,7 +114,7 @@ class Checkout extends AbstractBlock {
 			$this->asset_data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
 		}
 
-		if ( ! $data_registry->exists( 'countryLocale' ) ) {
+		if ( ! $this->asset_data_registry->exists( 'countryLocale' ) ) {
 			// Merge country and state data to work around https://github.com/woocommerce/woocommerce/issues/28944.
 			$country_locale = wc()->countries->get_country_locale();
 			$states         = wc()->countries->get_states();
@@ -125,7 +125,7 @@ class Checkout extends AbstractBlock {
 					$country_locale[ $country ]['state']['hidden']   = true;
 				}
 			}
-			$data_registry->add( 'countryLocale', $country_locale );
+			$this->asset_data_registry->add( 'countryLocale', $country_locale );
 		}
 
 		$permalink = ! empty( $attributes['cartPageId'] ) ? get_permalink( $attributes['cartPageId'] ) : false;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -1,10 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Blocks\Assets;
-use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
-
 /**
  * Checkout class.
  *
@@ -20,9 +16,22 @@ class Checkout extends AbstractBlock {
 	protected $block_name = 'checkout';
 
 	/**
-	 * Registers the block type with WordPress.
+	 * Registers the block type with WordPress. This is ran during init.
+	 *
+	 * @see Automattic\WooCommerce\Blocks\Library::register_blocks
 	 */
 	public function register_block_type() {
+		// Register the block script.
+		$this->asset_api->register_script(
+			'wc-' . $this->block_name . '-block',
+			$this->asset_api->get_block_asset_build_path( $this->block_name ),
+			array_merge(
+				[ 'wc-vendors', 'wc-blocks', 'wc-blocks-checkout', 'wc-price-format' ],
+				$this->integration_registry->get_all_registered_script_handles()
+			)
+		);
+
+		// Register the block type with WordPress.
 		register_block_type(
 			$this->namespace . '/' . $this->block_name,
 			array(
@@ -81,24 +90,22 @@ class Checkout extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
-		$data_registry = Package::container()->get(
-			AssetDataRegistry::class
-		);
+		parent::enqueue_data( $attributes );
 
-		if ( ! $data_registry->exists( 'allowedCountries' ) ) {
-			$data_registry->add( 'allowedCountries', $this->deep_sort_with_accents( WC()->countries->get_allowed_countries() ) );
+		if ( ! $this->asset_data_registry->exists( 'allowedCountries' ) ) {
+			$this->asset_data_registry->add( 'allowedCountries', $this->deep_sort_with_accents( WC()->countries->get_allowed_countries() ) );
 		}
 
-		if ( ! $data_registry->exists( 'allowedStates' ) ) {
-			$data_registry->add( 'allowedStates', $this->deep_sort_with_accents( WC()->countries->get_allowed_country_states() ) );
+		if ( ! $this->asset_data_registry->exists( 'allowedStates' ) ) {
+			$this->asset_data_registry->add( 'allowedStates', $this->deep_sort_with_accents( WC()->countries->get_allowed_country_states() ) );
 		}
 
-		if ( ! $data_registry->exists( 'shippingCountries' ) ) {
-			$data_registry->add( 'shippingCountries', $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() ) );
+		if ( ! $this->asset_data_registry->exists( 'shippingCountries' ) ) {
+			$this->asset_data_registry->add( 'shippingCountries', $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() ) );
 		}
 
-		if ( ! $data_registry->exists( 'shippingStates' ) ) {
-			$data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
+		if ( ! $this->asset_data_registry->exists( 'shippingStates' ) ) {
+			$this->asset_data_registry->add( 'shippingStates', $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() ) );
 		}
 
 		if ( ! $data_registry->exists( 'countryLocale' ) ) {
@@ -117,23 +124,23 @@ class Checkout extends AbstractBlock {
 
 		$permalink = ! empty( $attributes['cartPageId'] ) ? get_permalink( $attributes['cartPageId'] ) : false;
 
-		if ( $permalink && ! $data_registry->exists( 'page-' . $attributes['cartPageId'] ) ) {
-			$data_registry->add( 'page-' . $attributes['cartPageId'], $permalink );
+		if ( $permalink && ! $this->asset_data_registry->exists( 'page-' . $attributes['cartPageId'] ) ) {
+			$this->asset_data_registry->add( 'page-' . $attributes['cartPageId'], $permalink );
 		}
 
 		// Hydrate the following data depending on admin or frontend context.
-		if ( is_admin() ) {
-			$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : false;
+		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
 
-			if ( $screen && $screen->is_block_editor() && ! $data_registry->exists( 'shippingMethodsExist' ) ) {
+			if ( $screen && $screen->is_block_editor() && ! $this->asset_data_registry->exists( 'shippingMethodsExist' ) ) {
 				$methods_exist = wc_get_shipping_method_count( false, true ) > 0;
-				$data_registry->add( 'shippingMethodsExist', $methods_exist );
+				$this->asset_data_registry->add( 'shippingMethodsExist', $methods_exist );
 			}
 		}
 
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$this->hydrate_from_api( $data_registry );
-			$this->hydrate_customer_payment_methods( $data_registry );
+			$this->hydrate_from_api();
+			$this->hydrate_customer_payment_methods();
 		}
 
 		do_action( 'woocommerce_blocks_checkout_enqueue_data' );
@@ -167,20 +174,18 @@ class Checkout extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend' );
+		$this->asset_api->register_block_script( $this->block_name . '-frontend', $this->block_name . '-block-frontend', [] );
 	}
 
 	/**
 	 * Get customer payment methods for use in checkout.
-	 *
-	 * @param AssetDataRegistry $data_registry Data registry instance.
 	 */
-	protected function hydrate_customer_payment_methods( AssetDataRegistry $data_registry ) {
-		if ( ! is_user_logged_in() || $data_registry->exists( 'customerPaymentMethods' ) ) {
+	protected function hydrate_customer_payment_methods() {
+		if ( ! is_user_logged_in() || $this->asset_data_registry->exists( 'customerPaymentMethods' ) ) {
 			return;
 		}
 		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'include_token_id_with_payment_methods' ], 10, 2 );
-		$data_registry->add(
+		$this->asset_data_registry->add(
 			'customerPaymentMethods',
 			wc_get_customer_saved_methods_list( get_current_user_id() )
 		);
@@ -189,20 +194,18 @@ class Checkout extends AbstractBlock {
 
 	/**
 	 * Hydrate the checkout block with data from the API.
-	 *
-	 * @param AssetDataRegistry $data_registry Data registry instance.
 	 */
-	protected function hydrate_from_api( AssetDataRegistry $data_registry ) {
+	protected function hydrate_from_api() {
 		// Print existing notices now, otherwise they are caught by the Cart
 		// Controller and converted to exceptions.
 		wc_print_notices();
 
-		if ( ! $data_registry->exists( 'cartData' ) ) {
-			$data_registry->add( 'cartData', WC()->api->get_endpoint_data( '/wc/store/cart' ) );
+		if ( ! $this->asset_data_registry->exists( 'cartData' ) ) {
+			$this->asset_data_registry->add( 'cartData', WC()->api->get_endpoint_data( '/wc/store/cart' ) );
 		}
-		if ( ! $data_registry->exists( 'checkoutData' ) ) {
+		if ( ! $this->asset_data_registry->exists( 'checkoutData' ) ) {
 			add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
-			$data_registry->add( 'checkoutData', WC()->api->get_endpoint_data( '/wc/store/checkout' ) );
+			$this->asset_data_registry->add( 'checkoutData', WC()->api->get_endpoint_data( '/wc/store/checkout' ) );
 			remove_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
 		}
 	}

--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -31,20 +31,21 @@ class FeaturedCategory extends AbstractDynamicBlock {
 	/**
 	 * Render the Featured Category block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		$id       = isset( $attributes['categoryId'] ) ? (int) $attributes['categoryId'] : 0;
+	protected function render( $attributes, $content ) {
+		$id       = absint( isset( $attributes['categoryId'] ) ? $attributes['categoryId'] : 0 );
 		$category = get_term( $id, 'product_cat' );
+
 		if ( ! $category || is_wp_error( $category ) ) {
 			return '';
 		}
+
 		$attributes = wp_parse_args( $attributes, $this->defaults );
-		if ( ! $attributes['height'] ) {
-			$attributes['height'] = wc_get_theme_support( 'featured_block::default_height', 500 );
-		}
+
+		$attributes['height'] = $attributes['height'] ? $attributes['height'] : wc_get_theme_support( 'featured_block::default_height', 500 );
 
 		$title = sprintf(
 			'<h2 class="wc-block-featured-category__title">%s</h2>',

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -32,20 +32,19 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	/**
 	 * Render the Featured Product block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		$id      = isset( $attributes['productId'] ) ? (int) $attributes['productId'] : 0;
+	protected function render( $attributes, $content ) {
+		$id      = absint( isset( $attributes['productId'] ) ? $attributes['productId'] : 0 );
 		$product = wc_get_product( $id );
 		if ( ! $product ) {
 			return '';
 		}
 		$attributes = wp_parse_args( $attributes, $this->defaults );
-		if ( ! $attributes['height'] ) {
-			$attributes['height'] = wc_get_theme_support( 'featured_block::default_height', 500 );
-		}
+
+		$attributes['height'] = $attributes['height'] ? $attributes['height'] : wc_get_theme_support( 'featured_block::default_height', 500 );
 
 		$title = sprintf(
 			'<h2 class="wc-block-featured-product__title">%s</h2>',

--- a/src/BlockTypes/HandpickedProducts.php
+++ b/src/BlockTypes/HandpickedProducts.php
@@ -46,7 +46,7 @@ class HandpickedProducts extends AbstractProductGrid {
 	 *
 	 * @return array
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array(
 			'align'             => $this->get_schema_align(),
 			'alignButtons'      => $this->get_schema_boolean( false ),

--- a/src/BlockTypes/PriceFilter.php
+++ b/src/BlockTypes/PriceFilter.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Assets;
-
 /**
  * PriceFilter class.
  */
@@ -14,30 +12,4 @@ class PriceFilter extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'price-filter';
-
-	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Register/enqueue scripts used for this block.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( $this->block_name . '-frontend' );
-	}
 }

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -49,11 +49,11 @@ class ProductCategories extends AbstractDynamicBlock {
 	/**
 	 * Render the Product Categories List block.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
+	protected function render( $attributes, $content ) {
 		$uid        = uniqid( 'product-categories-' );
 		$categories = $this->get_categories( $attributes );
 

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -31,9 +31,9 @@ class ProductCategories extends AbstractDynamicBlock {
 	 *
 	 * @return array
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array_merge(
-			parent::get_attributes(),
+			parent::get_block_type_attributes(),
 			array(
 				'align'          => $this->get_schema_align(),
 				'className'      => $this->get_schema_string(),

--- a/src/BlockTypes/ProductCategory.php
+++ b/src/BlockTypes/ProductCategory.php
@@ -24,9 +24,9 @@ class ProductCategory extends AbstractProductGrid {
 	 *
 	 * @return array
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array_merge(
-			parent::get_attributes(),
+			parent::get_block_type_attributes(),
 			array(
 				'className' => $this->get_schema_string(),
 				'orderby'   => $this->get_schema_orderby(),

--- a/src/BlockTypes/ProductOnSale.php
+++ b/src/BlockTypes/ProductOnSale.php
@@ -26,9 +26,9 @@ class ProductOnSale extends AbstractProductGrid {
 	 *
 	 * @return array
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array_merge(
-			parent::get_attributes(),
+			parent::get_block_type_attributes(),
 			array(
 				'className' => $this->get_schema_string(),
 				'orderby'   => $this->get_schema_orderby(),

--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -12,4 +12,14 @@ class ProductSearch extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'product-search';
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return null
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
 }

--- a/src/BlockTypes/ProductTag.php
+++ b/src/BlockTypes/ProductTag.php
@@ -33,7 +33,7 @@ class ProductTag extends AbstractProductGrid {
 	 *
 	 * @return array
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array(
 			'className'         => $this->get_schema_string(),
 			'columns'           => $this->get_schema_number( wc_get_theme_support( 'product_blocks::default_columns', 3 ) ),

--- a/src/BlockTypes/ProductsByAttribute.php
+++ b/src/BlockTypes/ProductsByAttribute.php
@@ -37,7 +37,7 @@ class ProductsByAttribute extends AbstractProductGrid {
 	 *
 	 * @return array
 	 */
-	protected function get_attributes() {
+	protected function get_block_type_attributes() {
 		return array(
 			'align'             => $this->get_schema_align(),
 			'alignButtons'      => $this->get_schema_boolean( false ),

--- a/src/BlockTypes/ReviewsByCategory.php
+++ b/src/BlockTypes/ReviewsByCategory.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Assets;
-
 /**
  * ReviewsByCategory class.
  */
@@ -15,28 +13,18 @@ class ReviewsByCategory extends AbstractBlock {
 	protected $block_name = 'reviews-by-category';
 
 	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Register/enqueue scripts used for this block.
+	 * Get the frontend script handle for this block type.
 	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string
 	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( 'reviews-frontend' );
+	protected function get_block_type_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-reviews-frontend',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'reviews-frontend' ),
+			'dependencies' => [],
+		];
+		return $key ? $script[ $key ] : $script;
 	}
 }

--- a/src/BlockTypes/ReviewsByProduct.php
+++ b/src/BlockTypes/ReviewsByProduct.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Assets;
-
 /**
  * ReviewsByProduct class.
  */
@@ -15,28 +13,18 @@ class ReviewsByProduct extends AbstractBlock {
 	protected $block_name = 'reviews-by-product';
 
 	/**
-	 * Registers the block type with WordPress.
-	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name,
-				'editor_style'    => 'wc-block-editor',
-				'style'           => 'wc-block-style',
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
-	}
-
-	/**
-	 * Register/enqueue scripts used for this block.
+	 * Get the frontend script handle for this block type.
 	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
+	 * @see $this->register_block_type()
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string
 	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( 'reviews-frontend' );
+	protected function get_block_type_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-reviews-frontend',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'reviews-frontend' ),
+			'dependencies' => [],
+		];
+		return $key ? $script[ $key ] : $script;
 	}
 }

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Assets;
-
 /**
  * SingleProduct class.
  */
@@ -15,45 +13,38 @@ class SingleProduct extends AbstractBlock {
 	protected $block_name = 'single-product';
 
 	/**
-	 * Registers the block type with WordPress.
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
 	 */
-	public function register_block_type() {
-		register_block_type(
-			$this->namespace . '/' . $this->block_name,
-			array(
-				'render_callback' => array( $this, 'render' ),
-				'editor_script'   => 'wc-' . $this->block_name . '-block',
-				'editor_style'    => 'wc-block-editor',
-				'style'           => [ 'wc-block-style', 'wc-block-vendors-style' ],
-				'script'          => 'wc-' . $this->block_name . '-frontend',
-				'supports'        => [],
-			)
-		);
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name ),
+			'dependencies' => [ 'wc-vendors', 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
 	}
 
 	/**
-	 * Register/enqueue scripts used for this block.
+	 * Get the frontend style handle for this block type.
 	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 *                           Note, this will be empty in the editor context when the block is
-	 *                           not in the post content on editor load.
+	 * @see $this->register_block_type()
+	 * @return string|array
 	 */
-	protected function enqueue_scripts( array $attributes = [] ) {
-		Assets::register_block_script( $this->block_name . '-frontend', $this->block_name . '-frontend' );
+	protected function get_block_type_style() {
+		return [ 'wc-block-style', 'wc-block-vendors-style' ];
 	}
 
 	/**
 	 * Render the block on the frontend.
 	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $content    Block content. Default empty string.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
 	 * @return string Rendered block type output.
 	 */
-	public function render( $attributes = array(), $content = '' ) {
-		$block_attributes = is_a( $attributes, '\WP_Block' ) ? $attributes->attributes : $attributes;
-
-		$this->enqueue_assets( $block_attributes );
-
-		return $this->inject_html_data_attributes( $content, $block_attributes );
+	protected function render( $attributes, $content ) {
+		return $this->inject_html_data_attributes( $content, $attributes );
 	}
 }

--- a/src/Integrations/IntegrationInterface.php
+++ b/src/Integrations/IntegrationInterface.php
@@ -15,7 +15,7 @@ interface IntegrationInterface {
 	public function get_name();
 
 	/**
-	 * When called invokes any initialization/setup for the payment method type instance.
+	 * When called invokes any initialization/setup for the integration.
 	 */
 	public function initialize();
 
@@ -27,11 +27,11 @@ interface IntegrationInterface {
 	public function get_script_handles();
 
 	/**
-	 * Returns an array of script handles to enqueue in the admin context.
+	 * Returns an array of script handles to enqueue in the editor context.
 	 *
 	 * @return string[]
 	 */
-	public function get_admin_script_handles();
+	public function get_editor_script_handles();
 
 	/**
 	 * An array of key, value pairs of data made available to the block on the client side.

--- a/src/Integrations/IntegrationInterface.php
+++ b/src/Integrations/IntegrationInterface.php
@@ -1,0 +1,42 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Integrations;
+
+/**
+ * Integration.Interface
+ *
+ * Integrations must use this interface when registering themselves with blocks,
+ */
+interface IntegrationInterface {
+	/**
+	 * The name of the integration.
+	 *
+	 * @return string
+	 */
+	public function get_name();
+
+	/**
+	 * When called invokes any initialization/setup for the payment method type instance.
+	 */
+	public function initialize();
+
+	/**
+	 * Returns an array of script handles to enqueue in the frontend context.
+	 *
+	 * @return string[]
+	 */
+	public function get_script_handles();
+
+	/**
+	 * Returns an array of script handles to enqueue in the admin context.
+	 *
+	 * @return string[]
+	 */
+	public function get_admin_script_handles();
+
+	/**
+	 * An array of key, value pairs of data made available to the block on the client side.
+	 *
+	 * @return array
+	 */
+	public function get_script_data();
+}

--- a/src/Integrations/IntegrationRegistry.php
+++ b/src/Integrations/IntegrationRegistry.php
@@ -128,6 +128,25 @@ class IntegrationRegistry {
 	 *
 	 * @return string[]
 	 */
+	public function get_all_registered_editor_script_handles() {
+		$script_handles          = [];
+		$registered_integrations = $this->get_all_registered();
+
+		foreach ( $registered_integrations as $registered_integration ) {
+			$script_handles = array_merge(
+				$script_handles,
+				$registered_integration->get_editor_script_handles()
+			);
+		}
+
+		return array_unique( array_filter( $script_handles ) );
+	}
+
+	/**
+	 * Gets an array of all registered integration's script handles.
+	 *
+	 * @return string[]
+	 */
 	public function get_all_registered_script_handles() {
 		$script_handles          = [];
 		$registered_integrations = $this->get_all_registered();
@@ -135,7 +154,7 @@ class IntegrationRegistry {
 		foreach ( $registered_integrations as $registered_integration ) {
 			$script_handles = array_merge(
 				$script_handles,
-				is_admin() ? $registered_integration->get_admin_script_handles() : $registered_integration->get_script_handles()
+				$registered_integration->get_script_handles()
 			);
 		}
 

--- a/src/Integrations/IntegrationRegistry.php
+++ b/src/Integrations/IntegrationRegistry.php
@@ -20,20 +20,17 @@ class IntegrationRegistry {
 	protected $registered_integrations = [];
 
 	/**
-	 * Integration Registry Constructor.
+	 * Initializes all registered integrations.
+	 *
+	 * Integration identifier is used to construct hook names and is given when the integration registry is initialized.
 	 *
 	 * @param string $registry_identifier Identifier for this registry.
 	 */
-	public function __construct( $registry_identifier = '' ) {
+	public function initialize( $registry_identifier = '' ) {
 		if ( $registry_identifier ) {
 			$this->registry_identifier = $registry_identifier;
 		}
-	}
 
-	/**
-	 * Initializes all registered integrations.
-	 */
-	public function initialize() {
 		if ( empty( $this->registry_identifier ) ) {
 			_doing_it_wrong( __METHOD__, esc_html( __( 'Integration registry requires an identifier.', 'woo-gutenberg-products-block' ) ) );
 			return false;

--- a/src/Integrations/IntegrationRegistry.php
+++ b/src/Integrations/IntegrationRegistry.php
@@ -1,0 +1,163 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Integrations;
+
+/**
+ * Class used for tracking registered integrations with various Block types.
+ */
+class IntegrationRegistry {
+	/**
+	 * Integration identifier is used to construct hook names and is given when the integration registry is initialized.
+	 *
+	 * @var string
+	 */
+	protected $registry_identifier = '';
+
+	/**
+	 * Registered integrations, as `$name => $instance` pairs.
+	 *
+	 * @var IntegrationInterface[]
+	 */
+	protected $registered_integrations = [];
+
+	/**
+	 * Integration Registry Constructor.
+	 *
+	 * @param string $registry_identifier Identifier for this registry.
+	 */
+	public function __construct( $registry_identifier = '' ) {
+		if ( $registry_identifier ) {
+			$this->registry_identifier = $registry_identifier;
+		}
+	}
+
+	/**
+	 * Initializes all registered integrations.
+	 */
+	public function initialize() {
+		if ( empty( $this->registry_identifier ) ) {
+			_doing_it_wrong( __METHOD__, esc_html( __( 'Integration registry requires an identifier.', 'woo-gutenberg-products-block' ) ) );
+			return false;
+		}
+
+		/**
+		 * Hook: integration_registration.
+		 *
+		 * Runs before integrations are initialized allowing new integration to be registered for use. This should be
+		 * used as the primary hook for integrations to include their scripts, styles, and other code extending the
+		 * blocks.
+		 *
+		 * @param IntegrationRegistry $this Instance of the IntegrationRegistry class which exposes the IntegrationRegistry::register() method.
+		 */
+		do_action( 'woocommerce_blocks_' . $this->registry_identifier . '_registration', $this );
+
+		foreach ( $this->get_all_registered() as $registered_integration ) {
+			$registered_integration->initialize();
+		}
+	}
+
+	/**
+	 * Registers an integration.
+	 *
+	 * @param IntegrationInterface $integration An instance of IntegrationInterface.
+	 *
+	 * @return boolean True means registered successfully.
+	 */
+	public function register( IntegrationInterface $integration ) {
+		$name = $integration->get_name();
+
+		if ( $this->is_registered( $name ) ) {
+			/* translators: %s: Class name. */
+			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( '"%s" is already registered.', 'woo-gutenberg-products-block' ), $name ) ) );
+			return false;
+		}
+
+		$this->registered_integrations[ $name ] = $integration;
+		return true;
+	}
+
+	/**
+	 * Checks if an integration is already registered.
+	 *
+	 * @param string $name Integration name.
+	 * @return bool True if the integration is registered, false otherwise.
+	 */
+	public function is_registered( $name ) {
+		return isset( $this->registered_integrations[ $name ] );
+	}
+
+	/**
+	 * Un-register an integration.
+	 *
+	 * @param string|IntegrationInterface $name Integration name, or alternatively a IntegrationInterface instance.
+	 * @return boolean|IntegrationInterface Returns the unregistered integration instance if unregistered successfully.
+	 */
+	public function unregister( $name ) {
+		if ( $name instanceof IntegrationInterface ) {
+			$name = $name->get_name();
+		}
+
+		if ( ! $this->is_registered( $name ) ) {
+			/* translators: %s: Integration name. */
+			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Integration "%s" is not registered.', 'woo-gutenberg-products-block' ), $name ) ) );
+			return false;
+		}
+
+		$unregistered = $this->registered_integrations[ $name ];
+		unset( $this->registered_integrations[ $name ] );
+		return $unregistered;
+	}
+
+	/**
+	 * Retrieves a registered Integration by name.
+	 *
+	 * @param string $name Integration name.
+	 * @return IntegrationInterface|null The registered integration, or null if it is not registered.
+	 */
+	public function get_registered( $name ) {
+		return $this->is_registered( $name ) ? $this->registered_integrations[ $name ] : null;
+	}
+
+	/**
+	 * Retrieves all registered integrations.
+	 *
+	 * @return IntegrationInterface[]
+	 */
+	public function get_all_registered() {
+		return $this->registered_integrations;
+	}
+
+	/**
+	 * Gets an array of all registered integration's script handles.
+	 *
+	 * @return string[]
+	 */
+	public function get_all_registered_script_handles() {
+		$script_handles          = [];
+		$registered_integrations = $this->get_all_registered();
+
+		foreach ( $registered_integrations as $registered_integration ) {
+			$script_handles = array_merge(
+				$script_handles,
+				is_admin() ? $registered_integration->get_admin_script_handles() : $registered_integration->get_script_handles()
+			);
+		}
+
+		return array_unique( array_filter( $script_handles ) );
+	}
+
+	/**
+	 * Gets an array of all registered integration's script data.
+	 *
+	 * @return array
+	 */
+	public function get_all_registered_script_data() {
+		$script_data             = [];
+		$registered_integrations = $this->get_all_registered();
+
+		foreach ( $registered_integrations as $registered_integration ) {
+			$script_data[ $registered_integration->get_name() . '_data' ] = $registered_integration->get_script_data();
+		}
+
+		return array_filter( $script_data );
+	}
+}

--- a/src/Integrations/IntegrationRegistry.php
+++ b/src/Integrations/IntegrationRegistry.php
@@ -63,7 +63,7 @@ class IntegrationRegistry {
 		$name = $integration->get_name();
 
 		if ( $this->is_registered( $name ) ) {
-			/* translators: %s: Class name. */
+			/* translators: %s: Integration name. */
 			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( '"%s" is already registered.', 'woo-gutenberg-products-block' ), $name ) ) );
 			return false;
 		}

--- a/src/Integrations/IntegrationRegistry.php
+++ b/src/Integrations/IntegrationRegistry.php
@@ -124,7 +124,7 @@ class IntegrationRegistry {
 	}
 
 	/**
-	 * Gets an array of all registered integration's script handles.
+	 * Gets an array of all registered integration's script handles for the editor.
 	 *
 	 * @return string[]
 	 */

--- a/src/Library.php
+++ b/src/Library.php
@@ -1,7 +1,11 @@
 <?php
 namespace Automattic\WooCommerce\Blocks;
 
+use Automattic\WooCommerce\Blocks\BlockTypes\AtomicBlock;
 use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 
 /**
  * Library class.
@@ -63,38 +67,52 @@ class Library {
 			'AttributeFilter',
 			'ActiveFilters',
 		];
+
 		if ( Package::feature()->is_feature_plugin_build() ) {
 			$blocks[] = 'Checkout';
 			$blocks[] = 'Cart';
 		}
+
 		if ( Package::feature()->is_experimental_build() ) {
 			$blocks[] = 'SingleProduct';
 		}
+
 		/**
 		 * This disables specific blocks in Widget Areas by not registering them.
 		 */
 		if ( 'themes.php' === $pagenow ) {
-			$blocks_to_unset = [
-				'AllProducts',
-				'PriceFilter',
-				'AttributeFilter',
-				'ActiveFilters',
-			];
-			$blocks          = array_diff( $blocks, $blocks_to_unset );
+			$blocks = array_diff(
+				$blocks,
+				[
+					'AllProducts',
+					'PriceFilter',
+					'AttributeFilter',
+					'ActiveFilters',
+				]
+			);
 		}
-		foreach ( $blocks as $class ) {
-			$class    = __NAMESPACE__ . '\\BlockTypes\\' . $class;
-			$instance = new $class();
-			$instance->register_block_type();
+
+		// Provide block types access to assets, data registry, and integration registry.
+		$asset_api     = Package::container()->get( AssetApi::class );
+		$data_registry = Package::container()->get( AssetDataRegistry::class );
+
+		foreach ( $blocks as $block_type ) {
+			$block_type_class    = __NAMESPACE__ . '\\BlockTypes\\' . $block_type;
+			$block_type_instance = new $block_type_class( $asset_api, $data_registry, new IntegrationRegistry() );
 		}
-		self::register_atomic_blocks();
+
+		foreach ( self::get_atomic_blocks() as $block_type ) {
+			$block_type_instance = new AtomicBlock( $asset_api, $data_registry, new IntegrationRegistry(), $block_type );
+		}
 	}
 
 	/**
-	 * Register atomic blocks on the PHP side.
+	 * Get atomic blocks types.
+	 *
+	 * @return array
 	 */
-	protected static function register_atomic_blocks() {
-		$atomic_blocks = [
+	protected static function get_atomic_blocks() {
+		return [
 			'product-title',
 			'product-button',
 			'product-image',
@@ -108,9 +126,5 @@ class Library {
 			'product-stock-indicator',
 			'product-add-to-cart',
 		];
-		foreach ( $atomic_blocks as $atomic_block ) {
-			$instance = new \Automattic\WooCommerce\Blocks\BlockTypes\AtomicBlock( $atomic_block );
-			$instance->register_block_type();
-		}
 	}
 }

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -65,7 +65,7 @@ class Api {
 		if ( ! in_array( $handle, [ 'wc-checkout-block', 'wc-checkout-block-frontend', 'wc-cart-block', 'wc-cart-block-frontend' ], true ) ) {
 			return $dependencies;
 		}
-		return array_merge( $dependencies, $this->payment_method_registry->get_all_registered_script_handles() );
+		return array_merge( $dependencies, $this->payment_method_registry->get_all_active_payment_method_script_dependencies() );
 	}
 
 	/**

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -107,7 +107,7 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	 *
 	 * @return string[]
 	 */
-	public function get_admin_script_handles() {
+	public function get_editor_script_handles() {
 		return $this->get_payment_method_script_handles_for_admin();
 	}
 

--- a/src/Payments/Integrations/AbstractPaymentMethodType.php
+++ b/src/Payments/Integrations/AbstractPaymentMethodType.php
@@ -88,4 +88,37 @@ abstract class AbstractPaymentMethodType implements PaymentMethodTypeInterface {
 	public function get_payment_method_data() {
 		return [];
 	}
+
+	/**
+	 * Returns an array of script handles to enqueue in the frontend context.
+	 *
+	 * Alias of get_payment_method_script_handles. Defined by IntegrationInterface.
+	 *
+	 * @return string[]
+	 */
+	public function get_script_handles() {
+		return $this->get_payment_method_script_handles();
+	}
+
+	/**
+	 * Returns an array of script handles to enqueue in the admin context.
+	 *
+	 * Alias of get_payment_method_script_handles_for_admin. Defined by IntegrationInterface.
+	 *
+	 * @return string[]
+	 */
+	public function get_admin_script_handles() {
+		return $this->get_payment_method_script_handles_for_admin();
+	}
+
+	/**
+	 * An array of key, value pairs of data made available to the block on the client side.
+	 *
+	 * Alias of get_payment_method_data. Defined by IntegrationInterface.
+	 *
+	 * @return array
+	 */
+	public function get_script_data() {
+		return $this->get_payment_method_data();
+	}
 }

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -1,114 +1,20 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Payments;
 
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
+
 /**
  * Class used for interacting with payment method types.
  *
  * @since 2.6.0
  */
-final class PaymentMethodRegistry {
-
+final class PaymentMethodRegistry extends IntegrationRegistry {
 	/**
-	 * Registered payment methods, as `$name => $instance` pairs.
+	 * Integration identifier is used to construct hook names and is given when the integration registry is initialized.
 	 *
-	 * @var PaymentMethodTypeInterface[]
+	 * @var string
 	 */
-	private $registered_payment_methods = [];
-
-	/**
-	 * Registers a payment method.
-	 *
-	 * @param PaymentMethodTypeInterface $payment_method_type An instance of PaymentMethodTypeInterface.
-	 *
-	 * @return boolean True means registered successfully.
-	 */
-	public function register( PaymentMethodTypeInterface $payment_method_type ) {
-		$name = $payment_method_type->get_name();
-		if ( $this->is_registered( $name ) ) {
-			/* translators: %s: Payment method name. */
-			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Payment method "%s" is already registered.', 'woo-gutenberg-products-block' ), $name ) ), '2.5.0' );
-			return false;
-		}
-		$this->registered_payment_methods[ $name ] = $payment_method_type;
-		return true;
-	}
-
-	/**
-	 * Initializes all payment method types.
-	 */
-	public function initialize() {
-		/**
-		 * Hook: payment_method_type_registration.
-		 *
-		 * Runs before payment methods are initialized allowing new methods to be registered for use.
-		 *
-		 * @param PaymentMethodRegistry $this Instance of the PaymentMethodRegistry class which exposes the
-		 *                                    PaymentMethodRegistry::register() method.
-		 */
-		do_action( 'woocommerce_blocks_payment_method_type_registration', $this );
-
-		$registered_payment_method_types = $this->get_all_registered();
-
-		foreach ( $registered_payment_method_types as $registered_type ) {
-			$registered_type->initialize();
-		}
-	}
-
-	/**
-	 * Un-register a payment method.
-	 *
-	 * @param string|PaymentMethodTypeInterface $name Payment method name, or alternatively a PaymentMethodTypeInterface instance.
-	 * @return boolean True means unregistered successfully.
-	 */
-	public function unregister( $name ) {
-		if ( $name instanceof PaymentMethodTypeInterface ) {
-			$name = $name->get_name();
-		}
-
-		if ( ! $this->is_registered( $name ) ) {
-			/* translators: %s: Payment method name. */
-			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Payment method "%s" is not registered.', 'woo-gutenberg-products-block' ), $name ) ), '2.5.0' );
-			return false;
-		}
-
-		$unregistered_payment_method = $this->registered_payment_methods[ $name ];
-		unset( $this->registered_payment_methods[ $name ] );
-
-		return $unregistered_payment_method;
-	}
-
-	/**
-	 * Retrieves a registered payment method.
-	 *
-	 * @param string $name Payment method name.
-	 * @return PaymentMethodTypeInterface|null The registered payment method, or null if it is not registered.
-	 */
-	public function get_registered( $name ) {
-		if ( ! $this->is_registered( $name ) ) {
-			return null;
-		}
-
-		return $this->registered_payment_methods[ $name ];
-	}
-
-	/**
-	 * Retrieves all registered payment methods.
-	 *
-	 * @return PaymentMethodTypeInterface[]
-	 */
-	public function get_all_registered() {
-		return $this->registered_payment_methods;
-	}
-
-	/**
-	 * Checks if a payment method is registered.
-	 *
-	 * @param string $name Payment method name.
-	 * @return bool True if the payment method is registered, false otherwise.
-	 */
-	public function is_registered( $name ) {
-		return isset( $this->registered_payment_methods[ $name ] );
-	}
+	protected $registry_identifier = 'payment_method_type';
 
 	/**
 	 * Retrieves all registered payment methods that are also active.
@@ -125,7 +31,7 @@ final class PaymentMethodRegistry {
 	}
 
 	/**
-	 * Gets an array of all registered payment method script handles.
+	 * Gets an array of all registered payment method script handles, but only for active payment methods.
 	 *
 	 * @return string[]
 	 */
@@ -144,7 +50,7 @@ final class PaymentMethodRegistry {
 	}
 
 	/**
-	 * Gets an array of all registered payment method script data.
+	 * Gets an array of all registered payment method script data, but only for active payment methods.
 	 *
 	 * @return array
 	 */

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -35,7 +35,7 @@ final class PaymentMethodRegistry extends IntegrationRegistry {
 	 *
 	 * @return string[]
 	 */
-	public function get_all_registered_script_handles() {
+	public function get_all_active_payment_method_script_dependencies() {
 		$script_handles  = [];
 		$payment_methods = $this->get_all_active_registered();
 

--- a/src/Payments/PaymentMethodTypeInterface.php
+++ b/src/Payments/PaymentMethodTypeInterface.php
@@ -1,26 +1,15 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Payments;
 
-interface PaymentMethodTypeInterface {
-	/**
-	 * The name of the payment method
-	 *
-	 * @return string
-	 */
-	public function get_name();
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationInterface;
 
+interface PaymentMethodTypeInterface extends IntegrationInterface {
 	/**
 	 * Returns if this payment method should be active. If false, the scripts will not be enqueued.
 	 *
 	 * @return boolean
 	 */
 	public function is_active();
-
-	/**
-	 * When called invokes any initialization/setup for the payment method type
-	 * instance.
-	 */
-	public function initialize();
 
 	/**
 	 * Returns an array of script handles to enqueue for this payment method in


### PR DESCRIPTION
This is a fairly hefty PR which refactors our Block Type classes (and makes some changes to the Payments Integration classes).

## 1. Removes editor script registration from the Assets class to the block type classes

This keeps block type definitions together with the script registration, avoids the need to do additional checks for build type when registering assets (because blocks are not registered if they do not support the current build), and allows each block type to define it's own dependencies.

## 2. Abstracts `PaymentMethodRegistry` and `PaymentMethodTypeInterface` with `IntegrationRegistry` and `IntegrationInterface`

Since we needed something similar for other integrations (block types) I created `IntegrationRegistry` and `IntegrationInterface` and moved the code that can be reused to those.

`AbstractPaymentMethodType` takes care of the differences and this seems to be used by WC Pay etc so shouldn't break anything.

## 3. `AbstractBlock` refactor

This class will now:

- Register the editor script
- Register the frontend script
- Enqueue the frontend script when the block is rendered 
- Use the `IntegrationRegistry` based on the block name, and with this append registered dependencies and data whenever assets are registered or enqueued.

@senadir before this is merged I want to update subscriptions with it to ensure it covers all use cases. We will hook in via:

`woocommerce_blocks_{registry_identifier}_registration` is the hook where 3rd parties can register themselves. In the case of subscriptions it will be both:

- woocommerce_blocks_cart_block_registration
- woocommerce_blocks_checkout_block_registration

Fixes #3532

### How to test the changes in this Pull Request:

This touches on quite a lot of code so we need to ensure:

1. All tests pass, which should cover block rendering issues
2. Smoke test all blocks (frontend and editor) to ensure they render. This will confirm scripts are still loaded.
3. Payment methods should still show up during checkout. Test full checkout flow.
4. Check console for 404s to ensure no invalid scripts are loaded.
5. Check experimental block types like atomic blocks still function

<!-- If you can, add the appropriate labels -->

### Changelog

> Refactor block type registration to support 3rd party integrations.

### Dev note:

An important note that internally, this release has modified how `AbstractBlock` (the base class for all of our blocks) functions, and how it loads assets. `AbstractBlock` is internal to this project and does not seem like something that would ever need to be extended by 3rd parties, but note if you are doing so for whatever reason, your implementation would need to be updated to match.
