### PR TITLE
Fix filtering by product type on Store API

### DIFF
--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -40,6 +40,9 @@ class ProductQuery {
 		if ( ! empty( $request['sku'] ) ) {
 			$args['post_type'] = [ 'product', 'product_variation' ];
 		}
+		
+		// Taxonomy query to filter products by type, category, tag, shipping class, and attribute.
+		$tax_query = [];
 
 		// Filter product type by slug.
 		if ( ! empty( $request['type'] ) ) {
@@ -87,9 +90,6 @@ class ProductQuery {
 				$args[ $key ] = $request[ $key ];
 			}
 		}
-
-		// Taxonomy query to filter products by type, category, tag, shipping class, and attribute.
-		$tax_query = [];
 
 		$operator_mapping = [
 			'in'     => 'IN',

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -40,7 +40,6 @@ class ProductQuery {
 		if ( ! empty( $request['sku'] ) ) {
 			$args['post_type'] = [ 'product', 'product_variation' ];
 		}
-		
 		// Taxonomy query to filter products by type, category, tag, shipping class, and attribute.
 		$tax_query = [];
 

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -40,6 +40,7 @@ class ProductQuery {
 		if ( ! empty( $request['sku'] ) ) {
 			$args['post_type'] = [ 'product', 'product_variation' ];
 		}
+
 		// Taxonomy query to filter products by type, category, tag, shipping class, and attribute.
 		$tax_query = [];
 


### PR DESCRIPTION
I moved the $tax_query variable above the code where filtering happens for the product type. The reason for this change is to avoid resetting the $tax_query after a product type is specified for filtering. Which leaves you with an unfiltered product type result.