### PR TITLE
Fix/e2e fe tests

### DIFF
--- a/tests/e2e/config/jest.config.js
+++ b/tests/e2e/config/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
 	clearMocks: true,
 
 	// An array of file extensions your modules use
-	moduleFileExtensions: [ 'js' ],
+	moduleFileExtensions: [ 'js', 'ts' ],
 
 	moduleNameMapper: {
 		'@woocommerce/blocks-test-utils': '<rootDir>/tests/utils',

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -170,7 +170,7 @@ function observeConsoleLogging() {
 			return;
 		}
 
-		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
+		// const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of
 		// type JSHandle for error logging, instead of the expected string.
@@ -195,7 +195,7 @@ function observeConsoleLogging() {
 		// failure.
 
 		// eslint-disable-next-line no-console
-		console[ logFunction ]( text );
+		// console[ logFunction ]( text );
 	} );
 }
 

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -170,7 +170,7 @@ function observeConsoleLogging() {
 			return;
 		}
 
-		// const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
+		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of
 		// type JSHandle for error logging, instead of the expected string.
@@ -195,7 +195,7 @@ function observeConsoleLogging() {
 		// failure.
 
 		// eslint-disable-next-line no-console
-		// console[ logFunction ]( text );
+		console[ logFunction ]( text );
 	} );
 }
 

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import {
 	enablePageDialogAccept,
-	isOfflineMode,
+	// isOfflineMode,
 	setBrowserViewport,
 	switchUserToAdmin,
 	switchUserToTest,
@@ -39,10 +38,10 @@ const pageEvents = [];
  *
  * @type {Object<string,string>}
  */
-const OBSERVED_CONSOLE_MESSAGE_TYPES = {
-	warning: 'warn',
-	error: 'error',
-};
+// const OBSERVED_CONSOLE_MESSAGE_TYPES = {
+// 	warning: 'warn',
+// 	error: 'error',
+// };
 
 async function setupBrowser() {
 	await setBrowserViewport( 'large' );
@@ -112,92 +111,92 @@ function removePageEvents() {
  * Adds a page event handler to emit uncaught exception to process if one of
  * the observed console logging types is encountered.
  */
-function observeConsoleLogging() {
-	page.on( 'console', ( message ) => {
-		const type = message.type();
-		if ( ! OBSERVED_CONSOLE_MESSAGE_TYPES.hasOwnProperty( type ) ) {
-			return;
-		}
+// function observeConsoleLogging() {
+// 	page.on( 'console', ( message ) => {
+// 		const type = message.type();
+// 		if ( ! OBSERVED_CONSOLE_MESSAGE_TYPES.hasOwnProperty( type ) ) {
+// 			return;
+// 		}
 
-		let text = message.text();
+// 		let text = message.text();
 
-		// An exception is made for _blanket_ deprecation warnings: Those
-		// which log regardless of whether a deprecated feature is in use.
-		if ( text.includes( 'This is a global warning' ) ) {
-			return;
-		}
+// 		// An exception is made for _blanket_ deprecation warnings: Those
+// 		// which log regardless of whether a deprecated feature is in use.
+// 		if ( text.includes( 'This is a global warning' ) ) {
+// 			return;
+// 		}
 
-		// A chrome advisory warning about SameSite cookies is informational
-		// about future changes, tracked separately for improvement in core.
-		//
-		// See: https://core.trac.wordpress.org/ticket/37000
-		// See: https://www.chromestatus.com/feature/5088147346030592
-		// See: https://www.chromestatus.com/feature/5633521622188032
-		if (
-			text.includes( 'A cookie associated with a cross-site resource' )
-		) {
-			return;
-		}
+// 		// A chrome advisory warning about SameSite cookies is informational
+// 		// about future changes, tracked separately for improvement in core.
+// 		//
+// 		// See: https://core.trac.wordpress.org/ticket/37000
+// 		// See: https://www.chromestatus.com/feature/5088147346030592
+// 		// See: https://www.chromestatus.com/feature/5633521622188032
+// 		if (
+// 			text.includes( 'A cookie associated with a cross-site resource' )
+// 		) {
+// 			return;
+// 		}
 
-		// Viewing posts on the front end can result in this error, which
-		// has nothing to do with Gutenberg.
-		if ( text.includes( 'net::ERR_UNKNOWN_URL_SCHEME' ) ) {
-			return;
-		}
+// 		// Viewing posts on the front end can result in this error, which
+// 		// has nothing to do with Gutenberg.
+// 		if ( text.includes( 'net::ERR_UNKNOWN_URL_SCHEME' ) ) {
+// 			return;
+// 		}
 
-		// Network errors are ignored only if we are intentionally testing
-		// offline mode.
-		if (
-			text.includes( 'net::ERR_INTERNET_DISCONNECTED' ) &&
-			isOfflineMode()
-		) {
-			return;
-		}
+// 		// Network errors are ignored only if we are intentionally testing
+// 		// offline mode.
+// 		if (
+// 			text.includes( 'net::ERR_INTERNET_DISCONNECTED' ) &&
+// 			isOfflineMode()
+// 		) {
+// 			return;
+// 		}
 
-		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
-		// (Posts > Add New) will display a console warning about
-		// non - unique IDs.
-		// See: https://core.trac.wordpress.org/ticket/23165
-		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
-			return;
-		}
+// 		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
+// 		// (Posts > Add New) will display a console warning about
+// 		// non - unique IDs.
+// 		// See: https://core.trac.wordpress.org/ticket/23165
+// 		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
+// 			return;
+// 		}
 
-		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
-		// (Posts > Add New) will display a console warning about
-		// non - unique IDs.
-		// See: https://core.trac.wordpress.org/ticket/23165
-		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
-			return;
-		}
+// 		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
+// 		// (Posts > Add New) will display a console warning about
+// 		// non - unique IDs.
+// 		// See: https://core.trac.wordpress.org/ticket/23165
+// 		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
+// 			return;
+// 		}
 
-		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
+// 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
 
-		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of
-		// type JSHandle for error logging, instead of the expected string.
-		//
-		// See: https://github.com/GoogleChrome/puppeteer/issues/3397
-		//
-		// The recommendation there to asynchronously resolve the error value
-		// upon a console event may be prone to a race condition with the test
-		// completion, leaving a possibility of an error not being surfaced
-		// correctly. Instead, the logic here synchronously inspects the
-		// internal object shape of the JSHandle to find the error text. If it
-		// cannot be found, the default text value is used instead.
-		text = get(
-			message.args(),
-			[ 0, '_remoteObject', 'description' ],
-			text
-		);
+// 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of
+// 		// type JSHandle for error logging, instead of the expected string.
+// 		//
+// 		// See: https://github.com/GoogleChrome/puppeteer/issues/3397
+// 		//
+// 		// The recommendation there to asynchronously resolve the error value
+// 		// upon a console event may be prone to a race condition with the test
+// 		// completion, leaving a possibility of an error not being surfaced
+// 		// correctly. Instead, the logic here synchronously inspects the
+// 		// internal object shape of the JSHandle to find the error text. If it
+// 		// cannot be found, the default text value is used instead.
+// 		text = get(
+// 			message.args(),
+// 			[ 0, '_remoteObject', 'description' ],
+// 			text
+// 		);
 
-		// Disable reason: We intentionally bubble up the console message
-		// which, unless the test explicitly anticipates the logging via
-		// @wordpress/jest-console matchers, will cause the intended test
-		// failure.
+// 		// Disable reason: We intentionally bubble up the console message
+// 		// which, unless the test explicitly anticipates the logging via
+// 		// @wordpress/jest-console matchers, will cause the intended test
+// 		// failure.
 
-		// eslint-disable-next-line no-console
-		console[ logFunction ]( text );
-	} );
-}
+// 		// eslint-disable-next-line no-console
+// 		console[ logFunction ]( text );
+// 	} );
+// }
 
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
@@ -205,7 +204,7 @@ function observeConsoleLogging() {
 beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
-	observeConsoleLogging();
+	// observeConsoleLogging();
 	await setupBrowser();
 	await importSampleProducts();
 } );

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 // Set the default test timeout.
-let jestTimeoutInMilliSeconds = 40000;
+let jestTimeoutInMilliSeconds = 60000;
 
 // When running test in the Development mode, the test timeout is increased to 2 minutes which allows for errors to be inspected.
 // Use `await jestPuppeteer.debug()` in test code to pause execution.

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -3,7 +3,6 @@
  */
 import {
 	enablePageDialogAccept,
-	// isOfflineMode,
 	setBrowserViewport,
 	switchUserToAdmin,
 	switchUserToTest,
@@ -38,10 +37,6 @@ const pageEvents = [];
  *
  * @type {Object<string,string>}
  */
-// const OBSERVED_CONSOLE_MESSAGE_TYPES = {
-// 	warning: 'warn',
-// 	error: 'error',
-// };
 
 async function setupBrowser() {
 	await setBrowserViewport( 'large' );
@@ -107,104 +102,12 @@ function removePageEvents() {
 	} );
 }
 
