### PR TITLE
Set default store currency to USD in tests

### DIFF
--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -95,7 +95,7 @@ class Cart extends TestCase {
 		$this->assertEquals( true, $data['needs_shipping'] );
 		$this->assertEquals( '30', $data['items_weight'] );
 
-		$this->assertEquals( 'GBP', $data['totals']->currency_code );
+		$this->assertEquals( 'USD', $data['totals']->currency_code );
 		$this->assertEquals( 2, $data['totals']->currency_minor_unit );
 		$this->assertEquals( '3000', $data['totals']->total_items );
 		$this->assertEquals( '0', $data['totals']->total_items_tax );


### PR DESCRIPTION
After a change in WC Core that changes the default currency from `GBP` to `USD` (https://github.com/woocommerce/woocommerce/pull/29752), we need to update a PHP test which relies on it.

### How to test the changes in this Pull Request:

1. Verify PHP tests pass.