### PR TITLE
Add OrderSummary test for #3876

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/test/index.js
+++ b/assets/js/base/components/cart-checkout/order-summary/test/index.js
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { previewCart } from '@woocommerce/resource-previews';
+
+/**
+ * Internal dependencies
+ */
+import OrderSummary from '../index';
+
+jest.mock( '@woocommerce/base-context', () => ( {
+	...jest.requireActual( '@woocommerce/base-context' ),
+	useContainerWidthContext: () => ( {
+		isLarge: false,
+		hasContainerWidth: true,
+	} ),
+} ) );
+
+describe( 'Order Summary', () => {
+	it( 'renders correct cart line subtotal when currency has 0 decimals', async () => {
+		render(
+			<OrderSummary
+				cartItems={ [
+					{
+						...previewCart.items[ 0 ],
+						totals: {
+							...previewCart.items[ 0 ].totals,
+							// Change price format so there are no decimals.
+							currency_minor_unit: 0,
+							currency_prefix: '',
+							currency_suffix: '€',
+							line_subtotal: '16',
+							line_total: '18',
+						},
+					},
+				] }
+			/>
+		);
+
+		expect( screen.getByText( '16€' ) ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
This PR adds an extra test to the changes introduced in #3876. That PR only included tests covering the Cart block but not the Checkout block (which uses the `OrderSummary` component).

### How to test the changes in this Pull Request:

1. Verify tests pass.
