### PR TITLE
Remove source assets from ZIP and releases

### DIFF
--- a/bin/copy-plugin-files.sh
+++ b/bin/copy-plugin-files.sh
@@ -1,5 +1,6 @@
 cd "$1" || exit
 rsync ./ "$2"/ --recursive --delete --delete-excluded \
+	--exclude=assets/ \
 	--exclude=".*/" \
 	--exclude="*.md" \
 	--exclude=".*" \


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR removes the `assets` folder from the ZIP file, thereby removing it from releases. Hopefully this translates well to tagged released, I haven't been able to test this really. 
The `source files` zip in tags would still contain assets, but the `woo-gutenberg-products-block.zip` won't, I'm assuming that's the file that wp.org would use.

This is a non-destructive PR so even if it was included, we can still rectify it.
<!-- Reference any related issues or PRs here -->
Fixes #4299

### How to test the changes in this Pull Request:

1. Run `npm run package-plugin:zip-only`
2. Verify the zip doesn't contain the assets folder.
3. Use the zip in a website, make sure blocks load.

### Changelog

> Remove source files from releases.