### PR TITLE
Update design of cart and checkout sidebars

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -5,6 +5,7 @@
 $no-stock-color: $alert-red;
 $low-stock-color: $alert-yellow;
 $in-stock-color: $alert-green;
+$discount-color: $alert-green;
 
 $placeholder-color: var(--global--color-primary, $gray-200);
 $input-border-gray: #50575e;

--- a/assets/js/base/components/cart-checkout/product-summary/index.tsx
+++ b/assets/js/base/components/cart-checkout/product-summary/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import Summary from '@woocommerce/base-components/summary';
 import { blocksConfig } from '@woocommerce/block-settings';
 

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -4,11 +4,10 @@
 import classNames from 'classnames';
 import { _n, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import Label from '@woocommerce/base-components/label';
-import Title from '@woocommerce/base-components/title';
 import type { ReactElement } from 'react';
 import type { PackageRateOption } from '@woocommerce/type-defs/shipping';
 import { Panel } from '@woocommerce/blocks-checkout';
+import Label from '@woocommerce/base-components/label';
 import { useSelectShippingRate } from '@woocommerce/base-context/hooks';
 import type { CartShippingPackageShippingRate } from '@woocommerce/type-defs/cart';
 
@@ -77,12 +76,9 @@ export const ShippingRatesControlPackage = ( {
 	const header = (
 		<>
 			{ ( showItems || collapsible ) && (
-				<Title
-					className="wc-block-components-shipping-rates-control__package-title"
-					headingLevel="3"
-				>
+				<div className="wc-block-components-shipping-rates-control__package-title">
 					{ packageData.name }
-				</Title>
+				</div>
 			) }
 			{ showItems && (
 				<ul className="wc-block-components-shipping-rates-control__package-items">

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -6,12 +6,6 @@
 		padding-top: em($gap-small);
 	}
 
-	.wc-block-components-shipping-rates-control__package-title {
-		@include text-heading();
-		font-weight: bold;
-		margin: 0;
-	}
-
 	// Remove panel padding because we are adding bottom padding to `.wc-block-components-radio-control`
 	// and `.wc-block-components-radio-control__option-layout` in the next ruleset.
 	.wc-block-components-panel__content {

--- a/assets/js/base/components/cart-checkout/totals/coupon/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.js
@@ -51,11 +51,11 @@ const TotalsCoupon = ( {
 			title={
 				<Label
 					label={ __(
-						'Coupon Code?',
+						'Coupon code',
 						'woo-gutenberg-products-block'
 					) }
 					screenReaderLabel={ __(
-						'Introduce Coupon Code',
+						'Apply a coupon code',
 						'woo-gutenberg-products-block'
 					) }
 					htmlFor={ textInputId }

--- a/assets/js/base/components/cart-checkout/totals/coupon/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.js
@@ -25,6 +25,7 @@ const TotalsCoupon = ( {
 	isLoading = false,
 	initialOpen = false,
 	onSubmit = () => {},
+	isCouponAddedSuccessfully = false,
 } ) => {
 	const [ couponValue, setCouponValue ] = useState( '' );
 	const currentIsLoading = useRef( false );
@@ -108,6 +109,14 @@ const TotalsCoupon = ( {
 						propertyName="coupon"
 						elementId={ textInputId }
 					/>
+					{ isCouponAddedSuccessfully && (
+						<div className="wc-block-components-totals-coupon__success-notice">
+							{ __(
+								'Discount applied successfully!',
+								'woo-gutenberg-products-block'
+							) }
+						</div>
+					) }
 				</div>
 			</LoadingMask>
 		</Panel>

--- a/assets/js/base/components/cart-checkout/totals/coupon/index.js
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.js
@@ -25,7 +25,6 @@ const TotalsCoupon = ( {
 	isLoading = false,
 	initialOpen = false,
 	onSubmit = () => {},
-	isCouponAddedSuccessfully = false,
 } ) => {
 	const [ couponValue, setCouponValue ] = useState( '' );
 	const currentIsLoading = useRef( false );
@@ -109,14 +108,6 @@ const TotalsCoupon = ( {
 						propertyName="coupon"
 						elementId={ textInputId }
 					/>
-					{ isCouponAddedSuccessfully && (
-						<div className="wc-block-components-totals-coupon__success-notice">
-							{ __(
-								'Discount applied successfully!',
-								'woo-gutenberg-products-block'
-							) }
-						</div>
-					) }
 				</div>
 			</LoadingMask>
 		</Panel>

--- a/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -23,7 +23,3 @@
 	flex-direction: column;
 	position: relative;
 }
-
-.wc-block-components-totals-coupon__success-notice {
-	color: $discount-color;
-}

--- a/assets/js/base/components/cart-checkout/totals/coupon/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/coupon/style.scss
@@ -23,3 +23,7 @@
 	flex-direction: column;
 	position: relative;
 }
+
+.wc-block-components-totals-coupon__success-notice {
+	color: $discount-color;
+}

--- a/assets/js/base/components/cart-checkout/totals/discount/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/discount/style.scss
@@ -3,3 +3,7 @@
 	margin: 0;
 	padding: 0;
 }
+
+.wc-block-components-totals-discount .wc-block-components-totals-item__value {
+	color: $discount-color;
+}

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -9,6 +9,7 @@ import { TotalsItem } from '@woocommerce/blocks-checkout';
 import type { Currency } from '@woocommerce/price-format';
 import type { ReactElement } from 'react';
 import { getSetting, EnteredAddress } from '@woocommerce/settings';
+import { ShippingVia } from '@woocommerce/base-components/cart-checkout/totals/shipping/shipping-via';
 
 /**
  * Internal dependencies
@@ -146,6 +147,14 @@ const TotalsShipping = ( {
 		setIsShippingCalculatorOpen,
 	};
 
+	const selectedShippingRates = shippingRates.flatMap(
+		( shippingPackage ) => {
+			return shippingPackage.shipping_rates
+				.filter( ( rate ) => rate.selected )
+				.flatMap( ( rate ) => rate.name );
+		}
+	);
+
 	return (
 		<div
 			className={ classnames(
@@ -168,11 +177,18 @@ const TotalsShipping = ( {
 				description={
 					<>
 						{ cartHasCalculatedShipping && (
-							<ShippingAddress
-								shippingAddress={ shippingAddress }
-								showCalculator={ showCalculator }
-								{ ...calculatorButtonProps }
-							/>
+							<>
+								<ShippingVia
+									selectedShippingRates={
+										selectedShippingRates
+									}
+								/>
+								<ShippingAddress
+									shippingAddress={ shippingAddress }
+									showCalculator={ showCalculator }
+									{ ...calculatorButtonProps }
+								/>
+							</>
 						) }
 					</>
 				}

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-via.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-via.tsx
@@ -7,7 +7,7 @@ export const ShippingVia = ( {
 	selectedShippingRates,
 }: {
 	selectedShippingRates: string[];
-} ) => {
+} ): JSX.Element => {
 	return (
 		<div className="wc-block-components-totals-item__description wc-block-components-totals-shipping__via">
 			{ __( 'via', 'woo-gutenberg-products-block' ) }{ ' ' }

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-via.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-via.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const ShippingVia = ( {
+	selectedShippingRates,
+}: {
+	selectedShippingRates: string[];
+} ) => {
+	return (
+		<div className="wc-block-components-totals-item__description wc-block-components-totals-shipping__via">
+			{ __( 'via', 'woo-gutenberg-products-block' ) }{ ' ' }
+			{ selectedShippingRates.join( ', ' ) }
+		</div>
+	);
+};

--- a/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -8,7 +8,6 @@
 	}
 
 	.wc-block-components-totals-shipping__via {
-		font-weight: 700;
 		margin-bottom: $gap;
 	}
 

--- a/assets/js/base/components/cart-checkout/totals/shipping/style.scss
+++ b/assets/js/base/components/cart-checkout/totals/shipping/style.scss
@@ -7,6 +7,11 @@
 		border: 0;
 	}
 
+	.wc-block-components-totals-shipping__via {
+		font-weight: 700;
+		margin-bottom: $gap;
+	}
+
 	.wc-block-components-totals-shipping__options {
 		.wc-block-components-radio-control__label,
 		.wc-block-components-radio-control__description,

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -52,6 +52,13 @@
 	}
 }
 
+.wc-block-components-sidebar .wc-block-components-panel > h2 {
+	@include reset-typography();
+	.wc-block-components-panel__button {
+		font-weight: 400;
+	}
+}
+
 // For Twenty Twenty we need to increase specificity a bit more.
 .theme-twentytwenty {
 	.wc-block-components-sidebar .wc-block-components-panel > h2 {

--- a/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -8,7 +8,6 @@ import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import type { StoreCartCoupon } from '@woocommerce/types';
-import { useState } from 'wordpress-element';
 
 /**
  * Internal dependencies

--- a/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -29,10 +29,6 @@ export const useStoreCartCoupons = (): StoreCartCoupon => {
 	const { cartCoupons, cartIsLoading } = useStoreCart();
 	const { addErrorNotice, addSnackbarNotice } = useStoreNotices();
 	const { setValidationErrors } = useValidationContext();
-	const [
-		isCouponAddedSuccessfully,
-		setIsCouponAddedSuccessfully,
-	] = useState( false );
 
 	const results: Pick<
 		StoreCartCoupon,
@@ -68,12 +64,6 @@ export const useStoreCartCoupons = (): StoreCartCoupon => {
 								{
 									id: 'coupon-form',
 								}
-							);
-
-							setIsCouponAddedSuccessfully( true );
-							setTimeout(
-								() => setIsCouponAddedSuccessfully( false ),
-								4000
 							);
 						}
 					} )
@@ -124,13 +114,12 @@ export const useStoreCartCoupons = (): StoreCartCoupon => {
 				isRemovingCoupon,
 			};
 		},
-		[ addErrorNotice, addSnackbarNotice, isCouponAddedSuccessfully ]
+		[ addErrorNotice, addSnackbarNotice ]
 	);
 
 	return {
 		appliedCoupons: cartCoupons,
 		isLoading: cartIsLoading,
-		isCouponAddedSuccessfully,
 		...results,
 	};
 };

--- a/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-coupons.ts
@@ -8,6 +8,7 @@ import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import type { StoreCartCoupon } from '@woocommerce/types';
+import { useState } from 'wordpress-element';
 
 /**
  * Internal dependencies
@@ -28,6 +29,10 @@ export const useStoreCartCoupons = (): StoreCartCoupon => {
 	const { cartCoupons, cartIsLoading } = useStoreCart();
 	const { addErrorNotice, addSnackbarNotice } = useStoreNotices();
 	const { setValidationErrors } = useValidationContext();
+	const [
+		isCouponAddedSuccessfully,
+		setIsCouponAddedSuccessfully,
+	] = useState( false );
 
 	const results: Pick<
 		StoreCartCoupon,
@@ -63,6 +68,12 @@ export const useStoreCartCoupons = (): StoreCartCoupon => {
 								{
 									id: 'coupon-form',
 								}
+							);
+
+							setIsCouponAddedSuccessfully( true );
+							setTimeout(
+								() => setIsCouponAddedSuccessfully( false ),
+								4000
 							);
 						}
 					} )
@@ -113,12 +124,13 @@ export const useStoreCartCoupons = (): StoreCartCoupon => {
 				isRemovingCoupon,
 			};
 		},
-		[ addErrorNotice, addSnackbarNotice ]
+		[ addErrorNotice, addSnackbarNotice, isCouponAddedSuccessfully ]
 	);
 
 	return {
 		appliedCoupons: cartCoupons,
 		isLoading: cartIsLoading,
+		isCouponAddedSuccessfully,
 		...results,
 	};
 };

--- a/assets/js/blocks/cart-checkout/cart/attributes.js
+++ b/assets/js/blocks/cart-checkout/cart/attributes.js
@@ -21,6 +21,10 @@ const blockAttributes = {
 		type: 'boolean',
 		default: getSetting( 'hasDarkEditorStyleSupport', false ),
 	},
+	showRateAfterTaxName: {
+		type: 'boolean',
+		default: getSetting( 'displayCartPricesIncludingTax', false ),
+	},
 };
 
 export default blockAttributes;

--- a/assets/js/blocks/cart-checkout/cart/attributes.js
+++ b/assets/js/blocks/cart-checkout/cart/attributes.js
@@ -23,7 +23,7 @@ const blockAttributes = {
 	},
 	showRateAfterTaxName: {
 		type: 'boolean',
-		default: getSetting( 'displayCartPricesIncludingTax', false ),
+		default: true,
 	},
 };
 

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -96,7 +96,8 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					/>
 				</PanelBody>
 			) }
-			{ getSetting( 'displayItemizedTaxes', false ) &&
+			{ getSetting( 'taxesEnabled' ) &&
+				getSetting( 'displayItemizedTaxes', false ) &&
 				! getSetting( 'displayCartPricesIncludingTax', false ) && (
 					<PanelBody
 						title={ __( 'Taxes', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -39,6 +39,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		isShippingCalculatorEnabled,
 		checkoutPageId,
 		hasDarkControls,
+		showRateAfterTaxName,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCheckoutPageId } = useRef( checkoutPageId );
@@ -95,6 +96,29 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					/>
 				</PanelBody>
 			) }
+			{ getSetting( 'displayItemizedTaxes', false ) &&
+				! getSetting( 'displayCartPricesIncludingTax', false ) && (
+					<PanelBody
+						title={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
+					>
+						<ToggleControl
+							label={ __(
+								'Tax rates',
+								'woo-gutenberg-products-block'
+							) }
+							help={ __(
+								'Show the percentage rate alongside each tax line in the summary.',
+								'woo-gutenberg-products-block'
+							) }
+							checked={ showRateAfterTaxName }
+							onChange={ () =>
+								setAttributes( {
+									showRateAfterTaxName: ! showRateAfterTaxName,
+								} )
+							}
+						/>
+					</PanelBody>
+				) }
 			{ ! (
 				currentPostId === CART_PAGE_ID && savedCheckoutPageId === 0
 			) && (

--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -103,7 +103,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					>
 						<ToggleControl
 							label={ __(
-								'Tax rates',
+								'Show rate after tax name',
 								'woo-gutenberg-products-block'
 							) }
 							help={ __(

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
@@ -141,6 +141,12 @@ const Cart = ( { attributes }: CartProps ) => {
 						removeCoupon={ removeCoupon }
 						values={ cartTotals }
 					/>
+					{ getSetting( 'couponsEnabled', true ) && (
+						<TotalsCoupon
+							onSubmit={ applyCoupon }
+							isLoading={ isApplyingCoupon }
+						/>
+					) }
 					{ cartNeedsShipping && (
 						<TotalsShipping
 							showCalculator={ isShippingCalculatorEnabled }
@@ -158,12 +164,7 @@ const Cart = ( { attributes }: CartProps ) => {
 							values={ cartTotals }
 						/>
 					) }
-					{ getSetting( 'couponsEnabled', true ) && (
-						<TotalsCoupon
-							onSubmit={ applyCoupon }
-							isLoading={ isApplyingCoupon }
-						/>
-					) }
+
 					<TotalsFooterItem
 						currency={ totalsCurrency }
 						values={ cartTotals }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
@@ -79,6 +79,7 @@ const Cart = ( { attributes }: CartProps ) => {
 		isApplyingCoupon,
 		isRemovingCoupon,
 		appliedCoupons,
+		isCouponAddedSuccessfully,
 	} = useStoreCartCoupons();
 
 	const { addErrorNotice } = useStoreNotices();
@@ -145,6 +146,9 @@ const Cart = ( { attributes }: CartProps ) => {
 						<TotalsCoupon
 							onSubmit={ applyCoupon }
 							isLoading={ isApplyingCoupon }
+							isCouponAddedSuccessfully={
+								isCouponAddedSuccessfully
+							}
 						/>
 					) }
 					{ cartNeedsShipping && (

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
@@ -48,6 +48,7 @@ interface CartAttributes {
 	isShippingCalculatorEnabled: boolean;
 	checkoutPageId: number;
 	isPreview: boolean;
+	showRateAfterTaxName: boolean;
 }
 
 interface CartProps {
@@ -60,7 +61,11 @@ interface CartProps {
  * @param {Object} props.attributes Incoming attributes for block.
  */
 const Cart = ( { attributes }: CartProps ) => {
-	const { isShippingCalculatorEnabled, hasDarkControls } = attributes;
+	const {
+		isShippingCalculatorEnabled,
+		hasDarkControls,
+		showRateAfterTaxName,
+	} = attributes;
 
 	const {
 		cartItems,
@@ -164,6 +169,7 @@ const Cart = ( { attributes }: CartProps ) => {
 						false
 					) && (
 						<TotalsTaxes
+							showRateAfterTaxName={ showRateAfterTaxName }
 							currency={ totalsCurrency }
 							values={ cartTotals }
 						/>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
@@ -84,7 +84,6 @@ const Cart = ( { attributes }: CartProps ) => {
 		isApplyingCoupon,
 		isRemovingCoupon,
 		appliedCoupons,
-		isCouponAddedSuccessfully,
 	} = useStoreCartCoupons();
 
 	const { addErrorNotice } = useStoreNotices();
@@ -151,9 +150,6 @@ const Cart = ( { attributes }: CartProps ) => {
 						<TotalsCoupon
 							onSubmit={ applyCoupon }
 							isLoading={ isApplyingCoupon }
-							isCouponAddedSuccessfully={
-								isCouponAddedSuccessfully
-							}
 						/>
 					) }
 					{ cartNeedsShipping && (

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -85,6 +85,10 @@ table.wc-block-cart-items {
 		margin: 0;
 		padding: em($gap-small) 0;
 	}
+
+	.wc-block-components-totals-footer-item {
+		@include with-translucent-border(1px 0);
+	}
 }
 
 // Loading placeholder state.

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -245,12 +245,14 @@ table.wc-block-cart-items {
 		}
 		td {
 			@include with-translucent-border(1px 0 0);
-			padding: $gap $gap $gap 0;
+			padding: $gap 0 $gap $gap;
 			vertical-align: top;
 		}
-		th:last-child,
-		td:last-child {
+		th:last-child {
 			padding-right: 0;
+		}
+		td:last-child {
+			padding-right: $gap;
 		}
 	}
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -78,8 +78,13 @@ table.wc-block-cart-items {
 	}
 }
 
-.wc-block-cart .wc-block-components-shipping-rates-control__package {
-	@include with-translucent-border(1px 0 0);
+.wc-block-cart {
+	.wc-block-components-totals-taxes,
+	.wc-block-components-totals-footer-item {
+		@include with-translucent-border(1px 0 0);
+		margin: 0;
+		padding: em($gap-small) 0;
+	}
 }
 
 // Loading placeholder state.

--- a/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
@@ -473,7 +473,15 @@ exports[`Testing cart Contains a Taxes section if Core options are set to show i
           </span>
           <div
             class="wc-block-components-totals-item__description"
-          />
+          >
+            <div
+              class="wc-block-components-totals-item__description wc-block-components-totals-shipping__via"
+            >
+              via
+               
+              Free shipping
+            </div>
+          </div>
         </div>
         <fieldset
           class="wc-block-components-totals-shipping__fieldset"
@@ -1156,7 +1164,15 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
           </span>
           <div
             class="wc-block-components-totals-item__description"
-          />
+          >
+            <div
+              class="wc-block-components-totals-item__description wc-block-components-totals-shipping__via"
+            >
+              via
+               
+              Free shipping
+            </div>
+          </div>
         </div>
         <fieldset
           class="wc-block-components-totals-shipping__fieldset"
@@ -1318,11 +1334,6 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
               class="wc-block-components-totals-item__label"
             >
               Sales tax
-            </span>
-            <span
-              class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
-            >
-              $6.00
             </span>
             <div
               class="wc-block-components-totals-item__description"
@@ -1858,7 +1869,15 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
           </span>
           <div
             class="wc-block-components-totals-item__description"
-          />
+          >
+            <div
+              class="wc-block-components-totals-item__description wc-block-components-totals-shipping__via"
+            >
+              via
+               
+              Free shipping
+            </div>
+          </div>
         </div>
         <fieldset
           class="wc-block-components-totals-shipping__fieldset"
@@ -2020,11 +2039,6 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
               class="wc-block-components-totals-item__label"
             >
               Sales tax 20%
-            </span>
-            <span
-              class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
-            >
-              $6.00
             </span>
             <div
               class="wc-block-components-totals-item__description"

--- a/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
@@ -1,0 +1,2088 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing cart Contains a Taxes section if Core options are set to show it 1`] = `
+<div>
+  <div
+    aria-hidden="true"
+    class="with-scroll-to-top__scroll-point"
+  />
+  <h2
+    class="wc-block-components-title"
+  >
+    Your cart (3 items)
+  </h2>
+  <div
+    class="wc-block-components-sidebar-layout wc-block-cart"
+  >
+    <iframe
+      aria-hidden="true"
+      frameborder="0"
+      src="about:blank"
+      style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+      tabindex="-1"
+    />
+    <div
+      class="wc-block-components-main wc-block-cart__main"
+    >
+      <table
+        class="wc-block-cart-items"
+      >
+        <thead>
+          <tr
+            class="wc-block-cart-items__header"
+          >
+            <th
+              class="wc-block-cart-items__header-image"
+            >
+              <span>
+                Product
+              </span>
+            </th>
+            <th
+              class="wc-block-cart-items__header-product"
+            >
+              <span>
+                Details
+              </span>
+            </th>
+            <th
+              class="wc-block-cart-items__header-total"
+            >
+              <span>
+                Total
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            class="wc-block-cart-items__row"
+          >
+            <td
+              aria-hidden="true"
+              class="wc-block-cart-item__image"
+            >
+              <a
+                href="https://example.org"
+                tabindex="-1"
+              >
+                <img
+                  alt=""
+                  src="assets/img/beanie.jpg"
+                />
+              </a>
+            </td>
+            <td
+              class="wc-block-cart-item__product"
+            >
+              <a
+                class="wc-block-components-product-name"
+                href="https://example.org"
+              >
+                Beanie
+              </a>
+              <div
+                class="wc-block-components-product-badge wc-block-components-product-low-stock-badge"
+              >
+                2 left in stock
+              </div>
+              <div
+                class="wc-block-cart-item__prices"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $6.40
+                  </span>
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-metadata"
+              >
+                <div
+                  class="wc-block-components-product-metadata__description"
+                >
+                  <p>
+                    Warm hat for winter
+                  </p>
+                  
+
+                </div>
+                <ul
+                  class="wc-block-components-product-details"
+                >
+                  <li
+                    class="wc-block-components-product-details__color"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Color
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Yellow
+                    </span>
+                  </li>
+                  <li
+                    class="wc-block-components-product-details__size"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Size
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Small
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="wc-block-cart-item__quantity"
+              >
+                <div
+                  class="wc-block-components-quantity-selector"
+                >
+                  <input
+                    aria-label="Quantity of Beanie in your cart."
+                    class="wc-block-components-quantity-selector__input"
+                    min="0"
+                    step="1"
+                    type="number"
+                    value="2"
+                  />
+                  <button
+                    aria-label="Reduce quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+                  >
+                    －
+                  </button>
+                  <button
+                    aria-label="Increase quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+                  >
+                    ＋
+                  </button>
+                </div>
+                <button
+                  class="wc-block-cart-item__remove-link"
+                >
+                  Remove item
+                </button>
+              </div>
+            </td>
+            <td
+              class="wc-block-cart-item__total"
+            >
+              <div
+                class="wc-block-cart-item__total-price-and-sale-badge-wrapper"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $12.80
+                  </span>
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="wc-block-cart-items__row"
+          >
+            <td
+              aria-hidden="true"
+              class="wc-block-cart-item__image"
+            >
+              <a
+                href="https://example.org"
+                tabindex="-1"
+              >
+                <img
+                  alt=""
+                  src="assets/img/cap.jpg"
+                />
+              </a>
+            </td>
+            <td
+              class="wc-block-cart-item__product"
+            >
+              <a
+                class="wc-block-components-product-name"
+                href="https://example.org"
+              >
+                Cap
+              </a>
+              <div
+                class="wc-block-cart-item__prices"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Previous price:
+                  </span>
+                  <del
+                    class="wc-block-components-product-price__regular"
+                  >
+                    $12.80
+                  </del>
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Discounted price:
+                  </span>
+                  <ins
+                    class="wc-block-components-product-price__value is-discounted"
+                  >
+                    $11.20
+                  </ins>
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-badge wc-block-components-sale-badge"
+              >
+                Save 
+                <span
+                  class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                >
+                  $1.60
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-metadata"
+              >
+                <div
+                  class="wc-block-components-product-metadata__description"
+                >
+                  <p>
+                    Lightweight baseball cap
+                  </p>
+                  
+
+                </div>
+                <ul
+                  class="wc-block-components-product-details"
+                >
+                  <li
+                    class="wc-block-components-product-details__color"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Color
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Orange
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="wc-block-cart-item__quantity"
+              >
+                <div
+                  class="wc-block-components-quantity-selector"
+                >
+                  <input
+                    aria-label="Quantity of Cap in your cart."
+                    class="wc-block-components-quantity-selector__input"
+                    min="0"
+                    step="1"
+                    type="number"
+                    value="1"
+                  />
+                  <button
+                    aria-label="Reduce quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+                    disabled=""
+                  >
+                    －
+                  </button>
+                  <button
+                    aria-label="Increase quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+                  >
+                    ＋
+                  </button>
+                </div>
+                <button
+                  class="wc-block-cart-item__remove-link"
+                >
+                  Remove item
+                </button>
+              </div>
+            </td>
+            <td
+              class="wc-block-cart-item__total"
+            >
+              <div
+                class="wc-block-cart-item__total-price-and-sale-badge-wrapper"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $11.20
+                  </span>
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="wc-block-components-sidebar wc-block-cart__sidebar"
+    >
+      <h2
+        class="wc-block-components-title wc-block-cart__totals-title"
+      >
+        Cart totals
+      </h2>
+      <div
+        class="wc-block-components-totals-item"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Subtotal
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $24.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+      <div
+        class="wc-block-components-totals-coupon wc-block-components-panel has-border"
+      >
+        <div>
+          <button
+            aria-expanded="false"
+            class="wc-block-components-panel__button"
+          >
+            <svg
+              aria-hidden="true"
+              class="wc-block-components-panel__button-icon"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17 9.4L12 14 7 9.4l-1 1.2 6 5.4 6-5.4z"
+              />
+            </svg>
+            <span
+              aria-hidden="true"
+            >
+              Coupon code
+            </span>
+            <span
+              class="screen-reader-text"
+            >
+              Apply a coupon code
+            </span>
+          </button>
+        </div>
+        <div
+          class="wc-block-components-panel__content"
+          hidden=""
+        >
+          <div
+            class="wc-block-components-totals-coupon__content"
+          >
+            <form
+              class="wc-block-components-totals-coupon__form"
+            >
+              <div
+                class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
+              >
+                <input
+                  aria-describedby=""
+                  aria-label="Enter code"
+                  autocapitalize="off"
+                  autocomplete="off"
+                  id="wc-block-components-totals-coupon__input-3"
+                  type="text"
+                  value=""
+                />
+                <label
+                  for="wc-block-components-totals-coupon__input-3"
+                >
+                  Enter code
+                </label>
+              </div>
+              <button
+                class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
+                disabled=""
+                type="submit"
+              >
+                <span
+                  class="wc-block-components-button__text"
+                >
+                  Apply
+                </span>
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div
+        class="wc-block-components-totals-shipping"
+      >
+        <div
+          class="wc-block-components-totals-item"
+        >
+          <span
+            class="wc-block-components-totals-item__label"
+          >
+            Shipping
+          </span>
+          <span
+            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+          >
+            $0.00
+          </span>
+          <div
+            class="wc-block-components-totals-item__description"
+          />
+        </div>
+        <fieldset
+          class="wc-block-components-totals-shipping__fieldset"
+        >
+          <legend
+            class="screen-reader-text"
+          >
+            Shipping options
+          </legend>
+          <div
+            class="wc-block-components-shipping-rates-control wc-block-components-totals-shipping__options"
+          >
+            <div
+              class="wc-block-components-shipping-rates-control__package wc-block-components-panel"
+            >
+              <div>
+                <button
+                  aria-expanded="true"
+                  class="wc-block-components-panel__button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="wc-block-components-panel__button-icon"
+                    focusable="false"
+                    height="24"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 8l-6 5.4 1 1.2 5-4.6 5 4.6 1-1.2z"
+                    />
+                  </svg>
+                  <div
+                    class="wc-block-components-shipping-rates-control__package-title"
+                  >
+                    Shipping
+                  </div>
+                </button>
+              </div>
+              <div
+                class="wc-block-components-panel__content"
+              >
+                <div
+                  class="wc-block-components-radio-control"
+                >
+                  <label
+                    class="wc-block-components-radio-control__option wc-block-components-radio-control__option-checked"
+                    for="radio-control-3-free_shipping:1"
+                  >
+                    <input
+                      aria-describedby="radio-control-3-free_shipping:1__label radio-control-3-free_shipping:1__description"
+                      checked=""
+                      class="wc-block-components-radio-control__input"
+                      id="radio-control-3-free_shipping:1"
+                      name="radio-control-3"
+                      type="radio"
+                      value="free_shipping:1"
+                    />
+                    <div
+                      class="wc-block-components-radio-control__option-layout"
+                    >
+                      <div
+                        class="wc-block-components-radio-control__label-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__label"
+                          id="radio-control-3-free_shipping:1__label"
+                        >
+                          Free shipping
+                        </span>
+                      </div>
+                      <div
+                        class="wc-block-components-radio-control__description-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__description"
+                          id="radio-control-3-free_shipping:1__description"
+                        >
+                          <span
+                            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                          >
+                            $0.00
+                          </span>
+                          
+                        </span>
+                      </div>
+                    </div>
+                  </label>
+                  <label
+                    class="wc-block-components-radio-control__option"
+                    for="radio-control-3-local_pickup:1"
+                  >
+                    <input
+                      aria-describedby="radio-control-3-local_pickup:1__label radio-control-3-local_pickup:1__description"
+                      class="wc-block-components-radio-control__input"
+                      id="radio-control-3-local_pickup:1"
+                      name="radio-control-3"
+                      type="radio"
+                      value="local_pickup:1"
+                    />
+                    <div
+                      class="wc-block-components-radio-control__option-layout"
+                    >
+                      <div
+                        class="wc-block-components-radio-control__label-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__label"
+                          id="radio-control-3-local_pickup:1__label"
+                        >
+                          Local pickup
+                        </span>
+                      </div>
+                      <div
+                        class="wc-block-components-radio-control__description-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__description"
+                          id="radio-control-3-local_pickup:1__description"
+                        >
+                          <span
+                            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                          >
+                            $2.00
+                          </span>
+                          
+                        </span>
+                      </div>
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        class="wc-block-components-totals-item wc-block-components-totals-taxes"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Taxes
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $6.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+      <div
+        class="wc-block-components-totals-item wc-block-components-totals-footer-item"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Total
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $30.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+      <div
+        class="wc-block-components-order-meta"
+      />
+      <div
+        class="wc-block-cart__payment-options"
+      >
+        <div
+          class="wc-block-cart__submit"
+        >
+          <div
+            aria-hidden="true"
+            style="bottom: 0px; left: 0px; opacity: 0; pointer-events: none; position: absolute; right: 0px; top: 0px; z-index: -1;"
+          />
+          <div
+            class="wc-block-cart__submit-container"
+          >
+            <a
+              class="components-button wc-block-components-button wc-block-cart__submit-button"
+              href=""
+            >
+              <span
+                class="wc-block-components-button__text"
+              >
+                Proceed to Checkout
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="display: none;"
+  />
+</div>
+`;
+
+exports[`Testing cart Shows individual tax lines if the store is set to do so 1`] = `
+<div>
+  <div
+    aria-hidden="true"
+    class="with-scroll-to-top__scroll-point"
+  />
+  <h2
+    class="wc-block-components-title"
+  >
+    Your cart (3 items)
+  </h2>
+  <div
+    class="wc-block-components-sidebar-layout wc-block-cart"
+  >
+    <iframe
+      aria-hidden="true"
+      frameborder="0"
+      src="about:blank"
+      style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+      tabindex="-1"
+    />
+    <div
+      class="wc-block-components-main wc-block-cart__main"
+    >
+      <table
+        class="wc-block-cart-items"
+      >
+        <thead>
+          <tr
+            class="wc-block-cart-items__header"
+          >
+            <th
+              class="wc-block-cart-items__header-image"
+            >
+              <span>
+                Product
+              </span>
+            </th>
+            <th
+              class="wc-block-cart-items__header-product"
+            >
+              <span>
+                Details
+              </span>
+            </th>
+            <th
+              class="wc-block-cart-items__header-total"
+            >
+              <span>
+                Total
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            class="wc-block-cart-items__row"
+          >
+            <td
+              aria-hidden="true"
+              class="wc-block-cart-item__image"
+            >
+              <a
+                href="https://example.org"
+                tabindex="-1"
+              >
+                <img
+                  alt=""
+                  src="assets/img/beanie.jpg"
+                />
+              </a>
+            </td>
+            <td
+              class="wc-block-cart-item__product"
+            >
+              <a
+                class="wc-block-components-product-name"
+                href="https://example.org"
+              >
+                Beanie
+              </a>
+              <div
+                class="wc-block-components-product-badge wc-block-components-product-low-stock-badge"
+              >
+                2 left in stock
+              </div>
+              <div
+                class="wc-block-cart-item__prices"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $6.40
+                  </span>
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-metadata"
+              >
+                <div
+                  class="wc-block-components-product-metadata__description"
+                >
+                  <p>
+                    Warm hat for winter
+                  </p>
+                  
+
+                </div>
+                <ul
+                  class="wc-block-components-product-details"
+                >
+                  <li
+                    class="wc-block-components-product-details__color"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Color
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Yellow
+                    </span>
+                  </li>
+                  <li
+                    class="wc-block-components-product-details__size"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Size
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Small
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="wc-block-cart-item__quantity"
+              >
+                <div
+                  class="wc-block-components-quantity-selector"
+                >
+                  <input
+                    aria-label="Quantity of Beanie in your cart."
+                    class="wc-block-components-quantity-selector__input"
+                    min="0"
+                    step="1"
+                    type="number"
+                    value="2"
+                  />
+                  <button
+                    aria-label="Reduce quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+                  >
+                    －
+                  </button>
+                  <button
+                    aria-label="Increase quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+                  >
+                    ＋
+                  </button>
+                </div>
+                <button
+                  class="wc-block-cart-item__remove-link"
+                >
+                  Remove item
+                </button>
+              </div>
+            </td>
+            <td
+              class="wc-block-cart-item__total"
+            >
+              <div
+                class="wc-block-cart-item__total-price-and-sale-badge-wrapper"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $12.80
+                  </span>
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="wc-block-cart-items__row"
+          >
+            <td
+              aria-hidden="true"
+              class="wc-block-cart-item__image"
+            >
+              <a
+                href="https://example.org"
+                tabindex="-1"
+              >
+                <img
+                  alt=""
+                  src="assets/img/cap.jpg"
+                />
+              </a>
+            </td>
+            <td
+              class="wc-block-cart-item__product"
+            >
+              <a
+                class="wc-block-components-product-name"
+                href="https://example.org"
+              >
+                Cap
+              </a>
+              <div
+                class="wc-block-cart-item__prices"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Previous price:
+                  </span>
+                  <del
+                    class="wc-block-components-product-price__regular"
+                  >
+                    $12.80
+                  </del>
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Discounted price:
+                  </span>
+                  <ins
+                    class="wc-block-components-product-price__value is-discounted"
+                  >
+                    $11.20
+                  </ins>
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-badge wc-block-components-sale-badge"
+              >
+                Save 
+                <span
+                  class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                >
+                  $1.60
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-metadata"
+              >
+                <div
+                  class="wc-block-components-product-metadata__description"
+                >
+                  <p>
+                    Lightweight baseball cap
+                  </p>
+                  
+
+                </div>
+                <ul
+                  class="wc-block-components-product-details"
+                >
+                  <li
+                    class="wc-block-components-product-details__color"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Color
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Orange
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="wc-block-cart-item__quantity"
+              >
+                <div
+                  class="wc-block-components-quantity-selector"
+                >
+                  <input
+                    aria-label="Quantity of Cap in your cart."
+                    class="wc-block-components-quantity-selector__input"
+                    min="0"
+                    step="1"
+                    type="number"
+                    value="1"
+                  />
+                  <button
+                    aria-label="Reduce quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+                    disabled=""
+                  >
+                    －
+                  </button>
+                  <button
+                    aria-label="Increase quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+                  >
+                    ＋
+                  </button>
+                </div>
+                <button
+                  class="wc-block-cart-item__remove-link"
+                >
+                  Remove item
+                </button>
+              </div>
+            </td>
+            <td
+              class="wc-block-cart-item__total"
+            >
+              <div
+                class="wc-block-cart-item__total-price-and-sale-badge-wrapper"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $11.20
+                  </span>
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="wc-block-components-sidebar wc-block-cart__sidebar"
+    >
+      <h2
+        class="wc-block-components-title wc-block-cart__totals-title"
+      >
+        Cart totals
+      </h2>
+      <div
+        class="wc-block-components-totals-item"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Subtotal
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $24.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+      <div
+        class="wc-block-components-totals-coupon wc-block-components-panel has-border"
+      >
+        <div>
+          <button
+            aria-expanded="false"
+            class="wc-block-components-panel__button"
+          >
+            <svg
+              aria-hidden="true"
+              class="wc-block-components-panel__button-icon"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17 9.4L12 14 7 9.4l-1 1.2 6 5.4 6-5.4z"
+              />
+            </svg>
+            <span
+              aria-hidden="true"
+            >
+              Coupon code
+            </span>
+            <span
+              class="screen-reader-text"
+            >
+              Apply a coupon code
+            </span>
+          </button>
+        </div>
+        <div
+          class="wc-block-components-panel__content"
+          hidden=""
+        >
+          <div
+            class="wc-block-components-totals-coupon__content"
+          >
+            <form
+              class="wc-block-components-totals-coupon__form"
+            >
+              <div
+                class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
+              >
+                <input
+                  aria-describedby=""
+                  aria-label="Enter code"
+                  autocapitalize="off"
+                  autocomplete="off"
+                  id="wc-block-components-totals-coupon__input-5"
+                  type="text"
+                  value=""
+                />
+                <label
+                  for="wc-block-components-totals-coupon__input-5"
+                >
+                  Enter code
+                </label>
+              </div>
+              <button
+                class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
+                disabled=""
+                type="submit"
+              >
+                <span
+                  class="wc-block-components-button__text"
+                >
+                  Apply
+                </span>
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div
+        class="wc-block-components-totals-shipping"
+      >
+        <div
+          class="wc-block-components-totals-item"
+        >
+          <span
+            class="wc-block-components-totals-item__label"
+          >
+            Shipping
+          </span>
+          <span
+            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+          >
+            $0.00
+          </span>
+          <div
+            class="wc-block-components-totals-item__description"
+          />
+        </div>
+        <fieldset
+          class="wc-block-components-totals-shipping__fieldset"
+        >
+          <legend
+            class="screen-reader-text"
+          >
+            Shipping options
+          </legend>
+          <div
+            class="wc-block-components-shipping-rates-control wc-block-components-totals-shipping__options"
+          >
+            <div
+              class="wc-block-components-shipping-rates-control__package wc-block-components-panel"
+            >
+              <div>
+                <button
+                  aria-expanded="true"
+                  class="wc-block-components-panel__button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="wc-block-components-panel__button-icon"
+                    focusable="false"
+                    height="24"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 8l-6 5.4 1 1.2 5-4.6 5 4.6 1-1.2z"
+                    />
+                  </svg>
+                  <div
+                    class="wc-block-components-shipping-rates-control__package-title"
+                  >
+                    Shipping
+                  </div>
+                </button>
+              </div>
+              <div
+                class="wc-block-components-panel__content"
+              >
+                <div
+                  class="wc-block-components-radio-control"
+                >
+                  <label
+                    class="wc-block-components-radio-control__option wc-block-components-radio-control__option-checked"
+                    for="radio-control-5-free_shipping:1"
+                  >
+                    <input
+                      aria-describedby="radio-control-5-free_shipping:1__label radio-control-5-free_shipping:1__description"
+                      checked=""
+                      class="wc-block-components-radio-control__input"
+                      id="radio-control-5-free_shipping:1"
+                      name="radio-control-5"
+                      type="radio"
+                      value="free_shipping:1"
+                    />
+                    <div
+                      class="wc-block-components-radio-control__option-layout"
+                    >
+                      <div
+                        class="wc-block-components-radio-control__label-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__label"
+                          id="radio-control-5-free_shipping:1__label"
+                        >
+                          Free shipping
+                        </span>
+                      </div>
+                      <div
+                        class="wc-block-components-radio-control__description-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__description"
+                          id="radio-control-5-free_shipping:1__description"
+                        >
+                          <span
+                            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                          >
+                            $0.00
+                          </span>
+                          
+                        </span>
+                      </div>
+                    </div>
+                  </label>
+                  <label
+                    class="wc-block-components-radio-control__option"
+                    for="radio-control-5-local_pickup:1"
+                  >
+                    <input
+                      aria-describedby="radio-control-5-local_pickup:1__label radio-control-5-local_pickup:1__description"
+                      class="wc-block-components-radio-control__input"
+                      id="radio-control-5-local_pickup:1"
+                      name="radio-control-5"
+                      type="radio"
+                      value="local_pickup:1"
+                    />
+                    <div
+                      class="wc-block-components-radio-control__option-layout"
+                    >
+                      <div
+                        class="wc-block-components-radio-control__label-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__label"
+                          id="radio-control-5-local_pickup:1__label"
+                        >
+                          Local pickup
+                        </span>
+                      </div>
+                      <div
+                        class="wc-block-components-radio-control__description-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__description"
+                          id="radio-control-5-local_pickup:1__description"
+                        >
+                          <span
+                            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                          >
+                            $2.00
+                          </span>
+                          
+                        </span>
+                      </div>
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        class="wc-block-components-totals-item wc-block-components-totals-taxes"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Taxes
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $6.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        >
+          <div
+            class="wc-block-components-totals-item wc-block-components-totals-taxes__tax-line"
+          >
+            <span
+              class="wc-block-components-totals-item__label"
+            >
+              Sales tax
+            </span>
+            <span
+              class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+            >
+              $6.00
+            </span>
+            <div
+              class="wc-block-components-totals-item__description"
+            />
+          </div>
+           
+        </div>
+      </div>
+      <div
+        class="wc-block-components-totals-item wc-block-components-totals-footer-item"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Total
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $30.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+      <div
+        class="wc-block-components-order-meta"
+      />
+      <div
+        class="wc-block-cart__payment-options"
+      >
+        <div
+          class="wc-block-cart__submit"
+        >
+          <div
+            aria-hidden="true"
+            style="bottom: 0px; left: 0px; opacity: 0; pointer-events: none; position: absolute; right: 0px; top: 0px; z-index: -1;"
+          />
+          <div
+            class="wc-block-cart__submit-container"
+          >
+            <a
+              class="components-button wc-block-components-button wc-block-cart__submit-button"
+              href=""
+            >
+              <span
+                class="wc-block-components-button__text"
+              >
+                Proceed to Checkout
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="display: none;"
+  />
+</div>
+`;
+
+exports[`Testing cart Shows rate percentages after tax lines if the block is set to do so 1`] = `
+<div>
+  <div
+    aria-hidden="true"
+    class="with-scroll-to-top__scroll-point"
+  />
+  <h2
+    class="wc-block-components-title"
+  >
+    Your cart (3 items)
+  </h2>
+  <div
+    class="wc-block-components-sidebar-layout wc-block-cart"
+  >
+    <iframe
+      aria-hidden="true"
+      frameborder="0"
+      src="about:blank"
+      style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+      tabindex="-1"
+    />
+    <div
+      class="wc-block-components-main wc-block-cart__main"
+    >
+      <table
+        class="wc-block-cart-items"
+      >
+        <thead>
+          <tr
+            class="wc-block-cart-items__header"
+          >
+            <th
+              class="wc-block-cart-items__header-image"
+            >
+              <span>
+                Product
+              </span>
+            </th>
+            <th
+              class="wc-block-cart-items__header-product"
+            >
+              <span>
+                Details
+              </span>
+            </th>
+            <th
+              class="wc-block-cart-items__header-total"
+            >
+              <span>
+                Total
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            class="wc-block-cart-items__row"
+          >
+            <td
+              aria-hidden="true"
+              class="wc-block-cart-item__image"
+            >
+              <a
+                href="https://example.org"
+                tabindex="-1"
+              >
+                <img
+                  alt=""
+                  src="assets/img/beanie.jpg"
+                />
+              </a>
+            </td>
+            <td
+              class="wc-block-cart-item__product"
+            >
+              <a
+                class="wc-block-components-product-name"
+                href="https://example.org"
+              >
+                Beanie
+              </a>
+              <div
+                class="wc-block-components-product-badge wc-block-components-product-low-stock-badge"
+              >
+                2 left in stock
+              </div>
+              <div
+                class="wc-block-cart-item__prices"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $6.40
+                  </span>
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-metadata"
+              >
+                <div
+                  class="wc-block-components-product-metadata__description"
+                >
+                  <p>
+                    Warm hat for winter
+                  </p>
+                  
+
+                </div>
+                <ul
+                  class="wc-block-components-product-details"
+                >
+                  <li
+                    class="wc-block-components-product-details__color"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Color
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Yellow
+                    </span>
+                  </li>
+                  <li
+                    class="wc-block-components-product-details__size"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Size
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Small
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="wc-block-cart-item__quantity"
+              >
+                <div
+                  class="wc-block-components-quantity-selector"
+                >
+                  <input
+                    aria-label="Quantity of Beanie in your cart."
+                    class="wc-block-components-quantity-selector__input"
+                    min="0"
+                    step="1"
+                    type="number"
+                    value="2"
+                  />
+                  <button
+                    aria-label="Reduce quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+                  >
+                    －
+                  </button>
+                  <button
+                    aria-label="Increase quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+                  >
+                    ＋
+                  </button>
+                </div>
+                <button
+                  class="wc-block-cart-item__remove-link"
+                >
+                  Remove item
+                </button>
+              </div>
+            </td>
+            <td
+              class="wc-block-cart-item__total"
+            >
+              <div
+                class="wc-block-cart-item__total-price-and-sale-badge-wrapper"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $12.80
+                  </span>
+                </span>
+              </div>
+            </td>
+          </tr>
+          <tr
+            class="wc-block-cart-items__row"
+          >
+            <td
+              aria-hidden="true"
+              class="wc-block-cart-item__image"
+            >
+              <a
+                href="https://example.org"
+                tabindex="-1"
+              >
+                <img
+                  alt=""
+                  src="assets/img/cap.jpg"
+                />
+              </a>
+            </td>
+            <td
+              class="wc-block-cart-item__product"
+            >
+              <a
+                class="wc-block-components-product-name"
+                href="https://example.org"
+              >
+                Cap
+              </a>
+              <div
+                class="wc-block-cart-item__prices"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Previous price:
+                  </span>
+                  <del
+                    class="wc-block-components-product-price__regular"
+                  >
+                    $12.80
+                  </del>
+                  <span
+                    class="screen-reader-text"
+                  >
+                    Discounted price:
+                  </span>
+                  <ins
+                    class="wc-block-components-product-price__value is-discounted"
+                  >
+                    $11.20
+                  </ins>
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-badge wc-block-components-sale-badge"
+              >
+                Save 
+                <span
+                  class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                >
+                  $1.60
+                </span>
+              </div>
+              <div
+                class="wc-block-components-product-metadata"
+              >
+                <div
+                  class="wc-block-components-product-metadata__description"
+                >
+                  <p>
+                    Lightweight baseball cap
+                  </p>
+                  
+
+                </div>
+                <ul
+                  class="wc-block-components-product-details"
+                >
+                  <li
+                    class="wc-block-components-product-details__color"
+                  >
+                    <span
+                      class="wc-block-components-product-details__name"
+                    >
+                      Color
+                      :
+                    </span>
+                     
+                    <span
+                      class="wc-block-components-product-details__value"
+                    >
+                      Orange
+                    </span>
+                  </li>
+                </ul>
+              </div>
+              <div
+                class="wc-block-cart-item__quantity"
+              >
+                <div
+                  class="wc-block-components-quantity-selector"
+                >
+                  <input
+                    aria-label="Quantity of Cap in your cart."
+                    class="wc-block-components-quantity-selector__input"
+                    min="0"
+                    step="1"
+                    type="number"
+                    value="1"
+                  />
+                  <button
+                    aria-label="Reduce quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+                    disabled=""
+                  >
+                    －
+                  </button>
+                  <button
+                    aria-label="Increase quantity"
+                    class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+                  >
+                    ＋
+                  </button>
+                </div>
+                <button
+                  class="wc-block-cart-item__remove-link"
+                >
+                  Remove item
+                </button>
+              </div>
+            </td>
+            <td
+              class="wc-block-cart-item__total"
+            >
+              <div
+                class="wc-block-cart-item__total-price-and-sale-badge-wrapper"
+              >
+                <span
+                  class="price wc-block-components-product-price"
+                >
+                  <span
+                    class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-product-price__value"
+                  >
+                    $11.20
+                  </span>
+                </span>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div
+      class="wc-block-components-sidebar wc-block-cart__sidebar"
+    >
+      <h2
+        class="wc-block-components-title wc-block-cart__totals-title"
+      >
+        Cart totals
+      </h2>
+      <div
+        class="wc-block-components-totals-item"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Subtotal
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $24.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+      <div
+        class="wc-block-components-totals-coupon wc-block-components-panel has-border"
+      >
+        <div>
+          <button
+            aria-expanded="false"
+            class="wc-block-components-panel__button"
+          >
+            <svg
+              aria-hidden="true"
+              class="wc-block-components-panel__button-icon"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M17 9.4L12 14 7 9.4l-1 1.2 6 5.4 6-5.4z"
+              />
+            </svg>
+            <span
+              aria-hidden="true"
+            >
+              Coupon code
+            </span>
+            <span
+              class="screen-reader-text"
+            >
+              Apply a coupon code
+            </span>
+          </button>
+        </div>
+        <div
+          class="wc-block-components-panel__content"
+          hidden=""
+        >
+          <div
+            class="wc-block-components-totals-coupon__content"
+          >
+            <form
+              class="wc-block-components-totals-coupon__form"
+            >
+              <div
+                class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
+              >
+                <input
+                  aria-describedby=""
+                  aria-label="Enter code"
+                  autocapitalize="off"
+                  autocomplete="off"
+                  id="wc-block-components-totals-coupon__input-7"
+                  type="text"
+                  value=""
+                />
+                <label
+                  for="wc-block-components-totals-coupon__input-7"
+                >
+                  Enter code
+                </label>
+              </div>
+              <button
+                class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
+                disabled=""
+                type="submit"
+              >
+                <span
+                  class="wc-block-components-button__text"
+                >
+                  Apply
+                </span>
+              </button>
+            </form>
+          </div>
+        </div>
+      </div>
+      <div
+        class="wc-block-components-totals-shipping"
+      >
+        <div
+          class="wc-block-components-totals-item"
+        >
+          <span
+            class="wc-block-components-totals-item__label"
+          >
+            Shipping
+          </span>
+          <span
+            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+          >
+            $0.00
+          </span>
+          <div
+            class="wc-block-components-totals-item__description"
+          />
+        </div>
+        <fieldset
+          class="wc-block-components-totals-shipping__fieldset"
+        >
+          <legend
+            class="screen-reader-text"
+          >
+            Shipping options
+          </legend>
+          <div
+            class="wc-block-components-shipping-rates-control wc-block-components-totals-shipping__options"
+          >
+            <div
+              class="wc-block-components-shipping-rates-control__package wc-block-components-panel"
+            >
+              <div>
+                <button
+                  aria-expanded="true"
+                  class="wc-block-components-panel__button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="wc-block-components-panel__button-icon"
+                    focusable="false"
+                    height="24"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 8l-6 5.4 1 1.2 5-4.6 5 4.6 1-1.2z"
+                    />
+                  </svg>
+                  <div
+                    class="wc-block-components-shipping-rates-control__package-title"
+                  >
+                    Shipping
+                  </div>
+                </button>
+              </div>
+              <div
+                class="wc-block-components-panel__content"
+              >
+                <div
+                  class="wc-block-components-radio-control"
+                >
+                  <label
+                    class="wc-block-components-radio-control__option wc-block-components-radio-control__option-checked"
+                    for="radio-control-7-free_shipping:1"
+                  >
+                    <input
+                      aria-describedby="radio-control-7-free_shipping:1__label radio-control-7-free_shipping:1__description"
+                      checked=""
+                      class="wc-block-components-radio-control__input"
+                      id="radio-control-7-free_shipping:1"
+                      name="radio-control-7"
+                      type="radio"
+                      value="free_shipping:1"
+                    />
+                    <div
+                      class="wc-block-components-radio-control__option-layout"
+                    >
+                      <div
+                        class="wc-block-components-radio-control__label-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__label"
+                          id="radio-control-7-free_shipping:1__label"
+                        >
+                          Free shipping
+                        </span>
+                      </div>
+                      <div
+                        class="wc-block-components-radio-control__description-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__description"
+                          id="radio-control-7-free_shipping:1__description"
+                        >
+                          <span
+                            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                          >
+                            $0.00
+                          </span>
+                          
+                        </span>
+                      </div>
+                    </div>
+                  </label>
+                  <label
+                    class="wc-block-components-radio-control__option"
+                    for="radio-control-7-local_pickup:1"
+                  >
+                    <input
+                      aria-describedby="radio-control-7-local_pickup:1__label radio-control-7-local_pickup:1__description"
+                      class="wc-block-components-radio-control__input"
+                      id="radio-control-7-local_pickup:1"
+                      name="radio-control-7"
+                      type="radio"
+                      value="local_pickup:1"
+                    />
+                    <div
+                      class="wc-block-components-radio-control__option-layout"
+                    >
+                      <div
+                        class="wc-block-components-radio-control__label-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__label"
+                          id="radio-control-7-local_pickup:1__label"
+                        >
+                          Local pickup
+                        </span>
+                      </div>
+                      <div
+                        class="wc-block-components-radio-control__description-group"
+                      >
+                        <span
+                          class="wc-block-components-radio-control__description"
+                          id="radio-control-7-local_pickup:1__description"
+                        >
+                          <span
+                            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount"
+                          >
+                            $2.00
+                          </span>
+                          
+                        </span>
+                      </div>
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <div
+        class="wc-block-components-totals-item wc-block-components-totals-taxes"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Taxes
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $6.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        >
+          <div
+            class="wc-block-components-totals-item wc-block-components-totals-taxes__tax-line"
+          >
+            <span
+              class="wc-block-components-totals-item__label"
+            >
+              Sales tax 20%
+            </span>
+            <span
+              class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+            >
+              $6.00
+            </span>
+            <div
+              class="wc-block-components-totals-item__description"
+            />
+          </div>
+           
+        </div>
+      </div>
+      <div
+        class="wc-block-components-totals-item wc-block-components-totals-footer-item"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Total
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $30.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+      <div
+        class="wc-block-components-order-meta"
+      />
+      <div
+        class="wc-block-cart__payment-options"
+      >
+        <div
+          class="wc-block-cart__submit"
+        >
+          <div
+            aria-hidden="true"
+            style="bottom: 0px; left: 0px; opacity: 0; pointer-events: none; position: absolute; right: 0px; top: 0px; z-index: -1;"
+          />
+          <div
+            class="wc-block-cart__submit-container"
+          >
+            <a
+              class="components-button wc-block-components-button wc-block-cart__submit-button"
+              href=""
+            >
+              <span
+                class="wc-block-components-button__text"
+              >
+                Proceed to Checkout
+              </span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="display: none;"
+  />
+</div>
+`;

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -12,6 +12,7 @@ import { default as fetchMock } from 'jest-fetch-mock';
  */
 import CartBlock from '../block';
 import { defaultCartState } from '../../../../data/default-states';
+import { allSettings } from '../../../../settings/shared/settings-init';
 
 describe( 'Testing cart', () => {
 	beforeEach( async () => {
@@ -47,6 +48,59 @@ describe( 'Testing cart', () => {
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
 		expect( console ).toHaveWarned();
+	} );
+
+	it( 'Contains a Taxes section if Core options are set to show it', async () => {
+		allSettings.displayCartPricesIncludingTax = false;
+		// The criteria for showing the Taxes section is:
+		// Display prices during basket and checkout: 'Excluding tax'.
+		const { container } = render(
+			<CartBlock
+				emptyCart={ null }
+				attributes={ {
+					isShippingCalculatorEnabled: false,
+				} }
+			/>
+		);
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'Shows individual tax lines if the store is set to do so', async () => {
+		allSettings.displayCartPricesIncludingTax = false;
+		allSettings.displayItemizedTaxes = true;
+		// The criteria for showing the lines in the Taxes section is:
+		// Display prices during basket and checkout: 'Excluding tax'.
+		// Display tax totals: 'Itemized';
+		const { container } = render(
+			<CartBlock
+				emptyCart={ null }
+				attributes={ {
+					isShippingCalculatorEnabled: false,
+				} }
+			/>
+		);
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'Shows rate percentages after tax lines if the block is set to do so', async () => {
+		allSettings.displayCartPricesIncludingTax = false;
+		allSettings.displayItemizedTaxes = true;
+		// The criteria for showing the lines in the Taxes section is:
+		// Display prices during basket and checkout: 'Excluding tax'.
+		// Display tax totals: 'Itemized';
+		const { container } = render(
+			<CartBlock
+				emptyCart={ null }
+				attributes={ {
+					showRateAfterTaxName: true,
+					isShippingCalculatorEnabled: false,
+				} }
+			/>
+		);
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		expect( container ).toMatchSnapshot();
 	} );
 
 	it( 'renders empty cart if there are no items in the cart', async () => {

--- a/assets/js/blocks/cart-checkout/checkout/attributes.js
+++ b/assets/js/blocks/cart-checkout/checkout/attributes.js
@@ -53,6 +53,10 @@ const blockAttributes = {
 		type: 'boolean',
 		default: getSetting( 'hasDarkEditorStyleSupport', false ),
 	},
+	showRateAfterTaxName: {
+		type: 'boolean',
+		default: getSetting( 'displayCartPricesIncludingTax', false ),
+	},
 };
 
 export default blockAttributes;

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -15,7 +15,6 @@ import {
 	useEditorContext,
 	useValidationContext,
 } from '@woocommerce/base-context';
-import Title from '@woocommerce/base-components/title';
 import { useStoreCart, useStoreNotices } from '@woocommerce/base-context/hooks';
 import {
 	Sidebar,
@@ -151,15 +150,6 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 					{ attributes.showPolicyLinks && <Policies /> }
 				</Main>
 				<Sidebar className="wc-block-checkout__sidebar">
-					<Title
-						headingLevel="2"
-						className="wc-block-checkout__sidebar-title"
-					>
-						{ __(
-							'Order summary',
-							'woo-gutenberg-products-block'
-						) }
-					</Title>
 					<CheckoutSidebar
 						cartCoupons={ cartCoupons }
 						cartItems={ cartItems }

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -165,6 +165,7 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 						cartItems={ cartItems }
 						cartTotals={ cartTotals }
 						cartFees={ cartFees }
+						showRateAfterTaxName={ attributes.showRateAfterTaxName }
 					/>
 				</Sidebar>
 			</SidebarLayout>

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -15,6 +15,7 @@ import {
 	useEditorContext,
 	useValidationContext,
 } from '@woocommerce/base-context';
+import Title from '@woocommerce/base-components/title';
 import { useStoreCart, useStoreNotices } from '@woocommerce/base-context/hooks';
 import {
 	Sidebar,
@@ -150,6 +151,15 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 					{ attributes.showPolicyLinks && <Policies /> }
 				</Main>
 				<Sidebar className="wc-block-checkout__sidebar">
+					<Title
+						headingLevel="2"
+						className="wc-block-checkout__sidebar-title"
+					>
+						{ __(
+							'Order summary',
+							'woo-gutenberg-products-block'
+						) }
+					</Title>
 					<CheckoutSidebar
 						cartCoupons={ cartCoupons }
 						cartItems={ cartItems }

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -299,7 +299,8 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 						} }
 					/>
 				) }
-			{ getSetting( 'displayItemizedTaxes', false ) &&
+			{ getSetting( 'taxesEnabled' ) &&
+				getSetting( 'displayItemizedTaxes', false ) &&
 				! getSetting( 'displayCartPricesIncludingTax', false ) && (
 					<PanelBody
 						title={ __( 'Taxes', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -306,7 +306,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 					>
 						<ToggleControl
 							label={ __(
-								'Tax rates',
+								'Show rate after tax name',
 								'woo-gutenberg-products-block'
 							) }
 							help={ __(

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -52,6 +52,7 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 		showReturnToCart,
 		cartPageId,
 		hasDarkControls,
+		showRateAfterTaxName,
 	} = attributes;
 	const { currentPostId } = useEditorContext();
 	const { current: savedCartPageId } = useRef( cartPageId );
@@ -297,6 +298,29 @@ const BlockSettings = ( { attributes, setAttributes } ) => {
 							),
 						} }
 					/>
+				) }
+			{ getSetting( 'displayItemizedTaxes', false ) &&
+				! getSetting( 'displayCartPricesIncludingTax', false ) && (
+					<PanelBody
+						title={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
+					>
+						<ToggleControl
+							label={ __(
+								'Tax rates',
+								'woo-gutenberg-products-block'
+							) }
+							help={ __(
+								'Show the percentage rate alongside each tax line in the summary.',
+								'woo-gutenberg-products-block'
+							) }
+							checked={ showRateAfterTaxName }
+							onChange={ () =>
+								setAttributes( {
+									showRateAfterTaxName: ! showRateAfterTaxName,
+								} )
+							}
+						/>
+					</PanelBody>
 				) }
 			<PanelBody title={ __( 'Style', 'woo-gutenberg-products-block' ) }>
 				<ToggleControl

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -61,6 +61,13 @@ const CheckoutSidebar = ( {
 				removeCoupon={ removeCoupon }
 				values={ cartTotals }
 			/>
+			{ getSetting( 'couponsEnabled', true ) && (
+				<TotalsCoupon
+					onSubmit={ applyCoupon }
+					initialOpen={ false }
+					isLoading={ isApplyingCoupon }
+				/>
+			) }
 			{ needsShipping && (
 				<TotalsShipping
 					showCalculator={ false }
@@ -73,13 +80,6 @@ const CheckoutSidebar = ( {
 				<TotalsTaxes
 					currency={ totalsCurrency }
 					values={ cartTotals }
-				/>
-			) }
-			{ getSetting( 'couponsEnabled', true ) && (
-				<TotalsCoupon
-					onSubmit={ applyCoupon }
-					initialOpen={ false }
-					isLoading={ isApplyingCoupon }
 				/>
 			) }
 			<TotalsFooterItem

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -35,6 +35,7 @@ const CheckoutSidebar = ( {
 		removeCoupon,
 		isApplyingCoupon,
 		isRemovingCoupon,
+		isCouponAddedSuccessfully,
 	} = useStoreCartCoupons();
 
 	const { needsShipping } = useShippingDataContext();
@@ -66,6 +67,7 @@ const CheckoutSidebar = ( {
 					onSubmit={ applyCoupon }
 					initialOpen={ false }
 					isLoading={ isApplyingCoupon }
+					isCouponAddedSuccessfully={ isCouponAddedSuccessfully }
 				/>
 			) }
 			{ needsShipping && (

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+
 import {
 	OrderSummary,
 	TotalsCoupon,
@@ -14,6 +15,7 @@ import {
 	TotalsTaxes,
 	ExperimentalOrderMeta,
 } from '@woocommerce/blocks-checkout';
+
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import { useShippingDataContext } from '@woocommerce/base-context';
 import {

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -29,6 +29,7 @@ const CheckoutSidebar = ( {
 	cartItems = [],
 	cartFees = [],
 	cartTotals = {},
+	showRateAfterTaxName = false,
 } ) => {
 	const {
 		applyCoupon,
@@ -81,6 +82,7 @@ const CheckoutSidebar = ( {
 			{ ! getSetting( 'displayCartPricesIncludingTax', false ) && (
 				<TotalsTaxes
 					currency={ totalsCurrency }
+					showRateAfterTaxName={ showRateAfterTaxName }
 					values={ cartTotals }
 				/>
 			) }

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -36,7 +36,6 @@ const CheckoutSidebar = ( {
 		removeCoupon,
 		isApplyingCoupon,
 		isRemovingCoupon,
-		isCouponAddedSuccessfully,
 	} = useStoreCartCoupons();
 
 	const { needsShipping } = useShippingDataContext();
@@ -68,7 +67,6 @@ const CheckoutSidebar = ( {
 					onSubmit={ applyCoupon }
 					initialOpen={ false }
 					isLoading={ isApplyingCoupon }
-					isCouponAddedSuccessfully={ isCouponAddedSuccessfully }
 				/>
 			) }
 			{ needsShipping && (

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
@@ -120,11 +120,6 @@ exports[`Testing checkout sidebar Shows rate percentages after tax lines if the 
         >
           Sales tax 20%
         </span>
-        <span
-          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
-        >
-          $6.00
-        </span>
         <div
           class="wc-block-components-totals-item__description"
         />

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing checkout sidebar Shows rate percentages after tax lines if the block is set to do so 1`] = `
+<div>
+  <div
+    class="wc-block-components-totals-item"
+  >
+    <span
+      class="wc-block-components-totals-item__label"
+    >
+      Subtotal
+    </span>
+    <span
+      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    >
+      $24.00
+    </span>
+    <div
+      class="wc-block-components-totals-item__description"
+    />
+  </div>
+  <div
+    class="wc-block-components-totals-coupon wc-block-components-panel has-border"
+  >
+    <div>
+      <button
+        aria-expanded="false"
+        class="wc-block-components-panel__button"
+      >
+        <svg
+          aria-hidden="true"
+          class="wc-block-components-panel__button-icon"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M17 9.4L12 14 7 9.4l-1 1.2 6 5.4 6-5.4z"
+          />
+        </svg>
+        <span
+          aria-hidden="true"
+        >
+          Coupon code
+        </span>
+        <span
+          class="screen-reader-text"
+        >
+          Apply a coupon code
+        </span>
+      </button>
+    </div>
+    <div
+      class="wc-block-components-panel__content"
+      hidden=""
+    >
+      <div
+        class="wc-block-components-totals-coupon__content"
+      >
+        <form
+          class="wc-block-components-totals-coupon__form"
+        >
+          <div
+            class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
+          >
+            <input
+              aria-describedby="wc-block-components-totals-coupon__input-0"
+              aria-label="Enter code"
+              autocapitalize="off"
+              autocomplete="off"
+              id="wc-block-components-totals-coupon__input-0"
+              type="text"
+              value=""
+            />
+            <label
+              for="wc-block-components-totals-coupon__input-0"
+            >
+              Enter code
+            </label>
+          </div>
+          <button
+            class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
+            disabled=""
+            type="submit"
+          >
+            <span
+              class="wc-block-components-button__text"
+            >
+              Apply
+            </span>
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div
+    class="wc-block-components-totals-item wc-block-components-totals-taxes"
+  >
+    <span
+      class="wc-block-components-totals-item__label"
+    >
+      Taxes
+    </span>
+    <span
+      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    >
+      $6.00
+    </span>
+    <div
+      class="wc-block-components-totals-item__description"
+    >
+      <div
+        class="wc-block-components-totals-item wc-block-components-totals-taxes__tax-line"
+      >
+        <span
+          class="wc-block-components-totals-item__label"
+        >
+          Sales tax 20%
+        </span>
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+        >
+          $6.00
+        </span>
+        <div
+          class="wc-block-components-totals-item__description"
+        />
+      </div>
+       
+    </div>
+  </div>
+  <div
+    class="wc-block-components-totals-item wc-block-components-totals-footer-item"
+  >
+    <span
+      class="wc-block-components-totals-item__label"
+    >
+      Total
+    </span>
+    <span
+      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    >
+      $30.00
+    </span>
+    <div
+      class="wc-block-components-totals-item__description"
+    />
+  </div>
+  <div
+    class="wc-block-components-order-meta"
+  />
+</div>
+`;

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/test/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/test/index.js
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { previewCart } from '@woocommerce/resource-previews';
+
+/**
+ * Internal dependencies
+ */
+import { allSettings } from '../../../../../settings/shared/settings-init';
+import CheckoutSidebar from '../index';
+
+describe( 'Testing checkout sidebar', () => {
+	it( 'Shows rate percentages after tax lines if the block is set to do so', async () => {
+		allSettings.displayCartPricesIncludingTax = false;
+		allSettings.displayItemizedTaxes = true;
+		const { totals: cartTotals, items: cartItems } = previewCart;
+		const { container } = render(
+			<CheckoutSidebar
+				cartItems={ cartItems }
+				cartTotals={ cartTotals }
+				showRateAfterTaxName={ true }
+			/>
+		);
+		expect( container ).toMatchSnapshot();
+		// ["Components must be wrapped within `SlotFillProvider`. See https://developer.wordpress.org/block-editor/components/slot-fill/"]
+		expect( console ).toHaveWarned();
+	} );
+} );

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -19,6 +19,12 @@
 		// Required by IE11.
 		flex-basis: 0;
 	}
+	.wc-block-components-totals-taxes,
+	.wc-block-components-totals-footer-item {
+		@include with-translucent-border(1px 0 0);
+		margin: 0;
+		padding: em($gap-small) 0;
+	}
 }
 
 .wc-block-checkout__actions {

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -3,6 +3,15 @@
 }
 
 .wc-block-checkout__sidebar {
+	.wc-block-checkout__sidebar-title {
+		@include text-heading();
+		@include font-size(smaller);
+		display: block;
+		font-weight: 600;
+		padding: 0.25rem 0;
+		text-align: right;
+		text-transform: uppercase;
+	}
 	.wc-block-components-product-name {
 		display: block;
 		color: inherit;

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -3,15 +3,6 @@
 }
 
 .wc-block-checkout__sidebar {
-	.wc-block-checkout__sidebar-title {
-		@include text-heading();
-		@include font-size(smaller);
-		display: block;
-		font-weight: 600;
-		padding: 0.25rem 0;
-		text-align: right;
-		text-transform: uppercase;
-	}
 	.wc-block-components-product-name {
 		display: block;
 		color: inherit;

--- a/assets/js/previews/cart.ts
+++ b/assets/js/previews/cart.ts
@@ -11,6 +11,7 @@ import { getSetting } from '@woocommerce/settings';
  */
 import { previewShippingRates } from './shipping-rates';
 
+const displayWithTax = getSetting( 'displayCartPricesIncludingTax', false );
 // Sample data for cart block.
 // This closely resembles the data returned from the Store API /cart endpoint.
 // https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/src/RestApi/StoreApi#cart-api
@@ -66,14 +67,14 @@ export const previewCart: CartResponse = {
 				currency_thousand_separator: ',',
 				currency_prefix: '$',
 				currency_suffix: '',
-				price: '800',
-				regular_price: '800',
-				sale_price: '800',
+				price: displayWithTax ? '800' : '640',
+				regular_price: displayWithTax ? '800' : '640',
+				sale_price: displayWithTax ? '800' : '640',
 				raw_prices: {
 					precision: 6,
-					price: '8000000',
-					regular_price: '8000000',
-					sale_price: '8000000',
+					price: displayWithTax ? '8000000' : '6400000',
+					regular_price: displayWithTax ? '8000000' : '6400000',
+					sale_price: displayWithTax ? '8000000' : '6400000',
 				},
 			},
 			totals: {
@@ -84,10 +85,10 @@ export const previewCart: CartResponse = {
 				currency_thousand_separator: ',',
 				currency_prefix: '$',
 				currency_suffix: '',
-				line_subtotal: '1600',
+				line_subtotal: displayWithTax ? '1600' : '1280',
 				line_subtotal_tax: '0',
 				line_total: '1600',
-				line_total_tax: '0',
+				line_total_tax: displayWithTax ? '0' : '320',
 			},
 			extensions: {},
 		},
@@ -132,14 +133,14 @@ export const previewCart: CartResponse = {
 				currency_thousand_separator: ',',
 				currency_prefix: '$',
 				currency_suffix: '',
-				price: '1400',
-				regular_price: '1600',
-				sale_price: '1400',
+				price: displayWithTax ? '1400' : '1120',
+				regular_price: displayWithTax ? '1600' : '1280',
+				sale_price: displayWithTax ? '1400' : '1120',
 				raw_prices: {
 					precision: 6,
-					price: '14000000',
-					regular_price: '16000000',
-					sale_price: '14000000',
+					price: displayWithTax ? '14000000' : '11200000',
+					regular_price: displayWithTax ? '16000000' : '12800000',
+					sale_price: displayWithTax ? '14000000' : '11200000',
 				},
 			},
 			totals: {
@@ -150,10 +151,10 @@ export const previewCart: CartResponse = {
 				currency_thousand_separator: ',',
 				currency_prefix: '$',
 				currency_suffix: '',
-				line_subtotal: '1400',
-				line_subtotal_tax: '0',
+				line_subtotal: displayWithTax ? '1400' : '1120',
+				line_subtotal_tax: displayWithTax ? '0' : '280',
 				line_total: '1400',
-				line_total_tax: '0',
+				line_total_tax: displayWithTax ? '0' : '280',
 			},
 			extensions: {},
 		},
@@ -197,7 +198,7 @@ export const previewCart: CartResponse = {
 		currency_thousand_separator: ',',
 		currency_prefix: '$',
 		currency_suffix: '',
-		total_items: '3000',
+		total_items: displayWithTax ? '3000' : '2400',
 		total_items_tax: '0',
 		total_fees: '0',
 		total_fees_tax: '0',
@@ -205,8 +206,14 @@ export const previewCart: CartResponse = {
 		total_discount_tax: '0',
 		total_shipping: '0',
 		total_shipping_tax: '0',
-		total_tax: '0',
+		total_tax: '600',
 		total_price: '3000',
-		tax_lines: [],
+		tax_lines: [
+			{
+				name: __( 'Sales tax', 'woo-gutenberg-products-block' ),
+				rate: '20%',
+				price: 600,
+			},
+		],
 	},
 };

--- a/assets/js/type-defs/cart-response.ts
+++ b/assets/js/type-defs/cart-response.ts
@@ -157,6 +157,7 @@ export interface CartResponseItem {
 export interface CartResponseTotalsTaxLineItem {
 	name: string;
 	price: string;
+	rate: string;
 }
 
 export interface CartResponseFeeItemTotals extends CurrencyResponseInfo {

--- a/assets/js/type-defs/cart.ts
+++ b/assets/js/type-defs/cart.ts
@@ -137,6 +137,7 @@ export interface CartItem {
 export interface CartTotalsTaxLineItem {
 	name: string;
 	price: string;
+	rate: string;
 }
 
 export interface CartFeeItemTotals extends CurrencyInfo {

--- a/assets/js/type-defs/hooks.ts
+++ b/assets/js/type-defs/hooks.ts
@@ -28,6 +28,7 @@ export interface StoreCartCoupon {
 	removeCoupon: ( coupon: string ) => void;
 	isApplyingCoupon: boolean;
 	isRemovingCoupon: boolean;
+	isCouponAddedSuccessfully: boolean;
 }
 
 export interface StoreCart {

--- a/assets/js/type-defs/hooks.ts
+++ b/assets/js/type-defs/hooks.ts
@@ -28,7 +28,6 @@ export interface StoreCartCoupon {
 	removeCoupon: ( coupon: string ) => void;
 	isApplyingCoupon: boolean;
 	isRemovingCoupon: boolean;
-	isCouponAddedSuccessfully: boolean;
 }
 
 export interface StoreCart {

--- a/packages/checkout/totals/taxes/index.tsx
+++ b/packages/checkout/totals/taxes/index.tsx
@@ -55,7 +55,7 @@ const TotalsTaxes = ( {
 						className="wc-block-components-totals-taxes__tax-line"
 						currency={ currency }
 						label={ label }
-						value={ parseInt( price, 10 ) }
+						value={ null }
 					/>
 				);
 			} ) }{ ' ' }

--- a/packages/checkout/totals/taxes/index.tsx
+++ b/packages/checkout/totals/taxes/index.tsx
@@ -45,7 +45,7 @@ const TotalsTaxes = ( {
 		false
 	) ? (
 		<>
-			{ taxLines.map( ( { name, price, rate }, i ) => {
+			{ taxLines.map( ( { name, rate }, i ) => {
 				const label = `${ name }${
 					showRateAfterTaxName ? ` ${ rate }` : ''
 				}`;

--- a/packages/checkout/totals/taxes/index.tsx
+++ b/packages/checkout/totals/taxes/index.tsx
@@ -24,6 +24,7 @@ interface Values {
 interface TotalsTaxesProps {
 	className?: string;
 	currency: Currency;
+	showRateAfterTaxName: boolean;
 	values: Values | Record< string, never >;
 }
 
@@ -31,6 +32,7 @@ const TotalsTaxes = ( {
 	currency,
 	values,
 	className,
+	showRateAfterTaxName,
 }: TotalsTaxesProps ): ReactElement | null => {
 	const { total_tax: totalTax, tax_lines: taxLines } = values;
 
@@ -43,15 +45,20 @@ const TotalsTaxes = ( {
 		false
 	) ? (
 		<>
-			{ taxLines.map( ( { name, price, rate }, i ) => (
-				<TotalsItem
-					key={ `tax-line-${ i }` }
-					className="wc-block-components-totals-taxes__tax-line"
-					currency={ currency }
-					label={ `${ name } ${ rate }` }
-					value={ parseInt( price, 10 ) }
-				/>
-			) ) }{ ' ' }
+			{ taxLines.map( ( { name, price, rate }, i ) => {
+				const label = `${ name }${
+					showRateAfterTaxName ? ` ${ rate }` : ''
+				}`;
+				return (
+					<TotalsItem
+						key={ `tax-line-${ i }` }
+						className="wc-block-components-totals-taxes__tax-line"
+						currency={ currency }
+						label={ label }
+						value={ parseInt( price, 10 ) }
+					/>
+				);
+			} ) }{ ' ' }
 		</>
 	) : null;
 

--- a/packages/checkout/totals/taxes/index.tsx
+++ b/packages/checkout/totals/taxes/index.tsx
@@ -12,6 +12,7 @@ import { ReactElement } from 'react';
  * Internal dependencies
  */
 import TotalsItem from '../item';
+import './style.scss';
 
 interface Values {
 	// eslint-disable-next-line camelcase
@@ -37,8 +38,25 @@ const TotalsTaxes = ( {
 		return null;
 	}
 
-	if ( ! getSetting( 'displayItemizedTaxes', false ) ) {
-		return (
+	const itemisedTaxItems: ReactElement | null = getSetting(
+		'displayItemizedTaxes',
+		false
+	) ? (
+		<>
+			{ taxLines.map( ( { name, price, rate }, i ) => (
+				<TotalsItem
+					key={ `tax-line-${ i }` }
+					className="wc-block-components-totals-taxes__tax-line"
+					currency={ currency }
+					label={ `${ name } ${ rate }` }
+					value={ parseInt( price, 10 ) }
+				/>
+			) ) }{ ' ' }
+		</>
+	) : null;
+
+	return (
+		<>
 			<TotalsItem
 				className={ classnames(
 					'wc-block-components-totals-taxes',
@@ -47,21 +65,8 @@ const TotalsTaxes = ( {
 				currency={ currency }
 				label={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
 				value={ parseInt( totalTax, 10 ) }
+				description={ itemisedTaxItems }
 			/>
-		);
-	}
-
-	return (
-		<>
-			{ taxLines.map( ( { name, price }, i ) => (
-				<TotalsItem
-					key={ `tax-line-${ i }` }
-					className="wc-block-components-totals-taxes"
-					currency={ currency }
-					label={ name }
-					value={ parseInt( price, 10 ) }
-				/>
-			) ) }{ ' ' }
 		</>
 	);
 };

--- a/packages/checkout/totals/taxes/style.scss
+++ b/packages/checkout/totals/taxes/style.scss
@@ -1,0 +1,6 @@
+.wc-block-components-totals-item__description
+.wc-block-components-totals-item.wc-block-components-totals-taxes__tax-line {
+	padding: 0;
+	@include font-size(small);
+	margin: $gap-smallest / 2;
+}

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -120,6 +120,7 @@ class Cart extends AbstractBlock {
 		);
 		$this->asset_data_registry->add( 'baseLocation', wc_get_base_location(), true );
 		$this->asset_data_registry->add( 'isShippingCalculatorEnabled', filter_var( get_option( 'woocommerce_enable_shipping_calc' ), FILTER_VALIDATE_BOOLEAN ), true );
+		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ), true );
 		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', 'incl' === get_option( 'woocommerce_tax_display_cart' ), true );
 		$this->asset_data_registry->add( 'taxesEnabled', wc_tax_enabled(), true );
 		$this->asset_data_registry->add( 'couponsEnabled', wc_coupons_enabled(), true );

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use WC_Tax;
 use WP_Error;
 
 
@@ -287,6 +288,12 @@ class CartSchema extends AbstractSchema {
 										'context'     => [ 'view', 'edit' ],
 										'readonly'    => true,
 									],
+									'rate'  => [
+										'description' => __( 'The rate at which tax is applied.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+										'readonly'    => true,
+									],
 								],
 							],
 						],
@@ -389,6 +396,7 @@ class CartSchema extends AbstractSchema {
 			$tax_lines[] = array(
 				'name'  => $cart_tax_total->label,
 				'price' => $this->prepare_money_response( $cart_tax_total->amount, wc_get_price_decimals() ),
+				'rate'  => WC_Tax::get_rate_percent( $cart_tax_total->tax_rate_id ),
 			);
 		}
 

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -739,10 +739,10 @@ class CartController {
 			$index > 1 ?
 				sprintf(
 					/* translators: %d: shipping package number */
-					_x( 'Shipping %d', 'shipping packages', 'woo-gutenberg-products-block' ),
+					_x( 'Shipping method %d', 'shipping packages', 'woo-gutenberg-products-block' ),
 					$index
 				) :
-				_x( 'Shipping', 'shipping packages', 'woo-gutenberg-products-block' ),
+				_x( 'Shipping method', 'shipping packages', 'woo-gutenberg-products-block' ),
 			$package['package_id'],
 			$package
 		);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
### Summary of changes
@mikejolley Made these changes:
- Reorder the output of components in `/full-cart/index.tsx` so the Coupon input is in the correct place
- Add styles to reflect new design changes
- Update wording in Coupon input and Shipping methods components
- Add order summary heading to Checkout block sidebar

Thanks Mike!

I made these:
- Modify `src/BlockTypes/Cart.php` to ensure the `displayItemizedTaxes` option is available to the Cart block.
- Modify `CartSchema.php` to include a `rate` option on the tax line. This is needed to display the rate alongside tax names e.g <pre>CA Sales tax **7.5%**</pre> as per the design. This is enabled on a per-block basis.
- Modify `TotalsTaxes` component to add the itemised tax rates as children of the "main" tax line. There is also a stylesheet to ensure these display as per the design.
- Add an attribute to the Cart and Checkout blocks: `showRateAfterTaxName` this can be used to toggle whether the rate is shown after a tax's name.
- Updated the preview data of the cart to include some taxes.
- Added a `ShippingVia` component to show the rates that will be used to send the packages.
- Updated the Cart and Checkout blocks `edit.js` file to ensure the correct tax rates are displayed based on store settings.
- Added JS tests to the Cart and Checkout blocks to ensure these new options are working as intended. These tests use snapshots that I inspected myself 👀 

<!-- Reference any related issues or PRs here -->
Fixes #4093

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots
#### Cart sidebar
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/117444911-fabed200-af31-11eb-84a4-e1fffdded141.png) [Full size image](https://user-images.githubusercontent.com/5656702/117444911-fabed200-af31-11eb-84a4-e1fffdded141.png) | ![image](https://user-images.githubusercontent.com/5656702/118136128-addc6f00-b3fb-11eb-9a52-43133f823648.png) [Full size image](https://user-images.githubusercontent.com/5656702/118136128-addc6f00-b3fb-11eb-9a52-43133f823648.png)


#### Checkout sidebar
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/117698354-8f883080-b1bb-11eb-9787-f78ae2e63481.png) [Full size image](https://user-images.githubusercontent.com/5656702/117698354-8f883080-b1bb-11eb-9787-f78ae2e63481.png) |  ![image](https://user-images.githubusercontent.com/5656702/118120982-afe90280-b3e8-11eb-8ca4-4526db34b79b.png) [Full size image](https://user-images.githubusercontent.com/5656702/118120982-afe90280-b3e8-11eb-8ca4-4526db34b79b.png) |


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

#### Setup steps
1. Ensure some items in your store are taxable, and add a few of them to your cart, for bonus points you can set up additional tax rates and add products from each rate to your cart.
2. Ensure you have a coupon available to use in your store.
3. Go to `WooCommerce -> Settings -> Tax` and set `Display tax totals` to `Itemized` and `Display prices during basket and checkout` to `Excluding Tax`.
2. Using the designs presented in #4093 - Figma link: eaQcoMs7E8Ys0YgxfkOKxR-fi-727%3A1243 do the following:

#### Editor testing - do these in the block editor

**These instructions are for both the Cart and Checkout block!**
1. Add the block and ensure it matches the designs from the Figma file.
2. Ensure you have the option to `Show rate after tax name` in the editor sidebar.
2. Toggle this on and off and verify the rate percentage is shown in the Taxes section of the block preview.
4. Go to `WooCommerce -> Settings -> Tax` and set `Display tax totals` to `As a single total` and then ensure the option to `Show rate after tax name` is no longer available in the Cart and Checkout blocks.
5. Ensure the individual tax lines are not shown in the block preview.
6. Set it back to `Itemized`.
6.  Go to `WooCommerce -> Settings -> Tax` and set `Display prices during basket and checkout` to `Including Tax`.
7. Ensure the Taxes section is not shown, but that the amount of tax is shown under the total.
8. Set it back to `Excluding Tax`.
8. While doing the next set of testing instructions, experiment with combinations of these settings ensuring they work correctly.

#### Front-end testing
1. Go to the Cart/Checkout and ensure the rendered cart matches the Figma file. Ensure you have the correct Taxes section based on your configuration.
4. Go to `WooCommerce -> Settings -> Tax` and set `Display tax totals` to `As a single total` and then ensure the Taxes section of the sidebar does not include a further breakdown of rates.
5. Set it back to `Itemized` and ensure the rates are broken down correctly.
6. Toggle the `Show rate after tax name` option in the block and ensure the changes are reflected on the front-end.
6.  Go to `WooCommerce -> Settings -> Tax` and set `Display prices during basket and checkout` to `Including Tax`.
7. Ensure the Taxes section is not shown, but that the amount of tax is shown under the total.
8. Select different shipping methods and ensure the `via X` updates in the Shipping section of the sidebar. Do this in both Cart and Checkout.
9. Add a coupon and ensure the discounts section shows the reduction amount.

#### Automated testing
1. Ensure JS tests are passing.

<!-- If you can, add the appropriate labels -->

### Changelog

> Update the display of the sidebar/order summary in the Cart and Checkout blocks.