### PR TITLE
Fix duplicate plugins by using wp.components global in the editor.

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -22,6 +22,8 @@ const {
 	CHECK_CIRCULAR_DEPS,
 	requestToExternal,
 	requestToHandle,
+	requestToExternalInsideGB,
+	requestToHandleInsideGB,
 	findModuleMatch,
 } = require( './webpack-helpers' );
 
@@ -40,6 +42,20 @@ const sharedPlugins = [
 	} ),
 ].filter( Boolean );
 
+const mainBlocksPlugins = [
+	CHECK_CIRCULAR_DEPS === 'true'
+		? new CircularDependencyPlugin( {
+				exclude: /node_modules/,
+				cwd: process.cwd(),
+				failOnError: 'warn',
+		  } )
+		: false,
+	new DependencyExtractionWebpackPlugin( {
+		injectPolyfill: true,
+		requestToExternal: requestToExternalInsideGB,
+		requestToHandle: requestToHandleInsideGB,
+	} ),
+].filter( Boolean );
 const getProgressBarPluginConfig = ( name, fileSuffix ) => {
 	const isLegacy = fileSuffix && fileSuffix === 'legacy';
 	const progressBarPrefix = isLegacy ? 'Legacy ' : '';
@@ -137,6 +153,42 @@ woocommerce_blocks_env = ${ NODE_ENV }
 	};
 };
 
+const getCoreEditorConfig = ( options = {} ) => {
+	return {
+		...getCoreConfig( options ),
+		entry: {
+			blocksCheckout: './packages/checkout/index.js',
+		},
+		output: {
+			filename: ( chunkData ) => {
+				return `${ kebabCase( chunkData.chunk.name ) }-editor.js`;
+			},
+			path: path.resolve( __dirname, '../build/' ),
+			library: [ 'wc', '[name]-editor' ],
+			libraryTarget: 'this',
+			// This fixes an issue with multiple webpack projects using chunking
+			// overwriting each other's chunk loader function.
+			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
+			jsonpFunction: 'webpackWcBlocksJsonp',
+		},
+		plugins: [
+			...mainBlocksPlugins,
+			new ProgressBarPlugin(
+				getProgressBarPluginConfig( 'Core', options.fileSuffix )
+			),
+			new CreateFileWebpack( {
+				path: './',
+				// file name
+				fileName: 'blocks.ini',
+				// content of the file
+				content: `
+woocommerce_blocks_phase = ${ process.env.WOOCOMMERCE_BLOCKS_PHASE || 3 }
+woocommerce_blocks_env = ${ NODE_ENV }
+`.trim(),
+			} ),
+		],
+	};
+};
 const getMainConfig = ( options = {} ) => {
 	let { fileSuffix } = options;
 	const { alias, resolvePlugins = [] } = options;
@@ -207,7 +259,7 @@ const getMainConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...sharedPlugins,
+			...mainBlocksPlugins,
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Main', options.fileSuffix )
 			),
@@ -661,4 +713,5 @@ module.exports = {
 	getPaymentsConfig,
 	getExtensionsConfig,
 	getStylingConfig,
+	getCoreEditorConfig,
 };

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -164,7 +164,7 @@ const getCoreEditorConfig = ( options = {} ) => {
 				return `${ kebabCase( chunkData.chunk.name ) }-editor.js`;
 			},
 			path: path.resolve( __dirname, '../build/' ),
-			library: [ 'wc', '[name]-editor' ],
+			library: [ 'wc', '[name]' ],
 			libraryTarget: 'this',
 			// This fixes an issue with multiple webpack projects using chunking
 			// overwriting each other's chunk loader function.

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -153,6 +153,7 @@ woocommerce_blocks_env = ${ NODE_ENV }
 	};
 };
 
+// This is meant to fix issue #3839 in which we have two instances of SlotFillProvider context. Should be deleted once wordpress/gutenberg#27462.
 const getCoreEditorConfig = ( options = {} ) => {
 	return {
 		...getCoreConfig( options ),
@@ -259,7 +260,7 @@ const getMainConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...mainBlocksPlugins,
+			...sharedPlugins,
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Main', options.fileSuffix )
 			),

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -152,7 +152,7 @@ woocommerce_blocks_env = ${ NODE_ENV }
 		},
 	};
 };
