### PR TITLE
Make error messages in front-end cart E2E tests better

### DIFF
--- a/tests/e2e/specs/frontend/cart.test.js
+++ b/tests/e2e/specs/frontend/cart.test.js
@@ -77,15 +77,22 @@ describe( `${ block.name } Block (frontend)`, () => {
 	} );
 
 	it( 'Shows the freshest cart data when using browser navigation buttons', async () => {
-		await jest.setTimeout( 60000 );
+		//await jest.setTimeout( 60000 );
 		await page.goto( cartBlockPermalink );
-		await page.waitForFunction( () => {
-			const wcCartStore = wp.data.select( 'wc/store/cart' );
-			return (
-				! wcCartStore.isResolving( 'getCartData' ) &&
-				wcCartStore.hasFinishedResolution( 'getCartData', [] )
-			);
-		} );
+
+		await page
+			.waitForFunction( () => {
+				const wcCartStore = wp.data.select( 'wc/store/cart' );
+				return (
+					! wcCartStore.isResolving( 'getCartData' ) &&
+					wcCartStore.hasFinishedResolution( 'getCartData', [] )
+				);
+			} )
+			.catch( ( err ) => {
+				throw new Error(
+					'Waiting for the wc/store/cart to not be resolving and to have finished resolution failed. This probably means the block did not load correctly.'
+				);
+			} );
 		await page.click(
 			'.wc-block-cart__main .wc-block-components-quantity-selector__button--plus'
 		);
@@ -110,19 +117,21 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await page.waitForSelector( '.wc-block-checkout' );
 		await page.goBack( { waitUntil: 'networkidle0' } );
 
-		try {
-			await page.waitForFunction( () => {
-				const timeStamp = window.localStorage.getItem(
-					'wc-blocks_cart_update_timestamp'
+		await page
+			.waitForFunction(
+				() => {
+					const timeStamp = window.localStorage.getItem(
+						'wc-blocks_cart_update_timestamp'
+					);
+					return typeof timeStamp === 'string' && timeStamp;
+				},
+				{ timeout: 5000 }
+			)
+			.catch( ( err ) => {
+				throw new Error(
+					'Could not get the wc-blocks_cart_update_timestamp item from local storage. It must not have been set by the cartUpdateMiddleware.'
 				);
-				return typeof timeStamp === 'string' && timeStamp;
 			} );
-		} catch ( err ) {
-			throw new Error(
-				'Could not get the wc-blocks_cart_update_timestamp item from local storage.'
-			);
-			return;
-		}
 
 		const timestamp = await page.evaluate( () => {
 			return window.localStorage.getItem(
@@ -131,34 +140,32 @@ describe( `${ block.name } Block (frontend)`, () => {
 		} );
 		expect( timestamp ).not.toBeNull();
 
-		try {
-			// We need this to check if the block is done loading.
-			await page.waitForFunction( () => {
+		// We need this to check if the block is done loading.
+		await page
+			.waitForFunction( () => {
 				const wcCartStore = wp.data.select( 'wc/store/cart' );
 				return (
 					! wcCartStore.isResolving( 'getCartData' ) &&
 					wcCartStore.hasFinishedResolution( 'getCartData', [] )
 				);
+			} )
+			.catch( ( err ) => {
+				throw new Error(
+					'Waiting for the wc/store/cart to not be resolving and to have finished resolution failed. This probably means the block did not load correctly.'
+				);
 			} );
-		} catch ( err ) {
-			throw new Error(
-				'Waiting for the wc/store/cart to not be resolving and to have finished resolution failed. This probably means the block did not load correctly.'
-			);
-			return;
-		}
 
-		try {
-			// Then we check to ensure the stale cart action has been emitted, so it'll fetch the cart from the API.
-			await page.waitForFunction( () => {
+		// Then we check to ensure the stale cart action has been emitted, so it'll fetch the cart from the API.
+		await page
+			.waitForFunction( () => {
 				const wcCartStore = wp.data.select( 'wc/store/cart' );
 				return wcCartStore.isCartDataStale() === true;
+			} )
+			.catch( ( err ) => {
+				throw new Error(
+					'isCartDataStale on the wc/store/cart store is not true. The cart contents were not correctly marked as stale.'
+				);
 			} );
-		} catch ( err ) {
-			throw new Error(
-				'isCartDataStale on the wc/store/cart store is not true. The cart contents were not correctly marked as stale.'
-			);
-			return;
-		}
 
 		const value = parseInt(
 			await page.$eval(

--- a/tests/e2e/specs/frontend/cart.test.js
+++ b/tests/e2e/specs/frontend/cart.test.js
@@ -77,7 +77,6 @@ describe( `${ block.name } Block (frontend)`, () => {
 	} );
 
 	it( 'Shows the freshest cart data when using browser navigation buttons', async () => {
-		//await jest.setTimeout( 60000 );
 		await page.goto( cartBlockPermalink );
 
 		await page


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will cause calls to `page.waitForFunction` that time out (and subsequently throw an error) to be caught and allow a more descriptive error to be displayed.

### How to test the changes in this Pull Request:

1. Edit `assets/js/data/cart/constants.ts` and change the value of `LAST_CART_UPDATE_TIMESTAMP_KEY` to something else.
2. Run the tests and ensure the error message shown to you tells you that the value couldn't be found in local storage.
