### PR TITLE
Inherit line height in Cart item total

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -64,7 +64,7 @@ table.wc-block-cart-items {
 		.wc-block-cart-item__total {
 			@include font-size(regular);
 			text-align: right;
-			line-height: 1.25;
+			line-height: inherit;
 		}
 		.wc-block-components-product-metadata {
 			margin-bottom: 0.75em;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will change the line height of the price and sale badge (and any other items that may appear in the total column of a Cart line item). Previously, this line height being set was causing the sale badge in this column to appear differently to the sale badge under the product name.

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/5656702/109493773-e0293200-7a84-11eb-8153-fdc47125835f.png)

#### After
![image](https://user-images.githubusercontent.com/5656702/109491715-dce07700-7a81-11eb-8dee-8258626b71ae.png)


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Add an item that's on sale to your cart then go to the cart block. Increase its quantity to 2 or more.
2. Verify the sale badges are the same height.
3. Try this with a subscription product and our branch of subscriptions checked out. The text in the sales badges will be longer but should still display well.
4. Try this in other themes to ensure the badges display the same in them.

<!-- If you can, add the appropriate labels -->

### Changelog

> Ensure sale badges have a uniform height in the Cart block.
