### PR TITLE
Expose the shouldSavePayment method value to registered payment methods

### DIFF
--- a/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/hooks/payment-methods/use-payment-method-interface.js
@@ -98,6 +98,7 @@ export const usePaymentMethodInterface = () => {
 		activePaymentMethod,
 		onPaymentProcessing,
 		setExpressPaymentError,
+		shouldSavePayment,
 	} = usePaymentMethodDataContext();
 	const {
 		shippingErrorStatus,
@@ -194,5 +195,6 @@ export const usePaymentMethodInterface = () => {
 		onSubmit,
 		activePaymentMethod,
 		setExpressPaymentError,
+		shouldSavePayment,
 	};
 };

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -218,6 +218,9 @@
  *                                                                 when the express payment method
  *                                                                 modal closes and control is
  *                                                                 returned to checkout.
+ * @property {boolean}                    shouldSavePayment        A boolean which indicates whether
+ *                                                                 the shopper has checked the save
+ *                                                                 payment method checkbox.
  */
 
 export {};

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -153,6 +153,7 @@ A big part of the payment method integration is the interface that is exposed fo
   - `ValidationInputError` — a container for holding validation errors which typically you'll include after any inputs
   - [`PaymentMethodLabel`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/paypal/index.js#L37-L40) — use this component for the payment method label, including an optional icon
 -   `setExpressPaymentError`: This function receives a string and allows express payment methods to set an error notice for the express payment area on demand. This can be necessary because some express payment method processing might happen outside of checkout events.
+-   `shouldSavePayment`: This is a boolean type value that indicates whether or not the shopper has selected to save their payment method details (for payment methods that support saved payments). True if selected, false otherwise. Defaults to false.
 
 Any registered `savedTokenComponent` node will also receive a `token` prop which includes the id for the selected saved token in case your payment method needs to use it for some internal logic. However, keep in mind, this is just the id representing this token in the database (and the value of the radio input the shopper checked), not the actual customer payment token (since processing using that usually happens on the server for security).
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3988

This is a very low impact change that exposes the `shouldSavePayment` value as a prop to registered payment methods. Existing payment methods will not be impacted because they have no dependency on the prop.

Exposing this prop is needed by payment methods that need to know the value of this checked item client side before sending info to the server. In the case of Square, saved payment methods involving intents are processed client side before the token is passed through to the server (which differs from Stripe which is able to do all the processing server side - an assumption incorrectly expanded to cover all payment methods made in initial interface design).

## To Test

Just smoke test existing payment methods to ensure there is no breakage with existing behaviour. It should surface immediately if there is.

### Changelog

> Registered payment methods now have access to the `shouldSavePayment` prop in their components (which indicates whether the shopper has checked the save payment method checkbox).
