### PR TITLE
Cleanup Assets class.

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -35,5 +35,4 @@ class Assets {
 		$asset_api = Package::container()->get( AssetApi::class );
 		$asset_api->register_block_script( $script_name, $handle, $dependencies );
 	}
-
 }

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -8,120 +8,16 @@ use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
  * Assets class.
  * Initializes block assets.
  *
+ * @since 2.5.0
+ * Moved most initialization to BootStrap and AssetDataRegistry
+ * classes as a part of ongoing refactor
+ * @since 4.6.0
+ * Blocks common data registration was moved to the AbstractBlock.
+ * Assets initialization was moved to AssetsInitialization class.
+ *
  * @internal
  */
 class Assets {
-
-	/**
-	 * Initialize class features on init.
-	 *
-	 * @since 2.5.0
-	 * Moved most initialization to BootStrap and AssetDataRegistry
-	 * classes as a part of ongoing refactor
-	 */
-	public static function init() {
-		add_action( 'init', array( __CLASS__, 'register_assets' ) );
-		add_action( 'body_class', array( __CLASS__, 'add_theme_body_class' ), 1 );
-		add_action( 'admin_body_class', array( __CLASS__, 'add_theme_admin_body_class' ), 1 );
-		add_action( 'woocommerce_login_form_end', array( __CLASS__, 'redirect_to_field' ) );
-	}
-
-	/**
-	 * Register block scripts & styles.
-	 *
-	 * @since 2.5.0
-	 * Moved data related enqueuing to new AssetDataRegistry class
-	 * as part of ongoing refactoring.
-	 */
-	public static function register_assets() {
-		$asset_api = Package::container()->get( AssetApi::class );
-
-		// @todo Remove fix to load our stylesheets after editor CSS.
-		// See #3068 for the rationale of this fix. It should be no longer
-		// necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
-		if ( is_admin() ) {
-			$block_style_dependencies = array( 'wp-edit-post' );
-		} else {
-			$block_style_dependencies = array();
-		}
-
-		self::register_style( 'wc-block-vendors-style', plugins_url( $asset_api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ), $block_style_dependencies );
-		self::register_style( 'wc-block-editor', plugins_url( $asset_api->get_block_asset_build_path( 'editor', 'css' ), __DIR__ ), array( 'wp-edit-blocks' ) );
-		self::register_style( 'wc-block-style', plugins_url( $asset_api->get_block_asset_build_path( 'style', 'css' ), __DIR__ ), array( 'wc-block-vendors-style' ) );
-
-		wp_style_add_data( 'wc-block-editor', 'rtl', 'replace' );
-		wp_style_add_data( 'wc-block-style', 'rtl', 'replace' );
-
-		// Shared libraries and components across multiple blocks.
-		$asset_api->register_script( 'wc-blocks-middleware', 'build/wc-blocks-middleware.js', [], false );
-		$asset_api->register_script( 'wc-blocks-data-store', 'build/wc-blocks-data.js', [ 'wc-blocks-middleware' ], false );
-		$asset_api->register_script( 'wc-blocks', $asset_api->get_block_asset_build_path( 'blocks' ), [], false );
-		$asset_api->register_script( 'wc-vendors', $asset_api->get_block_asset_build_path( 'vendors' ), [], false );
-		$asset_api->register_script( 'wc-blocks-registry', 'build/wc-blocks-registry.js', [], false );
-		$asset_api->register_script( 'wc-shared-context', 'build/wc-shared-context.js', [], false );
-		$asset_api->register_script( 'wc-shared-hocs', 'build/wc-shared-hocs.js', [], false );
-		$asset_api->register_script( 'wc-price-format', 'build/price-format.js', [], false );
-
-		if ( Package::feature()->is_feature_plugin_build() ) {
-			$asset_api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [], false );
-		}
-
-		wp_add_inline_script(
-			'wc-blocks-middleware',
-			"
-			var wcStoreApiNonce = '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "';
-			var wcStoreApiNonceTimestamp = '" . esc_js( time() ) . "';
-			",
-			'before'
-		);
-	}
-
-	/**
-	 * Add body classes.
-	 *
-	 * @param array $classes Array of CSS classnames.
-	 * @return array Modified array of CSS classnames.
-	 */
-	public static function add_theme_body_class( $classes = [] ) {
-		$classes[] = 'theme-' . get_template();
-		return $classes;
-	}
-
-	/**
-	 * Add theme class to admin body.
-	 *
-	 * @param array $classes String with the CSS classnames.
-	 * @return array Modified string of CSS classnames.
-	 */
-	public static function add_theme_admin_body_class( $classes = '' ) {
-		$classes .= ' theme-' . get_template();
-		return $classes;
-	}
-
-	/**
-	 * Adds a redirect field to the login form so blocks can redirect users after login.
-	 */
-	public static function redirect_to_field() {
-		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( empty( $_GET['redirect_to'] ) ) {
-			return;
-		}
-		echo '<input type="hidden" name="redirect" value="' . esc_attr( esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) ) . '" />'; // phpcs:ignore WordPress.Security.NonceVerification
-	}
-
-	/**
-	 * Get the file modified time as a cache buster if we're in dev mode.
-	 *
-	 * @param string $file Local path to the file.
-	 * @return string The cache buster value to use for the given file.
-	 */
-	protected static function get_file_version( $file ) {
-		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && file_exists( \Automattic\WooCommerce\Blocks\Package::get_path() . $file ) ) {
-			return filemtime( \Automattic\WooCommerce\Blocks\Package::get_path() . $file );
-		}
-		return \Automattic\WooCommerce\Blocks\Package::get_version();
-	}
-
 	/**
 	 * Queues a block script in the frontend.
 	 *
@@ -140,20 +36,4 @@ class Assets {
 		$asset_api->register_block_script( $script_name, $handle, $dependencies );
 	}
 
-	/**
-	 * Registers a style according to `wp_register_style`.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param string $handle Name of the stylesheet. Should be unique.
-	 * @param string $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
-	 * @param array  $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
-	 * @param string $media  Optional. The media for which this stylesheet has been defined. Default 'all'. Accepts media types like
-	 *                       'all', 'print' and 'screen', or media queries like '(orientation: portrait)' and '(max-width: 640px)'.
-	 */
-	protected static function register_style( $handle, $src, $deps = [], $media = 'all' ) {
-		$filename = str_replace( plugins_url( '/', __DIR__ ), '', $src );
-		$ver      = self::get_file_version( $filename );
-		wp_register_style( $handle, $src, $deps, $ver, $media );
-	}
 }

