### PR TITLE
Make Product Categories List links unclickable in the editor

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -5,7 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
-import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
+import {
+	Disabled,
+	PanelBody,
+	ToggleControl,
+	Placeholder,
+} from '@wordpress/components';
 import { Icon, list } from '@woocommerce/icons';
 import ToggleButtonControl from '@woocommerce/editor-components/toggle-button-control';
 
@@ -181,11 +186,13 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	return (
 		<>
 			{ getInspectorControls() }
-			<ServerSideRender
-				block={ name }
-				attributes={ attributes }
-				EmptyResponsePlaceholder={ EmptyPlaceholder }
-			/>
+			<Disabled>
+				<ServerSideRender
+					block={ name }
+					attributes={ attributes }
+					EmptyResponsePlaceholder={ EmptyPlaceholder }
+				/>
+			</Disabled>
 		</>
 	);
 };


### PR DESCRIPTION
Fixes #4337.

### How to test the changes in this Pull Request:

1. Add the Product Categories List block to a post or page.
2. Try to click on a Category Link.
![Scheenshot of pointer cursor over a category name](https://user-images.githubusercontent.com/3616980/121380040-d8f7a700-c944-11eb-98e1-24736043dc0a.png)
3. Verify you can't click on it and you aren't redirected to the Category page.

### Changelog

> Make links in the Product Categories List block unclickable in the editor