### PR TITLE
Fix click on Proceed to checkout bug when Coupon error is visible.

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/coupon/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.js
@@ -106,6 +106,12 @@ const TotalsCoupon = ( {
 						propertyName="coupon"
 						elementId={ textInputId }
 					/>
+					{ /* prevent layout shift caused the by error message */ }
+					{ ! validationError && (
+						<div className="wc-block-components-validation-error">
+							<p></p>
+						</div>
+					) }
 				</div>
 			</LoadingMask>
 		</Panel>

--- a/assets/js/base/components/cart-checkout/totals/coupon/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.js
@@ -108,7 +108,10 @@ const TotalsCoupon = ( {
 					/>
 					{ /* prevent layout shift caused the by error message */ }
 					{ ! validationError && (
-						<div className="wc-block-components-validation-error">
+						<div
+							className="wc-block-components-validation-error"
+							aria-hidden="true"
+						>
 							<p></p>
 						</div>
 					) }

--- a/assets/js/base/components/cart-checkout/totals/coupon/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.js
@@ -106,15 +106,6 @@ const TotalsCoupon = ( {
 						propertyName="coupon"
 						elementId={ textInputId }
 					/>
-					{ /* prevent layout shift caused the by error message */ }
-					{ ! validationError && (
-						<div
-							className="wc-block-components-validation-error"
-							aria-hidden="true"
-						>
-							<p></p>
-						</div>
-					) }
 				</div>
 			</LoadingMask>
 		</Panel>

--- a/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -1,6 +1,6 @@
 .wc-block-components-totals-coupon__form {
 	display: flex;
-	margin-bottom: 0;
+	margin-bottom: 0.5em;
 	width: 100%;
 
 	.wc-block-components-totals-coupon__input {
@@ -22,10 +22,4 @@
 .wc-block-components-totals-coupon__content {
 	flex-direction: column;
 	position: relative;
-
-	.wc-block-components-validation-error {
-		margin-top: $gap-smaller;
-		position: relative;
-		width: 100%;
-	}
 }


### PR DESCRIPTION
The bug happened because of the layout shift produced by the error message disappearance.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds an in-place fix for the Coupon code field. It adds an empty space equal to the space taken up by the error message. 
If this becomes an issue for other parts of the project we will need to implement a project-wide sollution.

<!-- Reference any related issues or PRs here -->
Fixes #3968 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->



### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
The ticket has the original behavior.

<img width="264" alt="Screenshot 2021-03-24 at 15 45 21" src="https://user-images.githubusercontent.com/1628454/112339980-0b83f300-8cb8-11eb-8a30-322f2b2c5bd9.png">
<img width="260" alt="Screenshot 2021-03-24 at 15 45 13" src="https://user-images.githubusercontent.com/1628454/112339988-0cb52000-8cb8-11eb-842c-e7e6825572e9.png">

Changes seen here.
### How to test the changes in this Pull Request:

Steps to reproduce the behavior:

Make sure you use the Cart block
Add any product to the cart and go to the Cart block.
Enter an invalid coupon code.
See coupon validation error appear
Click on the "Proceed to Checkout" button
Notice you are directed to the Checkout

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix the Proceed to checkout button click bug happening when the Coupon error is visible in the Cart block
