### PR TITLE
Update Cart Widget when adding an item in All Products

### DIFF
--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -12,13 +12,14 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducers';
-import { controls } from '../shared-controls';
+import { controls as sharedControls } from '../shared-controls';
+import { controls } from './controls';
 
 registerStore< State >( STORE_KEY, {
 	reducer,
 	actions,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	controls: { ...dataControls, ...controls } as any,
+	controls: { ...dataControls, ...sharedControls, ...controls } as any,
 	selectors,
 	resolvers,
 } );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4075 we refactored our data store, a new control file was created inside the `cart` store that had only one controller, which managed triggering the update fragment, we didn't import that control and so it wasn't registered, this PR fixes it.
<!-- Reference any related issues or PRs here -->
Fixes #4287

### How to test the changes in this Pull Request:

1. In storefront or any theme that support Cart widgets, go to a page with All Products
2. Add a product to cart from there.
3. The widget should be updated.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix a bug in which Cart Widget didn't update when adding items from All Products block
