### PR TITLE
unqeueue WooCore scripts instead of deregister.

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -69,10 +69,10 @@ class Cart extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content ) {
 		// Deregister core cart scripts and styles.
-		wp_deregister_script( 'wc-cart' );
-		wp_deregister_script( 'wc-password-strength-meter' );
-		wp_deregister_script( 'selectWoo' );
-		wp_deregister_style( 'select2' );
+		wp_dequeue_script( 'wc-cart' );
+		wp_dequeue_script( 'wc-password-strength-meter' );
+		wp_dequeue_script( 'selectWoo' );
+		wp_dequeue_style( 'select2' );
 
 		return $this->inject_html_data_attributes( $content . $this->get_skeleton(), $attributes );
 	}

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -71,10 +71,10 @@ class Checkout extends AbstractBlock {
 		}
 
 		// Deregister core checkout scripts and styles.
-		wp_deregister_script( 'wc-checkout' );
-		wp_deregister_script( 'wc-password-strength-meter' );
-		wp_deregister_script( 'selectWoo' );
-		wp_deregister_style( 'select2' );
+		wp_dequeue_script( 'wc-checkout' );
+		wp_dequeue_script( 'wc-password-strength-meter' );
+		wp_dequeue_script( 'selectWoo' );
+		wp_dequeue_style( 'select2' );
 
 		return $this->inject_html_data_attributes( $content . $this->get_skeleton(), $attributes );
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4003

Previously, we deregistered Woo Core scripts, this didn't prevent them from showing up on Query monitor, this PR unqeueue them, which does both.

### Testing steps 
- Install query monitor plugin from wordpress.org
- Load Cart block page.
- Open the query monitor tab by clicking on it on the topbar.
- Go to scripts tab.
- There should be no errors as shown on #4003