### PR TITLE
Add cart data to filters

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 import Dinero from 'dinero.js';
 import { getSetting } from '@woocommerce/settings';
 import { useCallback, useMemo } from '@wordpress/element';
+import { useStoreCart } from '@woocommerce/base-context/hooks';
 
 /**
  * Internal dependencies
@@ -41,6 +42,11 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		extensions = {},
 	} = cartItem;
 
+	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
+	// We need to pluck out receiveCart.
+	// eslint-disable-next-line no-unused-vars
+	const { receiveCart, ...cart } = useStoreCart();
+
 	const productPriceValidation = useCallback(
 		( value ) => mustBeString( value ) && mustContain( value, '<price/>' ),
 		[]
@@ -50,8 +56,9 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		() => ( {
 			context: 'summary',
 			cartItem,
+			cart,
 		} ),
-		[ cartItem ]
+		[ cartItem, cart ]
 	);
 
 	const priceCurrency = getCurrencyFromPriceResponse( prices );

--- a/assets/js/base/components/cart-checkout/totals/footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/index.js
@@ -28,11 +28,11 @@ const TotalsFooterItem = ( { currency, values } ) => {
 	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
 	// We need to pluck out receiveCart.
 	// eslint-disable-next-line no-unused-vars
-	const { extensions, receiveCart, ...cart } = useStoreCart();
+	const { receiveCart, ...cart } = useStoreCart();
 	const label = __experimentalApplyCheckoutFilter( {
 		filterName: 'totalLabel',
 		defaultValue: __( 'Total', 'woo-gutenberg-products-block' ),
-		extensions,
+		extensions: cart.extensions,
 		arg: { cart },
 		// Only accept strings.
 		validation: mustBeString,

--- a/assets/js/base/components/cart-checkout/totals/footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/index.js
@@ -24,11 +24,16 @@ const SHOW_TAXES =
 
 const TotalsFooterItem = ( { currency, values } ) => {
 	const { total_price: totalPrice, total_tax: totalTax } = values;
-	const { extensions } = useStoreCart();
+
+	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
+	// We need to pluck out receiveCart.
+	// eslint-disable-next-line no-unused-vars
+	const { extensions, receiveCart, ...cart } = useStoreCart();
 	const label = __experimentalApplyCheckoutFilter( {
 		filterName: 'totalLabel',
 		defaultValue: __( 'Total', 'woo-gutenberg-products-block' ),
 		extensions,
+		arg: { cart },
 		// Only accept strings.
 		validation: mustBeString,
 	} );

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -9,6 +9,7 @@ import ProductName from '@woocommerce/base-components/product-name';
 import {
 	useStoreCartItemQuantity,
 	useStoreEvents,
+	useStoreCart,
 } from '@woocommerce/base-context/hooks';
 import {
 	ProductBackorderBadge,
@@ -114,12 +115,18 @@ const CartLineItemRow = ( {
 		( value ) => mustBeString( value ) && mustContain( value, '<price/>' ),
 		[]
 	);
+
+	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
+	// We need to pluck out receiveCart.
+	// eslint-disable-next-line no-unused-vars
+	const { receiveCart, ...cart } = useStoreCart();
 	const arg = useMemo(
 		() => ( {
 			context: 'cart',
 			cartItem: lineItem,
+			cart,
 		} ),
-		[ lineItem ]
+		[ lineItem, cart ]
 	);
 	const priceCurrency = getCurrencyFromPriceResponse( prices );
 	const name = __experimentalApplyCheckoutFilter( {


### PR DESCRIPTION
This PR adds cart data to all of our filters, it makes sense to provide this since a lineItem data alone might be enough to extend that item (sometimes you need other items as well).

### Testing instructions 
Currently, we don't have any other plugin using filters except Subscriptions, [so load trunk](https://github.com/woocommerce/woocommerce-subscriptions), run `npm install` and `npm run build` and make sure the filters are working fine.

This might cause a performance decrease by having useStoreCart in all child items, but this is yet to be confirmed so I won't beat myself about it until we have a process to measure performance decrease.  

cc @franticpsyx