### PR TITLE
Show cart item subtotal instead of total in Cart and Checkout blocks

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -78,12 +78,12 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		.getAmount();
 	const totalsCurrency = getCurrencyFromPriceResponse( totals );
 
-	let lineTotal = parseInt( totals.line_total, 10 );
+	let lineSubtotal = parseInt( totals.line_subtotal, 10 );
 	if ( DISPLAY_CART_PRICES_INCLUDING_TAX ) {
-		lineTotal += parseInt( totals.line_total_tax, 10 );
+		lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
 	}
-	const totalsPrice = Dinero( {
-		amount: lineTotal,
+	const subtotalPrice = Dinero( {
+		amount: lineSubtotal,
 		precision: totalsCurrency.minorUnit,
 	} ).getAmount();
 	const subtotalPriceFormat = __experimentalApplyCheckoutFilter( {
@@ -153,7 +153,7 @@ const OrderSummaryItem = ( { cartItem } ) => {
 				<ProductPrice
 					currency={ totalsCurrency }
 					format={ productPriceFormat }
-					price={ totalsPrice }
+					price={ subtotalPrice }
 				/>
 			</div>
 		</div>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -86,8 +86,8 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 			currency_suffix: '',
 			currency_decimal_separator: '.',
 			currency_thousand_separator: ',',
-			line_total: '0',
-			line_total_tax: '0',
+			line_subtotal: '0',
+			line_subtotal_tax: '0',
 		},
 		extensions,
 	} = lineItem;
@@ -132,12 +132,12 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 	);
 	const saleAmount = saleAmountSingle.multiply( quantity );
 	const totalsCurrency = getCurrencyFromPriceResponse( totals );
-	let lineTotal = parseInt( totals.line_total, 10 );
+	let lineSubtotal = parseInt( totals.line_subtotal, 10 );
 	if ( DISPLAY_CART_PRICES_INCLUDING_TAX ) {
-		lineTotal += parseInt( totals.line_total_tax, 10 );
+		lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
 	}
-	const totalsPrice = Dinero( {
-		amount: lineTotal,
+	const subtotalPrice = Dinero( {
+		amount: lineSubtotal,
 		precision: totalsCurrency.minorUnit,
 	} );
 
@@ -260,7 +260,7 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 					<ProductPrice
 						currency={ totalsCurrency }
 						format={ productPriceFormat }
-						price={ totalsPrice.getAmount() }
+						price={ subtotalPrice.getAmount() }
 					/>
 
 					{ quantity > 1 && (

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -86,7 +86,7 @@ describe( 'Testing cart', () => {
 								currency_prefix: '',
 								currency_suffix: '€',
 								line_subtotal: '16',
-								line_total: '16',
+								line_total: '18',
 							},
 						},
 					],


### PR DESCRIPTION
Fixes #3904.

This PR fixes an issue introduced by myself in #3750 because I confused `total` and `subtotal`. In the Cart and Checkout blocks we want to display the Subtotal of cart items intead of the Total. This is how the shortcodes work and it makes it so coupon discounts, for example, aren't subtracted from the cart item price.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/109636611-12ea2d80-7b4c-11eb-8816-b37b4171c9bf.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/109644356-ab38e000-7b55-11eb-912f-cd4a4759169b.png)

Notice the cart item subtotal is now `20` instead of `10`.

### How to test the changes in this Pull Request:

1. Add a product to your cart.
2. Go to the Cart block and apply a coupon with a fixed cart discount.
3. Verify the cart item subtotal doesn't change when the coupon discount is applied.