### PR TITLE
Add type argument to `getSetting`

### DIFF
--- a/assets/js/settings/shared/utils.ts
+++ b/assets/js/settings/shared/utils.ts
@@ -15,14 +15,14 @@ import { allSettings } from './settings-init';
  * the `fallback` will be returned instead. An optional `filter`
  * callback can be passed to format the returned value.
  */
-export const getSetting = (
+export const getSetting = < T >(
 	name: string,
 	fallback: unknown = false,
 	filter = ( val: unknown, fb: unknown ) =>
 		typeof val !== 'undefined' ? val : fb
-): unknown => {
+): T => {
 	const value = name in allSettings ? allSettings[ name ] : fallback;
-	return filter( value, fallback );
+	return filter( value, fallback ) as T;
 };
 
 /**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR allows us to pass a type argument to `getSetting` - since TS has no idea what type will be returned, we need to give it a hand.

When using this, you should make very sure that the type is correct, and that you cater for any situations where data may be incomplete or different. Remember TypeScript is only a compile-time tool!

<!-- Reference any related issues or PRs here -->
Fixes #4250

### How to test the changes in this Pull Request:

1. Add the following to any TypeScript file:
```typescript
const input: { key: string } = { key: 'test' };
const testValue = getSetting< typeof input >( 'test', input );
```
2. Verify that your IDE correctly shows the type of `testValue` to be `{ key: string }`.
3. Try adding a type argument to any other existing use of `getSetting` and ensure there are no TS errors displayed when doing so.
