### PR TITLE
Followups and improvements on TS implementation in the Cart data store.

### DIFF
--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -27,7 +27,7 @@ import type { ResponseError } from '../types';
  *
  * @param  {CartResponse}      response
  */
-export function receiveCart( response: CartResponse ) {
+export const receiveCart = ( response: CartResponse ) => {
 	const cart = ( mapKeys( response, ( _, key ) =>
 		camelCase( key )
 	) as unknown ) as Cart;
@@ -35,7 +35,7 @@ export function receiveCart( response: CartResponse ) {
 		type: types.RECEIVE_CART,
 		response: cart,
 	} as const;
-}
+};
 
 /**
  * Returns an action object used for receiving customer facing errors from the API.
@@ -45,51 +45,47 @@ export function receiveCart( response: CartResponse ) {
  * @param   {boolean}       [replace=true] Should existing errors be replaced,
  *                                         or should the error be appended.
  */
-export function receiveError(
+export const receiveError = (
 	error: ResponseError | null = null,
 	replace = true
-) {
-	return {
+) =>
+	( {
 		type: replace ? types.REPLACE_ERRORS : types.RECEIVE_ERROR,
 		error,
-	} as const;
-}
+	} as const );
 
 /**
  * Returns an action object used to track when a coupon is applying.
  *
  * @param  {string} [couponCode] Coupon being added.
  */
-export function receiveApplyingCoupon( couponCode: string ) {
-	return {
+export const receiveApplyingCoupon = ( couponCode: string ) =>
+	( {
 		type: types.APPLYING_COUPON,
 		couponCode,
-	} as const;
-}
+	} as const );
 
 /**
  * Returns an action object used to track when a coupon is removing.
  *
  * @param   {string} [couponCode] Coupon being removed..
  */
-export function receiveRemovingCoupon( couponCode: string ) {
-	return {
+export const receiveRemovingCoupon = ( couponCode: string ) =>
+	( {
 		type: types.REMOVING_COUPON,
 		couponCode,
-	} as const;
-}
+	} as const );
 
 /**
  * Returns an action object for updating a single cart item in the store.
  *
  * @param  {CartResponseItem} [response=null] A cart item API response.
  */
-export function receiveCartItem( response: CartResponseItem | null = null ) {
-	return {
+export const receiveCartItem = ( response: CartResponseItem | null = null ) =>
+	( {
 		type: types.RECEIVE_CART_ITEM,
 		cartItem: response,
-	} as const;
-}
+	} as const );
 
 /**
  * Returns an action object to indicate if the specified cart item quantity is
@@ -99,16 +95,15 @@ export function receiveCartItem( response: CartResponseItem | null = null ) {
  * @param   {boolean} [isPendingQuantity=true] Flag for update state; true if API
  *                                             request is pending.
  */
-export function itemIsPendingQuantity(
+export const itemIsPendingQuantity = (
 	cartItemKey: string,
 	isPendingQuantity = true
-) {
-	return {
+) =>
+	( {
 		type: types.ITEM_PENDING_QUANTITY,
 		cartItemKey,
 		isPendingQuantity,
-	} as const;
-}
+	} as const );
 
 /**
  * Returns an action object to remove a cart item from the store.
@@ -117,27 +112,25 @@ export function itemIsPendingQuantity(
  * @param   {boolean} [isPendingDelete=true] Flag for update state; true if API
  *                                           request is pending.
  */
-export function itemIsPendingDelete(
+export const itemIsPendingDelete = (
 	cartItemKey: string,
 	isPendingDelete = true
-) {
-	return {
+) =>
+	( {
 		type: types.RECEIVE_REMOVED_ITEM,
 		cartItemKey,
 		isPendingDelete,
-	} as const;
-}
+	} as const );
 
 /**
  * Returns an action object used to track when customer data is being updated
  * (billing and/or shipping).
  */
-export function updatingCustomerData( isResolving: boolean ) {
-	return {
+export const updatingCustomerData = ( isResolving: boolean ) =>
+	( {
 		type: types.UPDATING_CUSTOMER_DATA,
 		isResolving,
-	} as const;
-}
+	} as const );
 
 /**
  * Returns an action object used to track whether the shipping rate is being
@@ -145,12 +138,11 @@ export function updatingCustomerData( isResolving: boolean ) {
  *
  * @param  {boolean} isResolving True if shipping rate is being selected.
  */
-export function shippingRatesBeingSelected( isResolving: boolean ) {
-	return {
+export const shippingRatesBeingSelected = ( isResolving: boolean ) =>
+	( {
 		type: types.UPDATING_SELECTED_SHIPPING_RATE,
 		isResolving,
-	} as const;
-}
+	} as const );
 
 /**
  * Applies a coupon code and either invalidates caches, or receives an error if

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -3,6 +3,7 @@
  */
 import { registerStore } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
