### PR TITLE
Strip tags from exceptions that are converted from notices

### DIFF
--- a/src/StoreApi/Utilities/NoticeHandler.php
+++ b/src/StoreApi/Utilities/NoticeHandler.php
@@ -34,7 +34,7 @@ class NoticeHandler {
 		wc_clear_notices();
 
 		foreach ( $error_notices as $error_notice ) {
-			throw new RouteException( $error_code, $error_notice['notice'], 400 );
+			throw new RouteException( $error_code, wp_strip_all_tags( $error_notice['notice'] ), 400 );
 		}
 	}
 }

--- a/tests/php/StoreApi/Utilities/NoticeHandler.php
+++ b/tests/php/StoreApi/Utilities/NoticeHandler.php
@@ -7,21 +7,16 @@ namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\NoticeHandler;
 use PHPUnit\Framework\TestCase;
 use \WC_Helper_Product as ProductHelper;
 
 class NoticeHandlerTests extends TestCase {
 
-	public function test_api_does_not_return_html() {
-		// We expect validate_cart_items to throw
+	public function test_convert_notices_to_exceptions() {
 		$this->expectException(RouteException::class);
 		$this->expectExceptionMessage('This is an error message with Some HTML in it.');
-		$class = new CartController();
-		add_action( 'woocommerce_check_cart_items', function() {
-			wc_add_notice( '<strong>This is an error message with <a href="#">Some HTML in it</a>.', 'error' );
-		} );
-		$product = ProductHelper::create_simple_product();
-		wc()->cart->add_to_cart( $product->get_id(), 2 );
-		$class->validate_cart_items();
+		wc_add_notice( '<strong>This is an error message with <a href="#">Some HTML in it</a>.', 'error' );
+		$errors = NoticeHandler::convert_notices_to_exceptions( 'test_error' );
 	}
 }

--- a/tests/php/StoreApi/Utilities/NoticeHandler.php
+++ b/tests/php/StoreApi/Utilities/NoticeHandler.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * NoticeHandler Tests.
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;
+
+use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use PHPUnit\Framework\TestCase;
+use \WC_Helper_Product as ProductHelper;
+
+class NoticeHandlerTests extends TestCase {
+
+	public function test_api_does_not_return_html() {
+		// We expect validate_cart_items to throw
+		$this->expectException(RouteException::class);
+		$this->expectExceptionMessage('This is an error message with Some HTML in it.');
+		$class = new CartController();
+		add_action( 'woocommerce_check_cart_items', function() {
+			wc_add_notice( '<strong>This is an error message with <a href="#">Some HTML in it</a>.', 'error' );
+		} );
+		$product = ProductHelper::create_simple_product();
+		wc()->cart->add_to_cart( $product->get_id(), 2 );
+		$class->validate_cart_items();
+	}
+}

--- a/tests/php/StoreApi/Utilities/NoticeHandler.php
+++ b/tests/php/StoreApi/Utilities/NoticeHandler.php
@@ -14,8 +14,8 @@ use \WC_Helper_Product as ProductHelper;
 class NoticeHandlerTests extends TestCase {
 
 	public function test_convert_notices_to_exceptions() {
-		$this->expectException(RouteException::class);
-		$this->expectExceptionMessage('This is an error message with Some HTML in it.');
+		$this->expectException( RouteException::class );
+		$this->expectExceptionMessage( 'This is an error message with Some HTML in it.' );
 		wc_add_notice( '<strong>This is an error message with <a href="#">Some HTML in it</a>.', 'error' );
 		$errors = NoticeHandler::convert_notices_to_exceptions( 'test_error' );
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When an extension adds a notice that contains HTML using `wc_add_notice` and then it is converted using the `NoticeHandler::convert_notices_to_exceptions` method, then the resulting exception contains HTML which is displayed incorrectly on the front-end. The changes in this PR will strip the tags from notices before returning.

There is also a simple PHP unit test included with this PR.

<!-- Reference any related issues or PRs here -->
Fixes #3977 - but it does _not_ fix the underlying issue causing the error to display in the first place.

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/5656702/112754817-c15f8200-8fd5-11eb-9124-682ff4e5160f.png)

#### After
![image](https://user-images.githubusercontent.com/5656702/112754832-d9cf9c80-8fd5-11eb-8221-fd7ec34d15ad.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

**You will need WooCommerce Shipping and Tax set up and linked to your WPCOM account. If you don't have this, then you can test on _my_ local site using my ngrok tunnel. Just message me when you're ready to test.**

1. Enable WooCommerce Shipping and Tax
2. Go to the shortcode cart.
3. Use the shipping calculator, select United States as your country, but leave ZIP code empty.
4. Proceed to checkout.
5. Fill in all fields, including ZIP code.
6. See error.

<!-- If you can, add the appropriate labels -->

### Changelog

> Prevent error messages returned by the API from displaying raw HTML.
