### PR TITLE
Add 5.3.1 testing instructions

### DIFF
--- a/docs/testing/releases/531.md
+++ b/docs/testing/releases/531.md
@@ -1,0 +1,40 @@
+## Testing notes and ZIP for release 5.3.1
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6653798/woocommerce-gutenberg-products-block.zip)
+
+## Feature plugin and package inclusion in WooCommerce core
+
+### Fix Product Categories List display issues in WP 5.8. ([4335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4335))
+
+1. With Gutenberg and TT1 Blocks, go to the Site Editor.
+2. Add a Product Categories List block.
+3. Set the `Show category images` attribute to true.
+4. Verify images have the correct size:
+
+| Before | After |
+| --- | --- |
+| ![Screenshot of Products Categories List rendering huge images](https://user-images.githubusercontent.com/3616980/121377547-b6fd2500-c942-11eb-8823-1dec7e8f4e72.png) | ![Screenshot of Products Categories List rendering images of the correct size](https://user-images.githubusercontent.com/3616980/121376793-1a3a8780-c942-11eb-914b-911192b07250.png) |
+
+5. With the same theme, add the Product Categories List block to a post or page and verify there is no bottom space between the image and the border.
+
+| Before | After |
+| --- | --- |
+| ![Screenshot of Products Categories List images having a border offset](https://user-images.githubusercontent.com/3616980/121377492-ac429000-c942-11eb-86ac-8075341ab1ac.png) | ![Screenshot of Products Categories List images without the border offset](https://user-images.githubusercontent.com/3616980/121376865-2c1c2a80-c942-11eb-9f6e-79c51bfa2a49.png) |
+
+### Make Product Categories List links unclickable in the editor. ([4339](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4339))
+
+1. Add the Product Categories List block to a post or page.
+2. Try to click on a Category Link.<br>
+![Scheenshot of pointer cursor over a category name](https://user-images.githubusercontent.com/3616980/121380040-d8f7a700-c944-11eb-98e1-24736043dc0a.png)
+3. Verify you can't click on it and you aren't redirected to the Category page.
+
+### Load woocommerce.css in Site editor. ([4345](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4345))
+
+1. Make sure you are using the latest version of WooCommerce `trunk`.
+2. Enable a block-based theme (ie: TT1 Blocks) and Gutenberg.
+3. Go to the Site Editor.
+4. Add a Reviews block and verify rating stars are rendered correctly.
+
+| Before | After |
+| --- | --- |
+| ![Screenshot where rating stars are replaced by S](https://user-images.githubusercontent.com/3616980/121849894-3cd6f280-ccec-11eb-81e4-de37f47ef9d3.png) | ![Schreenshot where rating stars are rendered correctly](https://user-images.githubusercontent.com/3616980/121849806-1fa22400-ccec-11eb-9359-007a4c6dd8a7.png) |

--- a/docs/testing/releases/531.md
+++ b/docs/testing/releases/531.md
@@ -1,6 +1,6 @@
 ## Testing notes and ZIP for release 5.3.1
 
-Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6653798/woocommerce-gutenberg-products-block.zip)
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6654288/woocommerce-gutenberg-products-block.zip)
 
 ## Feature plugin and package inclusion in WooCommerce core
 

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -33,3 +33,4 @@ Every release includes specific testing instructions for new features and bug fi
 -   [5.1.0](./510.md)
 -   [5.2.0](./520.md)
 -   [5.3.0](./530.md)
+-   [5.3.1](./531.md)

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, woocommerce, claudiulodro, tiagonoronha, jameskoster, ryelle, levinmedia, aljullu, mikejolley, nerrad, joshuawold, assassinateur, haszari
 Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 5.5
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 7.0
 Stable tag: 5.3.0-dev
 License: GPLv3
@@ -84,6 +84,11 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 5. WooCommerce Product Blocks in the block inserter menu
 
 == Changelog ==
+
+= 5.3.1 - 2021-06-15 =
+- Fix Product Categories List block display in Site Editor ([#4335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4335)).
+- Make links in the Product Categories List block unclickable in the editor ([#4339](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4339)).
+- Fix rating stars not being shown in the Site Editor ([#4345](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4345)).
 
 = 5.3.0 - 2021-06-08 =
 

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -9,8 +9,8 @@
  * Text Domain:  woo-gutenberg-products-block
  * Requires at least: 5.5
  * Requires PHP: 7.0
- * WC requires at least: 4.9
- * WC tested up to: 5.3
+ * WC requires at least: 5.2
+ * WC tested up to: 5.5
  *
  * @package WooCommerce\Blocks
  * @internal This file is only used when running as a feature plugin.


### PR DESCRIPTION
Given that #4348 has commits we don't want to merge to `trunk` (see #4350), I'm creating this PR which cherry-picks the version updates and testing instructions from 5.3.1.