### PR TITLE
Change `couponName` filter to `coupons` and update documentation

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -41,12 +41,20 @@ const TotalsDiscount = ( {
 		? discountValue + discountTaxValue
 		: discountValue;
 
+	const filteredCartCoupons = __experimentalApplyCheckoutFilter( {
+		arg: {
+			context: 'summary',
+		},
+		filterName: 'coupons',
+		defaultValue: cartCoupons,
+	} );
+
 	return (
 		<TotalsItem
 			className="wc-block-components-totals-discount"
 			currency={ currency }
 			description={
-				cartCoupons.length !== 0 && (
+				filteredCartCoupons.length !== 0 && (
 					<LoadingMask
 						screenReaderLabel={ __(
 							'Removing coupon…',
@@ -56,30 +64,19 @@ const TotalsDiscount = ( {
 						showSpinner={ false }
 					>
 						<ul className="wc-block-components-totals-discount__coupon-list">
-							{ cartCoupons.map( ( cartCoupon ) => {
-								const filteredCouponCode = __experimentalApplyCheckoutFilter(
-									{
-										arg: {
-											context: 'summary',
-											coupon: cartCoupon,
-										},
-										filterName: 'couponName',
-										defaultValue: cartCoupon.code,
-									}
-								);
-
+							{ filteredCartCoupons.map( ( cartCoupon ) => {
 								return (
 									<RemovableChip
 										key={ 'coupon-' + cartCoupon.code }
 										className="wc-block-components-totals-discount__coupon-list-item"
-										text={ filteredCouponCode }
+										text={ cartCoupon.code }
 										screenReaderText={ sprintf(
 											/* translators: %s Coupon code. */
 											__(
 												'Coupon: %s',
 												'woo-gutenberg-products-block'
 											),
-											filteredCouponCode
+											cartCoupon.code
 										) }
 										disabled={ isRemovingCoupon }
 										onRemove={ () => {
@@ -92,7 +89,7 @@ const TotalsDiscount = ( {
 												'Remove coupon "%s"',
 												'woo-gutenberg-products-block'
 											),
-											filteredCouponCode
+											cartCoupon.code
 										) }
 									/>
 								);

--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -69,14 +69,14 @@ const TotalsDiscount = ( {
 									<RemovableChip
 										key={ 'coupon-' + cartCoupon.code }
 										className="wc-block-components-totals-discount__coupon-list-item"
-										text={ cartCoupon.code }
+										text={ cartCoupon.text }
 										screenReaderText={ sprintf(
 											/* translators: %s Coupon code. */
 											__(
 												'Coupon: %s',
 												'woo-gutenberg-products-block'
 											),
-											cartCoupon.code
+											cartCoupon.text
 										) }
 										disabled={ isRemovingCoupon }
 										onRemove={ () => {
@@ -89,7 +89,7 @@ const TotalsDiscount = ( {
 												'Remove coupon "%s"',
 												'woo-gutenberg-products-block'
 											),
-											cartCoupon.code
+											cartCoupon.text
 										) }
 									/>
 								);

--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -89,7 +89,7 @@ const TotalsDiscount = ( {
 												'Remove coupon "%s"',
 												'woo-gutenberg-products-block'
 											),
-											cartCoupon.text
+											cartCoupon.label
 										) }
 									/>
 								);

--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -69,14 +69,14 @@ const TotalsDiscount = ( {
 									<RemovableChip
 										key={ 'coupon-' + cartCoupon.code }
 										className="wc-block-components-totals-discount__coupon-list-item"
-										text={ cartCoupon.text }
+										text={ cartCoupon.label }
 										screenReaderText={ sprintf(
 											/* translators: %s Coupon code. */
 											__(
 												'Coupon: %s',
 												'woo-gutenberg-products-block'
 											),
-											cartCoupon.text
+											cartCoupon.label
 										) }
 										disabled={ isRemovingCoupon }
 										onRemove={ () => {

--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -175,8 +175,16 @@ export const useStoreCart = (
 				decodeValues( fee )
 			);
 
+			// Add a text property to the coupon to allow extensions to modify
+			// the text used to display the coupon, without affecting the
+			// functionality when it comes to removing the coupon.
+			const cartCoupons = cartData.coupons.map( ( coupon ) => ( {
+				...coupon,
+				text: coupon.code,
+			} ) );
+
 			return {
-				cartCoupons: cartData.coupons,
+				cartCoupons,
 				cartItems: cartData.items || [],
 				cartFees,
 				cartItemsCount: cartData.itemsCount,

--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -14,6 +14,8 @@ import type {
 	CartResponseFeeItem,
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
+	CartResponseCouponItem,
+	CartResponseCouponItemWithLabel,
 } from '@woocommerce/types';
 import {
 	emptyHiddenAddressFields,
@@ -178,10 +180,12 @@ export const useStoreCart = (
 			// Add a text property to the coupon to allow extensions to modify
 			// the text used to display the coupon, without affecting the
 			// functionality when it comes to removing the coupon.
-			const cartCoupons = cartData.coupons.map( ( coupon ) => ( {
-				...coupon,
-				text: coupon.code,
-			} ) );
+			const cartCoupons: CartResponseCouponItemWithLabel[] = cartData.coupons.map(
+				( coupon: CartResponseCouponItem ) => ( {
+					...coupon,
+					label: coupon.code,
+				} )
+			);
 
 			return {
 				cartCoupons,

--- a/assets/js/types/type-defs/cart-response.ts
+++ b/assets/js/types/type-defs/cart-response.ts
@@ -22,6 +22,11 @@ export interface CartResponseCouponItem {
 	totals: CartResponseTotalsItem;
 }
 
+export interface CartResponseCouponItemWithLabel
+	extends CartResponseCouponItem {
+	label: string;
+}
+
 export interface ResponseFirstNameLastName {
 	first_name: string;
 	last_name: string;

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -25,6 +25,7 @@ export interface CartTotalsItem extends CurrencyInfo {
 
 export interface CartCouponItem {
 	code: string;
+	label: string;
 	discount_type: string;
 	totals: CartTotalsItem;
 }

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -87,20 +87,24 @@ The word 'Total' that precedes the amount due, present in both the Cart _and_ Ch
 
 There are no additional arguments passed to this filter.
 
-### Coupon names
+### Coupons
 
 The current functionality is to display the coupon codes in the Cart and Checkout sidebars. This could be undesirable
-if you dynamically generate a coupon code that is not user friendly. It may, therefore, be desirable to change the way
-this code is displayed. To do this, the filter `couponName` exists. 
+if you dynamically generate a coupon code that is not user-friendly. It may, therefore, be desirable to change the way
+this code is displayed. To do this, the filter `couponName` exists.
+
+This filter could also be used to show or hide coupons.
+
+This filter must _not_ be used to alter the value/totals of a coupon. This will not carry through to the Cart totals.
 
 | Filter name  | Description | Return type  |
 |---|---|---|
-| `couponName`  | This is the coupon code of a coupon currently applied to the cart. Its value will be the same as the code the customer entered to apply the discount. | `string`
+| `coupons`  | This is an array of coupons currently applied to the cart. | `CartCoupon[]`
 
-The additional argument supplied to this filter is: `{ context: 'summary', coupon: CartCoupon }`. A `CartCoupon` has the following shape:
+The additional argument supplied to this filter is: `{ context: 'summary' }`. A `CartCoupon` has the following shape:
 
 ```typescript
-interface CartCoupon {
+CartCoupon {
   code: string
   discount_type: string
   totals: {

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -230,6 +230,15 @@ const filterCoupons = ( coupons ) => {
 };
 ```
 
+We'd register our filter like this:
+```typescript
+import { __experimentalRegisterCheckoutFilters } from '@woocommerce/blocks-checkout';
+
+__experimentalRegisterCheckoutFilters( 'automatic-coupon-extension', {
+	coupons: filterCoupons,
+} );
+```
+
 | Before | After |
 |---|---|
 | <img src="https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png" /> | ![image](https://user-images.githubusercontent.com/5656702/124126048-2c57a380-da72-11eb-9b45-b2cae0cffc37.png) |

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -219,16 +219,12 @@ Our filtering function may look like this:
 const filterCoupons = ( coupons ) => {
   return coupons.map( ( coupon ) => {
   	// Regex to match autocoupon then unlimited undersores and numbers
-    if ( ! coupon.text.match( /autocoupon(?:_\d+)+/ ) ) {
+    if ( ! coupon.label.match( /autocoupon(?:_\d+)+/ ) ) {
       return coupon;
     }
     return {
       ...coupon,
-      text: sprintf(
-        /* translators: %s is the custom label for points, e.g. coins, tokens etc. */
-        __( '%s redemption', 'woocommerce-points-and-rewards' ),
-        pointsLabelPlural
-      ),
+      label: 'Automatic coupon'
     };
   } );
 };
@@ -236,7 +232,7 @@ const filterCoupons = ( coupons ) => {
 
 | Before | After |
 |---|---|
-| <img src="https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png" /> | * |
+| <img src="https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png" /> | ![image](https://user-images.githubusercontent.com/5656702/124126048-2c57a380-da72-11eb-9b45-b2cae0cffc37.png) |
 
 
 ## Troubleshooting

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -91,7 +91,7 @@ There are no additional arguments passed to this filter.
 
 The current functionality is to display the coupon codes in the Cart and Checkout sidebars. This could be undesirable
 if you dynamically generate a coupon code that is not user-friendly. It may, therefore, be desirable to change the way
-this code is displayed. To do this, the filter `couponName` exists.
+this code is displayed. To do this, the filter `coupons` exists.
 
 This filter could also be used to show or hide coupons.
 

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -106,6 +106,7 @@ The additional argument supplied to this filter is: `{ context: 'summary' }`. A 
 ```typescript
 CartCoupon {
   code: string
+  label: string
   discount_type: string
   totals: {
     currency_code: string
@@ -204,6 +205,39 @@ __experimentalRegisterCheckoutFilters( 'my-hypothetical-price-plugin', {
 | Before | After |
 |---|---|
 | <img src="https://user-images.githubusercontent.com/5656702/117035086-d5488300-acfb-11eb-9954-feb326916168.png" width=400 /> | <img src="https://user-images.githubusercontent.com/5656702/117035616-70415d00-acfc-11eb-98d3-6c8096817e5b.png" width=400 /> |
+
+### Change the name of a coupon
+Let's say we're the author of an extension that automatically creates coupons for users, and applies them to the cart
+when certain items are bought in combination.
+
+Due to the internal workings of our extension, our automatically generated coupons are named something like
+`autocoupon_2020_06_29` - this doesn't look fantastic, so we want to change this to look a bit nicer.
+
+Our filtering function may look like this:
+
+```typescript
+const filterCoupons = ( coupons ) => {
+  return coupons.map( ( coupon ) => {
+  	// Regex to match autocoupon then unlimited undersores and numbers
+    if ( ! coupon.text.match( /autocoupon(?:_\d+)+/ ) ) {
+      return coupon;
+    }
+    return {
+      ...coupon,
+      text: sprintf(
+        /* translators: %s is the custom label for points, e.g. coins, tokens etc. */
+        __( '%s redemption', 'woocommerce-points-and-rewards' ),
+        pointsLabelPlural
+      ),
+    };
+  } );
+};
+```
+
+| Before | After |
+|---|---|
+| <img src="https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png" /> | * |
+
 
 ## Troubleshooting
 If you are logged in to the store as an administrator, you should be shown an error like this if your filter is not

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -4,6 +4,7 @@
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -34,6 +35,20 @@ export const __experimentalRegisterCheckoutFilters = (
 	namespace: string,
 	filters: Record< string, CheckoutFilterFunction >
 ): void => {
+	/**
+	 * Let the user know couponName is no longer available as a filter.
+	 *
+	 * See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4312
+	 */
+	if ( Object.keys( filters ).includes( 'couponName' ) ) {
+		deprecated( 'couponName', {
+			alternative: 'coupons',
+			plugin: 'WooCommerce Blocks',
+			link:
+				'https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/bb921d21f42e21f38df2b1c87b48e07aa4cb0538/docs/extensibility/available-filters.md#coupons',
+		} );
+	}
+
 	checkoutFilters = {
 		...checkoutFilters,
 		[ namespace ]: filters,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
#### Description
There is a bug where the coupon filter doesn't work if more than one coupon is added to the cart. This PR will change the way the coupon filter works to ensure the filter is only invoked once per render. Unfortunately this is a breaking change.

Another way to solve this would be to implement our own memoization function, and use that in `__experimentalApplyCheckoutFilter` rather than `React.useMemo`, or to simply remove memoization altogether (not desirable).

---

#### Changes made in this PR
- Add a `text` property to each `coupon` in the cart. This is required because when extensions change how the coupon is displayed, we need to keep a record of the code, so we can remove it from the cart if the shopper desires.
- Remove the `couponNames` filter, and replace it with `coupons`. Move the filter outside of the loop so it is always called once per render.
- Add deprecation notice if an extension has included `couponNames` in its filters object.
- Add documentation about new filter.

<!-- Reference any related issues or PRs here -->
Fixes #4311

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

1. Ensure two coupons are available on your store. **Name one of them `testcoupon`.**
2. Go to the Cart block and add them both.
3. Ensure they work, and can be removed.
4. Try with three+ coupons.
5. Add this code somewhere in your application (I added it to the bottom of `packages/checkout/registry/index.ts`)
```typescript
__experimentalRegisterCheckoutFilters( 'blocks', {
	couponName: ( value ) => {
		return value;
	},
} );
```
6. Ensure the deprecation warning is shown in the console. `couponName is deprecated. Please use coupons instead.`
7. Remove that code and add:
```typescript
__experimentalRegisterCheckoutFilters( 'blocks', {
	coupons: ( value ) => {
		return value.map( ( coupon ) => {
			if ( coupon.code !== 'testcoupon' ) {
				return coupon;
			}
			return {
				...coupon,
				text: 'this is custom coupon text!',
			};
		} );
	},
} );
```
8. Reload the page and ensure the coupon that was previously labelled `testcoupon` is now shown as `this is custom coupon text!`
<!-- If you can, add the appropriate labels -->

### Changelog

> Remove `couponName` filter and replace it with `coupons` filter.
