### PR TITLE
Switch to `rest_preload_api_request` for API hydration in cart and checkout blocks.

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout-state/constants.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/constants.js
@@ -15,10 +15,12 @@ export const STATUS = {
 	AFTER_PROCESSING: 'after_processing',
 };
 
-const checkoutData = getSetting( 'checkoutData', {
+const preloadedApiRequests = getSetting( 'preloadedApiRequests', {} );
+const checkoutData = {
 	order_id: 0,
 	customer_id: 0,
-} );
+	...( preloadedApiRequests[ '/wc/store/checkout' ]?.body || {} ),
+};
 
 export const DEFAULT_STATE = {
 	redirectUrl: '',

--- a/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/checkout-order-error/index.js
@@ -34,7 +34,13 @@ const cartItemErrorCodes = [
  * checkout block.
  */
 const CheckoutOrderError = () => {
-	const checkoutData = getSetting( 'checkoutData', {} );
+	const preloadedApiRequests = getSetting( 'preloadedApiRequests', {} );
+	const checkoutData = {
+		code: '',
+		message: '',
+		...( preloadedApiRequests[ '/wc/store/checkout' ]?.body || {} ),
+	};
+
 	const errorData = {
 		code: checkoutData.code || 'unknown',
 		message:

--- a/assets/js/hocs/with-store-cart-api-hydration.js
+++ b/assets/js/hocs/with-store-cart-api-hydration.js
@@ -17,13 +17,19 @@ import { LAST_CART_UPDATE_TIMESTAMP_KEY } from '../data/cart/constants';
  * Makes cart data available without an API request to wc/store/cart/.
  */
 const useStoreCartApiHydration = () => {
-	const cartData = useRef( getSetting( 'cartData' ) );
+	const preloadedApiRequests = useRef(
+		getSetting( 'preloadedApiRequests', {} )
+	);
 	const { setIsCartDataStale } = useDispatch( CART_STORE_KEY );
 
 	useSelect( ( select, registry ) => {
-		if ( ! cartData.current ) {
+		const cartData =
+			preloadedApiRequests.current[ '/wc/store/cart' ]?.body || false;
+
+		if ( ! cartData ) {
 			return;
 		}
+
 		const { isResolving, hasFinishedResolution, isCartDataStale } = select(
 			CART_STORE_KEY
 		);
@@ -46,7 +52,7 @@ const useStoreCartApiHydration = () => {
 			if ( lastCartUpdateRaw ) {
 				const lastCartUpdate = parseFloat( lastCartUpdateRaw );
 				const cartGeneratedTimestamp = parseFloat(
-					cartData.current.generated_timestamp
+					cartData.generated_timestamp
 				);
 
 				const needsUpdateFromAPI =
@@ -72,10 +78,10 @@ const useStoreCartApiHydration = () => {
 			! hasFinishedResolution( 'getCartData', [] )
 		) {
 			startResolution( 'getCartData', [] );
-			if ( cartData.current?.code?.includes( 'error' ) ) {
-				receiveError( cartData.current );
+			if ( cartData?.code?.includes( 'error' ) ) {
+				receiveError( cartData );
 			} else {
-				receiveCart( cartData.current );
+				receiveCart( cartData );
 			}
 			finishResolution( 'getCartData', [] );
 		}

--- a/assets/js/hocs/with-store-cart-api-hydration.js
+++ b/assets/js/hocs/with-store-cart-api-hydration.js
@@ -23,8 +23,7 @@ const useStoreCartApiHydration = () => {
 	const { setIsCartDataStale } = useDispatch( CART_STORE_KEY );
 
 	useSelect( ( select, registry ) => {
-		const cartData =
-			preloadedApiRequests.current[ '/wc/store/cart' ]?.body || false;
+		const cartData = preloadedApiRequests.current[ '/wc/store/cart' ]?.body;
 
 		if ( ! cartData ) {
 			return;

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -273,6 +273,20 @@ class AssetDataRegistry {
 	}
 
 	/**
+	 * Hydrate from API.
+	 *
+	 * @param string $path REST API path to preload.
+	 */
+	public function hydrate_api_request( $path ) {
+		if ( ! isset( $this->data['preloadedApiRequests'] ) ) {
+			$this->data['preloadedApiRequests'] = [];
+		}
+		if ( ! isset( $this->data['preloadedApiRequests'][ $path ] ) ) {
+			rest_preload_api_request( $this->data['preloadedApiRequests'], $path );
+		}
+	}
+
+	/**
 	 * Adds a page permalink to the data registry.
 	 *
 	 * @param integer $page_id Page ID to add to the registry.

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -282,7 +282,7 @@ class AssetDataRegistry {
 			$this->data['preloadedApiRequests'] = [];
 		}
 		if ( ! isset( $this->data['preloadedApiRequests'][ $path ] ) ) {
-			rest_preload_api_request( $this->data['preloadedApiRequests'], $path );
+			$this->data['preloadedApiRequests'] = rest_preload_api_request( $this->data['preloadedApiRequests'], $path );
 		}
 	}
 

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -159,9 +159,7 @@ class Cart extends AbstractBlock {
 	 * Hydrate the cart block with data from the API.
 	 */
 	protected function hydrate_from_api() {
-		if ( ! $this->asset_data_registry->exists( 'cartData' ) ) {
-			$this->asset_data_registry->add( 'cartData', WC()->api->get_endpoint_data( '/wc/store/cart' ) );
-		}
+		$this->asset_data_registry->hydrate_api_request( '/wc/store/cart' );
 	}
 
 	/**

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -216,14 +216,10 @@ class Checkout extends AbstractBlock {
 		// Controller and converted to exceptions.
 		wc_print_notices();
 
-		if ( ! $this->asset_data_registry->exists( 'cartData' ) ) {
-			$this->asset_data_registry->add( 'cartData', WC()->api->get_endpoint_data( '/wc/store/cart' ) );
-		}
-		if ( ! $this->asset_data_registry->exists( 'checkoutData' ) ) {
-			add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
-			$this->asset_data_registry->add( 'checkoutData', WC()->api->get_endpoint_data( '/wc/store/checkout' ) );
-			remove_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
-		}
+		add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
+		$this->asset_data_registry->hydrate_api_request( '/wc/store/cart' );
+		$this->asset_data_registry->hydrate_api_request( '/wc/store/checkout' );
+		remove_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
 	}
 
 	/**


### PR DESCRIPTION
Implements `rest_preload_api_request` for api hydration in place of `WC()->api->get_endpoint_data`.  Added a `hydrate_api_request` helper to the asset data registry to prevent the same data being added multiple times.

`rest_preload_api_request` works pretty similar to the previous method, however, it has the advantage of also returning `headers` which we can use in our hydration HOC (cc @opr).

Fixes #3736

### How to test the changes in this Pull Request:

1. Visit cart - ensure block loads (no regression)
2. Repeat for checkout.
3. Viewing source on either page you should see `preloadedApiRequests` encoded in the page/settings with the various routes populated.

### Changelog

> Switched to `rest_preload_api_request` for API hydration in cart and checkout blocks.
