### PR TITLE
Add missing step in e2e test for single product.

### DIFF
--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -166,6 +166,7 @@ jobs:
       - name: Npm install and build
         run: |
           npm ci
+          npm install @wordpress/e2e-test-utils@latest
           FORCE_REDUCED_MOTION=true npm run build:e2e-test
 
       - name: blocks.ini setup
@@ -201,7 +202,6 @@ jobs:
           npm run wp-env start
           npm run wp-env clean all
           npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
-          npm install @wordpress/e2e-test-utils@latest
           npm run test:e2e
 
   JSE2ETestsWP56:

--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -201,6 +201,7 @@ jobs:
           npm run wp-env start
           npm run wp-env clean all
           npm run wp-env run tests-cli "wp plugin install gutenberg --activate"
+          npm install @wordpress/e2e-test-utils@latest
           npm run test:e2e
 
   JSE2ETestsWP56:

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -8,7 +8,41 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+/**
+ * Due to an issue with the Popover component not being scrollable
+ * under certain conditions, Pupeteer cannot "see" the "Remove Block"
+ * button. This is a workaround until that issue is resolved.
+ *
+ * see: https://github.com/WordPress/gutenberg/pull/14908#discussion_r284725956
+ */
+const clickOnBlockSettingsMenuRemoveBlockButton = async () => {
+	await clickBlockToolbarButton( 'Options' );
 
+	let isRemoveButton = false;
+
+	let numButtons = await page.$$eval(
+		'.block-editor-block-settings-menu__content button',
+		( btns ) => btns.length
+	);
+
+	// Limit by the number of buttons available
+	while ( --numButtons ) {
+		await page.keyboard.press( 'Tab' );
+
+		isRemoveButton = await page.evaluate( () => {
+			return document.activeElement.innerText.includes( 'Remove block' );
+		} );
+
+		// Stop looping once we find the button
+		if ( isRemoveButton ) {
+			await pressKeyTimes( 'Enter', 1 );
+			break;
+		}
+	}
+
+	// Makes failures more explicit
+	await expect( isRemoveButton ).toBe( true );
+};
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 )
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( 'skipping all other things', () => {} );
@@ -28,7 +62,7 @@ describe( `${ block.name } Block`, () => {
 	it( 'can be inserted more than once', async () => {
 		await insertBlock( block.name );
 		expect( await getAllBlocks() ).toHaveLength( 2 );
-		await page.keyboard.press( 'Backspace' );
+		await clickOnBlockSettingsMenuRemoveBlockButton();
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );
 

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -28,10 +28,7 @@ describe( `${ block.name } Block`, () => {
 	it( 'can be inserted more than once', async () => {
 		await insertBlock( block.name );
 		expect( await getAllBlocks() ).toHaveLength( 2 );
-		await page.keyboard.down( 'Shift' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.up( 'Shift' );
-		await page.keyboard.press( 'Delete' );
+		await page.keyboard.press( 'Backspace' );
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );
 

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -5,6 +5,8 @@ import {
 	insertBlock,
 	getAllBlocks,
 	switchUserToAdmin,
+	pressKeyTimes,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
@@ -62,6 +64,9 @@ describe( `${ block.name } Block`, () => {
 	it( 'can be inserted more than once', async () => {
 		await insertBlock( block.name );
 		expect( await getAllBlocks() ).toHaveLength( 2 );
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.up( 'Shift' );
 		await clickOnBlockSettingsMenuRemoveBlockButton();
 		expect( await getAllBlocks() ).toHaveLength( 1 );
 	} );


### PR DESCRIPTION
npm install @wordpress/e2e-test-utils@latest was missing from the test configuration

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1.
2.
3.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.
