### PR TITLE
Add styles to stop totals items being padded inside panels

### DIFF
--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -49,9 +49,7 @@
 			padding-left: $gap;
 			padding-right: $gap;
 		}
-	}
 
-	.wc-block-components-sidebar {
 		.wc-block-components-panel {
 			.wc-block-components-totals-item {
 				padding: 0;

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -51,7 +51,6 @@
 		}
 	}
 
-
 	.wc-block-components-sidebar {
 		.wc-block-components-panel {
 			.wc-block-components-totals-item {

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -50,6 +50,16 @@
 			padding-right: $gap;
 		}
 	}
+
+
+	.wc-block-components-sidebar {
+		.wc-block-components-panel {
+			.wc-block-components-totals-item {
+				padding-left: 0;
+				padding-right: 0;
+			}
+		}
+	}
 }
 
 .wc-block-components-sidebar .wc-block-components-panel > h2 {

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -54,8 +54,7 @@
 	.wc-block-components-sidebar {
 		.wc-block-components-panel {
 			.wc-block-components-totals-item {
-				padding-left: 0;
-				padding-right: 0;
+				padding: 0;
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will remove padding from `TotalsItem` that are inside a panel component. The work done in #4415 went some way to solving this, but the additions in this PR will fully solve it.

The CSS I added specifically targets `TotalsItem`s inside a `Panel` component in the sidebar.

<!-- Reference any related issues or PRs here -->
Fixes #3669

### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/124741599-c8225d00-df13-11eb-8650-2fd3cdabac5f.png) | ![image](https://user-images.githubusercontent.com/5656702/124741331-7d084a00-df13-11eb-9ccf-34a7dd398d1d.png) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Add a subscription product to your cart.
2. Go to the Cart and Checkout blocks.
3. Expand the "Daily/Weekly/Monthly recurring total" section at the bottom of the sidebar in both blocks.
4. Ensure there is no extra padding and that the totals for each recurring section are aligned well.

<!-- If you can, add the appropriate labels -->

### Changelog

> Ensure cart totals displayed within a Panel component are aligned well and do not have extra padding.