-
+// @todo delete getCoreEditorConfig when wordpress/gutenberg#27462 or rquivalent is merged.
 // This is meant to fix issue #3839 in which we have two instances of SlotFillProvider context. Should be deleted once wordpress/gutenberg#27462.
 const getCoreEditorConfig = ( options = {} ) => {
 	return {

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -9,10 +9,7 @@ const CHECK_CIRCULAR_DEPS = process.env.CHECK_CIRCULAR_DEPS || false;
 
 // If a package is not available, or missing functionality, in an old but __supported__ version of WordPress, it should be listed here.
 // Some packages are not available in legacy versions of WordPress, so we don't want to extract them.
-const requiredPackagesInWPLegacy = [
-	// The package included in WP 5.4 version doesn't include `useResizeObserver`. This can be removed when we support 5.5+.
-	'@wordpress/compose',
-];
+const requiredPackagesInWPLegacy = [];
 
 const wcDepMap = {
 	'@woocommerce/blocks-registry': [ 'wc', 'wcBlocksRegistry' ],
@@ -109,6 +106,16 @@ const requestToExternal = ( request ) => {
 	}
 };
 
+const requestToExternalInsideGB = ( request ) => {
+	if ( request === 'wordpress-components' ) {
+		return [ 'wp', 'components' ];
+	}
+	if ( request === '@woocommerce/blocks-checkout' ) {
+		return [ 'wc', 'blocksCheckoutEditor' ];
+	}
+	return requestToExternal( request );
+};
+
 const requestToHandle = ( request ) => {
 	if ( requiredPackagesInWPLegacy.includes( request ) ) {
 		return false;
@@ -116,6 +123,16 @@ const requestToHandle = ( request ) => {
 	if ( wcHandleMap[ request ] ) {
 		return wcHandleMap[ request ];
 	}
+};
+
+const requestToHandleInsideGB = ( request ) => {
+	if ( request === 'wordpress-components' ) {
+		return 'wp-components';
+	}
+	if ( request === '@woocommerce/blocks-checkout' ) {
+		return 'wc-blocks-checkout-editor';
+	}
+	return requestToHandle( request );
 };
 
 module.exports = {
@@ -126,4 +143,6 @@ module.exports = {
 	findModuleMatch,
 	requestToHandle,
 	requestToExternal,
+	requestToHandleInsideGB,
+	requestToExternalInsideGB,
 };

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -110,9 +110,6 @@ const requestToExternalInsideGB = ( request ) => {
 	if ( request === 'wordpress-components' ) {
 		return [ 'wp', 'components' ];
 	}
-	if ( request === '@woocommerce/blocks-checkout' ) {
-		return [ 'wc', 'blocksCheckoutEditor' ];
-	}
 	return requestToExternal( request );
 };
 
@@ -128,9 +125,6 @@ const requestToHandle = ( request ) => {
 const requestToHandleInsideGB = ( request ) => {
 	if ( request === 'wordpress-components' ) {
 		return 'wp-components';
-	}
-	if ( request === '@woocommerce/blocks-checkout' ) {
-		return 'wc-blocks-checkout-editor';
 	}
 	return requestToHandle( request );
 };

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -61,6 +61,7 @@ final class AssetsController {
 
 		if ( Package::feature()->is_feature_plugin_build() ) {
 			$this->api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [] );
+			$this->api->register_script( 'wc-blocks-checkout-editor', 'build/blocks-checkout-editor.js', [] );
 		}
 
 		wp_add_inline_script(

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -60,8 +60,7 @@ final class AssetsController {
 		$this->api->register_script( 'wc-price-format', 'build/price-format.js', [], false );
 
 		if ( Package::feature()->is_feature_plugin_build() ) {
-			$this->api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [] );
-			$this->api->register_script( 'wc-blocks-checkout-editor', 'build/blocks-checkout-editor.js', [] );
+			$this->api->register_script( 'wc-blocks-checkout', is_admin() ? 'build/blocks-checkout-editor.js' : 'build/blocks-checkout.js', [] );
 		}
 
 		wp_add_inline_script(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ const {
 	getPaymentsConfig,
 	getExtensionsConfig,
 	getStylingConfig,
+	getCoreEditorConfig,
 } = require( './bin/webpack-configs.js' );
 
 // Only options shared between all configs should be defined here.
@@ -37,6 +38,12 @@ const sharedConfig = {
 const CoreConfig = {
 	...sharedConfig,
 	...getCoreConfig( { alias: getAlias() } ),
+};
+
+// Core config for shared libraries to be run inside the editor.
+const CoreEditorConfig = {
+	...sharedConfig,
+	...getCoreEditorConfig( { alias: getAlias() } ),
 };
 
 // Main Blocks config for registering Blocks and for the Editor.
@@ -166,4 +173,5 @@ module.exports = [
 	ExtensionsConfig,
 	PaymentsConfig,
 	StylingConfig,
+	CoreEditorConfig,
 ];


### PR DESCRIPTION
Fixes #3839

This PR fixes the issue with duplicate plugins in the editor.

It does that by creating two output files of `blocks-checkout` one that includes wp.components and one that uses the external value.

The first is loaded in frontend, the second is loaded inside wp-admin.

### Testing instructions
- Install Jetpack or Yoast SEO and enable it.
- Install WC Subscriptions 3.1 or a branch that contains our built integration code.
- Load the editor with Cart or Checkout block, make sure both blocks render fine.
- There should be a single Yoast or Jetpack icon and a single panel only, not two.
- Load the block in frontend, add subscription product to your cart.
- Subscription integration (recurring totals, future shipping) should load fine.
- There should be no console issues.

## Changelog
> Fixes an issue where plugins like Yoast and Jetpack are duplicated inside the editor when Cart or Checkout blocks are present.