### PR TITLE
Fix cart preview when shipping calculator is false and core setting for require address is true	

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -43,15 +43,13 @@ const ShippingLocation = ( { address } ) => {
 	const formattedLocation = addressParts.filter( Boolean ).join( ', ' );
 
 	return (
-		formattedLocation && (
-			<span className="wc-block-components-shipping-address">
-				{ sprintf(
-					/* translators: %s location. */
-					__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
-					formattedLocation
-				) + ' ' }
-			</span>
-		)
+		<span className="wc-block-components-shipping-address">
+			{ sprintf(
+				/* translators: %s location. */
+				__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
+				formattedLocation
+			) + ' ' }
+		</span>
 	);
 };
 

--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -42,6 +42,10 @@ const ShippingLocation = ( { address } ) => {
 
 	const formattedLocation = addressParts.filter( Boolean ).join( ', ' );
 
+	if ( ! formattedLocation ) {
+		return null;
+	}
+
 	return (
 		<span className="wc-block-components-shipping-address">
 			{ sprintf(

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.js
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.js
@@ -12,6 +12,7 @@ import {
 	ShippingLocation,
 } from '@woocommerce/base-components/cart-checkout';
 import { TotalsItem } from '@woocommerce/blocks-checkout';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -58,6 +59,12 @@ const TotalsShipping = ( {
 		isShippingCalculatorOpen,
 		setIsShippingCalculatorOpen,
 	};
+	// used for the editor logic as an extra check
+	// because previewData.cartHasCalculatedShipping is always true and shipping is always showed
+	const shippingCostRequiresAddress = getSetting(
+		'shippingCostRequiresAddress',
+		false
+	);
 
 	return (
 		<div
@@ -69,7 +76,8 @@ const TotalsShipping = ( {
 			<TotalsItem
 				label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
 				value={
-					cartHasCalculatedShipping ? (
+					cartHasCalculatedShipping &&
+					! shippingCostRequiresAddress ? (
 						totalShippingValue
 					) : (
 						<NoShippingPlaceholder
@@ -80,13 +88,14 @@ const TotalsShipping = ( {
 				}
 				description={
 					<>
-						{ cartHasCalculatedShipping && (
-							<ShippingAddress
-								shippingAddress={ shippingAddress }
-								showCalculator={ showCalculator }
-								{ ...calculatorButtonProps }
-							/>
-						) }
+						{ cartHasCalculatedShipping &&
+							! shippingCostRequiresAddress && (
+								<ShippingAddress
+									shippingAddress={ shippingAddress }
+									showCalculator={ showCalculator }
+									{ ...calculatorButtonProps }
+								/>
+							) }
 					</>
 				}
 				currency={ currency }
@@ -98,13 +107,15 @@ const TotalsShipping = ( {
 					} }
 				/>
 			) }
-			{ showRateSelector && cartHasCalculatedShipping && (
-				<ShippingRateSelector
-					hasRates={ hasRates }
-					shippingRates={ shippingRates }
-					shippingRatesLoading={ shippingRatesLoading }
-				/>
-			) }
+			{ showRateSelector &&
+				cartHasCalculatedShipping &&
+				! shippingCostRequiresAddress && (
+					<ShippingRateSelector
+						hasRates={ hasRates }
+						shippingRates={ shippingRates }
+						shippingRatesLoading={ shippingRatesLoading }
+					/>
+				) }
 		</div>
 	);
 };

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -11,7 +11,6 @@ import {
 	ShippingLocation,
 } from '@woocommerce/base-components/cart-checkout';
 import { TotalsItem } from '@woocommerce/blocks-checkout';
-import { getSetting } from '@woocommerce/settings';
 import type { Currency } from '@woocommerce/price-format';
 import type { ReactElement } from 'react';
 /**
@@ -144,12 +143,6 @@ const TotalsShipping = ( {
 		isShippingCalculatorOpen,
 		setIsShippingCalculatorOpen,
 	};
-	// used for the editor logic as an extra check
-	// because previewData.cartHasCalculatedShipping is always true and shipping is always showed
-	const shippingCostRequiresAddress = getSetting(
-		'shippingCostRequiresAddress',
-		false
-	);
 
 	return (
 		<div
@@ -161,8 +154,7 @@ const TotalsShipping = ( {
 			<TotalsItem
 				label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
 				value={
-					cartHasCalculatedShipping &&
-					! shippingCostRequiresAddress ? (
+					cartHasCalculatedShipping ? (
 						totalShippingValue
 					) : (
 						<NoShippingPlaceholder
@@ -173,14 +165,13 @@ const TotalsShipping = ( {
 				}
 				description={
 					<>
-						{ cartHasCalculatedShipping &&
-							! shippingCostRequiresAddress && (
-								<ShippingAddress
-									shippingAddress={ shippingAddress }
-									showCalculator={ showCalculator }
-									{ ...calculatorButtonProps }
-								/>
-							) }
+						{ cartHasCalculatedShipping && (
+							<ShippingAddress
+								shippingAddress={ shippingAddress }
+								showCalculator={ showCalculator }
+								{ ...calculatorButtonProps }
+							/>
+						) }
 					</>
 				}
 				currency={ currency }
@@ -192,15 +183,13 @@ const TotalsShipping = ( {
 					} }
 				/>
 			) }
-			{ showRateSelector &&
-				cartHasCalculatedShipping &&
-				! shippingCostRequiresAddress && (
-					<ShippingRateSelector
-						hasRates={ hasRates }
-						shippingRates={ shippingRates }
-						shippingRatesLoading={ shippingRatesLoading }
-					/>
-				) }
+			{ showRateSelector && cartHasCalculatedShipping && (
+				<ShippingRateSelector
+					hasRates={ hasRates }
+					shippingRates={ shippingRates }
+					shippingRatesLoading={ shippingRatesLoading }
+				/>
+			) }
 		</div>
 	);
 };

--- a/assets/js/previews/cart.ts
+++ b/assets/js/previews/cart.ts
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
+	SHIPPING_COST_REQUIRES_ADDRESS,
 	SHIPPING_METHODS_EXIST,
 	WC_BLOCKS_ASSET_URL,
 	SHIPPING_ENABLED,
@@ -164,7 +165,7 @@ export const previewCart: CartResponse = {
 	items_weight: 0,
 	needs_payment: true,
 	needs_shipping: SHIPPING_ENABLED,
-	has_calculated_shipping: true,
+	has_calculated_shipping: ! SHIPPING_COST_REQUIRES_ADDRESS,
 	extensions: {},
 	shipping_address: {
 		first_name: '',

--- a/assets/js/settings/blocks/constants.js
+++ b/assets/js/settings/blocks/constants.js
@@ -49,6 +49,11 @@ export const IS_SHIPPING_CALCULATOR_ENABLED = getSetting(
 	'isShippingCalculatorEnabled',
 	true
 );
+// used for the editor logic as an extra check
+export const SHIPPING_COST_REQUIRES_ADDRESS = getSetting(
+	'shippingCostRequiresAddress',
+	false
+);
 export const IS_SHIPPING_COST_HIDDEN = getSetting(
 	'isShippingCostHidden',
 	false

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -162,6 +162,7 @@ class Assets {
 				'productCount'                  => array_sum( (array) $product_counts ),
 				'attributes'                    => array_values( wc_get_attribute_taxonomies() ),
 				'isShippingCalculatorEnabled'   => filter_var( get_option( 'woocommerce_enable_shipping_calc' ), FILTER_VALIDATE_BOOLEAN ),
+				'shippingCostRequiresAddress'   => filter_var( get_option( 'woocommerce_shipping_cost_requires_address' ), FILTER_VALIDATE_BOOLEAN ),
 				'wcBlocksAssetUrl'              => plugins_url( 'assets/', __DIR__ ),
 				'wcBlocksBuildUrl'              => plugins_url( 'build/', __DIR__ ),
 				'restApiRoutes'                 => [


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When WooCommerce > Settings > Shipping > Hide shipping costs until an address is entered is true and the cart block's Shipping calculator is false, the preview of the cart block should reflect what will be displayed on the front-end.

First commit actual fix, 2nd TS change.

<!-- Reference any related issues or PRs here -->
Fixes #3566

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->



### Screenshots
BEFORE: 
<img width="737" alt="Screenshot 2021-03-10 at 15 01 10" src="https://user-images.githubusercontent.com/1628454/110649430-7d851400-81b1-11eb-8eb0-b2a1cea80f63.png">


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
AFTER: 
<img width="1032" alt="Screenshot 2021-03-10 at 14 58 04" src="https://user-images.githubusercontent.com/1628454/110648926-10717e80-81b1-11eb-83c4-f57f254107f3.png">

### How to test the changes in this Pull Request:

- Tick WooCommerce > Settings > Shipping > Hide shipping costs until an address is entered
- Add a cart block to a page, and in the block options disable "Shipping Calculator"
- See the preview of the block

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix cart preview when shipping rates are set to be hidden until an address is entered.