### PR TITLE
Refactor Payment Methods Integration API to fire `onPaymentProcessing` event with saved tokens.

### DIFF
--- a/assets/js/base/context/cart-checkout/payment-methods/actions.ts
+++ b/assets/js/base/context/cart-checkout/payment-methods/actions.ts
@@ -49,9 +49,21 @@ export const failed = ( {
 export const success = ( {
 	paymentMethodData,
 }: {
-	paymentMethodData: Record< string, unknown >;
+	paymentMethodData?: Record< string, unknown >;
 } ): ActionType => ( {
 	type: STATUS.SUCCESS,
+	paymentMethodData,
+} );
+
+/**
+ * Used to dispatch a payment started status update.
+ */
+export const started = ( {
+	paymentMethodData,
+}: {
+	paymentMethodData?: Record< string, unknown >;
+} ): ActionType => ( {
+	type: STATUS.STARTED,
 	paymentMethodData,
 } );
 

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.tsx
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.tsx
@@ -248,7 +248,7 @@ export const PaymentMethodDataProvider = ( {
 				);
 			},
 			success: (
-				paymentMethodData = {},
+				paymentMethodData,
 				billingData = undefined,
 				shippingData = undefined
 			) => {

--- a/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.tsx
+++ b/assets/js/base/context/cart-checkout/payment-methods/payment-method-data-context.tsx
@@ -27,6 +27,7 @@ import {
 	error,
 	failed,
 	success,
+	started,
 	setRegisteredPaymentMethods,
 	setRegisteredExpressPaymentMethods,
 	setShouldSavePaymentMethod,
@@ -112,8 +113,8 @@ export const PaymentMethodDataProvider = ( {
 	const currentObservers = useRef( observers );
 	const { onPaymentProcessing } = useEventEmitters( observerDispatch );
 
+	// ensure observers are always current.
 	useEffect( () => {
-		// ensure observers are always current.
 		currentObservers.current = observers;
 	}, [ observers ] );
 
@@ -221,7 +222,13 @@ export const PaymentMethodDataProvider = ( {
 
 	const setPaymentStatus = useCallback(
 		(): PaymentStatusDispatchers => ( {
-			started: () => dispatch( statusOnly( STARTED ) ),
+			started: ( paymentMethodData ) => {
+				dispatch(
+					started( {
+						paymentMethodData,
+					} )
+				);
+			},
 			processing: () => dispatch( statusOnly( PROCESSING ) ),
 			completed: () => dispatch( statusOnly( COMPLETE ) ),
 			error: ( errorMessage ) => dispatch( error( errorMessage ) ),

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.ts
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.ts
@@ -24,7 +24,7 @@ const reducer = (
 	state = DEFAULT_PAYMENT_DATA_CONTEXT_STATE,
 	{
 		type,
-		paymentMethodData = undefined,
+		paymentMethodData,
 		shouldSavePaymentMethod = false,
 		errorMessage = '',
 		paymentMethods = {},

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.ts
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.ts
@@ -10,7 +10,7 @@ import type { PaymentMethodDataContextState } from './types';
 import type { ActionType } from './actions';
 
 const hasSavedPaymentToken = (
-	paymentMethodData: Record< string, unknown >
+	paymentMethodData: Record< string, unknown > | undefined
 ): boolean => {
 	return !! (
 		typeof paymentMethodData === 'object' && paymentMethodData.isSavedToken
@@ -24,7 +24,7 @@ const reducer = (
 	state = DEFAULT_PAYMENT_DATA_CONTEXT_STATE,
 	{
 		type,
-		paymentMethodData = {},
+		paymentMethodData = undefined,
 		shouldSavePaymentMethod = false,
 		errorMessage = '',
 		paymentMethods = {},

--- a/assets/js/base/context/cart-checkout/payment-methods/reducer.ts
+++ b/assets/js/base/context/cart-checkout/payment-methods/reducer.ts
@@ -36,6 +36,11 @@ const reducer = (
 				? {
 						...state,
 						currentStatus: STATUS.STARTED,
+						paymentMethodData:
+							paymentMethodData || state.paymentMethodData,
+						hasSavedToken: hasSavedPaymentToken(
+							paymentMethodData || state.paymentMethodData
+						),
 				  }
 				: state;
 		case STATUS.ERROR:
@@ -64,7 +69,7 @@ const reducer = (
 						paymentMethodData:
 							paymentMethodData || state.paymentMethodData,
 						hasSavedToken: hasSavedPaymentToken(
-							paymentMethodData
+							paymentMethodData || state.paymentMethodData
 						),
 				  }
 				: state;

--- a/assets/js/base/context/cart-checkout/payment-methods/types.ts
+++ b/assets/js/base/context/cart-checkout/payment-methods/types.ts
@@ -67,7 +67,7 @@ export type PaymentMethodsDispatcherType = (
 ) => void;
 
 export interface PaymentStatusDispatchers {
-	started: () => void;
+	started: ( paymentMethodData?: ObjectType | EmptyObjectType ) => void;
 	processing: () => void;
 	completed: () => void;
 	error: ( error: string ) => void;

--- a/assets/js/blocks/cart-checkout/payment-methods/express-payment-methods.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/express-payment-methods.js
@@ -38,7 +38,7 @@ const ExpressPaymentMethods = () => {
 		( paymentMethodId ) => () => {
 			previousActivePaymentMethod.current = activePaymentMethod;
 			previousPaymentMethodData.current = paymentMethodData;
-			setPaymentStatus().started();
+			setPaymentStatus().started( {} );
 			setActivePaymentMethod( paymentMethodId );
 		},
 		[
@@ -51,7 +51,7 @@ const ExpressPaymentMethods = () => {
 	const onExpressPaymentClose = useCallback( () => {
 		setActivePaymentMethod( previousActivePaymentMethod.current );
 		if ( previousPaymentMethodData.current.isSavedToken ) {
-			setPaymentStatus().success( previousPaymentMethodData.current );
+			setPaymentStatus().started( previousPaymentMethodData.current );
 		}
 	}, [ setActivePaymentMethod, setPaymentStatus ] );
 	const paymentMethodIds = Object.keys( paymentMethods );

--- a/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
@@ -50,7 +50,7 @@ const getCcOrEcheckPaymentMethodOption = (
 		onChange: ( token ) => {
 			const savedTokenKey = `wc-${ method.gateway }-payment-token`;
 			setActivePaymentMethod( method.gateway );
-			setPaymentStatus().success( {
+			setPaymentStatus().started( {
 				payment_method: method.gateway,
 				[ savedTokenKey ]: token + '',
 				isSavedToken: true,
@@ -84,7 +84,7 @@ const getDefaultPaymentMethodOptions = (
 		onChange: ( token ) => {
 			const savedTokenKey = `wc-${ method.gateway }-payment-token`;
 			setActivePaymentMethod( method.gateway );
-			setPaymentStatus().success( {
+			setPaymentStatus().started( {
 				payment_method: method.gateway,
 				[ savedTokenKey ]: token + '',
 				isSavedToken: true,
@@ -114,12 +114,9 @@ const SavedPaymentMethodOptions = () => {
 
 	const updateToken = useCallback(
 		( token ) => {
-			if ( token === '0' ) {
-				setPaymentStatus().started();
-			}
 			setActiveSavedToken( token );
 		},
-		[ setActiveSavedToken, setPaymentStatus ]
+		[ setActiveSavedToken ]
 	);
 
 	useEffect( () => {

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -81,7 +81,7 @@
 /**
  * @typedef {Object} PaymentStatusDispatchers
  *
- * @property {function()}                        started    Sets started status.
+ * @property {function(Object=)}                 started    Sets started status.
  * @property {function()}                        processing Sets processing status.
  * @property {function()}                        completed  Sets complete status.
  * @property {function(string)}                  error      Sets error status.


### PR DESCRIPTION
Fixes: #3980 

Currently there exists what is arguably a flaw in the checkout event system in that `onPaymentProcessing` event can be observed by express payment methods and regular payment methods but _not_ by saved payment methods (implementing the [`savedTokenComponent`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3961) configuration property). This inconsistency is a flaw in that some payment methods implementing this component will have no way to reliably update the `paymentMethodData` in the checkout state before it is passed along on the checkout endpoint request for server side processing. You can read more about where this can manifest in #3980.

A significant reason for why this inconsistency existed is because when the system was initially designed, an assumption was made that saved tokens would always be processed server side and payment method logic would never need to interact on the client. This was a faulty assumption which I started rectifying in #3961 and now finished with this PR here.

As a result, this PR implements the following changes to ensure the `onPaymentProcessing` event is accessible to the `savedTokenComponent`:

- Implemented a `started` action creator that returns an action object that when dispatched will allow for updating the payment method data in the checkout state. 
- The above allows the checkout flow to "initialize" selected saved payment method tokens to a `started` status for the payment method and store data about the saved token in the checkout state. This replaces the existing logic that was setting the payment method status for saved tokens to "success".
- Some slight improvements of types (TS) to account for the fact that both `started` and `success` payment method status changes allow for _retaining_ existing payment method data in the state if it's not provided by the action. This improves performance because there are many places where just the payment status needs updated by checkout _without changing anything else in the state_. 
- The above change does however mean that any place we change the status to success or started where the payment method data does need wiped, must be done _explicitly_ (by passing in an empty object to the dispatched action). Thus one change was needed here for express payment methods. Also where express payment methods restored the saved token status (if the modal was closed without completing), the action dispatched was switched from `success` to `started` in order to reflect the changes made for saved token handling.

Outside of the necessary TypeScript type changes for existing typescript files, I didn't implement typescript anywhere else mostly because there's some time sensitivity around the need for this API change.

Regarding documentation, I did do a pass through the existing documentation and I don't see anywhere that needs updated. Indeed, the existing documentation already pointed to the `onPaymentProcessing` event being available for `savedTokenComponent` so the changes here are actually more in line with what the documentation already indicates!

## To Test

The changes here implement any payment method type processing, so it's important to verify there is no impact to existing payment method handling by these changes. This means setting up an environment where you have the core payment methods and Stripe (along with Stripe express payments, either Chrome Pay or Apple Pay) available for testing.

* [ ] Verify that you can pay with a saved token.
* [ ] Verify that you can pay with an express payment method (Apple Pay or Chrome Pay - either working should be sufficient).
* [ ] Verify that you can pay with a Stripe Credit Card
* [ ] Verify that you can pay with any other Woo core payment method.
* [ ] Try all of the above (except saved token) in incognito mode.

Besides the above smoke tests, try intentionally confusing or breaking the system. Some example scenarios:

* [ ] When checkout loads with available multiple saved tokens (which you might have to setup in previous purchases), try switching between saved tokens and different payment methods, and back to a saved token before completing the purchase. Ensure the saved payment method you selected was used for the payment.
* [ ] Try different payment methods and triggering a scenario that fails payment or causes an error. In the case of Stripe CC (or express payment) there are a [bunch of test cards](https://stripe.com/docs/testing) you can access for triggering different payment failure conditions. After a payment method failure, ensure you can pay with an alternative method of payment that should succeed without issues.
* [ ] Trigger starting an express payment method, selecting different shipping addresses and different rates and ensure it completes successfully after submitting.
* [ ] Do the above, but instead of completing the payment, just cancel and close the modal. Ensure that you can make a payment with the saved payment method token after doing so without issue.
* [ ] Optional (I tested this fairly throughly): For this test you'll have to use Stripe built with [this pr](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1467). Verify that if your saved token is using a 3DS card always 3DS auth ( such as `4000002760003184`), then the 3DS validation process still works when attempting to make a payment using the token.

The above all validates that the changes in this PR don't break _existing_ behaviour. There's no easy way to test (currently) the actual implementation exposing `onPaymentProcessing` event for savedTokenComponents without manually implementing a dummy test. I did this to verify it works as expected. However, this PR will also be tested as a part of the work being done for the Square extension.

### Changelog

> Payment methods implementing the `savedTokenComponent` configuration property will now have the `onPaymentProcessing` event available to the registered component.