+import type { DispatchFromMap, SelectFromMap } from '@automattic/data-stores';
 
 /**
  * Internal dependencies
@@ -11,19 +12,25 @@ import { STORE_KEY } from './constants';
 import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
-import reducer from './reducers';
+import reducer, { State } from './reducers';
 import { controls } from '../shared-controls';
 
-registerStore( STORE_KEY, {
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore -- Can't figure out how to resolve this now
+registerStore< State >( STORE_KEY, {
 	reducer,
 	actions,
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore -- not sure how to resolve the type issues here.
-	controls: { ...dataControls, ...controls },
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	controls: { ...dataControls, ...controls } as any,
 	selectors,
 	resolvers,
 } );
 
 export const CART_STORE_KEY = STORE_KEY;
+
+declare module '@wordpress/data' {
+	function dispatch(
+		key: typeof CART_STORE_KEY
+	): DispatchFromMap< typeof actions >;
+	function select(
+		key: typeof CART_STORE_KEY
+	): SelectFromMap< typeof selectors >;
+}

--- a/assets/js/data/cart/reducers.ts
+++ b/assets/js/data/cart/reducers.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { CartItem } from '@woocommerce/types';
+import type { Reducer } from 'redux';
 
 /**
  * Internal dependencies
@@ -18,7 +19,7 @@ import type { CartAction } from './actions';
  */
 const cartItemsReducer = (
 	state: Array< CartItem > = [],
-	action: CartAction
+	action: Partial< CartAction >
 ) => {
 	switch ( action.type ) {
 		case types.RECEIVE_CART_ITEM:
@@ -41,10 +42,10 @@ const cartItemsReducer = (
  *
  * @return  {CartState}          New or existing state.
  */
-const reducer = (
-	state: CartState = defaultCartState,
-	action: CartAction
-): CartState => {
+const reducer: Reducer< CartState > = (
+	state = defaultCartState,
+	action: Partial< CartAction >
+) => {
 	switch ( action.type ) {
 		case types.RECEIVE_ERROR:
 			if ( action.error ) {
@@ -72,7 +73,7 @@ const reducer = (
 			}
 			break;
 		case types.APPLYING_COUPON:
-			if ( action.couponCode || action.couponCode === '' ) {
+			if ( action.couponCode ) {
 				state = {
 					...state,
 					metaData: {
@@ -83,7 +84,7 @@ const reducer = (
 			}
 			break;
 		case types.REMOVING_COUPON:
-			if ( action.couponCode || action.couponCode === '' ) {
+			if ( action.couponCode ) {
 				state = {
 					...state,
 					metaData: {
@@ -151,5 +152,7 @@ const reducer = (
 	}
 	return state;
 };
+
+export type State = ReturnType< typeof reducer >;
 
 export default reducer;

--- a/assets/js/data/cart/reducers.ts
+++ b/assets/js/data/cart/reducers.ts
@@ -73,7 +73,7 @@ const reducer: Reducer< CartState > = (
 			}
 			break;
 		case types.APPLYING_COUPON:
-			if ( action.couponCode ) {
+			if ( action.couponCode || action.couponCode === '' ) {
 				state = {
 					...state,
 					metaData: {
@@ -84,7 +84,7 @@ const reducer: Reducer< CartState > = (
 			}
 			break;
 		case types.REMOVING_COUPON:
-			if ( action.couponCode ) {
+			if ( action.couponCode || action.couponCode === '' ) {
 				state = {
 					...state,
 					metaData: {

--- a/assets/js/data/shared-controls.ts
+++ b/assets/js/data/shared-controls.ts
@@ -4,27 +4,17 @@
 import { __ } from '@wordpress/i18n';
 import triggerFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 
-export interface ApiFetchWithHeadersAction {
-	type: string;
-	options: APIFetchOptions;
-}
-
 /**
  * Dispatched a control action for triggering an api fetch call with no parsing.
  * Typically this would be used in scenarios where headers are needed.
  *
  * @param {APIFetchOptions} options The options for the API request.
- *
- * @return {ApiFetchWithHeadersAction} The control action descriptor.
  */
-export const apiFetchWithHeaders = (
-	options: APIFetchOptions
-): ApiFetchWithHeadersAction => {
-	return {
+export const apiFetchWithHeaders = ( options: APIFetchOptions ) =>
+	( {
 		type: 'API_FETCH_WITH_HEADERS',
 		options,
-	};
-};
+	} as const );
 
 /**
  * Error thrown when JSON cannot be parsed.
@@ -44,11 +34,9 @@ const invalidJsonError = {
  *                  the controls property of the registration object.
  */
 export const controls = {
-	API_FETCH_WITH_HEADERS( {
+	API_FETCH_WITH_HEADERS: ( {
 		options,
-	}: {
-		options: APIFetchOptions;
-	} ): Promise< unknown > {
+	}: ReturnType< typeof apiFetchWithHeaders > ): Promise< unknown > => {
 		return new Promise( ( resolve, reject ) => {
 			triggerFetch( { ...options, parse: false } )
 				.then( ( fetchResponse ) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,45 @@
 			"integrity": "sha512-xdiW5uBONTi3+R6Eee1PpsPxWQH9DGPpEu5NN0/uHd5DjL6EfBNAOI7qujz4eqz76bWoz2R/zRNNjCn91caWjw==",
 			"dev": true
 		},
+		"@automattic/data-stores": {
+			"version": "1.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@automattic/data-stores/-/data-stores-1.0.0-alpha.0.tgz",
+			"integrity": "sha512-HFf10YQ7Gmo3jZD39b/5DmlvG45HAdxl0zXomo9447AC1owWYYUzncigOzcU9lCFi8FCB0PUuHEPdW+03BonvQ==",
+			"dev": true,
+			"requires": {
+				"@wordpress/data": "^4.10.0",
+				"@wordpress/data-controls": "^1.4.0",
+				"@wordpress/url": "^2.8.2",
+				"debug": "^4.1.1",
+				"fast-json-stable-stringify": "^2.1.0",
+				"redux": "^4.0.4",
+				"tslib": "^1.10.0",
+				"wpcom-proxy-request": "^5.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"tslib": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/cli": {
 			"version": "7.13.0",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.13.0.tgz",
@@ -11647,6 +11686,12 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+			"dev": true
+		},
+		"component-event": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/component-event/-/component-event-0.1.4.tgz",
+			"integrity": "sha1-PeePwoeCOBeH4kvyp8U2vwFCybQ=",
 			"dev": true
 		},
 		"compute-scroll-into-view": {
@@ -26610,6 +26655,12 @@
 				}
 			}
 		},
+		"progress-event": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/progress-event/-/progress-event-1.0.0.tgz",
+			"integrity": "sha1-EUbfS2GEndvpPugfk2WvkbiQHFE=",
+			"dev": true
+		},
 		"promise": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -32151,6 +32202,12 @@
 			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
 			"dev": true
 		},
+		"uid": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/uid/-/uid-0.0.2.tgz",
+			"integrity": "sha1-XkpdS3gTi09w+J/Tx2/FmqnS8QM=",
+			"dev": true
+		},
 		"unbzip2-stream": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -32440,6 +32497,23 @@
 			"dev": true,
 			"requires": {
 				"upper-case": "^1.1.1"
+			}
+		},
+		"uppercamelcase": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/uppercamelcase/-/uppercamelcase-1.1.0.tgz",
+			"integrity": "sha1-Mk2YprOvx+iolT4QZBUJsOTiP5c=",
+			"dev": true,
+			"requires": {
+				"camelcase": "^1.2.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true
+				}
 			}
 		},
 		"uri-js": {
@@ -33988,6 +34062,54 @@
 			"dev": true,
 			"requires": {
 				"microevent.ts": "~0.1.1"
+			}
+		},
+		"wp-error": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/wp-error/-/wp-error-1.3.0.tgz",
+			"integrity": "sha1-cgJHqjJkJJkcWHdcsv7cm/2IVCA=",
+			"dev": true,
+			"requires": {
+				"builtin-status-codes": "^2.0.0",
+				"uppercamelcase": "^1.1.0"
+			},
+			"dependencies": {
+				"builtin-status-codes": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz",
+					"integrity": "sha1-byIAO6rPADzNKHr+aHIVH93FhXk=",
+					"dev": true
+				}
+			}
+		},
+		"wpcom-proxy-request": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-5.0.2.tgz",
+			"integrity": "sha512-2MTJNiadTdZIaobhv9XJiPa/7eS1CIF4Zzp0HUKee27lhCfdoMktrjF/K+WSj7LkFZvWVR37Qh7DWfRDUiNGNQ==",
+			"dev": true,
+			"requires": {
+				"component-event": "0.1.4",
+				"debug": "^3.1.0",
+				"progress-event": "~1.0.0",
+				"uid": "0.0.2",
+				"wp-error": "^1.3.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+					"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+					"dev": true
+				}
 			}
 		},
 		"wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "2.4.0",
+		"@automattic/data-stores": "^1.0.0-alpha.0",
 		"@babel/cli": "7.13.0",
 		"@babel/core": "7.13.1",
 		"@babel/plugin-proposal-class-properties": "7.13.0",


### PR DESCRIPTION
This PR is a followup to #3768 that improves the TS implementation in the Cart data store. In this PR:

- `@automattic/data-stores` is installed as a dev package to gain access to some helpful types/generics for use in our data stores (in particular [mapped-types](https://github.com/Automattic/wp-calypso/blob/61acc957638fc7009632af4c0c058aa6bc0e82b7/packages/data-stores/src/mapped-types.ts) which are implemented in the Cart Store registration (see 5d93996).
- Fixing TSLint warnings for the actions related to the `explicit-module-boundary-types` rule.  There's now only one warning for that lint rule. I'm thinking we might want to turn off this rule for typescript files (it's not handling the `as const` declaration well on non-arrow functions).
- Improving some typing in the reducer, controls and main entry point to remove usage of the `@ts-ignore` (as things are now properly typed! 🎉 ).

## To test

The changes here should have nil impact on production runtime. However, it does impact anything using the cart store so smoke testing of Cart and Checkout block (ensure coupons work and various interactivity related to cart data works) should be done.
