### PR TITLE
Always set value in the fromEntries polyfill

### DIFF
--- a/assets/js/base/utils/from-entries-polyfill.ts
+++ b/assets/js/base/utils/from-entries-polyfill.ts
@@ -8,8 +8,6 @@ export const fromEntriesPolyfill = (
 	array: Array< [ string, unknown ] >
 ): Record< string, unknown > =>
 	array.reduce< Record< string, unknown > >( ( obj, [ key, val ] ) => {
-		if ( val ) {
-			obj[ key ] = val;
-		}
+		obj[ key ] = val;
 		return obj;
 	}, {} );


### PR DESCRIPTION
The new fromEntries polyfill strips empty values. This causes a error boundary hit in incognito mode on the cart page due to missing address postcode. The fix is to always set the value.