### PR TITLE
Check for element before trying to click it in cart backend test

### DIFF
--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -96,6 +96,11 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'shows empty cart when changing the view', async () => {
+			await page.waitForSelector( block.class ).catch( () => {
+				throw new Error(
+					`Could not find an element with class ${ block.class } - the block probably did not load correctly.`
+				);
+			} );
 			await page.click( block.class );
 			await expect( page ).toMatchElement(
 				'[hidden] .wc-block-cart__empty-cart__title'


### PR DESCRIPTION
<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->
I noticed that the backend cart tests sometimes failed because they were trying to click an element that didn't exist. I believe this flakiness was down to a race condition, so I have added a check to stall the test until the element is available.

If the selector never resolves, we can output an error message saying the block didn't load. This would indicate something wrong with the block, rather than the tests.

### How to test the changes in this Pull Request:
Not really sure how we can test this apart from merging it and seeing how it works on future PRs, I have run the GitHub actions twice here and both times all tests have been green.