### PR TITLE
Append SKU to name for SearchListControl

### DIFF
--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -67,7 +67,9 @@ const ProductsControl = ( {
 		<SearchListControl
 			className="woocommerce-products"
 			list={ products.map( ( product ) => {
-				const formattedSku = product.sku ? ' (' + product.sku + ')' : '';
+				const formattedSku = product.sku
+					? ' (' + product.sku + ')'
+					: '';
 				return {
 					...product,
 					name: `${ product.name }${ formattedSku }`,

--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -67,10 +67,10 @@ const ProductsControl = ( {
 		<SearchListControl
 			className="woocommerce-products"
 			list={ products.map( ( product ) => {
-				const formattedSku = product.sku ? '(' + product.sku + ')' : '';
+				const formattedSku = product.sku ? ' (' + product.sku + ')' : '';
 				return {
 					...product,
-					name: `${ product.name } ${ formattedSku }`,
+					name: `${ product.name }${ formattedSku }`,
 				};
 			} ) }
 			isCompact={ isCompact }

--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -66,7 +66,13 @@ const ProductsControl = ( {
 	return (
 		<SearchListControl
 			className="woocommerce-products"
-			list={ products }
+			list={ products.map( ( product ) => {
+				const formattedSku = product.sku ? '(' + product.sku + ')' : '';
+				return {
+					...product,
+					name: `${ product.name } ${ formattedSku }`,
+				};
+			} ) }
 			isCompact={ isCompact }
 			isLoading={ isLoading }
 			selected={ products.filter( ( { id } ) =>


### PR DESCRIPTION
We had some requests to allow SKUs to be searched in some of our product blocks. `SearchListControl` only allows searching by the given names, so to support this we can render the SKU appended to the name. This also makes it clearer what product is what when they are similarly named.

Fixes #1098

### Screenshots

![Screenshot 2021-06-16 at 18 20 52](https://user-images.githubusercontent.com/90977/122264632-a6632680-cecf-11eb-880f-76c5542c45e5.png)

### How to test the changes in this Pull Request:

1. Insert the hand picked product block
2. See SKUs shown for products with a SKU
3. Try searching for a SKU. See results.

### Changelog

> Allow products to be added by SKU in the Hand-Picked Products block
