### PR TITLE
Fix Storybook after TypeScript changes

### DIFF
--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -12,7 +12,7 @@ const {
 	getMainConfig,
 	getStylingConfig,
 } = require( '../bin/webpack-configs.js' );
-const tsConfig = require( '../tsconfig.json' );
+const tsConfig = require( '../tsconfig.base.json' );
 
 const aliases = Object.keys( tsConfig.compilerOptions.paths ).reduce(
 	( acc, key ) => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,10 +6,8 @@
 	"baseUrl": ".",
 	"module": "esnext",
 	"emitDeclarationOnly": true,
-	// Import non-ES modules as default imports.
 	"esModuleInterop": true,
 	"resolveJsonModule": true,
-	// Preserve JSX, allows compatibility with wp-element jsx babel transforms
 	"jsx": "preserve",
 	"target": "esnext",
 	"allowJs": true,
@@ -41,6 +39,7 @@
 	  "@woocommerce/block-hocs": [ "assets/js/hocs" ],
 	  "@woocommerce/blocks-registry": [ "assets/js/blocks-registry" ],
 	  "@woocommerce/blocks-checkout": [ "packages/checkout" ],
+	  "@woocommerce/price-format": [ "packages/prices" ],
 	  "@woocommerce/block-settings": [ "assets/js/settings/blocks" ],
 	  "@woocommerce/e2e-tests": [ "node_modules/woocommerce/tests/e2e" ],
 	  "@woocommerce/icons": [ "assets/js/icons" ],


### PR DESCRIPTION
`npm run storybook` was failing with an error:

```
ERR! TypeError: Cannot read property 'paths' of undefined
ERR!     at Object.<anonymous> (/wp-content/plugins/woocommerce-gutenberg-products-block/storybook/webpack.config.js:17:55)
```

(I think the issue was introduced in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3768 cc @nerrad)

This PR fixes it:
* Storybook's webpack config now points to `tsconfig.base.json`, where `compilerOptions` where moved.
* I needed to remove the comments from the JSON file in order not to throw when reading it.
* I also needed to add the `@woocommerce/price-format` alias.

### How to test the changes in this Pull Request:

1. Run `npm run storybook` and verify it generates the storybook and you can view it in the browser.
