### PR TITLE
Add ExtendRestAPI and SlotFills docs

### DIFF
--- a/docs/extensibility/README.md
+++ b/docs/extensibility/README.md
@@ -9,3 +9,8 @@ These documents are all dealing with extensibility in the various WooCommerce Bl
 [Payment Method Integration](./payment-method-integration.md) | Information about implementing payment methods.
 [Checkout Flow and Events](./checkout-flow-and-events.md) | All about the checkout flow in the checkout block and the various emitted events that can be subscribed to.
 [Available Filters](./available-filters.md) | All about the filters that you may use to change values of certain elements of WooCommerce Blocks.
+[Exposing your data in the Store API.](./extend-rest-api-add-data.md) | Explains how you can add additional data to Store API endpoints.
+[Available endpoints to extend with ExtendRestAPI.](./available-endpoints-to-extend.md) | A list of all available endpoints to extend.
+[Adding an endpoint to ExtendRestAPI.](./extend-rest-api-new-endpoint.md) | A step by step process for contributors to expose a new endpoint via ExtendRestApi.
+[Slots and Fills.](./slot-fills.md) | Explains Slot Fills and how to use them to render your own components in Cart and Checkout.
+[Available Slot Fills.](./available-slot-fills.md) | Available Slots that you can use and their positions in Cart and Checkout.

--- a/docs/extensibility/available-endpoints-to-extend.md
+++ b/docs/extensibility/available-endpoints-to-extend.md
@@ -2,7 +2,7 @@
 
 To see how to add your data to Store API using ExtendRestAPI, [check this document](./extend-rest-api-add-data.md).
 
-This is a list of Available endpoints that you can extend, if you want to add a new endpoint, [check this document](./extend-rest-api-new-endpoint.md).
+This is a list of available endpoints that you can extend. If you want to add a new endpoint, [check this document](./extend-rest-api-new-endpoint.md).
 
 ## `wc/store/cart`
 

--- a/docs/extensibility/available-endpoints-to-extend.md
+++ b/docs/extensibility/available-endpoints-to-extend.md
@@ -8,7 +8,7 @@ This is a list of available endpoints that you can extend. If you want to add a 
 
 The main cart endpoint is extensible via ExtendRestAPI. The data is available via the `extensions` key in the response.
 
-### Passes Parameters:
+### Passed Parameters:
 
 - `data_callback`: none.
 - `schema_callback`: none.

--- a/docs/extensibility/available-endpoints-to-extend.md
+++ b/docs/extensibility/available-endpoints-to-extend.md
@@ -19,7 +19,7 @@ The main cart endpoint is extensible via ExtendRestAPI. The data is available vi
 
 ## `wc/store/cart/items`
 
-The items endpoint, which is also available on `wc/store/cart` inside the `items` key. The data would be avalaible inside each item of the `items` array.
+The items endpoint, which is also available on `wc/store/cart` inside the `items` key. The data would be available inside each item of the `items` array.
 
 ### Passed Parameters:
 

--- a/docs/extensibility/available-endpoints-to-extend.md
+++ b/docs/extensibility/available-endpoints-to-extend.md
@@ -6,7 +6,7 @@ This is a list of available endpoints that you can extend. If you want to add a 
 
 ## `wc/store/cart`
 
-The main cart endpoint is exntesible via ExtendRestAPI, the data is available on `exntesions` key in the response.
+The main cart endpoint is extensible via ExtendRestAPI. The data is available via the `extensions` key in the response.
 
 ### Passes Parameters:
 

--- a/docs/extensibility/available-endpoints-to-extend.md
+++ b/docs/extensibility/available-endpoints-to-extend.md
@@ -1,0 +1,31 @@
+# Available endpoints to extend with ExtendRestAPI
+
+To see how to add your data to Store API using ExtendRestAPI, [check this document](./extend-rest-api-add-data.md).
+
+This is a list of Available endpoints that you can extend, if you want to add a new endpoint, [check this document](./extend-rest-api-new-endpoint.md).
+
+## `wc/store/cart`
+
+The main cart endpoint is exntesible via ExtendRestAPI, the data is available on `exntesions` key in the response.
+
+### Passes Parameters:
+
+- `data_callback`: none.
+- `schema_callback`: none.
+
+### Key:
+
+- `CartSchema::IDENTIFIER`
+
+## `wc/store/cart/items`
+
+The items endpoint, which is also available on `wc/store/cart` inside the `items` key. The data would be avalaible inside each item of the `items` array.
+
+### Passed Parameters:
+
+- `data_callback`: `$cart_item`.
+- `schema_callback` none.
+
+### Key:
+
+- `CartItemSchema::IDENTIFIER`

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -4,6 +4,9 @@ To see how to use a slotFill, [check this document](./slot-fills.md).
 
 This is a list of available slots that you can use. If you want to add a new slotFill, [check this document](../../pacakges/checkout/slot/README.md).
 
