### PR TITLE
Add When to employ end to end (E2E) testing documentation

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -4,6 +4,7 @@ This folder contains documentation around manual testing of WooCommerce Blocks.
 
 | Document                                                         | Description                                                                         |
 | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [When to employ end to end testing](when-to-employ-e2e-testing.md) | This doc explains when End to End tests should be used and when unit tests will suffice. |
 | [Smoke Testing](smoke-testing.md)                                | This doc explains how to smoke test key Blocks functionality.                       |
 | [Cart and Checkout Testing](./cart-checkout/readme.md) | Various testing flows for Cart and Checkout Blocks |
 | [Releases](./releases/README.md) | We document all testing flows for releases in this folder |

--- a/docs/testing/when-to-employ-e2e-testing.md
+++ b/docs/testing/when-to-employ-e2e-testing.md
@@ -1,0 +1,26 @@
+### When to employ end to end (E2E) testing
+
+We use Puppeteer to run tests in a real browser, these are called End to End tests. These tests are fairly expensive to run and often fail randomly due to flaky browser behaviour, with this in mind, we should be careful about when we use them.
+
+Ultimately, the front-end is a representation of our application's state, and in most cases we will be able
+to reliably determine that it is behaving the way we want it to without setting up a full browser environment
+to verify this. For example, if we want to test that the quantity of an item in the cart is increased when
+the `+` button is pressed, we can mock the store and ensure the correct action is dispatched, we can also mock
+the function used to make requests to the API and test that it is called with the correct parameters.
+We can then use PHP tests to ensure the API returns the correct response, and then test the cart to ensure
+receiving new cart data results in an updated DOM (with the new quantity in the quantity selector!)
+
+If the functionality you're testing relies on a third party library whose functions would be difficult to mock, then
+setting it up as an E2E test would be a good way to check your code is working as intended. An example of this
+is testing how our blocks behave in the Gutenberg block editor. It would be too difficult to mock all of the
+interfaces of Gutenberg that would be required to test our blocks.
+
+If the functionality you're testing doesn't rely on a browser function (e.g. the browser back/forward buttons, or local storage) then you may be able to forego using an E2E test and instead write a unit test or integration test using React Testing Library.
+
+An example of things that _should_ be tested with E2E tests:
+
+1.   Blocks cannot be added to the block editor more than once. Reason: **We cannot really mock the Gutenberg functionality
+    to test that this happens without some serious effort.**
+2.   Fresh cart data is fetched when using the browser's back buttons. Reason: **We need to emulate the behaviour of a
+    browser when the back button is pressed and this can't be done in unit tests.**
+3.   The compatability notice is shown when first adding the checkout block. Reason: **same as 1**

--- a/docs/testing/when-to-employ-e2e-testing.md
+++ b/docs/testing/when-to-employ-e2e-testing.md
@@ -1,4 +1,4 @@
-### When to employ end to end (E2E) testing
+# When to employ end to end (E2E) testing
 
 We use [Puppeteer](https://pptr.dev/) to run tests in a real browser, these are called End to End tests. These tests are fairly expensive to run and often fail randomly due to flaky browser behaviour, with this in mind, we should be careful about when we use them.
 

--- a/docs/testing/when-to-employ-e2e-testing.md
+++ b/docs/testing/when-to-employ-e2e-testing.md
@@ -26,8 +26,3 @@ An example of things that _should_ be tested with E2E tests:
 2.   Fresh cart data is fetched when using the browser's back buttons. Reason: **We need to emulate the behaviour of a
     browser when the back button is pressed and this can't be done in unit tests.**
 3.   The compatability notice is shown when first adding the checkout block. Reason: **same as 1**
-
-
-**React testing library documentation:** https://testing-library.com/docs/react-testing-library/intro/
-
-**Puppeteer documentation**: https://pptr.dev/ 

--- a/docs/testing/when-to-employ-e2e-testing.md
+++ b/docs/testing/when-to-employ-e2e-testing.md
@@ -1,6 +1,6 @@
 ### When to employ end to end (E2E) testing
 
-We use Puppeteer to run tests in a real browser, these are called End to End tests. These tests are fairly expensive to run and often fail randomly due to flaky browser behaviour, with this in mind, we should be careful about when we use them.
+We use [Puppeteer](https://pptr.dev/) to run tests in a real browser, these are called End to End tests. These tests are fairly expensive to run and often fail randomly due to flaky browser behaviour, with this in mind, we should be careful about when we use them.
 
 Ultimately, the front-end is a representation of our application's state, and in most cases we will be able
 to reliably determine that it is behaving the way we want it to without setting up a full browser environment
@@ -15,7 +15,9 @@ setting it up as an E2E test would be a good way to check your code is working a
 is testing how our blocks behave in the Gutenberg block editor. It would be too difficult to mock all of the
 interfaces of Gutenberg that would be required to test our blocks.
 
-If the functionality you're testing doesn't rely on a browser function (e.g. the browser back/forward buttons, or local storage) then you may be able to forego using an E2E test and instead write a unit test or integration test using React Testing Library.
+If the functionality you're testing doesn't rely on a browser function (e.g. the browser back/forward buttons,
+or local storage) then you may be able to forego using an E2E test and instead write a unit test or integration
+test using [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
 
 An example of things that _should_ be tested with E2E tests:
 
@@ -24,3 +26,8 @@ An example of things that _should_ be tested with E2E tests:
 2.   Fresh cart data is fetched when using the browser's back buttons. Reason: **We need to emulate the behaviour of a
     browser when the back button is pressed and this can't be done in unit tests.**
 3.   The compatability notice is shown when first adding the checkout block. Reason: **same as 1**
+
+
+**React testing library documentation:** https://testing-library.com/docs/react-testing-library/intro/
+
+**Puppeteer documentation**: https://pptr.dev/ 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds documentation explaining when E2E tests should be used, and when they should be avoided. This is part of the "Document all the things!" post on our team P2. pca54o-9i-p2

To test please view https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/9ab62b2d0fecdb2e97ae36aab10445334d067f5f/docs/testing/README.md and https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/2dfcda91f8812c30a052f0a376846159f8c66358/docs/testing/when-to-employ-e2e-testing.md and ensure it reads well, makes sense, and correctly explains when to use E2E tests!