### PR TITLE
Fix TwentyX styling issues for cart/checkout form fields

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -6,14 +6,6 @@ $no-stock-color: $alert-red;
 $low-stock-color: $alert-yellow;
 $in-stock-color: $alert-green;
 
-:root {
-	--wc-blocks-input-dark: rgba(0, 0, 0, 0.1);
-}
-
-.editor-styles-wrapper {
-	--wc-blocks-input-dark: #1e1e1e;
-}
-
 $placeholder-color: var(--global--color-primary, $gray-200);
 $input-border-gray: #50575e;
 $input-border-dark: rgba(255, 255, 255, 0.4);
@@ -22,7 +14,7 @@ $controls-border-dark: rgba(255, 255, 255, 0.6);
 $input-text-active: #2b2d2f;
 $input-placeholder-dark: rgba(255, 255, 255, 0.6);
 $input-text-dark: #fff;
-$input-background-dark: var(--wc-blocks-input-dark);
+$input-background-dark: rgba(0, 0, 0, 0.1);
 $select-dropdown-dark: #1e1e1e;
 $select-dropdown-light: #fff;
 $select-item-dark: rgba(0, 0, 0, 0.4);

--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -6,6 +6,14 @@ $no-stock-color: $alert-red;
 $low-stock-color: $alert-yellow;
 $in-stock-color: $alert-green;
 
+:root {
+	--wc-blocks-input-dark: rgba(0, 0, 0, 0.1);
+}
+
+.editor-styles-wrapper {
+	--wc-blocks-input-dark: #1e1e1e;
+}
+
 $placeholder-color: var(--global--color-primary, $gray-200);
 $input-border-gray: #50575e;
 $input-border-dark: rgba(255, 255, 255, 0.4);
@@ -14,7 +22,7 @@ $controls-border-dark: rgba(255, 255, 255, 0.6);
 $input-text-active: #2b2d2f;
 $input-placeholder-dark: rgba(255, 255, 255, 0.6);
 $input-text-dark: #fff;
-$input-background-dark: rgba(0, 0, 0, 0.1);
+$input-background-dark: var(--wc-blocks-input-dark);
 $select-dropdown-dark: #1e1e1e;
 $select-dropdown-light: #fff;
 $select-item-dark: rgba(0, 0, 0, 0.4);

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -6,6 +6,7 @@
 	position: relative;
 
 	.wc-block-components-checkbox__input[type="checkbox"] {
+		font-size: 1em;
 		appearance: none;
 		border: 2px solid $input-border-gray;
 		border-radius: 2px;
@@ -22,6 +23,11 @@
 		&:checked {
 			background: #fff;
 			border-color: $input-border-gray;
+		}
+
+		&::before,
+		&::after {
+			content: "";
 		}
 
 		&:not(:checked) + .wc-block-components-checkbox__mark {
@@ -75,7 +81,8 @@
 	}
 
 	.wc-block-components-checkbox__input[type="checkbox"]:checked,
-	.has-dark-controls .wc-block-components-checkbox__input[type="checkbox"]:checked {
+	.has-dark-controls
+	.wc-block-components-checkbox__input[type="checkbox"]:checked {
 		background-color: #fff;
 		border-color: var(--form--border-color);
 	}

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -67,6 +67,7 @@
 		-webkit-appearance: none;
 		margin: 0;
 	}
+
 	.wc-block-components-quantity-selector__button {
 		@include reset-button;
 		@include font-size(regular);
@@ -75,6 +76,7 @@
 		color: $gray-900;
 		font-style: normal;
 		text-align: center;
+		text-decoration: none;
 
 		&:hover,
 		&:focus {
@@ -99,10 +101,21 @@
 			}
 		}
 	}
