### PR TITLE
Remove the mustBeString validation utility and its usage

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -7,7 +7,6 @@ import ProductName from '@woocommerce/base-components/product-name';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import {
 	__experimentalApplyCheckoutFilter,
-	mustBeString,
 	mustContain,
 	Label,
 } from '@woocommerce/blocks-checkout';
@@ -48,7 +47,7 @@ const OrderSummaryItem = ( { cartItem } ) => {
 	const { receiveCart, ...cart } = useStoreCart();
 
 	const productPriceValidation = useCallback(
-		( value ) => mustBeString( value ) && mustContain( value, '<price/>' ),
+		( value ) => mustContain( value, '<price/>' ),
 		[]
 	);
 
@@ -68,7 +67,6 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		defaultValue: initialName,
 		extensions,
 		arg,
-		validation: mustBeString,
 	} );
 
 	const regularPriceSingle = Dinero( {

--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -7,7 +7,6 @@ import { RemovableChip } from '@woocommerce/base-components/chip';
 import PropTypes from 'prop-types';
 import {
 	__experimentalApplyCheckoutFilter,
-	mustBeString,
 	TotalsItem,
 } from '@woocommerce/blocks-checkout';
 import { getSetting } from '@woocommerce/settings';
@@ -60,7 +59,6 @@ const TotalsDiscount = ( {
 							{ cartCoupons.map( ( cartCoupon ) => {
 								const filteredCouponCode = __experimentalApplyCheckoutFilter(
 									{
-										validation: mustBeString,
 										arg: {
 											context: 'summary',
 											coupon: cartCoupon,

--- a/assets/js/base/components/cart-checkout/totals/footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/index.js
@@ -7,7 +7,6 @@ import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-mone
 import PropTypes from 'prop-types';
 import {
 	__experimentalApplyCheckoutFilter,
-	mustBeString,
 	TotalsItem,
 } from '@woocommerce/blocks-checkout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
@@ -34,8 +33,6 @@ const TotalsFooterItem = ( { currency, values } ) => {
 		defaultValue: __( 'Total', 'woo-gutenberg-products-block' ),
 		extensions: cart.extensions,
 		arg: { cart },
-		// Only accept strings.
-		validation: mustBeString,
 	} );
 
 	const parsedTaxValue = parseInt( totalTax, 10 );

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -24,7 +24,6 @@ import {
 } from '@woocommerce/price-format';
 import {
 	__experimentalApplyCheckoutFilter,
-	mustBeString,
 	mustContain,
 } from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
@@ -112,7 +111,7 @@ const CartLineItemRow = ( {
 	const { dispatchStoreEvent } = useStoreEvents();
 
 	const productPriceValidation = useCallback(
-		( value ) => mustBeString( value ) && mustContain( value, '<price/>' ),
+		( value ) => mustContain( value, '<price/>' ),
 		[]
 	);
 
@@ -134,7 +133,6 @@ const CartLineItemRow = ( {
 		defaultValue: initialName,
 		extensions,
 		arg,
-		validation: mustBeString,
 	} );
 
 	const regularAmountSingle = Dinero( {

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -74,7 +74,7 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 	/** Object containing arguments for the filter function. */
 	arg: CheckoutFilterArguments;
 	/** Function that needs to return true when the filtered value is passed in order for the filter to be applied. */
-	validation: ( value: unknown ) => true | Error;
+	validation?: ( value: T ) => true | Error;
 } ): T => {
 	return useMemo( () => {
 		const filters = getCheckoutFilters( filterName );

--- a/packages/checkout/utils/validation/index.ts
+++ b/packages/checkout/utils/validation/index.ts
@@ -4,25 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * Checks if value passed is a string, throws an error if not.
- */
-export const mustBeString = ( value: unknown ): true | Error => {
-	if ( typeof value !== 'string' ) {
-		throw Error(
-			sprintf(
-				/* translators: %s is type of value passed */
-				__(
-					'Returned value must be a string, you passed "%s"',
-					'woo-gutenberg-products-block'
-				),
-				typeof value
-			)
-		);
-	}
-	return true;
-};
-
-/**
  * Checks if value passed contain passed label.
  */
 export const mustContain = ( value: string, label: string ): true | Error => {


### PR DESCRIPTION
This is a refactoring issue, [we recently introduced same-type-validation in our Checkout filters](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/11a9b23d737a6fefeff0569debc22749d0ff5cc2/packages/checkout/registry/index.ts#L86-L98), making `mustBeString` useless here because it's no longer being used. This PR removes `mustBeString` and its usage, it also makes `validation` an optional value.

### Testing steps
- Install and enable WooCommerce Subscriptions, add subscriptions products to your cart.
- Smoke test Cart and Checkout, make sure there are no console errors.

### Changelog
> Remove the mustBeString validation utility and its usage