### PR TITLE
Ensure directories with spaces work with our WP Deploy script

### DIFF
--- a/bin/wordpress-deploy.sh
+++ b/bin/wordpress-deploy.sh
@@ -142,7 +142,7 @@ fi
 
 # Copy GIT directory to trunk
 output 2 "Copying project files to SVN trunk..."
-sh ${RELEASER_PATH}/bin/copy-plugin-files.sh "$GIT_PATH" "$SVN_PATH/trunk"
+sh "${RELEASER_PATH}/bin/copy-plugin-files.sh" "$GIT_PATH" "$SVN_PATH/trunk"
 cd "$SVN_PATH"
 
 # Update stable tag on trunk/readme.txt


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will ensure that people deploying Blocks from a directory containing spaces don't get an error when deploying to WordPress.org.

It looks like the other script that could fail, `build-plugin-zip.sh` was fixed here https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3900/commits/b271c6b3797210000760034a5280e109ae099ae1
<!-- Reference any related issues or PRs here -->
Fixes #3799

### How to test the changes in this Pull Request:

1. I'm not sure if there's a real way to test it, but if you create a directory with spaces, create a test script `test-script.sh`:
```bash
#!/bin/sh
echo $@
```
This will echo the arguments passed to the script.
2.  then extract these parts of the `wordpress-deploy` script into a bash file:
```bash
#!/bin/sh

RELEASER_PATH=$(pwd)
PLUGIN_SLUG="woo-gutenberg-products-block"
GITHUB_ORG="woocommerce"
GITHUB_SLUG="woocommerce-gutenberg-products-block"
IS_PRE_RELEASE=false
BUILD_PATH="${HOME}/blocks-deployment"
SVN_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-svn"
GIT_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-git"
sh "${RELEASER_PATH}/test-script.sh" "$GIT_PATH" "$SVN_PATH/trunk"
```
2. Run this and ensure the test script is executed. You should see the `GIT_PATH` and `SVN_PATH` echoed onto the command line.
2. You can also change the bash script to show how the command would have looked before this PR
```bash
#!/bin/sh

RELEASER_PATH=$(pwd)
PLUGIN_SLUG="woo-gutenberg-products-block"
GITHUB_ORG="woocommerce"
GITHUB_SLUG="woocommerce-gutenberg-products-block"
IS_PRE_RELEASE=false
BUILD_PATH="${HOME}/blocks-deployment"
SVN_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-svn"
GIT_PATH="${BUILD_PATH}/${PLUGIN_SLUG}-git"
sh ${RELEASER_PATH}/test-script.sh "$GIT_PATH" "$SVN_PATH/trunk"
```
And verify you get an error: `sh: /Users/me/space: No such file or directory`

