### PR TITLE
Only use SHOP_URL if set

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
@@ -12,6 +12,69 @@ import PropTypes from 'prop-types';
 import iconDataUri from './icon-data-uri.js';
 import './style.scss';
 
+const templateItemBrowseStore = SHOP_URL
+	? [
+			'core/paragraph',
+			{
+				align: 'center',
+				content: sprintf(
+					// Translators: %s is the link to the store product directory.
+					__(
+						'<a href="%s">Browse store</a>.',
+						'woo-gutenberg-products-block'
+					),
+					SHOP_URL
+				),
+				dropCap: false,
+			},
+	  ]
+	: null;
+
+const templateItems = [
+	[
+		'core/image',
+		{
+			align: 'center',
+			url: iconDataUri,
+			sizeSlug: 'small',
+		},
+	],
+	[
+		'core/heading',
+		{
+			align: 'center',
+			content: __(
+				'Your cart is currently empty!',
+				'woo-gutenberg-products-block'
+			),
+			level: 2,
+			className: 'wc-block-cart__empty-cart__title',
+		},
+	],
+	templateItemBrowseStore,
+	[
+		'core/separator',
+		{
+			className: 'is-style-dots',
+		},
+	],
+	[
+		'core/heading',
+		{
+			align: 'center',
+			content: __( 'New in store', 'woo-gutenberg-products-block' ),
+			level: 2,
+		},
+	],
+	[
+		'woocommerce/product-new',
+		{
+			columns: 3,
+			rows: 1,
+		},
+	],
+].filter( Boolean );
+
 /**
  * Component to handle edit mode for the Cart block when cart is empty.
  *
@@ -23,67 +86,7 @@ const EmptyCartEdit = ( { hidden = false } ) => {
 		<div hidden={ hidden }>
 			<InnerBlocks
 				templateInsertUpdatesSelection={ false }
-				template={ [
-					[
-						'core/image',
-						{
-							align: 'center',
-							url: iconDataUri,
-							sizeSlug: 'small',
-						},
-					],
-					[
-						'core/heading',
-						{
-							align: 'center',
-							content: __(
-								'Your cart is currently empty!',
-								'woo-gutenberg-products-block'
-							),
-							level: 2,
-							className: 'wc-block-cart__empty-cart__title',
-						},
-					],
-					[
-						'core/paragraph',
-						{
-							align: 'center',
-							content: sprintf(
-								// Translators: %s is the link to the store product directory.
-								__(
-									'<a href="%s">Browse store</a>.',
-									'woo-gutenberg-products-block'
-								),
-								SHOP_URL
-							),
-							dropCap: false,
-						},
-					],
-					[
-						'core/separator',
-						{
-							className: 'is-style-dots',
-						},
-					],
-					[
-						'core/heading',
-						{
-							align: 'center',
-							content: __(
-								'New in store',
-								'woo-gutenberg-products-block'
-							),
-							level: 2,
-						},
-					],
-					[
-						'woocommerce/product-new',
-						{
-							columns: 3,
-							rows: 1,
-						},
-					],
-				] }
+				template={ templateItems }
 			/>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/empty-cart/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/empty-cart/index.js
@@ -23,11 +23,13 @@ const EmptyCart = () => {
 					'woo-gutenberg-products-block'
 				) }
 			</p>
-			<span className="wp-block-button">
-				<a href={ SHOP_URL } className="wp-block-button__link">
-					{ __( 'Browse store', 'woo-gutenberg-products-block' ) }
-				</a>
-			</span>
+			{ SHOP_URL && (
+				<span className="wp-block-button">
+					<a href={ SHOP_URL } className="wp-block-button__link">
+						{ __( 'Browse store', 'woo-gutenberg-products-block' ) }
+					</a>
+				</span>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
This is a small tweak to ensure we only use SHOP_URL if it's actually set. This cannot affect existing blocks because they store content as inner blocks on creation.

Fixes #2600

### How to test the changes in this Pull Request:

1. In WC > Settings > Products unset the shop page and save.
2. Insert a NEW cart block
3. Confirm the empty cart template does not include a link to browse shop.

<!-- If you can, add the appropriate labels -->

### Changelog

> Hide Browse Shop link in cart block empty state when there is no shop page.
