### PR TITLE
Fix missing translation in Cart and Checkout blocks

### DIFF
--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -316,7 +316,7 @@ class AssetDataRegistry {
 			$this->handle,
 			'build/wc-settings.js',
 			[],
-			false
+			true
 		);
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In a recent refactor, we moved `defaultAddressFields` to wc-settings, that script was marked with no translation, and so no translation file was being loaded, this PR adds it back.

I also verified all other files we register to make sure non of them have any i18n that we aren't loading.
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4273

### How to test the changes in this Pull Request:

1. Change the website translation to something else that is well translated (Spanish, French, Japanese).
2. Go to Updates, scroll down and click update translation.
3. Go to Checkout, make sure the checkout fields are being translated correctly.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix some missing translations from the Cart and Checkout blocks.
