### PR TITLE
Cart: fix headline alignment in the empty state of the cart block

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
+++ b/assets/js/blocks/cart-checkout/cart/empty-cart-edit/index.js
@@ -42,7 +42,7 @@ const templateItems = [
 	[
 		'core/heading',
 		{
-			align: 'center',
+			textAlign: 'center',
 			content: __(
 				'Your cart is currently empty!',
 				'woo-gutenberg-products-block'
@@ -61,7 +61,7 @@ const templateItems = [
 	[
 		'core/heading',
 		{
-			align: 'center',
+			textAlign: 'center',
 			content: __( 'New in store', 'woo-gutenberg-products-block' ),
 			level: 2,
 		},


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This PR fixes an issue where headlines in the empty state of the cart block are left aligned instead of center aligned as intended in the design. This issue is caused by the headline blocks using the align option instead of the text align option.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3903

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->



### Screenshots

|Design|Before|After|
|-|-|-|
|<img width="529" alt="Screenshot 2021-04-07 at 15 09 15" src="https://user-images.githubusercontent.com/1562646/113874264-e8783980-97b5-11eb-85c8-5fcce112f65c.png">|<img width="825" alt="Screenshot 2021-04-07 at 15 19 57" src="https://user-images.githubusercontent.com/1562646/113873096-c631ec00-97b4-11eb-9d04-e96f25dac34a.png">|<img width="821" alt="Screenshot 2021-04-07 at 15 18 52" src="https://user-images.githubusercontent.com/1562646/113873114-c9c57300-97b4-11eb-8857-4399a5786c11.png">|


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Prerequisite: ensure you have an empty cart.
2. Create a new page and add the Cart block.
2. Check that the empty state looks as expected in the editor (see After state above).
3. Publish the page and check the empty state in the frontend.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix headline alignment in the empty state of the cart block.