+**Note About Naming:** Slots that are prefixed with `Experminetal` are, as they say, exprimental and not final, they're are subject to change or remove, once they graduate from expermintal, the naming would change so you should be aware of that.
+Check the [Feature Gating document](../blocks/feature-flags-and-experimental-interfaces.md) from more information.
+
 ## ExperimentalOrderMeta
 This Slot renders below the Checkout summary section and above the "Proceed to Checkout" button in the Cart.
 

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -1,0 +1,37 @@
+# Available Slots
+
+To see how to use a slotFill, [check this document](./slot-fills.md).
+
+This is a list of available slots that you can use, if you want to add a new slotFill, [check this document](../../pacakges/checkout/slot/README.md).
+
+## ExperimentalOrderMeta
+This Slot renders below Checkouy summary section and above the "Continue to Checkout" in Cart.
+
+<img width="1135" alt="image" src="https://user-images.githubusercontent.com/6165348/118398683-a0202700-b651-11eb-8a4f-cd8b6ebff53f.png">
+
+### Passed parameters
+
+- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188);
+- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExntedRestAPI` on `wc/store/cart` you would find your data here under your namespace.
+
+## ExperimentalOrderShippingPackages
+This slot renders inside the shipping step of Checkout and inside the shipping options in Cart.
+
+Cart:
+
+<img width="1151" alt="image" src="https://user-images.githubusercontent.com/6165348/118399054-2b4dec80-b653-11eb-94a0-989e2e6e362a.png">
+
+Checkout:
+
+<img width="1233" alt="image" src="https://user-images.githubusercontent.com/6165348/118399133-90094700-b653-11eb-8ff0-c917947c199f.png">
+
+### Passed parameters
+
+- `collapsible`: `Boolean` If a shipping package panel should be collapsible or not, this is false in Checkout and true in Cart.
+- `collapse`: `Boolean` If a panel should be collapsed by default, this is true if there's more than 1 fill registred (Core Shipping options are registered as a fill and they're counted).
+- `showItems`: `Boolean` If we should the content of each package, this is true if there's more than 1 fill registred (Core Shipping options are registered as a fill and they're counted).
+- `noResultsMessage`: A react element that you can render if there're no shipping.
+- `renderOption`: a render function that takes a rate object and returns a render option.
+- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188);
+- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExntedRestAPI` on `wc/store/cart` you would find your data here under your namespace.
+- `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -12,7 +12,7 @@ This Slot renders below the Checkout summary section and above the "Proceed to C
 ### Passed parameters
 
 - `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
-- `extensions`: external data registered by third-party developers using `ExtendRestAPI`. If you used `ExntedRestAPI` on `wc/store/cart` you would find your data under your namespace here.
+- `extensions`: external data registered by third-party developers using `ExtendRestAPI`. If you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
 
 ## ExperimentalOrderShippingPackages
 This slot renders inside the shipping step of Checkout and inside the shipping options in Cart.
@@ -28,9 +28,9 @@ Checkout:
 ### Passed parameters
 
 - `collapsible`: `Boolean` If a shipping package panel should be collapsible or not, this is false in Checkout and true in Cart.
-- `collapse`: `Boolean` If a panel should be collapsed by default, this is true if there's more than 1 fill registred (Core Shipping options are registered as a fill and they're counted).
-- `showItems`: `Boolean` If we should the content of each package, this is true if there's more than 1 fill registred (Core Shipping options are registered as a fill and they're counted).
-- `noResultsMessage`: A react element that you can render if there're no shipping.
+- `collapse`: `Boolean` If a panel should be collapsed by default, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
+- `showItems`: `Boolean` If we should show the content of each package, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
+- `noResultsMessage`: A React element that you can render if there are no shipping options.
 - `renderOption`: a render function that takes a rate object and returns a render option.
 - `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
 - `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -2,17 +2,17 @@
 
 To see how to use a slotFill, [check this document](./slot-fills.md).
 
