### PR TITLE
Rename onCheckoutBeforeProcessing to onCheckoutValidationBeforeProcessing

### DIFF
--- a/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.js
+++ b/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.js
@@ -85,9 +85,10 @@ export const usePaymentMethodInterface = () => {
 		isComplete,
 		isIdle,
 		isProcessing,
+		onCheckoutBeforeProcessing,
+		onCheckoutValidationBeforeProcessing,
 		onCheckoutAfterProcessingWithSuccess,
 		onCheckoutAfterProcessingWithError,
-		onCheckoutBeforeProcessing,
 		onSubmit,
 		customerId,
 	} = useCheckoutContext();
@@ -175,9 +176,10 @@ export const usePaymentMethodInterface = () => {
 			customerId,
 		},
 		eventRegistration: {
+			onCheckoutBeforeProcessing,
+			onCheckoutValidationBeforeProcessing,
 			onCheckoutAfterProcessingWithSuccess,
 			onCheckoutAfterProcessingWithError,
-			onCheckoutBeforeProcessing,
 			onShippingRateSuccess,
 			onShippingRateFail,
 			onShippingRateSelectSuccess,

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/event-emit.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/event-emit.js
@@ -9,7 +9,8 @@ import {
 } from '../../../event-emit';
 
 const EMIT_TYPES = {
-	CHECKOUT_BEFORE_PROCESSING: 'checkout_before_processing',
+	CHECKOUT_VALIDATION_BEFORE_PROCESSING:
+		'checkout_validation_before_processing',
 	CHECKOUT_AFTER_PROCESSING_WITH_SUCCESS:
 		'checkout_after_processing_with_success',
 	CHECKOUT_AFTER_PROCESSING_WITH_ERROR:
@@ -38,8 +39,8 @@ const emitterObservers = ( dispatcher ) => ( {
 		EMIT_TYPES.CHECKOUT_AFTER_PROCESSING_WITH_ERROR,
 		dispatcher
 	),
-	onCheckoutBeforeProcessing: emitterCallback(
-		EMIT_TYPES.CHECKOUT_BEFORE_PROCESSING,
+	onCheckoutValidationBeforeProcessing: emitterCallback(
+		EMIT_TYPES.CHECKOUT_VALIDATION_BEFORE_PROCESSING,
 		dispatcher
 	),
 } );

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
@@ -124,14 +124,19 @@ export const CheckoutStateProvider = ( {
 	 * @deprecated use onCheckoutValidationBeforeProcessing instead
 	 */
 	const onCheckoutBeforeProcessing = useMemo( () => {
-		deprecated( 'onCheckoutBeforeProcessing', {
-			alternative: 'onCheckoutValidationBeforeProcessing',
-			plugin: 'WooCommerce Blocks',
-		} );
-
-		return emitterObservers( observerDispatch )
+		const callback = emitterObservers( observerDispatch )
 			.onCheckoutValidationBeforeProcessing;
+
+		return function ( ...args ) {
+			deprecated( 'onCheckoutBeforeProcessing', {
+				alternative: 'onCheckoutValidationBeforeProcessing',
+				plugin: 'WooCommerce Blocks',
+			} );
+
+			return callback( ...args );
+		};
 	}, [ observerDispatch ] );
+
 	const onCheckoutValidationBeforeProcessing = useMemo(
 		() =>
 			emitterObservers( observerDispatch )

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
@@ -123,7 +123,7 @@ export const CheckoutStateProvider = ( {
 	/**
 	 * @deprecated use onCheckoutValidationBeforeProcessing instead
 	 *
-	 * To prevent the deprecation message to be shown at render time
+	 * To prevent the deprecation message being shown at render time
 	 * we need an extra function between useMemo and emitterObservers
 	 * so that the deprecated message gets shown only at invocation time.
 	 * (useMemo calls the passed function at render time)

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
@@ -127,6 +127,7 @@ export const CheckoutStateProvider = ( {
 	 * we need an extra function between useMemo and emitterObservers
 	 * so that the deprecated message gets shown only at invocation time.
 	 * (useMemo calls the passed function at render time)
+	 * See: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4039/commits/a502d1be8828848270993264c64220731b0ae181
 	 */
 	const onCheckoutBeforeProcessing = useMemo( () => {
 		const callback = emitterObservers( observerDispatch )

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
@@ -122,6 +122,11 @@ export const CheckoutStateProvider = ( {
 	}, [ observers ] );
 	/**
 	 * @deprecated use onCheckoutValidationBeforeProcessing instead
+	 *
+	 * To prevent the deprecation message to be shown at render time
+	 * we need an extra function between useMemo and emitterObservers
+	 * so that the deprecated message gets shown only at invocation time.
+	 * (useMemo calls the passed function at render time)
 	 */
 	const onCheckoutBeforeProcessing = useMemo( () => {
 		const callback = emitterObservers( observerDispatch )

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.js
@@ -120,6 +120,9 @@ export const CheckoutStateProvider = ( {
 	useEffect( () => {
 		currentObservers.current = observers;
 	}, [ observers ] );
+	/**
+	 * @deprecated use onCheckoutValidationBeforeProcessing instead
+	 */
 	const onCheckoutBeforeProcessing = useMemo( () => {
 		deprecated( 'onCheckoutBeforeProcessing', {
 			alternative: 'onCheckoutValidationBeforeProcessing',

--- a/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
@@ -37,7 +37,7 @@ import { useStoreNotices } from '../../../../hooks/use-store-notices';
 const CheckoutProcessor = () => {
 	const {
 		hasError: checkoutHasError,
-		onCheckoutBeforeProcessing,
+		onCheckoutValidationBeforeProcessing,
 		dispatchActions,
 		redirectUrl,
 		isProcessing: checkoutIsProcessing,
@@ -147,7 +147,7 @@ const CheckoutProcessor = () => {
 	useEffect( () => {
 		let unsubscribeProcessing;
 		if ( ! expressPaymentMethodActive ) {
-			unsubscribeProcessing = onCheckoutBeforeProcessing(
+			unsubscribeProcessing = onCheckoutValidationBeforeProcessing(
 				checkValidation,
 				0
 			);
@@ -158,7 +158,7 @@ const CheckoutProcessor = () => {
 			}
 		};
 	}, [
-		onCheckoutBeforeProcessing,
+		onCheckoutValidationBeforeProcessing,
 		checkValidation,
 		expressPaymentMethodActive,
 	] );

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -120,16 +120,16 @@
  *                                                                               have triggered a notice.
  * @property {string}                       redirectUrl                          This is the url that checkout will
  *                                                                               redirect to when it's ready.
+ * @property {function(function(),number=)} onCheckoutValidationBeforeProcessing Used to register a callback that will
+ *                                                                               fire when the validation of the submitted checkout
+ *                                                                               data happens, before it's sent off to the
+ *                                                                               server.
  * @property {function(function(),number=)} onCheckoutAfterProcessingWithSuccess Used to register a callback that will
  *                                                                               fire after checkout has been processed
  *                                                                               and there are no errors.
  * @property {function(function(),number=)} onCheckoutAfterProcessingWithError   Used to register a callback that will
  *                                                                               fire when the checkout has been
  *                                                                               processed and has an error.
- * @property {function(function(),number=)} onCheckoutBeforeProcessing           Used to register a callback that will
- *                                                                               fire when the checkout has been
- *                                                                               submitted before being sent off to the
- *                                                                               server.
  * @property {CheckoutDispatchActions}      dispatchActions                      Various actions that can be dispatched
  *                                                                               for the checkout context data.
  * @property {number}                       orderId                              This is the ID for the draft order if

--- a/assets/js/type-defs/registered-payment-method-props.js
+++ b/assets/js/type-defs/registered-payment-method-props.js
@@ -132,16 +132,15 @@
 /**
  * @typedef EventRegistrationProps
  *
+ * @property {function(function())} onCheckoutValidationBeforeProcessing Used to subscribe callbacks firing when
+ *                                                              validation of the submitted checkout data happens,
+ *                                                              before it's sent off to the server.
  * @property {function(function())} onCheckoutAfterProcessingWithSuccess Used to subscribe callbacks
  *                                                              firing when checkout has completed
  *                                                              processing successfully.
  * @property {function(function())} onCheckoutAfterProcessingWithError Used to subscribe callbacks
  *                                                              firing when checkout has completed
  *                                                              processing with an error.
- * @property {function(function())} onCheckoutBeforeProcessing  Used to subscribe callbacks that
- *                                                              will fire when checkout begins
- *                                                              processing (as a part of the
- *                                                              processing process).
  * @property {function(function())} onShippingRateSuccess       Used to subscribe callbacks that
  *                                                              will fire when shipping rates for a
  *                                                              given address have been received

--- a/docs/block-client-apis/checkout/checkout-api.md
+++ b/docs/block-client-apis/checkout/checkout-api.md
@@ -3,15 +3,16 @@
 This document gives an overview of some of the major architectural components/APIs for the checkout block. If you haven't already, you may also want to read about the [Checkout Flow and Events](../../extensibility/checkout-flow-and-events.md).
 
 ## Table of Contents <!-- omit in toc -->
-- [Checkout Block API overview](#checkout-block-api-overview)
-    - [Contexts](#contexts)
-      - [Notices Context](#notices-context)
-      - [Billing Data Context](#billing-data-context)
-      - [Shipping Method Data context](#shipping-method-data-context)
-      - [Payment Method Data Context](#payment-method-data-context)
-      - [Checkout Context](#checkout-context)
-  - [Hooks](#hooks)
-    - [`usePaymentMethodInterface`](#usepaymentmethodinterface)
+
+-   [Checkout Block API overview](#checkout-block-api-overview)
+    -   [Contexts](#contexts)
+        -   [Notices Context](#notices-context)
+        -   [Billing Data Context](#billing-data-context)
+        -   [Shipping Method Data context](#shipping-method-data-context)
+        -   [Payment Method Data Context](#payment-method-data-context)
+        -   [Checkout Context](#checkout-context)
+    -   [Hooks](#hooks)
+        -   [`usePaymentMethodInterface`](#usepaymentmethodinterface)
 
 ### Contexts
 
@@ -101,9 +102,9 @@ Via `useCheckoutContext`, the following are exposed:
 -   `isCalculating`: This is true when the total is being re-calculated for the order. There are numerous things that might trigger a recalculation of the total: coupons being added or removed, shipping rates updated, shipping rate selected etc. This flag consolidates all activity that might be occurring (including requests to the server that potentially affect calculation of totals). So instead of having to check each of those individual states you can reliably just check if this boolean is true (calculating) or false (not calculating).
 -   `hasError`: This is true when anything in the checkout has created an error condition state. This might be validation errors, request errors, coupon application errors, payment processing errors etc.
 -   `redirectUrl`: The current set url that the checkout will redirect to when it is complete.
+-   `onCheckoutValidationBeforeProcessing`: Used to register observers that will be invoked at validation time, after the checkout has been submitted but before the processing request is sent to the server.
 -   `onCheckoutAfterProcessingWithSuccess`: Used to register observers that will be invoked after checkout has been processed by the server successfully.
 -   `onCheckoutAfterProcessingWithError`: Used to register observers that will be invoked after checkout has been processed by the server and there was an error.
--   `onCheckoutBeforeProcessing`: Used to register observers that will be invoked after the checkout has been submitted but before the processing request is sent to the server.
 -   `dispatchActions`: This is an object with various functions for dispatching status in the checkout. It is not exposed to extensions but is for internal use only.
 -   `orderId`: The order id for the order attached to the current checkout.
 -   `isCart`: This is true if the cart is being viewed. Note: usage of `CheckoutProvider` will automatically set this to false. There is also a `CartProvider` that wraps children in the `ShippingDataProvider` and exposes the same api as checkout context. The `CartProvider` automatically sets `isCart` to true. This allows components that implement `useCheckoutContext` to use the same api in either the cart or checkout context but still have specific behaviour to whether `isCart` is true or not.

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -56,26 +56,29 @@ The options you feed the configuration instance should be an object in this shap
 
 ```js
 const options = {
-  name: 'my_payment_method',
-  content: <div>A React node</div>,
-  edit: <div>A React node</div>,
-  canMakePayment: () => true,
-  paymentMethodId: 'new_payment_method',
-  supports: {
-      features: [],
-  }
+	name: 'my_payment_method',
+	content: <div>A React node</div>,
+	edit: <div>A React node</div>,
+	canMakePayment: () => true,
+	paymentMethodId: 'new_payment_method',
+	supports: {
+		features: [],
+	},
 };
 ```
 
 Here's some more details on the configuration options:
 
 #### `name` (required)
+
 This should be a unique string (wise to try to pick something unique for your gateway that wouldn't be used by another implementation) that is used as the identifier for the gateway client side. If `paymentMethodId` is not provided, `name` is used for `paymentMethodId` as well.
 
 #### `content` (required)
+
 This should be a React node that will output in the express payment method area when the block is rendered in the frontend. It will be cloned in the rendering process. When cloned, this React node will receive props passed in from the checkout payment method interface that will allow your component to interact with checkout data (more on [these props later](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/extensibility/payment-method-integration.md#props-fed-to-payment-method-nodes)).
 
 #### `edit` (required)
+
 This should be a React node that will be output in the express payment method area when the block is rendered in the editor. It will be cloned in the rendering process. When cloned, this React node will receive props from the payment method interface to checkout (but they will contain preview data).
 
 #### `canMakePayment` (required):
@@ -98,9 +101,11 @@ Returns a boolean value - true if payment method is available for use. If your g
 **Keep in mind this function could be invoked multiple times in the lifecycle of the checkout and thus any expensive logic in the callback provided on this property should be memoized.**
 
 #### `paymentMethodId`
+
 This is the only optional configuration object. The value of this property is what will accompany the checkout processing request to the server and is used to identify what payment method gateway class to load for processing the payment (if the shopper selected the gateway). So for instance if this is `stripe`, then `WC_Gateway_Stripe::process_payment` will be invoked for processing the payment.
 
 #### `supports:features`
+
 This is an array of payment features supported by the gateway. It is used to crosscheck if the payment method can be used for the content of the cart. By default payment methods should support at least `products` feature. If no value is provided then this assumes that `['products']` are supported.
 
 ---
@@ -131,13 +136,13 @@ registerPaymentMethod( options );
 
 The options you feed the configuration instance are the same as those for express payment methods with the following additions:
 
-- `savedTokenComponent`: This should be a React node that contains logic handling any processing your payment method has to do with saved payment methods if your payment method supports them. This component will be rendered whenever a customer's saved token using your payment method for processing is selected for making the purchase.
+-   `savedTokenComponent`: This should be a React node that contains logic handling any processing your payment method has to do with saved payment methods if your payment method supports them. This component will be rendered whenever a customer's saved token using your payment method for processing is selected for making the purchase.
 -   `label`: This should be a React node that will be used to output the label for the option where the payment methods are. For example it might be `<strong>Credit/Debit Cart</strong>` or you might output images.
 -   `ariaLabel`: This is the label that will be read out via screen-readers when the payment method is selected.
 -   `placeOrderButtonLabel`: This is an optional label which will change the default "Place Order" button text to something else when the payment method is selected. As an example, the PayPal Standard payment method [changes the text of the button to "Proceed to PayPal"](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/paypal/index.js#L37-L40) when it is selected as the payment method for checkout because the payment method takes the shopper offsite to PayPal for completing the payment.
 -   `supports`: This is an object containing information about what features your payment method supports. The following keys are valid here:
-    - `showSavedCards`: This value will determine whether saved cards associated with your payment method are shown to the customer.
-    - `showSaveOption`: This value will control whether to show the checkbox which allows customers to save their payment method for future payments.
+    -   `showSavedCards`: This value will determine whether saved cards associated with your payment method are shown to the customer.
+    -   `showSaveOption`: This value will control whether to show the checkbox which allows customers to save their payment method for future payments.
 
 ### Props Fed to Payment Method Nodes
 
@@ -148,15 +153,15 @@ A big part of the payment method integration is the interface that is exposed fo
 -   `shippingStatus`: This object has two properties - `shippingErrorStatus`, which is an object with various error statuses that might exist for shipping, and `shippingErrorTypes`, which is an object containing all the possible types for shipping error status.
 -   `shippingData`: This object contains all shipping related data (outside of status) - `shippingRates`, `shippingRatesLoading`, `selectedRates`, `setSelectedRates`, `isSelectingRate`, `shippingAddress`, `setShippingAddress`, and `needsShipping`.
 -   `billing`: This object contains everything related to billing - `billingData`, `cartTotal`, `currency`, `cartTotalItems`, `displayPricesIncludingTax`, `appliedCoupons`, `customerId`
--   `eventRegistration`: This object contains all the checkout event emitter registration functions. These are functions the payment method can register observers on to interact with various points in the checkout flow (see [this doc](./checkout-flow-and-events.md) for more info). The following properties are available - `onCheckoutBeforeProcessing`, `onCheckoutAfterProcessingWithSuccess`, `onCheckoutAfterProcessingWithError`, `onPaymentProcessing`, `onShippingRateSuccess`, `onShippingRateFail`, `onShippingRateSelectSuccess`, `onShippingRateSelectFail`
-- `emitResponse`: This object contains some constants that can be helpful when using the event emitter. You can read the _[Emitting Events](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e267cd96a4329a4eeef816b2ef627e113ebb72a5/docs/extensibility/checkout-flow-and-events.md#emitting-events)_ section in the docs for more details.
-  - `noticeContexts`: This is an object containing properties referencing areas where notices can be targeted in the checkout. The object has the following properties:
-    - `PAYMENTS`: This is a reference to the notice area in the payment methods step.
-    - `EXPRESS_PAYMENTS`: This is a reference to the notice area in the express payment methods step.
-  - `responseTypes`: This is an object containing properties referencing the various response types that can be returned by observers for some event emitters. It makes it easier for autocompleting the types and avoiding typos due to human error. The types are `SUCCESS`, `FAIL`, `ERROR`. The values for these types also correspond to the [payment status types](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/34e17c3622637dbe8b02fac47b5c9b9ebf9e3596/src/Payments/PaymentResult.php#L21) from the [checkout endpoint response from the server](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/34e17c3622637dbe8b02fac47b5c9b9ebf9e3596/src/RestApi/StoreApi/Schemas/CheckoutSchema.php#L103-L113).
+-   `eventRegistration`: This object contains all the checkout event emitter registration functions. These are functions the payment method can register observers on to interact with various points in the checkout flow (see [this doc](./checkout-flow-and-events.md) for more info). The following properties are available - `onCheckoutValidationBeforeProcessing`, `onCheckoutAfterProcessingWithSuccess`, `onCheckoutAfterProcessingWithError`, `onPaymentProcessing`, `onShippingRateSuccess`, `onShippingRateFail`, `onShippingRateSelectSuccess`, `onShippingRateSelectFail`
+-   `emitResponse`: This object contains some constants that can be helpful when using the event emitter. You can read the _[Emitting Events](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e267cd96a4329a4eeef816b2ef627e113ebb72a5/docs/extensibility/checkout-flow-and-events.md#emitting-events)_ section in the docs for more details.
+    -   `noticeContexts`: This is an object containing properties referencing areas where notices can be targeted in the checkout. The object has the following properties:
+        -   `PAYMENTS`: This is a reference to the notice area in the payment methods step.
+        -   `EXPRESS_PAYMENTS`: This is a reference to the notice area in the express payment methods step.
+    -   `responseTypes`: This is an object containing properties referencing the various response types that can be returned by observers for some event emitters. It makes it easier for autocompleting the types and avoiding typos due to human error. The types are `SUCCESS`, `FAIL`, `ERROR`. The values for these types also correspond to the [payment status types](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/34e17c3622637dbe8b02fac47b5c9b9ebf9e3596/src/Payments/PaymentResult.php#L21) from the [checkout endpoint response from the server](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/34e17c3622637dbe8b02fac47b5c9b9ebf9e3596/src/RestApi/StoreApi/Schemas/CheckoutSchema.php#L103-L113).
 -   `components`: The properties on this object are exposed components that can be implemented by your payment method for various common interface elements used by payment methods. Currently the available components on this property are:
-  - `ValidationInputError` — a container for holding validation errors which typically you'll include after any inputs
-  - [`PaymentMethodLabel`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/paypal/index.js#L37-L40) — use this component for the payment method label, including an optional icon
+-   `ValidationInputError` — a container for holding validation errors which typically you'll include after any inputs
+-   [`PaymentMethodLabel`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/e089ae17043fa525e8397d605f0f470959f2ae95/assets/js/payment-method-extensions/payment-methods/paypal/index.js#L37-L40) — use this component for the payment method label, including an optional icon
 -   `setExpressPaymentError`: This function receives a string and allows express payment methods to set an error notice for the express payment area on demand. This can be necessary because some express payment method processing might happen outside of checkout events.
 -   `shouldSavePayment`: This is a boolean type value that indicates whether or not the shopper has selected to save their payment method details (for payment methods that support saved payments). True if selected, false otherwise. Defaults to false.
 
@@ -166,7 +171,7 @@ Any registered `savedTokenComponent` node will also receive a `token` prop which
 
 ### Processing Payment
 
-The checkout block currently has legacy handling for payment processing.  It converts incoming `payment_data` provided by the client-side payment method to `$_POST` and calls the payment gateway's `process_payment` function.  If you already have a WooCommerce Payment method extension integrated with the existing shortcode checkout flow, the checkout block's legacy handling will take care of processing your payment for you on the server side.  However, If your payment method hooks into the core checkout `process_checkout` function in any way, you will need to account for this behavior and make appropriate adjustments.  (See the section below about hooking into the checkout process via the Store API.)
+The checkout block currently has legacy handling for payment processing. It converts incoming `payment_data` provided by the client-side payment method to `$_POST` and calls the payment gateway's `process_payment` function. If you already have a WooCommerce Payment method extension integrated with the existing shortcode checkout flow, the checkout block's legacy handling will take care of processing your payment for you on the server side. However, If your payment method hooks into the core checkout `process_checkout` function in any way, you will need to account for this behavior and make appropriate adjustments. (See the section below about hooking into the checkout process via the Store API.)
 
 ### Registering Assets
 
@@ -187,7 +192,7 @@ In your class:
 
 There may be some cases where the fallback legacy processing of Checkout requests from the StoreAPI mentioned earlier doesn't work for your existing payment method integration. For these cases, there is also an [action hook you can implement to hook into the server side processing of the order](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/308e968c700028180cab391f2223eb0a43dd2d4d/src/RestApi/StoreApi/Routes/Checkout.php#L350-L361). **Note:** a good place to register your callback on this hook is in the `initialize` method of the payment method class you created from the above instructions.
 
-This hook is the *preferred* place to hook in your payment processing and if you set a status on the provided `PaymentResult` object, then the legacy processing will be ignored for your payment method. Hook callbacks will receive:
+This hook is the _preferred_ place to hook in your payment processing and if you set a status on the provided `PaymentResult` object, then the legacy processing will be ignored for your payment method. Hook callbacks will receive:
 
 [`Automattic\WooCommerce\Blocks\Payments\PaymentContext`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/Payments/PaymentContext.php)
 
@@ -203,7 +208,7 @@ This contains various details about the payment result returned to the client an
 
 ### Putting it all together
 
-So you've created a class extending `Automattic\WooCommerce\Blocks\Payments\Integration\AbstractPaymentMethodType`, but you still need to *register* this with the server side handling of payment methods. In order to do this you need to register a callback on the `woocommerce_blocks_payment_method_type_registration` action. Your callback will receive an instance of `Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry` which has a `register` method for registering an instance of the class you created. It's also recommended that you register your callback on this action within the context of a callback on the `woocommerce_blocks_loaded` action.
+So you've created a class extending `Automattic\WooCommerce\Blocks\Payments\Integration\AbstractPaymentMethodType`, but you still need to _register_ this with the server side handling of payment methods. In order to do this you need to register a callback on the `woocommerce_blocks_payment_method_type_registration` action. Your callback will receive an instance of `Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry` which has a `register` method for registering an instance of the class you created. It's also recommended that you register your callback on this action within the context of a callback on the `woocommerce_blocks_loaded` action.
 
 > Note: With Cart and Checkout Blocks currently only available in the WooCommerce Blocks Feature plugin, you will want to make sure you check for the availability of the `Automattic\WooCommerce\Blocks\Payments\Integration\AbstractPaymentMethodType` class before registering your payment method integration server side.
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This commit also adds a deprecation warning when using onCheckoutBeforeProcessing.
See the issue below for details.

<!-- Reference any related issues or PRs here -->
Fixes #3984

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


### How to test the changes in this Pull Request:
The renaming part could be tested by smoke testing the Checkout Block:

1. Add something to checkout
2. Submit without a required field
3. Observe validation happens
4. Fix validation and place order

To see the warning you have to call yourself the old `onCheckoutBeforeProcessing`. What I did:

1. I added this component to [Order Summary](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/base/components/cart-checkout/order-summary/index.js) and included it as a child.
2. I went to the Checkout block and tried to submit it without some required fields.
3. I checked the console for the deprecation warning
4. I then fixed the warnings and  successfully submitted the order



```js
const Component = () => {
	const { onCheckoutBeforeProcessing } = useCheckoutContext();
	useEffect( () => {
		const unsubscribe = onCheckoutBeforeProcessing( () => {
			console.log( 'My custom validation callback' );
			return true;
		} );
		return unsubscribe;
	}, [ onCheckoutBeforeProcessing ] );
	return null;
};
```

One thing that could also help with testing is checking the registered observers by adding `console.log(observersByType)` in [emitters.ts](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/base/context/shared/event-emit/emitters.ts#L26). This is logged after submitting with missing inputs.

<!-- If you can, add the appropriate labels -->

### Changelog

> Rename onCheckoutBeforeProcessing to onCheckoutValidationBeforeProcessing.

### Dev note

> `onCheckoutBeforeProcessing` has been renamed to `onCheckoutValidationBeforeProcessing` to more clearly articulate its coupling to the validation happening when the Checkout form is submitted. `onCheckoutBeforeProcessing` will be deprecated in the future.