### PR TITLE
Add documentation for the `couponName` filter

### DIFF
--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -87,6 +87,36 @@ The word 'Total' that precedes the amount due, present in both the Cart _and_ Ch
 
 There are no additional arguments passed to this filter.
 
+### Coupon names
+
+The current functionality is to display the coupon codes in the Cart and Checkout sidebars. This could be undesirable
+if you dynamically generate a coupon code that is not user friendly. It may, therefore, be desirable to change the way
+this code is displayed. To do this, the filter `couponName` exists. 
+
+| Filter name  | Description | Return type  |
+|---|---|---|
+| `couponName`  | This is the coupon code of a coupon currently applied to the cart. Its value will be the same as the code the customer entered to apply the discount. | `string`
+
+The additional argument supplied to this filter is: `{ context: 'summary', coupon: CartCoupon }`. A `CartCoupon` has the following shape:
+
+```typescript
+interface CartCoupon {
+  code: string
+  discount_type: string
+  totals: {
+    currency_code: string
+    currency_decimal_separator: string
+    currency_minor_unit: number
+    currency_prefix: string
+    currency_suffix: string
+    currency_symbol: string
+    currency_thousand_separator: string
+    total_discount: string
+    total_discount_tax: string
+  }
+}
+```
+
 ## Examples
 
 ### Changing the wording of the Totals label in the Cart and Checkout


### PR DESCRIPTION
Because this this was somehow omitted from #4166, I am re-adding it in this PR. I know we said that we should avoid using TS syntax in our example documentation, so we can go back and revisit these docs during a cooldown. For now this PR is to simply include a file that was already written, for the purposes of documenting a new filter.

### How to test the changes in this Pull Request:

1. Please refer to #4166 and verify that the documentation included in this PR makes sense.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add suggested changelog entry here.
