### PR TITLE
Add guards around monkey-patched `setNonce` function on apiFetch.

### DIFF
--- a/assets/js/data/shared-controls.ts
+++ b/assets/js/data/shared-controls.ts
@@ -37,6 +37,29 @@ const invalidJsonError = {
 	),
 };
 
+const setNonceOnFetch = ( headers: Headers ): void => {
+	if (
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore -- this does exist because it's monkey patched in
+		// middleware/store-api-nonce.
+		triggerFetch.setNonce &&
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore -- this does exist because it's monkey patched in
+		// middleware/store-api-nonce.
+		typeof triggerFetch.setNonce === 'function'
+	) {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore -- this does exist because it's monkey patched in
+		// middleware/store-api-nonce.
+		triggerFetch.setNonce( headers );
+	} else {
+		// eslint-disable-next-line no-console
+		console.error(
+			'The monkey patched function on APIFetch, "setNonce", is not present, likely another plugin or some other code has removed this augmentation'
+		);
+	}
+};
+
 /**
  * Default export for registering the controls with the store.
  *
@@ -59,18 +82,14 @@ export const controls = {
 								response,
 								headers: fetchResponse.headers,
 							} );
-							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-							// @ts-ignore -- this does exist but doesn't appear to be typed in the api-fetch types.
-							triggerFetch.setNonce( fetchResponse.headers );
+							setNonceOnFetch( fetchResponse.headers );
 						} )
 						.catch( () => {
 							reject( invalidJsonError );
 						} );
 				} )
 				.catch( ( errorResponse ) => {
-					// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-					// @ts-ignore -- this does exist but doesn't appear to be typed in the api-fetch types.
-					triggerFetch.setNonce( errorResponse.headers );
+					setNonceOnFetch( errorResponse.headers );
 					if ( typeof errorResponse.json === 'function' ) {
 						// Parse error response before rejecting it.
 						errorResponse


### PR DESCRIPTION
In a special control we created for automatically handling setting a new nonce on our fetch responses (via some [custom middleware](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/middleware/store-api-nonce.js) we monkey patch the `apiFetch` library to add a `setNonce` function.

In the move to TypeScript, it'd be nice to augment the type definition for apiFetch to include this monkey-patched function. I spent some time on trying to do this unsuccessfully (a large part of the difficulty lies in the default export). Given the limited use of this function, I don't think there's much value in spending too much time trying to type this so I'm fine with keeping `tslint-ignore` on this for now. 

However, what I do think is important is that we have appropriate guards in place for runtime execution where some external code might have either caused `setNonce` to be unset, or redefined it. So I decided to add that here instead. Since we rely on this for updating the nonce and having it missing could be problematic, I've added a console.error in the case where a valid `setNonce` function is not found to aid with debugging in the rare cases where this might happen. I'm comfortable with the message of this error (even for production builds) given the value this offers for troubleshooting in those environments.

## To Test

An easy way to test the impact of this change is to verify while in an incognito instance of the browser, test adding products to the cart via the "add to cart" button in the output of the All Products block in the frontend. Subsequent add to carts should work as expected (however, note that there is a known bug with clicking add to cart quickly on multiple products triggering multiple requests before one has completed, so in testing, allow time for each request to complete - which is when the quantity updates in the view).