### PR TITLE
Sync cart item quantity if its Implicitly changed.

### DIFF
--- a/assets/js/base/hooks/cart/use-store-cart-item-quantity.js
+++ b/assets/js/base/hooks/cart/use-store-cart-item-quantity.js
@@ -38,6 +38,12 @@ export const useStoreCartItemQuantity = ( cartItem ) => {
 	// Store quantity in hook state. This is used to keep the UI
 	// updated while server request is updated.
 	const [ quantity, changeQuantity ] = useState( cartItemQuantity );
+	// Quantity can be updated from somewhere else, this is to keep it in sync.
+	useEffect( () => {
+		if ( cartItemQuantity !== quantity ) {
+			changeQuantity( cartItemQuantity );
+		}
+	}, [ cartItemQuantity, quantity ] );
 	const [ debouncedQuantity ] = useDebounce( quantity, 400 );
 	const previousDebouncedQuantity = usePrevious( debouncedQuantity );
 	const { removeItemFromCart, changeCartItemQuantity } = useDispatch(


### PR DESCRIPTION
The main way of changing a cart item quantity is via the quantity selector, but quantity can be changed imperatively from the server, or from another source by directly calling the datastore. This PR fixes it so it's always synced.

This happens because we keep a local copy of the item quantity in a state for optimistic updates.

- We can move that state to the component level instead of the hook level and sync there.
- We can move the optimistic update section to the data store.
- We can react to changes in the data store and sync them back to the state in our hook.

The 1st option would require us to do the 3rd anyway, so I opted for the 3rd now.

### testing

- Add an item to your cart.
- In console, run `wp.data.dispatch('wc/store/cart').changeCartItemQuantity(wcSettings.cartData.items[0].key, 10)` this would change the quantity of your first item to 10.
- Make sure the quantity selector is now 10.
- Try updating it from the selector.

### changelog

> Fix a bug in which cart item quantity didn't react to the changes from server.
