### PR TITLE
Add documentation for `ExperimentalDiscountsMeta`, `cart/extensions` endpoint, and `extensionCartUpdate`

### DIFF
--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -40,7 +40,7 @@ Checkout:
 - `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.
 
 ## ExperimentalDiscountsMeta
-This slot renders below the `CouponCode` input 
+This slot renders below the `CouponCode` input. 
 
 Cart:
 <img alt="Cart showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122774218-ea27a880-d2a0-11eb-9450-11f119567f26.png" />

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -46,7 +46,7 @@ Cart:
 <img alt="Cart showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122774218-ea27a880-d2a0-11eb-9450-11f119567f26.png" />
 
 Checkout:
-<img alt="Checkout showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122774626-425eaa80-d2a1-11eb-8f50-6363eaed09f8.png" />
+<img alt="Checkout showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122779277-a08d8c80-d2a5-11eb-9de9-a5f14170058f.png" />
 
 ### Passed paramters
 - `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -46,7 +46,7 @@ Cart:
 <img alt="Cart showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122774218-ea27a880-d2a0-11eb-9450-11f119567f26.png" />
 
 Checkout:
-<img alt="Checkout showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122779277-a08d8c80-d2a5-11eb-9de9-a5f14170058f.png" />
+<img alt="Checkout showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122779606-efd3bd00-d2a5-11eb-8c84-6525eca5d704.png" />
 
 ### Passed paramters
 - `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -38,3 +38,16 @@ Checkout:
 - `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
 - `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
 - `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.
+
+## ExperimentalDiscountsMeta
+This slot renders below the `CouponCode` input 
+
+Cart:
+<img alt="Cart showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122774218-ea27a880-d2a0-11eb-9450-11f119567f26.png" />
+
+Checkout:
+<img alt="Checkout showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122774626-425eaa80-d2a1-11eb-8f50-6363eaed09f8.png" />
+
+### Passed paramters
+- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
+- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.

--- a/docs/extensibility/extend-rest-api-update-cart.md
+++ b/docs/extensibility/extend-rest-api-update-cart.md
@@ -133,8 +133,7 @@ that will apply the redemption.
 
 Your extension adds these UI elements to the sidebar in the Cart and Checkout blocks using the [`DiscountsMeta`](./available-slot-fills.md) Slot.
 
-More information on how to use Slots is available in our [Slots and Fills documentation](./slot-fills.md), and thus we
-will not be demonstrating how to use them in _this_ document.
+More information on how to use Slots is available in our [Slots and Fills documentation](./slot-fills.md).
 
 Once implemented, the sidebar has a control added to it like this:
 

