### PR TITLE
Checkout should only link through to pages that are published

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -225,7 +225,7 @@ class Assets {
 		if ( is_numeric( $page ) && $page > 0 ) {
 			$page = get_post( $page );
 		}
-		if ( ! is_a( $page, '\WP_Post' ) ) {
+		if ( ! is_a( $page, '\WP_Post' ) || 'publish' !== $page->post_status ) {
 			return [
 				'id'        => 0,
 				'title'     => '',


### PR DESCRIPTION
Pages thats Blocks plugin links to (such as shop, privacy policy, and terms) must be published pages, otherwise they are not valid. This PR adds a check to ensure a page is published before passing it's ID and details to blocks.

Fixes #2599

### How to test the changes in this Pull Request:

1. In WC > Settings > Advanced, set the terms page to a page that exists in the store.
2. Go to checkout. See the terms page link in the footer of the checkout.
3. Go to admin and trash the page.
4. Check the checkout again; the link should no longer be visible.

### Changelog

> Prevent checkout linking to trashed terms and policy pages.
