### PR TITLE
Improvements to `emitEventWithAbort`.

### DIFF
--- a/assets/js/base/context/event-emit/emitters.ts
+++ b/assets/js/base/context/event-emit/emitters.ts
@@ -3,6 +3,7 @@
  */
 import { getObserversByPriority } from './utils';
 import type { EventObserversType } from './types';
+import { isErrorResponse, isFailResponse } from '../hooks/use-emit-response';
 
 /**
  * Emits events on registered observers for the provided type and passes along
@@ -44,20 +45,24 @@ export const emitEvent = async (
 
 /**
  * Emits events on registered observers for the provided type and passes along
- * the provided data. This event emitter will abort and return any value from
- * observers that return an object which should contain a type property.
+ * the provided data. This event emitter will abort if an observer throws an
+ * error or if the response includes an object with an error type property.
+ *
+ * Any successful observer responses before abort will be included in the returned package.
  *
  * @param {Object} observers The registered observers to omit to.
  * @param {string} eventType The event type being emitted.
  * @param {*}      data      Data passed along to the observer when it is invoked.
  *
- * @return {Promise} Returns a promise that resolves to either boolean or the return value of the aborted observer.
+ * @return {Promise} Returns a promise that resolves to either boolean, or an array of responses
+ *                   from registered observers that were invoked up to the point of an error.
  */
 export const emitEventWithAbort = async (
 	observers: EventObserversType,
 	eventType: string,
 	data: unknown
-): Promise< unknown > => {
+): Promise< Array< unknown > > => {
+	const observerResponses = [];
 	const observersByType = getObserversByPriority( observers, eventType );
 	for ( const observer of observersByType ) {
 		try {
@@ -67,16 +72,22 @@ export const emitEventWithAbort = async (
 			}
 			if ( ! response.hasOwnProperty( 'type' ) ) {
 				throw new Error(
-					'If you want to abort event emitter processing, your observer must return an object with a type property'
+					'Returned objects from event emitter observers must return an object with a type property'
 				);
 			}
-			return response;
+			if ( isErrorResponse( response ) || isFailResponse( response ) ) {
+				observerResponses.push( response );
+				// early abort.
+				return observerResponses;
+			}
+			// all potential abort conditions have been considered push the
+			// response to the array.
+			observerResponses.push( response );
 		} catch ( e ) {
 			// We don't handle thrown errors but just console.log for troubleshooting.
 			// eslint-disable-next-line no-console
 			console.error( e );
-			return { type: 'error' };
 		}
 	}
-	return true;
+	return observerResponses;
 };

--- a/assets/js/base/context/event-emit/emitters.ts
+++ b/assets/js/base/context/event-emit/emitters.ts
@@ -87,6 +87,8 @@ export const emitEventWithAbort = async (
 			// We don't handle thrown errors but just console.log for troubleshooting.
 			// eslint-disable-next-line no-console
 			console.error( e );
+			observerResponses.push( { type: 'error' } );
+			return observerResponses;
 		}
 	}
 	return observerResponses;

