### PR TITLE
Fix display of itemised taxes

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
@@ -1312,35 +1312,26 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
         </fieldset>
       </div>
       <div
-        class="wc-block-components-totals-item wc-block-components-totals-taxes"
+        class="wc-block-components-totals-taxes"
       >
-        <span
-          class="wc-block-components-totals-item__label"
-        >
-          Taxes
-        </span>
-        <span
-          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
-        >
-          $6.00
-        </span>
         <div
-          class="wc-block-components-totals-item__description"
+          class="wc-block-components-totals-item wc-block-components-totals-taxes__grouped-rate"
         >
-          <div
-            class="wc-block-components-totals-item wc-block-components-totals-taxes__tax-line"
+          <span
+            class="wc-block-components-totals-item__label"
           >
-            <span
-              class="wc-block-components-totals-item__label"
-            >
-              Sales tax
-            </span>
-            <div
-              class="wc-block-components-totals-item__description"
-            />
-          </div>
-           
+            Sales tax
+          </span>
+          <span
+            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+          >
+            $6.00
+          </span>
+          <div
+            class="wc-block-components-totals-item__description"
+          />
         </div>
+         
       </div>
       <div
         class="wc-block-components-totals-item wc-block-components-totals-footer-item"
@@ -2017,35 +2008,26 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
         </fieldset>
       </div>
       <div
-        class="wc-block-components-totals-item wc-block-components-totals-taxes"
+        class="wc-block-components-totals-taxes"
       >
-        <span
-          class="wc-block-components-totals-item__label"
-        >
-          Taxes
-        </span>
-        <span
-          class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
-        >
-          $6.00
-        </span>
         <div
-          class="wc-block-components-totals-item__description"
+          class="wc-block-components-totals-item wc-block-components-totals-taxes__grouped-rate"
         >
-          <div
-            class="wc-block-components-totals-item wc-block-components-totals-taxes__tax-line"
+          <span
+            class="wc-block-components-totals-item__label"
           >
-            <span
-              class="wc-block-components-totals-item__label"
-            >
-              Sales tax 20%
-            </span>
-            <div
-              class="wc-block-components-totals-item__description"
-            />
-          </div>
-           
+            Sales tax 20%
+          </span>
+          <span
+            class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+          >
+            $6.00
+          </span>
+          <div
+            class="wc-block-components-totals-item__description"
+          />
         </div>
+         
       </div>
       <div
         class="wc-block-components-totals-item wc-block-components-totals-footer-item"

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
@@ -97,35 +97,26 @@ exports[`Testing checkout sidebar Shows rate percentages after tax lines if the 
     </div>
   </div>
   <div
-    class="wc-block-components-totals-item wc-block-components-totals-taxes"
+    class="wc-block-components-totals-taxes"
   >
-    <span
-      class="wc-block-components-totals-item__label"
-    >
-      Taxes
-    </span>
-    <span
-      class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
-    >
-      $6.00
-    </span>
     <div
-      class="wc-block-components-totals-item__description"
+      class="wc-block-components-totals-item wc-block-components-totals-taxes__grouped-rate"
     >
-      <div
-        class="wc-block-components-totals-item wc-block-components-totals-taxes__tax-line"
+      <span
+        class="wc-block-components-totals-item__label"
       >
-        <span
-          class="wc-block-components-totals-item__label"
-        >
-          Sales tax 20%
-        </span>
-        <div
-          class="wc-block-components-totals-item__description"
-        />
-      </div>
-       
+        Sales tax 20%
+      </span>
+      <span
+        class="wc-block-formatted-money-amount wc-block-components-formatted-money-amount wc-block-components-totals-item__value"
+      >
+        $6.00
+      </span>
+      <div
+        class="wc-block-components-totals-item__description"
+      />
     </div>
+     
   </div>
   <div
     class="wc-block-components-totals-item wc-block-components-totals-footer-item"

--- a/packages/checkout/totals/taxes/index.tsx
+++ b/packages/checkout/totals/taxes/index.tsx
@@ -40,29 +40,38 @@ const TotalsTaxes = ( {
 		return null;
 	}
 
-	const itemisedTaxItems: ReactElement | null = getSetting(
+	const showItemisedTaxes = getSetting(
 		'displayItemizedTaxes',
 		false
-	) ? (
-		<>
-			{ taxLines.map( ( { name, rate }, i ) => {
+	) as boolean;
+
+	const itemisedTaxItems: ReactElement | null = showItemisedTaxes ? (
+		<div
+			className={ classnames(
+				'wc-block-components-totals-taxes',
+				className
+			) }
+		>
+			{ taxLines.map( ( { name, rate, price }, i ) => {
 				const label = `${ name }${
 					showRateAfterTaxName ? ` ${ rate }` : ''
 				}`;
 				return (
 					<TotalsItem
 						key={ `tax-line-${ i }` }
-						className="wc-block-components-totals-taxes__tax-line"
+						className="wc-block-components-totals-taxes__grouped-rate"
 						currency={ currency }
 						label={ label }
-						value={ null }
+						value={ parseInt( price, 10 ) }
 					/>
 				);
 			} ) }{ ' ' }
-		</>
+		</div>
 	) : null;
 
-	return (
+	return showItemisedTaxes ? (
+		itemisedTaxItems
+	) : (
 		<>
 			<TotalsItem
 				className={ classnames(
@@ -72,7 +81,7 @@ const TotalsTaxes = ( {
 				currency={ currency }
 				label={ __( 'Taxes', 'woo-gutenberg-products-block' ) }
 				value={ parseInt( totalTax, 10 ) }
-				description={ itemisedTaxItems }
+				description={ null }
 			/>
 		</>
 	);

--- a/packages/checkout/totals/taxes/style.scss
+++ b/packages/checkout/totals/taxes/style.scss
@@ -1,6 +1,10 @@
-.wc-block-components-totals-item__description
-.wc-block-components-totals-item.wc-block-components-totals-taxes__tax-line {
-	padding: 0;
-	@include font-size(small);
-	margin: $gap-smallest / 2;
+.wc-block-components-totals-item.wc-block-components-totals-taxes__grouped-rate {
+	margin: $gap-smallest 0;
+	&:first-child {
+		margin-top: 0;
+	}
+
+	&:last-child {
+		margin-bottom: 0;
+	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In the current (new design) of the Cart and Checkout sidebars, when the merchant had the `Show tax totals` setting set to `Itemised` the tax lines did not have a price next to them. This was correct (as per the designs) but it was a regression in terms of UX.

Following this slack thread: p1622027500383600-slack-C8X6Q7XQU I:
- When `Itemised` taxes were enabled, remove the `Taxes` item, and in its place output the individual rates with the associated prices
- Updated the CSS to reduce the vertical space between tax lines, and ensure the first and last individual lines do not have margins above, and below them.

### Screenshots
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/119657326-aa95aa00-be23-11eb-87b5-71775d71f4d7.png) | ![image](https://user-images.githubusercontent.com/5656702/119657293-a10c4200-be23-11eb-90c7-551e24a92228.png) |
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Go `WooCommerce -> Settings -> Tax` and set `Display prices during basket and checkout` to `Excluding Tax`.
2. Set `Display tax totals` to `Itemised`
3. Set up a few products to use different tax rates.
4. Add them to the cart and verify you see each tax rate shown in the sidebar of both the Cart and Checkout blocks and that the totals are correct.
5. Set `Display tax totals` back to `As a single total` and check that the individual rates are no longer shown, but a `Taxes` total is shown in their place.
6. Check the blocks in the editor context too and ensure they display correctly.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.