### PR TITLE
Handle out of stock product visibility setting in All Products block.

### DIFF
--- a/assets/js/base/components/product-list/product-list.js
+++ b/assets/js/base/components/product-list/product-list.js
@@ -18,6 +18,7 @@ import {
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
 import { useInnerBlockLayoutContext } from '@woocommerce/shared-context';
 import { speak } from '@wordpress/a11y';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -50,11 +51,17 @@ const generateQuery = ( { sortValue, currentPage, attributes } ) => {
 				};
 		}
 	};
+
+	const hideOutOfStockItems = getSetting( 'hideOutOfStockItems', false );
+
 	return {
 		...getSortArgs( sortValue ),
 		catalog_visibility: 'catalog',
 		per_page: columns * rows,
 		page: currentPage,
+		...( hideOutOfStockItems && {
+			stock_status: [ 'instock', 'onbackorder' ],
+		} ),
 	};
 };
 

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -185,6 +185,7 @@ class Assets {
 				 * Do not translate into your own language.
 				 */
 				'wordCountType'                 => _x( 'words', 'Word count type. Do not translate!', 'woo-gutenberg-products-block' ),
+				'hideOutOfStockItems'           => 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ),
 			]
 		);
 	}

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -309,10 +309,14 @@ class Products extends AbstractRoute {
 
 		$params['stock_status'] = array(
 			'description'       => __( 'Limit result set to products with specified stock status.', 'woo-gutenberg-products-block' ),
-			'type'              => 'string',
-			'enum'              => array_keys( wc_get_product_stock_status_options() ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+			),
+			'default'           => [],
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
+
 		);
 
 		$params['attributes'] = array(

--- a/src/StoreApi/Routes/Products.php
+++ b/src/StoreApi/Routes/Products.php
@@ -308,15 +308,15 @@ class Products extends AbstractRoute {
 		);
 
 		$params['stock_status'] = array(
-			'description'       => __( 'Limit result set to products with specified stock status.', 'woo-gutenberg-products-block' ),
-			'type'              => 'array',
-			'items'             => array(
-				'type' => 'string',
+			'description' => __( 'Limit result set to products with specified stock status.', 'woo-gutenberg-products-block' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type'              => 'string',
+				'enum'              => array_keys( wc_get_product_stock_status_options() ),
+				'sanitize_callback' => 'sanitize_text_field',
+				'validate_callback' => 'rest_validate_request_arg',
 			),
-			'default'           => [],
-			'sanitize_callback' => 'sanitize_text_field',
-			'validate_callback' => 'rest_validate_request_arg',
-
+			'default'     => [],
 		);
 
 		$params['attributes'] = array(

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -316,7 +316,7 @@ class ProductQuery {
 
 		if ( $wp_query->get( 'stock_status' ) ) {
 			$args['join']   = $this->append_product_sorting_table_join( $args['join'] );
-			$args['where'] .= $wpdb->prepare( ' AND wc_product_meta_lookup.stock_status = %s ', $wp_query->get( 'stock_status' ) );
+			$args['where'] .= ' AND wc_product_meta_lookup.stock_status IN ("' . implode( '","', array_map( 'esc_sql', $wp_query->get( 'stock_status' ) ) ) . '")';
 		}
 
 		if ( $wp_query->get( 'min_price' ) || $wp_query->get( 'max_price' ) ) {

--- a/src/StoreApi/docs/products.md
+++ b/src/StoreApi/docs/products.md
@@ -27,7 +27,7 @@ GET /products?attributes[0][attribute]=pa_color&attributes[0][slug]=red
 GET /products?on_sale=true
 GET /products?min_price=5000
 GET /products?max_price=10000
-GET /products?stock_status=outofstock
+GET /products?stock_status=['outofstock']
 GET /products?catalog_visibility=search
 GET /products?rating=4,5
 GET /products?return_price_range=true
@@ -58,7 +58,7 @@ GET /products?return_rating_counts=true
 | `on_sale`            | boolean |    no    | Limit result set to products on sale.                                                                                                                                     |
 | `min_price`          | string  |    no    | Limit result set to products based on a minimum price, provided using the smallest unit of the currency.                                                                  |
 | `max_price`          | string  |    no    | Limit result set to products based on a maximum price, provided using the smallest unit of the currency.                                                                  |
-| `stock_status`       | string  |    no    | Limit result set to products with specified stock status.                                                                                                                 |
+| `stock_status`       | array   |    no    | Limit result set to products with specified stock statuses. Expects an array of strings containing 'instock', 'outofstock' or 'onbackorder'.                              |
 | `attributes`         | array   |    no    | Limit result set to specific attribute terms. Expects an array of objects containing `attribute` (taxonomy), `term_id` or `slug`, and optional `operator` for comparison. |
 | `attribute_relation` | string  |    no    | The logical relationship between attributes when filtering across multiple at once.                                                                                       |
 | `catalog_visibility` | string  |    no    | Determines if hidden or visible catalog products are shown. Allowed values: `any`, `visible`, `catalog`, `search`, `hidden`                                               |


### PR DESCRIPTION


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
A new `hideOutOfStockItems` setting flag has been added to reflect the user setting `Hide out of stock items from the catalog`. When true, the products call will include a field for `stock_status: ['instock', 'onbackorder']`.

<!-- Reference any related issues or PRs here -->
Fixes #2824 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


### How to test the changes in this Pull Request:

1. Add All Products block to a page
2. Mark one product as `Out of stock`, and one as `On back order`
3. Select WC > Settings > Products > Inventory > Hide out of stock items from the catalog
4. Go to the products block and see that the `Out of stock` product is missing, but the `On back order` is visible

<!-- If you can, add the appropriate labels -->

### PHP Changes
Not sure if the code here is the best, feel free to suggest improvements. Also make sure the code is not missing any edge cases.

### Changelog

> Handle out-of-stock product visibility setting in All Products block.


