### PR TITLE
Fix "save payment" checkbox not showing for payment methods

### DIFF
--- a/assets/js/blocks/cart-checkout/payment-methods/payment-method-options.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/payment-method-options.js
@@ -58,7 +58,7 @@ const PaymentMethodOptions = () => {
 					  } ),
 			name: `wc-saved-payment-method-token-${ name }`,
 			content: (
-				<PaymentMethodCard allowsSaving={ supports.savePaymentInfo }>
+				<PaymentMethodCard showSaveOption={ supports.showSaveOption }>
 					{ cloneElement( component, {
 						activePaymentMethod,
 						...paymentMethodInterface,


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3928
Regression from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3439
Initially implemented int https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686

The issue is that "save payment method" checkbox is not visible on payment methods that sets it.
We updated some of our support methods to provide more granular control over saving cards, #3686 did the change.
#3439 existed before but was merged after, a bad rebase brought in the old code instead of the new, causing the updated variable to not pass, something TS would have caught.

### Testing
- Enable stripe or WCPay (stripe is easier).
- Enable using saved payment methods.
- Add a regular (not a subscription product) to your cart and checkout.
- Open Stripe payment box, see if the save checkbox is visible.

### Changelog
> Fix an issue in which "Save payment information" didn't show up for payment methods that supported it.