### PR TITLE
Check if there are tax lines before rendering the container for them

### DIFF
--- a/packages/checkout/totals/taxes/index.tsx
+++ b/packages/checkout/totals/taxes/index.tsx
@@ -45,29 +45,30 @@ const TotalsTaxes = ( {
 		false
 	) as boolean;
 
-	const itemisedTaxItems: ReactElement | null = showItemisedTaxes ? (
-		<div
-			className={ classnames(
-				'wc-block-components-totals-taxes',
-				className
-			) }
-		>
-			{ taxLines.map( ( { name, rate, price }, i ) => {
-				const label = `${ name }${
-					showRateAfterTaxName ? ` ${ rate }` : ''
-				}`;
-				return (
-					<TotalsItem
-						key={ `tax-line-${ i }` }
-						className="wc-block-components-totals-taxes__grouped-rate"
-						currency={ currency }
-						label={ label }
-						value={ parseInt( price, 10 ) }
-					/>
-				);
-			} ) }{ ' ' }
-		</div>
-	) : null;
+	const itemisedTaxItems: ReactElement | null =
+		showItemisedTaxes && taxLines.length > 0 ? (
+			<div
+				className={ classnames(
+					'wc-block-components-totals-taxes',
+					className
+				) }
+			>
+				{ taxLines.map( ( { name, rate, price }, i ) => {
+					const label = `${ name }${
+						showRateAfterTaxName ? ` ${ rate }` : ''
+					}`;
+					return (
+						<TotalsItem
+							key={ `tax-line-${ i }` }
+							className="wc-block-components-totals-taxes__grouped-rate"
+							currency={ currency }
+							label={ label }
+							value={ parseInt( price, 10 ) }
+						/>
+					);
+				} ) }{ ' ' }
+			</div>
+		) : null;
 
 	return showItemisedTaxes ? (
 		itemisedTaxItems


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When taxes are set to be shown as `Itemised` there is a div that contains the individual lines, this div was previously rendered even if there are no tax lines to be shown. This PR will check if there are lines to output, and only render the div with borders if there are.

<!-- Reference any related issues or PRs here -->
Introduced in #4279 😞 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/119813140-d2971300-bee0-11eb-8569-f4410625d2e8.png) | ![image](https://user-images.githubusercontent.com/5656702/119813417-26a1f780-bee1-11eb-90f1-e3605d0bd194.png) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Go WooCommerce -> Settings -> Tax and set Display prices during basket and checkout to Excluding Tax.
2. Set Display tax totals to Itemised
2. Add an item to the cart with a zero-rated tax rate.
3. Check there are no borders without anything in them, like the before screenshot above.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix a display issue when itemised taxes are enabled, but no products in the cart are taxable.
