### PR TITLE
Only return a single handle for block styles

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -198,7 +198,7 @@ abstract class AbstractBlock {
 	 * Get the editor style handle for this block type.
 	 *
 	 * @see $this->register_block_type()
-	 * @return string|array
+	 * @return string|null
 	 */
 	protected function get_block_type_editor_style() {
 		return 'wc-block-editor';
@@ -224,7 +224,7 @@ abstract class AbstractBlock {
 	 * Get the frontend style handle for this block type.
 	 *
 	 * @see $this->register_block_type()
-	 * @return string|array
+	 * @return string|null
 	 */
 	protected function get_block_type_style() {
 		return 'wc-block-style';

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -50,16 +50,6 @@ class Cart extends AbstractBlock {
 	}
 
 	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @see $this->register_block_type()
-	 * @return string|array
-	 */
-	protected function get_block_type_style() {
-		return [ 'wc-block-style', 'wc-block-vendors-style' ];
-	}
-
-	/**
 	 * Enqueue frontend assets for this block, just in time for rendering.
 	 *
 	 * @param array $attributes  Any attributes that currently are available from the block.

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -28,16 +28,6 @@ class SingleProduct extends AbstractBlock {
 	}
 
 	/**
-	 * Get the frontend style handle for this block type.
-	 *
-	 * @see $this->register_block_type()
-	 * @return string|array
-	 */
-	protected function get_block_type_style() {
-		return [ 'wc-block-style', 'wc-block-vendors-style' ];
-	}
-
-	/**
 	 * Render the block on the frontend.
 	 *
 	 * @param array  $attributes Block attributes.


### PR DESCRIPTION
For background, see https://github.com/WordPress/gutenberg/pull/29473

Gutenberg only expects a single style handle, not an array of handles. We already have vendor styles set up as a dependency of block styles, so enqueueing multiple handles is not needed. Behaviour does not change with this PR.

### Changelog

> Fix block style handle definition.
