### PR TITLE
Change checkoutAllowsGuest to the correct value.

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -144,9 +144,23 @@ class Checkout extends AbstractBlock {
 			true
 		);
 		$this->asset_data_registry->add( 'baseLocation', wc_get_base_location(), true );
-		$this->asset_data_registry->add( 'checkoutAllowsGuest', WC()->checkout()->is_registration_required(), true );
-		$this->asset_data_registry->add( 'checkoutAllowsSignup', WC()->checkout()->is_registration_enabled(), true );
-		$this->asset_data_registry->add( 'checkoutShowLoginReminder', 'yes' === get_option( 'woocommerce_enable_checkout_login_reminder' ), true );
+		$this->asset_data_registry->add(
+			'checkoutAllowsGuest',
+			false === filter_var(
+				WC()->checkout()->is_registration_required(),
+				FILTER_VALIDATE_BOOLEAN
+			),
+			true
+		);
+		$this->asset_data_registry->add(
+			'checkoutAllowsSignup',
+			filter_var(
+				$checkout->is_registration_enabled(),
+				FILTER_VALIDATE_BOOLEAN
+			),
+			true
+		);
+		$this->asset_data_registry->add( 'checkoutShowLoginReminder', filter_var( get_option( 'woocommerce_enable_checkout_login_reminder' ), FILTER_VALIDATE_BOOLEAN ), true );
 		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', 'incl' === get_option( 'woocommerce_tax_display_cart' ), true );
 		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ), true );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled(), true );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -155,7 +155,7 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add(
 			'checkoutAllowsSignup',
 			filter_var(
-				$checkout->is_registration_enabled(),
+				WC()->checkout()->is_registration_enabled(),
 				FILTER_VALIDATE_BOOLEAN
 			),
 			true


### PR DESCRIPTION
Fixes an issue in which `checkoutAllowsGuest` value was reversed (we use `is_registration_required` which is the opposite of allow guest, but we didn't flip it).

### How to test the changes in this Pull Request:

1. In WooCommerce settings,  prevent customers from placing orders without an account,  Allow them to create an account during checkout
<img width="812" alt="image" src="https://user-images.githubusercontent.com/6165348/116407897-22bf7e80-a82a-11eb-982f-03d09dcc0e1f.png">
2. Allow customers to create account during checkout (blocks option)

![image](https://user-images.githubusercontent.com/6165348/116408030-4682c480-a82a-11eb-8bc4-b2b5c9bf3065.png)

3. Add an item and Checkout, you shouldn't see `Create an Account?` checkbox on Checkout.
4. When placing an order, an account will be created.


