### PR TITLE
StoreAPI: Inject Order and Cart Controllers into Routes

### DIFF
--- a/src/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/AbstractCartRoute.php
@@ -28,7 +28,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	/**
 	 * Cart controller class instance.
 	 *
-	 * @var CartSchema
+	 * @var CartController
 	 */
 	protected $cart_controller;
 

--- a/src/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/AbstractCartRoute.php
@@ -26,15 +26,24 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	protected $cart_schema;
 
 	/**
+	 * Cart controller class instance.
+	 *
+	 * @var CartSchema
+	 */
+	protected $cart_controller;
+
+	/**
 	 * Constructor accepts two types of schema; one for the item being returned, and one for the cart as a whole. These
 	 * may be the same depending on the route.
 	 *
 	 * @param CartSchema     $cart_schema Schema class for the cart.
 	 * @param AbstractSchema $item_schema Schema class for this route's items if it differs from the cart schema.
+	 * @param CartController $cart_controller Cart controller class.
 	 */
-	public function __construct( CartSchema $cart_schema, AbstractSchema $item_schema = null ) {
-		$this->schema      = is_null( $item_schema ) ? $cart_schema : $item_schema;
-		$this->cart_schema = $cart_schema;
+	public function __construct( CartSchema $cart_schema, AbstractSchema $item_schema = null, CartController $cart_controller ) {
+		$this->schema          = is_null( $item_schema ) ? $cart_schema : $item_schema;
+		$this->cart_schema     = $cart_schema;
+		$this->cart_controller = $cart_controller;
 	}
 
 	/**
@@ -44,7 +53,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public function get_response( \WP_REST_Request $request ) {
-		$this->maybe_load_cart();
+		$this->cart_controller->load_cart();
 		$this->calculate_totals();
 
 		try {
@@ -145,8 +154,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		switch ( $http_status_code ) {
 			case 409:
 				// If there was a conflict, return the cart so the client can resolve it.
-				$controller = new CartController();
-				$cart       = $controller->get_cart_instance();
+				$cart = $this->cart_controller->get_cart_instance();
 
 				return new \WP_Error(
 					$error_code,
@@ -161,16 +169,5 @@ abstract class AbstractCartRoute extends AbstractRoute {
 				);
 		}
 		return new \WP_Error( $error_code, $error_message, [ 'status' => $http_status_code ] );
-	}
-
-	/**
-	 * Makes the cart and sessions available to a route by loading them from core.
-	 */
-	protected function maybe_load_cart() {
-		if ( ! did_action( 'woocommerce_load_cart_from_session' ) && function_exists( 'wc_load_cart' ) ) {
-			include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
-			include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
-			wc_load_cart();
-		}
 	}
 }

--- a/src/StoreApi/Routes/Cart.php
+++ b/src/StoreApi/Routes/Cart.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * Cart class.
  *
@@ -45,9 +43,6 @@ class Cart extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
-
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $this->cart_controller->get_cart_instance() ) );
 	}
 }

--- a/src/StoreApi/Routes/CartAddItem.php
+++ b/src/StoreApi/Routes/CartAddItem.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartAddItem class.
  *
