### PR TITLE
Switch arrow unicode characters

### DIFF
--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -58,7 +58,7 @@ const Pagination = ( {
 			/>
 			{ displayNextAndPreviousArrows && (
 				<button
-					className="wc-block-pagination-page wc-block-components-pagination__page"
+					className="wc-block-pagination-page wc-block-components-pagination__page wc-block-pagination-page--arrow"
 					onClick={ () => onPageChange( currentPage - 1 ) }
 					title={ __(
 						'Previous page',
@@ -175,7 +175,7 @@ const Pagination = ( {
 			) }
 			{ displayNextAndPreviousArrows && (
 				<button
-					className="wc-block-pagination-page wc-block-components-pagination__page"
+					className="wc-block-pagination-page wc-block-components-pagination__page wc-block-pagination-page--arrow"
 					onClick={ () => onPageChange( currentPage + 1 ) }
 					title={ __( 'Next page', 'woo-gutenberg-products-block' ) }
 					disabled={ currentPage >= totalPages }

--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -67,7 +67,7 @@ const Pagination = ( {
 					disabled={ currentPage <= 1 }
 				>
 					<Label
-						label="<"
+						label="&larr;"
 						screenReaderLabel={ __(
 							'Previous page',
 							'woo-gutenberg-products-block'
@@ -181,7 +181,7 @@ const Pagination = ( {
 					disabled={ currentPage >= totalPages }
 				>
 					<Label
-						label=">"
+						label="&rarr;"
 						screenReaderLabel={ __(
 							'Next page',
 							'woo-gutenberg-products-block'

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -49,3 +49,8 @@
 		opacity: 1 !important;
 	}
 }
+
+html[dir="rtl"] .wc-block-pagination-page--arrow span {
+	display: inline-block;
+	transform: scale(-1, 1);
+}


### PR DESCRIPTION
This is a small change to make the [pagination arrows match core](https://github.com/woocommerce/woocommerce/blob/b19500728b4b292562afb65eb3a0c0f50d5859de/templates/loop/pagination.php#L42-L43).

Fixes #1821

### Screenshots

Before:
![Screenshot 2021-06-16 at 17 28 38](https://user-images.githubusercontent.com/90977/122258064-8bd97f00-cec8-11eb-8e0a-a82e62a4804a.png)

After:
![Screenshot 2021-06-16 at 17 25 45](https://user-images.githubusercontent.com/90977/122258089-9136c980-cec8-11eb-90a0-543ca30dc482.png)

### How to test the changes in this Pull Request:

View the pagination rendered on the all products block and confirm the symbol matches the screenshot above.

<!-- If you can, add the appropriate labels -->

### Changelog

> Update pagination arrows to match core.
