### PR TITLE
Don't clear email and phone fields when using separate billing address.

### DIFF
--- a/assets/js/base/context/hooks/use-checkout-address.js
+++ b/assets/js/base/context/hooks/use-checkout-address.js
@@ -88,7 +88,7 @@ export const useCheckoutAddress = () => {
 				setBillingData( shippingAddress );
 			} else {
 				const {
-					// We need to pluck out email and phone from previous billing data because they can be empty, causing the current email and phone to get emptied.
+					// We need to pluck out email and phone from previous billing data because they can be empty, causing the current email and phone to get emptied. See issue #4155
 					/* eslint-disable no-unused-vars */
 					email,
 					phone,

--- a/assets/js/base/context/hooks/use-checkout-address.js
+++ b/assets/js/base/context/hooks/use-checkout-address.js
@@ -88,9 +88,9 @@ export const useCheckoutAddress = () => {
 				setBillingData( shippingAddress );
 			} else {
 				setBillingData( {
-					...previousBillingData.current,
 					email: undefined,
 					phone: undefined,
+					...previousBillingData.current,
 				} );
 			}
 			currentShippingAsBilling.current = shippingAsBilling;

--- a/assets/js/base/context/hooks/use-checkout-address.js
+++ b/assets/js/base/context/hooks/use-checkout-address.js
@@ -87,10 +87,16 @@ export const useCheckoutAddress = () => {
 				previousBillingData.current = billingData;
 				setBillingData( shippingAddress );
 			} else {
+				const {
+					// We need to pluck out email and phone from previous billing data because they can be empty, causing the current email and phone to get emptied.
+					/* eslint-disable no-unused-vars */
+					email,
+					phone,
+					/* eslint-enable no-unused-vars */
+					...billingAddress
+				} = previousBillingData.current;
 				setBillingData( {
-					email: undefined,
-					phone: undefined,
-					...previousBillingData.current,
+					...billingAddress,
 				} );
 			}
 			currentShippingAsBilling.current = shippingAsBilling;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When unchecking "Use shipping as billing", the email and address fields are wiped out due to a code order, it seems @nerrad [anticipated this in his review](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3358/files#r524545700) but @mikejolley confirmed it didn't happen, not sure what changed between now and then but I updated the spread order so it doesn't override any existing email and billing fields.

I went along and removed the empty email and phone fields from the previous billing address, to not affect the current values.
<!-- Reference any related issues or PRs here -->
Fixes #4155

### How to test the changes in this Pull Request:

1. On checkout (guest and logged in), fill out your email, shipping fields and phone number.
2. Uncheck "use shipping for billing"
3. Make sure email and phone still have their values.
4. Submit the order and make sure those values persisted on the server.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix issue in which email and phone fields are cleared when using a separate billing address.
