### PR TITLE
Remove extra padding from payment methods with no description

### DIFF
--- a/assets/js/blocks/cart-checkout/payment-methods/style.scss
+++ b/assets/js/blocks/cart-checkout/payment-methods/style.scss
@@ -235,6 +235,10 @@
 
 .wc-block-components-radio-control-accordion-content {
 	padding: 0 $gap em($gap) $gap;
+
+	&:empty {
+		display: none;
+	}
 }
 
 .wc-block-checkout__order-notes {

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -26,7 +26,7 @@ const label = decodeEntities( settings.title ) || defaultLabel;
  * Content component
  */
 const Content = () => {
-	return <div>{ decodeEntities( settings.description || '' ) }</div>;
+	return decodeEntities( settings.description || '' );
 };
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -23,7 +23,7 @@ const label = decodeEntities( settings.title ) || defaultLabel;
  * Content component
  */
 const Content = () => {
-	return <div>{ decodeEntities( settings.description || '' ) }</div>;
+	return decodeEntities( settings.description || '' );
 };
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/cod/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cod/index.js
@@ -23,7 +23,7 @@ const label = decodeEntities( settings.title ) || defaultLabel;
  * Content component
  */
 const Content = () => {
-	return <div>{ decodeEntities( settings.description || '' ) }</div>;
+	return decodeEntities( settings.description || '' );
 };
 
 /**

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -21,7 +21,7 @@ const settings = getSetting( 'paypal_data', {} );
  * Content component
  */
 const Content = () => {
-	return <div>{ decodeEntities( settings.description || '' ) }</div>;
+	return decodeEntities( settings.description || '' );
 };
 
 const paypalPaymentMethod = {

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -55,7 +55,7 @@ const options = {
   edit: <div>A React node</div>,
   canMakePayment: () => true,
   paymentMethodId: 'new_payment_method',
-  supports = {
+  supports: {
       features: [],
   }
 };


### PR DESCRIPTION
This PR:
* Fixes an issue that was displaying too much bottom padding in the selected payment method if it had no description (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3952/commits/8a5816ff846a56c5cd056cf95d31ac014a463b7b).
* Fixes a typo in a code snippet in payment method integration docs (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3952/commits/2e4b719f3a49330b5c58615d50b39eb598e8ed4a).

### Screenshots

_Before:_
<img src="https://user-images.githubusercontent.com/3616980/110822161-150d6400-8291-11eb-91c9-a442b63d5f67.gif" alt="Screenshot before" width="548" />
(notice the extra padding that appears when selecting check payments)

_After:_
<img src="https://user-images.githubusercontent.com/3616980/110822189-19d21800-8291-11eb-8c51-bdca2bfdc087.gif" alt="Screenshot before" width="548" />

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Payments, edit one of the payment methods and remove any text in its description field.
2. Go to the Checkout block and select the payment method you modified in step 1.
3. Verify there isn't extra padding at the bottom.
