### PR TITLE
Update Single Product Test

### DIFF
--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -363,7 +363,7 @@ jobs:
       - name: Npm install and build
         run: |
           npm ci
-          npm install @wordpress/e2e-tests@1.9.1
+          npm install @wordpress/e2e-test-utils@4.5.0
           FORCE_REDUCED_MOTION=true npm run build:e2e-test
 
       - name: blocks.ini setup

--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -363,6 +363,7 @@ jobs:
       - name: Npm install and build
         run: |
           npm ci
+          npm install @wordpress/e2e-tests@1.9.1
           FORCE_REDUCED_MOTION=true npm run build:e2e-test
 
       - name: blocks.ini setup

--- a/bin/.htaccess
+++ b/bin/.htaccess
@@ -1,12 +1,15 @@
 # BEGIN WordPress
-# The directives (lines) between `BEGIN WordPress` and `END WordPress` are
+# The directives (lines) between "BEGIN WordPress" and "END WordPress" are
 # dynamically generated, and should only be modified via WordPress filters.
 # Any changes to the directives between these markers will be overwritten.
 <IfModule mod_rewrite.c>
 RewriteEngine On
+RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 RewriteBase /
 RewriteRule ^index\.php$ - [L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule . /index.php [L]
 </IfModule>
+
+# END WordPress

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -28,11 +28,8 @@ describe( `${ block.name } Block`, () => {
 	it( 'can be inserted more than once', async () => {
 		await insertBlock( block.name );
 		expect( await getAllBlocks() ).toHaveLength( 2 );
-		await page.keyboard.down( 'Shift' );
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.up( 'Shift' );
-		await page.keyboard.press( 'Delete' );
-		expect( await getAllBlocks() ).toHaveLength( 1 );
+		await insertBlock( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 3 );
 	} );
 
 	it( 'renders without crashing', async () => {

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -28,8 +28,6 @@ describe( `${ block.name } Block`, () => {
 	it( 'can be inserted more than once', async () => {
 		await insertBlock( block.name );
 		expect( await getAllBlocks() ).toHaveLength( 2 );
-		await insertBlock( block.name );
-		expect( await getAllBlocks() ).toHaveLength( 3 );
 	} );
 
 	it( 'renders without crashing', async () => {


### PR DESCRIPTION
Fixes e2e tests by removing an erroneous test from single product, and installing a compatible version of e2e-test-utils for WP 5.4