### PR TITLE
Use variation prices in Store API prices response.

### DIFF
--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -676,9 +676,18 @@ class ProductSchema extends AbstractSchema {
 		$tax_display_mode = $this->get_tax_display_mode( $tax_display_mode );
 		$price_function   = $this->get_price_function_from_tax_display_mode( $tax_display_mode );
 
+		// If we have a variable product, get the price from the variations (this will use the min value).
+		if ( $product->is_type( 'variable' ) ) {
+			$regular_price = $product->get_variation_regular_price();
+			$sale_price    = $product->get_variation_sale_price();
+		} else {
+			$regular_price = $product->get_regular_price();
+			$sale_price    = $product->get_sale_price();
+		}
+
 		$prices['price']         = $this->prepare_money_response( $price_function( $product ), wc_get_price_decimals() );
-		$prices['regular_price'] = $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_regular_price() ] ), wc_get_price_decimals() );
-		$prices['sale_price']    = $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_sale_price() ] ), wc_get_price_decimals() );
+		$prices['regular_price'] = $this->prepare_money_response( $price_function( $product, [ 'price' => $regular_price ] ), wc_get_price_decimals() );
+		$prices['sale_price']    = $this->prepare_money_response( $price_function( $product, [ 'price' => $sale_price ] ), wc_get_price_decimals() );
 		$prices['price_range']   = $this->get_price_range( $product, $tax_display_mode );
 
 		return $this->prepare_currency_response( $prices );


### PR DESCRIPTION
Discovered when testing https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3853

If a variable product only has a single variation, and this variation is on sale, the sale price will always match the regular price in the API response.

This is because variable products have empty regular/sale prices: https://github.com/woocommerce/woocommerce/blob/e4b78cedbfc9c5fc20abc3e7218ac1a72eabec47/includes/data-stores/class-wc-product-variable-data-store-cpt.php#L103-L109

We can fix this by using the price from the variation rather than the parent product. I tested this with a variable product with 1 variation, price 50, sale price 40. 

Before:

```json
"prices": {
    "price": "4000",
    "regular_price": "4000",
    "sale_price": "4000",
    "price_range": null,
    "currency_code": "GBP",
    "currency_symbol": "£",
    "currency_minor_unit": 2,
    "currency_decimal_separator": ".",
    "currency_thousand_separator": ",",
    "currency_prefix": "£",
    "currency_suffix": ""
}
```

After:

```json
"prices": {
    "price": "4000",
    "regular_price": "5000",
    "sale_price": "4000",
    "price_range": null,
    "currency_code": "GBP",
    "currency_symbol": "£",
    "currency_minor_unit": 2,
    "currency_decimal_separator": ".",
    "currency_thousand_separator": ",",
    "currency_prefix": "£",
    "currency_suffix": ""
}
```

### Changelog

> Return correct sale/regular prices for variable products in the Store API.
