### PR TITLE
Fix the flickering of the Proceed to Checkout button on quantity update in the Cart Block

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
@@ -83,7 +83,6 @@ export const useStoreCartItemQuantity = (
 		},
 		[ cartItemKey ]
 	);
-	const previousIsPending = usePrevious( isPending );
 
 	const removeItem = () => {
 		return cartItemKey
@@ -112,32 +111,30 @@ export const useStoreCartItemQuantity = (
 	] );
 
 	useEffect( () => {
-		if ( typeof previousIsPending === 'undefined' ) {
-			return;
-		}
-		if ( previousIsPending.quantity !== isPending.quantity ) {
-			if ( isPending.quantity ) {
-				dispatchActions.incrementCalculating();
-			} else {
-				dispatchActions.decrementCalculating();
-			}
-		}
-		if ( previousIsPending.delete !== isPending.delete ) {
-			if ( isPending.delete ) {
-				dispatchActions.incrementCalculating();
-			} else {
-				dispatchActions.decrementCalculating();
-			}
+		if ( isPending.delete ) {
+			dispatchActions.incrementCalculating();
+		} else {
+			dispatchActions.decrementCalculating();
 		}
 		return () => {
-			if ( isPending.quantity ) {
-				dispatchActions.decrementCalculating();
-			}
 			if ( isPending.delete ) {
 				dispatchActions.decrementCalculating();
 			}
 		};
-	}, [ dispatchActions, isPending, previousIsPending ] );
+	}, [ dispatchActions, isPending.delete ] );
+
+	useEffect( () => {
+		if ( isPending.quantity || debouncedQuantity !== quantity ) {
+			dispatchActions.incrementCalculating();
+		} else {
+			dispatchActions.decrementCalculating();
+		}
+		return () => {
+			if ( isPending.quantity || debouncedQuantity !== quantity ) {
+				dispatchActions.decrementCalculating();
+			}
+		};
+	}, [ dispatchActions, isPending.quantity, debouncedQuantity, quantity ] );
 
 	return {
 		isPendingDelete: isPending.delete,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3314 we introduced `previousIsPendingQuantity` and `previousIsPendingDelete` to fix an issue with checkout button flickering on quantity changes.

After refactoring it over time, the issue surfaced again, deleting the code added in that PR fixed the issue.

Currently, we set isCalculating to true if we have quantity pending in our store, or if we're deleting an item. The other new part of this PR is that we also set isCalculating in the debouncing period, this is to fix a delay between clicking update and the button is greyed out.

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4289


### How to test the changes in this Pull Request:

1. Smoke test Cart block, make sure changing quantity works fine.
2. Make sure removing items works fine.
3. When changing an item quantity, make sure the button is disabled immediately as you change the quantity and is re-enabled once the server request finishes

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix the flickering of the Proceed to Checkout button on quantity update in the Cart Block
