### PR TITLE
Update `snackbarNotices` filter to `snackbarNoticeVisibility`

### DIFF
--- a/assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js
+++ b/assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js
@@ -19,10 +19,19 @@ const SnackbarNoticesContainer = ( {
 		( notice ) => notice.type === 'snackbar'
 	);
 
+	const noticeVisibility = snackbarNotices.reduce( ( acc, { content } ) => {
+		acc[ content ] = true;
+		return acc;
+	}, {} );
+
 	const filteredNotices = __experimentalApplyCheckoutFilter( {
-		filterName: 'snackbarNotices',
-		defaultValue: snackbarNotices,
+		filterName: 'snackbarNoticeVisibility',
+		defaultValue: noticeVisibility,
 	} );
+
+	const noticesToDisplay = snackbarNotices.filter(
+		( notice ) => filteredNotices[ notice.content ] === true
+	);
 
 	const wrapperClass = classnames(
 		className,
@@ -31,7 +40,7 @@ const SnackbarNoticesContainer = ( {
 
 	return (
 		<SnackbarList
-			notices={ filteredNotices }
+			notices={ noticesToDisplay }
 			className={ wrapperClass }
 			onRemove={ removeNotice }
 		/>

--- a/assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js
+++ b/assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js
@@ -29,7 +29,7 @@ const SnackbarNoticesContainer = ( {
 		defaultValue: noticeVisibility,
 	} );
 
-	const noticesToDisplay = snackbarNotices.filter(
+	const visibleNotices = snackbarNotices.filter(
 		( notice ) => filteredNotices[ notice.content ] === true
 	);
 
@@ -40,7 +40,7 @@ const SnackbarNoticesContainer = ( {
 
 	return (
 		<SnackbarList
-			notices={ noticesToDisplay }
+			notices={ visibleNotices }
 			className={ wrapperClass }
 			onRemove={ removeNotice }
 		/>

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -36,6 +36,17 @@ export const __experimentalRegisterCheckoutFilters = (
 	filters: Record< string, CheckoutFilterFunction >
 ): void => {
 	/**
+	 * Let developers know snackbarNotices is no longer available as a filter.
+	 */
+	if ( Object.keys( filters ).includes( 'couponName' ) ) {
+		deprecated( 'snackbarNotices', {
+			alternative: 'snackbarNoticeVisibility',
+			plugin: 'WooCommerce Blocks',
+			link: '',
+		} );
+	}
+
+	/**
 	 * Let the user know couponName is no longer available as a filter.
 	 *
 	 * See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4312

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -37,12 +37,15 @@ export const __experimentalRegisterCheckoutFilters = (
 ): void => {
 	/**
 	 * Let developers know snackbarNotices is no longer available as a filter.
+	 *
+	 * See: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4417
 	 */
 	if ( Object.keys( filters ).includes( 'couponName' ) ) {
 		deprecated( 'snackbarNotices', {
 			alternative: 'snackbarNoticeVisibility',
 			plugin: 'WooCommerce Blocks',
-			link: '',
+			link:
+				'https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4417',
 		} );
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
After internal discussion at pca54o-1Gs-p2 I wanted to put this PR out there to see what folks think, the changes are made to stop third party extensions being able to modify the particulars of any snackbar notice, and control only whether it is shown to the user or not. An overview of the changes is:

- Change the filter so that only an object keyed by the notice's message is passed to the filter - initially all values in this object will be `true`.
- After the filters have done their work, remove any entries from the array whose value is false.
- Filter the original list of notices so that only notices that have a corresponding entry in the one returned by the filter are shown.

### How to test the changes in this Pull Request:

1. Check out `update/snackbar-filtering-function` in [WooCommerce Points and Rewards](https://github.com/woocommerce/woocommerce-points-and-rewards/)
2. Run `npm run build` in the WC P&R directory.
3. Ensure your user account has points (WooCoomerce > Points and Rewards)
4. Add items to your cart and go to the Cart block.
5. Try adding a coupon, ensure the snackbar notice shows for coupon addition.
6. Remove the coupon, ensure the snackbar notice shows for coupon removal.
7. Please don't add more than one coupon, we have a known issue with this, https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4312
8. Use the points redemption panel to redeem some points.
9. Remove the coupon that was added as a result of redeeming points.
10. Ensure no snackbar notice shows.
11. In the WooCommerce Points and Rewards file: [`assets/js/filters.js`](https://github.com/woocommerce/woocommerce-points-and-rewards/blob/0c8eb7539c42764176ee2af19050c0cbe9b7f3e3/assets/js/filters.js#L24) change `snackbarNoticeVisibility` to `snackbarNotices` and run `npm run build`.
12. Add a coupon to the cart again and ensure a deprecation notice is shown in the console.

<!-- If you can, add the appropriate labels -->

### Changelog

> Deprecate snackbarNotices filter in favour of snackbarNoticeVisibility to allow extensions to hide snackbar notices in the Cart and Checkout blocks.