### PR TITLE
provide fallback for extensions when store hasn't loaded yet

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -38,7 +38,7 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		item_data: itemData = [],
 		variation,
 		totals,
-		extensions,
+		extensions = {},
 	} = cartItem;
 
 	const productPriceValidation = useCallback(

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.js
@@ -92,7 +92,7 @@ const CartLineItemRow = ( { lineItem = {} } ) => {
 			line_subtotal: '0',
 			line_subtotal_tax: '0',
 		},
-		extensions,
+		extensions = {},
 	} = lineItem;
 
 	const {

--- a/assets/js/type-defs/cart.js
+++ b/assets/js/type-defs/cart.js
@@ -152,6 +152,8 @@
  *                                                     provided using the
  *                                                     smallest unit of the
  *                                                     currency.
+ * @property {Object}              extensions          Extra data registered
+ *                                                     by plugins.
  */
 
 /**

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -73,7 +73,7 @@ export const __experimentalApplyCheckoutFilter = ( {
 	/** Object containing arguments for the filter function. */
 	arg: CheckoutFilterArguments;
 	/** Function that needs to return true when the filtered value is passed in order for the filter to be applied. */
-	validation: ( value: unknown ) => boolean;
+	validation: ( value: unknown ) => true | Error;
 } ): unknown => {
 	return useMemo( () => {
 		const filters = getCheckoutFilters( filterName );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4001

Filters try to load early, before the store actually loads (on the first render, before hooks are triggered), this causes filters to run with an `undefined` `extenstions`. I added a default `{}` to it so this doesn't happen.

### Testing instructions
- Check out 3993-gh-woocommerce/woocommerce-subscriptions since it's the only PR that register filters right now.
- Add a product to cart, visit it.
- Remove the item.
- Add another item from the products shown on empty cart.
- There should be no error.