### PR TITLE
Check if product can be added to cart before adding ajax class to button

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -485,7 +485,11 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'class'            => 'wp-block-button__link add_to_cart_button',
 		);
 
-		if ( $product->supports( 'ajax_add_to_cart' ) ) {
+		if (
+			$product->supports( 'ajax_add_to_cart' ) &&
+			$product->is_purchasable() &&
+			( $product->is_in_stock() || $product->backorders_allowed() )
+		) {
 			$attributes['class'] .= ' ajax_add_to_cart';
 		}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In `AbstractProductGrid.php` there was no check to see whether the product _could_ be added to the cart before adding the `ajax_add_to_cart` class to the `Read more`/`Add to cart` button.

This PR will check if the product is purchasable, and it is in stock, or available on backorder.

<!-- Reference any related issues or PRs here -->
Fixes #4264

### How to test the changes in this Pull Request:

1. Go to 'WooCommerce > Settings > Products > Enable AJAX add to cart buttons on archives'
2. Edit a page and add a 'Products by Category' block (choose a category with an out of stock product)
3. On the front-end, go to the page and click on the out of stock product's "Read more" link
4. Verify you cannot see the spinner on the button and when redirected on the product page, the WooCommerce error message does not show.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix an issue where an attempt to add an out of stock product to the cart was made when clicking the "Read more" button.