--- a/docs/extensibility/extend-rest-api-update-cart.md
+++ b/docs/extensibility/extend-rest-api-update-cart.md
@@ -1,0 +1,74 @@
+# Updating the cart with the Store API
+If you're an extension developer, and your extension does some server-side processing as a result of some client-side
+input, for example: a user presses a button your extension has added to the cart sidebar, and your extension performs
+some checks (server-side) then applies a coupon, then you may want to use the `cart/extensions` endpoint to signal to
+the Store API that some processing needs to take place.
+
+Extensions may register a callback to run when the `cart/extensions` endpoint is hit. When it is, the server will
+execute all registered callbacks for a specified namespace.
+
+## Registering a callback to run when the `cart/extensions` endpoint is hit
+Much like adding data to the Store API (described in more detail in
+[Exposing your data in the Store API]('./extend-rest-api-add-data.md).) you may add the callback
+by using a method on the `ExtendRestApi` class from WooCommerce Blocks.
+
+```PHP
+
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
+
+add_action('woocommerce_blocks_loaded', function() {
+ // ExtendRestApi is stored in the container as a shared instance between the API and consumers.
+ // You shouldn't initiate your own ExtendRestApi instance using `new ExtendRestApi` but should always use the shared instance from the Package dependency injection container.
+ $extend = Package::container()->get( ExtendRestApi::class );
+ $extend->register_update_callback(
+   [
+    'namespace' => 'my-extensions-unique-namespace',
+    'callback'  => /* Add your callable here */
+   ]
+ )
+} );
+```
+The namespace you provide to the `register_update_callback` method should be unique to your extension.
+
+Your callable should accept a single argument. This will be an array containing whatever data you choose to pass to it.
+More information on how data gets passed from the client to the callback will be detailed over the next sections.
+
+The callable need not return anything, its return value will not be used.
+
+## Making the request to the `cart/extensions` endpoint
+When you wish to make a request to the endpoint, you should do it by calling the `extensionCartUpdate` function, available
+from `@woocommerce/blocks-checkout`.
+
+This function takes a single argument, of type object. The object must contain two properties: `namespace` and `data`.
+
+- `namespace` should be the same as the one you used when registering your callback with `ExtendRestApi` on the
+server-side.
+- `data` is an object containing the data you want to pass to the server-side function. These data must be serializable.
+
+```javascript
+extensionCartUpdate(
+  {
+    namespace: 'my-extensions-unique-namespace',
+    data: {
+      key: 'value',
+      another_key: 100,
+      third_key: {
+        fourth_key: true,
+      }
+    }
+  }
+);
+```
+
+When this function is executed, after a short delay (due to batch requests) a POST request will be made to the
+`cart/extensions` endpoint, the POSTed data will be the value of the `data` key in the argument object.
+
+When the request completes, the API will return the current server-side cart to the client. The client will then update
+the UI.
+
+## Why can't I just POST to `cart/extensions` directly?
+This endpoint returns an object representing the customer's cart, WooCommerce Blocks will then update the client-side
+stores with the new cart data. The methods to do this are not available to third party extensions, which is why you must
+use the `extensionCartUpdate` method.

--- a/docs/extensibility/extend-rest-api-update-cart.md
+++ b/docs/extensibility/extend-rest-api-update-cart.md
@@ -17,7 +17,7 @@ signalled to do so by the client-side Cart or Checkout.
 WooCommerce Blocks also provides a front-end function called `extensionCartUpdate` which can be called by client-side
 code, this will send data (specified by you when calling `extensionCartUpdate`) to  the `cart/extensions` endpoint.
 When this endpoint gets hit, any relevant (based on the namespace provided to `extensionCartUpdate`) callbacks get
-executed, and the latest server-side cart data gets returned.
+executed, and the latest server-side cart data gets returned and the block is updated with this new data.
 
 ## Basic usage
 In your extension's server-side integration code: 
@@ -44,7 +44,7 @@ import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
 
 extensionCartUpdate(
   {
-    namespace: 'extensions-unique-namespace',
+    namespace: 'extension-unique-namespace',
     data: {
       key: 'value',
       another_key: 100,
@@ -64,7 +64,7 @@ cart. As mentioned, extensions are not permitted to update the client-side cart'
 would cause the entire block to break, preventing the user from continuing their checkout. Instead you _must_ do this
 through the `extensionCartUpdate` function.
 
-### Only one callback for a given namespace may be registered.
+### Only one callback for a given namespace may be registered
 With this in mind, if your extension has several client-side interactions that result in different code paths being
 executed on the server-side, you may wish to pass additional data through in `extensionsCartUpdate`. For example
 if you have two actions the user can take, one to _add_ a discount, and the other to _remove_ it, you may wish to pass
@@ -91,7 +91,7 @@ add_action('woocommerce_blocks_loaded', function() {
  $extend = Package::container()->get( ExtendRestApi::class );
  $extend->register_update_callback(
    [
-    'namespace' => 'extensions-unique-namespace',
+    'namespace' => 'extension-unique-namespace',
     'callback'  => function( $data ) {
       if ( $data['action'] === 'add' ) {
           add_discount( );

--- a/docs/extensibility/extend-rest-api-update-cart.md
+++ b/docs/extensibility/extend-rest-api-update-cart.md
@@ -1,22 +1,31 @@
 # Updating the cart with the Store API
 If you're an extension developer, and your extension does some server-side processing as a result of some client-side
-input, for example: a user presses a button your extension has added to the cart sidebar, and your extension performs
-some checks (server-side) then applies a coupon, then you may want to use the `cart/extensions` endpoint to signal to
+input, then you may want to use the `cart/extensions` endpoint to signal to
 the Store API that some processing needs to take place.
 
 Extensions may register a callback to run when the `cart/extensions` endpoint is hit. When it is, the server will
 execute all registered callbacks for a specified namespace.
 
+## Example use case
+You are the author of an extension that automatically applies valid coupons to a user's cart when they press a
+button.
+
+Your extension adds a button to the sidebar in the Cart and Checkout blocks using the [`DiscountsMeta`](./available-slot-fills.md) Slot.
+
+When this button is clicked, you want the server to do some work to figure out which coupons the customer is eligible
+for, and then apply them to the cart.
+
+When this is done, you expect to see the updated cart data in the client.
+
 ## Registering a callback to run when the `cart/extensions` endpoint is hit
 Much like adding data to the Store API (described in more detail in
-[Exposing your data in the Store API]('./extend-rest-api-add-data.md).) you may add the callback
-by using a method on the `ExtendRestApi` class from WooCommerce Blocks.
+[Exposing your data in the Store API](./extend-rest-api-add-data.md).) you may add the callback
+by invoking the `register_update_callback` method on the `ExtendRestApi` class from WooCommerce Blocks.
 
 ```PHP
 
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
-use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
 
 add_action('woocommerce_blocks_loaded', function() {
  // ExtendRestApi is stored in the container as a shared instance between the API and consumers.
@@ -30,12 +39,17 @@ add_action('woocommerce_blocks_loaded', function() {
  )
 } );
 ```
-The namespace you provide to the `register_update_callback` method should be unique to your extension.
 
-Your callable should accept a single argument. This will be an array containing whatever data you choose to pass to it.
+The method takes a single argument, an associative array.
+
+The associative array must have the following entries:
+- `namespace` (string) - The unique namespace of your extension.
+- `callback` (Callable) - The function/method (or Callable) that will be executed when the `cart/extensions` endpoint is
+  hit with a `namespace` that matches your extension's. The callable should take a single argument. The data passed into
+  the callback via this argument will be an array containing whatever data you choose to pass to it.
 More information on how data gets passed from the client to the callback will be detailed over the next sections.
 
-The callable need not return anything, its return value will not be used.
+The callable does not need to return anything, if it does, then its return value will not be used.
 
 ## Making the request to the `cart/extensions` endpoint
 When you wish to make a request to the endpoint, you should do it by calling the `extensionCartUpdate` function, available
@@ -48,6 +62,8 @@ server-side.
 - `data` is an object containing the data you want to pass to the server-side function. These data must be serializable.
 
 ```javascript
+import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
+
 extensionCartUpdate(
   {
     namespace: 'my-extensions-unique-namespace',

--- a/docs/extensibility/extend-rest-api-update-cart.md
+++ b/docs/extensibility/extend-rest-api-update-cart.md
@@ -40,7 +40,7 @@ add_action('woocommerce_blocks_loaded', function() {
 
 and on the client side:
 ```typescript
-import { extensionCartUpdate } from '@woocommerce/blocks-checkout';
+const { extensionCartUpdate } = wc.blocksCheckout;
 
 extensionCartUpdate(
   {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds documentation for the `ExperimentalDiscountsMeta` Slot/Fill, the `extensionCartUpdate` JS function, and the `cart/extensions` endpoint, and the `register_update_callback` method on the `ExtendRestApi` class.

### How to test the changes in this Pull Request:

1. From a third-party developer's point of view, please read the documentation and see if it makes sense.
2. Check the links added to the documentation work correctly.

<!-- If you can, add the appropriate labels -->

### Changelog

> Add documentation for `extensionCartUpdate` method - this allows extensions to update the client-side cart after it has been modified on the server.
