### PR TITLE
Fix Featured Product and Featured Category button alignment

### DIFF
--- a/assets/js/blocks/featured-category/style.scss
+++ b/assets/js/blocks/featured-category/style.scss
@@ -82,6 +82,10 @@
 		}
 	}
 
+	.wp-block-button.aligncenter {
+		text-align: center;
+	}
+
 	&.has-background-dim::before {
 		content: "";
 		position: absolute;

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -94,6 +94,10 @@
 		}
 	}
 
+	.wp-block-button.aligncenter {
+		text-align: center;
+	}
+
 	&.has-background-dim::before {
 		content: "";
 		position: absolute;


### PR DESCRIPTION
Fixes #3788.

We were relying on some styles from Gutenberg which are no longer present in recent versions.

### Screenshots

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/113333925-5985a000-9323-11eb-8c11-25796187bbcc.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/113333839-3e1a9500-9323-11eb-9e12-4bd783487638.png)

### How to test the changes in this Pull Request:

1. Add a Featured Product and Featured Category blocks.
2. Without making any change on them, preview them in the frontend and verify the button is centered.
3. Change the alignment of the button to the left, right, back to the center, etc. and verify it works.

### Changelog

> Fix button alignment in Featured Product and Featured Category blocks.