### PR TITLE
Hide "including X in taxes" when the amount of tax is 0

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/index.js
@@ -18,11 +18,11 @@ import { getSetting } from '@woocommerce/settings';
  */
 import './style.scss';
 
-const SHOW_TAXES =
-	getSetting( 'taxesEnabled', true ) &&
-	getSetting( 'displayCartPricesIncludingTax', false );
-
 const TotalsFooterItem = ( { currency, values } ) => {
+	const SHOW_TAXES =
+		getSetting( 'taxesEnabled', true ) &&
+		getSetting( 'displayCartPricesIncludingTax', false );
+
 	const { total_price: totalPrice, total_tax: totalTax } = values;
 
 	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.

--- a/assets/js/base/components/cart-checkout/totals/footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/index.js
@@ -38,6 +38,8 @@ const TotalsFooterItem = ( { currency, values } ) => {
 		validation: mustBeString,
 	} );
 
+	const parsedTaxValue = parseInt( totalTax, 10 );
+
 	return (
 		<TotalsItem
 			className="wc-block-components-totals-footer-item"
@@ -45,7 +47,8 @@ const TotalsFooterItem = ( { currency, values } ) => {
 			label={ label }
 			value={ parseInt( totalPrice, 10 ) }
 			description={
-				SHOW_TAXES && (
+				SHOW_TAXES &&
+				parsedTaxValue !== 0 && (
 					<p className="wc-block-components-totals-footer-item-tax">
 						{ createInterpolateElement(
 							__(
@@ -57,7 +60,7 @@ const TotalsFooterItem = ( { currency, values } ) => {
 									<FormattedMonetaryAmount
 										className="wc-block-components-totals-footer-item-tax-value"
 										currency={ currency }
-										value={ parseInt( totalTax, 10 ) }
+										value={ parsedTaxValue }
 									/>
 								),
 							}

--- a/assets/js/base/components/cart-checkout/totals/footer-item/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/test/__snapshots__/index.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TotalsFooterItem Does not show the "including %s of tax" line if tax is 0 1`] = `
+<div>
+  <div
+    class="wc-block-components-totals-item wc-block-components-totals-footer-item"
+  >
+    <span
+      class="wc-block-components-totals-item__label"
+    >
+      Total
+    </span>
+    <span
+      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    >
+      £85.00
+    </span>
+    <div
+      class="wc-block-components-totals-item__description"
+    />
+  </div>
+</div>
+`;
+
+exports[`TotalsFooterItem Does not show the "including %s of tax" line if tax is disabled 1`] = `
+<div>
+  <div
+    class="wc-block-components-totals-item wc-block-components-totals-footer-item"
+  >
+    <span
+      class="wc-block-components-totals-item__label"
+    >
+      Total
+    </span>
+    <span
+      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    >
+      £85.00
+    </span>
+    <div
+      class="wc-block-components-totals-item__description"
+    />
+  </div>
+</div>
+`;
+
+exports[`TotalsFooterItem Shows the "including %s of tax" line if tax is greater than 0 1`] = `
+<div>
+  <div
+    class="wc-block-components-totals-item wc-block-components-totals-footer-item"
+  >
+    <span
+      class="wc-block-components-totals-item__label"
+    >
+      Total
+    </span>
+    <span
+      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+    >
+      £85.00
+    </span>
+    <div
+      class="wc-block-components-totals-item__description"
+    >
+      <p
+        class="wc-block-components-totals-footer-item-tax"
+      >
+        Including 
+        <span
+          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-footer-item-tax-value"
+        >
+          £1.00
+        </span>
+         in taxes
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/assets/js/base/components/cart-checkout/totals/footer-item/test/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/test/index.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import TotalsFooterItem from '../index';
+import { allSettings } from '../../../../../../settings/shared/settings-init';
+
+describe( 'TotalsFooterItem', () => {
+	beforeEach( () => {
+		allSettings.taxesEnabled = true;
+		allSettings.displayCartPricesIncludingTax = true;
+	} );
+	const currency = {
+		code: 'GBP',
+		decimalSeparator: '.',
+		minorUnit: 2,
+		prefix: '£',
+		suffix: '',
+		symbol: '£',
+		thousandSeparator: ',',
+	};
+
+	const values = {
+		currency_code: 'GBP',
+		currency_decimal_separator: '.',
+		currency_minor_unit: 2,
+		currency_prefix: '£',
+		currency_suffix: '',
+		currency_symbol: '£',
+		currency_thousand_separator: ',',
+		tax_lines: [],
+		length: 2,
+		total_discount: '0',
+		total_discount_tax: '0',
+		total_fees: '0',
+		total_fees_tax: '0',
+		total_items: '7100',
+		total_items_tax: '0',
+		total_price: '8500',
+		total_shipping: '0',
+		total_shipping_tax: '0',
+		total_tax: '0',
+	};
+
+	it( 'Does not show the "including %s of tax" line if tax is 0', () => {
+		const { container } = render(
+			<TotalsFooterItem currency={ currency } values={ values } />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'Does not show the "including %s of tax" line if tax is disabled', () => {
+		allSettings.taxesEnabled = false;
+		/* This shouldn't ever happen if taxes are disabled, but this is to test whether the taxesEnabled setting works */
+		const valuesWithTax = {
+			...values,
+			total_tax: '100',
+			total_items_tax: '100',
+		};
+		const { container } = render(
+			<TotalsFooterItem currency={ currency } values={ valuesWithTax } />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'Shows the "including %s of tax" line if tax is greater than 0', () => {
+		const valuesWithTax = {
+			...values,
+			total_tax: '100',
+			total_items_tax: '100',
+		};
+		const { container } = render(
+			<TotalsFooterItem currency={ currency } values={ valuesWithTax } />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,7 @@
 		"composite": true,
 		"rootDir": ".",
 		"typeRoots": [ "./node_modules/@types" ],
-		"types": [],
+		"types": ["jest"],
 		"paths": {
 			"@woocommerce/atomic-blocks": [ "assets/js/base/atomic/blocks" ],
 			"@woocommerce/atomic-blocks/*": [


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a check to see if the amount of tax is 0 before rendering the "Including X in taxes" line in the cart and checkout blocks. It also includes some tests for this, and a small change to make the `TotalsFooterItem` component a little more testable.

I moved the `SHOW_TAXES` constant _into_ the function to achieve this. Admittedly there is a slight performance downside to this, but it is negligible and I am satisfied that the tradeoff for testability is a good one.

The reason that this was less testable before is `SET_TAXES` was given a value as soon as the file was imported, therefore any test suites that may have wanted to change the settings (from which `SHOW_TAXES` was derived) would not be able to.

I am also sneaking in a change to `tsconfig.json` to enable jest types to be considered by TypeScript. In my IDE they were showing as errors when working on test files.

<!-- Reference any related issues or PRs here -->
Fixes #4243

### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/119370465-333e0a00-bcad-11eb-820b-e3853b73ffe2.png) | ![image](https://user-images.githubusercontent.com/5656702/119369337-f58cb180-bcab-11eb-90bc-f79f62f516e4.png) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Enable taxes and ensure "Display prices during basket and checkout" is set to "Including taxes"
2. Add an item to your cart with a zero-rate tax setting.
3. View the Cart and Checkout block and ensure it does not say "Including £0.00 in taxes".

<!-- If you can, add the appropriate labels -->

### Changelog

> Hide tax breakdown if the total amount of tax to be paid is 0.
