### PR TITLE
Convert Product summary to TypeScript

### DIFF
--- a/assets/js/base/components/cart-checkout/product-summary/index.tsx
+++ b/assets/js/base/components/cart-checkout/product-summary/index.tsx
@@ -5,6 +5,11 @@ import PropTypes from 'prop-types';
 import Summary from '@woocommerce/base-components/summary';
 import { blocksConfig } from '@woocommerce/block-settings';
 
+interface ProductSummaryProps {
+	className?: string;
+	shortDescription?: string;
+	fullDescription?: string;
+}
 /**
  * Returns an element containing a summary of the product.
  *
@@ -17,7 +22,7 @@ const ProductSummary = ( {
 	className,
 	shortDescription = '',
 	fullDescription = '',
-} ) => {
+}: ProductSummaryProps ): JSX.Element | null => {
 	const source = shortDescription ? shortDescription : fullDescription;
 
 	if ( ! source ) {
@@ -32,12 +37,6 @@ const ProductSummary = ( {
 			countType={ blocksConfig.wordCountType || 'words' }
 		/>
 	);
-};
-
-ProductSummary.propTypes = {
-	className: PropTypes.string,
-	shortDescription: PropTypes.string,
-	fullDescription: PropTypes.string,
 };
 
 export default ProductSummary;

--- a/assets/js/base/components/summary/index.tsx
+++ b/assets/js/base/components/summary/index.tsx
@@ -2,12 +2,19 @@
  * External dependencies
  */
 import { RawHTML, useMemo } from '@wordpress/element';
+import { WordCountType } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
  */
 import { generateSummary } from './utils';
 
+interface SummaryProps {
+	className?: string;
+	source: string;
+	maxLength?: number;
+	countType?: WordCountType;
+}
 /**
  * Summary component.
  *
@@ -22,7 +29,7 @@ export const Summary = ( {
 	maxLength = 15,
 	countType = 'words',
 	className = '',
-} ) => {
+}: SummaryProps ): JSX.Element => {
 	const summaryText = useMemo( () => {
 		return generateSummary( source, maxLength, countType );
 	}, [ source, maxLength, countType ] );

--- a/assets/js/settings/blocks/constants.ts
+++ b/assets/js/settings/blocks/constants.ts
@@ -3,12 +3,17 @@
  */
 import { getSetting, STORE_PAGES } from '@woocommerce/settings';
 
+export type WordCountType =
+	| 'words'
+	| 'characters_excluding_spaces'
+	| 'characters_including_spaces';
+
 interface WcBlocksConfig {
 	buildPhase: number;
 	pluginUrl: string;
 	productCount: number;
 	restApiRoutes: Record< string, string[] >;
-	wordCountType: string;
+	wordCountType: WordCountType;
 }
 
 export const blocksConfig = getSetting( 'wcBlocksConfig', {


### PR DESCRIPTION
⚠️ Please note this PR was based on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4098 so the diff is large. Please wait until that one is merged before reviewing this so the diff is smaller.

This PR converts `ProductSummary` and `Summary` to TypeScript. It also adds the `WordCountType` since this is limited to one of three strings it makes sense for it to have its own type, rather than allowing it to be a string.

### How to test the changes in this Pull Request:

1. Add a decent amount of text to a product's short description.
2. Add it to your cart.
3. Go to the cart block and ensure the summary is displayed correctly, and truncated where appropriate.