### PR TITLE
Show total sale badge in medium carts & make it display below price

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -174,10 +174,6 @@
 	}
 }
 
-.wc-block-components-product-price {
-	display: block;
-}
-
 .theme-twentysixteen {
 	.wc-block-grid {
 		// Prevent white theme styles.

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -174,6 +174,10 @@
 	}
 }
 
+.wc-block-components-product-price {
+	display: block;
+}
+
 .theme-twentysixteen {
 	.wc-block-grid {
 		// Prevent white theme styles.

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -256,22 +256,24 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 				</div>
 			</td>
 			<td className="wc-block-cart-item__total">
-				<ProductPrice
-					currency={ totalsCurrency }
-					format={ productPriceFormat }
-					price={ totalsPrice.getAmount() }
-				/>
-
-				{ quantity > 1 && (
-					<ProductSaleBadge
-						currency={ priceCurrency }
-						saleAmount={ getAmountFromRawPrice(
-							saleAmount,
-							priceCurrency
-						) }
-						format={ saleBadgePriceFormat }
+				<div className="wc-block-cart-item__total-price-and-sale-badge">
+					<ProductPrice
+						currency={ totalsCurrency }
+						format={ productPriceFormat }
+						price={ totalsPrice.getAmount() }
 					/>
-				) }
+
+					{ quantity > 1 && (
+						<ProductSaleBadge
+							currency={ priceCurrency }
+							saleAmount={ getAmountFromRawPrice(
+								saleAmount,
+								priceCurrency
+							) }
+							format={ saleBadgePriceFormat }
+						/>
+					) }
+				</div>
 			</td>
 		</tr>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -256,7 +256,7 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 				</div>
 			</td>
 			<td className="wc-block-cart-item__total">
-				<div className="wc-block-cart-item__total-price-and-sale-wrapper">
+				<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
 					<ProductPrice
 						currency={ totalsCurrency }
 						format={ productPriceFormat }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -256,7 +256,7 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 				</div>
 			</td>
 			<td className="wc-block-cart-item__total">
-				<div className="wc-block-cart-item__total-price-and-sale-badge">
+				<div className="wc-block-cart-item__total-price-and-sale-wrapper">
 					<ProductPrice
 						currency={ totalsCurrency }
 						format={ productPriceFormat }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -150,6 +150,14 @@ table.wc-block-cart-items {
 	display: flex;
 }
 
+.is-small {
+	.wc-block-cart-item__total {
+		.wc-block-components-sale-badge {
+			display: none;
+		}
+	}
+}
+
 .is-medium,
 .is-small,
 .is-mobile {
@@ -201,10 +209,6 @@ table.wc-block-cart-items {
 
 				.wc-block-components-formatted-money-amount {
 					display: inline-block;
-				}
-
-				.wc-block-components-sale-badge {
-					display: none;
 				}
 			}
 		}

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -150,7 +150,7 @@ table.wc-block-cart-items {
 	display: flex;
 }
 
-.wc-block-cart-item__total-price-and-sale-badge {
+.wc-block-cart-item__total-price-and-sale-wrapper {
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -150,6 +150,16 @@ table.wc-block-cart-items {
 	display: flex;
 }
 
+.wc-block-cart-item__total-price-and-sale-badge {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+
+	.wc-block-components-sale-badge {
+		margin-top: $gap-smallest;
+	}
+}
+
 .is-small {
 	.wc-block-cart-item__total {
 		.wc-block-components-sale-badge {

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -160,7 +160,8 @@ table.wc-block-cart-items {
 	}
 }
 
-.is-small {
+.is-small,
+.is-mobile {
 	.wc-block-cart-item__total {
 		.wc-block-components-sale-badge {
 			display: none;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -150,7 +150,7 @@ table.wc-block-cart-items {
 	display: flex;
 }
 
-.wc-block-cart-item__total-price-and-sale-wrapper {
+.wc-block-cart-item__total-price-and-sale-badge-wrapper {
 	display: flex;
 	flex-direction: column;
 	align-items: flex-end;


### PR DESCRIPTION
When the price and sale badge are short, they appear on the same line. During testing, the product sale badge was usually long enough to cause it to break onto a new line so this went unnoticed.

By setting the class `.wc-block-components-product-price` to be block it ensures the badge will always display below the price.

I also noticed that the sale badge didn't display when the block size was medium, so I have allowed it to display there. This was especially noticeable in the TwentyTwenty theme when the block size is always medium.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/5656702/108725265-1cf1a800-751e-11eb-833c-c035aa8400ae.png)

#### After
![image](https://user-images.githubusercontent.com/5656702/108726108-f8e29680-751e-11eb-9caa-ed150f94cb6b.png)


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Set your currency settings to display without a decimal place, like this: ![image](https://user-images.githubusercontent.com/3616980/108694932-fae92d00-74ff-11eb-8ab5-d2038527ea98.png)
1. Add a product that is on sale to your cart, if you've got an up to date WooCommerce Subscriptions repo (on branch: `feature/checkout-block-simple-multiple-subscriptions`) then add a subscription product that's on sale, too.
2. View the Cart block and ensure the price and sale badge display well.
3.

<!-- If you can, add the appropriate labels -->

### Changelog

> Ensure the sale badge is displayed well when a product price is short in the Cart block.