### PR TITLE
Use value rather than name for list items within the ProductDetails component

### DIFF
--- a/assets/js/base/components/cart-checkout/product-details/index.tsx
+++ b/assets/js/base/components/cart-checkout/product-details/index.tsx
@@ -37,7 +37,7 @@ const ProductDetails = ( {
 					: '';
 				return (
 					<li
-						key={ detail.name + ( detail.display || detail.name ) }
+						key={ detail.name + ( detail.display || detail.value ) }
 						className={ className }
 					>
 						{ detail.name && (


### PR DESCRIPTION
Keys were based on "name" and "display", falling back to "name". With product addons, this produced keys such as `Added extrasAdded extras`.

"display" is actually a variation of the value prop, so to make the items more unique we should actually be using the value prop. This produces keys like `Added extrasValue` and solves the issue.

Fixes #4081

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

See instructions in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4081. Ensure SCRIPT_DEBUG is true in your environment.

### Changelog

> Fix duplicate react keys in ProductDetails component.
