### PR TITLE
Check if variation data is iterable before trying to format in CartItemSchema

### DIFF
--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -392,6 +392,10 @@ class CartItemSchema extends ProductSchema {
 	protected function format_variation_data( $variation_data, $product ) {
 		$return = [];
 
+		if ( ! is_iterable( $variation_data ) ) {
+			return $return;
+		}
+
 		foreach ( $variation_data as $key => $value ) {
 			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( $key ) ) );
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When using force sells, I get this warning in the Cart block when adding a product with a synced force sell:
```
Warning: Invalid argument supplied for foreach() in /var/www/html/wp-content/plugins/woocommerce-gutenberg-products-block/src/StoreApi/Schemas/CartItemSchema.php on line 399
```
By checking if the variation data is iterable before supplying it to the foreach we can avoid this warning.

### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/117461599-aa516f80-af45-11eb-85be-fdc3f0479237.png) |  ![image](https://user-images.githubusercontent.com/5656702/117461660-b806f500-af45-11eb-956f-51d3997e7d78.png) |
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Install WooCommerce Force Sells (https://woocommerce.com/products/force-sells/ or https://github.com/woocommerce/woocommerce-force-sells/)
2. Edit a product to add a "Synced force sell" 
![image](https://user-images.githubusercontent.com/5656702/117461956-0caa7000-af46-11eb-9638-40671d798570.png)
3. Add this product to your cart
4. Go to the Cart block and ensure no warnings are visible
5. Do the same for the Checkout block

### Changelog

> Stopped a warning being shown when using WooCommerce Force Sells and adding a product with a Synced Force Sell to the cart.
