### PR TITLE
Fix Product Categories List display issues in WP 5.8

### DIFF
--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -36,7 +36,10 @@
 		border: 1px solid #eee;
 
 		img {
+			display: block;
+			height: auto;
 			margin: 0;
+			max-width: 100%;
 			padding: 0;
 		}
 	}


### PR DESCRIPTION
Fixes #4334.

### How to test the changes in this Pull Request:

1. With Gutenberg and TT1 Blocks, go to the Site Editor.
2. Add a Product Categories List block.
3. Set the `Show category images` attribute to true.
4. Verify images have the correct size:

| Before | After |
| --- | --- |
| ![Screenshot of Products Categories List rendering huge images](https://user-images.githubusercontent.com/3616980/121377547-b6fd2500-c942-11eb-8823-1dec7e8f4e72.png) | ![Screenshot of Products Categories List rendering images of the correct size](https://user-images.githubusercontent.com/3616980/121376793-1a3a8780-c942-11eb-914b-911192b07250.png) |

5. With the same theme, add the Product Categories List block to a post or page and verify there is no bottom space between the image and the border.

| Before | After |
| --- | --- |
| ![Screenshot of Products Categories List images having a border offset](https://user-images.githubusercontent.com/3616980/121377492-ac429000-c942-11eb-86ac-8075341ab1ac.png) | ![Screenshot of Products Categories List images without the border offset](https://user-images.githubusercontent.com/3616980/121376865-2c1c2a80-c942-11eb-9f6e-79c51bfa2a49.png) |

### Changelog

> Fix Product Categories List block display in Site Editor.
