### PR TITLE
[Prototype] Add terms and conditions checkbox

### DIFF
--- a/assets/js/base/context/cart-checkout/checkout-state/actions.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/actions.js
@@ -20,6 +20,7 @@ const {
 	SET_ORDER_ID,
 	SET_SHOULD_CREATE_ACCOUNT,
 	SET_ORDER_NOTES,
+	SET_IS_TERMS_ACCEPTED_CHECKBOX_PRISTINE,
 } = TYPES;
 
 /**
@@ -79,4 +80,10 @@ export const actions = {
 		type: SET_ORDER_NOTES,
 		orderNotes,
 	} ),
+	setIsTermsAcceptedCheckboxPristine: ( isTermsAcceptedCheckboxPristine ) => {
+		return {
+			type: SET_IS_TERMS_ACCEPTED_CHECKBOX_PRISTINE,
+			isTermsAcceptedCheckboxPristine,
+		};
+	},
 };

--- a/assets/js/base/context/cart-checkout/checkout-state/constants.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/constants.js
@@ -30,6 +30,7 @@ export const DEFAULT_STATE = {
 	customerId: checkoutData.customer_id,
 	shouldCreateAccount: false,
 	processingResponse: null,
+	isTermsAcceptedCheckboxPristine: true,
 };
 
 export const TYPES = {
@@ -48,4 +49,6 @@ export const TYPES = {
 	SET_ORDER_NOTES: 'set_checkout_order_notes',
 	INCREMENT_CALCULATING: 'increment_calculating',
 	DECREMENT_CALCULATING: 'decrement_calculating',
+	SET_IS_TERMS_ACCEPTED_CHECKBOX_PRISTINE:
+		'set_is_terms_accepted_checkbox_pristine',
 };

--- a/assets/js/base/context/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/index.js
@@ -64,10 +64,13 @@ const CheckoutContext = createContext( {
 		setCustomerId: ( id ) => void id,
 		setOrderId: ( id ) => void id,
 		setOrderNotes: ( orderNotes ) => void orderNotes,
+		setTermsAcceptedCheckboxPristine: ( termsAcceptedCheckboxPristine ) =>
+			void termsAcceptedCheckboxPristine,
 	},
 	hasOrder: false,
 	isCart: false,
 	shouldCreateAccount: false,
+	isTermsAcceptedCheckboxPristine: true,
 	setShouldCreateAccount: ( value ) => void value,
 } );
 
@@ -155,6 +158,10 @@ export const CheckoutStateProvider = ( {
 				void dispatch( actions.setOrderId( orderId ) ),
 			setOrderNotes: ( orderNotes ) =>
 				void dispatch( actions.setOrderNotes( orderNotes ) ),
+			setIsTermsAcceptedCheckboxPristine: () =>
+				void dispatch(
+					actions.setIsTermsAcceptedCheckboxPristine( false )
+				),
 			setAfterProcessing: ( response ) => {
 				// capture general error message if this is an error response.
 				if (
@@ -336,6 +343,7 @@ export const CheckoutStateProvider = ( {
 		checkoutState.customerId,
 		checkoutState.customerNote,
 		checkoutState.processingResponse,
+		checkoutState.isTermsAcceptedCheckboxPristine,
 		previousStatus,
 		previousHasError,
 		dispatchActions,
@@ -350,9 +358,9 @@ export const CheckoutStateProvider = ( {
 	] );
 
 	const onSubmit = useCallback( () => {
+		dispatch( actions.setIsTermsAcceptedCheckboxPristine( false ) );
 		dispatch( actions.setBeforeProcessing() );
 	}, [] );
-
 	/**
 	 * @type {CheckoutDataContext}
 	 */
