### PR TITLE
Make payment method icons display well even if theme tries to override their height/width

### DIFF
--- a/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
@@ -1,15 +1,19 @@
 .wc-block-components-payment-method-icons {
-	display: block;
 	text-align: center;
 	margin: 0 0 #{$gap - 2px};
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	justify-content: center;
 
 	.wc-block-components-payment-method-icon {
 		display: inline-block;
 		margin: 0 4px 2px;
 		padding: 0;
 		width: auto;
+		max-width: 38px;
 		height: 24px;
-		vertical-align: middle;
+		max-height: 24px;
 	}
 
 	&--align-left {

--- a/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
+++ b/assets/js/base/components/cart-checkout/payment-method-icons/style.scss
@@ -1,5 +1,4 @@
 .wc-block-components-payment-method-icons {
-	text-align: center;
 	margin: 0 0 #{$gap - 2px};
 	display: flex;
 	flex-direction: row;
@@ -17,7 +16,7 @@
 	}
 
 	&--align-left {
-		text-align: left;
+		justify-content: flex-start;
 
 		.wc-block-components-payment-method-icon {
 			margin-left: 0;
@@ -26,7 +25,7 @@
 	}
 
 	&--align-right {
-		text-align: right;
+		justify-content: flex-end;
 
 		.wc-block-components-payment-method-icon {
 			margin-right: 0;

--- a/assets/js/blocks/cart-checkout/payment-methods/style.scss
+++ b/assets/js/blocks/cart-checkout/payment-methods/style.scss
@@ -209,8 +209,16 @@
 		.wc-block-components-radio-control__option::after {
 			border-width: 0;
 		}
+		.wc-block-components-radio-control__label {
+			display: flex;
+			align-items: center;
+			justify-content: flex-start;
+		}
 		.wc-block-components-radio-control__label img {
 			height: 24px;
+			max-height: 24px;
+			object-fit: contain;
+			object-position: center left;
 		}
 	}
 

--- a/assets/js/blocks/cart-checkout/payment-methods/style.scss
+++ b/assets/js/blocks/cart-checkout/payment-methods/style.scss
@@ -218,7 +218,7 @@
 			height: 24px;
 			max-height: 24px;
 			object-fit: contain;
-			object-position: center left;
+			object-position: left;
 		}
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Note: I couldn't replicate the issue reported in #4371 without adding custom CSS, such as:
```css
.wp-block-woocommerce-cart img,
.wp-block-woocommerce-checkout img {
    height: auto !important;
    width: 100% !important;
}
```
I added this through an option in the theme, but you could also add it to `{your-theme}/style.css`.

This PR will add a max-height and max-width to payment method icons, we've seen a couple of instances of themes adding 100% width to images which have been applied to the payment icons.

It also adds the icons to a flex container to ensure they display in a row and wrap onto the next line if there are too many icons to fit on one line.

It also changes the display of the individual payment method icons on the Checkout page, it sets `object-fit: cover` and `object-position: left` so that even if themes have set 100% width on images, any payment method image won't stretch.

<!-- Reference any related issues or PRs here -->
Fixes #4371 (I can't replicate #4371 but have emulated using custom CSS.)

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

Cart
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/124503622-dbbbaf80-ddbd-11eb-9465-3647810ce35d.png) | ![image](https://user-images.githubusercontent.com/5656702/124503569-c3e42b80-ddbd-11eb-9dd3-c9cd83ee771d.png) |

Checkout
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/124503666-ed04bc00-ddbd-11eb-9da1-f9bf9fe3c274.png) | ![image](https://user-images.githubusercontent.com/5656702/124503503-9eefb880-ddbd-11eb-9bd9-e3d0e7145169.png) |

### How to test the changes in this Pull Request:

1. Add some custom CSS to your theme, do something that will "accidentally" catch all images in the Cart/Checkout blocks, e.g:
```css
.wp-block-woocommerce-cart img,
.wp-block-woocommerce-checkout img {
    height: auto !important;
    width: 100% !important;
}
```
2. Go to the Cart and Checkout blocks and ensure that the payment method icons display correctly and are not too large.
3. Experiment with a few different themes and ensure this works for each one you test.

<!-- If you can, add the appropriate labels -->

### Changelog

> Ensure payment method icons are constrained to a reasonable size in the Cart and Checkout blocks.
