### PR TITLE
Add information about hub authentication and GitHub releases to the release PR template

### DIFF
--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -39,12 +39,19 @@ Additionally, make sure to differentiate between things in the testing notes tha
 * [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
 * [ ] Ask a team member to review the changes in the release pull request and for anyone who has done testing that they approve the pull request.
 
+## Ensure hub is set up and you're authenticated
+* [ ] Make sure you've got `hub` installed (`brew install hub`)
+* [ ] Make sure `hub api user` returns JSON with information about your GitHub user account, if it doesn't:
+  * [ ] Create a [GitHub access token](https://github.com/settings/tokens) with the `repo` permission.
+  * [ ] Set the environment variables: `GITHUB_USERNAME` with your GitHub Username, and `GITHUB_TOKEN` with the token you just generated. (You may want to add these to `.bashrc` or the equivalent)
+  * [ ] Run `hub api user` again and ensure JSON with information about your GitHub user account is returned.
+
 ## Push the button - Deploy!
 
 * [ ] Execute `npm run deploy`
   * Note: the script automatically updates version numbers (commits on your behalf).
   * **ALERT**: This script will ask you if this release will be deployed to WordPress.org. You should answer yes for this release even if it is a pre-release. A GitHub release will automatically be created and this will trigger a workflow that automatically deploys the plugin to WordPress.org.
-* [ ] Edit the [GitHub release](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases) and copy changelog into the release notes.
+* [ ] Edit the [GitHub release](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases) and copy changelog into the release notes. Ensure there is a release with the correct version (i.e. the one we're releasing right now). Do not publish any dev tags as a release.
 * [ ] The `#team-rubik` slack instance will be notified about the progress with the WordPress.org deploy. Watch for that. If anything goes wrong, an error will be reported and you can followup via the GitHub actions tab and the log for that workflow.
 
 ## After Workflow completes


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR updates the template of the PR that is generated during release to include information about `hub` and ensuring that it is set up to authenticate properly, and also adds a line explicitly directing you _not_ to publish dev tags as releases. 

### How to test the changes in this Pull Request:

1. Aside from creating a release PR, you can read [the document](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/bdb766821a64688344ff3e2a22fefc5d12e7c6fb/.github/release-initial-checklist.md) in GitHub and ensure it looks right.