### PR TITLE
Fix product price not displaying properly when product is on sale

### DIFF
--- a/assets/js/base/components/product-price/index.js
+++ b/assets/js/base/components/product-price/index.js
@@ -126,7 +126,6 @@ const ProductPrice = ( {
 	}
 
 	const isDiscounted = regularPrice && price !== regularPrice;
-
 	let priceComponent = (
 		<span
 			className={ classNames(
@@ -148,9 +147,7 @@ const ProductPrice = ( {
 				regularPriceStyle={ regularPriceStyle }
 			/>
 		);
-	}
-
-	if ( minPrice !== null && maxPrice !== null ) {
+	} else if ( minPrice !== null && maxPrice !== null ) {
 		priceComponent = (
 			<PriceRange
 				currency={ currency }
@@ -160,9 +157,7 @@ const ProductPrice = ( {
 				priceStyle={ priceStyle }
 			/>
 		);
-	}
-
-	if ( price !== null ) {
+	} else if ( price !== null ) {
 		priceComponent = (
 			<FormattedMonetaryAmount
 				className={ classNames(

--- a/assets/js/base/components/product-price/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/product-price/test/__snapshots__/index.js.snap
@@ -6,10 +6,25 @@ exports[`ProductPrice should apply the format if one is provided 1`] = `
 >
   pre price 
   <span
-    className="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+    className="screen-reader-text"
+  >
+    Previous price:
+  </span>
+  <del
+    className="wc-block-components-product-price__regular"
+  >
+    £1.00
+  </del>
+  <span
+    className="screen-reader-text"
+  >
+    Discounted price:
+  </span>
+  <ins
+    className="wc-block-components-product-price__value is-discounted"
   >
     £0.50
-  </span>
+  </ins>
    Test format
 </span>
 `;
@@ -19,9 +34,24 @@ exports[`ProductPrice should use default price if no format is provided 1`] = `
   className="price wc-block-components-product-price"
 >
   <span
-    className="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+    className="screen-reader-text"
+  >
+    Previous price:
+  </span>
+  <del
+    className="wc-block-components-product-price__regular"
+  >
+    £1.00
+  </del>
+  <span
+    className="screen-reader-text"
+  >
+    Discounted price:
+  </span>
+  <ins
+    className="wc-block-components-product-price__value is-discounted"
   >
     £0.50
-  </span>
+  </ins>
 </span>
 `;


### PR DESCRIPTION
This PR fixes an issue where the Sale price of a product would not display properly, the reason this wasn't happening is because in the ProductPrice component, we choose which component to render based on a set of conditions, one of which is whether the price is less than the regular price. This is fine, but there are also other conditions that evaluate as true, meaning the component we chose gets overridden later in the execution path. By using `else if` we can ensure only the first true condition is executed.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3852

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
Before | After
-------|------
![image](https://user-images.githubusercontent.com/5656702/108046255-5026c980-703c-11eb-9d9a-9ec345f710e1.png) | ![image](https://user-images.githubusercontent.com/5656702/108047943-51f18c80-703e-11eb-9ba0-31e2f48d04cc.png)

### How to test the changes in this Pull Request:

1. Set a product to be on sale and add it to the cart
2. Go to the cart and checkout blocks and make sure you can see the struckthrough regular price and the sale price is displayed normally.
