### PR TITLE
Remove checks for WP 5.4 from e2e tests

### DIFF
--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -59,7 +59,8 @@ To modify the environment used by tests locally, you will need to modify `.wp-en
 
 ```diff
 {
-+	"core": "WordPress/WordPress#5.6",
+-	"core": "WordPress/WordPress#5.7-branch",
++	"core": "WordPress/WordPress#5.6-branch",
 	"plugins": [
 		"https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip",
 		"https://github.com/WP-API/Basic-Auth/archive/master.zip",

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -15,7 +15,6 @@ import {
 import {
 	insertBlockDontWaitForInsertClose,
 	closeInserter,
-	conditionalDescribe,
 } from '../../utils.js';
 
 const block = {
@@ -41,27 +40,24 @@ describe( `${ block.name } Block`, () => {
 		} );
 	} );
 
-	conditionalDescribe( process.env.WP_VERSION > 5.4 )(
-		'before compatibility notice is dismissed',
-		() => {
-			beforeEach( async () => {
-				await page.evaluate( () => {
-					localStorage.setItem(
-						'wc-blocks_dismissed_compatibility_notices',
-						'[]'
-					);
-				} );
-				await visitBlockPage( `${ block.name } Block` );
-			} );
-
-			it( 'shows compatibility notice', async () => {
-				const compatibilityNoticeTitle = await page.$x(
-					`//h1[contains(text(), 'Compatibility notice')]`
+	describe( 'before compatibility notice is dismissed', () => {
+		beforeEach( async () => {
+			await page.evaluate( () => {
+				localStorage.setItem(
+					'wc-blocks_dismissed_compatibility_notices',
+					'[]'
 				);
-				expect( compatibilityNoticeTitle.length ).toBe( 1 );
 			} );
-		}
-	);
+			await visitBlockPage( `${ block.name } Block` );
+		} );
+
+		it( 'shows compatibility notice', async () => {
+			const compatibilityNoticeTitle = await page.$x(
+				`//h1[contains(text(), 'Compatibility notice')]`
+			);
+			expect( compatibilityNoticeTitle.length ).toBe( 1 );
+		} );
+	} );
 
 	describe( 'once compatibility notice is dismissed', () => {
 		beforeEach( async () => {

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -14,7 +14,6 @@ import {
 import {
 	insertBlockDontWaitForInsertClose,
 	closeInserter,
-	conditionalDescribe,
 } from '../../utils.js';
 
 const block = {
@@ -40,27 +39,24 @@ describe( `${ block.name } Block`, () => {
 		} );
 	} );
 
-	conditionalDescribe( process.env.WP_VERSION > 5.4 )(
-		'before compatibility notice is dismissed',
-		() => {
-			beforeEach( async () => {
-				await page.evaluate( () => {
-					localStorage.setItem(
-						'wc-blocks_dismissed_compatibility_notices',
-						'[]'
-					);
-				} );
-				await visitBlockPage( `${ block.name } Block` );
-			} );
-
-			it( 'shows compatibility notice', async () => {
-				const compatibilityNoticeTitle = await page.$x(
-					`//h1[contains(text(), 'Compatibility notice')]`
+	describe( 'before compatibility notice is dismissed', () => {
+		beforeEach( async () => {
+			await page.evaluate( () => {
+				localStorage.setItem(
+					'wc-blocks_dismissed_compatibility_notices',
+					'[]'
 				);
-				expect( compatibilityNoticeTitle.length ).toBe( 1 );
 			} );
-		}
-	);
+			await visitBlockPage( `${ block.name } Block` );
+		} );
+
+		it( 'shows compatibility notice', async () => {
+			const compatibilityNoticeTitle = await page.$x(
+				`//h1[contains(text(), 'Compatibility notice')]`
+			);
+			expect( compatibilityNoticeTitle.length ).toBe( 1 );
+		} );
+	} );
 
 	describe( 'once compatibility notice is dismissed', () => {
 		beforeEach( async () => {

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -20,7 +20,3 @@ export async function insertBlockDontWaitForInsertClose( searchTerm ) {
 export const closeInserter = async () => {
 	await page.click( '.edit-post-header [aria-label="Add block"]' );
 };
-
-export const conditionalDescribe = ( condition ) => {
-	return condition ? describe : describe.skip;
-};


### PR DESCRIPTION
Small PR that:

* b398b4fc775196378168ca8c3d957bdc343b0012: removes checks for WP 5.4 from e2e tests now that we no longer have e2e tests for that version (those checks were added in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3937)
* 7637524facbdb8bcd4f4f2ad11f43cc5c039357a: updates the docs to customize the e2e tests local environment based on the latest changes in `.wp-env.json` (those docs were added in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3945)

### How to test the changes in this Pull Request:

1. Verify tests keep passing.
2. Optionally, add `expect( 1 ).toBe( 2 )` in the cart [test with title `shows compatibility notice`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/99efa16e158310ac09d8337d9ad48247c2627968/tests/e2e/specs/backend/cart.test.js#L54) and verify it fails.
