### PR TITLE
Fix/cart backend test

### DIFF
--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -3,9 +3,9 @@
  */
 import {
 	clickButton,
-	getAllBlocks,
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
+	getAllBlocks,
 } from '@wordpress/e2e-test-utils';
 import {
 	findLabelWithText,
@@ -23,13 +23,89 @@ const block = {
 	class: '.wc-block-cart',
 };
 
-if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `skipping ${ block.name } tests`, () => {} );
+}
 
 describe( `${ block.name } Block`, () => {
 	beforeAll( async () => {
+		await page.evaluate( () => {
+			localStorage.removeItem(
+				'wc-blocks_dismissed_compatibility_notices'
+			);
+		} );
+		await page.evaluate( () => {
+			localStorage.setItem(
+				'wc-blocks_dismissed_compatibility_notices',
+				'["cart"]'
+			);
+		} );
 		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'can only be inserted once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 1 );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+
+	it( 'shows empty cart when changing the view', async () => {
+		await page.waitForSelector( block.class ).catch( () => {
+			throw new Error(
+				`Could not find an element with class ${ block.class } - the block probably did not load correctly.`
+			);
+		} );
+		await page.click( block.class );
+		await expect( page ).toMatchElement(
+			'[hidden] .wc-block-cart__empty-cart__title'
+		);
+		await clickButton( 'Empty Cart' );
+		await expect( page ).not.toMatchElement(
+			'[hidden] .wc-block-cart__empty-cart__title'
+		);
+		// Simulate user scrolling up so the block toolbar doesn't cover
+		// the `Full Cart` button.
+		await page.evaluate( () => {
+			document
+				.querySelector( '.wc-block-view-switch-control' )
+				.scrollIntoView( { block: 'center', inline: 'center' } );
+		} );
+		await clickButton( 'Full Cart' );
+		await expect( page ).toMatchElement(
+			'[hidden] .wc-block-cart__empty-cart__title'
+		);
+	} );
+
+	describe( 'attributes', () => {
+		beforeEach( async () => {
+			await openDocumentSettingsSidebar();
+			await page.click( block.class );
+		} );
+
+		it( 'can toggle Shipping calculator', async () => {
+			const selector = `${ block.class } .wc-block-components-totals-shipping__change-address-button`;
+			const toggleLabel = await findLabelWithText(
+				'Shipping calculator'
+			);
+			await expect( toggleLabel ).toToggleElement( selector );
+		} );
+	} );
+} );
+
+describe( 'before compatibility notice is dismissed', () => {
+	beforeEach( async () => {
+		await page.evaluate( () => {
+			localStorage.setItem(
+				'wc-blocks_dismissed_compatibility_notices',
+				'[]'
+			);
+		} );
+		await visitBlockPage( `${ block.name } Block` );
 	} );
 
 	afterEach( async () => {
@@ -40,86 +116,10 @@ describe( `${ block.name } Block`, () => {
 		} );
 	} );
 
-	describe( 'before compatibility notice is dismissed', () => {
-		beforeEach( async () => {
-			await page.evaluate( () => {
-				localStorage.setItem(
-					'wc-blocks_dismissed_compatibility_notices',
-					'[]'
-				);
-			} );
-			await visitBlockPage( `${ block.name } Block` );
-		} );
-
-		it( 'shows compatibility notice', async () => {
-			const compatibilityNoticeTitle = await page.$x(
-				`//h1[contains(text(), 'Compatibility notice')]`
-			);
-			expect( compatibilityNoticeTitle.length ).toBe( 1 );
-		} );
-	} );
-
-	describe( 'once compatibility notice is dismissed', () => {
-		beforeEach( async () => {
-			await page.evaluate( () => {
-				localStorage.setItem(
-					'wc-blocks_dismissed_compatibility_notices',
-					'["cart"]'
-				);
-			} );
-			await visitBlockPage( `${ block.name } Block` );
-		} );
-
-		it( 'can only be inserted once', async () => {
-			await insertBlockDontWaitForInsertClose( block.name );
-			await closeInserter();
-			expect( await getAllBlocks() ).toHaveLength( 1 );
-		} );
-
-		it( 'renders without crashing', async () => {
-			await expect( page ).toRenderBlock( block );
-		} );
-
-		describe( 'attributes', () => {
-			beforeEach( async () => {
-				await openDocumentSettingsSidebar();
-				await page.click( block.class );
-			} );
-
-			it( 'can toggle Shipping calculator', async () => {
-				const selector = `${ block.class } .wc-block-components-totals-shipping__change-address-button`;
-				const toggleLabel = await findLabelWithText(
-					'Shipping calculator'
-				);
-				await expect( toggleLabel ).toToggleElement( selector );
-			} );
-		} );
-
-		it( 'shows empty cart when changing the view', async () => {
-			await page.waitForSelector( block.class ).catch( () => {
-				throw new Error(
-					`Could not find an element with class ${ block.class } - the block probably did not load correctly.`
-				);
-			} );
-			await page.click( block.class );
-			await expect( page ).toMatchElement(
-				'[hidden] .wc-block-cart__empty-cart__title'
-			);
-			await clickButton( 'Empty Cart' );
-			await expect( page ).not.toMatchElement(
-				'[hidden] .wc-block-cart__empty-cart__title'
-			);
-			// Simulate user scrolling up so the block toolbar doesn't cover
-			// the `Full Cart` button.
-			await page.evaluate( () => {
-				document
-					.querySelector( '.wc-block-view-switch-control' )
-					.scrollIntoView( { block: 'center', inline: 'center' } );
-			} );
-			await clickButton( 'Full Cart' );
-			await expect( page ).toMatchElement(
-				'[hidden] .wc-block-cart__empty-cart__title'
-			);
-		} );
+	it( 'shows compatibility notice', async () => {
+		const compatibilityNoticeTitle = await page.$x(
+			`//h1[contains(text(), 'Compatibility notice')]`
+		);
+		expect( compatibilityNoticeTitle.length ).toBe( 1 );
 	} );
 } );

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -29,97 +29,99 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 }
 
 describe( `${ block.name } Block`, () => {
-	beforeAll( async () => {
-		await page.evaluate( () => {
-			localStorage.removeItem(
-				'wc-blocks_dismissed_compatibility_notices'
+	describe( `before compatibility notice is dismissed`, () => {
+		beforeAll( async () => {
+			await page.evaluate( () => {
+				localStorage.setItem(
+					'wc-blocks_dismissed_compatibility_notices',
+					'[]'
+				);
+			} );
+			await visitBlockPage( `${ block.name } Block` );
+		} );
+
+		afterEach( async () => {
+			await page.evaluate( () => {
+				localStorage.removeItem(
+					'wc-blocks_dismissed_compatibility_notices'
+				);
+			} );
+		} );
+
+		it( 'shows compatibility notice', async () => {
+			const compatibilityNoticeTitle = await page.$x(
+				`//h1[contains(text(), 'Compatibility notice')]`
 			);
+			expect( compatibilityNoticeTitle.length ).toBe( 1 );
 		} );
-		await page.evaluate( () => {
-			localStorage.setItem(
-				'wc-blocks_dismissed_compatibility_notices',
-				'["cart"]'
-			);
-		} );
-		await switchUserToAdmin();
-		await visitBlockPage( `${ block.name } Block` );
 	} );
 
-	it( 'can only be inserted once', async () => {
-		await insertBlockDontWaitForInsertClose( block.name );
-		expect( await getAllBlocks() ).toHaveLength( 1 );
-	} );
-
-	it( 'renders without crashing', async () => {
-		await expect( page ).toRenderBlock( block );
-	} );
-
-	it( 'shows empty cart when changing the view', async () => {
-		await page.waitForSelector( block.class ).catch( () => {
-			throw new Error(
-				`Could not find an element with class ${ block.class } - the block probably did not load correctly.`
-			);
+	describe( 'after compatibility notice is dismissed', () => {
+		beforeAll( async () => {
+			await page.evaluate( () => {
+				localStorage.removeItem(
+					'wc-blocks_dismissed_compatibility_notices'
+				);
+			} );
+			await page.evaluate( () => {
+				localStorage.setItem(
+					'wc-blocks_dismissed_compatibility_notices',
+					'["cart"]'
+				);
+			} );
+			await switchUserToAdmin();
+			await visitBlockPage( `${ block.name } Block` );
 		} );
-		await page.click( block.class );
-		await expect( page ).toMatchElement(
-			'[hidden] .wc-block-cart__empty-cart__title'
-		);
-		await clickButton( 'Empty Cart' );
-		await expect( page ).not.toMatchElement(
-			'[hidden] .wc-block-cart__empty-cart__title'
-		);
-		// Simulate user scrolling up so the block toolbar doesn't cover
-		// the `Full Cart` button.
-		await page.evaluate( () => {
-			document
-				.querySelector( '.wc-block-view-switch-control' )
-				.scrollIntoView( { block: 'center', inline: 'center' } );
-		} );
-		await clickButton( 'Full Cart' );
-		await expect( page ).toMatchElement(
-			'[hidden] .wc-block-cart__empty-cart__title'
-		);
-	} );
 
-	describe( 'attributes', () => {
-		beforeEach( async () => {
-			await openDocumentSettingsSidebar();
+		it( 'can only be inserted once', async () => {
+			await insertBlockDontWaitForInsertClose( block.name );
+			expect( await getAllBlocks() ).toHaveLength( 1 );
+		} );
+
+		it( 'renders without crashing', async () => {
+			await expect( page ).toRenderBlock( block );
+		} );
+
+		it( 'shows empty cart when changing the view', async () => {
+			await page.waitForSelector( block.class ).catch( () => {
+				throw new Error(
+					`Could not find an element with class ${ block.class } - the block probably did not load correctly.`
+				);
+			} );
 			await page.click( block.class );
-		} );
-
-		it( 'can toggle Shipping calculator', async () => {
-			const selector = `${ block.class } .wc-block-components-totals-shipping__change-address-button`;
-			const toggleLabel = await findLabelWithText(
-				'Shipping calculator'
+			await expect( page ).toMatchElement(
+				'[hidden] .wc-block-cart__empty-cart__title'
 			);
-			await expect( toggleLabel ).toToggleElement( selector );
-		} );
-	} );
-} );
-
-describe( 'before compatibility notice is dismissed', () => {
-	beforeEach( async () => {
-		await page.evaluate( () => {
-			localStorage.setItem(
-				'wc-blocks_dismissed_compatibility_notices',
-				'[]'
+			await clickButton( 'Empty Cart' );
+			await expect( page ).not.toMatchElement(
+				'[hidden] .wc-block-cart__empty-cart__title'
 			);
-		} );
-		await visitBlockPage( `${ block.name } Block` );
-	} );
-
-	afterEach( async () => {
-		await page.evaluate( () => {
-			localStorage.removeItem(
-				'wc-blocks_dismissed_compatibility_notices'
+			// Simulate user scrolling up so the block toolbar doesn't cover
+			// the `Full Cart` button.
+			await page.evaluate( () => {
+				document
+					.querySelector( '.wc-block-view-switch-control' )
+					.scrollIntoView( { block: 'center', inline: 'center' } );
+			} );
+			await clickButton( 'Full Cart' );
+			await expect( page ).toMatchElement(
+				'[hidden] .wc-block-cart__empty-cart__title'
 			);
 		} );
-	} );
 
-	it( 'shows compatibility notice', async () => {
-		const compatibilityNoticeTitle = await page.$x(
-			`//h1[contains(text(), 'Compatibility notice')]`
-		);
-		expect( compatibilityNoticeTitle.length ).toBe( 1 );
+		describe( 'attributes', () => {
+			beforeEach( async () => {
+				await openDocumentSettingsSidebar();
+				await page.click( block.class );
+			} );
+
+			it( 'can toggle Shipping calculator', async () => {
+				const selector = `${ block.class } .wc-block-components-totals-shipping__change-address-button`;
+				const toggleLabel = await findLabelWithText(
+					'Shipping calculator'
+				);
+				await expect( toggleLabel ).toToggleElement( selector );
+			} );
+		} );
 	} );
 } );

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -22,25 +22,14 @@ const block = {
 	class: '.wc-block-checkout',
 };
 
-if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `skipping ${ block.name } tests`, () => {} );
+}
 
 describe( `${ block.name } Block`, () => {
-	beforeAll( async () => {
-		await switchUserToAdmin();
-	} );
-
-	afterEach( async () => {
-		await page.evaluate( () => {
-			localStorage.removeItem(
-				'wc-blocks_dismissed_compatibility_notices'
-			);
-		} );
-	} );
-
-	describe( 'before compatibility notice is dismissed', () => {
-		beforeEach( async () => {
+	describe( `before compatibility notice is dismissed`, () => {
+		beforeAll( async () => {
 			await page.evaluate( () => {
 				localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
@@ -48,6 +37,14 @@ describe( `${ block.name } Block`, () => {
 				);
 			} );
 			await visitBlockPage( `${ block.name } Block` );
+		} );
+
+		afterEach( async () => {
+			await page.evaluate( () => {
+				localStorage.removeItem(
+					'wc-blocks_dismissed_compatibility_notices'
+				);
+			} );
 		} );
 
 		it( 'shows compatibility notice', async () => {
@@ -58,14 +55,20 @@ describe( `${ block.name } Block`, () => {
 		} );
 	} );
 
-	describe( 'once compatibility notice is dismissed', () => {
-		beforeEach( async () => {
+	describe( 'after compatibility notice is dismissed', () => {
+		beforeAll( async () => {
+			await page.evaluate( () => {
+				localStorage.removeItem(
+					'wc-blocks_dismissed_compatibility_notices'
+				);
+			} );
 			await page.evaluate( () => {
 				localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
 					'["checkout"]'
 				);
 			} );
+			await switchUserToAdmin();
 			await visitBlockPage( `${ block.name } Block` );
 		} );
 


### PR DESCRIPTION
This PR fixes the e2e test for Cart in the editor. 

It makes sure that the compatibility notice is fully closed when testing by setting the corresponding cookie correctly in the beforeAll statement. The structure of the test has also been improved.