-	.wc-block-components-quantity-selector__button--minus {
+
+	> .wc-block-components-quantity-selector__button--minus {
 		order: 1;
 	}
-	.wc-block-components-quantity-selector__button--plus {
+
+	> .wc-block-components-quantity-selector__button--plus {
 		order: 3;
+	}
+}
+
+.theme-twentyseventeen {
+	.wc-block-components-quantity-selector .wc-block-components-quantity-selector__button {
+		&:hover,
+		&:focus {
+			background: none transparent;
+		}
 	}
 }

--- a/assets/js/base/components/select/style.scss
+++ b/assets/js/base/components/select/style.scss
@@ -1,8 +1,9 @@
+.wc-block-components-form .wc-block-components-select,
 .wc-block-components-select {
 	height: 3em;
 	position: relative;
 
-	label {
+	label.components-custom-select-control__label {
 		@include reset-typography();
 		@include font-size(regular);
 		line-height: 1.375; // =22px when font-size is 16px.
@@ -70,6 +71,8 @@
 			text-transform: none;
 			white-space: nowrap;
 			width: 100%;
+			opacity: initial;
+			border-radius: 4px;
 			.has-dark-controls & {
 				background: $input-background-dark;
 				border-color: $input-border-dark;
@@ -138,6 +141,22 @@
 		// If the theme is in dark mode, but the block isn't, then this selector will match.
 		.components-custom-select-control__item {
 			color: $input-text-active;
+		}
+	}
+}
+
+.theme-twentyseventeen {
+	// Extra classes for specificity.
+	&.theme-twentyseventeen.theme-twentyseventeen {
+		.components-custom-select-control__button {
+			background-color: $select-dropdown-light;
+			color: $input-text-active;
+		}
+		.has-dark-controls {
+			.components-custom-select-control__button {
+				background-color: $select-dropdown-dark;
+				color: $input-text-dark;
+			}
 		}
 	}
 }

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -1,3 +1,4 @@
+.wc-block-components-form .wc-block-components-text-input,
 .wc-block-components-text-input {
 	position: relative;
 	margin-top: em($gap-large);
@@ -56,11 +57,18 @@
 
 		&:focus {
 			background-color: #fff;
+			color: $input-text-active;
 		}
+
 		.has-dark-controls & {
 			background-color: $input-background-dark;
 			border-color: $input-border-dark;
 			color: $input-text-dark;
+
+			&:focus {
+				background-color: $input-background-dark;
+				color: $input-text-dark;
+			}
 		}
 	}
 

--- a/packages/checkout/panel/style.scss
+++ b/packages/checkout/panel/style.scss
@@ -56,6 +56,11 @@
 
 .theme-twentytwenty .wc-block-components-panel__button,
 .theme-twentyseventeen .wc-block-components-panel__button {
-	background: transparent;
+	background: none transparent;
 	color: inherit;
+
+	&.wc-block-components-panel__button:hover,
+	&.wc-block-components-panel__button:focus {
+		background: none transparent;
+	}
 }


### PR DESCRIPTION
Fixes the styling issues raised in #3006.

- https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/b75fc4d2b2bbbf2150ea086eced10d66e0fc6a18 Checkbox mark is misaligned on TwentyTwenty and TwentySeventeen. This was caused by a missing font size rule on the inputs.
- https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/2caf286f8b7fba541015063b429a536473421fe3 Quantity selector controls have an underline in TwentyTwenty. Just had to remove those styles with greater specificity. 
- Buttons have a gray background on hover and click in TwentySeventeen dark mode. Same as above. Specificity on buttons.
- Select-control is misshaped in Editor view in all themes. We were missing styles for rounded corners, and some dark mode colors.

The "Regular and Sale price are misaligned" issue was already solved.

Fixes #3006

### Screenshots

Dark and light mode inputs:

![Screenshot 2021-04-08 at 10 38 17](https://user-images.githubusercontent.com/90977/114004904-fd58d980-9856-11eb-843c-b94b95fa68f2.png)
![Screenshot 2021-04-08 at 10 38 08](https://user-images.githubusercontent.com/90977/114004909-fe8a0680-9856-11eb-9d63-338ce91873fe.png)

### How to test the changes in this Pull Request:

1. In Twenty Seventeen theme, enable dark mode in the customiser.
2. Add any item to the cart then go to the cart page.
3. Hover over a qty input. There should be no underline or background change.
4. Hover over the coupon code button. There should be no underline or background change.
5. Go to checkout.
6. Confirm the checkbox styling is correct (no overlap of check mark and box)
7. Go to the editor for the checkout page. See that the select box (country) is styling with rounded corners like other inputs.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fixed styling issues on the cart and checkout page in TwentyX themes.
