### PR TITLE
Allow FormattedMonetaryAmount to deal with string based numbers

### DIFF
--- a/assets/js/base/components/formatted-monetary-amount/index.tsx
+++ b/assets/js/base/components/formatted-monetary-amount/index.tsx
@@ -17,7 +17,7 @@ import './style.scss';
 interface FormattedMonetaryAmountProps {
 	className?: string;
 	displayType?: NumberFormatProps[ 'displayType' ];
-	value: number; // Value of money amount.
+	value: number | string; // Value of money amount.
 	currency: Currency | Record< string, never >; // Currency configuration object.
 	onValueChange?: ( unit: number ) => void; // Function to call when value changes.
 }
@@ -46,12 +46,15 @@ const currencyToNumberFormat = (
  */
 const FormattedMonetaryAmount = ( {
 	className,
-	value,
+	value: rawValue,
 	currency,
 	onValueChange,
 	displayType = 'text',
 	...props
 }: FormattedMonetaryAmountProps ): ReactElement | null => {
+	const value =
+		typeof rawValue === 'string' ? parseInt( rawValue, 10 ) : rawValue;
+
 	if ( ! Number.isFinite( value ) ) {
 		return null;
 	}


### PR DESCRIPTION
Some of the typescript changes touched `FormattedMonetaryAmount` where we asserted value would be numeric. Prices for products are numeric, but are strings. This causes the price component to render as null.

To fix this, I've added string to number conversion in `FormattedMonetaryAmount` and updated the incoming types.

Fixes #3954

### How to test the changes in this Pull Request:

1. View all Products Block
2. Confirm prices are displayed
3. Confirm prices still display in cart/checkout to verify no regressions
