### PR TITLE
Fix broken phpunit tests

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,4 @@ WORDPRESS_LOGIN=admin
 WORDPRESS_PASSWORD=password
 WORDPRESS_EMAIL=admin@woocommercecoree2etestsuite.com
 WP_VERSION=5.4
+WOO_VERSION=5.3.0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -94,6 +94,8 @@ jobs:
           echo -e 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = tests' > blocks.ini
 
       - name: Run PHP Unit tests
+        env:
+          WOO_VERSION: 5.3.0
         run: |
           npm run phpunit
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,13 +22,14 @@ services:
       - 8085:80
     restart: on-failure
     environment:
-      WORDPRESS_DB_HOST:
-      WORDPRESS_DB_NAME:
-      WORDPRESS_DB_USER:
-      WORDPRESS_DB_PASSWORD:
-      WORDPRESS_TABLE_PREFIX: wp_test_
-      WP_CORE_DIR: /var/www/html
-      WP_TESTS_DIR: /tmp/wordpress-tests-lib
+      - WORDPRESS_DB_HOST
+      - WORDPRESS_DB_NAME
+      - WORDPRESS_DB_USER
+      - WORDPRESS_DB_PASSWORD
+      - WORDPRESS_TABLE_PREFIX=wp_test_
+      - WP_CORE_DIR=/var/www/html
+      - WP_TESTS_DIR=/tmp/wordpress-tests-lib
+      - WOO_VERSION
     volumes:
       - "./:/var/www/html/wp-content/plugins/woocommerce-gutenberg-products-block"
       - wordpress:/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - db
     build:
       context: ./tests/bin
+      args:
+        WOO_INSTALL_VERSION: ${WOO_VERSION}
     ports:
       - 8085:80
     restart: on-failure

--- a/tests/bin/Dockerfile
+++ b/tests/bin/Dockerfile
@@ -1,5 +1,7 @@
 FROM wordpress:latest
 
+ARG WOO_INSTALL_VERSION=latest
+
 CMD echo "Installing dependencies..."
 
 RUN apt-get update && \
@@ -9,6 +11,7 @@ CMD echo "Installing tests..."
 
 ENV WP_TESTS_DIR=/tmp/wordpress-tests-lib
 ENV WP_CORE_DIR=/tmp/src/wordpress
+ENV WOO_VERSION=$WOO_INSTALL_VERSION
 
 COPY install-wp-tests.sh /usr/local/bin/dockerInit
 RUN chmod +x /usr/local/bin/dockerInit

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -11,6 +11,7 @@ DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
 SKIP_DB_CREATE=${6-false}
+WOO_VERSION=${WOO_VERSION-latest}
 
 # directories
 TMPDIR=${TMPDIR-/tmp}
@@ -149,21 +150,25 @@ install_db() {
 }
 
 install_woocommerce() {
+	WOO_INSTALL_VERSION=$WOO_VERSION
+	echo "Woo Version: $WOO_VERSION"
+	if [ $WOO_VERSION == 'latest' ] ; then
+		WOO_INSTALL_VERSION=latest-stable
+	fi
+	echo "Woo Install Version: $WOO_INSTALL_VERSION";
 	# get built plugin from .org
-	download https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip "$TMPDIR/woocommerce.zip"
+	download "https://downloads.wordpress.org/plugin/woocommerce.$WOO_INSTALL_VERSION.zip" "$TMPDIR/woocommerce.zip"
 	unzip -q $TMPDIR/woocommerce.zip -d "$WP_CORE_DIR/wp-content/plugins"
 
-	# Script Variables
-	BRANCH=$TRAVIS_BRANCH
-	REPO=$TRAVIS_REPO_SLUG
-
-	# Get github version
-	if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
-		BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
-		REPO=$TRAVIS_PULL_REQUEST_SLUG
+	git clone "https://github.com/woocommerce/woocommerce.git" "$TMPDIR/woocommerce-git"
+	# if specific version, then checkout the tag
+	if [ $WOO_VERSION != 'latest' ] ; then
+		echo "Checking out specific Woo Version test suite (tag)"
+		cd "$TMPDIR/woocommerce-git"
+		git checkout ${WOO_VERSION}
+		cd ..
 	fi
 
-	git clone --depth 1 "https://github.com/woocommerce/woocommerce.git" "$TMPDIR/woocommerce-git"
 	mv "$TMPDIR/woocommerce-git/tests" "$WP_CORE_DIR/wp-content/plugins/woocommerce"
 }
 


### PR DESCRIPTION
Recently PHPUnit tests started failing in the repository and I narrowed it down to the fact that for the test environment setup:

- The latest version of WooCommerce _released_ (from WP.org) is installed.
- The WooCommerce test utilities are retrieved from the `trunk` branch of WooCommerce core.

The above resulted in the test utilities referencing a class that is not available in the current released version of Woo Core (5.3) which resulted in the reported fatals.

For now, to get tests running, this PR has reconfigured the test setup so it synchronizes the test utilities used with the version of WooCommerce core being tested. The synchronization is accomplished via:

- updating `install-wp-tests.sh` script to use the `WOO_VERSION` environment variable to determine what to download for Woo.
- update docker configuration to pass through environment variable correctly.
- add environment variable to `.env` file for local Woo test runs.
- add environment variable to GitHub workflow for phpunit test runs.

## Tradeoffs.

While this does fix the immediate problem, there are some tradeoffs with this approach:

- the test utilities are currently being pulled in via a checked out tag in the WooCommerce repo. This requires cloning the entire WooCommerce repository increasing the overall impact to test run time by 1-2 min. There might be another way of doing this but in the interest of time I didn't dig too deep here
- the docker configuration we're currently using seems to have a lot of unused parts and could likely be cleaned up a bit. What I added here complicates things a bit more.
- Woo Core version is now hardcoded instead of always pulling the "latest". That means that we'll need to manually update the Woo Core version we test against whenever there's a new Woo Core release.

## Benefits

While it's listed as a tradeoff, we do have a benefit now of being able to explicitly specify Woo Core version to run phpunit tests against. This could be useful for increasing our test coverage to run against all Woo Core versions we support. However, I'm not sure how needed this is given the L2 policy keeps the version support range fairly small anyways.

## Next Steps

Some potential followups after merging this:

- Investigate whether we can automatically infer Woo Core version from the latest release on the downloaded WP.org package and use that to know what tag to checkout from the Woo Core repo. This could eliminate the manual version bumps we'd have to do to maintain this suite.
- Investigate alternative ways to obtain the correct Woo Core test utilities for the version of Woo Core being tested against other than cloning the entire repository. This will become especially problematic when WC Admin (and potentially other products) are merged directly into Woo Core and the size of the clone increases.
- Switch our test suite to use `wp-env` for phpunit tests (see the [pr I started here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3691)). With that change we'll be able to more easily switch PHP versions being tested with and even start testing against PHP8. Right now we're only testing against one version of PHP. The actual test reporting will be much better too (there currently is a lot of noise in the action logs from docker setup which makes it more time consuming to scroll to the actual phpunit test results).
- Potentially introduce testing against more than one WooCommerce version (eg. latest and earliest matching our requirements) as a part of a test matrix. Although this is likely not as important as PHP version testing.