### PR TITLE
Add a workflow for the assign-milestone automation

### DIFF
--- a/.github/workflows/approved-with-labels.yml
+++ b/.github/workflows/approved-with-labels.yml
@@ -22,4 +22,4 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   automations: assign-milestone
-                  milestone_bump_strategy: minor
+                  milestone_bump_strategy: none

--- a/.github/workflows/approved-with-labels.yml
+++ b/.github/workflows/approved-with-labels.yml
@@ -1,14 +1,24 @@
 on: pull_request_review
-name: Add Labels to Approved Pull Requests
+name: Approved Pull Requests
 jobs:
-  labelWhenApproved:
-    name: Label when approved
-    runs-on: ubuntu-latest
-    steps:
-    - name: Label when approved
-      uses: pullreminders/label-when-approved-action@master
-      env:
-        APPROVALS: "1"
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ADD_LABEL: "status: ready to merge"
-        REMOVE_LABEL: "status:%20needs%20review"
+    labelWhenApproved:
+        name: Add Labels
+        runs-on: ubuntu-latest
+        steps:
+            - name: Ready to merge label
+              uses: pullreminders/label-when-approved-action@master
+              env:
+                  APPROVALS: '1'
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  ADD_LABEL: 'status: ready to merge'
+                  REMOVE_LABEL: 'status:%20needs%20review'
+    milestoneWhenApproved:
+        name: Add Milestone
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Latest milestone
+              uses: woocommerce/automations@v1
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  automations: assign-milestone

--- a/.github/workflows/approved-with-labels.yml
+++ b/.github/workflows/approved-with-labels.yml
@@ -22,3 +22,4 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   automations: assign-milestone
+                  milestone_bump_strategy: minor


### PR DESCRIPTION
Includes the assign-milestone automation added in https://github.com/woocommerce/automations/pull/41

To test, approve this PR. It should be assigned a milestone automatically when approved. Other workflows should continue to run normally (label etc).

If this assigns to the wrong milestone, please unapproved so we can tweak somehow.