### PR TITLE
Load translation file for JS files that has translatable strings

### DIFF
--- a/src/Assets.php
+++ b/src/Assets.php
@@ -46,16 +46,16 @@ class Assets {
 
 		// Shared libraries and components across multiple blocks.
 		$asset_api->register_script( 'wc-blocks-middleware', 'build/wc-blocks-middleware.js', [], false );
-		$asset_api->register_script( 'wc-blocks-data-store', 'build/wc-blocks-data.js', [ 'wc-blocks-middleware' ], false );
+		$asset_api->register_script( 'wc-blocks-data-store', 'build/wc-blocks-data.js', [ 'wc-blocks-middleware' ] );
 		$asset_api->register_script( 'wc-blocks', $asset_api->get_block_asset_build_path( 'blocks' ), [], false );
 		$asset_api->register_script( 'wc-vendors', $asset_api->get_block_asset_build_path( 'vendors' ), [], false );
 		$asset_api->register_script( 'wc-blocks-registry', 'build/wc-blocks-registry.js', [], false );
-		$asset_api->register_script( 'wc-shared-context', 'build/wc-shared-context.js', [], false );
+		$asset_api->register_script( 'wc-shared-context', 'build/wc-shared-context.js', [] );
 		$asset_api->register_script( 'wc-shared-hocs', 'build/wc-shared-hocs.js', [], false );
 		$asset_api->register_script( 'wc-price-format', 'build/price-format.js', [], false );
 
 		if ( Package::feature()->is_feature_plugin_build() ) {
-			$asset_api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [], false );
+			$asset_api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [] );
 		}
 
 		wp_add_inline_script(


### PR DESCRIPTION
Fixes #4037 

While registering some of our lib scripts (middleware, store, 3rd packages), we didn't load the JSON translation file for those scripts; this results in some translation not loading on the front-end.

This PR enables that loading. I checked each package to see if it has translatable strings and enable it.

### How to test
- Change website language to something other than English; Spanish is a good example of a 100% translated language.
- Go to Dashboard -> Updates and scroll down to download the new translations immidiatly.
- Visit Cart or Checkout block.
- Strings like Subtotal and Taxes should be translated.
### Before 
![image](https://user-images.githubusercontent.com/6165348/114048658-aec13480-9882-11eb-93bb-1a6d5d83b5ed.png)

### After
![image](https://user-images.githubusercontent.com/6165348/114048836-d0bab700-9882-11eb-830f-68feb1b56d9d.png)


### Changelog
> Fix a bug in which certain strings didn't load the translated version.