### PR TITLE
Remove work-around to load our stylesheets after wp-edit-post

### DIFF
--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -37,14 +37,13 @@ final class AssetsController {
 		add_action( 'init', array( $this, 'register_assets' ) );
 		add_action( 'body_class', array( $this, 'add_theme_body_class' ), 1 );
 		add_action( 'admin_body_class', array( $this, 'add_theme_body_class' ), 1 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 	}
 
 	/**
 	 * Register block scripts & styles.
 	 */
 	public function register_assets() {
+		$this->register_style( 'wc-block-vendors-style', plugins_url( $this->api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ) );
 		$this->register_style( 'wc-block-editor', plugins_url( $this->api->get_block_asset_build_path( 'editor', 'css' ), __DIR__ ), array( 'wp-edit-blocks' ) );
 		$this->register_style( 'wc-block-style', plugins_url( $this->api->get_block_asset_build_path( 'style', 'css' ), __DIR__ ), array( 'wc-block-vendors-style' ) );
 
@@ -74,17 +73,6 @@ final class AssetsController {
 			",
 			'before'
 		);
-	}
-
-	/**
-	 * Register the vendors style file. We need to do it after the other files
-	 * because we need to check if `wp-edit-post` has been enqueued.
-	 */
-	public function enqueue_scripts() {
-		// @todo Remove fix to load our stylesheets after editor CSS.
-		// See #3068 and #3898 for the rationale of this fix. It should be no
-		// longer necessary when the editor is loaded in an iframe (https://github.com/WordPress/gutenberg/issues/20797).
-		$this->register_style( 'wc-block-vendors-style', plugins_url( $this->api->get_block_asset_build_path( 'vendors-style', 'css' ), __DIR__ ), wp_style_is( 'wp-edit-post' ) ? [ 'wp-edit-post' ] : [] );
 	}
 
 	/**


### PR DESCRIPTION
Closes #3225.

### Background

In the past, some of the styles of the Checkout block were conflicting with those from the editor, that affected the Country selector, which was rendering with a smaller size in the editor than in the frontend (see #3068 for more details). To fix that, in #3219 we forced our styles to be loaded after `wp-edit-post` styles in order to fix the specificity battle.

However, I recently tested it and it looks like we no longer need that. So this PR takes care of removing that work-around from the code.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/115833554-78ec8600-a414-11eb-8828-c52ec427fa79.png)

### How to test the changes in this Pull Request:

1. Open the Checkout block in the editor and verify the `Country/Region` selector has the same high as the `City` field next to it, rounded corners, etc.
2. Bonus points if you can test it in different versions of WordPress (I tested 5.5 and 5.7 with and without Gutenberg) and different themes.