### PR TITLE
Update extensions types and fix inconsistent type from server.

### DIFF
--- a/assets/js/data/default-states.ts
+++ b/assets/js/data/default-states.ts
@@ -75,7 +75,7 @@ export const defaultCartState: CartState = {
 		},
 		errors: [],
 		paymentRequirements: [],
-		extensions: [],
+		extensions: {},
 	},
 	metaData: {
 		updatingCustomerData: false,

--- a/assets/js/previews/cart.ts
+++ b/assets/js/previews/cart.ts
@@ -90,6 +90,7 @@ export const previewCart: CartResponse = {
 				line_total: '1600',
 				line_total_tax: '0',
 			},
+			extensions: {},
 		},
 		{
 			key: '2',
@@ -155,6 +156,7 @@ export const previewCart: CartResponse = {
 				line_total: '1400',
 				line_total_tax: '0',
 			},
+			extensions: {},
 		},
 	],
 	fees: [],

--- a/assets/js/previews/cart.ts
+++ b/assets/js/previews/cart.ts
@@ -165,6 +165,7 @@ export const previewCart: CartResponse = {
 	needs_payment: true,
 	needs_shipping: SHIPPING_ENABLED,
 	has_calculated_shipping: true,
+	extensions: {},
 	shipping_address: {
 		first_name: '',
 		last_name: '',

--- a/assets/js/type-defs/cart-response.ts
+++ b/assets/js/type-defs/cart-response.ts
@@ -45,6 +45,10 @@ export interface MetaKeyValue {
 	value: string;
 }
 
+export type ExtensionsData =
+	| Record< string, unknown >
+	| Record< string, never >;
+
 export interface CartResponseShippingRateItemShippingRate
 	extends CurrencyResponseInfo {
 	rate_id: string;
@@ -189,5 +193,5 @@ export interface CartResponse {
 	totals: CartResponseTotals;
 	errors: Array< CartResponseErrorItem >;
 	payment_requirements: Array< unknown >;
-	extensions: Array< CartResponseExtensionItem >;
+	extensions: ExtensionsData;
 }

--- a/assets/js/type-defs/cart.ts
+++ b/assets/js/type-defs/cart.ts
@@ -123,6 +123,7 @@ export interface CartItem {
 	variation: Array< CartVariationItem >;
 	prices: CartItemPrices;
 	totals: CartItemTotals;
+	extensions: ExtensionsData;
 }
 
 export interface CartTotalsTaxLineItem {
@@ -160,9 +161,7 @@ export interface CartErrorItem {
 	message: string;
 }
 
-export interface CartExtensionItem {
-	[ key: string ]: unknown;
-}
+export type ExtensionsData = Record< string, unknown >;
 export interface Cart {
 	coupons: Array< CartCouponItem >;
 	shippingRates: Array< CartShippingRateItem >;
@@ -178,7 +177,7 @@ export interface Cart {
 	totals: CartTotals;
 	errors: Array< CartErrorItem >;
 	paymentRequirements: Array< unknown >;
-	extensions: Array< CartExtensionItem >;
+	extensions: ExtensionsData;
 }
 export interface CartMeta {
 	updatingCustomerData: boolean;

--- a/assets/js/type-defs/cart.ts
+++ b/assets/js/type-defs/cart.ts
@@ -3,7 +3,11 @@
 /**
  * Internal dependencies
  */
-import { MetaKeyValue, ShippingRateItemItem } from './cart-response';
+import {
+	MetaKeyValue,
+	ShippingRateItemItem,
+	ExtensionsData,
+} from './cart-response';
 export interface CurrencyInfo {
 	currency_code: string;
 	currency_symbol: string;
@@ -161,7 +165,6 @@ export interface CartErrorItem {
 	message: string;
 }
 
-export type ExtensionsData = Record< string, unknown > | Record< string, never >;
 export interface Cart {
 	coupons: Array< CartCouponItem >;
 	shippingRates: Array< CartShippingRateItem >;

--- a/assets/js/type-defs/cart.ts
+++ b/assets/js/type-defs/cart.ts
@@ -161,7 +161,7 @@ export interface CartErrorItem {
 	message: string;
 }
 
-export type ExtensionsData = Record< string, unknown >;
+export type ExtensionsData = Record< string, unknown > | Record< string, never >;
 export interface Cart {
 	coupons: Array< CartCouponItem >;
 	shippingRates: Array< CartShippingRateItem >;

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -78,6 +78,7 @@ final class ExtendRestApi {
 	 *     @type string   $namespace Plugin namespace.
 	 *     @type callable $schema_callback Callback executed to add schema data.
 	 *     @type callable $data_callback Callback executed to add endpoint data.
+	 *     @type string   $data_type The type of data, object or array.
 	 * }
 	 *
 	 * @throws Exception On failure to register.
@@ -102,9 +103,16 @@ final class ExtendRestApi {
 			$this->throw_exception( '$data_callback must be a callable function.' );
 		}
 
+		if ( isset( $args['data_type'] ) && ! in_array( $args['data_type'], [ ARRAY_N, ARRAY_A ], true ) ) {
+			$this->throw_exception(
+				sprintf( 'Data type must be either ARRAY_N for a numeric array or ARRAY_A for an object like array. You provided %1$s.', $args['endpoint'] )
+			);
+		}
+
 		$this->extend_data[ $args['endpoint'] ][ $args['namespace'] ] = [
 			'schema_callback' => $args['schema_callback'],
 			'data_callback'   => $args['data_callback'],
+			'data_type'       => isset( $args['data_type'] ) ? $args['data_type'] : ARRAY_A,
 		];
 
 		return true;
@@ -140,6 +148,41 @@ final class ExtendRestApi {
 			$registered_data[ $namespace ] = $data;
 		}
 		return (object) $registered_data;
+	}
+
+	/**
+	 * Returns the registered endpoint schema
+	 *
+	 * @param string $endpoint    A valid identifier.
+	 * @param array  $passed_args Passed arguments from the Schema class.
+	 * @return array Returns an array with registered schema data.
+	 * @throws Exception If a registered callback throws an error, or silently logs it.
+	 */
+	public function get_endpoint_schema( $endpoint, array $passed_args = [] ) {
+		$registered_schema = [];
+		if ( ! isset( $this->extend_data[ $endpoint ] ) ) {
+			return (object) $registered_schema;
+		}
+
+		foreach ( $this->extend_data[ $endpoint ] as $namespace => $callbacks ) {
+			$schema = [];
+
+			try {
+				$schema = $callbacks['schema_callback']( ...$passed_args );
+
+				if ( ! is_array( $schema ) ) {
+					throw new Exception( '$schema_callback must return an array.' );
+				}
+			} catch ( Throwable $e ) {
+				$this->throw_exception( $e );
+				continue;
+			}
+
+			$schema = $this->format_extensions_properties( $namespace, $schema, $callbacks['data_type'] );
+
+			$registered_schema[ $namespace ] = $schema;
+		}
+		return (object) $registered_schema;
 	}
 
 	/**
@@ -197,41 +240,6 @@ final class ExtendRestApi {
 	}
 
 	/**
-	 * Returns the registered endpoint schema
-	 *
-	 * @param string $endpoint    A valid identifier.
-	 * @param array  $passed_args Passed arguments from the Schema class.
-	 * @return array Returns an array with registered schema data.
-	 * @throws Exception If a registered callback throws an error, or silently logs it.
-	 */
-	public function get_endpoint_schema( $endpoint, array $passed_args = [] ) {
-		$registered_schema = [];
-		if ( ! isset( $this->extend_data[ $endpoint ] ) ) {
-			return (object) $registered_schema;
-		}
-
-		foreach ( $this->extend_data[ $endpoint ] as $namespace => $callbacks ) {
-			$schema = [];
-
-			try {
-				$schema = $callbacks['schema_callback']( ...$passed_args );
-
-				if ( ! is_array( $schema ) ) {
-					throw new Exception( '$schema_callback must return an array.' );
-				}
-			} catch ( Throwable $e ) {
-				$this->throw_exception( $e );
-				continue;
-			}
-
-			$schema = $this->format_extensions_properties( $namespace, $schema );
-
-			$registered_schema[ $namespace ] = $schema;
-		}
-		return (object) $registered_schema;
-	}
-
-	/**
 	 * Throws error and/or silently logs it.
 	 *
 	 * @param string|Throwable $exception_or_error Error message or Exception.
@@ -255,10 +263,21 @@ final class ExtendRestApi {
 	 *
 	 * @param string $namespace Error message or Exception.
 	 * @param array  $schema An error to throw if we have debug enabled and user is admin.
+	 * @param string $data_type How should data be shaped.
 	 *
 	 * @return array Formatted schema.
 	 */
-	private function format_extensions_properties( $namespace, $schema ) {
+	private function format_extensions_properties( $namespace, $schema, $data_type ) {
+		if ( ARRAY_N === $data_type ) {
+			return [
+				/* translators: %s: extension namespace */
+				'description' => sprintf( __( 'Extension data registered by %s', 'woo-gutenberg-products-block' ), $namespace ),
+				'type'        => [ 'array', 'null' ],
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => $schema,
+			];
+		}
 		return [
 			/* translators: %s: extension namespace */
 			'description' => sprintf( __( 'Extension data registered by %s', 'woo-gutenberg-products-block' ), $namespace ),

--- a/src/Domain/Services/ExtendRestApi.php
+++ b/src/Domain/Services/ExtendRestApi.php
@@ -105,7 +105,7 @@ final class ExtendRestApi {
 
 		if ( isset( $args['data_type'] ) && ! in_array( $args['data_type'], [ ARRAY_N, ARRAY_A ], true ) ) {
 			$this->throw_exception(
-				sprintf( 'Data type must be either ARRAY_N for a numeric array or ARRAY_A for an object like array. You provided %1$s.', $args['endpoint'] )
+				sprintf( 'Data type must be either ARRAY_N for a numeric array or ARRAY_A for an object like array. You provided %1$s.', $args['data_type'] )
 			);
 		}
 


### PR DESCRIPTION
Extensions data wasn't inside our preview data, so it would break Cart and Checkout in the editor if you had WCS Subscriptions integration on.

It also updates some types to the correct format.

I also added a new param to `extendRestApi::register_endpoint_data` `schema_type` which can be either `ARRAY_N` or `ARRAY_A` to signal if the data schema should be an object or an array of items.
The value is optional and defaults to `ARRAY_A`.

### Testing
- Enable WCS in our feature branch `feature/checkout-block-simple-multiple-subscriptions` and build `npm run build`.
-  Visit the editor and insert cart or checkout.

### changelog
> Update ExtendRestApi to include the type of extended data.

