### PR TITLE
Don't use fallback in getSetting if value is falsy

### DIFF
--- a/assets/js/settings/shared/test/get-setting.js
+++ b/assets/js/settings/shared/test/get-setting.js
@@ -11,6 +11,9 @@ describe( 'getSetting', () => {
 	it( 'returns expected value for existing setting', () => {
 		expect( getSetting( 'adminUrl', 'not this' ) ).toEqual( ADMIN_URL );
 	} );
+	it( "returns expected value for existing setting even if it's a falsy value", () => {
+		expect( getSetting( 'currentUserIsAdmin', true ) ).toBe( false );
+	} );
 	it( 'filters value via provided filter callback', () => {
 		expect( getSetting( 'some value', 'default', () => 42 ) ).toBe( 42 );
 	} );

--- a/assets/js/settings/shared/utils.ts
+++ b/assets/js/settings/shared/utils.ts
@@ -11,13 +11,15 @@ import { allSettings } from './settings-init';
 /**
  * Retrieves a setting value from the setting state.
  *
- * If a setting with key `name` does not exist, the `fallback` will be returned instead. An optional `filter` callback
- * can be passed to format the returned value.
+ * If a setting with key `name` does not exist or is undefined,
+ * the `fallback` will be returned instead. An optional `filter`
+ * callback can be passed to format the returned value.
  */
 export const getSetting = (
 	name: string,
 	fallback: unknown = false,
-	filter = ( val: unknown, fb: unknown ) => val || fb
+	filter = ( val: unknown, fb: unknown ) =>
+		typeof val !== 'undefined' ? val : fb
 ): unknown => {
 	const value = name in allSettings ? allSettings[ name ] : fallback;
 	return filter( value, fallback );


### PR DESCRIPTION
Fixes #4201.

With the changes introduced in #4059, any setting which had a falsy value would not be evaluated and the fallback would be used. For example, `getSetting( 'couponsEnabled', true )` would always evaluate to `true` even if coupons were disabled in the store.

Adding it to the 5.2.0 milestone since this is fixing a regression.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > General and uncheck Enable the use of coupon codes.
2. Go to the Cart or Checkout blocks and verify there is no Coupon panel in the sidebar.

### Changelog

> Prevent Coupon code panel from appearing in stores were coupons are disabled.