### PR TITLE
Block Widgets: add block transforms for legacy widgets with a block equivalent

### DIFF
--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -94,10 +94,10 @@ registerBlockType( 'woocommerce/product-categories', {
 					!! instance?.raw,
 				transform: ( { instance } ) =>
 					createBlock( 'woocommerce/product-categories', {
-						hasCount: instance.raw.count,
+						hasCount: !! instance.raw.count,
 						hasEmpty: ! instance.raw.hide_empty,
-						isDropdown: instance.raw.dropdown,
-						isHierarchical: instance.raw.hierarchical,
+						isDropdown: !! instance.raw.dropdown,
+						isHierarchical: !! instance.raw.hierarchical,
 					} ),
 			},
 		],

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType } from '@wordpress/blocks';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { Icon, list } from '@woocommerce/icons';
 
 /**
@@ -81,6 +81,26 @@ registerBlockType( 'woocommerce/product-categories', {
 			type: 'boolean',
 			default: true,
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/legacy-widget' ],
+				// We can't transform if raw instance isn't shown in the REST API.
+				isMatch: ( { idBase, instance } ) =>
+					idBase === 'woocommerce_product_categories' &&
+					!! instance?.raw,
+				transform: ( { instance } ) =>
+					createBlock( 'woocommerce/product-categories', {
+						hasCount: instance.raw.count,
+						hasEmpty: ! instance.raw.hide_empty,
+						isDropdown: instance.raw.dropdown,
+						isHierarchical: instance.raw.hierarchical,
+					} ),
+			},
+		],
 	},
 
 	deprecated: [

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType } from '@wordpress/blocks';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { Icon, search } from '@woocommerce/icons';
 /**
  * Internal dependencies
@@ -69,6 +69,25 @@ registerBlockType( 'woocommerce/product-search', {
 			type: 'string',
 			default: '',
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/legacy-widget' ],
+				// We can't transform if raw instance isn't shown in the REST API.
+				isMatch: ( { idBase, instance } ) =>
+					idBase === 'woocommerce_product_search' && !! instance?.raw,
+				transform: ( { instance } ) =>
+					createBlock( 'woocommerce/product-search', {
+						label:
+							instance.raw.title === ''
+								? __( 'Search', 'woo-gutenberg-products-block' )
+								: instance.raw.title,
+					} ),
+			},
+		],
 	},
 
 	edit,

--- a/assets/js/blocks/reviews/all-reviews/index.js
+++ b/assets/js/blocks/reviews/all-reviews/index.js
@@ -62,6 +62,11 @@ registerBlockType( 'woocommerce/all-reviews', {
 				transform: ( { instance } ) =>
 					createBlock( 'woocommerce/all-reviews', {
 						reviewsOnPageLoad: instance.raw.number,
+						imageType: 'product',
+						showLoadMore: false,
+						showOrderby: false,
+						showReviewDate: false,
+						showReviewContent: false,
 					} ),
 			},
 		],

--- a/assets/js/blocks/reviews/all-reviews/index.js
+++ b/assets/js/blocks/reviews/all-reviews/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { registerBlockType } from '@wordpress/blocks';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { Icon, discussion } from '@woocommerce/icons';
 
 /**
@@ -49,6 +49,22 @@ registerBlockType( 'woocommerce/all-reviews', {
 			type: 'boolean',
 			default: true,
 		},
+	},
+
+	transforms: {
+		from: [
+			{
+				type: 'block',
+				blocks: [ 'core/legacy-widget' ],
+				// We can't transform if raw instance isn't shown in the REST API.
+				isMatch: ( { idBase, instance } ) =>
+					idBase === 'woocommerce_recent_reviews' && !! instance?.raw,
+				transform: ( { instance } ) =>
+					createBlock( 'woocommerce/all-reviews', {
+						reviewsOnPageLoad: instance.raw.number,
+					} ),
+			},
+		],
 	},
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4220

This PR aims to provide block transforms for legacy widgets that have a block equivalent.

As per the product decision outlined in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4220, the widgets we want to provide transforms for are: 
Product Search, Product Categories, and Recent Product Reviews

|Before|After|
|-|-|
|<img width="381" alt="Screenshot 2021-05-31 at 12 11 27" src="https://user-images.githubusercontent.com/1562646/120178086-63cff780-c209-11eb-9df3-eb073fbcf37a.png">|<img width="384" alt="Screenshot 2021-05-31 at 12 10 37" src="https://user-images.githubusercontent.com/1562646/120178103-69c5d880-c209-11eb-99a8-e1cacd79f08b.png">|

### How to test the changes in this Pull Request:

Widgets to test: Product Search, Product Categories, Recent Product Reviews

**Prerequisites:** 

1. Install the latest nightly version of WordPress 5.8 (for example using [WordPress beta tester](https://wordpress.org/plugins/wordpress-beta-tester/)).
2. Install the latest version of [Gutenberg](https://wordpress.org/plugins/gutenberg/).
3. In order for the block transforms to work, we also need the raw widget instance to be exposed in the REST API. This change is done over in WooCommerce core in a separate PR. To be able to test this, you'll need to use WooCommerce with changes in said PR applied: https://github.com/woocommerce/woocommerce/pull/30012.
4. In order to test this, you'll need to add the above-mentioned legacy widgets in the Widgets screen. We're already hiding these as options for the user as we want them to use the blocks instead. The easiest way for you to make them show up for testing again is probably to just remove the following line in `woocommerce-gutenberg-products-block`:
<img width="859" alt="Screenshot 2021-05-31 at 11 47 30" src="https://user-images.githubusercontent.com/1562646/120176730-ece62f00-c207-11eb-9d5f-d68642572aae.png">


**What to test:**

1. Go to the Widgets editor in Appearance > Widgets.
2. Add the Product Search, Product Categories, Recent Product Reviews widgets.
3. Transform each of the widgets using the provided block transform option. 
4. Confirm the default transformation to the Product Search block, the Product Categories List block and the All Reviews block work as expected.
5. Test each of the widgets again, this time changing options on the widgets. For example for Recent Product Reviews change the "Number of reviews to show" to a small number. In the Product Search widget add a "Title". In the Product Categories List change various combinations of options.
6. Transform each of the widgets using the provided block transform option.
7. Confirm the transformations work as expected and retain the changed options that have an equivalent in the blocks.

<!-- If you can, add the appropriate labels -->

### Changelog

> Provide block transforms for legacy widgets with a feature-complete block equivalent.