### PR TITLE
Block Widgets: fix product grid display

### DIFF
--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -55,6 +55,11 @@
 	list-style: none;
 }
 
+// The block widgets editor's generic @reset overrides box sizing on all children
+.blocks-widgets-container .wc-block-grid__product {
+	box-sizing: border-box;
+}
+
 .theme-twentytwenty .wc-block-grid,
 .wc-block-grid {
 	&.has-aligned-buttons {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4189

This PR fixes an issue where the product grid in all blocks it is used in displays the wrong number of columns.

The issue is caused by [this generic Gutenberg @reset mixin](https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_mixins.scss#L375) overriding the box-sizing of all children of the `.blocks-widgets-container` in the [edit widgets styles here](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-widgets/src/style.scss#L27).

|Before|After|
|-|-|
|<img width="1008" alt="Screenshot 2021-07-01 at 13 18 04" src="https://user-images.githubusercontent.com/1562646/124119268-983a0c00-da72-11eb-8660-5465e3cbbdd8.png">|<img width="1035" alt="Screenshot 2021-07-01 at 13 29 19" src="https://user-images.githubusercontent.com/1562646/124119281-9bcd9300-da72-11eb-9a33-3a171e6aa72f.png">|

### How to test the changes in this Pull Request:

1. Ensure the Gutenberg feature plugin is enabled and up to date.
2. Go to the Widgets editor in Appearance > Widgets. 
3. Go to Sidebar widgets and insert blocks that use the product grid e.g. _Top Rated Products_.
4. Confirm that the number of columns displayed equals the number set in the block settings (Default: 3).

<!-- If you can, add the appropriate labels -->

### Changelog

> Ensure product grids display as intended in the widget editor.