### PR TITLE
Add scope to PluginArea

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/index.js
@@ -47,7 +47,7 @@ export const CheckoutProvider = ( {
 									CURRENT_USER_IS_ADMIN ? null : () => null
 								}
 							>
-								<PluginArea />
+								<PluginArea scope="woocommerce-checkout" />
 							</BlockErrorBoundary>
 						</SlotFillProvider>
 						<CheckoutProcessor />


### PR DESCRIPTION
With https://github.com/WordPress/gutenberg/pull/27438 merged and available in Gutenberg 10.2, we can now add scope to our PluginArea safely, it's already added in WooCommerce Subscriptions and it's a backward compatible change.

### Testing instructions
- Have GB 10.2 enabled.
- Build this branch 3993-gh-woocommerce/woocommerce-subscriptions
- Make sure Shipping and Recurring Totals are working fine.