### PR TITLE
Only set wp-edit-post style dependency if it has already been enqueued

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -77,8 +77,8 @@ class Assets {
 		$asset_api = Package::container()->get( AssetApi::class );
 
 		// @todo Remove fix to load our stylesheets after editor CSS.
-		// See #3068 for the rationale of this fix. It should be no longer
-		// necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
+		// See #3068 and #3898 for the rationale of this fix. It should be no
+		// longer necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
 		if ( wp_style_is( 'wp-edit-post' ) ) {
 			$block_style_dependencies = array( 'wp-edit-post' );
 		} else {

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -25,6 +25,8 @@ class Assets {
 		add_action( 'admin_body_class', array( __CLASS__, 'add_theme_admin_body_class' ), 1 );
 		add_filter( 'woocommerce_shared_settings', array( __CLASS__, 'get_wc_block_data' ) );
 		add_action( 'woocommerce_login_form_end', array( __CLASS__, 'redirect_to_field' ) );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 	}
 
 	/**
@@ -37,16 +39,6 @@ class Assets {
 	public static function register_assets() {
 		$asset_api = Package::container()->get( AssetApi::class );
 
-		// @todo Remove fix to load our stylesheets after editor CSS.
-		// See #3068 for the rationale of this fix. It should be no longer
-		// necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
-		if ( is_admin() ) {
-			$block_style_dependencies = array( 'wp-edit-post' );
-		} else {
-			$block_style_dependencies = array();
-		}
-
-		self::register_style( 'wc-block-vendors-style', plugins_url( $asset_api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ), $block_style_dependencies );
 		self::register_style( 'wc-block-editor', plugins_url( $asset_api->get_block_asset_build_path( 'editor', 'css' ), __DIR__ ), array( 'wp-edit-blocks' ) );
 		self::register_style( 'wc-block-style', plugins_url( $asset_api->get_block_asset_build_path( 'style', 'css' ), __DIR__ ), array( 'wc-block-vendors-style' ) );
 
@@ -75,6 +67,24 @@ class Assets {
 			",
 			'before'
 		);
+	}
+
+	/**
+	 * Register the vendors style file. We need to do it after the other files
+	 * because we need to check if `wp-edit-post` has been enqueued.
+	 */
+	public static function enqueue_scripts() {
+		$asset_api = Package::container()->get( AssetApi::class );
+
+		// @todo Remove fix to load our stylesheets after editor CSS.
+		// See #3068 for the rationale of this fix. It should be no longer
+		// necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
+		if ( wp_style_is( 'wp-edit-post' ) ) {
+			$block_style_dependencies = array( 'wp-edit-post' );
+		} else {
+			$block_style_dependencies = array();
+		}
+		self::register_style( 'wc-block-vendors-style', plugins_url( $asset_api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ), $block_style_dependencies );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3626.

In #3219 we marked the Gutenberg post editor CSS as a dependency of our styles in the editor, that allowed us to print our styles after theirs to fix some specificity issues. That broken FSE, because the post editor CSS is not loaded when editing the templates.

This PR fixes that making so `wp-edit-post` is only marked as a dependency is it has already been enqueued.

### How to test the changes in this Pull Request:

1. Install a FSE compatible theme (ie, [Armando](https://wordpress.org/themes/download/armando.1.0.0.zip?nostats=1)).
2. Enable Gutenberg and WooCommerce.
3. Click on the _Site Editor_ sidebar menu item.
4. Verify the FSE page loads correctly.

Test for no regressions:

1. Create a post or page and add some WC Blocks.
2. Verify they look correct and styles loaded properly.
3. Publish that post or page.
4. In the frontend, verify blocks also look correct and styles loaded properly.

### Changelog

> Fix FSE not being visible when WC Blocks was enabled.