### PR TITLE
Add checkout filter for coupon names

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -5,7 +5,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
 import { RemovableChip } from '@woocommerce/base-components/chip';
 import PropTypes from 'prop-types';
-import { TotalsItem } from '@woocommerce/blocks-checkout';
+import {
+	__experimentalApplyCheckoutFilter,
+	mustBeString,
+	TotalsItem,
+} from '@woocommerce/blocks-checkout';
 import { getSetting } from '@woocommerce/settings';
 
 /**
@@ -53,34 +57,48 @@ const TotalsDiscount = ( {
 						showSpinner={ false }
 					>
 						<ul className="wc-block-components-totals-discount__coupon-list">
-							{ cartCoupons.map( ( cartCoupon ) => (
-								<RemovableChip
-									key={ 'coupon-' + cartCoupon.code }
-									className="wc-block-components-totals-discount__coupon-list-item"
-									text={ cartCoupon.code }
-									screenReaderText={ sprintf(
-										/* translators: %s Coupon code. */
-										__(
-											'Coupon: %s',
-											'woo-gutenberg-products-block'
-										),
-										cartCoupon.code
-									) }
-									disabled={ isRemovingCoupon }
-									onRemove={ () => {
-										removeCoupon( cartCoupon.code );
-									} }
-									radius="large"
-									ariaLabel={ sprintf(
-										/* translators: %s is a coupon code. */
-										__(
-											'Remove coupon "%s"',
-											'woo-gutenberg-products-block'
-										),
-										cartCoupon.code
-									) }
-								/>
-							) ) }
+							{ cartCoupons.map( ( cartCoupon ) => {
+								const filteredCouponCode = __experimentalApplyCheckoutFilter(
+									{
+										validation: mustBeString,
+										arg: {
+											context: 'summary',
+											coupon: cartCoupon,
+										},
+										filterName: 'couponName',
+										defaultValue: cartCoupon.code,
+									}
+								);
+
+								return (
+									<RemovableChip
+										key={ 'coupon-' + cartCoupon.code }
+										className="wc-block-components-totals-discount__coupon-list-item"
+										text={ filteredCouponCode }
+										screenReaderText={ sprintf(
+											/* translators: %s Coupon code. */
+											__(
+												'Coupon: %s',
+												'woo-gutenberg-products-block'
+											),
+											filteredCouponCode
+										) }
+										disabled={ isRemovingCoupon }
+										onRemove={ () => {
+											removeCoupon( cartCoupon.code );
+										} }
+										radius="large"
+										ariaLabel={ sprintf(
+											/* translators: %s is a coupon code. */
+											__(
+												'Remove coupon "%s"',
+												'woo-gutenberg-products-block'
+											),
+											filteredCouponCode
+										) }
+									/>
+								);
+							} ) }
 						</ul>
 					</LoadingMask>
 				)

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -61,7 +61,7 @@ const getCheckoutFilters = ( filterName: string ): CheckoutFilterFunction[] => {
 export const __experimentalApplyCheckoutFilter = < T >( {
 	filterName,
 	defaultValue,
-	extensions,
+	extensions = {},
 	arg = null,
 	validation = returnTrue,
 }: {
@@ -70,7 +70,7 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 	/** Default value to filter. */
 	defaultValue: T;
 	/** Values extend to REST API response. */
-	extensions: Record< string, unknown >;
+	extensions?: Record< string, unknown >;
 	/** Object containing arguments for the filter function. */
 	arg: CheckoutFilterArguments;
 	/** Function that needs to return true when the filtered value is passed in order for the filter to be applied. */


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will introduce a new filter location. It will be used to allow extensions to change the text in the `RemovableChip` components used to represent a discount that has been applied to the cart.

The filter's name will be `couponCode`, and the value passed to the filter function will be the coupon code. The context (summary) will also be passed to the filter function, along with the rest of the coupon data (`totals` and `discount_type`).

Documentation for this filter has been added too.

<!-- Reference any related issues or PRs here -->
Fixes #4151 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

|Before|After|
|---|---|
|<img src="https://user-images.githubusercontent.com/5656702/117165462-6d5a7100-adbd-11eb-8aa4-997f854010c1.png" width=400 />|<img src="https://user-images.githubusercontent.com/5656702/117169842-62a1db00-adc1-11eb-8e0b-da4c1b1d7099.png" width=350 />|


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Check out 422-gh-woocommerce/woocommerce-points-and-rewards 
2. Run npm run build in both repositories.
3. In the dashboard, go to **WooCommerce > Points and rewards > Manage points** and add some points to your user account.
4. Add items to your cart.
5. Go to the shortcode cart, apply the points discount using the notice and, observe the discount in the cart.
6. Go to the Cart Block and ensure the coupon applied reads `Points redemption` and not the long system generated coupon code.
7. Try removing the coupon and ensure the discount is removed, and no errors are shown

<!-- If you can, add the appropriate labels -->

### Changelog

> Add couponName filter to allow extensions to modify how coupons are displayed in the Cart and Checkout summary.