### PR TITLE
Update @wordpress/is-shallow-equal to v3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6971,12 +6971,12 @@
 			}
 		},
 		"@wordpress/is-shallow-equal": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.8.0.tgz",
-			"integrity": "sha512-OV3qJqP9LhjuOzt85TsyBwv+//CvC8Byf/81D3NmjPKlstLaD/bBCC5nBhH6dKAv4bShYtQ2Hmut+V4dZnOM1A==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.0.1.tgz",
+			"integrity": "sha512-enrOrfArOImeqT207i3ayZ0yPCnc/LvvvSPEd4aSPNV27zC7sTor/ksoN2NNyrGaC9P2pZ6IlkMEr+BCN02OXw==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.8.3"
+				"@babel/runtime": "^7.12.5"
 			}
 		},
 		"@wordpress/jest-console": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
 		"@wordpress/env": "3.0.0",
 		"@wordpress/html-entities": "2.8.0",
 		"@wordpress/i18n": "3.15.0",
-		"@wordpress/is-shallow-equal": "1.8.0",
+		"@wordpress/is-shallow-equal": "3.0.1",
 		"@wordpress/scripts": "13.0.1",
 		"autoprefixer": "10.2.3",
 		"axios": "0.21.1",


### PR DESCRIPTION
This PR updates @wordpress/is-shallow-equal to v3 so we can benefit from the typescript definitions.