--- a/src/Domain/AssetsInitialization.php
+++ b/src/Domain/AssetsInitialization.php
@@ -1,0 +1,139 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Domain;
+
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+
+/**
+ * Class instance for assets initialization.
+ *
+ * @since 4.6.0
+ */
+class AssetsInitialization {
+
+	/**
+	 * Asset API interface for various asset registration.
+	 *
+	 * @var API
+	 */
+	private $api;
+
+	/**
+	 * Constructor
+	 *
+	 * @param Api $asset_api  Asset API interface for various asset registration.
+	 */
+	public function __construct( Api $asset_api ) {
+		$this->api = $asset_api;
+		$this->init();
+	}
+
+	/**
+	 * Hook into WP asset initialization.
+	 */
+	protected function init() {
+		add_action( 'init', array( $this, 'register_assets' ) );
+		add_action( 'body_class', array( __CLASS__, 'add_theme_body_class' ), 1 );
+		add_action( 'admin_body_class', array( __CLASS__, 'add_theme_admin_body_class' ), 1 );
+		add_action( 'woocommerce_login_form_end', array( __CLASS__, 'redirect_to_field' ) );
+	}
+
+	/**
+	 * Register block scripts & styles.
+	 *
+	 * @since 2.5.0
+	 * @since 4.6.0 moved from Assets.php in a refactor.
+	 */
+	public function register_assets() {
+		$this->register_blocks_styles();
+		$this->register_blocks_scripts();
+	}
+
+	/**
+	 * Register blocks styles.
+	 *
+	 * @since 4.6.0
+	 */
+	private function register_blocks_styles() {
+		// @todo Remove fix to load our stylesheets after editor CSS.
+		// See #3068 for the rationale of this fix. It should be no longer
+		// necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
+		if ( is_admin() ) {
+			$block_style_dependencies = array( 'wp-edit-post' );
+		} else {
+			$block_style_dependencies = array();
+		}
+
+		$this->api->register_style( 'wc-block-vendors-style', $this->api->get_block_asset_build_path( 'vendors-style', 'css' ), $block_style_dependencies );
+		$this->api->register_style( 'wc-block-editor', $this->api->get_block_asset_build_path( 'editor', 'css' ), array( 'wp-edit-blocks' ) );
+		$this->api->register_style( 'wc-block-style', $this->api->get_block_asset_build_path( 'style', 'css' ), array( 'wc-block-vendors-style' ) );
+
+		wp_style_add_data( 'wc-block-editor', 'rtl', 'replace' );
+		wp_style_add_data( 'wc-block-style', 'rtl', 'replace' );
+	}
+
+	/**
+	 * Register blocks scripts.
+	 *
+	 * @since 4.6.0
+	 */
+	private function register_blocks_scripts() {
+		// Shared libraries and components across multiple blocks.
+		$this->api->register_script( 'wc-blocks-middleware', 'build/wc-blocks-middleware.js', [], false );
+		$this->api->register_script( 'wc-blocks-data-store', 'build/wc-blocks-data.js', [ 'wc-blocks-middleware' ], false );
+		$this->api->register_script( 'wc-blocks', $this->api->get_block_asset_build_path( 'blocks' ), [], false );
+		$this->api->register_script( 'wc-vendors', $this->api->get_block_asset_build_path( 'vendors' ), [], false );
+		$this->api->register_script( 'wc-blocks-registry', 'build/wc-blocks-registry.js', [], false );
+		$this->api->register_script( 'wc-shared-context', 'build/wc-shared-context.js', [], false );
+		$this->api->register_script( 'wc-shared-hocs', 'build/wc-shared-hocs.js', [], false );
+		$this->api->register_script( 'wc-price-format', 'build/price-format.js', [], false );
+
+		if ( Package::feature()->is_feature_plugin_build() ) {
+			$this->api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [], false );
+		}
+
+		wp_add_inline_script(
+			'wc-blocks-middleware',
+			"
+			var wcStoreApiNonce = '" . esc_js( wp_create_nonce( 'wc_store_api' ) ) . "';
+			var wcStoreApiNonceTimestamp = '" . esc_js( time() ) . "';
+			",
+			'before'
+		);
+	}
+
+	/**
+	 * Add body classes.
+	 *
+	 * @param array $classes Array of CSS classnames.
+	 * @return array Modified array of CSS classnames.
+	 */
+	public static function add_theme_body_class( $classes = [] ) {
+		$classes[] = 'theme-' . get_template();
+		return $classes;
+	}
+
+	/**
+	 * Add theme class to admin body.
+	 *
+	 * @param array $classes String with the CSS classnames.
+	 * @return array Modified string of CSS classnames.
+	 */
+	public static function add_theme_admin_body_class( $classes = '' ) {
+		$classes .= ' theme-' . get_template();
+		return $classes;
+	}
+
+
+	/**
+	 * Adds a redirect field to the login form so blocks can redirect users after login.
+	 */
+	public static function redirect_to_field() {
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( empty( $_GET['redirect_to'] ) ) {
+			return;
+		}
+		echo '<input type="hidden" name="redirect" value="' . esc_attr( esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) ) . '" />'; // phpcs:ignore WordPress.Security.NonceVerification
+	}
+
+}

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -20,7 +20,6 @@ use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
 use Automattic\WooCommerce\Blocks\Domain\Services\CreateAccount;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
