### PR TITLE
Add snackbar filter

### DIFF
--- a/assets/js/base/context/providers/store-notices/components/snackbar-notices-container.js
+++ b/assets/js/base/context/providers/store-notices/components/snackbar-notices-container.js
@@ -3,6 +3,7 @@
  */
 import { SnackbarList } from 'wordpress-components';
 import classnames from 'classnames';
+import { __experimentalApplyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
 const SnackbarNoticesContainer = ( {
 	className,
@@ -18,6 +19,11 @@ const SnackbarNoticesContainer = ( {
 		( notice ) => notice.type === 'snackbar'
 	);
 
+	const filteredNotices = __experimentalApplyCheckoutFilter( {
+		filterName: 'snackbarNotices',
+		defaultValue: snackbarNotices,
+	} );
+
 	const wrapperClass = classnames(
 		className,
 		'wc-block-components-notices__snackbar'
@@ -25,7 +31,7 @@ const SnackbarNoticesContainer = ( {
 
 	return (
 		<SnackbarList
-			notices={ snackbarNotices }
+			notices={ filteredNotices }
 			className={ wrapperClass }
 			onRemove={ removeNotice }
 		/>

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -116,6 +116,32 @@ interface CartCoupon {
   }
 }
 ```
+### Snackbar notices
+
+There is a snackbar at the bottom of the page used to display notices to the customer, it looks like this:
+
+<img src="https://user-images.githubusercontent.com/5656702/120882329-d573c100-c5ce-11eb-901b-d7f206f74a66.png" width=300 />
+
+It may be desirable to hide this (by removing it from the array) or to change the text in the notice.
+
+| Filter name  | Description | Return type  |
+|---|---|---|
+| `snackbarNotices`  | An array of notices waiting to be shown in the snackbar | `SnackbarNotice[]`
+
+These are the relevant members of a `SnackbarNotice` object.
+
+```typescript
+SnackbarNotice {
+  content: string;
+  explicitDismiss: boolean;
+  icon: string | null;
+  isDismissable: boolean;
+  onDismiss: Function;
+  spokenMessage: string;
+  status: string;
+  type: string
+}
+```
 
 ## Examples
 

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -72,7 +72,7 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 	/** Values extend to REST API response. */
 	extensions?: Record< string, unknown >;
 	/** Object containing arguments for the filter function. */
-	arg: CheckoutFilterArguments;
+	arg?: CheckoutFilterArguments;
 	/** Function that needs to return true when the filtered value is passed in order for the filter to be applied. */
 	validation?: ( value: T ) => true | Error;
 } ): T => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will add a filter that will let extensions modify the notices queued to be shown in the snackbar.

It also makes the `arg` property on the arguments passed to `__experimentalApplyCheckoutFilter` optional, as this is not always necessary to pass.

### How to test the changes in this Pull Request:

1. Add a coupon to your site called `testcoupon`.
1. Add the following code to the bottom of `packages/checkout/registry/index.ts`:
```typescript

__experimentalRegisterCheckoutFilters( 'blocks', {
	snackbarNotices: ( value ) => {
		return value.filter( ( notice ) => {
			return ! notice.content.match( /testcoupon/ );
		} );
	},
} );
```
2. When adding and removing this coupon ensure the snackbar is not shown.
3. Remove the coupon and add a different one. (Ensure you remove the coupon first, due to a known bug where adding two breaks the cart: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4312)
4. When adding a coupon that is not `testcoupon` ensure the snackbar _is_ shown.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add filter to allow extensions to control the notification snackbar.
