### PR TITLE
Update/5.3.2 testing instructions

### DIFF
--- a/docs/testing/releases/532.md
+++ b/docs/testing/releases/532.md
@@ -1,0 +1,15 @@
+## Testing notes and ZIP for release 5.3.2
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6724701/woocommerce-gutenberg-products-block.zip)
+
+## Feature plugin and package inclusion in WooCommerce core
+
+### Remove the ability to filter snackbar notices. ([4398](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4398))
+
+1. Add items to your cart and then go to the Cart block. Apply a coupon.
+2. Ensure the snackbar notice is shown in the bottom left of the screen.
+3. Remove the coupon, ensure the snackbar notice is shown again.
+
+## Feature plugin only
+
+No changes.

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -33,5 +33,6 @@ Every release includes specific testing instructions for new features and bug fi
 -   [5.1.0](./510.md)
 -   [5.2.0](./520.md)
 -   [5.3.0](./530.md)
--   [5.3.1](./531.md)
+    -   [5.3.1](./531.md)
+    -   [5.3.2](./532.md)
 -   [5.4.0](./540.md)

--- a/readme.txt
+++ b/readme.txt
@@ -102,7 +102,8 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Allow products to be added by SKU in the Hand-Picked Products block. ([4366](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4366))
 - Add Slot in the Discounts section of the Checkout sidebar to allow third party extensions to render their own components there. ([4310](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4310))
 
-
+= 5.3.2 - 2021-06-28 =
+- Remove the ability to filter snackbar notices ([#4398](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4398)).
 
 = 5.3.1 - 2021-06-15 =
 


### PR DESCRIPTION
Similar to the Add 5.3.1 testing instructions PR https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4351:


Given that #4348 has commits we don't want to merge to trunk (see #4350), I'm creating this PR which cherry-picks the version updates and testing instructions from 5.3.2.