### PR TITLE
Release/5.3.1

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -5,7 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
-import { PanelBody, ToggleControl, Placeholder } from '@wordpress/components';
+import {
+	Disabled,
+	PanelBody,
+	ToggleControl,
+	Placeholder,
+} from '@wordpress/components';
 import { Icon, list } from '@woocommerce/icons';
 import ToggleButtonControl from '@woocommerce/editor-components/toggle-button-control';
 
@@ -181,11 +186,13 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	return (
 		<>
 			{ getInspectorControls() }
-			<ServerSideRender
-				block={ name }
-				attributes={ attributes }
-				EmptyResponsePlaceholder={ EmptyPlaceholder }
-			/>
+			<Disabled>
+				<ServerSideRender
+					block={ name }
+					attributes={ attributes }
+					EmptyResponsePlaceholder={ EmptyPlaceholder }
+				/>
+			</Disabled>
 		</>
 	);
 };

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -36,7 +36,10 @@
 		border: 1px solid #eee;
 
 		img {
+			display: block;
+			height: auto;
 			margin: 0;
+			max-width: 100%;
 			padding: 0;
 		}
 	}

--- a/docs/testing/releases/531.md
+++ b/docs/testing/releases/531.md
@@ -1,0 +1,40 @@
+## Testing notes and ZIP for release 5.3.1
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6653798/woocommerce-gutenberg-products-block.zip)
+
+## Feature plugin and package inclusion in WooCommerce core
+
+### Fix Product Categories List display issues in WP 5.8. ([4335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4335))
+
+1. With Gutenberg and TT1 Blocks, go to the Site Editor.
+2. Add a Product Categories List block.
+3. Set the `Show category images` attribute to true.
+4. Verify images have the correct size:
+
+| Before | After |
+| --- | --- |
+| ![Screenshot of Products Categories List rendering huge images](https://user-images.githubusercontent.com/3616980/121377547-b6fd2500-c942-11eb-8823-1dec7e8f4e72.png) | ![Screenshot of Products Categories List rendering images of the correct size](https://user-images.githubusercontent.com/3616980/121376793-1a3a8780-c942-11eb-914b-911192b07250.png) |
+
+5. With the same theme, add the Product Categories List block to a post or page and verify there is no bottom space between the image and the border.
+
+| Before | After |
+| --- | --- |
+| ![Screenshot of Products Categories List images having a border offset](https://user-images.githubusercontent.com/3616980/121377492-ac429000-c942-11eb-86ac-8075341ab1ac.png) | ![Screenshot of Products Categories List images without the border offset](https://user-images.githubusercontent.com/3616980/121376865-2c1c2a80-c942-11eb-9f6e-79c51bfa2a49.png) |
+
+### Make Product Categories List links unclickable in the editor. ([4339](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4339))
+
+1. Add the Product Categories List block to a post or page.
+2. Try to click on a Category Link.<br>
+![Scheenshot of pointer cursor over a category name](https://user-images.githubusercontent.com/3616980/121380040-d8f7a700-c944-11eb-98e1-24736043dc0a.png)
+3. Verify you can't click on it and you aren't redirected to the Category page.
+
+### Load woocommerce.css in Site editor. ([4345](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4345))
+
+1. Make sure you are using the latest version of WooCommerce `trunk`.
+2. Enable a block-based theme (ie: TT1 Blocks) and Gutenberg.
+3. Go to the Site Editor.
+4. Add a Reviews block and verify rating stars are rendered correctly.
+
+| Before | After |
+| --- | --- |
+| ![Screenshot where rating stars are replaced by S](https://user-images.githubusercontent.com/3616980/121849894-3cd6f280-ccec-11eb-81e4-de37f47ef9d3.png) | ![Schreenshot where rating stars are rendered correctly](https://user-images.githubusercontent.com/3616980/121849806-1fa22400-ccec-11eb-9359-007a4c6dd8a7.png) |

--- a/docs/testing/releases/531.md
+++ b/docs/testing/releases/531.md
@@ -1,6 +1,6 @@
 ## Testing notes and ZIP for release 5.3.1
 
-Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6653798/woocommerce-gutenberg-products-block.zip)
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6654288/woocommerce-gutenberg-products-block.zip)
 
 ## Feature plugin and package inclusion in WooCommerce core
 

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -33,3 +33,4 @@ Every release includes specific testing instructions for new features and bug fi
 -   [5.1.0](./510.md)
 -   [5.2.0](./520.md)
 -   [5.3.0](./530.md)
+-   [5.3.1](./531.md)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "5.3.0",
+	"version": "5.3.1",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, woocommerce, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia, aljullu, mikejolley, nerrad, joshuawold, assassinateur, haszari
 Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.5
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 7.0
 Stable tag: 5.3.0
 License: GPLv3
@@ -84,6 +84,11 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 5. WooCommerce Product Blocks in the block inserter menu
 
 == Changelog ==
+
+= 5.3.1 - 2021-06-15 =
+- Fix Product Categories List block display in Site Editor ([#4335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4335)).
+- Make links in the Product Categories List block unclickable in the editor ([#4339](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4339)).
+- Fix rating stars not being shown in the Site Editor ([#4345](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4345)).
 
 = 5.3.0 - 2021-06-07 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.5
 Tested up to: 5.8
 Requires PHP: 7.0
-Stable tag: 5.3.0
+Stable tag: 5.3.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -127,7 +127,7 @@ final class AssetsController {
 	 */
 	public function update_block_style_dependencies() {
 		$wp_styles = wp_styles();
-		$style     = $wp_styles->query( 'wc-blocks-style', 'registered' );
+		$style     = $wp_styles->query( 'wc-block-style', 'registered' );
 
 		if ( ! $style ) {
 			return;

--- a/src/Package.php
+++ b/src/Package.php
@@ -106,7 +106,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '5.3.0';
+					$version = '5.3.1';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ ),

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -9,8 +9,8 @@
  * Text Domain:  woo-gutenberg-products-block
  * Requires at least: 5.5
  * Requires PHP: 7.0
- * WC requires at least: 4.9
- * WC tested up to: 5.3
+ * WC requires at least: 5.2
+ * WC tested up to: 5.5
  *
  * @package WooCommerce\Blocks
  * @internal This file is only used when running as a feature plugin.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 5.3.0
+ * Version: 5.3.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
This is the patch release pull request for WooCommerce Blocks plugin `5.3.1`.

## Changelog

---
```
- Fix Product Categories List block display in Site Editor (#4335).
- Make links in the Product Categories List block unclickable in the editor (#4339).
- Fix rating stars not being shown in the Site Editor (#4345).
```

---

## Communication

This release introduces some fixes in preparation for WordPress 5.8.

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

**Release announcement:** https://developer.woocommerce.com/2021/06/15/woocommerce-blocks-5-3-1-release-notes/

## Quality

> This section is for any notes related to quality around the release Please include any extra details with each item as needed. This can include notes about why something isn't checked or expanding info on your response to an item.

* [ ] Changes in this release are covered by Automated Tests.

      > This section is for confirming that the release changeset is covered by automated tests. If not, please leave some details on why not and any relevant information indicating confidence without those tests.

     * [ ] Unit tests
     * [ ] E2E tests
     * [ ] for each supported WordPress and WooCommerce core versions.

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [ ] This release affects public facing REST APIs.
    * [ ] It conforms to REST API versioning policy.

* [ ] This release impacts **other extensions** or **backward compatibility**.
    * [ ] The release changes the signature of public methods or functions
        * [ ] This is documented (see: *Enter a link to the documentation here*)
    * [ ] The release affects filters or action hooks.
        * [ ] This is documented (see: *Enter a link to the documentation here*)

* [x] Link to **testing instructions** for this release: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/49a88e911a8d9513f75d987a3ef17dedc2e6af67/docs/testing/releases/531.md

* [ ] The release has a negative performance impact on sites.
    * [ ] There are new assets (JavaScript or CSS bundles)
    * [ ] There is an increase to the size of JavaScrip or CSS bundles) *please include rationale for this increase*
    * [ ] Other negative performance impacts (if yes, include list below)

* [ ] The release has positive performance impact on sites. If checked, please document these improvements here.

------
