### PR TITLE
Check if Cart and Checkout are registered before removing payment methods

### DIFF
--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -216,6 +216,12 @@ class Api {
 
 					$cart_checkout_scripts = [ 'wc-cart-block', 'wc-cart-block-frontend', 'wc-checkout-block', 'wc-checkout-block-frontend' ];
 					foreach ( $cart_checkout_scripts as $script_handle ) {
+						if (
+							! array_key_exists( $script_handle, $wp_scripts->registered ) ||
+							! property_exists( $wp_scripts->registered[ $script_handle ], 'deps' )
+						) {
+							continue;
+						}
 						// Remove payment method script from dependencies.
 						$wp_scripts->registered[ $script_handle ]->deps = array_diff(
 							$wp_scripts->registered[ $script_handle ]->deps,


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/29656

Elementor empties `$wp_scripts` and `$wp_styles` when rendering its editor (which is very dangerous), this breaks our integrations which must run after `wp_enqueue_scripts` and at the beginning of `wp_print_scripts`.

In this PR, I check if our scripts are still registered before validating payment methods dependencies.

This might have caused a regression with #3920 so more testing should happen using that PR steps.

### Testing steps
- On a website with PHP 8, install Elementor.
- Create a new page, and select "Edit with Elementor", there should be no fatal errors.

### Regression testing.
- Follow testing steps in #3920, mainly, add a faux dep to an enabled payment method and check if Cart and Checkout render fine in frontend and backend.

### Changelog
> Fix a compatibility bug with Elementor editor and PHP 8 