### PR TITLE
Stop shipping package titles breaking in the middle of a word

### DIFF
--- a/assets/js/base/components/title/style.scss
+++ b/assets/js/base/components/title/style.scss
@@ -2,6 +2,7 @@
 .wc-block-components-title.wc-block-components-title {
 	@include reset-box();
 	@include font-size(large);
+	word-break: break-word;
 }
 
 // For Twenty Twenty we need to increase specificity a bit more.
@@ -9,5 +10,6 @@
 	.wc-block-components-title.wc-block-components-title {
 		@include reset-box();
 		@include font-size(large);
+		word-break: break-word;
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This is a simple fix to stop the titles of items in the sidebar of the checkout (rendered by the `Title` component) breaking in the middle of a word.

(You will need to check out 4059-gh-woocommerce/woocommerce-subscription or the `feature/checkout-block-simple-multiple-subscriptions` branch if 4059 is merged before this PR is reviewed)

### Screenshots
#### Before
<img src="https://user-images.githubusercontent.com/5656702/114028689-a95aee80-9870-11eb-9051-02c8a9bc559e.png" width="400" />

#### After
<img src="https://user-images.githubusercontent.com/5656702/114028793-c8f21700-9870-11eb-9214-4adf1220020f.png" width="400" />



<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Add a subscription product with a recurring shipment
2. Go to the checkout and ensure the title is split onto two lines if necessary and that the break is between a word, not in the middle of one.

<!-- If you can, add the appropriate labels -->

### Changelog

> Stop shipping package titles line-breaks occurring in the middle of a word.