### PR TITLE
Move SlotFillProvider to frontend only

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout/index.js
@@ -4,8 +4,6 @@
 import { PluginArea } from '@wordpress/plugins';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
-import { SlotFillProvider } from '@woocommerce/blocks-checkout';
-
 /**
  * Internal dependencies
  */
@@ -38,18 +36,16 @@ export const CheckoutProvider = ( {
 			<CustomerDataProvider>
 				<ShippingDataProvider>
 					<PaymentMethodDataProvider>
-						<SlotFillProvider>
-							{ children }
-							{ /* If the current user is an admin, we let BlockErrorBoundary render
+						{ children }
+						{ /* If the current user is an admin, we let BlockErrorBoundary render
 								the error, or we simply die silently. */ }
-							<BlockErrorBoundary
-								renderError={
-									CURRENT_USER_IS_ADMIN ? null : () => null
-								}
-							>
-								<PluginArea scope="woocommerce-checkout" />
-							</BlockErrorBoundary>
-						</SlotFillProvider>
+						<BlockErrorBoundary
+							renderError={
+								CURRENT_USER_IS_ADMIN ? null : () => null
+							}
+						>
+							<PluginArea scope="woocommerce-checkout" />
+						</BlockErrorBoundary>
 						<CheckoutProcessor />
 					</PaymentMethodDataProvider>
 				</ShippingDataProvider>

--- a/assets/js/blocks/cart-checkout/cart/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart/frontend.js
@@ -9,7 +9,9 @@ import { __ } from '@wordpress/i18n';
 import {
 	StoreNoticesProvider,
 	StoreSnackbarNoticesProvider,
+	CartProvider,
 } from '@woocommerce/base-context/providers';
+import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import {
 	renderFrontend,
@@ -31,7 +33,11 @@ const CartFrontend = ( props ) => {
 	return (
 		<StoreSnackbarNoticesProvider context="wc/cart">
 			<StoreNoticesProvider context="wc/cart">
-				<Block { ...props } />
+				<SlotFillProvider>
+					<CartProvider>
+						<Block { ...props } />
+					</CartProvider>
+				</SlotFillProvider>
 			</StoreNoticesProvider>
 		</StoreSnackbarNoticesProvider>
 	);

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
@@ -32,7 +32,6 @@ import Title from '@woocommerce/base-components/title';
 import { getSetting } from '@woocommerce/settings';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { CartProvider } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -210,12 +209,4 @@ const Cart = ( { attributes }: CartProps ) => {
 	);
 };
 
-const Block = ( props: CartProps ): JSX.Element => {
-	return (
-		<CartProvider>
-			<Cart { ...props } />
-		</CartProvider>
-	);
-};
-
-export default Block;
+export default Cart;

--- a/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
@@ -728,9 +728,6 @@ exports[`Testing cart Contains a Taxes section if Core options are set to show i
           </div>
         </div>
       </div>
-      <div
-        style="display: none;"
-      />
     </div>
   </div>
 </div>
@@ -1469,9 +1466,6 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
           </div>
         </div>
       </div>
-      <div
-        style="display: none;"
-      />
     </div>
   </div>
 </div>
@@ -2210,9 +2204,6 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
           </div>
         </div>
       </div>
-      <div
-        style="display: none;"
-      />
     </div>
   </div>
 </div>

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -5,15 +5,21 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { previewCart } from '@woocommerce/resource-previews';
 import { dispatch } from '@wordpress/data';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import { default as fetchMock } from 'jest-fetch-mock';
 
 /**
  * Internal dependencies
  */
-import CartBlock from '../block';
+import Block from '../block';
 import { defaultCartState } from '../../../../data/default-states';
 import { allSettings } from '../../../../settings/shared/settings-init';
 
+const CartBlock = ( props ) => (
+	<SlotFillProvider>
+		<Block { ...props } />
+	</SlotFillProvider>
+);
 describe( 'Testing cart', () => {
 	beforeEach( async () => {
 		fetchMock.mockResponse( ( req ) => {

--- a/assets/js/blocks/cart-checkout/checkout/block.js
+++ b/assets/js/blocks/cart-checkout/checkout/block.js
@@ -10,7 +10,6 @@ import {
 	ReturnToCartButton,
 } from '@woocommerce/base-components/cart-checkout';
 import {
-	CheckoutProvider,
 	useCheckoutContext,
 	useEditorContext,
 	useValidationContext,
@@ -33,20 +32,6 @@ import CheckoutOrderError from './checkout-order-error';
 import { CheckoutExpressPayment } from '../payment-methods';
 import { LOGIN_TO_CHECKOUT_URL } from './utils';
 import './style.scss';
-
-/**
- * Renders the Checkout block wrapped within the CheckoutProvider.
- *
- * @param {Object} props Component props.
- * @return {*} The component.
- */
-const Block = ( props ) => {
-	return (
-		<CheckoutProvider>
-			<Checkout { ...props } />
-		</CheckoutProvider>
-	);
-};
 
 /**
  * Main Checkout Component.
@@ -163,4 +148,4 @@ const Checkout = ( { attributes, scrollToTop } ) => {
 	);
 };
 
-export default withScrollToTop( Block );
+export default withScrollToTop( Checkout );

--- a/assets/js/blocks/cart-checkout/checkout/edit.js
+++ b/assets/js/blocks/cart-checkout/checkout/edit.js
@@ -24,6 +24,7 @@ import {
 	EditorProvider,
 	useEditorContext,
 	StoreNoticesProvider,
+	CheckoutProvider,
 } from '@woocommerce/base-context';
 import { CartCheckoutFeedbackPrompt } from '@woocommerce/editor-components/feedback-prompt';
 import PageSelector from '@woocommerce/editor-components/page-selector';
@@ -383,7 +384,9 @@ const CheckoutEditor = ( { attributes, setAttributes } ) => {
 					>
 						<StoreNoticesProvider context="wc/checkout">
 							<Disabled>
-								<Block attributes={ attributes } />
+								<CheckoutProvider>
+									<Block attributes={ attributes } />
+								</CheckoutProvider>
 							</Disabled>
 						</StoreNoticesProvider>
 					</BlockErrorBoundary>

--- a/assets/js/blocks/cart-checkout/checkout/frontend.js
+++ b/assets/js/blocks/cart-checkout/checkout/frontend.js
@@ -8,6 +8,7 @@ import {
 } from '@woocommerce/block-hocs';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import {
+	CheckoutProvider,
 	StoreNoticesProvider,
 	ValidationContextProvider,
 } from '@woocommerce/base-context';
@@ -18,6 +19,7 @@ import {
 	getValidBlockAttributes,
 } from '@woocommerce/base-utils';
 import { StoreSnackbarNoticesProvider } from '@woocommerce/base-context/providers';
+import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -59,7 +61,11 @@ const CheckoutFrontend = ( props ) => {
 					<StoreSnackbarNoticesProvider context="wc/checkout">
 						<StoreNoticesProvider context="wc/checkout">
 							<ValidationContextProvider>
-								<Block { ...props } />
+								<SlotFillProvider>
+									<CheckoutProvider>
+										<Block { ...props } />
+									</CheckoutProvider>
+								</SlotFillProvider>
 							</ValidationContextProvider>
 						</StoreNoticesProvider>
 					</StoreSnackbarNoticesProvider>

--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -108,13 +108,6 @@ const requestToExternal = ( request ) => {
 	}
 };
 
-const requestToExternalInsideGB = ( request ) => {
-	if ( request === 'wordpress-components' ) {
-		return [ 'wp', 'components' ];
-	}
-	return requestToExternal( request );
-};
-
 const requestToHandle = ( request ) => {
 	if ( requiredPackagesInWPLegacy.includes( request ) ) {
 		return false;
@@ -122,13 +115,6 @@ const requestToHandle = ( request ) => {
 	if ( wcHandleMap[ request ] ) {
 		return wcHandleMap[ request ];
 	}
-};
-
-const requestToHandleInsideGB = ( request ) => {
-	if ( request === 'wordpress-components' ) {
-		return 'wp-components';
-	}
-	return requestToHandle( request );
 };
 
 const getProgressBarPluginConfig = ( name, fileSuffix ) => {
@@ -159,7 +145,5 @@ module.exports = {
 	findModuleMatch,
 	requestToHandle,
 	requestToExternal,
-	requestToHandleInsideGB,
-	requestToExternalInsideGB,
 	getProgressBarPluginConfig,
 };

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -60,7 +60,7 @@ final class AssetsController {
 		$this->api->register_script( 'wc-price-format', 'build/price-format.js', [], false );
 
 		if ( Package::feature()->is_feature_plugin_build() ) {
-			$this->api->register_script( 'wc-blocks-checkout', is_admin() ? 'build/blocks-checkout-editor.js' : 'build/blocks-checkout.js', [] );
+			$this->api->register_script( 'wc-blocks-checkout', 'build/blocks-checkout.js', [] );
 		}
 
 		wp_add_inline_script(

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,6 @@ const {
 	getPaymentsConfig,
 	getExtensionsConfig,
 	getStylingConfig,
-	getCoreEditorConfig,
 } = require( './bin/webpack-configs.js' );
 
 // Only options shared between all configs should be defined here.
@@ -38,12 +37,6 @@ const sharedConfig = {
 const CoreConfig = {
 	...sharedConfig,
 	...getCoreConfig( { alias: getAlias() } ),
-};
-
-// Core config for shared libraries to be run inside the editor.
-const CoreEditorConfig = {
-	...sharedConfig,
-	...getCoreEditorConfig( { alias: getAlias() } ),
 };
 
 // Main Blocks config for registering Blocks and for the Editor.
@@ -173,5 +166,4 @@ module.exports = [
 	ExtensionsConfig,
 	PaymentsConfig,
 	StylingConfig,
-	CoreEditorConfig,
 ];


### PR DESCRIPTION
While working on Checkout i2, we used contextual settings for each inner block. Those settings seized to work on rebase because we had two instances of the same `SlotFillProvider` in the tree.

Settings in blocks are registered using Slots and Fills, the SlotFillProvider use introduced overwrote GB one, causing our settings to not show on the sidebar.

This PR moves SlotFillProvider to frontend scripts only, fixing the issue. cc @mikejolley I confirmed this fixes the issue in Checkout i2 branch.

By doing this, there was no need for #4211 so I removed that code as well.

Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4263
### Testing instructions:
- Enable WooCommerce Subscriptions, add a subscription product to your cart.
- Visit Cart, Checkout, and confirm recurring totals are loading fine.
- Install and enable Yoast or Jetpack.
- Visit the editor, insert Cart or Checkout, they should load fine, no console errors, and no duplicate Yoast/jetpack logo on the top and no duplicate settings.