@@ -378,6 +386,8 @@ export const CheckoutStateProvider = ( {
 		shouldCreateAccount: checkoutState.shouldCreateAccount,
 		setShouldCreateAccount: ( value ) =>
 			dispatch( actions.setShouldCreateAccount( value ) ),
+		isTermsAcceptedCheckboxPristine:
+			checkoutState.isTermsAcceptedCheckboxPristine,
 	};
 	return (
 		<CheckoutContext.Provider value={ checkoutData }>

--- a/assets/js/base/context/cart-checkout/checkout-state/reducer.js
+++ b/assets/js/base/context/cart-checkout/checkout-state/reducer.js
@@ -25,6 +25,7 @@ const {
 	SET_ORDER_ID,
 	SET_ORDER_NOTES,
 	SET_SHOULD_CREATE_ACCOUNT,
+	SET_IS_TERMS_ACCEPTED_CHECKBOX_PRISTINE,
 } = TYPES;
 
 const {
@@ -78,10 +79,20 @@ export const prepareResponseData = ( data ) => {
  * @param {Array} action.orderNotes Order notes.
  * @param {boolean} action.shouldCreateAccount True if shopper has requested a user account (signup checkbox).
  * @param {Object} action.data Other action payload.
+ * @param {boolean} action.isTermsAcceptedCheckboxPristine False if terms and conditions checkbox has been modified.
  */
 export const reducer = (
 	state = DEFAULT_STATE,
-	{ url, type, customerId, orderId, orderNotes, shouldCreateAccount, data }
+	{
+		url,
+		type,
+		customerId,
+		orderId,
+		orderNotes,
+		shouldCreateAccount,
+		data,
+		isTermsAcceptedCheckboxPristine,
+	}
 ) => {
 	let newState = state;
 	switch ( type ) {
@@ -218,6 +229,17 @@ export const reducer = (
 				newState = {
 					...state,
 					orderNotes,
+				};
+			}
+			break;
+		case SET_IS_TERMS_ACCEPTED_CHECKBOX_PRISTINE:
+			if (
+				state.isTermsAcceptedCheckboxPristine !==
+				isTermsAcceptedCheckboxPristine
+			) {
+				newState = {
+					...state,
+					isTermsAcceptedCheckboxPristine,
 				};
 			}
 			break;

--- a/assets/js/base/context/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/cart-checkout/checkout/processor/index.js
@@ -42,7 +42,7 @@ const CheckoutProcessor = () => {
 		orderNotes,
 		shouldCreateAccount,
 	} = useCheckoutContext();
-	const { hasValidationErrors } = useValidationContext();
+	const { hasValidationErrors, getValidationError } = useValidationContext();
 	const { shippingErrorStatus } = useShippingDataContext();
 	const { billingData, shippingAddress } = useCustomerDataContext();
 	const { cartNeedsPayment, receiveCart } = useStoreCart();
@@ -62,7 +62,6 @@ const CheckoutProcessor = () => {
 	const expressPaymentMethodActive = Object.keys(
 		expressPaymentMethods
 	).includes( activePaymentMethod );
-
 	const paymentMethodId = useMemo( () => {
 		const merged = { ...expressPaymentMethods, ...paymentMethods };
 		return merged?.[ activePaymentMethod ]?.paymentMethodId;
@@ -167,6 +166,8 @@ const CheckoutProcessor = () => {
 			shipping_address: currentShippingAddress.current,
 			customer_note: orderNotes,
 			should_create_account: shouldCreateAccount,
+			terms_and_conditions_accepted:
+				getValidationError( 'terms_and_conditions' ) === undefined,
 		};
 		if ( cartNeedsPayment ) {
 			data = {
@@ -245,17 +246,18 @@ const CheckoutProcessor = () => {
 				} );
 			} );
 	}, [
-		addErrorNotice,
 		removeNotice,
-		paymentMethodId,
-		activePaymentMethod,
-		paymentMethodData,
-		shouldSavePayment,
-		cartNeedsPayment,
-		receiveCart,
-		dispatchActions,
 		orderNotes,
 		shouldCreateAccount,
+		getValidationError,
+		cartNeedsPayment,
+		paymentMethodId,
+		paymentMethodData,
+		shouldSavePayment,
+		activePaymentMethod,
+		dispatchActions,
+		addErrorNotice,
+		receiveCart,
 	] );
 	// redirect when checkout is complete and there is a redirect url.
 	useEffect( () => {

--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -53,6 +53,10 @@ const blockAttributes = {
 		type: 'boolean',
 		default: HAS_DARK_EDITOR_STYLE_SUPPORT,
 	},
+	requireTermsAndConditions: {
+		type: 'boolean',
+		default: false,
+	},
 };
 
 export default blockAttributes;

--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { HAS_DARK_EDITOR_STYLE_SUPPORT } from '@woocommerce/block-settings';
 
 const blockAttributes = {
@@ -56,6 +57,14 @@ const blockAttributes = {
 	requireTermsAndConditions: {
 		type: 'boolean',
 		default: false,
+	},
+	termsAndConditionsText: {
+		type: 'string',
+		// translators: [terms] is the link to the Terms and Conditions page.
+		default: __(
+			'I have read and agree to the website [terms].',
+			'woocommerce'
+		),
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -3,6 +3,17 @@
  */
 import { __ } from '@wordpress/i18n';
 import { HAS_DARK_EDITOR_STYLE_SUPPORT } from '@woocommerce/block-settings';
+import { getSetting } from '@woocommerce/settings';
+
+const termsAndConditionsTextFromDb = getSetting( 'termsAndConditionsText' );
+let defaultTermsAndConditionsText = termsAndConditionsTextFromDb;
+
+if ( ! termsAndConditionsTextFromDb ) {
+	defaultTermsAndConditionsText = __(
+		'I have read and agree to the website [terms].',
+		'woocommerce'
+	);
+}
 
 const blockAttributes = {
 	isPreview: {
@@ -61,10 +72,7 @@ const blockAttributes = {
 	termsAndConditionsText: {
 		type: 'string',
 		// translators: [terms] is the link to the Terms and Conditions page.
-		default: __(
-			'I have read and agree to the website [terms].',
-			'woocommerce'
-		),
+		default: defaultTermsAndConditionsText,
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -139,6 +139,9 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 						requireCompanyField={ attributes.requireCompanyField }
 						requirePhoneField={ attributes.requirePhoneField }
 						allowCreateAccount={ allowCreateAccount }
+						requireTermsAndConditions={
+							attributes.requireTermsAndConditions
+						}
 					/>
 					<div className="wc-block-checkout__actions">
 						{ attributes.showReturnToCart && (

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -139,6 +139,9 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 						requireCompanyField={ attributes.requireCompanyField }
 						requirePhoneField={ attributes.requirePhoneField }
 						allowCreateAccount={ allowCreateAccount }
+						termsAndConditionsText={
+							attributes.termsAndConditionsText
+						}
 						requireTermsAndConditions={
 							attributes.requireTermsAndConditions
 						}

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -9,6 +9,7 @@ import {
 	ToggleControl,
 	CheckboxControl,
 	Notice,
+	TextControl,
 	Disabled,
 } from '@wordpress/components';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
@@ -54,6 +55,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		cartPageId,
 		hasDarkControls,
 		requireTermsAndConditions,
+		termsAndConditionsText,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCartPageId } = useRef( cartPageId );
@@ -291,28 +293,24 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						} )
 					}
 				/>
-				<Notice
-					className="wc-block-base-control-notice"
-					isDismissible={ false }
-				>
-					{ createInterpolateElement(
-						__(
-							'The text used to label this checkbox can be modified in the <strong>WooCommerce</strong> > <strong>Checkout</strong> section of the <a>Customizer</a>.',
-							'woo-gutenberg-products-block'
-						),
-						{
-							a: (
-								// eslint-disable-next-line jsx-a11y/anchor-has-content
-								<a
-									href={ getAdminLink( 'customize.php' ) }
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-							strong: <strong />,
-						}
-					) }
-				</Notice>
+				{ attributes.requireTermsAndConditions && (
+					<TextControl
+						label={ __(
+							'The text to accompany the checkbox',
+							'woocommerce'
+						) }
+						value={ termsAndConditionsText }
+						onChange={ ( value ) => {
+							setAttributes( {
+								termsAndConditionsText: value,
+							} );
+						} }
+						help={ __(
+							'Use the tag [terms] in this box to include a link to your terms and conditions page. If left blank, a default message will be shown.',
+							'woocommerce'
+						) }
+					/>
+				) }
 			</PanelBody>
 			{ showReturnToCart &&
 				! (

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -53,6 +53,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		showReturnToCart,
 		cartPageId,
 		hasDarkControls,
+		requireTermsAndConditions,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCartPageId } = useRef( cartPageId );
@@ -276,6 +277,42 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						} )
 					}
 				/>
+			</PanelBody>
+			<PanelBody title={ __( 'Terms and Conditions', 'woocommerce' ) }>
+				<ToggleControl
+					label={ __( 'Terms and conditions acceptance required' ) }
+					help={ __(
+						"Require users to agree to your site's terms and conditions before completing the checkout process."
+					) }
+					checked={ requireTermsAndConditions }
+					onChange={ () =>
+						setAttributes( {
+							requireTermsAndConditions: ! requireTermsAndConditions,
+						} )
+					}
+				/>
+				<Notice
+					className="wc-block-base-control-notice"
+					isDismissible={ false }
+				>
+					{ createInterpolateElement(
+						__(
+							'The text used to label this checkbox can be modified in the <strong>WooCommerce</strong> > <strong>Checkout</strong> section of the <a>Customizer</a>.',
+							'woo-gutenberg-products-block'
+						),
+						{
+							a: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<a
+									href={ getAdminLink( 'customize.php' ) }
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
+							strong: <strong />,
+						}
+					) }
+				</Notice>
 			</PanelBody>
 			{ showReturnToCart &&
 				! (

--- a/assets/js/blocks/cart-checkout/checkout/form/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/index.js
@@ -13,6 +13,7 @@ import OrderNotesStep from './order-notes-step';
 import PaymentMethodStep from './payment-method-step';
 import ShippingOptionsStep from './shipping-options-step';
 import './style.scss';
+import { TermsAndConditionsCheckbox } from '../terms-and-conditions-checkbox';
 
 const CheckoutForm = ( {
 	requireCompanyField,
@@ -22,6 +23,7 @@ const CheckoutForm = ( {
 	showOrderNotes,
 	showPhoneField,
 	allowCreateAccount,
+	requireTermsAndConditions,
 } ) => {
 	const { onSubmit } = useCheckoutContext();
 
@@ -37,6 +39,7 @@ const CheckoutForm = ( {
 			/>
 			<ShippingOptionsStep />
 			<PaymentMethodStep />
+			{ requireTermsAndConditions && <TermsAndConditionsCheckbox /> }
 			{ showOrderNotes && <OrderNotesStep /> }
 		</Form>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/form/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/index.js
@@ -23,6 +23,7 @@ const CheckoutForm = ( {
 	showOrderNotes,
 	showPhoneField,
 	allowCreateAccount,
+	termsAndConditionsText,
 	requireTermsAndConditions,
 } ) => {
 	const { onSubmit } = useCheckoutContext();
@@ -39,7 +40,9 @@ const CheckoutForm = ( {
 			/>
 			<ShippingOptionsStep />
 			<PaymentMethodStep />
-			{ requireTermsAndConditions && <TermsAndConditionsCheckbox /> }
+			{ requireTermsAndConditions && (
+				<TermsAndConditionsCheckbox text={ termsAndConditionsText } />
+			) }
 			{ showOrderNotes && <OrderNotesStep /> }
 		</Form>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
@@ -14,8 +14,15 @@ import { getSetting } from '@woocommerce/settings';
  * Internal dependencies
  */
 import { useValidationContext } from '../../../../base/context/shared';
+import blockAttributes from '../attributes';
 
-export const TermsAndConditionsCheckbox = (): ReactElement => {
+interface TermsAndConditionsCheckboxProps {
+	text: string;
+}
+
+export const TermsAndConditionsCheckbox = ( {
+	text,
+}: TermsAndConditionsCheckboxProps ): ReactElement => {
 	const {
 		isProcessing: checkoutIsProcessing,
 		isTermsAcceptedCheckboxPristine,
@@ -28,12 +35,18 @@ export const TermsAndConditionsCheckbox = (): ReactElement => {
 		getValidationError,
 	} = useValidationContext();
 
+	const defaultTermsAndConditionsText =
+		blockAttributes.termsAndConditionsText.default;
+
 	const [ termsAndConditionsText, setTermsAndConditionsText ] = useState<
 		string
 	>( getSetting( 'terms_and_conditions_text' ) );
 
 	useEffect( () => {
-		let termsText = getSetting( 'terms_and_conditions_text' );
+		let termsText = text;
+		if ( text === '' ) {
+			termsText = defaultTermsAndConditionsText;
+		}
 		if (
 			typeof termsText === 'string' &&
 			termsText.includes( '[terms]' )
@@ -41,7 +54,7 @@ export const TermsAndConditionsCheckbox = (): ReactElement => {
 			termsText = termsText.replace( /\[terms\]/, '<terms/>' );
 		}
 		setTermsAndConditionsText( termsText );
-	}, [ getSetting ] );
+	}, [ getSetting, text ] );
 
 	const isCheckboxInvalid =
 		! isTermsAcceptedCheckboxPristine &&

--- a/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
@@ -98,9 +98,13 @@ export const TermsAndConditionsCheckbox = (): ReactElement => {
 							),
 						}
 					) }
+					aria-invalid={ isCheckboxInvalid }
 				/>
 				{ isCheckboxInvalid && (
-					<div className="wc-block-components-validation-error wc-block-components__terms-and-conditions-checkbox__validation-error">
+					<div
+						aria-live="polite"
+						className="wc-block-components-validation-error wc-block-components__terms-and-conditions-checkbox__validation-error"
+					>
 						<p>
 							{ __(
 								'You must agree to the terms and conditions to continue.',

--- a/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
@@ -43,8 +43,8 @@ export const TermsAndConditionsCheckbox = ( {
 	>( defaultTermsAndConditionsText );
 
 	useEffect( () => {
-		let termsText = text;
-		if ( text === '' ) {
+		let termsText = text?.trim();
+		if ( ! termsText ) {
 			termsText = defaultTermsAndConditionsText;
 		}
 		if (

--- a/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import { useState, ReactElement, useEffect } from 'react';
+import CheckboxControl from '@woocommerce/base-components/checkbox-control';
+import { __ } from '@wordpress/i18n';
+import { useCheckoutContext } from '@woocommerce/base-context';
+import { FormStep } from '@woocommerce/base-components/cart-checkout';
+import { TERMS_URL, TERMS_PAGE_NAME } from '@woocommerce/block-settings';
+import { createInterpolateElement } from 'wordpress-element';
+import { getSetting } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import { useValidationContext } from '../../../../base/context/shared';
+
+export const TermsAndConditionsCheckbox = (): ReactElement => {
+	const {
+		isProcessing: checkoutIsProcessing,
+		isTermsAcceptedCheckboxPristine,
+		dispatchActions,
+	} = useCheckoutContext();
+
+	const {
+		setValidationErrors,
+		clearValidationError,
+		getValidationError,
+	} = useValidationContext();
+
+	const [ termsAndConditionsText, setTermsAndConditionsText ] = useState<
+		string
+	>( getSetting( 'terms_and_conditions_text' ) );
+
+	useEffect( () => {
+		let termsText = getSetting( 'terms_and_conditions_text' );
+		if (
+			typeof termsText === 'string' &&
+			termsText.includes( '[terms]' )
+		) {
+			termsText = termsText.replace( /\[terms\]/, '<terms/>' );
+		}
+		setTermsAndConditionsText( termsText );
+	}, [ getSetting ] );
+
+	const isCheckboxInvalid =
+		! isTermsAcceptedCheckboxPristine &&
+		getValidationError( 'terms_and_conditions' );
+
+	const setValidationError = () => {
+		setValidationErrors( {
+			terms_and_conditions: {
+				message: __(
+					'You must agree to the terms and conditions to continue.',
+					'woo-gutenberg-products-block'
+				),
+				hidden: false,
+			},
+		} );
+	};
+
+	useEffect( setValidationError, [ setValidationErrors ] );
+	return (
+		<FormStep
+			id="terms-and-conditions"
+			showStepNumber={ true }
+			title={ __( 'Terms and conditions', 'woocommerce' ) }
+			className="wc-block-checkout__terms-and-conditions-checkbox"
+			disabled={ checkoutIsProcessing }
+		>
+			<div className="wc-block-checkout__terms-and-conditions-checkbox">
+				<CheckboxControl
+					required={ true }
+					onChange={ ( termsAccepted: boolean ) => {
+						if ( isTermsAcceptedCheckboxPristine ) {
+							dispatchActions.setIsTermsAcceptedCheckboxPristine(
+								false
+							);
+						}
+						if ( ! termsAccepted ) {
+							setValidationError();
+							return;
+						}
+						clearValidationError( 'terms_and_conditions' );
+					} }
+					label={ createInterpolateElement(
+						// translators: <termsLink> is a link to the terms and conditions page of the site. The link text is the page's name.
+						termsAndConditionsText,
+						{
+							terms: (
+								<a
+									href={ TERMS_URL }
+									target="_blank"
+									rel="noreferrer"
+								>
+									{ TERMS_PAGE_NAME }
+								</a>
+							),
+						}
+					) }
+				/>
+				{ isCheckboxInvalid && (
+					<div className="wc-block-components-validation-error wc-block-components__terms-and-conditions-checkbox__validation-error">
+						<p>
+							{ __(
+								'You must agree to the terms and conditions to continue.',
+								'woo-gutenberg-products-block'
+							) }
+						</p>
+					</div>
+				) }
+			</div>
+		</FormStep>
+	);
+};

--- a/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
@@ -59,7 +59,19 @@ export const TermsAndConditionsCheckbox = (): ReactElement => {
 		} );
 	};
 
+	// Set a validation error as soon as the block loads. This will be hidden however, because the checkbox is pristine.
 	useEffect( setValidationError, [ setValidationErrors ] );
+
+	let terms = <>{ __( 'Terms and Conditions.', 'woocommerce' ) }</>;
+
+	if ( TERMS_URL && TERMS_PAGE_NAME ) {
+		terms = (
+			<a href={ TERMS_URL } target="_blank" rel="noreferrer">
+				{ TERMS_PAGE_NAME }
+			</a>
+		);
+	}
+
 	return (
 		<FormStep
 			id="terms-and-conditions"
@@ -87,15 +99,7 @@ export const TermsAndConditionsCheckbox = (): ReactElement => {
 						// translators: <termsLink> is a link to the terms and conditions page of the site. The link text is the page's name.
 						termsAndConditionsText,
 						{
-							terms: (
-								<a
-									href={ TERMS_URL }
-									target="_blank"
-									rel="noreferrer"
-								>
-									{ TERMS_PAGE_NAME }
-								</a>
-							),
+							terms,
 						}
 					) }
 					aria-invalid={ isCheckboxInvalid }

--- a/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/index.tsx
@@ -40,7 +40,7 @@ export const TermsAndConditionsCheckbox = ( {
 
 	const [ termsAndConditionsText, setTermsAndConditionsText ] = useState<
 		string
-	>( getSetting( 'terms_and_conditions_text' ) );
+	>( defaultTermsAndConditionsText );
 
 	useEffect( () => {
 		let termsText = text;

--- a/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/terms-and-conditions-checkbox/style.scss
@@ -1,0 +1,3 @@
+.wc-block-components__terms-and-conditions-checkbox__validation-error {
+	top: calc(100% - 17px);
+}

--- a/assets/js/type-defs/checkout.js
+++ b/assets/js/type-defs/checkout.js
@@ -1,15 +1,16 @@
 /**
  * @typedef {Object} CheckoutDispatchActions
  *
- * @property {function():void}              resetCheckout        Dispatches an action that resets the checkout to a pristine state.
- * @property {function(string):void}        setRedirectUrl       Dispatches an action that sets the redirectUrl.
- * @property {function(boolean=):void}      setHasError          Dispatches an action that sets the checkout status to having an error.
- * @property {function(Object):void}        setAfterProcessing   Dispatches an action that sets the checkout status to after processing and also sets the response data accordingly.
- * @property {function():void}              incrementCalculating Dispatches an action that increments  the calculating state for checkout by one.
- * @property {function():void}              decrementCalculating Dispatches an action that decrements the calculating state for checkout by one.
- * @property {function(number|string):void} setOrderId           Dispatches an action that stores the draft order ID and key.
- * @property {function(string):void}        setOrderNotes        Dispatches an action that sets the order notes.
- * @property {function(number):void}        setCustomerId        Dispatches an action that stores the customer ID.
+ * @property {function():void}              resetCheckout       				Dispatches an action that resets the checkout to a pristine state.
+ * @property {function(string):void}        setRedirectUrl       				 Dispatches an action that sets the redirectUrl.
+ * @property {function(boolean=):void}      setHasError          				 Dispatches an action that sets the checkout status to having an error.
+ * @property {function(Object):void}        setAfterProcessing   				 Dispatches an action that sets the checkout status to after processing and also sets the response data accordingly.
+ * @property {function():void}              incrementCalculating 				 Dispatches an action that increments  the calculating state for checkout by one.
+ * @property {function():void}              decrementCalculating 				 Dispatches an action that decrements the calculating state for checkout by one.
+ * @property {function(number|string):void} setOrderId           				 Dispatches an action that stores the draft order ID and key.
+ * @property {function(string):void}        setOrderNotes        				 Dispatches an action that sets the order notes.
+ * @property {function(number):void}        setCustomerId        				 Dispatches an action that stores the customer ID.
+ * @property {function(boolean):void}		setIsTermsAcceptedCheckboxPristine	 Dispatches an action that sets whether the terms and conditions checkbox is pristine.
  */
 
 /**

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -145,6 +145,9 @@
  * @property {boolean}                      shouldCreateAccount                  Should a user account be created?
  * @property {function(boolean)}            setShouldCreateAccount               Function to update the
  *                                                                               shouldCreateAccount property.
+ * @property {boolean}						isTermsAcceptedCheckboxPristine		 Whether the checkbox to accept terms
+ * 																				 and conditions has been previously
+ * 																				 modified.
  */
 
 /**

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -248,6 +248,7 @@ class Assets {
 				 */
 				'wordCountType'                 => _x( 'words', 'Word count type. Do not translate!', 'woo-gutenberg-products-block' ),
 				'hideOutOfStockItems'           => 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ),
+				'terms_and_conditions_text'     => wc_get_terms_and_conditions_checkbox_text(),
 			]
 		);
 	}

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -248,7 +248,7 @@ class Assets {
 				 */
 				'wordCountType'                 => _x( 'words', 'Word count type. Do not translate!', 'woo-gutenberg-products-block' ),
 				'hideOutOfStockItems'           => 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ),
-				'terms_and_conditions_text'     => wc_get_terms_and_conditions_checkbox_text(),
+				'termsAndConditionsText'        => wc_get_terms_and_conditions_checkbox_text(),
 			]
 		);
 	}

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -384,6 +384,10 @@ class Checkout extends AbstractCartRoute {
 	 */
 	public function validate_terms_and_conditions( \WP_REST_Request $request ) {
 		$terms_and_conditions_accepted = $request['terms_and_conditions_accepted'];
+		// If the Checkout block does not have the requireTermsAndConditions attribute set to true
+		// then the checkbox will not be present, and this value will not be sent to the API.
+		// The only time this can be explicitly false is if somehow the customer manages to submit
+		// the form to the point of it making an API request without ticking the checkbox.
 		if ( false === $terms_and_conditions_accepted ) {
 			throw new RouteException(
 				'woocommerce_rest_cart_error',

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -217,7 +217,7 @@ class Checkout extends AbstractCartRoute {
 		 * Validate items etc are allowed in the order before the order is processed. This will fix violations and tell
 		 * the customer.
 		 */
-		$this->cart_controller->validate_terms_and_conditions( $request );
+		$this->validate_terms_and_conditions( $request );
 		$this->cart_controller->validate_cart_items();
 		$this->cart_controller->validate_cart_coupons();
 
@@ -373,6 +373,23 @@ class Checkout extends AbstractCartRoute {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Validate the terms and conditions is true, or unset. If unset then the checkout block was not configured to
+	 * require the customer to agree to the terms and conditions.
+	 *
+	 * @param \WP_REST_Request $request The request with the posted data.
+	 * @throws RouteException           Throws if terms and conditions is false.
+	 */
+	public function validate_terms_and_conditions( \WP_REST_Request $request ) {
+		$terms_and_conditions_accepted = $request['terms_and_conditions_accepted'];
+		if ( false === $terms_and_conditions_accepted ) {
+			throw new RouteException(
+				'woocommerce_rest_cart_error',
+				__( 'You must accept the terms and conditions to place your order.', 'woo-gutenberg-products-block' )
+			);
+		}
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -217,6 +217,7 @@ class Checkout extends AbstractCartRoute {
 		 * Validate items etc are allowed in the order before the order is processed. This will fix violations and tell
 		 * the customer.
 		 */
+		$this->cart_controller->validate_terms_and_conditions( $request );
 		$this->cart_controller->validate_cart_items();
 		$this->cart_controller->validate_cart_coupons();
 

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -550,6 +550,23 @@ class CartController {
 	}
 
 	/**
+	 * Validate the terms and conditions is true, or unset. If unset then the checkout block was not configured to
+	 * require the customer to agree to the terms and conditions.
+	 *
+	 * @param \WP_REST_Request $request The request with the posted data.
+	 * @throws RouteException           Throws if terms and conditions is false.
+	 */
+	public function validate_terms_and_conditions( \WP_REST_Request $request ) {
+		$terms_and_conditions_accepted = $request['terms_and_conditions_accepted'];
+		if ( false === $terms_and_conditions_accepted ) {
+			throw new RouteException(
+				'woocommerce_rest_cart_error',
+				__( 'You must accept the terms and conditions to place your order.', 'woo-gutenberg-products-block' )
+			);
+		}
+	}
+
+	/**
 	 * Validate all items in the cart and get a list of errors.
 	 *
 	 * @return WP_Error[] An array of WP_Errors describing the cart's error state.

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -550,23 +550,6 @@ class CartController {
 	}
 
 	/**
-	 * Validate the terms and conditions is true, or unset. If unset then the checkout block was not configured to
-	 * require the customer to agree to the terms and conditions.
-	 *
-	 * @param \WP_REST_Request $request The request with the posted data.
-	 * @throws RouteException           Throws if terms and conditions is false.
-	 */
-	public function validate_terms_and_conditions( \WP_REST_Request $request ) {
-		$terms_and_conditions_accepted = $request['terms_and_conditions_accepted'];
-		if ( false === $terms_and_conditions_accepted ) {
-			throw new RouteException(
-				'woocommerce_rest_cart_error',
-				__( 'You must accept the terms and conditions to place your order.', 'woo-gutenberg-products-block' )
-			);
-		}
-	}
-
-	/**
 	 * Validate all items in the cart and get a list of errors.
 	 *
 	 * @return WP_Error[] An array of WP_Errors describing the cart's error state.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR is a prototype which adds a checkbox to accept the store's terms and conditions in the Checkout block.

The following changes have been made:

- Added an attribute to the Checkout block called `requireTermsAndConditions` and a toggle control to change its value. When toggled on, the block will display the terms and conditions checkbox.
- Added a `TextControl` option which appears when `requireTermsAndConditions` is true. This allows the user to edit the text of the checkbox label. Updating it updates the block preview in realtime.
- Added `terms_and_conditions_text` to `wcSettings` - this is the result of  wc_get_terms_and_conditions_checkbox_text()`
- Add a new method to `Checkout` called `validate_terms_and_conditions` - this validates based on the value of `terms_and_conditions_accepted` in the request _not_ being explicitly false. [There is a comment describing this here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/compare/add/terms-and-conditions-checkbox?expand=1#diff-af2c90fa556cc086b780c8fad99b68373d87fd6007e6e2ff1b4c68ebe9ccb551R387)
- Adds an action, selector, and reducer key for `isTermsAndConditionsCheckboxPristine` to track whether the checkbox has been changed. This is so we can show an error if it is not checked, but hide it if the user hasn't interacted with the checkbox yet.
- Add a new `TermsAndConditionsCheckbox` component which gets rendered on the `CheckoutForm` if the Checkout block's `requireTermsAndConditions` is true.
- Pass whether the checkbox is checked to the API. The way this is checked is by the presence of an error keyed by `terms_and_conditions` in the `useValidationContext` hook. When the checkbox is checked, this error is cleared, and re-added when it is unchecked.

<!-- Reference any related issues or PRs here -->
Fixes #3258

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
#### Front end
<img src="https://user-images.githubusercontent.com/5656702/112641819-a1478b80-8e3a-11eb-97b7-886500a276c1.png" width="500" />

#### Block controls
<img src="https://user-images.githubusercontent.com/5656702/112751785-a5ed7a80-8fc7-11eb-8efb-22f8d152d780.png" width="300" />
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

#### General functionality
1. Go to WooCommerce > Settings > Advanced and ensure you have a Terms page set up.
9. Go to **Customizer** > **WooCommerce** > **Checkout** and ensure the **Terms and Conditions** text contains `[terms]`.
1. Go to the checkout block in the editor, try toggling the checkbox for required terms and conditions. See that it shows up in the editor when the toggle is on, and it does not show when the toggle is off.
2. Enable the toggle and save the page.
3. Add an item to your cart then go to the Checkout page on the front-end. See that the checkbox for terms and conditions has appeared. Ensure no error shows up.
4. Submit the form without changing the checkbox.
5. Ensure checkout does not process and a validation error appears under the terms and conditions checkbox.
6. Refresh the page.
7. Tick then untick the checkbox, ensure the error appears.
8. Tick the checkbox again and complete the checkout process. Ensure it works.

#### Customisation
1. Go to **Customizer** > **WooCommerce** > **Checkout** and modify the **Terms and Conditions** text. Optionally remove `[terms]` from it.
10. Refresh the Checkout block and ensure the new text appears.
11. If you removed `[terms]` verify there is no link in the checkbox label.
12. Put `[terms]` back if you removed it.
11. Rename the Terms and conditions page to something else, then verify the link in the checkbox label is updated.

### Automated tests 🚧 
As this is a prototype I will not add automated tests _yet_. When this work is more refined and we are happy with the direction we can add them.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.
