### PR TITLE
Block Widgets: hide All Products and Filter blocks in the Customizer

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -118,7 +118,7 @@ final class BlockTypesController {
 		/**
 		 * This disables specific blocks in Widget Areas by not registering them.
 		 */
-		if ( 'themes.php' === $pagenow ) {
+		if ( in_array( $pagenow, [ 'themes.php', 'customize.php' ], true ) ) {
 			$block_types = array_diff(
 				$block_types,
 				[


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4217

This PR builds upon our workaround introduced in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3737 to hide the All Products and Filter blocks in the new Widget Editor. With this change, the blocks will now be hidden in the Customizer as well.

**Note:** This is a temporary workaround until we have a native way of excluding blocks from widget areas. You can find the related core issue here https://github.com/WordPress/gutenberg/issues/28517.

|Before|After|
|-|-|
|<img width="768" alt="Screenshot 2021-05-18 at 13 50 13" src="https://user-images.githubusercontent.com/1562646/118646078-033fc400-b7e0-11eb-803e-016f7adab2ee.png">|<img width="781" alt="Screenshot 2021-05-18 at 13 49 10" src="https://user-images.githubusercontent.com/1562646/118646088-06d34b00-b7e0-11eb-88b3-1b1fc2ecf3d3.png">|

### How to test the changes in this Pull Request:

1. Ensure Gutenberg feature plugin is enabled. To enable block widgets in the Customizer, go to Gutenberg -> Experiments and check the checkbox next to Widgets. After you’ve saved the experimental settings, navigate to Appearance -> Customize -> Widgets.
2. Go to Sidebar widgets and try to insert "All Products", "Price Filter", "Attribute Filter", and "Active Filter" blocks. You shouldn't be able to see them in the inspector!
3. Edit a page and try to insert "All Products", "Price Filter", "Attribute Filter", and "Active Filter" blocks. It should work as expected.

<!-- If you can, add the appropriate labels -->

### Changelog

> Hide the All Products Block from the Customizer Widget Areas until full support is achieved.