### PR TITLE
Use old wc-block-style handle

### DIFF
--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -127,7 +127,7 @@ final class AssetsController {
 	 */
 	public function update_block_style_dependencies() {
 		$wp_styles = wp_styles();
-		$style     = $wp_styles->query( 'wc-blocks-style', 'registered' );
+		$style     = $wp_styles->query( 'wc-block-style', 'registered' );
 
 		if ( ! $style ) {
 			return;


### PR DESCRIPTION
In #4345 we added `woocommerce-general` style as a dependency of `wc-blocks-style`. However, in 5.3.0, that stylesheet had a different handle: `wc-block-style`, so when cherry-picking that PR into `release/5.3.0`, it stopped working.

This PR updates the fix introduced in #4345 so it uses the old handle.

**Note: this PR should not be merge into `trunk`.**

### How to test the changes in this Pull Request:

Same as #4345:

1. Make sure you are using the latest version of WooCommerce `trunk`.
2. Enable a block-based theme (ie: TT1 Blocks) and Gutenberg.
3. Go to the Site Editor.
4. Add a Reviews block and verify rating stars are rendered correctly.

| Before | After |
| --- | --- |
| ![Screenshot where rating stars are replaced by S](https://user-images.githubusercontent.com/3616980/121849894-3cd6f280-ccec-11eb-81e4-de37f47ef9d3.png) | ![Schreenshot where rating stars are rendered correctly](https://user-images.githubusercontent.com/3616980/121849806-1fa22400-ccec-11eb-9359-007a4c6dd8a7.png) |
