### PR TITLE
Hide Cart and Checkout blocks from the widget editor

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -139,6 +139,8 @@ final class BlockTypesController {
 					'PriceFilter',
 					'AttributeFilter',
 					'ActiveFilters',
+					'Cart',
+					'Checkout',
 				]
 			);
 		}


### PR DESCRIPTION
Closes #4190.
Closes #4191.

After some more discussion (pca54o-1pT-p2#comment-1929) we decided to hide the Cart block and Checkout blocks from the widget editor. In the future we will have a 'Minicart block' (https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4138) which will serve the use-case of showing the cart contents in a widget area. Regarding the Checkout block, we don't see any use-case for it in a widget area.

### How to test the changes in this Pull Request:

1. Using a classic theme (ie: Storefront) with Gutenberg enabled, go to Appearance > Widgets.
2. Verify you can't add the Cart block or the Checkout block. (You will see a widget called Cart, that's the widget from WC core and is not related to this PR, so ignore it).
3. Now go to Appearance > Customize > Widgets and open a widget area.
4. Verify you can't add the Cart block or the Checkout block either.

### Changelog

> Hide the Cart and Checkout blocks from the new block-based widget editor.
