### PR TITLE
Add new config property for payment method registration that allows for additional saved customer token handling.

### DIFF
--- a/assets/js/blocks-registry/payment-methods/payment-method-config.js
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.js
@@ -14,6 +14,10 @@ import {
 
 import { canMakePaymentWithFeaturesCheck } from './payment-method-config-helper';
 
+const NullComponent = () => {
+	return null;
+};
+
 export default class PaymentMethodConfig {
 	constructor( config ) {
 		// validate config
@@ -23,6 +27,7 @@ export default class PaymentMethodConfig {
 		this.placeOrderButtonLabel = config.placeOrderButtonLabel;
 		this.ariaLabel = config.ariaLabel;
 		this.content = config.content;
+		this.savedTokenComponent = config.savedTokenComponent;
 		this.icons = config.icons;
 		this.edit = config.edit;
 		this.paymentMethodId = config.paymentMethodId || this.name;
@@ -41,6 +46,10 @@ export default class PaymentMethodConfig {
 	}
 
 	static assertValidConfig = ( config ) => {
+		// set default for optional
+		config.savedTokenComponent = config.savedTokenComponent || (
+			<NullComponent />
+		);
 		assertConfigHasProperties( config, [
 			'name',
 			'label',
@@ -82,6 +91,7 @@ export default class PaymentMethodConfig {
 		assertValidElementOrString( config.label, 'label' );
 		assertValidElement( config.content, 'content' );
 		assertValidElement( config.edit, 'edit' );
+		assertValidElement( config.savedTokenComponent, 'savedTokenComponent' );
 		if ( typeof config.ariaLabel !== 'string' ) {
 			throw new TypeError(
 				'The ariaLabel property for the payment method must be a string'

--- a/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
@@ -1,10 +1,19 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef, useCallback } from '@wordpress/element';
+import {
+	useEffect,
+	useRef,
+	useCallback,
+	cloneElement,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { usePaymentMethodDataContext } from '@woocommerce/base-context';
 import RadioControl from '@woocommerce/base-components/radio-control';
+import {
+	usePaymentMethodInterface,
+	usePaymentMethods,
+} from '@woocommerce/base-hooks';
 import { getPaymentMethods } from '@woocommerce/blocks-registry';
 
 /**
@@ -94,6 +103,8 @@ const SavedPaymentMethodOptions = () => {
 		setActiveSavedToken,
 	} = usePaymentMethodDataContext();
 	const standardMethods = getPaymentMethods();
+	const { paymentMethods } = usePaymentMethods();
+	const paymentMethodInterface = usePaymentMethodInterface();
 
 	/**
 	 * @type      {Object} Options
@@ -152,13 +163,25 @@ const SavedPaymentMethodOptions = () => {
 		standardMethods,
 	] );
 
+	const savedPaymentMethodHandler =
+		paymentMethods[ activePaymentMethod ] &&
+		paymentMethods[ activePaymentMethod ]?.savedTokenComponent
+			? cloneElement(
+					paymentMethods[ activePaymentMethod ]?.savedTokenComponent,
+					{ token: activeSavedToken, ...paymentMethodInterface }
+			  )
+			: null;
+
 	return currentOptions.current.length > 0 ? (
-		<RadioControl
-			id={ 'wc-payment-method-saved-tokens' }
-			selected={ activeSavedToken }
-			onChange={ updateToken }
-			options={ currentOptions.current }
-		/>
+		<>
+			<RadioControl
+				id={ 'wc-payment-method-saved-tokens' }
+				selected={ activeSavedToken }
+				onChange={ updateToken }
+				options={ currentOptions.current }
+			/>
+			{ savedPaymentMethodHandler }
+		</>
 	) : null;
 };
 

--- a/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
@@ -164,6 +164,7 @@ const SavedPaymentMethodOptions = () => {
 	] );
 
 	const savedPaymentMethodHandler =
+		!! activeSavedToken &&
 		paymentMethods[ activePaymentMethod ] &&
 		paymentMethods[ activePaymentMethod ]?.savedTokenComponent
 			? cloneElement(

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -6,6 +6,12 @@ The checkout block has an API interface for payment methods to integrate that co
 
 - [Client Side integration](#client-side-integration)
   - [Express payment methods - `registerExpressPaymentMethod( options )`](#express-payment-methods---registerexpresspaymentmethod-options-)
+    - [`name` (required)](#name-required)
+    - [`content` (required)](#content-required)
+    - [`edit` (required)](#edit-required)
+    - [`canMakePayment` (required):](#canmakepayment-required)
+    - [`paymentMethodId`](#paymentmethodid)
+    - [`supports:features`](#supportsfeatures)
   - [Payment Methods - `registerPaymentMethod( options )`](#payment-methods---registerpaymentmethod-options-)
   - [Props Fed to Payment Method Nodes](#props-fed-to-payment-method-nodes)
 - [Server Side Integration](#server-side-integration)
@@ -72,12 +78,12 @@ This should be a React node that will output in the express payment method area 
 #### `edit` (required)
 This should be a React node that will be output in the express payment method area when the block is rendered in the editor. It will be cloned in the rendering process. When cloned, this React node will receive props from the payment method interface to checkout (but they will contain preview data).
 
-#### `canMakePayment` (required): 
-    
+#### `canMakePayment` (required):
+
 A callback to determine whether the payment method should be available as an option for the shopper. The function will be passed an object containing data about the current order.
 
 ```
-canMakePayment( { 
+canMakePayment( {
     cartTotals: CartTotals,
     cartNeedsShipping: boolean,
     shippingAddress: CartShippingAddress,
@@ -87,7 +93,7 @@ canMakePayment( {
 } )
 ```
 
-Returns a boolean value - true if payment method is available for use. If your gateway needs to perform async initialization to determine availability, you can return a promise (resolving to boolean). This allows a payment method to be hidden based on the cart, e.g. if the cart has physical/shippable products (example: [`Cash on delivery`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/cod/index.js#L48-L70)); or for payment methods to control whether they are available depending on other conditions. 
+Returns a boolean value - true if payment method is available for use. If your gateway needs to perform async initialization to determine availability, you can return a promise (resolving to boolean). This allows a payment method to be hidden based on the cart, e.g. if the cart has physical/shippable products (example: [`Cash on delivery`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/cod/index.js#L48-L70)); or for payment methods to control whether they are available depending on other conditions.
 
 **Keep in mind this function could be invoked multiple times in the lifecycle of the checkout and thus any expensive logic in the callback provided on this property should be memoized.**
 
@@ -125,6 +131,7 @@ registerPaymentMethod( options );
 
 The options you feed the configuration instance are the same as those for express payment methods with the following additions:
 
+- `savedTokenComponent`: This should be a React node that contains logic handling any processing your payment method has to do with saved payment methods if your payment method supports them. This component will be rendered whenever a customer's saved token using your payment method for processing is selected for making the purchase.
 -   `label`: This should be a React node that will be used to output the label for the option where the payment methods are. For example it might be `<strong>Credit/Debit Cart</strong>` or you might output images.
 -   `ariaLabel`: This is the label that will be read out via screen-readers when the payment method is selected.
 -   `placeOrderButtonLabel`: This is an optional label which will change the default "Place Order" button text to something else when the payment method is selected. As an example, the PayPal Standard payment method [changes the text of the button to "Proceed to PayPal"](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/paypal/index.js#L37-L40) when it is selected as the payment method for checkout because the payment method takes the shopper offsite to PayPal for completing the payment.
@@ -146,6 +153,8 @@ A big part of the payment method integration is the interface that is exposed fo
   - `ValidationInputError` — a container for holding validation errors which typically you'll include after any inputs
   - [`PaymentMethodLabel`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/paypal/index.js#L37-L40) — use this component for the payment method label, including an optional icon
 -   `setExpressPaymentError`: This function receives a string and allows express payment methods to set an error notice for the express payment area on demand. This can be necessary because some express payment method processing might happen outside of checkout events.
+
+Any registered `savedTokenComponent` node will also receive a `token` prop which includes the id for the selected saved token in case your payment method needs to use it for some internal logic. However, keep in mind, this is just the id representing this token in the database (and the value of the radio input the shopper checked), not the actual customer payment token (since processing using that usually happens on the server for security).
 
 ## Server Side Integration
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3956 

See the reference issue for some background on the need for the changes in this pull request. Essentially this pull request fulfills the need for some payment methods that support saved customer tokens for future payments (such as Stripe) to handle any extra authorization or related logic when those selected saved tokens are processed.

For example, 3DS type of payment cards usually require some sort of additional authorization from the customer (2FA, text etc) to complete the payment. Via the Stripe API this is done using [payment intents](https://stripe.com/docs/payments/payment-intents). While the current Stripe Payment method integration for the checkout flow supports payment intents on _new_ purchases using a 3DS type card, it never had access to client side handling of server responses indicating further action was needed when the payment was being made with a _saved_ 3DS type card.

The solution introduced in this PR, is to expose a new configuration property on the payments registration function for payment methods to provide a component that handles any additional logic related to saved payment methods. In turn, this registered component is rendered for any **selected** saved payment method token that matches the `name` of the registered payment method.

A few additional notes for reviewers:

- Given this is a significant bug that (fortunately) has seemingly gone unnoticed in the wild but nevertheless impacts potential sales for merchants, we need to get this fix out sooner. This meant that I avoided any TypeScript work in the affected components for now.
- I'm not sure on the name of the config property, if you have suggestions for something other than `savedTokenComponent`, I'm all ears (maybe `savedTokenHandlerComponent`?)
- I did this in concert with implementation changes in the [corresponding Stripe PR I started](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1467) for migrating the stripe integration. This helped to confirm the new API is sufficient for the fixes needed in the Stripe integration. I _did not_ make the changes in the bundled implementation with C&C blocks figuring that customers should be encouraged to be on the latest Stripe extension anyways. I'm on the fence whether this is the best route to take and welcome feedback here.
- The new configuration property is optional and has a default set for registered payment methods registered without it. That preserves back-compat (and the scenario where most payment methods won't need this).

## Testing

First, the main thing to verify, is that this branch doesn't impact the current behaviour of payment methods being used for purchases. So smoke testing the checkout flow for bundled payment methods to ensure they work fine without errors (including saved payment methods and purchasing in incognito) is important.

- Test making a purchase with cheque payment method.
- Test making a purchase with bundled Stripe (with non 3DS type card).
- Test making a purchase with express payment method (with non 3DS type card).
- Test making a purchase with a saved payment method (this test is excluded for incognito mode because you need to be logged in).

The next set of tests should be done against a build of the Stripe extension using [this pr](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1467).  You also need to be logged in for this test.

- complete a checkout using a 3DS test card (`4000 0000 0000 3063`) with the "Save payment information to my account for future purchases" checkbox checked and verify you get the additional authorization modal for authorizing and completing the purchase. After completing the purchase, verify the order in the background shows the payment completed successfully.
- Do a new purchase on the frontend and select the card you used above from the saved payment method options (it should be available as an option in the checkout). When submitting the checkout, you should see a 3DS modal pop up for additional verification and continuing should complete the order (verify the payment was successful in the backend).
- Also try the above, but cancel the modal instead of authorizing, and validate that an error message shows in the checkout. You should also be able to pay with an alternative payment method at that point.

<!-- If you can, add the appropriate labels -->

### Changelog

> A new configuration property is available to registered payment methods for additional logic handling of saved payment method tokens. See the [updated payment method integration docs for details](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/extensibility/payment-method-integration.md#payment-methods---registerpaymentmethod-options-).
