### PR TITLE
Fix error regarding duplicate keys in TotalsFees

### DIFF
--- a/packages/checkout/totals/fees/index.tsx
+++ b/packages/checkout/totals/fees/index.tsx
@@ -26,7 +26,7 @@ const TotalsFees = ( {
 }: TotalsFeesProps ): ReactElement | null => {
 	return (
 		<>
-			{ cartFees.map( ( { id, name, totals } ) => {
+			{ cartFees.map( ( { id, name, totals }, index ) => {
 				const feesValue = parseInt( totals.total, 10 );
 
 				if ( ! feesValue ) {
@@ -37,7 +37,7 @@ const TotalsFees = ( {
 
 				return (
 					<TotalsItem
-						key={ id }
+						key={ id || `${ index }-${ name }` }
 						className={ classnames(
 							'wc-block-components-totals-fees',
 							className


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes the `Warning: Each child in a list should have a unique "key" prop.` experienced when fees are present on the cart.

This occurs when the fee does not have an ID, we can repair this by using the fee's ID as its key, but if it's not present then we can use the fee's name and its index in the fees list to generate a unique key.

### How to test the changes in this Pull Request:

1. Add fees to your cart (using the extra fees extension https://woocommerce.com/products/extra-fees-for-woocommerce/ set up an order fee, or any other combination of fees).
2. Go to the cart/checkout blocks and ensure no console warning is shown.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix a warning shown when fees are included in the order.