-This is a list of available slots that you can use, if you want to add a new slotFill, [check this document](../../pacakges/checkout/slot/README.md).
+This is a list of available slots that you can use. If you want to add a new slotFill, [check this document](../../pacakges/checkout/slot/README.md).
 
 ## ExperimentalOrderMeta
-This Slot renders below Checkouy summary section and above the "Continue to Checkout" in Cart.
+This Slot renders below the Checkout summary section and above the "Proceed to Checkout" button in the Cart.
 
 <img width="1135" alt="image" src="https://user-images.githubusercontent.com/6165348/118398683-a0202700-b651-11eb-8a4f-cd8b6ebff53f.png">
 
 ### Passed parameters
 
-- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188);
-- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExntedRestAPI` on `wc/store/cart` you would find your data here under your namespace.
+- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
+- `extensions`: external data registered by third-party developers using `ExtendRestAPI`. If you used `ExntedRestAPI` on `wc/store/cart` you would find your data under your namespace here.
 
 ## ExperimentalOrderShippingPackages
 This slot renders inside the shipping step of Checkout and inside the shipping options in Cart.
@@ -32,6 +32,6 @@ Checkout:
 - `showItems`: `Boolean` If we should the content of each package, this is true if there's more than 1 fill registred (Core Shipping options are registered as a fill and they're counted).
 - `noResultsMessage`: A react element that you can render if there're no shipping.
 - `renderOption`: a render function that takes a rate object and returns a render option.
-- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188);
-- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExntedRestAPI` on `wc/store/cart` you would find your data here under your namespace.
+- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
+- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
 - `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.

--- a/docs/extensibility/extend-rest-api-add-data.md
+++ b/docs/extensibility/extend-rest-api-add-data.md
@@ -1,0 +1,289 @@
+# Exposing your data in Store API.
+
+## The problem
+You want to extend the Cart and Checkout blocks, but you want to use some custom data not available on Store API or the context.
+You don't want to create your own endpoints or Ajax actions. You want to piggyback on the existing StoreAPI calls.
+
+## Solution
+ExtendRestAPI offers the possibility to add contextual custom data to Store API endpoints, like `wc/store/cart` and `wc/store/cart/items` endpoints.
+That data is namespaced to your plugin and protected from other plugins malfunctioning.
+The data is available on all frontend filters and slotFills for you to consume.
+
+## Basic usage
+You can use ExtendRestAPI by registering a couple of functions, `schema_callback` and `data_callback` on a specific endpoint namespace. Those functions are going to be called at execution time and are going to be passed relevant data.
+
+```PHP
+
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
+
+add_action('woocommerce_blocks_loaded', function() {
+ // ExtendRestApi relies on a Singleton that is shared between the API and consumers.
+ // You shouldn't initiate your own ExtendRestApi using new ExtendRestApi but should always get it from Package dependecy injection manager.
+ $extend = Package::container()->get( ExtendRestApi::class );
+
+ $extend->register_endpoint_data(
+ array(
+ 'endpoint' => CartSchema::IDENTIFIER,
+ 'namespace' => 'plugin_namespace',
+ 'data_callback' => 'my_data_callback',
+ 'schema_callback' => 'my_schema_callback',
+ 'schema_type' => ARRAY_A,
+ )
+ );
+});
+
+
+function my_data_callback() {
+ return [
+ 'custom-key' => 'custom-value';
+ ]
+}
+
+function my_schema_callback() {
+ return [
+ 'custom-key' => [
+ 'description' => __( 'My custom data', 'plugin-namespace' ),
+ 'type' => 'string'
+ 'readonly' => true,
+ ]
+ ]
+}
+```
+
+Data callback and Schema callback can also receive parameters:
+
+```PHP
+
+function my_cart_item_callback( $cart_item ) {
+ $product = $cart_item['data'];
+ if ( is_my_custom_product_type( $product ) ) {
+ $custom_value = get_custom_value( $product );
+ return [
+ 'custom-key' => $custom_value;
+ ]
+ }
+}
+
+```
+
+## API Definition
+
+- `ExtendRestAPI::register_endpoint_data`: Used to register data to a custom endpoint. It takes an array of arguments:
+
+| Attribute | Type | Required | Description |
+| :-------- | :----- | :------: | :------------------------------------ |
+| `endpoint` | string | Yes | The endpoint you're trying to extend, it is suggested that you use `::IDENTIFIER` Available on the route Schema class to avoid typos. |
+| `namespace` | string | Yes | Your plugin namespace, the data will be available under this namespace in the StoreAPI response. |
+| `data_callback` | callback | Yes | A callback that returns an array with your data. |
+| `schema_callback` | callback | Yes | A callback that returns the shape of your data. |
+| `data_type` | string | No (default: `ARRAY_A` ) | The type of your data, if you're adding an object (key => values), it should be `ARRAY_A`, you're adding a list of items, it should be `ARRAY_N`. |
+
+## Putting it all together
+
+This is a complete example that shows how you can register contextual WooCommerce Subscriptions data in each cart item (simplified).
+
+This example uses Formatters, another property documented here (TBD).
+
+```php
+<?php
+/**
+ * WooCommerce Subscriptions Extend Store API.
+ *
+ * A class to extend the store public API with subscription related data
+ * for each subscription item
+ *
+ * @package WooCommerce Subscriptions
+ */
+
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\StoreApi\SchemaController;
+use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartItemSchema;
+
+if ( class_exists( 'Package' ) && version_compare( Package::get_version(), '4.8.0', '>=' ) ) {
+	// This class needs to run after WooCommerce Blocks is ready.
+	add_action( 'woocommerce_blocks_loaded', array( 'WC_Subscriptions_Extend_Store_Endpoint', 'init' ) );
+}
+
+class WC_Subscriptions_Extend_Store_Endpoint {
+
+	/**
+	 * Stores Rest Schema Controller.
+	 *
+	 * @var ExtendRestApi
+	 */
+	private static $schema;
+
+	/**
+	 * Stores Rest Extending instance.
+	 *
+	 * @var ExtendRestApi
+	 */
+	private static $extend;
+
+	/**
+	 * Plugin Identifier, unique to each plugin.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'subscriptions';
+
+	/**
+	 * Bootstraps the class and hooks required data.
+	 *
+	 * @since WCBLOCKS-DEV
+	 */
+	public static function init() {
+		self::$schema = Package::container()->get( SchemaController::class );
+		self::$extend = Package::container()->get( ExtendRestApi::class );
+		self::extend_store();
+	}
+
+	/**
+	 * Registers the actual data into each endpoint.
+	 */
+	public static function extend_store() {
+
+		// Register into `cart/items`
+		self::$extend->register_endpoint_data(
+			array(
+				'endpoint'        => CartItemSchema::IDENTIFIER,
+				'namespace'       => self::IDENTIFIER,
+				'data_callback'   => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_item_data' ),
+				'schema_callback' => array( 'WC_Subscriptions_Extend_Store_Endpoint', 'extend_cart_item_schema' ),
+				'schema_type'     => ARRAY_A,
+			)
+		);
+	}
+
+	/**
+	 * Register subscription product data into cart/items endpoint.
+	 *
+	 * @param array $cart_item Current cart item data.
+	 *
+	 * @return array $item_data Registered data or empty array if condition is not satisfied.
+	 */
+	public static function extend_cart_item_data( $cart_item ) {
+		$product   = $cart_item['data'];
+		$item_data = array(
+			'billing_period'      => null,
+			'billing_interval'    => null,
+			'subscription_length' => null,
+			'trial_length'        => null,
+			'trial_period'        => null,
+			'sign_up_fees'        => null,
+			'sign_up_fees_tax'    => null,
+
+		);
+
+		if ( in_array( $product->get_type(), array( 'subscription', 'subscription_variation' ), true ) ) {
+			$item_data = array_merge(
+				array(
+					'billing_period'      => WC_Subscriptions_Product::get_period( $product ),
+					'billing_interval'    => (int) WC_Subscriptions_Product::get_interval( $product ),
+					'subscription_length' => (int) WC_Subscriptions_Product::get_length( $product ),
+					'trial_length'        => (int) WC_Subscriptions_Product::get_trial_length( $product ),
+					'trial_period'        => WC_Subscriptions_Product::get_trial_period( $product ),
+				),
+				self::format_sign_up_fees( $product )
+			);
+		}
+
+		return $item_data;
+	}
+
+	/**
+	 * Register subscription product schema into cart/items endpoint.
+	 *
+	 * @return array Registered schema.
+	 */
+	public static function extend_cart_item_schema() {
+		return array(
+			'billing_period'      => array(
+				'description' => __( 'Billing period for the subscription.', 'woocommerce-subscriptions' ),
+				'type'        => array( 'string', 'null' ),
+				'enum'        => array_keys( wcs_get_subscription_period_strings() ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'billing_interval'    => array(
+				'description' => __( 'The number of billing periods between subscription renewals.', 'woocommerce-subscriptions' ),
+				'type'        => array( 'integer', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'subscription_length' => array(
+				'description' => __( 'Subscription Product length.', 'woocommerce-subscriptions' ),
+				'type'        => array( 'integer', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'trial_period'        => array(
+				'description' => __( 'Subscription Product trial period.', 'woocommerce-subscriptions' ),
+				'type'        => array( 'string', 'null' ),
+				'enum'        => array_keys( wcs_get_subscription_period_strings() ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'trial_length'        => array(
+				'description' => __( 'Subscription Product trial interval.', 'woocommerce-subscriptions' ),
+				'type'        => array( 'integer', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'sign_up_fees'        => array(
+				'description' => __( 'Subscription Product signup fees.', 'woocommerce-subscriptions' ),
+				'type'        => array( 'string', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'sign_up_fees_tax'    => array(
+				'description' => __( 'Subscription Product signup fees taxes.', 'woocommerce-subscriptions' ),
+				'type'        => array( 'string', 'null' ),
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		);
+	}
+
+
+	/**
+	 * Format sign-up fees.
+	 *
+	 * @param \WC_Product $product current product.
+	 * @return array
+	 */
+	private static function format_sign_up_fees( $product ) {
+		$fees_excluding_tax = wcs_get_price_excluding_tax(
+			$product,
+			array(
+				'qty'   => 1,
+				'price' => WC_Subscriptions_Product::get_sign_up_fee( $product ),
+			)
+		);
+
+		$fees_including_tax = wcs_get_price_including_tax(
+			$product,
+			array(
+				'qty'   => 1,
+				'price' => WC_Subscriptions_Product::get_sign_up_fee( $product ),
+			)
+		);
+
+		$money_formatter = self::$extend->get_formatter( 'money' );
+
+		return array(
+			'sign_up_fees'     => $money_formatter->format(
+				$fees_excluding_tax
+			),
+			'sign_up_fees_tax' => $money_formatter->format(
+				$fees_including_tax
+				- $fees_excluding_tax
+			),
+
+		);
+	}
+}
+```

--- a/docs/extensibility/extend-rest-api-add-data.md
+++ b/docs/extensibility/extend-rest-api-add-data.md
@@ -1,4 +1,4 @@
-# Exposing your data in Store API.
+# Exposing your data in the Store API.
 
 ## The problem
 You want to extend the Cart and Checkout blocks, but you want to use some custom data not available on Store API or the context.
@@ -74,11 +74,11 @@ function my_cart_item_callback( $cart_item ) {
 
 | Attribute | Type | Required | Description |
 | :-------- | :----- | :------: | :------------------------------------ |
-| `endpoint` | string | Yes | The endpoint you're trying to extend, it is suggested that you use `::IDENTIFIER` Available on the route Schema class to avoid typos. |
+| `endpoint` | string | Yes | The endpoint you're trying to extend. It is suggested that you use the `::IDENTIFIER` available on the route Schema class to avoid typos. |
 | `namespace` | string | Yes | Your plugin namespace, the data will be available under this namespace in the StoreAPI response. |
 | `data_callback` | callback | Yes | A callback that returns an array with your data. |
 | `schema_callback` | callback | Yes | A callback that returns the shape of your data. |
-| `data_type` | string | No (default: `ARRAY_A` ) | The type of your data, if you're adding an object (key => values), it should be `ARRAY_A`, you're adding a list of items, it should be `ARRAY_N`. |
+| `data_type` | string | No (default: `ARRAY_A` ) | The type of your data. If you're adding an object (key => values), it should be `ARRAY_A`. If you're adding a list of items, it should be `ARRAY_N`. |
 
 ## Putting it all together
 

--- a/docs/extensibility/extend-rest-api-add-data.md
+++ b/docs/extensibility/extend-rest-api-add-data.md
@@ -19,8 +19,8 @@ use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
 
 add_action('woocommerce_blocks_loaded', function() {
- // ExtendRestApi relies on a Singleton that is shared between the API and consumers.
- // You shouldn't initiate your own ExtendRestApi using new ExtendRestApi but should always get it from Package dependecy injection manager.
+ // ExtendRestApi is stored in the container as a shared instance between the API and consumers.
+ // You shouldn't initiate your own ExtendRestApi instance using `new ExtendRestApi` but should always use the shared instance from the Package dependency injection container.
  $extend = Package::container()->get( ExtendRestApi::class );
 
  $extend->register_endpoint_data(

--- a/docs/extensibility/extend-rest-api-add-data.md
+++ b/docs/extensibility/extend-rest-api-add-data.md
@@ -6,11 +6,11 @@ You don't want to create your own endpoints or Ajax actions. You want to piggyba
 
 ## Solution
 ExtendRestAPI offers the possibility to add contextual custom data to Store API endpoints, like `wc/store/cart` and `wc/store/cart/items` endpoints.
-That data is namespaced to your plugin and protected from other plugins malfunctioning.
+That data is namespaced to your plugin and protected from other plugins causing it to malfunction.
 The data is available on all frontend filters and slotFills for you to consume.
 
 ## Basic usage
-You can use ExtendRestAPI by registering a couple of functions, `schema_callback` and `data_callback` on a specific endpoint namespace. Those functions are going to be called at execution time and are going to be passed relevant data.
+You can use ExtendRestAPI by registering a couple of functions, `schema_callback` and `data_callback` on a specific endpoint namespace. ExtendRestAPI will call them at execution time and will pass them relevant data as well.
 
 ```PHP
 

--- a/docs/extensibility/extend-rest-api-new-endpoint.md
+++ b/docs/extensibility/extend-rest-api-new-endpoint.md
@@ -1,0 +1,39 @@
+# Adding an endpoint to ExtendRestAPI
+
+## Exnteding `GET` endpoints in Store API.
+
+ExtendRestAPI needs to expose to each endpoint Individually, meaning if you want to expose a new endpoint, you have to follow those steps:
+
+1- In `ExtendRestApi` class, add your endpoint `IDENTIFIER` to the `$endpoints` variable.
+
+```php
+
+use Automattic\WooCommerce\Blocks\StoreApi\Schemas\BillingAddressSchema;
+
+private $endpoints = [ /* other identifiers */, BillingAddressSchema::IDENTIFIER ];
+
+```
+
+This is to prevent accidentally exposing new endpoints.
+
+2- Inside your endpoint schema class (for this example, inside `BillingAddressSchema`), in its `get_properties` method, add this call at the end of the returned array.
+
+You can pass extra parameters to `get_extended_schema` and those would be passed to third party code.
+
+```php
+self::EXTENDING_KEY    => $this->get_extended_schema( self::IDENTIFIER ),
+```
+
+`EXTENDING_KEY` value is `extensions`, we use a constant to make sure we don't have a typo.
+
+3- Inside the same class, in `get_item_response`, add the below line. Like `get_extended_schema`, you can pass extra parameters here as well.
+
+Make sure to only expose what's needed.
+
+```php
+self::EXTENDING_KEY    => $this->get_extended_data( self::IDENTIFIER, $cart_item ),
+```
+
+That's it, your endpoint would now contain `extensions` in your endpoint, and you can consume it in the frontend.
+
+Extending a new endpoint is usally half the work, you will need to recvieve this data in frontend and pass it to any other extensiblity point (Slot, Filter, Event).

--- a/docs/extensibility/extend-rest-api-new-endpoint.md
+++ b/docs/extensibility/extend-rest-api-new-endpoint.md
@@ -1,8 +1,8 @@
 # Adding an endpoint to ExtendRestAPI
 
-## Exnteding `GET` endpoints in Store API.
+## Extending `GET` endpoints in Store API.
 
-ExtendRestAPI needs to expose to each endpoint Individually, meaning if you want to expose a new endpoint, you have to follow those steps:
+ExtendRestAPI needs to expose each endpoint individually. If you want to expose a new endpoint, you have to follow these steps:
 
 1- In `ExtendRestApi` class, add your endpoint `IDENTIFIER` to the `$endpoints` variable.
 
@@ -36,4 +36,4 @@ self::EXTENDING_KEY    => $this->get_extended_data( self::IDENTIFIER, $cart_item
 
 That's it, your endpoint would now contain `extensions` in your endpoint, and you can consume it in the frontend.
 
-Extending a new endpoint is usally half the work, you will need to recvieve this data in frontend and pass it to any other extensiblity point (Slot, Filter, Event).
+Extending a new endpoint is usually half the work, you will need to receive this data in the frontend and pass it to any other extensibility point (Slot, Filter, Event).

--- a/docs/extensibility/extend-rest-api-new-endpoint.md
+++ b/docs/extensibility/extend-rest-api-new-endpoint.md
@@ -4,7 +4,7 @@
 
 ExtendRestAPI needs to expose each endpoint individually. If you want to expose a new endpoint, you have to follow these steps:
 
-1- In `ExtendRestApi` class, add your endpoint `IDENTIFIER` to the `$endpoints` variable.
+1. In `ExtendRestApi` class, add your endpoint `IDENTIFIER` to the `$endpoints` variable.
 
 ```php
 
@@ -16,7 +16,7 @@ private $endpoints = [ /* other identifiers */, BillingAddressSchema::IDENTIFIER
 
 This is to prevent accidentally exposing new endpoints.
 
-2- Inside your endpoint schema class (for this example, inside `BillingAddressSchema`), in its `get_properties` method, add this call at the end of the returned array.
+2. Inside your endpoint schema class (for this example, inside `BillingAddressSchema`), in its `get_properties` method, add this call at the end of the returned array.
 
 You can pass extra parameters to `get_extended_schema` and those would be passed to third party code.
 
@@ -26,7 +26,7 @@ self::EXTENDING_KEY    => $this->get_extended_schema( self::IDENTIFIER ),
 
 `EXTENDING_KEY` value is `extensions`, we use a constant to make sure we don't have a typo.
 
-3- Inside the same class, in `get_item_response`, add the below line. Like `get_extended_schema`, you can pass extra parameters here as well.
+3. Inside the same class, in `get_item_response`, add the below line. Like `get_extended_schema`, you can pass extra parameters here as well.
 
 Make sure to only expose what's needed.
 

--- a/docs/extensibility/extend-rest-api-new-endpoint.md
+++ b/docs/extensibility/extend-rest-api-new-endpoint.md
@@ -1,5 +1,7 @@
 # Adding an endpoint to ExtendRestAPI
 
+This document is intended for contrubtors to WooCommerce Blocks plugin, if you feel like a new endpoint should be added, feel free to open an issue or a PR detailing why.
+
 ## Extending `GET` endpoints in Store API.
 
 ExtendRestAPI needs to expose each endpoint individually. If you want to expose a new endpoint, you have to follow these steps:

--- a/docs/extensibility/slot-fills.md
+++ b/docs/extensibility/slot-fills.md
@@ -1,0 +1,50 @@
+# Slots and Fills
+
+## The problem
+You added custom data to the [Store API](./extend-rest-api-add-data.md), you changed several strings using [Checkout filters](./available-filters.md), but now, you want to render your own components in specific places in Cart and Checkout.
+
+## Solution
+
+Slots and Fills adds the possiblity to render your own HTML in pre-defined places in Cart and Checkout, your component would get access to contextual data and will get re-rendered when needed.
+
+A Slot is a place in Cart and Checkout that can render indefinite number of external components.
+
+A Fill is the component provided by third-party developers to render inside a Slot.
+
+Slots and Fills uses the WordPress's API, [so you can expand more on its API there.](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/slot-fill).
+
+## Basic Usage
+
+`ExperimentalOrderMeta` is a fill that will render in a slot below the order summary section in Cart and Checkout blocks.
+The `ExperimentalOrderMeta` will automatically pass props to its top level child, `cart` which contains cart data, `extensions` which contains data registered with `ExtendRestAPI` in `wc/store/cart` endpoint.
+
+```jsx
+const { registerPlugin } = wp.plugins;
+const { ExperimentalOrderMeta } = wc.blocksCheckout;
+
+const MyCustomComponent = ( { cart, extensions } ) => {
+	return <div className='my-component'>Hello WooCommerce</div>
+}
+
+const render = () => {
+	return (
+			<ExperimentalOrderMeta>
+				<MyCustomComponent />
+			</ExperimentalOrderMeta>
+	);
+};
+
+registerPlugin( 'my-plugin-namespace', {
+	render,
+	scope: 'woocommerce-checkout',
+} );
+```
+
+## registerPlugin
+
+In the above example, we're using `registerPlugin`, this plugin will take our component and render it, but it won't make visible, the SlotFill part is the one responsible for actually having it show up on the correct place.
+
+You use `registerPlugin` to feed in your plugin namespace, your component `render` and the scope of your `registerPlugin`, this value should always be `woocommerce-checkout`.
+
+## Requirements
+For this to work, you script must be enqueued after Cart and Checkout, you can follow the `IntegrationInterface` documentation to enqueue your script (TBD).

--- a/docs/extensibility/slot-fills.md
+++ b/docs/extensibility/slot-fills.md
@@ -1,22 +1,22 @@
 # Slots and Fills
 
 ## The problem
-You added custom data to the [Store API](./extend-rest-api-add-data.md), you changed several strings using [Checkout filters](./available-filters.md), but now, you want to render your own components in specific places in Cart and Checkout.
+You added custom data to the [Store API](./extend-rest-api-add-data.md). You changed several strings using [Checkout filters](./available-filters.md). Now you want to render your own components in specific places in the Cart and Checkout.
 
 ## Solution
 
-Slots and Fills adds the possiblity to render your own HTML in pre-defined places in Cart and Checkout, your component would get access to contextual data and will get re-rendered when needed.
+Slots and Fills add the possibility to render your own HTML in pre-defined places in the Cart and Checkout. Your component will get access to contextual data and will get re-rendered when needed.
 
-A Slot is a place in Cart and Checkout that can render indefinite number of external components.
+A Slot is a place in the Cart and Checkout that can render an indefinite number of external components.
 
 A Fill is the component provided by third-party developers to render inside a Slot.
 
-Slots and Fills uses the WordPress's API, [so you can expand more on its API there.](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/slot-fill).
+Slots and Fills uses WordPress's API, [so you can expand more on its API there.](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/slot-fill).
 
 ## Basic Usage
 
-`ExperimentalOrderMeta` is a fill that will render in a slot below the order summary section in Cart and Checkout blocks.
-The `ExperimentalOrderMeta` will automatically pass props to its top level child, `cart` which contains cart data, `extensions` which contains data registered with `ExtendRestAPI` in `wc/store/cart` endpoint.
+`ExperimentalOrderMeta` is a fill that will render in a slot below the order summary section in the Cart and Checkout blocks.
+The `ExperimentalOrderMeta` will automatically pass props to its top level child: `cart` which contains cart data, and `extensions` which contains data registered with `ExtendRestAPI` in `wc/store/cart` endpoint.
 
 ```jsx
 const { registerPlugin } = wp.plugins;
@@ -42,9 +42,9 @@ registerPlugin( 'my-plugin-namespace', {
 
 ## registerPlugin
 
-In the above example, we're using `registerPlugin`, this plugin will take our component and render it, but it won't make visible, the SlotFill part is the one responsible for actually having it show up on the correct place.
+In the above example, we're using `registerPlugin`. This plugin will take our component and render it, but it won't make it visible. The SlotFill part is the one responsible for actually having it show up in the correct place.
 
-You use `registerPlugin` to feed in your plugin namespace, your component `render` and the scope of your `registerPlugin`, this value should always be `woocommerce-checkout`.
+You use `registerPlugin` to feed in your plugin namespace, your component `render`, and the scope of your `registerPlugin`. The value of scope should always be `woocommerce-checkout`.
 
 ## Requirements
-For this to work, you script must be enqueued after Cart and Checkout, you can follow the `IntegrationInterface` documentation to enqueue your script (TBD).
+For this to work, your script must be enqueued after Cart and Checkout. You can follow the `IntegrationInterface` documentation to enqueue your script (TBD).

--- a/docs/extensibility/slot-fills.md
+++ b/docs/extensibility/slot-fills.md
@@ -11,7 +11,7 @@ A Slot is a place in the Cart and Checkout that can render an indefinite number 
 
 A Fill is the component provided by third-party developers to render inside a Slot.
 
-Slots and Fills uses WordPress's API, [so you can expand more on its API there.](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/slot-fill).
+Slot and Fill use WordPress' API, and you can learn more about how they work in [the Slot Fill documentation.](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/slot-fill).
 
 ## Basic Usage
 

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
-use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
 
 /**


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3407

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds documentation for:

- How ExtendRestAPI Works.
- Available Endpoints you can extend.
- How to make an endpoint extensible.
- How SlotFills works (from Third party perspective).
- Available SlotFills.

### Open questions

- Where should we consolidate docs? We have some docs in `src/StoreAPI`, We have documentation in `packages/checkout/slot/readme.md`, and we have other docs in `docs`. Some docs target our team, and other target third-party developers, should there be a distinction?