-use Automattic\WooCommerce\Blocks\Domain\Services\Email\CustomerNewAccount;
 use Automattic\WooCommerce\Blocks\StoreApi\Formatters;
 use Automattic\WooCommerce\Blocks\StoreApi\Formatters\MoneyFormatter;
 use Automattic\WooCommerce\Blocks\StoreApi\Formatters\HtmlFormatter;

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Domain;
 
 use Automattic\WooCommerce\Blocks\Assets as BlockAssets;
+use Automattic\WooCommerce\Blocks\Domain\AssetsInitialization;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Library;
@@ -79,6 +80,7 @@ class Bootstrap {
 		if ( ! $is_rest ) {
 			$this->add_build_notice();
 			$this->container->get( AssetDataRegistry::class );
+			$this->container->get( AssetsInitialization::class );
 			$this->container->get( Installer::class );
 			BlockAssets::init();
 		}
@@ -154,6 +156,13 @@ class Bootstrap {
 			function( Container $container ) {
 				$asset_api = $container->get( AssetApi::class );
 					return new AssetDataRegistry( $asset_api );
+			}
+		);
+		$this->container->register(
+			AssetsInitialization::class,
+			function( Container $container ) {
+				$asset_api = $container->get( AssetApi::class );
+					return new AssetsInitialization( $asset_api );
 			}
 		);
 		$this->container->register(

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Domain;
 
-use Automattic\WooCommerce\Blocks\Assets as BlockAssets;
 use Automattic\WooCommerce\Blocks\Domain\AssetsInitialization;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
@@ -81,7 +80,6 @@ class Bootstrap {
 			$this->container->get( AssetDataRegistry::class );
 			$this->container->get( AssetsInitialization::class );
 			$this->container->get( Installer::class );
-			BlockAssets::init();
 		}
 		$this->container->get( DraftOrders::class )->init();
 		$this->container->get( CreateAccount::class )->init();

--- a/src/Domain/Package.php
+++ b/src/Domain/Package.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Domain;
 
-use Automattic\WooCommerce\Blocks\Package as NewPackage;
 use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 
 /**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
As requested in #3868 a new `AssetsInitializaton` class was created in place of `Assets`. The new class is initialized in `Bootstrap` which matches the pattern used for the initialization of other classes. The `Assets` was stripped-down and only the method that was exposed externally is still in the class body.

<!-- Reference any related issues or PRs here -->
Fixes #3868

This is based on #3748 so it needs to wait on that.

### Changelog

> Add suggested changelog entry here.
Assets initialization cleanup.
