### PR TITLE
Avoid get_billing and get_shipping method when updating the order

### DIFF
--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -453,28 +453,29 @@ class OrderController {
 	 * @param \WC_Order $order The order object to update.
 	 */
 	protected function update_addresses_from_cart( \WC_Order $order ) {
-		$customer_billing = wc()->customer->get_billing();
-		$customer_billing = array_combine(
-			array_map(
-				function( $key ) {
-					return 'billing_' . $key;
-				},
-				array_keys( $customer_billing )
-			),
-			$customer_billing
+		$order->set_props(
+			[
+				'billing_first_name'  => wc()->customer->get_billing_first_name(),
+				'billing_last_name'   => wc()->customer->get_billing_last_name(),
+				'billing_company'     => wc()->customer->get_billing_company(),
+				'billing_address_1'   => wc()->customer->get_billing_address_1(),
+				'billing_address_2'   => wc()->customer->get_billing_address_2(),
+				'billing_city'        => wc()->customer->get_billing_city(),
+				'billing_state'       => wc()->customer->get_billing_state(),
+				'billing_postcode'    => wc()->customer->get_billing_postcode(),
+				'billing_country'     => wc()->customer->get_billing_country(),
+				'billing_email'       => wc()->customer->get_billing_email(),
+				'billing_phone'       => wc()->customer->get_billing_phone(),
+				'shipping_first_name' => wc()->customer->get_shipping_first_name(),
+				'shipping_last_name'  => wc()->customer->get_shipping_last_name(),
+				'shipping_company'    => wc()->customer->get_shipping_company(),
+				'shipping_address_1'  => wc()->customer->get_shipping_address_1(),
+				'shipping_address_2'  => wc()->customer->get_shipping_address_2(),
+				'shipping_city'       => wc()->customer->get_shipping_city(),
+				'shipping_state'      => wc()->customer->get_shipping_state(),
+				'shipping_postcode'   => wc()->customer->get_shipping_postcode(),
+				'shipping_country'    => wc()->customer->get_shipping_country(),
+			]
 		);
-		$order->set_props( $customer_billing );
-
-		$customer_shipping = wc()->customer->get_shipping();
-		$customer_shipping = array_combine(
-			array_map(
-				function( $key ) {
-					return 'shipping_' . $key;
-				},
-				array_keys( $customer_shipping )
-			),
-			$customer_shipping
-		);
-		$order->set_props( $customer_shipping );
 	}
 }


### PR DESCRIPTION
There is a core bug where the `get_shipping` and `get_billing` methods only return **changes**. This means when we go to update the order, some fields are missing which leads to the issue described in #3975

See https://github.com/woocommerce/woocommerce/pull/29538

This PR works around the issue by avoiding these methods and just using individual setters from the customer object.

Fixes #3975

@nerrad @ralucaStan this should be merged before 4.8 IMO.

### How to test the changes in this Pull Request:

See instructions in #3975.

Smoke test checkout taking care that addresses are saved correctly to the order.

### Changelog

> Fix customer address country saving to orders in certain circumstances.
