### PR TITLE
Block Widgets: hide legacy widgets with a feature-complete block equivalent

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -85,7 +85,7 @@ final class BlockTypesController {
 	 * @return array $widget_types An array inluding the WooCommerce widgets to hide.
 	 */
 	public function hide_legacy_widgets_with_block_equivalent( $widget_types ) {
-		array_push( $widget_types, 'woocommerce_product_search', 'woocommerce_product_categories', 'woocommerce_products', 'woocommerce_top_rated_products', 'woocommerce_recent_reviews' );
+		array_push( $widget_types, 'woocommerce_product_search', 'woocommerce_product_categories', 'woocommerce_recent_reviews' );
 		return $widget_types;
 	}
 

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -47,6 +47,7 @@ final class BlockTypesController {
 	protected function init() {
 		add_action( 'init', array( $this, 'register_blocks' ) );
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
+		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 	}
 
 	/**
@@ -74,6 +75,18 @@ final class BlockTypesController {
 			return;
 		}
 		echo '<input type="hidden" name="redirect" value="' . esc_attr( esc_url_raw( wp_unslash( $_GET['redirect_to'] ) ) ) . '" />'; // phpcs:ignore WordPress.Security.NonceVerification
+	}
+
+	/**
+	 * Hide legacy widgets with a feature complete block equivalent in the inserter
+	 * and prevent them from showing as an option in the Legacy Widget block.
+	 *
+	 * @param array $widget_types An array of widgets hidden in core.
+	 * @return array $widget_types An array inluding the WooCommerce widgets to hide.
+	 */
+	public function hide_legacy_widgets_with_block_equivalent( $widget_types ) {
+		array_push( $widget_types, 'woocommerce_product_search', 'woocommerce_product_categories', 'woocommerce_products', 'woocommerce_top_rated_products', 'woocommerce_recent_reviews' );
+		return $widget_types;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4219

This PR aims to hide legacy widgets that already have a feature-complete block equivalent from the block inserter as well as removing them as an option in the Legacy Widget block dropdown.

As per product decision in pca54o-KL-p2#comment-1112, the widgets we want to exclude at this point are:
**Product Search, Product Categories, ~~Products, Products by Rating,~~ and Recent Product Reviews**

|Before|After|
|-|-|
|<img width="649" alt="Screenshot 2021-05-19 at 10 56 56" src="https://user-images.githubusercontent.com/1562646/118794634-131bde80-b89a-11eb-9dd4-12d5e1fcc960.png">|<img width="641" alt="Screenshot 2021-05-19 at 10 55 05" src="https://user-images.githubusercontent.com/1562646/118794667-1adb8300-b89a-11eb-9697-73827da108c9.png">|

|Before|After|
|-|-|
|<img width="295" alt="Screenshot 2021-05-19 at 10 57 30" src="https://user-images.githubusercontent.com/1562646/118794761-2fb81680-b89a-11eb-808f-e2f1f25d47bc.png">|<img width="296" alt="Screenshot 2021-05-19 at 10 56 24" src="https://user-images.githubusercontent.com/1562646/118794778-33e43400-b89a-11eb-95e7-12cfb502c439.png">|

### How to test the changes in this Pull Request:

Widgets to test: Product Search, Product Categories, ~~Products, Products by Rating,~~ and Recent Product Reviews

1. Ensure the Gutenberg feature plugin is enabled. To enable block widgets in the Customizer, go to Gutenberg -> Experiments and check the checkbox next to Widgets. After you’ve saved the experimental settings, navigate to Appearance -> Customize -> Widgets.
2. Go to Sidebar widgets and try to insert the above-mentioned widgets. You shouldn't be able to see them in the inspector.
3. Insert the "Legacy Widget" block in the Sidebar. You shouldn't be able to see the above-mentioned widgets in the `Select widget` dropdown.

<!-- If you can, add the appropriate labels -->

### Changelog

> Hide legacy widgets with a feature-complete block equivalent from the widget area block inserter.