### PR TITLE
Replace uppercase Translators with translators & make comment style consistent

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js
@@ -127,7 +127,7 @@ const ButtonComponent = ( {
 		>
 			{ isDone && quantityInCart > 0
 				? sprintf(
-						// translators: %s number of products in cart.
+						/* translators: %s number of products in cart. */
 						_n(
 							'%d in cart',
 							'%d in cart',

--- a/assets/js/atomic/blocks/product-elements/button/block.js
+++ b/assets/js/atomic/blocks/product-elements/button/block.js
@@ -80,7 +80,7 @@ const AddToCartButton = ( { product } ) => {
 	);
 	const buttonText = addedToCart
 		? sprintf(
-				// translators: %s number of products in cart.
+				/* translators: %s number of products in cart. */
 				_n(
 					'%d in cart',
 					'%d in cart',

--- a/assets/js/atomic/blocks/product-elements/image/block.js
+++ b/assets/js/atomic/blocks/product-elements/image/block.js
@@ -60,7 +60,7 @@ export const Block = ( {
 	const image = hasProductImages ? product.images[ 0 ] : null;
 	const ParentComponent = showProductLink ? 'a' : Fragment;
 	const anchorLabel = sprintf(
-		/* Translators: %s is referring to the product name */
+		/* translators: %s is referring to the product name */
 		__( 'Link to %s', 'woo-gutenberg-products-block' ),
 		product.name
 	);

--- a/assets/js/atomic/blocks/product-elements/rating/block.js
+++ b/assets/js/atomic/blocks/product-elements/rating/block.js
@@ -36,7 +36,7 @@ const Block = ( { className } ) => {
 	};
 
 	const ratingText = sprintf(
-		/* Translators: %f is referring to the average rating value */
+		/* translators: %f is referring to the average rating value */
 		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
 		rating
 	);

--- a/assets/js/base/components/cart-checkout/address-form/country-address-fields.js
+++ b/assets/js/base/components/cart-checkout/address-form/country-address-fields.js
@@ -41,7 +41,7 @@ const getSupportedProps = ( localeField ) => {
 
 	if ( localeField.label !== undefined && ! localeField.optionalLabel ) {
 		fields.optionalLabel = sprintf(
-			/* Translators: %s Field label. */
+			/* translators: %s Field label. */
 			__( '%s (optional)', 'woo-gutenberg-products-block' ),
 			localeField.label
 		);

--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -46,7 +46,7 @@ const ShippingLocation = ( { address } ) => {
 		formattedLocation && (
 			<span className="wc-block-components-shipping-address">
 				{ sprintf(
-					/* Translators: %s location. */
+					/* translators: %s location. */
 					__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
 					formattedLocation
 				) + ' ' }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.js
@@ -47,7 +47,7 @@ const ShippingRatesControl = ( {
 		if ( packageCount === 1 ) {
 			speak(
 				sprintf(
-					// translators: %d number of shipping options found.
+					/* translators: %d number of shipping options found. */
 					_n(
 						'%d shipping option was found.',
 						'%d shipping options were found.',
@@ -60,7 +60,7 @@ const ShippingRatesControl = ( {
 		} else {
 			speak(
 				sprintf(
-					// translators: %d number of shipping packages packages.
+					/* translators: %d number of shipping packages packages. */
 					_n(
 						'Shipping option searched for %d package.',
 						'Shipping options searched for %d packages.',
@@ -71,7 +71,7 @@ const ShippingRatesControl = ( {
 				) +
 					' ' +
 					sprintf(
-						// translators: %d number of shipping options available.
+						/* translators: %d number of shipping options available. */
 						_n(
 							'%d shipping option was found',
 							'%d shipping options were found',

--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -56,7 +56,7 @@ const TotalsDiscount = ( {
 									className="wc-block-components-totals-discount__coupon-list-item"
 									text={ cartCoupon.code }
 									screenReaderText={ sprintf(
-										/* Translators: %s Coupon code. */
+										/* translators: %s Coupon code. */
 										__(
 											'Coupon: %s',
 											'woo-gutenberg-products-block'
@@ -69,7 +69,7 @@ const TotalsDiscount = ( {
 									} }
 									radius="large"
 									ariaLabel={ sprintf(
-										/* Translators: %s is a coupon code. */
+										/* translators: %s is a coupon code. */
 										__(
 											'Remove coupon "%s"',
 											'woo-gutenberg-products-block'

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -58,7 +58,7 @@ const CheckboxList = ( {
 						} }
 						aria-expanded={ false }
 						aria-label={ sprintf(
-							/* Translators: %s is referring the remaining count of options */
+							/* translators: %s is referring the remaining count of options */
 							_n(
 								'Show %s more option',
 								'Show %s more options',

--- a/assets/js/base/components/checkbox-list/index.js
+++ b/assets/js/base/components/checkbox-list/index.js
@@ -69,7 +69,7 @@ const CheckboxList = ( {
 						) }
 					>
 						{ sprintf(
-							// translators: %s number of options to reveal.
+							/* translators: %s number of options to reveal. */
 							_n(
 								'Show %s more',
 								'Show %s more',

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -155,7 +155,7 @@ const DropdownSelector = ( {
 								checked.length > 0 && multiple
 									? null
 									: sprintf(
-											// Translators: %s attribute name.
+											// translators: %s attribute name.
 											__(
 												'Any %s',
 												'woo-gutenberg-products-block'

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -155,7 +155,7 @@ const DropdownSelector = ( {
 								checked.length > 0 && multiple
 									? null
 									: sprintf(
-											// translators: %s attribute name.
+											/* translators: %s attribute name. */
 											__(
 												'Any %s',
 												'woo-gutenberg-products-block'

--- a/assets/js/base/components/dropdown-selector/menu.js
+++ b/assets/js/base/components/dropdown-selector/menu.js
@@ -38,7 +38,7 @@ const DropdownSelectorMenu = ( {
 							item: option.value,
 							'aria-label': selected
 								? sprintf(
-										/* Translators: %s is referring to the filter option being removed. */
+										/* translators: %s is referring to the filter option being removed. */
 										__(
 											'Remove %s filter',
 											'woo-gutenberg-products-block'

--- a/assets/js/base/components/dropdown-selector/selected-chip.js
+++ b/assets/js/base/components/dropdown-selector/selected-chip.js
@@ -13,7 +13,7 @@ const DropdownSelectorSelectedChip = ( { onRemoveItem, option } ) => {
 				onRemoveItem( option.value );
 			} }
 			ariaLabel={ sprintf(
-				/* Translators: %s is referring to the filter option being removed. */
+				/* translators: %s is referring to the filter option being removed. */
 				__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
 				option.name
 			) }

--- a/assets/js/base/components/filter-submit-button/index.js
+++ b/assets/js/base/components/filter-submit-button/index.js
@@ -14,7 +14,7 @@ import './style.scss';
 const FilterSubmitButton = ( {
 	className,
 	disabled,
-	// translators: Submit button text for filters.
+	/* translators: Submit button text for filters. */
 	label = __( 'Go', 'woo-gutenberg-products-block' ),
 	onClick,
 	screenReaderLabel = __( 'Apply filter', 'woo-gutenberg-products-block' ),

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -67,7 +67,7 @@ const getDefaultPaymentMethodOptions = (
 	return {
 		value: tokenId + '',
 		label: sprintf(
-			// translators: %s is the name of the payment method gateway.
+			/* translators: %s is the name of the payment method gateway. */
 			__( 'Saved token for %s', 'woo-gutenberg-products-block' ),
 			method.gateway
 		),

--- a/assets/js/base/components/payment-methods/saved-payment-method-options.js
+++ b/assets/js/base/components/payment-methods/saved-payment-method-options.js
@@ -28,7 +28,7 @@ const getCcOrEcheckPaymentMethodOption = (
 	return {
 		value: tokenId + '',
 		label: sprintf(
-			/* Translators: %1$s is referring to the payment method brand, %2$s is referring to the last 4 digits of the payment card, %3$s is referring to the expiry date.  */
+			/* translators: %1$s is referring to the payment method brand, %2$s is referring to the last 4 digits of the payment card, %3$s is referring to the expiry date.  */
 			__(
 				'%1$s ending in %2$s (expires %3$s)',
 				'woo-gutenberg-product-blocks'
@@ -67,7 +67,7 @@ const getDefaultPaymentMethodOptions = (
 	return {
 		value: tokenId + '',
 		label: sprintf(
-			// Translators: %s is the name of the payment method gateway.
+			// translators: %s is the name of the payment method gateway.
 			__( 'Saved token for %s', 'woo-gutenberg-products-block' ),
 			method.gateway
 		),

--- a/assets/js/base/components/product-list/product-list.js
+++ b/assets/js/base/components/product-list/product-list.js
@@ -83,7 +83,7 @@ const announceLoadingCompletion = ( totalProducts ) => {
 	} else {
 		speak(
 			sprintf(
-				// translators: %s is an integer higher than 0 (1, 2, 3...)
+				/* translators: %s is an integer higher than 0 (1, 2, 3...) */
 				_n(
 					'%d product found',
 					'%d products found',

--- a/assets/js/base/components/quantity-selector/index.js
+++ b/assets/js/base/components/quantity-selector/index.js
@@ -84,7 +84,7 @@ const QuantitySelector = ( {
 					}
 				} }
 				aria-label={ sprintf(
-					/* Translators: %s refers to the item name in the cart. */
+					/* translators: %s refers to the item name in the cart. */
 					__(
 						'Quantity of %s in your cart.',
 						'woo-gutenberg-products-block'
@@ -104,7 +104,7 @@ const QuantitySelector = ( {
 					onChange( newQuantity );
 					speak(
 						sprintf(
-							/* Translators: %s refers to the item name in the cart. */
+							/* translators: %s refers to the item name in the cart. */
 							__(
 								'Quantity reduced to %s.',
 								'woo-gutenberg-products-block'
@@ -128,7 +128,7 @@ const QuantitySelector = ( {
 					onChange( newQuantity );
 					speak(
 						sprintf(
-							/* Translators: %s refers to the item name in the cart. */
+							/* translators: %s refers to the item name in the cart. */
 							__(
 								'Quantity increased to %s.',
 								'woo-gutenberg-products-block'

--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -125,7 +125,7 @@ function getReviewRating( review ) {
 		width: ( rating / 5 ) * 100 + '%' /* stylelint-disable-line */,
 	};
 	const ratingText = sprintf(
-		/* Translators: %f is referring to the average rating value */
+		/* translators: %f is referring to the average rating value */
 		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
 		rating
 	);

--- a/assets/js/base/hooks/cart/use-store-cart-coupons.js
+++ b/assets/js/base/hooks/cart/use-store-cart-coupons.js
@@ -45,7 +45,7 @@ export const useStoreCartCoupons = () => {
 						if ( result === true ) {
 							addSnackbarNotice(
 								sprintf(
-									// translators: %s coupon code.
+									/* translators: %s coupon code. */
 									__(
 										'Coupon code "%s" has been applied to your cart.',
 										'woo-gutenberg-products-block'
@@ -76,7 +76,7 @@ export const useStoreCartCoupons = () => {
 						if ( result === true ) {
 							addSnackbarNotice(
 								sprintf(
-									// translators: %s coupon code.
+									/* translators: %s coupon code. */
 									__(
 										'Coupon code "%s" has been removed from your cart.',
 										'woo-gutenberg-products-block'

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -255,7 +255,7 @@ const AttributeFilterBlock = ( {
 				if ( filterAddedName && filterRemovedName ) {
 					speak(
 						sprintf(
-							/* Translators: %1$s and %2$s are attribute terms (for example: 'red', 'blue', 'large'...). */
+							/* translators: %1$s and %2$s are attribute terms (for example: 'red', 'blue', 'large'...). */
 							__(
 								'%1$s filter replaced with %2$s.',
 								'woo-gutenberg-products-block'
@@ -267,7 +267,7 @@ const AttributeFilterBlock = ( {
 				} else if ( filterAddedName ) {
 					speak(
 						sprintf(
-							/* Translators: %s attribute term (for example: 'red', 'blue', 'large'...) */
+							/* translators: %s attribute term (for example: 'red', 'blue', 'large'...) */
 							__(
 								'%s filter added.',
 								'woo-gutenberg-products-block'
@@ -278,7 +278,7 @@ const AttributeFilterBlock = ( {
 				} else if ( filterRemovedName ) {
 					speak(
 						sprintf(
-							/* Translators: %s attribute term (for example: 'red', 'blue', 'large'...) */
+							/* translators: %s attribute term (for example: 'red', 'blue', 'large'...) */
 							__(
 								'%s filter removed.',
 								'woo-gutenberg-products-block'

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -287,7 +287,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		setAttributes( {
 			attributeId: selectedId,
 			heading: sprintf(
-				// Translators: %s attribute name.
+				// translators: %s attribute name.
 				__( 'Filter by %s', 'woo-gutenberg-products-block' ),
 				attributeName
 			),
@@ -311,7 +311,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			),
 			selected: ( n ) =>
 				sprintf(
-					// Translators: %d is the number of attributes selected.
+					// translators: %d is the number of attributes selected.
 					_n(
 						'%d attribute selected',
 						'%d attributes selected',

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -287,7 +287,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 		setAttributes( {
 			attributeId: selectedId,
 			heading: sprintf(
-				// translators: %s attribute name.
+				/* translators: %s attribute name. */
 				__( 'Filter by %s', 'woo-gutenberg-products-block' ),
 				attributeName
 			),
@@ -311,7 +311,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			),
 			selected: ( n ) =>
 				sprintf(
-					// translators: %d is the number of attributes selected.
+					/* translators: %d is the number of attributes selected. */
 					_n(
 						'%d attribute selected',
 						'%d attributes selected',

--- a/assets/js/blocks/attribute-filter/label.js
+++ b/assets/js/blocks/attribute-filter/label.js
@@ -19,7 +19,7 @@ const AttributeFilterLabel = ( { name, count } ) => {
 				<Label
 					label={ count }
 					screenReaderLabel={ sprintf(
-						// translators: %s number of products.
+						/* translators: %s number of products. */
 						_n(
 							'%s product',
 							'%s products',

--- a/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
@@ -18,7 +18,7 @@ const templateItemBrowseStore = SHOP_URL
 			{
 				align: 'center',
 				content: sprintf(
-					// translators: %s is the link to the store product directory.
+					/* translators: %s is the link to the store product directory. */
 					__(
 						'<a href="%s">Browse store</a>.',
 						'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
@@ -18,7 +18,7 @@ const templateItemBrowseStore = SHOP_URL
 			{
 				align: 'center',
 				content: sprintf(
-					// Translators: %s is the link to the store product directory.
+					// translators: %s is the link to the store product directory.
 					__(
 						'<a href="%s">Browse store</a>.',
 						'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
@@ -9,7 +9,7 @@ const CartLineItemsTitle = ( { itemCount = 1 } ) => {
 	return (
 		<Title headingLevel="2">
 			{ sprintf(
-				// Translators: %d is the count of items in the cart.
+				// translators: %d is the count of items in the cart.
 				_n(
 					'Your cart (%d item)',
 					'Your cart (%d items)',

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-title.js
@@ -9,7 +9,7 @@ const CartLineItemsTitle = ( { itemCount = 1 } ) => {
 	return (
 		<Title headingLevel="2">
 			{ sprintf(
-				// translators: %d is the count of items in the cart.
+				/* translators: %d is the count of items in the cart. */
 				_n(
 					'Your cart (%d item)',
 					'Your cart (%d items)',

--- a/assets/js/blocks/reviews/frontend-container-block.js
+++ b/assets/js/blocks/reviews/frontend-container-block.js
@@ -51,7 +51,7 @@ class FrontendContainerBlock extends Component {
 	onReviewsAppended( { newReviews } ) {
 		speak(
 			sprintf(
-				// Translators: %d is the count of reviews loaded.
+				// translators: %d is the count of reviews loaded.
 				_n(
 					'%d review loaded.',
 					'%d reviews loaded.',

--- a/assets/js/blocks/reviews/frontend-container-block.js
+++ b/assets/js/blocks/reviews/frontend-container-block.js
@@ -51,7 +51,7 @@ class FrontendContainerBlock extends Component {
 	onReviewsAppended( { newReviews } ) {
 		speak(
 			sprintf(
-				// translators: %d is the count of reviews loaded.
+				/* translators: %d is the count of reviews loaded. */
 				_n(
 					'%d review loaded.',
 					'%d reviews loaded.',

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -61,7 +61,7 @@ const ReviewsByCategoryEditor = ( {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
-					// translators: %1$s is the search term name, %2$d is the number of products returned for search query.
+					/* translators: %1$s is the search term name, %2$d is the number of products returned for search query. */
 					_n(
 						'%1$s, has %2$d product',
 						'%1$s, has %2$d products',

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -61,7 +61,7 @@ const ReviewsByCategoryEditor = ( {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
-					// Translators: %1$s is the search term name, %2$d is the number of products returned for search query.
+					// translators: %1$s is the search term name, %2$d is the number of products returned for search query.
 					_n(
 						'%1$s, has %2$d product',
 						'%1$s, has %2$d products',

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -47,7 +47,7 @@ const ReviewsByProductEditor = ( {
 			<SearchListItem
 				{ ...args }
 				countLabel={ sprintf(
-					// Translators: %d is the review count.
+					// translators: %d is the review count.
 					_n(
 						'%d Review',
 						'%d Reviews',
@@ -58,7 +58,7 @@ const ReviewsByProductEditor = ( {
 				) }
 				showCount
 				aria-label={ sprintf(
-					// Translators: %1$s is the item name, and %2$d is the number of reviews for the item.
+					// translators: %1$s is the item name, and %2$d is the number of reviews for the item.
 					_n(
 						'%1$s, has %2$d review',
 						'%1$s, has %2$d reviews',

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -47,7 +47,7 @@ const ReviewsByProductEditor = ( {
 			<SearchListItem
 				{ ...args }
 				countLabel={ sprintf(
-					// translators: %d is the review count.
+					/* translators: %d is the review count. */
 					_n(
 						'%d Review',
 						'%d Reviews',
@@ -58,7 +58,7 @@ const ReviewsByProductEditor = ( {
 				) }
 				showCount
 				aria-label={ sprintf(
-					// translators: %1$s is the item name, and %2$d is the number of reviews for the item.
+					/* translators: %1$s is the item name, and %2$d is the number of reviews for the item. */
 					_n(
 						'%1$s, has %2$d review',
 						'%1$s, has %2$d reviews',

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -27,7 +27,7 @@ const NoReviewsPlaceholder = ( { error, getProduct, isLoading, product } ) => {
 			<Spinner />
 		) : (
 			sprintf(
-				// Translators: %s is the product name.
+				// translators: %s is the product name.
 				__(
 					"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
 					'woo-gutenberg-products-block'

--- a/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
+++ b/assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js
@@ -27,7 +27,7 @@ const NoReviewsPlaceholder = ( { error, getProduct, isLoading, product } ) => {
 			<Spinner />
 		) : (
 			sprintf(
-				// translators: %s is the product name.
+				/* translators: %s is the product name. */
 				__(
 					"This block lists reviews for a selected product. %s doesn't have any reviews yet, but they will show up here when it does.",
 					'woo-gutenberg-products-block'

--- a/assets/js/editor-components/heading-toolbar/index.js
+++ b/assets/js/editor-components/heading-toolbar/index.js
@@ -21,7 +21,7 @@ class HeadingToolbar extends Component {
 		const isActive = targetLevel === selectedLevel;
 		return {
 			icon: <HeadingLevelIcon level={ targetLevel } />,
-			// translators: %s: heading level e.g: "2", "3", "4"
+			/* translators: %s: heading level e.g: "2", "3", "4" */
 			title: sprintf( __( 'Heading %d' ), targetLevel ),
 			isActive,
 			onClick: () => onChange( targetLevel ),

--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -59,7 +59,7 @@ const ProductAttributeTermControl = ( {
 					disabled={ item.count === '0' }
 					aria-expanded={ expandedAttribute === item.id }
 					aria-label={ sprintf(
-						// translators: %1$s is the item name, %2$d is the count of terms for the item.
+						/* translators: %1$s is the item name, %2$d is the count of terms for the item. */
 						_n(
 							'%1$s, has %2$d term',
 							'%1$s, has %2$d terms',
@@ -113,7 +113,7 @@ const ProductAttributeTermControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
-				// translators: %d is the count of attributes selected.
+				/* translators: %d is the count of attributes selected. */
 				_n(
 					'%d attribute selected',
 					'%d attributes selected',

--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -59,7 +59,7 @@ const ProductAttributeTermControl = ( {
 					disabled={ item.count === '0' }
 					aria-expanded={ expandedAttribute === item.id }
 					aria-label={ sprintf(
-						// Translators: %1$s is the item name, %2$d is the count of terms for the item.
+						// translators: %1$s is the item name, %2$d is the count of terms for the item.
 						_n(
 							'%1$s, has %2$d term',
 							'%1$s, has %2$d terms',
@@ -113,7 +113,7 @@ const ProductAttributeTermControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
-				// Translators: %d is the count of attributes selected.
+				// translators: %d is the count of attributes selected.
 				_n(
 					'%d attribute selected',
 					'%d attributes selected',

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -41,7 +41,7 @@ const ProductCategoryControl = ( {
 
 		const listItemAriaLabel = showReviewCount
 			? sprintf(
-					// translators: %1$s is the item name, %2$d is the count of reviews for the item.
+					/* translators: %1$s is the item name, %2$d is the count of reviews for the item. */
 					_n(
 						'%1$s, has %2$d review',
 						'%1$s, has %2$d reviews',
@@ -52,7 +52,7 @@ const ProductCategoryControl = ( {
 					item.review_count
 			  )
 			: sprintf(
-					// translators: %1$s is the item name, %2$d is the count of products for the item.
+					/* translators: %1$s is the item name, %2$d is the count of products for the item. */
 					_n(
 						'%1$s, has %2$d product',
 						'%1$s, has %2$d products',
@@ -65,7 +65,7 @@ const ProductCategoryControl = ( {
 
 		const listItemCountLabel = showReviewCount
 			? sprintf(
-					// translators: %d is the count of reviews.
+					/* translators: %d is the count of reviews. */
 					_n(
 						'%d Review',
 						'%d Reviews',
@@ -75,7 +75,7 @@ const ProductCategoryControl = ( {
 					item.review_count
 			  )
 			: sprintf(
-					// translators: %d is the count of products.
+					/* translators: %d is the count of products. */
 					_n(
 						'%d Product',
 						'%d Products',
@@ -111,7 +111,7 @@ const ProductCategoryControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
-				// translators: %d is the count of selected categories.
+				/* translators: %d is the count of selected categories. */
 				_n(
 					'%d category selected',
 					'%d categories selected',

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -41,7 +41,7 @@ const ProductCategoryControl = ( {
 
 		const listItemAriaLabel = showReviewCount
 			? sprintf(
-					// Translators: %1$s is the item name, %2$d is the count of reviews for the item.
+					// translators: %1$s is the item name, %2$d is the count of reviews for the item.
 					_n(
 						'%1$s, has %2$d review',
 						'%1$s, has %2$d reviews',
@@ -52,7 +52,7 @@ const ProductCategoryControl = ( {
 					item.review_count
 			  )
 			: sprintf(
-					// Translators: %1$s is the item name, %2$d is the count of products for the item.
+					// translators: %1$s is the item name, %2$d is the count of products for the item.
 					_n(
 						'%1$s, has %2$d product',
 						'%1$s, has %2$d products',
@@ -65,7 +65,7 @@ const ProductCategoryControl = ( {
 
 		const listItemCountLabel = showReviewCount
 			? sprintf(
-					// Translators: %d is the count of reviews.
+					// translators: %d is the count of reviews.
 					_n(
 						'%d Review',
 						'%d Reviews',
@@ -75,7 +75,7 @@ const ProductCategoryControl = ( {
 					item.review_count
 			  )
 			: sprintf(
-					// Translators: %d is the count of products.
+					// translators: %d is the count of products.
 					_n(
 						'%d Product',
 						'%d Products',
@@ -111,7 +111,7 @@ const ProductCategoryControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
-				// Translators: %d is the count of selected categories.
+				// translators: %d is the count of selected categories.
 				_n(
 					'%d category selected',
 					'%d categories selected',

--- a/assets/js/editor-components/product-control/index.js
+++ b/assets/js/editor-components/product-control/index.js
@@ -128,7 +128,7 @@ const ProductControl = ( {
 					{ variationsCount ? (
 						<span className="woocommerce-search-list__item-variation-count">
 							{ sprintf(
-								// translators: %d is the count of variations.
+								/* translators: %d is the count of variations. */
 								_n(
 									'%d variation',
 									'%d variations',

--- a/assets/js/editor-components/product-control/index.js
+++ b/assets/js/editor-components/product-control/index.js
@@ -128,7 +128,7 @@ const ProductControl = ( {
 					{ variationsCount ? (
 						<span className="woocommerce-search-list__item-variation-count">
 							{ sprintf(
-								// Translators: %d is the count of variations.
+								// translators: %d is the count of variations.
 								_n(
 									'%d variation',
 									'%d variations',

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -74,7 +74,7 @@ class ProductTagControl extends Component {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
-					// translators: %1$d is the count of products, %2$s is the name of the tag.
+					/* translators: %1$d is the count of products, %2$s is the name of the tag. */
 					_n(
 						'%1$d product tagged as %2$s',
 						'%1$d products tagged as %2$s',
@@ -108,7 +108,7 @@ class ProductTagControl extends Component {
 			),
 			selected: ( n ) =>
 				sprintf(
-					// translators: %d is the count of selected tags.
+					/* translators: %d is the count of selected tags. */
 					_n(
 						'%d tag selected',
 						'%d tags selected',

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -74,7 +74,7 @@ class ProductTagControl extends Component {
 				{ ...args }
 				showCount
 				aria-label={ sprintf(
-					// Translators: %1$d is the count of products, %2$s is the name of the tag.
+					// translators: %1$d is the count of products, %2$s is the name of the tag.
 					_n(
 						'%1$d product tagged as %2$s',
 						'%1$d products tagged as %2$s',
@@ -108,7 +108,7 @@ class ProductTagControl extends Component {
 			),
 			selected: ( n ) =>
 				sprintf(
-					// Translators: %d is the count of selected tags.
+					// translators: %d is the count of selected tags.
 					_n(
 						'%d tag selected',
 						'%d tags selected',

--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -42,7 +42,7 @@ const ProductsControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
-				// translators: %d is the number of selected products.
+				/* translators: %d is the number of selected products. */
 				_n(
 					'%d product selected',
 					'%d products selected',

--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -42,7 +42,7 @@ const ProductsControl = ( {
 		),
 		selected: ( n ) =>
 			sprintf(
-				// Translators: %d is the number of selected products.
+				// translators: %d is the number of selected products.
 				_n(
 					'%d product selected',
 					'%d products selected',

--- a/packages/checkout/shipping/shipping-rates-control/package.js
+++ b/packages/checkout/shipping/shipping-rates-control/package.js
@@ -58,7 +58,7 @@ const Package = ( {
 											: `${ name }`
 									}
 									screenReaderLabel={ sprintf(
-										// translators: %1$s name of the product (ie: Sunglasses), %2$d number of units in the current cart package
+										/* translators: %1$s name of the product (ie: Sunglasses), %2$d number of units in the current cart package */
 										_n(
 											'%1$s (%2$d unit)',
 											'%1$s (%2$d units)',

--- a/packages/checkout/utils/validation/index.js
+++ b/packages/checkout/utils/validation/index.js
@@ -14,7 +14,7 @@ export const mustBeString = ( value ) => {
 	if ( typeof value !== 'string' ) {
 		throw Error(
 			sprintf(
-				// translators: %s is type of value passed
+				/* translators: %s is type of value passed */
 				__(
 					'Returned value must be a string, you passed "%s"',
 					'woo-gutenberg-products-block'
@@ -38,7 +38,7 @@ export const mustContain = ( value, label ) => {
 	if ( ! value.includes( label ) ) {
 		throw Error(
 			sprintf(
-				// translators: %1$s value passed to filter, %2$s : value that must be included.
+				/* translators: %1$s value passed to filter, %2$s : value that must be included. */
 				__(
 					'Returned value must include %1$s, you passed "%2$s"',
 					'woo-gutenberg-products-block'

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -93,7 +93,7 @@ class Api {
 						'admin_notices',
 						function() use ( $handle ) {
 								echo '<div class="error"><p>';
-								// Translators: %s file handle name.
+								// translators: %s file handle name.
 								printf( esc_html__( 'Script with handle %s had a dependency on itself which has been removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', 'woo-gutenberg-products-block' ), esc_html( $handle ) );
 								echo '</p></div>';
 						}

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -93,7 +93,7 @@ class Api {
 						'admin_notices',
 						function() use ( $handle ) {
 								echo '<div class="error"><p>';
-								// translators: %s file handle name.
+								/* translators: %s file handle name. */
 								printf( esc_html__( 'Script with handle %s had a dependency on itself which has been removed. This is an indicator that your JS code has a circular dependency that can cause bugs.', 'woo-gutenberg-products-block' ), esc_html( $handle ) );
 								echo '</p></div>';
 						}

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -123,7 +123,7 @@ class Bootstrap {
 			function() {
 				echo '<div class="error"><p>';
 				printf(
-					/* Translators: %1$s is the install command, %2$s is the build command, %3$s is the watch command. */
+					/* translators: %1$s is the install command, %2$s is the build command, %3$s is the watch command. */
 					esc_html__( 'WooCommerce Blocks development mode requires files to be built. From the plugin directory, run %1$s to install dependencies, %2$s to build the files or %3$s to build the files and watch for changes.', 'woo-gutenberg-products-block' ),
 					'<code>npm install</code>',
 					'<code>npm run build</code>',

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -104,7 +104,7 @@ class Installer {
 			function() use ( $table_name ) {
 				echo '<div class="error"><p>';
 				printf(
-					/* Translators: %1$s table name, %2$s database user, %3$s database name. */
+					/* translators: %1$s table name, %2$s database user, %3$s database name. */
 					esc_html__( 'WooCommerce %1$s table creation failed. Does the %2$s user have CREATE privileges on the %3$s database?', 'woo-gutenberg-products-block' ),
 					'<code>' . esc_html( $table_name ) . '</code>',
 					'<code>' . esc_html( DB_USER ) . '</code>',

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -244,48 +244,48 @@ class CartController {
 	private function get_error_message_for_stock_exception_type( $exception_type, $singular_or_plural ) {
 		$stock_error_messages = [
 			'out_of_stock'         => [
-				// translators: %s: product name.
+				/* translators: %s: product name. */
 				'singular' => __(
 					'%s is out of stock and cannot be purchased. Please remove it from your cart.',
 					'woo-gutenberg-products-block'
 				),
-				// translators: %s: product names.
+				/* translators: %s: product names. */
 				'plural'   => __(
 					'%s are out of stock and cannot be purchased. Please remove them from your cart.',
 					'woo-gutenberg-products-block'
 				),
 			],
 			'not_purchasable'      => [
-				// translators: %s: product name.
+				/* translators: %s: product name. */
 				'singular' => __(
 					'%s cannot be purchased.  Please remove it from your cart.',
 					'woo-gutenberg-products-block'
 				),
-				// translators: %s: product names.
+				/* translators: %s: product names. */
 				'plural'   => __(
 					'%s cannot be purchased. Please remove them from your cart.',
 					'woo-gutenberg-products-block'
 				),
 			],
 			'too_many_in_cart'     => [
-				// translators: %s: product names.
+				/* translators: %s: product names. */
 				'singular' => __(
 					'There are too many %s in the cart. Only 1 can be purchased. Please reduce the quantity in your cart.',
 					'woo-gutenberg-products-block'
 				),
-				// translators: %s: product names.
+				/* translators: %s: product names. */
 				'plural'   => __(
 					'There are too many %s in the cart. Only 1 of each can be purchased. Please reduce the quantities in your cart.',
 					'woo-gutenberg-products-block'
 				),
 			],
 			'partial_out_of_stock' => [
-				// translators: %s: product names.
+				/* translators: %s: product names. */
 				'singular' => __(
 					'There is not enough %s in stock. Please reduce the quantity in your cart.',
 					'woo-gutenberg-products-block'
 				),
-				// translators: %s: product names.
+				/* translators: %s: product names. */
 				'plural'   => __(
 					'There are not enough %s in stock. Please reduce the quantities in your cart.',
 					'woo-gutenberg-products-block'
@@ -855,7 +855,7 @@ class CartController {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
-					// translators: %1$s coupon code, %2$s reason.
+					/* translators: %1$s coupon code, %2$s reason. */
 					__( 'The "%1$s" coupon has been removed from your cart: %2$s', 'woo-gutenberg-products-block' ),
 					$coupon->get_code(),
 					wp_strip_all_tags( $coupon->get_error_message() )

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -772,7 +772,7 @@ class CartController {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
-					/* Translators: %s coupon code */
+					/* translators: %s coupon code */
 					__( '"%s" is an invalid coupon code.', 'woo-gutenberg-products-block' ),
 					esc_html( $coupon_code )
 				),
@@ -784,7 +784,7 @@ class CartController {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_error',
 				sprintf(
-					/* Translators: %s coupon code */
+					/* translators: %s coupon code */
 					__( 'Coupon code "%s" has already been applied.', 'woo-gutenberg-products-block' ),
 					esc_html( $coupon_code )
 				),

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -164,7 +164,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_errors',
 				sprintf(
-					// translators: %s Coupon codes.
+					/* translators: %s Coupon codes. */
 					__( 'Invalid coupons were removed from the cart: "%s"', 'woo-gutenberg-products-block' ),
 					implode( '", "', array_keys( $coupon_errors ) )
 				),
@@ -197,7 +197,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_email_address',
 				sprintf(
-					// translators: %s provided email.
+					/* translators: %s provided email. */
 					__( 'The provided email address (%s) is not valid—please provide a valid email address', 'woo-gutenberg-products-block' ),
 					esc_html( $email )
 				),
@@ -222,7 +222,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_address_country',
 				sprintf(
-					// translators: %s country code.
+					/* translators: %s country code. */
 					__( 'Sorry, we do not ship orders to the provided country (%s)', 'woo-gutenberg-products-block' ),
 					$shipping_address['country']
 				),
@@ -237,7 +237,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_address_country',
 				sprintf(
-					// translators: %s country code.
+					/* translators: %s country code. */
 					__( 'Sorry, we do not allow orders from the provided country (%s)', 'woo-gutenberg-products-block' ),
 					$billing_address['country']
 				),
@@ -268,7 +268,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_address',
 				sprintf(
-					// translators: %s Address type.
+					/* translators: %s Address type. */
 					__( 'There was a problem with the provided %s:', 'woo-gutenberg-products-block' ) . ' ' . implode( ', ', $error_messages ),
 					'shipping' === $code ? __( 'shipping address', 'woo-gutenberg-products-block' ) : __( 'billing address', 'woo-gutenberg-products-block' )
 				),
@@ -356,7 +356,7 @@ class OrderController {
 
 		foreach ( $address_fields as $address_field_key => $address_field ) {
 			if ( empty( $address[ $address_field_key ] ) && $address_field['required'] ) {
-				// translators: %s Field label.
+				/* translators: %s Field label. */
 				$errors->add( $address_type, sprintf( __( '%s is required', 'woo-gutenberg-products-block' ), $address_field['label'] ), $address_field_key );
 			}
 		}

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -164,7 +164,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_cart_coupon_errors',
 				sprintf(
-					// Translators: %s Coupon codes.
+					// translators: %s Coupon codes.
 					__( 'Invalid coupons were removed from the cart: "%s"', 'woo-gutenberg-products-block' ),
 					implode( '", "', array_keys( $coupon_errors ) )
 				),
@@ -197,7 +197,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_email_address',
 				sprintf(
-					// Translators: %s provided email.
+					// translators: %s provided email.
 					__( 'The provided email address (%s) is not valid—please provide a valid email address', 'woo-gutenberg-products-block' ),
 					esc_html( $email )
 				),
@@ -222,7 +222,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_address_country',
 				sprintf(
-					// Translators: %s country code.
+					// translators: %s country code.
 					__( 'Sorry, we do not ship orders to the provided country (%s)', 'woo-gutenberg-products-block' ),
 					$shipping_address['country']
 				),
@@ -237,7 +237,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_address_country',
 				sprintf(
-					// Translators: %s country code.
+					// translators: %s country code.
 					__( 'Sorry, we do not allow orders from the provided country (%s)', 'woo-gutenberg-products-block' ),
 					$billing_address['country']
 				),
@@ -268,7 +268,7 @@ class OrderController {
 			throw new RouteException(
 				'woocommerce_rest_invalid_address',
 				sprintf(
-					// Translators: %s Address type.
+					// translators: %s Address type.
 					__( 'There was a problem with the provided %s:', 'woo-gutenberg-products-block' ) . ' ' . implode( ', ', $error_messages ),
 					'shipping' === $code ? __( 'shipping address', 'woo-gutenberg-products-block' ) : __( 'billing address', 'woo-gutenberg-products-block' )
 				),
@@ -356,7 +356,7 @@ class OrderController {
 
 		foreach ( $address_fields as $address_field_key => $address_field ) {
 			if ( empty( $address[ $address_field_key ] ) && $address_field['required'] ) {
-				// Translators: %s Field label.
+				// translators: %s Field label.
 				$errors->add( $address_type, sprintf( __( '%s is required', 'woo-gutenberg-products-block' ), $address_field['label'] ), $address_field_key );
 			}
 		}

--- a/src/Utils/ArrayUtils.php
+++ b/src/Utils/ArrayUtils.php
@@ -25,7 +25,7 @@ class ArrayUtils {
 		$last = array_pop( $array );
 		if ( $array ) {
 			return sprintf(
-			// translators: 1: The first n-1 items of a list 2: the last item in the list.
+				/* translators: 1: The first n-1 items of a list 2: the last item in the list. */
 				__( '%1$s and %2$s', 'woo-gutenberg-products-block' ),
 				implode( ', ', $array ),
 				$last

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -91,7 +91,7 @@ if ( woocommerce_blocks_is_development_version() && ! defined( 'JETPACK_AUTOLOAD
 		function() {
 			echo '<div class="error"><p>';
 			printf(
-				/* Translators: %1$s is referring to a php constant name, %2$s is referring to the wp-config.php file. */
+				/* translators: %1$s is referring to a php constant name, %2$s is referring to the wp-config.php file. */
 				esc_html__( 'WooCommerce Blocks development mode requires the %1$s constant to be defined and true in your %2$s file. Otherwise you are loading the blocks package from WooCommerce core.', 'woo-gutenberg-products-block' ),
 				'JETPACK_AUTOLOAD_DEV',
 				'wp-config.php'


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

When translating text, you should add a comment to the preceding line explaining what the translation will be used for, if you think extra context needs to be given to translators.

The way this is done is to comment like: `/* translators: %s is the product name */` as per the [WordPress documentation](https://codex.wordpress.org/I18n_for_WordPress_Developers) - in our codebase we had a mixture of uppercase `Translators` strings, and `// translators:` style comments - while this still _worked_ it sometimes formatted the translation hint incorrectly, showing the `Translators` word when it shouldn't have been. Not a huge problem but it would be nice to keep the plugin polished.

I also changed all comment styles to `/* ... */` rather than `// ... ` to keep this consistent across our codebase.

<!-- Reference any related issues or PRs here -->
Fixes #3764

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

1. View code changes and ensure only comment lines have changed
2. Try translating some strings using LocoTranslate or some other translation method, you should only see the translation hint, e.g. `%s is the product name` not `Translators: %s is the product name`