--- a/assets/js/base/context/event-emit/test/emitters.js
+++ b/assets/js/base/context/event-emit/test/emitters.js
@@ -30,6 +30,13 @@ describe( 'Testing emitters', () => {
 				'observerPromiseWithResolvedValue',
 				{ priority: 10, callback: observerPromiseWithResolvedValue },
 			],
+			[
+				'observerSuccessType',
+				{
+					priority: 10,
+					callback: jest.fn().mockReturnValue( { type: 'success' } ),
+				},
+			],
 		] );
 	} );
 	describe( 'Testing emitEvent()', () => {
@@ -39,11 +46,11 @@ describe( 'Testing emitters', () => {
 			expect( console ).toHaveErroredWith( 'an error' );
 			expect( observerA ).toHaveBeenCalledTimes( 1 );
 			expect( observerB ).toHaveBeenCalledWith( 'foo' );
-			expect( response ).toBe( true );
+			expect( response ).toEqual( [ { type: 'success' } ] );
 		} );
 	} );
 	describe( 'Testing emitEventWithAbort()', () => {
-		it( 'does not abort on any return value other than an object with a type property', async () => {
+		it( 'does not abort on any return value other than an object with an error or fail type property', async () => {
 			observerMocks.delete( 'observerPromiseWithReject' );
 			const observers = { test: observerMocks };
 			const response = await emitEventWithAbort(
@@ -54,17 +61,16 @@ describe( 'Testing emitters', () => {
 			expect( console ).not.toHaveErrored();
 			expect( observerB ).toHaveBeenCalledTimes( 1 );
 			expect( observerPromiseWithResolvedValue ).toHaveBeenCalled();
-			expect( response ).toBe( true );
+			expect( response ).toEqual( [ { type: 'success' } ] );
 		} );
-		it( 'Aborts on a return value with an object that has a type property', async () => {
+		it( 'Aborts on a return value with an object that has a a fail type property', async () => {
 			const validObjectResponse = jest
 				.fn()
-				.mockReturnValue( { type: 'success' } );
+				.mockReturnValue( { type: 'failure' } );
 			observerMocks.set( 'observerValidObject', {
 				priority: 5,
 				callback: validObjectResponse,
 			} );
-			observerMocks.delete( 'observerPromiseWithReject' );
 			const observers = { test: observerMocks };
 			const response = await emitEventWithAbort(
 				observers,
@@ -74,7 +80,7 @@ describe( 'Testing emitters', () => {
 			expect( console ).not.toHaveErrored();
 			expect( validObjectResponse ).toHaveBeenCalledTimes( 1 );
 			expect( observerPromiseWithResolvedValue ).not.toHaveBeenCalled();
-			expect( response ).toEqual( { type: 'success' } );
+			expect( response ).toEqual( [ { type: 'failure' } ] );
 		} );
 		it( 'throws an error on an object returned from observer without a type property', async () => {
 			const failingObjectResponse = jest.fn().mockReturnValue( {} );
@@ -91,7 +97,7 @@ describe( 'Testing emitters', () => {
 			expect( console ).toHaveErrored();
 			expect( failingObjectResponse ).toHaveBeenCalledTimes( 1 );
 			expect( observerPromiseWithResolvedValue ).not.toHaveBeenCalled();
-			expect( response ).toEqual( { type: 'error' } );
+			expect( response ).toEqual( [ { type: 'error' } ] );
 		} );
 	} );
 	describe( 'Test Priority', () => {

--- a/assets/js/base/context/hooks/use-emit-response.js
+++ b/assets/js/base/context/hooks/use-emit-response.js
@@ -25,19 +25,19 @@ const noticeContexts = {
 	EXPRESS_PAYMENTS: 'wc/express-payment-area',
 };
 
-const isSuccessResponse = ( response ) => {
+export const isSuccessResponse = ( response ) => {
 	return isResponseOf( response, responseTypes.SUCCESS );
 };
 
-const isErrorResponse = ( response ) => {
+export const isErrorResponse = ( response ) => {
 	return isResponseOf( response, responseTypes.ERROR );
 };
 
-const isFailResponse = ( response ) => {
+export const isFailResponse = ( response ) => {
 	return isResponseOf( response, responseTypes.FAIL );
 };
 
-const shouldRetry = ( response ) => {
+export const shouldRetry = ( response ) => {
 	return typeof response.retry === 'undefined' || response.retry === true;
 };
 


### PR DESCRIPTION
Fixes: #4048 

As highlighted in #4048, the `emitEventWithAbort` emitter has a flaw in that it was aborting on `{ type: 'success' }` responses from subscribed observers. This creates complications where there are multiple observers subscribed as outlined with the example given in the issue. 

As implemented in this PR:

- `emitEventWithAbort` now only aborts if there is a thrown error or any subscribed observers return a fail or error type response (`{ type: 'error' }` or `{ type: 'failure' }`.
- If there is a failure by any of the observers, it doesn't matter if any of the previous observer calls up to that point executed successfully, there will be _no_ update to the checkout state.
- for the `onPaymentProcessing` event, if there are multiple success events (and no error events) then _only the response from the last observer_ will be used to update the state.

On the latter point, there's still some potential for payment method extensions having poor logic to result in unexpected behaviour on checkout submission. However, I think the behaviour I've implemented here is the best approach for now given there's no way to know which observer should "win" in terms of updating the state. 

I didn't do any conversion to TypeScript because this should get included in the next release of Blocks to support the various improvements made to the Stripe extension in the migration work there. Also, there are more and more payment methods integrating with the blocks so this prevents a class of bugs surfacing for them (especially payment methods that have additional verification processes).

## To Test

This impacts all payment processing in the checkout. So it does mean testing of the flows needs to be fairly thorough:

- Test all supported payment methods that completing a transaction works as expected.
- For Stripe, test various cards that fail (both for express payment methods and cc) - you [can get test card numbers here](https://stripe.com/docs/testing).
- Try various scenarios such as a payment card failing for express payment method and then being able to complete using a different payment method (or vice versa).
- Test with 3DS card for Stripe CC.
- Ensure saved payment methods work.
- Test express payment methods in the cart context.

### Testing pending Stripe integration migration (not for inclusion in blocks release testing notes)

Using the [branch for the Stripe integration migration here](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1467), build that version and test with this branch of blocks. Besides repeating the tests above with the Stripe integration included in blocks in this branch for Stripe you'll also want to verify behaviour of:

- payment with a token that is attached to a 3DS card (example `4000000000003063` which forces 3DS confirmation modal on every transaction).
- payment with a 3DS card via express payment methods. Unless you have a personal 3DS card, the only way I've been able to test this is to add the test card using the Chrome payment settings and then do the transaction with an incognito browser instance (which won't use Google Pay even if it's configured for your browser). This will ensure that just ChromePay is used and allows you to test with dummy cards.
- payment with a 3DS card for Stripe CC.