### PR TITLE
Add screen reader text to price range

### DIFF
--- a/assets/js/base/components/product-price/index.js
+++ b/assets/js/base/components/product-price/index.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { createInterpolateElement } from 'wordpress-element';
+import { formatPrice } from '@woocommerce/price-format';
 
 /**
  * Internal dependencies
@@ -21,25 +22,38 @@ const PriceRange = ( {
 } ) => {
 	return (
 		<>
-			<FormattedMonetaryAmount
-				className={ classNames(
-					'wc-block-components-product-price__value',
-					priceClassName
+			<span className="screen-reader-text">
+				{ sprintf(
+					/* translators: %1$s min price, %2$s max price */
+					__(
+						'Price between %1$s and %2$s',
+						'woo-gutenberg-products-block'
+					),
+					formatPrice( minPrice ),
+					formatPrice( maxPrice )
 				) }
-				currency={ currency }
-				value={ minPrice }
-				style={ priceStyle }
-			/>
-			&nbsp;&mdash;&nbsp;
-			<FormattedMonetaryAmount
-				className={ classNames(
-					'wc-block-components-product-price__value',
-					priceClassName
-				) }
-				currency={ currency }
-				value={ maxPrice }
-				style={ priceStyle }
-			/>
+			</span>
+			<span aria-hidden={ true }>
+				<FormattedMonetaryAmount
+					className={ classNames(
+						'wc-block-components-product-price__value',
+						priceClassName
+					) }
+					currency={ currency }
+					value={ minPrice }
+					style={ priceStyle }
+				/>
+				&nbsp;&mdash;&nbsp;
+				<FormattedMonetaryAmount
+					className={ classNames(
+						'wc-block-components-product-price__value',
+						priceClassName
+					) }
+					currency={ currency }
+					value={ maxPrice }
+					style={ priceStyle }
+				/>
+			</span>
 		</>
 	);
 };


### PR DESCRIPTION
Adds screen reader text to price ranges stating: "Price between X and X".

Fixes #1669

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### How to test the changes in this Pull Request:

1. View all products block
2. Find a product with a price range (grouped product). e.g. Logo Collection in default content.
3. Use voiceover or screen reader to read the price. It should announce "Price between X and X". Some tools will also read the other price but this is wrapped in aria-hidden so can be ignored.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add screen reader text to price ranges
