### PR TITLE
Fixing the rotation of the loading icon

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -81,7 +81,7 @@
 			margin-left: 0.5em;
 			display: inline-block;
 			width: auto;
-			height: auto;
+			height: 100%;
 		}
 	}
 }


### PR DESCRIPTION
### Fixes 
If there the screen size is small, the "Add to basket" text could break into two lines. Width height: auto, the loading icons element height is not as big as it's width, thus the loading icon is not rotating at it's centre.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
![before](https://user-images.githubusercontent.com/3168272/124488351-07d03400-ddb0-11eb-84cd-e40d7ac774ea.gif)
![after](https://user-images.githubusercontent.com/3168272/124488330-00a92600-ddb0-11eb-9b84-7ac7063b6a13.gif)

### How to test the changes in this Pull Request:

1. Open a WP page with Best selling products
2. Click on Add to basket (it's different if you're not using the US-EN locale)
3. It's spinning around it's centre.

### Changelog

> Add suggested changelog entry here.
Fixed the rotation of the add to cart loading icon, if the add to cart text is break to two or more lines.