### PR TITLE
Show cart item total price including taxes when DISPLAY_CART_PRICES_INCLUDING_TAX is true

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -9,6 +9,7 @@ import { getCurrency } from '@woocommerce/price-format';
 import { __experimentalApplyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import PropTypes from 'prop-types';
 import Dinero from 'dinero.js';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -60,8 +61,13 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		.convertPrecision( priceCurrency.minorUnit )
 		.getAmount();
 	const totalsCurrency = getCurrency( totals );
+
+	let lineTotal = parseInt( totals.line_total, 10 );
+	if ( DISPLAY_CART_PRICES_INCLUDING_TAX ) {
+		lineTotal += parseInt( totals.line_total_tax, 10 );
+	}
 	const totalsPrice = Dinero( {
-		amount: parseInt( totals.line_total, 10 ),
+		amount: lineTotal,
 	} )
 		.convertPrecision( totals.currency_minor_unit )
 		.getAmount();

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -18,6 +18,7 @@ import {
 import { getCurrency } from '@woocommerce/price-format';
 import { __experimentalApplyCheckoutFilter } from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
+import { DISPLAY_CART_PRICES_INCLUDING_TAX } from '@woocommerce/block-settings';
 
 /**
  * @typedef {import('@woocommerce/type-defs/cart').CartItem} CartItem
@@ -81,6 +82,7 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 			currency_decimal_separator: '.',
 			currency_thousand_separator: ',',
 			line_total: '0',
+			line_total_tax: '0',
 		},
 		extensions,
 	} = lineItem;
@@ -117,8 +119,12 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 	);
 	const saleAmount = saleAmountSingle.multiply( quantity );
 	const totalsCurrency = getCurrency( totals );
+	let lineTotal = parseInt( totals.line_total, 10 );
+	if ( DISPLAY_CART_PRICES_INCLUDING_TAX ) {
+		lineTotal += parseInt( totals.line_total_tax, 10 );
+	}
 	const totalsPrice = Dinero( {
-		amount: parseInt( totals.line_total, 10 ),
+		amount: lineTotal,
 	} );
 
 	const firstImage = images.length ? images[ 0 ] : {};


### PR DESCRIPTION
Fixes #3850.

### How to test the changes in this Pull Request:

In wp-admin:
1. Go to WooCommerce > Settings and check the option `Enable tax rates and calculations `.
2. Go to WooCommerce > Settings > Tax and set `Prices entered with tax` to `No, I will enter prices exclusive of tax` and `Display prices during cart and checkout` to `Including tax`.
3. Go to WooCommerce > Settings > Tax > Standard Rates and create a tax rate for a specific country.

In the frontend:
1. Add a product to your cart and go to the Cart or Checkout blocks.
2. Verify the product unitary price and the cart line total show the price including taxes:

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/108037796-5ddb4f80-703a-11eb-9656-cac05a57b8c5.png) | ![imatge](https://user-images.githubusercontent.com/3616980/108038392-10abad80-703b-11eb-8c96-52e1c0f2341f.png) |

### Changelog

> Fix a bug where the total price of items did not include tax in the cart and checkout blocks.