### PR TITLE
Twenty Nineteen: Fix link button style in editor

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -201,6 +201,9 @@
 	.wc-block-components-product-sale-badge {
 		line-height: 1;
 	}
+	.editor-styles-wrapper .wp-block-button .wp-block-button__link:not(.has-text-color) {
+		color: #fff;
+	}
 }
 
 .theme-twentytwenty {


### PR DESCRIPTION
Fixes button styles for links in Twenty Nineteen theme. I have also committed this fix upstream:

https://core.trac.wordpress.org/ticket/52555

Fixes #3523

### Screenshots

Before:
![Screenshot 2021-02-17 at 14 59 22](https://user-images.githubusercontent.com/90977/108222645-e2a89500-7130-11eb-8f50-9ccd7a987948.png)

After:
![Screenshot 2021-02-17 at 14 53 09](https://user-images.githubusercontent.com/90977/108222653-e3d9c200-7130-11eb-8cc9-1a9810df9c32.png)

### How to test the changes in this Pull Request:

1. Insert all products block
2. View a product with a link (external product)
3. Confirm text is white on blue background

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix button styles in Twenty Nineteen theme