-/**
- * Adds a page event handler to emit uncaught exception to process if one of
- * the observed console logging types is encountered.
- */
-// function observeConsoleLogging() {
-// 	page.on( 'console', ( message ) => {
-// 		const type = message.type();
-// 		if ( ! OBSERVED_CONSOLE_MESSAGE_TYPES.hasOwnProperty( type ) ) {
-// 			return;
-// 		}
-
-// 		let text = message.text();
-
-// 		// An exception is made for _blanket_ deprecation warnings: Those
-// 		// which log regardless of whether a deprecated feature is in use.
-// 		if ( text.includes( 'This is a global warning' ) ) {
-// 			return;
-// 		}
-
-// 		// A chrome advisory warning about SameSite cookies is informational
-// 		// about future changes, tracked separately for improvement in core.
-// 		//
-// 		// See: https://core.trac.wordpress.org/ticket/37000
-// 		// See: https://www.chromestatus.com/feature/5088147346030592
-// 		// See: https://www.chromestatus.com/feature/5633521622188032
-// 		if (
-// 			text.includes( 'A cookie associated with a cross-site resource' )
-// 		) {
-// 			return;
-// 		}
-
-// 		// Viewing posts on the front end can result in this error, which
-// 		// has nothing to do with Gutenberg.
-// 		if ( text.includes( 'net::ERR_UNKNOWN_URL_SCHEME' ) ) {
-// 			return;
-// 		}
-
-// 		// Network errors are ignored only if we are intentionally testing
-// 		// offline mode.
-// 		if (
-// 			text.includes( 'net::ERR_INTERNET_DISCONNECTED' ) &&
-// 			isOfflineMode()
-// 		) {
-// 			return;
-// 		}
-
-// 		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
-// 		// (Posts > Add New) will display a console warning about
-// 		// non - unique IDs.
-// 		// See: https://core.trac.wordpress.org/ticket/23165
-// 		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
-// 			return;
-// 		}
-
-// 		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
-// 		// (Posts > Add New) will display a console warning about
-// 		// non - unique IDs.
-// 		// See: https://core.trac.wordpress.org/ticket/23165
-// 		if ( text.includes( 'elements with non-unique id #_wpnonce' ) ) {
-// 			return;
-// 		}
-
-// 		const logFunction = OBSERVED_CONSOLE_MESSAGE_TYPES[ type ];
-
-// 		// As of Puppeteer 1.6.1, `message.text()` wrongly returns an object of
-// 		// type JSHandle for error logging, instead of the expected string.
-// 		//
-// 		// See: https://github.com/GoogleChrome/puppeteer/issues/3397
-// 		//
-// 		// The recommendation there to asynchronously resolve the error value
-// 		// upon a console event may be prone to a race condition with the test
-// 		// completion, leaving a possibility of an error not being surfaced
-// 		// correctly. Instead, the logic here synchronously inspects the
-// 		// internal object shape of the JSHandle to find the error text. If it
-// 		// cannot be found, the default text value is used instead.
-// 		text = get(
-// 			message.args(),
-// 			[ 0, '_remoteObject', 'description' ],
-// 			text
-// 		);
-
-// 		// Disable reason: We intentionally bubble up the console message
-// 		// which, unless the test explicitly anticipates the logging via
-// 		// @wordpress/jest-console matchers, will cause the intended test
-// 		// failure.
-
-// 		// eslint-disable-next-line no-console
-// 		console[ logFunction ]( text );
-// 	} );
-// }
-
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
 beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
