### PR TITLE
Remove woocommerce as a dependency and install @woocommerce/e2e-utils

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -88,10 +88,6 @@ const getAlias = ( options = {} ) => {
 			__dirname,
 			`../assets/js/${ pathPart }previews/`
 		),
-		'@woocommerce/e2e-tests': path.resolve(
-			__dirname,
-			'node_modules/woocommerce/tests/e2e'
-		),
 	};
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32750,11 +32750,6 @@
 			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
 			"dev": true
 		},
-		"woocommerce": {
-			"version": "git+https://github.com/woocommerce/woocommerce.git#70a069fbe3ad2cc09de61a8e131affc7b09d6f47",
-			"from": "git+https://github.com/woocommerce/woocommerce.git#release/4.4",
-			"dev": true
-		},
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,6 @@
 		"webpack": "4.44.2",
 		"webpack-cli": "3.3.12",
 		"webpack-rtl-plugin": "2.0.0",
-		"woocommerce": "git+https://github.com/woocommerce/woocommerce.git#release/4.4",
 		"zenhub-api": "0.2.0"
 	},
 	"engines": {

--- a/tests/e2e/config/jest.config.js
+++ b/tests/e2e/config/jest.config.js
@@ -8,8 +8,6 @@ module.exports = {
 	moduleFileExtensions: [ 'js' ],
 
 	moduleNameMapper: {
-		'@woocommerce/e2e-tests/(.*)':
-			'<rootDir>/node_modules/woocommerce/tests/e2e/$1',
 		'@woocommerce/blocks-test-utils': '<rootDir>/tests/utils',
 	},
 

--- a/tests/e2e/specs/backend/product-search.test.js
+++ b/tests/e2e/specs/backend/product-search.test.js
@@ -6,7 +6,7 @@ import {
 	getEditedPostContent,
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
-import { clearAndFillInput } from '@woocommerce/e2e-tests/utils';
+import { clearAndFillInput } from '@woocommerce/e2e-utils';
 import {
 	findLabelWithText,
 	visitBlockPage,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,7 +47,6 @@
 			"@woocommerce/blocks-checkout": [ "packages/checkout" ],
 			"@woocommerce/price-format": [ "packages/prices" ],
 			"@woocommerce/block-settings": [ "assets/js/settings/blocks" ],
-			"@woocommerce/e2e-tests": [ "node_modules/woocommerce/tests/e2e" ],
 			"@woocommerce/icons": [ "assets/js/icons" ],
 			"@woocommerce/resource-previews": [ "assets/js/previews" ],
 			"@woocommerce/knobs": [ "storybook/knobs" ],


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR stops the `woocommerce` repository being pulled in to our node_modules - it was previously required to use the `e2e-utils` package, but this is now available as the standalone `@woocommerce/e2e-utils` package on npm.

The webpack, jest, and tsconfig configuration files have been updated to reflect this.

<!-- Reference any related issues or PRs here -->
Fixes #1781 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

1. Run unit and e2e tests and ensure all pass.
2. General smoke test of Blocks functionality.

<!-- If you can, add the appropriate labels -->