### PR TITLE
Prevent unwanted parts of address being displayed

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
-import { emptyHiddenAddressFields } from '@woocommerce/base-utils';
 
 /**
  * Shows a formatted shipping location.
@@ -19,7 +18,6 @@ const ShippingLocation = ( { address } ) => {
 		return null;
 	}
 
-	address = emptyHiddenAddressFields( address );
 	const shippingCountries = getSetting( 'shippingCountries', {} );
 	const shippingStates = getSetting( 'shippingStates', {} );
 	const formattedCountry =

--- a/assets/js/base/components/cart-checkout/shipping-location/index.js
+++ b/assets/js/base/components/cart-checkout/shipping-location/index.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
+import { emptyHiddenAddressFields } from '@woocommerce/base-utils';
 
 /**
  * Shows a formatted shipping location.
@@ -17,6 +18,8 @@ const ShippingLocation = ( { address } ) => {
 	if ( Object.values( address ).length === 0 ) {
 		return null;
 	}
+
+	address = emptyHiddenAddressFields( address );
 	const shippingCountries = getSetting( 'shippingCountries', {} );
 	const shippingStates = getSetting( 'shippingStates', {} );
 	const formattedCountry =

--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -15,7 +15,10 @@ import type {
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
 } from '@woocommerce/types';
-import { fromEntriesPolyfill } from '@woocommerce/base-utils';
+import {
+	emptyHiddenAddressFields,
+	fromEntriesPolyfill,
+} from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -171,6 +174,7 @@ export const useStoreCart = (
 			const cartFees = cartData.fees.map( ( fee: CartResponseFeeItem ) =>
 				decodeValues( fee )
 			);
+
 			return {
 				cartCoupons: cartData.coupons,
 				cartItems: cartData.items || [],
@@ -183,8 +187,8 @@ export const useStoreCart = (
 				cartTotals,
 				cartIsLoading,
 				cartErrors,
-				billingAddress,
-				shippingAddress,
+				billingAddress: emptyHiddenAddressFields( billingAddress ),
+				shippingAddress: emptyHiddenAddressFields( shippingAddress ),
 				extensions: cartData.extensions || {},
 				shippingRates: cartData.shippingRates || [],
 				shippingRatesLoading,

--- a/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
@@ -10,7 +10,10 @@ import {
 	useState,
 	useMemo,
 } from '@wordpress/element';
-import { formatStoreApiErrorMessage } from '@woocommerce/base-utils';
+import {
+	emptyHiddenAddressFields,
+	formatStoreApiErrorMessage,
+} from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies

--- a/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
@@ -164,8 +164,12 @@ const CheckoutProcessor = () => {
 		setIsProcessingOrder( true );
 		removeNotice( 'checkout' );
 		let data = {
-			billing_address: currentBillingData.current,
-			shipping_address: currentShippingAddress.current,
+			billing_address: emptyHiddenAddressFields(
+				currentBillingData.current
+			),
+			shipping_address: emptyHiddenAddressFields(
+				currentShippingAddress.current
+			),
 			customer_note: orderNotes,
 			should_create_account: shouldCreateAccount,
 		};

--- a/assets/js/base/context/tsconfig.json
+++ b/assets/js/base/context/tsconfig.json
@@ -8,6 +8,8 @@
 		"../../settings/blocks/index.ts",
 		"../../base/hooks/index.js",
 		"../utils/type-guards.ts",
+	  	"../../base/utils/",
+	  	"../../data/",
 		"../../type-defs"
 	],
 	"exclude": [ "**/test/**" ]

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import defaultAddressFields from '@woocommerce/base-components/cart-checkout/address-form/default-address-fields';
+import prepareAddressFields from '@woocommerce/base-components/cart-checkout/address-form/prepare-address-fields';
+
+/**
  * pluckAddress takes a full address object and returns relevant fields for calculating
  * shipping, so we can track when one of them change to update rates.
  *
@@ -21,3 +27,22 @@ export const pluckAddress = ( {
 	city: city.trim(),
 	postcode: postcode ? postcode.replace( ' ', '' ).toUpperCase() : '',
 } );
+
+/**
+ * Removes fields from an address if they are hidden by the field config from core.
+ *
+ * @param {Object} address The address to remove fields from.
+ * @return {Object} The address with hidden fields removed.
+ */
+export const emptyHiddenAddressFields = ( address ) => {
+	const fields = Object.keys( defaultAddressFields );
+	const addressFields = prepareAddressFields( fields, {}, address.country );
+	const newAddress = {};
+	addressFields
+		.filter( ( field ) => ! field.hidden )
+		.forEach( ( field ) => {
+			newAddress[ field.key ] = address[ field.key ];
+		} );
+
+	return newAddress;
+};

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -43,5 +43,5 @@ export const emptyHiddenAddressFields = ( address ) => {
 			newAddress[ field.key ] = '';
 		}
 	} );
