### PR TITLE
Sync customer data during checkout with draft orders.

### DIFF
--- a/assets/js/base/context/tsconfig.json
+++ b/assets/js/base/context/tsconfig.json
@@ -8,9 +8,10 @@
 		"../../settings/blocks/index.ts",
 		"../../base/hooks/index.js",
 		"../utils/type-guards.ts",
-	  	"../../base/utils/",
-	  	"../../data/",
-		"../../type-defs"
+		"../../base/utils/",
+		"../../data/",
+		"../../type-defs",
+		"../components"
 	],
 	"exclude": [ "**/test/**" ]
 }

--- a/src/StoreApi/Routes/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/CartUpdateCustomer.php
@@ -119,9 +119,50 @@ class CartUpdateCustomer extends AbstractCartRoute {
 		);
 		wc()->customer->save();
 
-		$cart->calculate_shipping();
-		$cart->calculate_totals();
+		$this->calculate_totals();
+		$this->maybe_update_order();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+	}
+
+	/**
+	 * If there is a draft order, update customer data there also.
+	 *
+	 * @return void
+	 */
+	protected function maybe_update_order() {
+		$draft_order_id = wc()->session->get( 'store_api_draft_order', 0 );
+		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : false;
+
+		if ( ! $draft_order ) {
+			return;
+		}
+
+		$draft_order->set_props(
+			[
+				'billing_first_name'  => wc()->customer->get_billing_first_name(),
+				'billing_last_name'   => wc()->customer->get_billing_last_name(),
+				'billing_company'     => wc()->customer->get_billing_company(),
+				'billing_address_1'   => wc()->customer->get_billing_address_1(),
+				'billing_address_2'   => wc()->customer->get_billing_address_2(),
+				'billing_city'        => wc()->customer->get_billing_city(),
+				'billing_state'       => wc()->customer->get_billing_state(),
+				'billing_postcode'    => wc()->customer->get_billing_postcode(),
+				'billing_country'     => wc()->customer->get_billing_country(),
+				'billing_email'       => wc()->customer->get_billing_email(),
+				'billing_phone'       => wc()->customer->get_billing_phone(),
+				'shipping_first_name' => wc()->customer->get_shipping_first_name(),
+				'shipping_last_name'  => wc()->customer->get_shipping_last_name(),
+				'shipping_company'    => wc()->customer->get_shipping_company(),
+				'shipping_address_1'  => wc()->customer->get_shipping_address_1(),
+				'shipping_address_2'  => wc()->customer->get_shipping_address_2(),
+				'shipping_city'       => wc()->customer->get_shipping_city(),
+				'shipping_state'      => wc()->customer->get_shipping_state(),
+				'shipping_postcode'   => wc()->customer->get_shipping_postcode(),
+				'shipping_country'    => wc()->customer->get_shipping_country(),
+			]
+		);
+
+		$draft_order->save();
 	}
 }


### PR DESCRIPTION
Currently, when you enter checkout, a draft order is created. This is populated with any existing session data, but the order is not updated unless you re-enter checkout, or place the order using the button.

This PR improves how checkout data is persisted on the server by:

1. Syncing with the server when the billing email changes, not just the address
2. Syncing any existing draft order with customer data when customer data updates

This means if a customer field changes on checkout that is synced with the server, the order also gets updated to keep it current. This makes it usable by plugins that need access to the billing email before the order is placed.

Fixes #3661
Fixes #3150

### How to test the changes in this Pull Request:

1. Go to checkout
2. Fill out billing email
3. Go to admin, Orders > Drafts. See if the billing email is populated in the draft order.

### Changelog

> Sync customer data during checkout with draft orders.