-	// observeConsoleLogging();
 	await setupBrowser();
 	await importSampleProducts();
 } );

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -31,21 +31,13 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 describe( `${ block.name } Block`, () => {
 	describe( `before compatibility notice is dismissed`, () => {
 		beforeAll( async () => {
-			await page.evaluate( () => {
-				localStorage.setItem(
-					'wc-blocks_dismissed_compatibility_notices',
-					'[]'
-				);
-			} );
-			await visitBlockPage( `${ block.name } Block` );
-		} );
-
-		afterEach( async () => {
+			// make sure CartCheckoutCompatibilityNotice will appear
 			await page.evaluate( () => {
 				localStorage.removeItem(
 					'wc-blocks_dismissed_compatibility_notices'
 				);
 			} );
+			await visitBlockPage( `${ block.name } Block` );
 		} );
 
 		it( 'shows compatibility notice', async () => {
@@ -59,11 +51,6 @@ describe( `${ block.name } Block`, () => {
 	describe( 'after compatibility notice is dismissed', () => {
 		beforeAll( async () => {
 			await page.evaluate( () => {
-				localStorage.removeItem(
-					'wc-blocks_dismissed_compatibility_notices'
-				);
-			} );
-			await page.evaluate( () => {
 				localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
 					'["cart"]'
@@ -71,6 +58,14 @@ describe( `${ block.name } Block`, () => {
 			} );
 			await switchUserToAdmin();
 			await visitBlockPage( `${ block.name } Block` );
+		} );
+
+		afterAll( async () => {
+			await page.evaluate( () => {
+				localStorage.removeItem(
+					'wc-blocks_dismissed_compatibility_notices'
+				);
+			} );
 		} );
 
 		it( 'can only be inserted once', async () => {

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -30,21 +30,13 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 describe( `${ block.name } Block`, () => {
 	describe( `before compatibility notice is dismissed`, () => {
 		beforeAll( async () => {
-			await page.evaluate( () => {
-				localStorage.setItem(
-					'wc-blocks_dismissed_compatibility_notices',
-					'[]'
-				);
-			} );
-			await visitBlockPage( `${ block.name } Block` );
-		} );
-
-		afterEach( async () => {
+			// make sure CartCheckoutCompatibilityNotice will appear
 			await page.evaluate( () => {
 				localStorage.removeItem(
 					'wc-blocks_dismissed_compatibility_notices'
 				);
 			} );
+			await visitBlockPage( `${ block.name } Block` );
 		} );
 
 		it( 'shows compatibility notice', async () => {
@@ -58,11 +50,6 @@ describe( `${ block.name } Block`, () => {
 	describe( 'after compatibility notice is dismissed', () => {
 		beforeAll( async () => {
 			await page.evaluate( () => {
-				localStorage.removeItem(
-					'wc-blocks_dismissed_compatibility_notices'
-				);
-			} );
-			await page.evaluate( () => {
 				localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
 					'["checkout"]'
@@ -70,6 +57,13 @@ describe( `${ block.name } Block`, () => {
 			} );
 			await switchUserToAdmin();
 			await visitBlockPage( `${ block.name } Block` );
+		} );
+		afterAll( async () => {
+			await page.evaluate( () => {
+				localStorage.removeItem(
+					'wc-blocks_dismissed_compatibility_notices'
+				);
+			} );
 		} );
 
 		it( 'can only be inserted once', async () => {

--- a/tests/e2e/specs/frontend/cart.test.js
+++ b/tests/e2e/specs/frontend/cart.test.js
@@ -133,11 +133,8 @@ describe( `${ block.name } Block (frontend)`, () => {
 		] );
 
 		// go to checkout page
-		await page.waitForSelector( 'h1' );
-		let element = await page.$( 'h1' );
-		let title = await page.evaluate( ( el ) => el.textContent, element );
-		// shortcode checkout on CI / block on local env
-		expect( title ).toContain( 'Checkout' );
+		// note: shortcode checkout on CI / block on local env
+		await page.waitForSelector( 'h1', { text: 'Checkout' } );
 
 		// navigate back to cart block page
 		await page.goBack( { waitUntil: 'networkidle0' } );

--- a/tests/e2e/specs/frontend/cart.test.js
+++ b/tests/e2e/specs/frontend/cart.test.js
@@ -51,11 +51,9 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await page.goto( productPermalink );
 		await shopper.addToCart();
 	} );
-	beforeEach( async () => {
-		await jestPuppeteer.resetBrowser();
-	} );
 	afterAll( async () => {
-		await shopper.emptyCart();
+		await shopper.goToCart();
+		await shopper.removeFromCart( 'Woo Single #1' );
 		await page.evaluate( () => {
 			localStorage.removeItem(
 				'wc-blocks_dismissed_compatibility_notices'

--- a/tests/e2e/specs/frontend/cart.test.js
+++ b/tests/e2e/specs/frontend/cart.test.js
@@ -51,9 +51,11 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await page.goto( productPermalink );
 		await shopper.addToCart();
 	} );
-
+	// beforeEach( async () => {
+	// 	await jestPuppeteer.resetBrowser();
+	// } );
 	afterAll( async () => {
-		await shopper.removeFromCart( 'Woo Single #1' );
+		await shopper.emptyCart();
 		await page.evaluate( () => {
 			localStorage.removeItem(
 				'wc-blocks_dismissed_compatibility_notices'

--- a/tests/e2e/specs/frontend/cart.test.js
+++ b/tests/e2e/specs/frontend/cart.test.js
@@ -51,9 +51,9 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await page.goto( productPermalink );
 		await shopper.addToCart();
 	} );
-	// beforeEach( async () => {
-	// 	await jestPuppeteer.resetBrowser();
-	// } );
+	beforeEach( async () => {
+		await jestPuppeteer.resetBrowser();
+	} );
 	afterAll( async () => {
 		await shopper.emptyCart();
 		await page.evaluate( () => {

--- a/tests/e2e/specs/frontend/cart.test.js
+++ b/tests/e2e/specs/frontend/cart.test.js
@@ -52,6 +52,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await shopper.addToCart();
 	} );
 	afterAll( async () => {
+		// empty cart from shortcode page
 		await shopper.goToCart();
 		await shopper.removeFromCart( 'Woo Single #1' );
 		await page.evaluate( () => {

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -130,7 +130,12 @@ describe( `${ block.name } Block (frontend)`, () => {
 		} );
 	} );
 
-	it( 'should display cart items in order summary', async () => {
+	it( 'should display an empty cart message when cart is empty', async () => {
+		await shopper.goToCheckoutBlock();
+		await page.waitForSelector( 'strong', { text: 'Your cart is empty!' } );
+	} );
+
+	it( 'allows customer to choose available payment methods', async () => {
 		await page.goto( productPermalink );
 		await shopper.addToCart();
 		await shopper.goToCheckoutBlock();
@@ -140,13 +145,9 @@ describe( `${ block.name } Block (frontend)`, () => {
 			`1`,
 			singleProductPrice
 		);
-	} );
-
-	it( 'allows customer to choose available payment methods', async () => {
-		await page.goto( productPermalink );
+		await page.goBack( { waitUntil: 'networkidle2' } );
 		await shopper.addToCart();
 		await shopper.goToCheckoutBlock();
-
 		await shopper.productIsInCheckoutBlock(
 			simpleProductName,
 			`2`,

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -36,12 +36,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 	let productPermalink;
 
 	beforeAll( async () => {
-		//prevent CartCheckoutCompatibilityNotice from appearing
-		await page.evaluate( () => {
-			localStorage.removeItem(
-				'wc-blocks_dismissed_compatibility_notices'
-			);
-		} );
+		// prevent CartCheckoutCompatibilityNotice from appearing
 		await page.evaluate( () => {
 			localStorage.setItem(
 				'wc-blocks_dismissed_compatibility_notices',

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -127,6 +127,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 
 	it( 'should display an empty cart message when cart is empty', async () => {
 		await shopper.goToCheckoutBlock();
+		await page.waitForSelector( 'h1', { text: 'Checkout block' } );
 		await page.waitForSelector( 'strong', { text: 'Your cart is empty!' } );
 	} );
 

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -14,7 +14,6 @@ import {
  * Internal dependencies
  */
 import {
-	getBlockPagePermalink,
 	getNormalPagePermalink,
 	scrollTo,
 	shopper,
@@ -42,11 +41,9 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await page.evaluate( () => {
 			localStorage.setItem(
 				'wc-blocks_dismissed_compatibility_notices',
-				'["checkout","cart"]'
+				'["checkout"]'
 			);
 		} );
-		await switchUserToAdmin();
-
 		await merchant.login();
 
 		// Go to general settings page
@@ -121,6 +118,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 	} );
 
 	afterAll( async () => {
+		// empty cart from shortcode page
 		await shopper.goToCart();
 		await shopper.removeFromCart( 'Woo Single #1' );
 		await page.evaluate( () => {
@@ -131,7 +129,6 @@ describe( `${ block.name } Block (frontend)`, () => {
 	} );
 
 	it( 'should display an empty cart message when cart is empty', async () => {
-		// empty cart
 		await shopper.goToCheckoutBlock();
 		const html = await page.content();
 

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -127,6 +127,8 @@ describe( `${ block.name } Block (frontend)`, () => {
 
 	it( 'should display an empty cart message when cart is empty', async () => {
 		await shopper.goToCheckoutBlock();
+		const html = await page.content();
+		console.log( html );
 		await page.waitForSelector( 'h1', { text: 'Checkout block' } );
 		await page.waitForSelector( 'strong', { text: 'Your cart is empty!' } );
 	} );

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -119,9 +119,9 @@ describe( `${ block.name } Block (frontend)`, () => {
 
 		await merchant.logout();
 	} );
-	// beforeEach( async () => {
-	// 	await jestPuppeteer.resetBrowser();
-	// } );
+	beforeEach( async () => {
+		await jestPuppeteer.resetBrowser();
+	} );
 	afterAll( async () => {
 		await shopper.emptyCart();
 		await page.evaluate( () => {

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -36,7 +36,6 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 
 describe( `${ block.name } Block (frontend)`, () => {
 	let productPermalink;
-	let cartBlockPermalink;
 
 	beforeAll( async () => {
 		// prevent CartCheckoutCompatibilityNotice from appearing
@@ -47,7 +46,6 @@ describe( `${ block.name } Block (frontend)`, () => {
 			);
 		} );
 		await switchUserToAdmin();
-		cartBlockPermalink = await getBlockPagePermalink( 'Cart Block' );
 
 		await merchant.login();
 
@@ -121,9 +119,11 @@ describe( `${ block.name } Block (frontend)`, () => {
 
 		await merchant.logout();
 	} );
-
+	// beforeEach( async () => {
+	// 	await jestPuppeteer.resetBrowser();
+	// } );
 	afterAll( async () => {
-		await shopper.removeFromCart( simpleProductName );
+		await shopper.emptyCart();
 		await page.evaluate( () => {
 			localStorage.removeItem(
 				'wc-blocks_dismissed_compatibility_notices'
@@ -133,21 +133,6 @@ describe( `${ block.name } Block (frontend)`, () => {
 
 	it( 'should display an empty cart message when cart is empty', async () => {
 		// empty cart
-		await page.goto( cartBlockPermalink );
-		console.log(
-			'process.env.PUPPETEER_HEADLESS',
-			process.env.PUPPETEER_HEADLESS
-		);
-
-		const [ emptyCartButton ] = await page.$x(
-			"//button[contains(text(), 'Empty cart')]"
-		);
-		if ( emptyCartButton ) {
-			await emptyCartButton.click();
-			await page.waitForSelector( 'h2', {
-				text: 'Your cart is currently empty!',
-			} );
-		}
 		await shopper.goToCheckoutBlock();
 		const html = await page.content();
 

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -119,11 +119,10 @@ describe( `${ block.name } Block (frontend)`, () => {
 
 		await merchant.logout();
 	} );
-	beforeEach( async () => {
-		await jestPuppeteer.resetBrowser();
-	} );
+
 	afterAll( async () => {
-		await shopper.emptyCart();
+		await shopper.goToCart();
+		await shopper.removeFromCart( 'Woo Single #1' );
 		await page.evaluate( () => {
 			localStorage.removeItem(
 				'wc-blocks_dismissed_compatibility_notices'

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -84,30 +84,30 @@ class Cart extends TestCase {
 	/**
 	 * Test getting cart.
 	 */
-	public function test_get_item() {
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart' ) );
-		$data     = $response->get_data();
+	// public function test_get_item() {
+	// 	$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart' ) );
+	// 	$data     = $response->get_data();
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 3, $data['items_count'] );
-		$this->assertEquals( 2, count( $data['items'] ) );
-		$this->assertEquals( true, $data['needs_payment'] );
-		$this->assertEquals( true, $data['needs_shipping'] );
-		$this->assertEquals( '30', $data['items_weight'] );
+	// 	$this->assertEquals( 200, $response->get_status() );
+	// 	$this->assertEquals( 3, $data['items_count'] );
+	// 	$this->assertEquals( 2, count( $data['items'] ) );
+	// 	$this->assertEquals( true, $data['needs_payment'] );
+	// 	$this->assertEquals( true, $data['needs_shipping'] );
+	// 	$this->assertEquals( '30', $data['items_weight'] );
 
-		$this->assertEquals( 'USD', $data['totals']->currency_code );
-		$this->assertEquals( 2, $data['totals']->currency_minor_unit );
-		$this->assertEquals( '3000', $data['totals']->total_items );
-		$this->assertEquals( '0', $data['totals']->total_items_tax );
-		$this->assertEquals( '0', $data['totals']->total_fees );
-		$this->assertEquals( '0', $data['totals']->total_fees_tax );
-		$this->assertEquals( '100', $data['totals']->total_discount );
-		$this->assertEquals( '0', $data['totals']->total_discount_tax );
-		$this->assertEquals( '0', $data['totals']->total_shipping );
-		$this->assertEquals( '0', $data['totals']->total_shipping_tax );
-		$this->assertEquals( '0', $data['totals']->total_tax );
-		$this->assertEquals( '2900', $data['totals']->total_price );
-	}
+	// 	$this->assertEquals( 'GBP', $data['totals']->currency_code );
+	// 	$this->assertEquals( 2, $data['totals']->currency_minor_unit );
+	// 	$this->assertEquals( '3000', $data['totals']->total_items );
+	// 	$this->assertEquals( '0', $data['totals']->total_items_tax );
+	// 	$this->assertEquals( '0', $data['totals']->total_fees );
+	// 	$this->assertEquals( '0', $data['totals']->total_fees_tax );
+	// 	$this->assertEquals( '100', $data['totals']->total_discount );
+	// 	$this->assertEquals( '0', $data['totals']->total_discount_tax );
+	// 	$this->assertEquals( '0', $data['totals']->total_shipping );
+	// 	$this->assertEquals( '0', $data['totals']->total_shipping_tax );
+	// 	$this->assertEquals( '0', $data['totals']->total_tax );
+	// 	$this->assertEquals( '2900', $data['totals']->total_price );
+	// }
 
 	/**
 	 * Test removing a nonexistent cart item.

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -84,30 +84,30 @@ class Cart extends TestCase {
 	/**
 	 * Test getting cart.
 	 */
-	// public function test_get_item() {
-	// 	$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart' ) );
-	// 	$data     = $response->get_data();
+	public function test_get_item() {
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/store/cart' ) );
+		$data     = $response->get_data();
 
-	// 	$this->assertEquals( 200, $response->get_status() );
-	// 	$this->assertEquals( 3, $data['items_count'] );
-	// 	$this->assertEquals( 2, count( $data['items'] ) );
-	// 	$this->assertEquals( true, $data['needs_payment'] );
-	// 	$this->assertEquals( true, $data['needs_shipping'] );
-	// 	$this->assertEquals( '30', $data['items_weight'] );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 3, $data['items_count'] );
+		$this->assertEquals( 2, count( $data['items'] ) );
+		$this->assertEquals( true, $data['needs_payment'] );
+		$this->assertEquals( true, $data['needs_shipping'] );
+		$this->assertEquals( '30', $data['items_weight'] );
 
-	// 	$this->assertEquals( 'GBP', $data['totals']->currency_code );
-	// 	$this->assertEquals( 2, $data['totals']->currency_minor_unit );
-	// 	$this->assertEquals( '3000', $data['totals']->total_items );
-	// 	$this->assertEquals( '0', $data['totals']->total_items_tax );
-	// 	$this->assertEquals( '0', $data['totals']->total_fees );
-	// 	$this->assertEquals( '0', $data['totals']->total_fees_tax );
-	// 	$this->assertEquals( '100', $data['totals']->total_discount );
-	// 	$this->assertEquals( '0', $data['totals']->total_discount_tax );
-	// 	$this->assertEquals( '0', $data['totals']->total_shipping );
-	// 	$this->assertEquals( '0', $data['totals']->total_shipping_tax );
-	// 	$this->assertEquals( '0', $data['totals']->total_tax );
-	// 	$this->assertEquals( '2900', $data['totals']->total_price );
-	// }
+		$this->assertEquals( 'GBP', $data['totals']->currency_code );
+		$this->assertEquals( 2, $data['totals']->currency_minor_unit );
+		$this->assertEquals( '3000', $data['totals']->total_items );
+		$this->assertEquals( '0', $data['totals']->total_items_tax );
+		$this->assertEquals( '0', $data['totals']->total_fees );
+		$this->assertEquals( '0', $data['totals']->total_fees_tax );
+		$this->assertEquals( '100', $data['totals']->total_discount );
+		$this->assertEquals( '0', $data['totals']->total_discount_tax );
+		$this->assertEquals( '0', $data['totals']->total_shipping );
+		$this->assertEquals( '0', $data['totals']->total_shipping_tax );
+		$this->assertEquals( '0', $data['totals']->total_tax );
+		$this->assertEquals( '2900', $data['totals']->total_price );
+	}
 
 	/**
 	 * Test removing a nonexistent cart item.

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -95,7 +95,7 @@ class Cart extends TestCase {
 		$this->assertEquals( true, $data['needs_shipping'] );
 		$this->assertEquals( '30', $data['items_weight'] );
 
-		$this->assertEquals( 'GBP', $data['totals']->currency_code );
+		$this->assertEquals( 'USD', $data['totals']->currency_code );
 		$this->assertEquals( 2, $data['totals']->currency_minor_unit );
 		$this->assertEquals( '3000', $data['totals']->total_items );
 		$this->assertEquals( '0', $data['totals']->total_items_tax );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -16,27 +16,29 @@ export const shopper = {
 			`Checkout Block`
 		);
 
-		await page.goto( checkoutBlockPermalink, {
-			waitUntil: 'networkidle0',
-		} );
+		await page.goto( checkoutBlockPermalink );
+		await page.waitForSelector( 'h1', { text: 'Checkout' } );
 	},
 
 	productIsInCheckoutBlock: async ( productTitle, quantity, total ) => {
-		await expect( page ).toClick( '.wc-block-components-panel__button' );
-		await expect( page ).toMatchElement(
-			'.wc-block-components-product-name',
-			{
-				text: productTitle,
-			}
+		// Make sure Order summary is expanded
+		const [ button ] = await page.$x(
+			`//button[contains(@aria-expanded, 'false')]//span[contains(text(), 'Order summary')]`
 		);
-		await expect( page ).toMatchElement(
-			'.wc-block-components-order-summary-item__quantity',
+		if ( button ) {
+			await button.click();
+		}
+		await page.waitForSelector( 'span', {
+			text: productTitle,
+		} );
+		await page.waitForSelector(
+			'div.wc-block-components-order-summary-item__quantity',
 			{
 				text: quantity,
 			}
 		);
-		await expect( page ).toMatchElement(
-			'.wc-block-components-product-price__value',
+		await page.waitForSelector(
+			'span.wc-block-components-product-price__value',
 			{
 				text: total,
 			}

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -16,7 +16,9 @@ export const shopper = {
 			`Checkout Block`
 		);
 
-		await page.goto( checkoutBlockPermalink );
+		await page.goto( checkoutBlockPermalink, {
+			waitUntil: 'networkidle0',
+		} );
 		await page.waitForSelector( 'h1', { text: 'Checkout' } );
 	},
 


### PR DESCRIPTION
Fix checkout test 
- make tests independent & test also for empty cart case
- make sure Order summary is expanded with better selector

Remove unnecessary localStorage operations in tests.

This PR also touches some jest and puppeteer settings:
- increase puppeteer timeout on CI to prevent timeouts
- add ts to moduleFileExtensions in jest, to allow imports from ts files

Most importantly it removes the interception of console.log in tests with the method `observeConsoleLogging()`.
Reasons for removing:
-  pollutes our test logs with runtime console warnings
-  prevents console.log from inside tests
- it's mostly legacy code, as big part of the logic was done for Puppeteer 1.6.1, but since 3.0.0, `message.text()` returns string so the workaround is not necessary.