@@ -85,9 +83,8 @@ class CartAddItem extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_item_exists', __( 'Cannot create an existing cart item.', 'woo-gutenberg-products-block' ), 400 );
 		}
 
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
-		$result     = $controller->add_to_cart(
+		$cart   = $this->cart_controller->get_cart_instance();
+		$result = $this->cart_controller->add_to_cart(
 			[
 				'id'        => $request['id'],
 				'quantity'  => $request['quantity'],

--- a/src/StoreApi/Routes/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/CartApplyCoupon.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartApplyCoupon class.
  *
@@ -52,12 +50,11 @@ class CartApplyCoupon extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
-		$controller  = new CartController();
-		$cart        = $controller->get_cart_instance();
+		$cart        = $this->cart_controller->get_cart_instance();
 		$coupon_code = wc_format_coupon_code( wp_unslash( $request['code'] ) );
 
 		try {
-			$controller->apply_coupon( $coupon_code );
+			$this->cart_controller->apply_coupon( $coupon_code );
 		} catch ( \WC_REST_Exception $e ) {
 			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
 		}

--- a/src/StoreApi/Routes/CartCoupons.php
+++ b/src/StoreApi/Routes/CartCoupons.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartCoupons class.
  *
@@ -56,8 +54,7 @@ class CartCoupons extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$controller   = new CartController();
-		$cart_coupons = $controller->get_cart_coupons();
+		$cart_coupons = $this->cart_controller->get_cart_coupons();
 		$items        = [];
 
 		foreach ( $cart_coupons as $coupon_code ) {
@@ -85,10 +82,8 @@ class CartCoupons extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
-		$controller = new CartController();
-
 		try {
-			$controller->apply_coupon( $request['code'] );
+			$this->cart_controller->apply_coupon( $request['code'] );
 		} catch ( \WC_REST_Exception $e ) {
 			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
 		}
@@ -107,8 +102,8 @@ class CartCoupons extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_delete_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
+		$cart = $this->cart_controller->get_cart_instance();
+
 		$cart->remove_coupons();
 		$cart->calculate_totals();
 

--- a/src/StoreApi/Routes/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/CartCouponsByCode.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartCouponsByCode class.
  *
@@ -56,9 +54,7 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-
-		if ( ! $controller->has_coupon( $request['code'] ) ) {
+		if ( ! $this->cart_controller->has_coupon( $request['code'] ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
@@ -73,13 +69,12 @@ class CartCouponsByCode extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_delete_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-
-		if ( ! $controller->has_coupon( $request['code'] ) ) {
+		if ( ! $this->cart_controller->has_coupon( $request['code'] ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon does not exist in the cart.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
-		$cart = $controller->get_cart_instance();
+		$cart = $this->cart_controller->get_cart_instance();
+
 		$cart->remove_coupon( $request['code'] );
 		$cart->calculate_totals();
 

--- a/src/StoreApi/Routes/CartItems.php
+++ b/src/StoreApi/Routes/CartItems.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartItems class.
  *
@@ -56,8 +54,7 @@ class CartItems extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart_items = $controller->get_cart_items();
+		$cart_items = $this->cart_controller->get_cart_items();
 		$items      = [];
 
 		foreach ( $cart_items as $cart_item ) {
@@ -83,8 +80,7 @@ class CartItems extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_item_exists', __( 'Cannot create an existing cart item.', 'woo-gutenberg-products-block' ), 400 );
 		}
 
-		$controller = new CartController();
-		$result     = $controller->add_to_cart(
+		$result = $this->cart_controller->add_to_cart(
 			[
 				'id'        => $request['id'],
 				'quantity'  => $request['quantity'],
@@ -92,7 +88,7 @@ class CartItems extends AbstractCartRoute {
 			]
 		);
 
-		$response = rest_ensure_response( $this->prepare_item_for_response( $controller->get_cart_item( $result ), $request ) );
+		$response = rest_ensure_response( $this->prepare_item_for_response( $this->cart_controller->get_cart_item( $result ), $request ) );
 		$response->set_status( 201 );
 		return $response;
 	}
@@ -105,8 +101,7 @@ class CartItems extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_delete_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$controller->empty_cart();
+		$this->cart_controller->empty_cart();
 		return new \WP_REST_Response( [], 200 );
 	}
 

--- a/src/StoreApi/Routes/CartItemsByKey.php
+++ b/src/StoreApi/Routes/CartItemsByKey.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartItemsByKey class.
  *
@@ -62,8 +60,7 @@ class CartItemsByKey extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart_item  = $controller->get_cart_item( $request['key'] );
+		$cart_item = $this->cart_controller->get_cart_item( $request['key'] );
 
 		if ( empty( $cart_item ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );
@@ -83,14 +80,13 @@ class CartItemsByKey extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_update_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
+		$cart = $this->cart_controller->get_cart_instance();
 
 		if ( isset( $request['quantity'] ) ) {
-			$controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
+			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 		}
 
-		return rest_ensure_response( $this->prepare_item_for_response( $controller->get_cart_item( $request['key'] ), $request ) );
+		return rest_ensure_response( $this->prepare_item_for_response( $this->cart_controller->get_cart_item( $request['key'] ), $request ) );
 	}
 
 	/**
@@ -101,9 +97,8 @@ class CartItemsByKey extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_delete_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
-		$cart_item  = $controller->get_cart_item( $request['key'] );
+		$cart      = $this->cart_controller->get_cart_instance();
+		$cart_item = $this->cart_controller->get_cart_item( $request['key'] );
 
 		if ( empty( $cart_item ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item does not exist.', 'woo-gutenberg-products-block' ), 404 );

--- a/src/StoreApi/Routes/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/CartRemoveCoupon.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartRemoveCoupon class.
  *
@@ -52,8 +50,7 @@ class CartRemoveCoupon extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_coupon_disabled', __( 'Coupons are disabled.', 'woo-gutenberg-products-block' ), 404 );
 		}
 
-		$controller  = new CartController();
-		$cart        = $controller->get_cart_instance();
+		$cart        = $this->cart_controller->get_cart_instance();
 		$coupon_code = wc_format_coupon_code( $request['code'] );
 		$coupon      = new \WC_Coupon( $coupon_code );
 
@@ -61,11 +58,11 @@ class CartRemoveCoupon extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_coupon_error', __( 'Invalid coupon code.', 'woo-gutenberg-products-block' ), 400 );
 		}
 
-		if ( ! $controller->has_coupon( $coupon_code ) ) {
+		if ( ! $this->cart_controller->has_coupon( $coupon_code ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_coupon_invalid_code', __( 'Coupon cannot be removed because it is not already applied to the cart.', 'woo-gutenberg-products-block' ), 409 );
 		}
 
-		$cart = $controller->get_cart_instance();
+		$cart = $this->cart_controller->get_cart_instance();
 		$cart->remove_coupon( $coupon_code );
 		$cart->calculate_totals();
 

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartRemoveItem class.
  *
@@ -48,9 +46,8 @@ class CartRemoveItem extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
-		$cart_item  = $controller->get_cart_item( $request['key'] );
+		$cart      = $this->cart_controller->get_cart_instance();
+		$cart_item = $this->cart_controller->get_cart_item( $request['key'] );
 
 		if ( empty( $cart_item ) ) {
 			throw new RouteException( 'woocommerce_rest_cart_invalid_key', __( 'Cart item no longer exists or is invalid.', 'woo-gutenberg-products-block' ), 409 );

--- a/src/StoreApi/Routes/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/CartSelectShippingRate.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartSelectShippingRate class.
  *
@@ -62,13 +60,12 @@ class CartSelectShippingRate extends AbstractCartRoute {
 			throw new RouteException( 'woocommerce_rest_cart_missing_package_id', __( 'Invalid Package ID.', 'woo-gutenberg-products-block' ), 400 );
 		}
 
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
+		$cart       = $this->cart_controller->get_cart_instance();
 		$package_id = wc_clean( wp_unslash( $request['package_id'] ) );
 		$rate_id    = wc_clean( wp_unslash( $request['rate_id'] ) );
 
 		try {
-			$controller->select_shipping_rate( $package_id, $rate_id );
+			$this->cart_controller->select_shipping_rate( $package_id, $rate_id );
 		} catch ( \WC_Rest_Exception $e ) {
 			throw new RouteException( $e->getErrorCode(), $e->getMessage(), $e->getCode() );
 		}

--- a/src/StoreApi/Routes/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/CartUpdateCustomer.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\BillingAddressSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\ShippingAddressSchema;
@@ -74,10 +73,9 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
-		$billing    = isset( $request['billing_address'] ) ? $request['billing_address'] : [];
-		$shipping   = isset( $request['shipping_address'] ) ? $request['shipping_address'] : [];
+		$cart     = $this->cart_controller->get_cart_instance();
+		$billing  = isset( $request['billing_address'] ) ? $request['billing_address'] : [];
+		$shipping = isset( $request['shipping_address'] ) ? $request['shipping_address'] : [];
 
 		// If the cart does not need shipping, shipping address is forced to match billing address unless defined.
 		if ( ! $cart->needs_shipping() && ! isset( $request['shipping_address'] ) ) {

--- a/src/StoreApi/Routes/CartUpdateItem.php
+++ b/src/StoreApi/Routes/CartUpdateItem.php
@@ -1,8 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-
 /**
  * CartUpdateItem class.
  *
@@ -52,11 +50,10 @@ class CartUpdateItem extends AbstractCartRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		$controller = new CartController();
-		$cart       = $controller->get_cart_instance();
+		$cart = $this->cart_controller->get_cart_instance();
 
 		if ( isset( $request['quantity'] ) ) {
-			$controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
+			$this->cart_controller->set_cart_item_quantity( $request['key'], $request['quantity'] );
 		}
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -380,8 +380,7 @@ class Checkout extends AbstractCartRoute {
 	 * @throws RouteException On error.
 	 */
 	private function create_or_update_draft_order() {
-		$reserve_stock = new ReserveStock();
-		$this->order   = $this->get_draft_order_id() ? wc_get_order( $this->get_draft_order_id() ) : null;
+		$this->order = $this->get_draft_order_id() ? wc_get_order( $this->get_draft_order_id() ) : null;
 
 		if ( ! $this->is_valid_draft_order( $this->order ) ) {
 			$this->order = $this->order_controller->create_order_from_cart();
@@ -420,6 +419,7 @@ class Checkout extends AbstractCartRoute {
 
 		// Try to reserve stock for 10 mins, if available.
 		try {
+			$reserve_stock = new ReserveStock();
 			$reserve_stock->reserve_stock_for_order( $this->order, 10 );
 		} catch ( ReserveStockException $e ) {
 			$error_data = $e->getErrorData();

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -192,9 +192,8 @@ class Checkout extends AbstractCartRoute {
 		 * Validate items etc are allowed in the order before the order is processed. This will fix violations and tell
 		 * the customer.
 		 */
-		$cart_controller = new CartController();
-		$cart_controller->validate_cart_items();
-		$cart_controller->validate_cart_coupons();
+		$this->cart_controller->validate_cart_items();
+		$this->cart_controller->validate_cart_coupons();
 
 		/**
 		 * Obtain Draft Order and process request data.

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -602,8 +602,6 @@ class Checkout extends AbstractCartRoute {
 	 *
 	 * @internal CreateAccount class includes feature gating logic (i.e. this may not create an account depending on build).
 	 * @internal Checkout signup is feature gated to WooCommerce 4.7 and newer; Because it requires updated my-account/lost-password screen in 4.7+ for setting initial password.
-
-	 * @todo OrderController (and CartController) should be injected into Checkout Route Class.
 	 *
 	 * @throws RouteException API error object with error details.
 	 * @param WP_REST_Request $request Request object.

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\StoreApi;
 
 use Routes\AbstractRoute;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\OrderController;
 
 /**
  * RoutesController class.
@@ -83,7 +84,7 @@ class RoutesController {
 			'cart-select-shipping-rate' => new Routes\CartSelectShippingRate( $this->schemas->get( 'cart' ), null, $cart_controller ),
 			'cart-update-item'          => new Routes\CartUpdateItem( $this->schemas->get( 'cart' ), null, $cart_controller ),
 			'cart-update-customer'      => new Routes\CartUpdateCustomer( $this->schemas->get( 'cart' ), null, $cart_controller ),
-			'checkout'                  => new Routes\Checkout( $this->schemas->get( 'cart' ), $this->schemas->get( 'checkout' ) ),
+			'checkout'                  => new Routes\Checkout( $this->schemas->get( 'cart' ), $this->schemas->get( 'checkout' ), $cart_controller, $order_controller ),
 			'product-attributes'        => new Routes\ProductAttributes( $this->schemas->get( 'product-attribute' ) ),
 			'product-attributes-by-id'  => new Routes\ProductAttributesById( $this->schemas->get( 'product-attribute' ) ),
 			'product-attribute-terms'   => new Routes\ProductAttributeTerms( $this->schemas->get( 'term' ) ),

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi;
 
 use Routes\AbstractRoute;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 
 /**
  * RoutesController class.
@@ -66,19 +67,22 @@ class RoutesController {
 	 * Load route class instances.
 	 */
 	protected function initialize() {
+		$cart_controller  = new CartController();
+		$order_controller = new OrderController();
+
 		$this->routes = [
-			'cart'                      => new Routes\Cart( $this->schemas->get( 'cart' ) ),
-			'cart-add-item'             => new Routes\CartAddItem( $this->schemas->get( 'cart' ) ),
-			'cart-apply-coupon'         => new Routes\CartApplyCoupon( $this->schemas->get( 'cart' ) ),
-			'cart-coupons'              => new Routes\CartCoupons( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-coupon' ) ),
-			'cart-coupons-by-code'      => new Routes\CartCouponsByCode( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-coupon' ) ),
-			'cart-items'                => new Routes\CartItems( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-item' ) ),
-			'cart-items-by-key'         => new Routes\CartItemsByKey( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-item' ) ),
-			'cart-remove-coupon'        => new Routes\CartRemoveCoupon( $this->schemas->get( 'cart' ) ),
-			'cart-remove-item'          => new Routes\CartRemoveItem( $this->schemas->get( 'cart' ) ),
-			'cart-select-shipping-rate' => new Routes\CartSelectShippingRate( $this->schemas->get( 'cart' ) ),
-			'cart-update-item'          => new Routes\CartUpdateItem( $this->schemas->get( 'cart' ) ),
-			'cart-update-customer'      => new Routes\CartUpdateCustomer( $this->schemas->get( 'cart' ) ),
+			'cart'                      => new Routes\Cart( $this->schemas->get( 'cart' ), null, $cart_controller ),
+			'cart-add-item'             => new Routes\CartAddItem( $this->schemas->get( 'cart' ), null, $cart_controller ),
+			'cart-apply-coupon'         => new Routes\CartApplyCoupon( $this->schemas->get( 'cart' ), null, $cart_controller ),
+			'cart-coupons'              => new Routes\CartCoupons( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-coupon' ), $cart_controller ),
+			'cart-coupons-by-code'      => new Routes\CartCouponsByCode( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-coupon' ), $cart_controller ),
+			'cart-items'                => new Routes\CartItems( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-item' ), $cart_controller ),
+			'cart-items-by-key'         => new Routes\CartItemsByKey( $this->schemas->get( 'cart' ), $this->schemas->get( 'cart-item' ), $cart_controller ),
+			'cart-remove-coupon'        => new Routes\CartRemoveCoupon( $this->schemas->get( 'cart' ), null, $cart_controller ),
+			'cart-remove-item'          => new Routes\CartRemoveItem( $this->schemas->get( 'cart' ), null, $cart_controller ),
+			'cart-select-shipping-rate' => new Routes\CartSelectShippingRate( $this->schemas->get( 'cart' ), null, $cart_controller ),
+			'cart-update-item'          => new Routes\CartUpdateItem( $this->schemas->get( 'cart' ), null, $cart_controller ),
+			'cart-update-customer'      => new Routes\CartUpdateCustomer( $this->schemas->get( 'cart' ), null, $cart_controller ),
 			'checkout'                  => new Routes\Checkout( $this->schemas->get( 'cart' ), $this->schemas->get( 'checkout' ) ),
 			'product-attributes'        => new Routes\ProductAttributes( $this->schemas->get( 'product-attribute' ) ),
 			'product-attributes-by-id'  => new Routes\ProductAttributesById( $this->schemas->get( 'product-attribute' ) ),

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -15,6 +15,16 @@ use WP_Error;
  * @since 2.5.0
  */
 class CartController {
+	/**
+	 * Makes the cart and sessions available to a route by loading them from core.
+	 */
+	public function load_cart() {
+		if ( ! did_action( 'woocommerce_load_cart_from_session' ) && function_exists( 'wc_load_cart' ) ) {
+			include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
+			include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
+			wc_load_cart();
+		}
+	}
 
 	/**
 	 * Based on the core cart class but returns errors rather than rendering notices directly.


### PR DESCRIPTION
Resolves a todo in which we wanted to inject the OrderController and CartController classes into StoreAPI routes instead of creating new instances.

Fixes #3497

### How to test the changes in this Pull Request:

This should be covered by Unit tests, but for safety:

1. Smoke test some cart routes 
2. Do a checkout