### PR TITLE
Prevent PHP notice for variable products without enabled variations.

### DIFF
--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -556,7 +556,12 @@ class ProductSchema extends AbstractSchema {
 		}
 		global $wpdb;
 
-		$variation_ids               = $product->get_visible_children();
+		$variation_ids = $product->get_visible_children();
+
+		if ( ! count( $variation_ids ) ) {
+			return [];
+		}
+
 		$attributes                  = array_filter( $product->get_attributes(), [ $this, 'filter_variation_attribute' ] );
 		$default_variation_meta_data = array_reduce(
 			$attributes,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
`ProductSchema::get_variations` throws a PHP notice due to an invalid SQL query for products without enabled variations, for example for this query: `SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value FROM wp_postmeta WHERE post_id IN () AND meta_key IN ('attribute_pa_size')`

### How to test the changes in this Pull Request:

1. Create a variable product with one disabled variation and at least one variation attribute.
2. Create a new blog post with a "Product category" block and select the category that contains the newly created product.
3. Visiting the new blog post throws a PHP notice (`NOTICE: PHP message: WordPress database error You have an error in your SQL syntax ...`)

### Changelog

> Prevent PHP notice for variable products without enabled variations.
