### PR TITLE
Add camelcase rule to eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,13 @@ module.exports = {
 		'react-hooks/exhaustive-deps': 'error',
 		'react/jsx-fragments': [ 'error', 'syntax' ],
 		'@wordpress/no-global-active-element': 'warn',
+		camelcase: [
+			'error',
+			{
+				properties: 'never',
+				ignoreGlobals: true,
+			},
+		],
 	},
 	overrides: [
 		{
@@ -85,6 +92,27 @@ module.exports = {
 				'@typescript-eslint/no-unused-vars': [
 					'error',
 					{ ignoreRestSiblings: true },
+				],
+				camelcase: 'off',
+				'@typescript-eslint/naming-convention': [
+					'error',
+					{
+						selector: [ 'method', 'variableLike' ],
+						format: [ 'camelCase', 'PascalCase', 'UPPER_CASE' ],
+						leadingUnderscore: 'allowSingleOrDouble',
+						filter: {
+							regex: 'webpack_public_path__',
+							match: false,
+						},
+					},
+					{
+						selector: 'typeProperty',
+						format: [ 'camelCase', 'snake_case' ],
+						filter: {
+							regex: 'API_FETCH_WITH_HEADERS|Block',
+							match: false,
+						},
+					},
 				],
 			},
 		},

--- a/assets/js/atomic/blocks/component-init.js
+++ b/assets/js/atomic/blocks/component-init.js
@@ -6,7 +6,7 @@ import { lazy } from '@wordpress/element';
 import { WC_BLOCKS_BUILD_URL } from '@woocommerce/block-settings';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
-// eslint-disable-next-line no-undef,camelcase
+// eslint-disable-next-line no-undef, camelcase
 __webpack_public_path__ = WC_BLOCKS_BUILD_URL;
 
 registerBlockComponent( {

--- a/assets/js/atomic/blocks/component-init.js
+++ b/assets/js/atomic/blocks/component-init.js
@@ -6,7 +6,7 @@ import { lazy } from '@wordpress/element';
 import { WC_BLOCKS_BUILD_URL } from '@woocommerce/block-settings';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
-// eslint-disable-next-line no-undef, camelcase
+// eslint-disable-next-line no-undef,camelcase
 __webpack_public_path__ = WC_BLOCKS_BUILD_URL;
 
 registerBlockComponent( {

--- a/assets/js/atomic/blocks/product-elements/rating/block.js
+++ b/assets/js/atomic/blocks/product-elements/rating/block.js
@@ -66,7 +66,6 @@ const Block = ( { className } ) => {
 };
 
 const getAverageRating = ( product ) => {
-	// eslint-disable-next-line camelcase
 	const rating = parseFloat( product.average_rating );
 
 	return Number.isFinite( rating ) && rating > 0 ? rating : 0;

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -23,9 +23,7 @@ interface PackageItem {
 }
 
 interface Destination {
-	// eslint-disable-next-line camelcase
 	address_1: string;
-	// eslint-disable-next-line camelcase
 	address_2: string;
 	city: string;
 	state: string;
@@ -36,7 +34,6 @@ interface Destination {
 export interface PackageData {
 	destination: Destination;
 	name: string;
-	// eslint-disable-next-line camelcase
 	shipping_rates: CartShippingPackageShippingRate[];
 	items: PackageItem[];
 }

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -107,9 +107,7 @@ const NoShippingPlaceholder = ( {
 interface TotalShippingProps {
 	currency: Currency;
 	values: {
-		// eslint-disable-next-line camelcase
 		total_shipping: string;
-		// eslint-disable-next-line camelcase
 		total_shipping_tax: string;
 	}; // Values in use
 	showCalculator?: boolean; //Whether to display the rate selector below the shipping total.

--- a/assets/js/base/components/product-list/product-list.js
+++ b/assets/js/base/components/product-list/product-list.js
@@ -78,8 +78,8 @@ const generateQuery = ( {
  */
 
 const extractPaginationAndSortAttributes = ( query ) => {
-	/* eslint-disable-next-line no-unused-vars, camelcase */
-	const { order, orderby, page, per_page, ...totalQuery } = query;
+	/* eslint-disable-next-line no-unused-vars */
+	const { order, orderby, page, per_page: perPage, ...totalQuery } = query;
 	return totalQuery || {};
 };
 

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/types.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/types.ts
@@ -53,7 +53,6 @@ export type ExpressPaymentMethods =
 export interface CustomerPaymentMethod {
 	method: PaymentMethodConfig;
 	expires: string;
-	// eslint-disable-next-line camelcase
 	is_default: boolean;
 	tokenId: number;
 	actions: ObjectType;

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -76,14 +76,12 @@ class ProductsByAttributeBlock extends Component {
 					<ProductAttributeTermControl
 						selected={ attributes }
 						onChange={ ( value = [] ) => {
-							/* eslint-disable camelcase */
 							const result = value.map(
-								( { id, attr_slug } ) => ( {
+								( { id, attr_slug: attributeSlug } ) => ( {
 									id,
-									attr_slug,
+									attr_slug: attributeSlug,
 								} )
 							);
-							/* eslint-enable camelcase */
 							setAttributes( { attributes: result } );
 						} }
 						operator={ attrOperator }
@@ -136,14 +134,12 @@ class ProductsByAttributeBlock extends Component {
 					<ProductAttributeTermControl
 						selected={ blockAttributes.attributes }
 						onChange={ ( value = [] ) => {
-							/* eslint-disable camelcase */
 							const result = value.map(
-								( { id, attr_slug } ) => ( {
+								( { id, attr_slug: attributeSlug } ) => ( {
 									id,
-									attr_slug,
+									attr_slug: attributeSlug,
 								} )
 							);
-							/* eslint-enable camelcase */
 							setAttributes( { attributes: result } );
 						} }
 						operator={ blockAttributes.attrOperator }

--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -442,9 +442,7 @@ export function* selectShippingRate(
 }
 
 type BillingAddressShippingAddress = {
-	// eslint-disable-next-line camelcase
 	billing_address: CartBillingAddress;
-	// eslint-disable-next-line camelcase
 	shipping_address: CartShippingAddress;
 };
 

--- a/assets/js/extensions/google-analytics/utils.ts
+++ b/assets/js/extensions/google-analytics/utils.ts
@@ -8,7 +8,6 @@ import type {
 } from '@woocommerce/types';
 
 interface ImpressionItem extends Gtag.Item {
-	// eslint-disable-next-line camelcase
 	list_name?: string;
 }
 

--- a/assets/js/settings/shared/default-address-fields.ts
+++ b/assets/js/settings/shared/default-address-fields.ts
@@ -25,7 +25,6 @@ export interface LocaleSpecificAddressField extends AddressField {
 }
 
 export interface AddressFields {
-	// eslint-disable-next-line camelcase
 	first_name: AddressField;
 	// eslint-disable-next-line camelcase
 	last_name: AddressField;

--- a/assets/js/settings/shared/default-address-fields.ts
+++ b/assets/js/settings/shared/default-address-fields.ts
@@ -26,12 +26,9 @@ export interface LocaleSpecificAddressField extends AddressField {
 
 export interface AddressFields {
 	first_name: AddressField;
-	// eslint-disable-next-line camelcase
 	last_name: AddressField;
 	company: AddressField;
-	// eslint-disable-next-line camelcase
 	address_1: AddressField;
-	// eslint-disable-next-line camelcase
 	address_2: AddressField;
 	country: AddressField;
 	city: AddressField;
@@ -41,14 +38,10 @@ export interface AddressFields {
 
 export type AddressType = 'billing' | 'shipping';
 export interface EnteredAddress {
-	// eslint-disable-next-line camelcase
 	first_name: string;
-	// eslint-disable-next-line camelcase
 	last_name: string;
 	company: string;
-	// eslint-disable-next-line camelcase
 	address_1: string;
-	// eslint-disable-next-line camelcase
 	address_2: string;
 	country: string;
 	city: string;

--- a/assets/js/types/type-defs/cart-response.ts
+++ b/assets/js/types/type-defs/cart-response.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase -- API responses have camelcase properties */
 /**
  * Internal dependencies
  */

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase -- API responses have camelcase properties */
-
 /**
  * Internal dependencies
  */

--- a/assets/js/types/type-defs/currency.ts
+++ b/assets/js/types/type-defs/currency.ts
@@ -8,7 +8,6 @@ export interface Currency {
 	thousandSeparator: string;
 }
 
-/* eslint-disable camelcase -- API responses have camelcase properties */
 export interface CurrencyResponse {
 	currency_code: string;
 	currency_symbol: string;

--- a/assets/js/types/type-defs/product-response.ts
+++ b/assets/js/types/type-defs/product-response.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase -- API responses have camelcase properties */
-
 /**
  * Internal dependencies
  */

--- a/assets/js/types/type-defs/shipping.ts
+++ b/assets/js/types/type-defs/shipping.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase*/
-
 /**
  * External dependencies
  */

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,2 +1,3 @@
-// eslint-disable-next-line camelcase
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 declare let __webpack_public_path__: string;

--- a/packages/checkout/totals/subtotal/index.tsx
+++ b/packages/checkout/totals/subtotal/index.tsx
@@ -12,9 +12,7 @@ import { getSetting } from '@woocommerce/settings';
 import TotalsItem from '../item';
 
 interface Values {
-	// eslint-disable-next-line camelcase
 	total_items: string;
-	// eslint-disable-next-line camelcase
 	total_items_tax: string;
 }
 

--- a/packages/checkout/totals/taxes/index.tsx
+++ b/packages/checkout/totals/taxes/index.tsx
@@ -15,9 +15,7 @@ import TotalsItem from '../item';
 import './style.scss';
 
 interface Values {
-	// eslint-disable-next-line camelcase
 	tax_lines: CartTotalsTaxLineItem[];
-	// eslint-disable-next-line camelcase
 	total_tax: string;
 }
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR, inspired by @louwie17's p2 paJDYF-1ZD-p2 will add a configuration to our `.eslintrc.js` file changing the rules about when camelCase must be used. This is a follow on from #4340 where we discovered that changing values from the API to snake_case immediately caused problems with third-party extensions.

You will notice I have added some regex configuration to the `@typescript-eslint/naming-convention` rules, this targets the following variables:

- `Block` - found here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/40a8a72e276ed9f6ccd0050bc970d869a05bb7bf/assets/js/atomic/utils/render-parent-block.tsx#L24 
- `__webpack_public_path__` - found here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/7bb3b7ba47e4a5b98bc551f4f23b831c360e358a/assets/js/atomic/blocks/component-init.js#L10
- `API_FETCH_WITH_HEADERS` - found here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5261c4e9a733d5292ab40027a6ad6b3d61952e73/assets/js/data/shared-controls.ts#L123

I think we could possibly address the `Block` and `API_FETCH_WITH_HEADERS` ones in a follow-up PR.

<!-- Reference any related issues or PRs here -->
Fixes #4150
### How to test the changes in this Pull Request:

1. Run `npm run lint:js` on the command line and ensure no lint errors are found.
2. Test the "All products" block, ensure pagination works correctly.
3. Test the "Products by attribute" block.