### PR TITLE
Remove shadows from text buttons and gradient background from selects in some themes

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -124,6 +124,7 @@ $fontSizes: (
 	background: transparent;
 	box-shadow: none;
 	display: inline;
+	text-shadow: none;
 
 	&:hover,
 	&:focus,

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -55,7 +55,7 @@
 		&:focus,
 		&:active {
 			@include font-size(regular);
-			background-color: #fff;
+			background: #fff;
 			box-shadow: none;
 			color: $input-text-active;
 			font-family: inherit;
@@ -71,7 +71,7 @@
 			white-space: nowrap;
 			width: 100%;
 			.has-dark-controls & {
-				background-color: $input-background-dark;
+				background: $input-background-dark;
 				border-color: $input-border-dark;
 				color: $input-text-dark;
 			}


### PR DESCRIPTION
This PR:
* Sets `text-shadow` to none in the `text-button` mixin (buttons that we want to display as plain text).
* Resets the `background` property of the button of select components. Until now, it was only setting the `background-color` to white, but that didn't reset gradients (which are treated as `background-image`).

### How to test the changes in this Pull Request:

One theme that allows seeing both changes in action is [Bookshop](https://woocommerce.com/products/bookshop/).

1. Install and activate Bookshop.
2. Go to the Cart block and verify the `Delete item` button doesn't have text shadow:

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/107967337-4609ba00-6fad-11eb-9dd9-f4929f699bff.png) | ![imatge](https://user-images.githubusercontent.com/3616980/107967434-633e8880-6fad-11eb-9e7d-6dc21c8f3984.png) |

3. Go to the Checkout block and verify Country and State selects don't have a gradient in the background:

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/107967156-1195fe00-6fad-11eb-95ca-d9379e7ff794.png) | ![imatge](https://user-images.githubusercontent.com/3616980/107967052-ef03e500-6fac-11eb-8a76-e2ac0a73ce46.png) |