### PR TITLE
Login links should use the account page

### DIFF
--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -84,6 +84,7 @@ const defaultPage = {
 	permalink: '',
 };
 const storePages = getSetting( 'storePages', {
+	myaccount: defaultPage,
 	shop: defaultPage,
 	cart: defaultPage,
 	checkout: defaultPage,
@@ -109,4 +110,7 @@ export const CHECKOUT_ALLOWS_SIGNUP = getSetting(
 	'checkoutAllowsSignup',
 	false
 );
-export const LOGIN_URL = getSetting( 'loginUrl', '/wp-login.php' );
+
+export const LOGIN_URL = storePages.myaccount.permalink
+	? storePages.myaccount.permalink
+	: getSetting( 'loginUrl', '/wp-login.php' );

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -24,6 +24,7 @@ class Assets {
 		add_action( 'body_class', array( __CLASS__, 'add_theme_body_class' ), 1 );
 		add_action( 'admin_body_class', array( __CLASS__, 'add_theme_admin_body_class' ), 1 );
 		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'get_wc_block_data' ) );
+		add_action( 'woocommerce_login_form_end', array( __CLASS__, 'redirect_to_field' ) );
 	}
 
 	/**
@@ -141,11 +142,12 @@ class Assets {
 		$tag_count      = wp_count_terms( 'product_tag' );
 		$product_counts = wp_count_posts( 'product' );
 		$page_ids       = [
-			'shop'     => wc_get_page_id( 'shop' ),
-			'cart'     => wc_get_page_id( 'cart' ),
-			'checkout' => wc_get_page_id( 'checkout' ),
-			'privacy'  => wc_privacy_policy_page_id(),
-			'terms'    => wc_terms_and_conditions_page_id(),
+			'myaccount' => wc_get_page_id( 'myaccount' ),
+			'shop'      => wc_get_page_id( 'shop' ),
+			'cart'      => wc_get_page_id( 'cart' ),
+			'checkout'  => wc_get_page_id( 'checkout' ),
+			'privacy'   => wc_privacy_policy_page_id(),
+			'terms'     => wc_terms_and_conditions_page_id(),
 		];
 		$checkout       = WC()->checkout();
 
@@ -186,11 +188,12 @@ class Assets {
 				],
 				'homeUrl'                       => esc_url( home_url( '/' ) ),
 				'storePages'                    => [
-					'shop'     => self::format_page_resource( $page_ids['shop'] ),
-					'cart'     => self::format_page_resource( $page_ids['cart'] ),
-					'checkout' => self::format_page_resource( $page_ids['checkout'] ),
-					'privacy'  => self::format_page_resource( $page_ids['privacy'] ),
-					'terms'    => self::format_page_resource( $page_ids['terms'] ),
+					'myaccount' => self::format_page_resource( $page_ids['myaccount'] ),
+					'shop'      => self::format_page_resource( $page_ids['shop'] ),
+					'cart'      => self::format_page_resource( $page_ids['cart'] ),
+					'checkout'  => self::format_page_resource( $page_ids['checkout'] ),
+					'privacy'   => self::format_page_resource( $page_ids['privacy'] ),
+					'terms'     => self::format_page_resource( $page_ids['terms'] ),
 				],
 				'checkoutAllowsGuest'           => $checkout instanceof \WC_Checkout && false === filter_var(
 					$checkout->is_registration_required(),
@@ -213,6 +216,17 @@ class Assets {
 				'wordCountType'                 => _x( 'words', 'Word count type. Do not translate!', 'woo-gutenberg-products-block' ),
 			]
 		);
+	}
+
+	/**
+	 * Adds a redirect field to the login form so blocks can redirect users after login.
+	 */
+	public static function redirect_to_field() {
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( empty( $_GET['redirect_to'] ) ) {
+			return;
+		}
+		echo '<input type="hidden" name="redirect" value="' . esc_attr( esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) ) . '" />'; // phpcs:ignore WordPress.Security.NonceVerification
 	}
 
 	/**


### PR DESCRIPTION
This PR allows us to use the My Account page to login instead of the wp-login.php page.

To facilitate the login redirect, this uses the action hook to append a hidden redirect field. This field is set to the `redirect_to` query string variable given by blocks.

Fixes #2918

### How to test the changes in this Pull Request:

1. Ensure you have the My Account page setup in WooCommerce
2. In WC > Settings > Accounts, turn off guest checkout
3. Log out or use an incognito window
4. Add something to cart and go to checkout
5. You should see a login link. Click it.
6. You should be on the account page. Login.
7. You should be redirected back to the checkout page.

### Changelog

> Login links on the checkout should use the account page.
