### PR TITLE
Use font color in payment methods border

### DIFF
--- a/assets/js/blocks/cart-checkout/payment-methods/style.scss
+++ b/assets/js/blocks/cart-checkout/payment-methods/style.scss
@@ -195,20 +195,18 @@
 		font-weight: bold;
 	}
 
-	.wc-block-components-radio-control__option:last-child,
-	.wc-block-components-radio-control-accordion-option:last-child {
+	.wc-block-components-radio-control-accordion-option,
+	.wc-block-components-radio-control__option {
+		@include with-translucent-border(1px 1px 0 1px);
+	}
+
+	.wc-block-components-radio-control__option:last-child::after,
+	.wc-block-components-radio-control-accordion-option:last-child::after {
 		border-width: 1px;
 	}
 
-	.wc-block-components-radio-control-accordion-option,
-	.wc-block-components-radio-control__option {
-		border-width: 1px 1px 0 1px;
-		border-style: solid;
-		border-color: $gray-200;
-	}
-
 	.wc-block-components-radio-control-accordion-option {
-		.wc-block-components-radio-control__option {
+		.wc-block-components-radio-control__option::after {
 			border-width: 0;
 		}
 		.wc-block-components-radio-control__label img {


### PR DESCRIPTION
Changes the border color of the payment methods options so it inherits the font color. This way, it follows the same styling all other components of the Cart and Checkout blocks have.

### Screenshots

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/114059318-8b06ea00-9894-11eb-9097-401c8125db5d.png) | ![imatge](https://user-images.githubusercontent.com/3616980/114059261-7e829180-9894-11eb-978d-420cbfc4cf41.png) |

### How to test the changes in this Pull Request:

1. Using Storefront, in the admin go to Appearance > Customize.
2. Set the font color to something different than gray/black. For example, red.
3. Apply the changes and go to the Checkout page in the frontend.
4. Verify the payments methods of the Checkout block have a border with the same color as the text.
