### PR TITLE
Add DiscountsMeta slot to Checkout sidebar

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/index.js
@@ -14,6 +14,7 @@ import {
 	TotalsFees,
 	TotalsTaxes,
 	ExperimentalOrderMeta,
+	ExperimentalDiscountsMeta,
 } from '@woocommerce/blocks-checkout';
 
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
@@ -50,6 +51,11 @@ const CheckoutSidebar = ( {
 		cart,
 	};
 
+	const discountsSlotFillProps = {
+		extensions,
+		cart,
+	};
+
 	return (
 		<>
 			<OrderSummary cartItems={ cartItems } />
@@ -69,6 +75,7 @@ const CheckoutSidebar = ( {
 					isLoading={ isApplyingCoupon }
 				/>
 			) }
+			<ExperimentalDiscountsMeta.Slot { ...discountsSlotFillProps } />
 			{ needsShipping && (
 				<TotalsShipping
 					showCalculator={ false }

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
@@ -97,6 +97,9 @@ exports[`Testing checkout sidebar Shows rate percentages after tax lines if the 
     </div>
   </div>
   <div
+    class="wc-block-components-discounts-meta"
+  />
+  <div
     class="wc-block-components-totals-taxes"
   >
     <div


### PR DESCRIPTION
Following on from #4248 this PR will add the same Slot to the Checkout sidebar.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Check out `feature/add-inputs-for-points-redemption` from https://github.com/woocommerce/woocommerce-points-and-rewards/ and ensure you've run `npm run build` in that project.
2. Go to the file `includes/class-wc-points-rewards-extend-store-endpoint.php` in Points and Rewards and comment out the following lines (66-72):
```php
self::$extend->register_update_callback(
  array(
    'endpoint'          => CartExtensionsSchema::IDENTIFIER,
    'namespace'         => self::IDENTIFIER,
    'callback_function' => array( 'WC_Points_Rewards_Cart_Checkout', 'rest_apply_discount' ),
  )
);
```
3. Ensure you have added points to your user account ( WooCommerce -> Points and Rewards) and that you're logged in 
4. Add items to your cart and visit the Checkout block. See that the Points and Rewards input is present. Note that it won't function on this branch. This PR is just to get the display working.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add Slot in the Discounts section of the Checkout sidebar to allow third party extensions to render their own components there.
