### PR TITLE
Checkout State Provider: Export Context Module Functions

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
@@ -13,7 +13,11 @@ import type { CartItem, StoreCartItemQuantity } from '@woocommerce/types';
  * Internal dependencies
  */
 import { useStoreCart } from './use-store-cart';
-import { useCheckoutContext } from '../../providers/cart-checkout';
+import {
+	useCheckoutContext,
+	incrementCalculating,
+	decrementCalculating,
+} from '../../providers/cart-checkout/checkout-state';
 import {
 	isNumber,
 	isObject,
@@ -55,7 +59,7 @@ export const useStoreCartItemQuantity = (
 		quantity: cartItemQuantity = 1,
 	} = verifiedCartItem;
 	const { cartErrors } = useStoreCart();
-	const { dispatchActions } = useCheckoutContext();
+	const { dispatch: checkoutContextDispatch } = useCheckoutContext();
 
 	// Store quantity in hook state. This is used to keep the UI updated while server request is updated.
 	const [ quantity, setQuantity ] = useState< number >( cartItemQuantity );
@@ -116,27 +120,27 @@ export const useStoreCartItemQuantity = (
 		}
 		if ( previousIsPending.quantity !== isPending.quantity ) {
 			if ( isPending.quantity ) {
-				dispatchActions.incrementCalculating();
+				incrementCalculating( checkoutContextDispatch );
 			} else {
-				dispatchActions.decrementCalculating();
+				decrementCalculating( checkoutContextDispatch );
 			}
 		}
 		if ( previousIsPending.delete !== isPending.delete ) {
 			if ( isPending.delete ) {
-				dispatchActions.incrementCalculating();
+				incrementCalculating( checkoutContextDispatch );
 			} else {
-				dispatchActions.decrementCalculating();
+				decrementCalculating( checkoutContextDispatch );
 			}
 		}
 		return () => {
 			if ( isPending.quantity ) {
-				dispatchActions.decrementCalculating();
+				decrementCalculating( checkoutContextDispatch );
 			}
 			if ( isPending.delete ) {
-				dispatchActions.decrementCalculating();
+				decrementCalculating( checkoutContextDispatch );
 			}
 		};
-	}, [ dispatchActions, isPending, previousIsPending ] );
+	}, [ checkoutContextDispatch, isPending, previousIsPending ] );
 
 	return {
 		isPendingDelete: isPending.delete,

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/constants.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/constants.ts
@@ -38,17 +38,7 @@ const checkoutData = {
 };
 
 export const DEFAULT_CHECKOUT_STATE_DATA: CheckoutStateContextType = {
-	dispatchActions: {
-		resetCheckout: () => void null,
-		setRedirectUrl: ( url ) => void url,
-		setHasError: ( hasError ) => void hasError,
-		setAfterProcessing: ( response ) => void response,
-		incrementCalculating: () => void null,
-		decrementCalculating: () => void null,
-		setCustomerId: ( id ) => void id,
-		setOrderId: ( id ) => void id,
-		setOrderNotes: ( orderNotes ) => void orderNotes,
-	},
+	dispatch: () => void {},
 	onSubmit: () => void null,
 	isComplete: false,
 	isIdle: false,

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/types.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/types.ts
@@ -3,6 +3,7 @@
  */
 import { STATUS } from './constants';
 import type { emitterCallback } from '../../../event-emit';
+import type { ActionType } from './actions';
 
 export interface CheckoutResponseError {
 	code: string;
@@ -45,21 +46,9 @@ export type CheckoutStateContextState = {
 	processingResponse: PaymentResultDataType | null;
 };
 
-export type CheckoutStateDispatchActions = {
-	resetCheckout: () => void;
-	setRedirectUrl: ( url: string ) => void;
-	setHasError: ( hasError: boolean ) => void;
-	setAfterProcessing: ( response: CheckoutResponse ) => void;
-	incrementCalculating: () => void;
-	decrementCalculating: () => void;
-	setCustomerId: ( id: number ) => void;
-	setOrderId: ( id: number ) => void;
-	setOrderNotes: ( orderNotes: string ) => void;
-};
-
 export type CheckoutStateContextType = {
-	// Dispatch actions to the checkout provider.
-	dispatchActions: CheckoutStateDispatchActions;
+	// Checkout state provider dispatch function.
+	dispatch: React.Dispatch< ActionType >;
 	// Submits the checkout and begins processing.
 	onSubmit: () => void;
 	// True when checkout is complete and ready for redirect.

--- a/assets/js/base/context/providers/cart-checkout/shipping/index.js
+++ b/assets/js/base/context/providers/cart-checkout/shipping/index.js
@@ -24,7 +24,11 @@ import {
 	reducer as emitReducer,
 	emitEvent,
 } from './event-emit';
-import { useCheckoutContext } from '../checkout-state';
+import {
+	useCheckoutContext,
+	incrementCalculating,
+	decrementCalculating,
+} from '../checkout-state';
 import { useCustomerDataContext } from '../customer';
 import { useStoreCart } from '../../../hooks/cart/use-store-cart';
 import { useSelectShippingRates } from '../../../hooks/shipping/use-select-shipping-rates';
@@ -51,7 +55,7 @@ export const useShippingDataContext = () => {
  * @param {React.ReactElement} props.children
  */
 export const ShippingDataProvider = ( { children } ) => {
-	const { dispatchActions } = useCheckoutContext();
+	const { dispatch: checkoutContextDispatch } = useCheckoutContext();
 	const { shippingAddress, setShippingAddress } = useCustomerDataContext();
 	const {
 		cartNeedsShipping: needsShipping,
@@ -101,20 +105,20 @@ export const ShippingDataProvider = ( { children } ) => {
 	// increment/decrement checkout calculating counts when shipping is loading.
 	useEffect( () => {
 		if ( shippingRatesLoading ) {
-			dispatchActions.incrementCalculating();
+			incrementCalculating( checkoutContextDispatch );
 		} else {
-			dispatchActions.decrementCalculating();
+			decrementCalculating( checkoutContextDispatch );
 		}
-	}, [ shippingRatesLoading, dispatchActions ] );
+	}, [ shippingRatesLoading, checkoutContextDispatch ] );
 
 	// increment/decrement checkout calculating counts when shipping rates are being selected.
 	useEffect( () => {
 		if ( isSelectingRate ) {
-			dispatchActions.incrementCalculating();
+			incrementCalculating( checkoutContextDispatch );
 		} else {
-			dispatchActions.decrementCalculating();
+			decrementCalculating( checkoutContextDispatch );
 		}
-	}, [ isSelectingRate, dispatchActions ] );
+	}, [ isSelectingRate, checkoutContextDispatch ] );
 
 	// set shipping error status if there are shipping error codes
 	useEffect( () => {

--- a/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/contact-fields-step.js
@@ -4,7 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
-import { useCheckoutContext } from '@woocommerce/base-context';
+import {
+	useCheckoutContext,
+	setShouldCreateAccount,
+} from '@woocommerce/base-context/providers/cart-checkout/checkout-state';
 import { getSetting } from '@woocommerce/settings';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 
@@ -21,7 +24,7 @@ const ContactFieldsStep = ( {
 		isProcessing: checkoutIsProcessing,
 		customerId,
 		shouldCreateAccount,
-		setShouldCreateAccount,
+		dispatch,
 	} = useCheckoutContext();
 
 	const createAccountUI = ! customerId &&
@@ -35,7 +38,9 @@ const ContactFieldsStep = ( {
 					'woo-gutenberg-products-block'
 				) }
 				checked={ shouldCreateAccount }
-				onChange={ ( value ) => setShouldCreateAccount( value ) }
+				onChange={ ( value ) =>
+					setShouldCreateAccount( dispatch, value )
+				}
 			/>
 		);
 	return (

--- a/assets/js/blocks/cart-checkout/checkout/form/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/index.js
@@ -3,13 +3,11 @@
  */
 import PropTypes from 'prop-types';
 import { useEffect, useMemo } from '@wordpress/element';
-import {
-	useCheckoutContext,
-	useShippingDataContext,
-} from '@woocommerce/base-context';
+import { useShippingDataContext } from '@woocommerce/base-context';
 import {
 	useStoreEvents,
 	useCheckoutAddress,
+	useCheckoutSubmit,
 } from '@woocommerce/base-context/hooks';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
 import Form from '@woocommerce/base-components/form';
@@ -35,7 +33,7 @@ const CheckoutForm = ( {
 	showPhoneField,
 	allowCreateAccount,
 } ) => {
-	const { onSubmit } = useCheckoutContext();
+	const { onSubmit } = useCheckoutSubmit();
 	const {
 		defaultAddressFields,
 		billingFields,

--- a/assets/js/blocks/cart-checkout/checkout/form/order-notes-step.js
+++ b/assets/js/blocks/cart-checkout/checkout/form/order-notes-step.js
@@ -3,10 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
+import { useShippingDataContext } from '@woocommerce/base-context';
 import {
 	useCheckoutContext,
-	useShippingDataContext,
-} from '@woocommerce/base-context';
+	setOrderNotes,
+} from '@woocommerce/base-context/providers/cart-checkout/checkout-state';
 
 /**
  * Internal dependencies
@@ -18,9 +19,8 @@ const OrderNotesStep = () => {
 	const {
 		isProcessing: checkoutIsProcessing,
 		orderNotes,
-		dispatchActions,
+		dispatch,
 	} = useCheckoutContext();
-	const { setOrderNotes } = dispatchActions;
 
 	return (
 		<FormStep
@@ -31,7 +31,9 @@ const OrderNotesStep = () => {
 		>
 			<CheckoutOrderNotes
 				disabled={ checkoutIsProcessing }
-				onChange={ setOrderNotes }
+				onChange={ ( value ) => {
+					setOrderNotes( dispatch, value );
+				} }
 				placeholder={
 					needsShipping
 						? __(

--- a/assets/js/type-defs/contexts.js
+++ b/assets/js/type-defs/contexts.js
@@ -3,7 +3,6 @@
  * @typedef {import('./cart').CartShippingOption} CartShippingOption
  * @typedef {import('./shipping').ShippingAddress} CartShippingAddress
  * @typedef {import('./cart').CartData} CartData
- * @typedef {import('./checkout').CheckoutDispatchActions} CheckoutDispatchActions
  * @typedef {import('./add-to-cart-form').AddToCartFormDispatchActions} AddToCartFormDispatchActions
  * @typedef {import('./add-to-cart-form').AddToCartFormEventRegistration} AddToCartFormEventRegistration
  */
@@ -91,60 +90,6 @@
 
 /**
  * @typedef {function():PaymentStatusDispatchers} PaymentStatusDispatch
- */
-
-/**
- * @typedef {Object} CheckoutDataContext
- *
- * @property {function()}                   onSubmit                             The callback to register with the
- *                                                                               checkout submit button.
- * @property {boolean}                      isComplete                           True when checkout is complete and
- *                                                                               ready for redirect.
- * @property {boolean}                      isBeforeProcessing                   True during any observers executing
- *                                                                               logic before checkout processing
- *                                                                               (eg. validation).
- * @property {boolean}                      isAfterProcessing                    True when checkout status is
- *                                                                               AFTER_PROCESSING.
- * @property {boolean}                      isIdle                               True when the checkout state has
- *                                                                               changed and checkout has no activity.
- * @property {boolean}                      isProcessing                         True when checkout has been submitted
- *                                                                               and is being processed. Note, payment
- *                                                                               related processing happens during this
- *                                                                               state. When payment status is success,
- *                                                                               processing happens on the server.
- * @property {boolean}                      isCalculating                        True when something in the checkout is
- *                                                                               resulting in totals being calculated.
- * @property {boolean}                      hasError                             True when the checkout is in an error
- *                                                                               state. Whatever caused the error
- *                                                                               (validation/payment method) will likely
- *                                                                               have triggered a notice.
- * @property {string}                       redirectUrl                          This is the url that checkout will
- *                                                                               redirect to when it's ready.
- * @property {function(function(),number=)} onCheckoutValidationBeforeProcessing Used to register a callback that will
- *                                                                               fire when the validation of the submitted checkout
- *                                                                               data happens, before it's sent off to the
- *                                                                               server.
- * @property {function(function(),number=)} onCheckoutAfterProcessingWithSuccess Used to register a callback that will
- *                                                                               fire after checkout has been processed
- *                                                                               and there are no errors.
- * @property {function(function(),number=)} onCheckoutAfterProcessingWithError   Used to register a callback that will
- *                                                                               fire when the checkout has been
- *                                                                               processed and has an error.
- * @property {CheckoutDispatchActions}      dispatchActions                      Various actions that can be dispatched
- *                                                                               for the checkout context data.
- * @property {number}                       orderId                              This is the ID for the draft order if
- *                                                                               one exists.
- * @property {number}                       orderNotes                           Order notes introduced by the user in
- *                                                                               the checkout form.
- * @property {boolean}                      hasOrder                             True when the checkout has a draft
- *                                                                               order from the API.
- * @property {boolean}                      isCart                               When true, means the provider is
- *                                                                               providing data for the cart.
- * @property {number}                       customerId                           This is the ID of the customer the
- *                                                                               draft order belongs to.
- * @property {boolean}                      shouldCreateAccount                  Should a user account be created?
- * @property {function(boolean)}            setShouldCreateAccount               Function to update the
- *                                                                               shouldCreateAccount property.
  */
 
 /**

--- a/docs/block-client-apis/checkout/checkout-api.md
+++ b/docs/block-client-apis/checkout/checkout-api.md
@@ -92,6 +92,7 @@ The provider receives the following props:
 
 Via `useCheckoutContext`, the following are exposed:
 
+-   `dispatch`: Exposes the checkout state provider dispatch function.
 -   `onSubmit`: This is a callback to be invoked either by submitting the checkout button, or by express payment methods to start checkout processing after they have finished their initialization process when their button has been clicked.
 -   `isComplete`: True when checkout has finished processing and the subscribed checkout processing callbacks have all been invoked along with a successful processing of the checkout by the server.
 -   `isIdle`: When the checkout status is `IDLE` this flag is true. Checkout will be this status after any change to checkout state after the block is loaded. It will also be this status when retrying a purchase is possible after processing happens with an error.
@@ -105,7 +106,6 @@ Via `useCheckoutContext`, the following are exposed:
 -   `onCheckoutValidationBeforeProcessing`: Used to register observers that will be invoked at validation time, after the checkout has been submitted but before the processing request is sent to the server.
 -   `onCheckoutAfterProcessingWithSuccess`: Used to register observers that will be invoked after checkout has been processed by the server successfully.
 -   `onCheckoutAfterProcessingWithError`: Used to register observers that will be invoked after checkout has been processed by the server and there was an error.
--   `dispatchActions`: This is an object with various functions for dispatching status in the checkout. It is not exposed to extensions but is for internal use only.
 -   `orderId`: The order id for the order attached to the current checkout.
 -   `isCart`: This is true if the cart is being viewed. Note: usage of `CheckoutProvider` will automatically set this to false. There is also a `CartProvider` that wraps children in the `ShippingDataProvider` and exposes the same api as checkout context. The `CartProvider` automatically sets `isCart` to true. This allows components that implement `useCheckoutContext` to use the same api in either the cart or checkout context but still have specific behaviour to whether `isCart` is true or not.
 -   `hasOrder`: This is true when orderId is truthy.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
 			"@woocommerce/atomic-utils": [ "assets/js/atomic/utils" ],
 			"@woocommerce/base-components/*": [ "assets/js/base/components/*" ],
 			"@woocommerce/base-context": [ "assets/js/base/context" ],
+			"@woocommerce/base-context/*": [ "assets/js/base/context/*" ],
 			"@woocommerce/base-context/hooks": [
 				"assets/js/base/context/hooks"
 			],


### PR DESCRIPTION
Taken from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3983 Based on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4200 which has the Typescript updates.

Inspired by epic react I added some new functions exported from the context provider which take dispatch as a parameter and do something. These were previously exported by the context provider, but with this method we only need to export the dispatcher which means the functions can be tree-shaken.

- submitCheckout
- resetCheckout
- setRedirectUrl
- setHasError
- incrementCalculating
- decrementCalculating
- setCustomerId
- setOrderId
- setOrderNotes
- setShouldCreateAccount
- setAfterProcessing

Example usage:

```
import {
	useCheckoutContext,
	setOrderNotes,
} from '@woocommerce/base-context/cart-checkout/checkout-state';

...

const { dispatch } = useCheckoutContext();

setOrderNotes( dispatch, value );
```

EpicReact was fuzzy on the tangible benefits ([linking through to this tweet](https://twitter.com/dan_abramov/status/1125774170154065920) and citing potential performance improvements), but the reasons given seem to include:

- The context provider should only pass down necessary props via the context API, and in this case, `dispatch` is the only thing required
- Having exported functions that accept the dispatch object means that the exports can be tree shaken
- Whilst the functions do require dispatch, it's arguably easier to just import what you need, rather than getting everything via context
- I guess you could also argue that in the future if similar context providers had similar or overlapping functionality, they could share the same functions but accept different dispatch props.

Looking for feedback on this approach, and are we happy how these functions are exported?

### How to test the changes in this Pull Request:

Smoke test the checkout process, including making payment. Checkout state provider is only used during checkout.