-	return address;
+	return newAddress;
 };

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -29,20 +29,18 @@ export const pluckAddress = ( {
 } );
 
 /**
- * Removes fields from an address if they are hidden by the field config from core.
+ * Sets fields to an empty string in an address if they are hidden by the settings in countryLocale.
  *
- * @param {Object} address The address to remove fields from.
- * @return {Object} The address with hidden fields removed.
+ * @param {Object} address The address to empty fields from.
+ * @return {Object} The address with hidden fields values removed.
  */
 export const emptyHiddenAddressFields = ( address ) => {
 	const fields = Object.keys( defaultAddressFields );
 	const addressFields = prepareAddressFields( fields, {}, address.country );
 	const newAddress = {};
-	addressFields
-		.filter( ( field ) => ! field.hidden )
-		.forEach( ( field ) => {
-			newAddress[ field.key ] = address[ field.key ];
-		} );
+	addressFields.forEach( ( field ) => {
+		newAddress[ field.key ] = field.hidden ? '' : address[ field.key ];
+	} );
 
 	return newAddress;
 };

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -37,10 +37,10 @@ export const pluckAddress = ( {
 export const emptyHiddenAddressFields = ( address ) => {
 	const fields = Object.keys( defaultAddressFields );
 	const addressFields = prepareAddressFields( fields, {}, address.country );
-	const newAddress = Object.assign( {}, address );
 	addressFields.forEach( ( field ) => {
-		newAddress[ field.key ] = field.hidden ? '' : address[ field.key ];
+		if ( field.hidden ) {
+			address[ field.key ] = '';
+		}
 	} );
-
-	return newAddress;
+	return address;
 };

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import defaultAddressFields from '@woocommerce/base-components/cart-checkout/address-form/default-address-fields';
+import { defaultAddressFields } from '@woocommerce/settings';
 import prepareAddressFields from '@woocommerce/base-components/cart-checkout/address-form/prepare-address-fields';
 
 /**

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -37,9 +37,10 @@ export const pluckAddress = ( {
 export const emptyHiddenAddressFields = ( address ) => {
 	const fields = Object.keys( defaultAddressFields );
 	const addressFields = prepareAddressFields( fields, {}, address.country );
+	const newAddress = Object.assign( {}, address );
 	addressFields.forEach( ( field ) => {
 		if ( field.hidden ) {
-			address[ field.key ] = '';
+			newAddress[ field.key ] = '';
 		}
 	} );
 	return address;

--- a/assets/js/base/utils/address.js
+++ b/assets/js/base/utils/address.js
@@ -37,7 +37,7 @@ export const pluckAddress = ( {
 export const emptyHiddenAddressFields = ( address ) => {
 	const fields = Object.keys( defaultAddressFields );
 	const addressFields = prepareAddressFields( fields, {}, address.country );
-	const newAddress = {};
+	const newAddress = Object.assign( {}, address );
 	addressFields.forEach( ( field ) => {
 		newAddress[ field.key ] = field.hidden ? '' : address[ field.key ];
 	} );

--- a/assets/js/base/utils/test/address.ts
+++ b/assets/js/base/utils/test/address.ts
@@ -19,6 +19,6 @@ describe( 'emptyHiddenAddressFields', () => {
 			phone: '',
 		};
 		const filteredAddress = emptyHiddenAddressFields( address );
-		expect( filteredAddress ).not.toHaveProperty( 'state' );
+		expect( filteredAddress ).toHaveProperty( 'state', '' );
 	} );
 } );

--- a/assets/js/base/utils/test/address.ts
+++ b/assets/js/base/utils/test/address.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { emptyHiddenAddressFields } from '@woocommerce/base-utils';
+
+describe( 'emptyHiddenAddressFields', () => {
+	it( "Removes state from an address where the country doesn't use states", () => {
+		const address = {
+			first_name: 'Jonny',
+			last_name: 'Awesome',
+			company: 'WordPress',
+			address_1: '123 Address Street',
+			address_2: 'Address 2',
+			city: 'Vienna',
+			postcode: '1120',
+			country: 'AT',
+			state: 'CA', // This should be removed.
+			email: 'jonny.awesome@email.com',
+			phone: '',
+		};
+		const filteredAddress = emptyHiddenAddressFields( address );
+		expect( filteredAddress ).not.toHaveProperty( 'state' );
+	} );
+} );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The changes introduced in this PR will cause parts of an address that should be hidden (based on the settings in `countryLocale`) to be set to an empty string in the address object.

The reason we can't simply set the unwanted parts of the address to empty strings when updating it is because in core there is the notion of `changes` to the address object, which when applied only updates fields for which there are new values (see source here: https://github.com/woocommerce/woocommerce/blob/trunk/includes/abstracts/abstract-wc-data.php#L764-L767 - e.g. so when `state` is empty on a new address, but present in the old address, it will not be updated) I'm not sure if this is something that _should_ be changed in core - it appears that the logic used for this is used by several different classes and adding checks around it for parts of an address would decrease performance.

Core has some [similar functionality](https://github.com/woocommerce/woocommerce/blob/trunk/includes/class-wc-countries.php#L563) to display the address in the shortcode cart's shipping calculator.

**Changes**
- Add the `emptyHiddenAddressFields` function
- Add tests for `emptyHiddenAddressFields`.
- Ensure the address is formatted before posting it to the API in the checkout, and before displaying it in the shipping calculator.

<!-- Reference any related issues or PRs here -->
Fixes #3979

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

1. Add an item to the cart.
2. Go to the shortcode cart - use the shipping calculator to enter a US address. (`State: California, City: Beverly Hills, ZIP: 90210`)
3. Proceed to checkout and successfully complete. If you get errors, ensure the form is filled properly, and submit again. This is a known issue in #3975 
4. Add another item to the cart and go back to the shortcode cart, change your address on the shipping calculator to a Polish one (or any other that doesn't use states). (`City: Gdansk, Postcode: 80-000`)
4. Go to the cart _Block_ and see there is no `CA` shown in the address.
5. Check out and inspect the request made to the API. Ensure the posted data does not contain the state, or any other information that should not be posted.

<!-- If you can, add the appropriate labels -->

### Changelog

> Prevent parts of old addresses being displayed in the shipping calculator when changing countries.
