### PR TITLE
Add add-hoc Block locking from WooCommerce Blocks side.

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/edit.tsx
@@ -12,7 +12,10 @@ import {
  * Internal dependencies
  */
 import { Columns } from './columns';
-import { AddCurrentlySelectedBlockClass } from './hacks';
+import { addClassToBody } from './hacks';
+
+// This is adds a class to body to signal if the selected block is locked
+addClassToBody();
 
 // Array of allowed block names.
 const ALLOWED_BLOCKS: string[] = [
@@ -29,24 +32,21 @@ const TEMPLATE = [
 // @todo templateLock all prevents load after saving content for some reason.
 export const Edit = (): JSX.Element => {
 	return (
-		<>
-			<AddCurrentlySelectedBlockClass />
-			<EditorProvider
-				previewData={ { previewCart, previewSavedPaymentMethods } }
-			>
-				<CheckoutProvider>
-					<Columns>
-						<SidebarLayout className={ 'wc-block-checkout' }>
-							<InnerBlocks
-								allowedBlocks={ ALLOWED_BLOCKS }
-								template={ TEMPLATE }
-								templateLock="insert"
-							/>
-						</SidebarLayout>
-					</Columns>
-				</CheckoutProvider>
-			</EditorProvider>
-		</>
+		<EditorProvider
+			previewData={ { previewCart, previewSavedPaymentMethods } }
+		>
+			<CheckoutProvider>
+				<Columns>
+					<SidebarLayout className={ 'wc-block-checkout' }>
+						<InnerBlocks
+							allowedBlocks={ ALLOWED_BLOCKS }
+							template={ TEMPLATE }
+							templateLock="insert"
+						/>
+					</SidebarLayout>
+				</Columns>
+			</CheckoutProvider>
+		</EditorProvider>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/edit.tsx
@@ -12,6 +12,7 @@ import {
  * Internal dependencies
  */
 import { Columns } from './columns';
+import { AddCurrentlySelectedBlockClass } from './hacks';
 
 // Array of allowed block names.
 const ALLOWED_BLOCKS: string[] = [
@@ -28,21 +29,24 @@ const TEMPLATE = [
 // @todo templateLock all prevents load after saving content for some reason.
 export const Edit = (): JSX.Element => {
 	return (
-		<EditorProvider
-			previewData={ { previewCart, previewSavedPaymentMethods } }
-		>
-			<CheckoutProvider>
-				<Columns>
-					<SidebarLayout className={ 'wc-block-checkout' }>
-						<InnerBlocks
-							allowedBlocks={ ALLOWED_BLOCKS }
-							template={ TEMPLATE }
-							templateLock="insert"
-						/>
-					</SidebarLayout>
-				</Columns>
-			</CheckoutProvider>
-		</EditorProvider>
+		<>
+			<AddCurrentlySelectedBlockClass />
+			<EditorProvider
+				previewData={ { previewCart, previewSavedPaymentMethods } }
+			>
+				<CheckoutProvider>
+					<Columns>
+						<SidebarLayout className={ 'wc-block-checkout' }>
+							<InnerBlocks
+								allowedBlocks={ ALLOWED_BLOCKS }
+								template={ TEMPLATE }
+								templateLock="insert"
+							/>
+						</SidebarLayout>
+					</Columns>
+				</CheckoutProvider>
+			</EditorProvider>
+		</>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
@@ -23,4 +23,20 @@
 
 .wc-block-checkout__address-fields-notice {
 	margin: $gap 0 0;
+body.wc-lock-selected-block-from-move {
+	.block-editor-block-mover__move-button-container,
+	.block-editor-block-mover {
+		display: none;
+	}
+}
+
+body.wc-lock-selected-block-from-remove {
+	.block-editor-block-settings-menu__popover {
+		.components-menu-group:last-child {
+			display: none;
+		}
+		.components-menu-group:nth-last-child(2) {
+			margin-bottom: -12px;
+		}
+	}
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
@@ -23,6 +23,8 @@
 
 .wc-block-checkout__address-fields-notice {
 	margin: $gap 0 0;
+}
+
 body.wc-lock-selected-block-from-move {
 	.block-editor-block-mover__move-button-container,
 	.block-editor-block-mover {

--- a/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
@@ -25,14 +25,14 @@
 	margin: $gap 0 0;
 }
 
-body.wc-lock-selected-block-from-move {
+body.wc-lock-selected-block--move {
 	.block-editor-block-mover__move-button-container,
 	.block-editor-block-mover {
 		display: none;
 	}
 }
 
-body.wc-lock-selected-block-from-remove {
+body.wc-lock-selected-block--remove {
 	.block-editor-block-settings-menu__popover {
 		.components-menu-group:last-child {
 			display: none;

--- a/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/editor.scss
@@ -27,7 +27,8 @@
 
 body.wc-lock-selected-block--move {
 	.block-editor-block-mover__move-button-container,
-	.block-editor-block-mover {
+	.block-editor-block-mover,
+	.block-editor-block-settings-menu {
 		display: none;
 	}
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/form-step-block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/form-step-block.tsx
@@ -3,18 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import {
-	PlainText,
-	useBlockProps,
-	InspectorControls,
-} from '@wordpress/block-editor';
+import { PlainText, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import FormStepHeading from './form-step-heading';
-
+import { useBlockPropsWithLocking } from '../hacks';
 export interface FormStepBlockProps {
 	attributes: { title: string; description: string; showStepNumber: boolean };
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
@@ -31,7 +27,7 @@ export const FormStepBlock = ( {
 	className = '',
 	children,
 }: FormStepBlockProps ): JSX.Element => {
-	const blockProps = useBlockProps( {
+	const blockProps = useBlockPropsWithLocking( {
 		className: classnames( 'wc-block-components-checkout-step', className, {
 			'wc-block-components-checkout-step--with-step-number': showStepNumber,
 		} ),

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -4,7 +4,8 @@
  * This file contains functionality to "lock" blocks i.e. to prevent blocks being moved or deleted. This needs to be
  * kept in place until native support for locking is available in WordPress (estimated WordPress 5.9).
  *
- * @todo Remove custom Block locking support when supported natively in WordPress (5.9)
+ * @todo Checkout i2: Remove custom Block locking support when supported natively in WordPress (5.9) and minimum supported version allows
+ * @todo Checkout i2: Disable custom Block locking if native locking support is detected.
  */
 
 /**
@@ -46,17 +47,29 @@ const toggleBodyClass = ( className: string, add = true ) => {
  */
 export const addClassToBody = (): void => {
 	subscribe( () => {
-		const { getSelectedBlock } = _select( blockEditorStore );
-		if ( ! getSelectedBlock() ) {
+		const blockEditorSelect = _select( blockEditorStore );
+
+		if ( ! blockEditorSelect ) {
 			return;
 		}
-		const { getBlockType } = _select( blocksStore );
-		const selectedBlockType = getBlockType( getSelectedBlock().name );
+
+		const selectedBlock = blockEditorSelect.getSelectedBlock();
+
+		if ( ! selectedBlock ) {
+			return;
+		}
+
+		const blockSelect = _select( blocksStore );
+
+		const selectedBlockType = blockSelect.getBlockType(
+			selectedBlock.name
+		);
 
 		toggleBodyClass(
 			'wc-lock-selected-block--remove',
 			!! selectedBlockType?.supports?.lock?.remove
 		);
+
 		toggleBodyClass(
 			'wc-lock-selected-block--move',
 			!! selectedBlockType?.supports?.lock?.move

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -1,4 +1,13 @@
 /**
+ * HACKS
+ *
+ * This file contains functionality to "lock" blocks i.e. to prevent blocks being moved or deleted. This needs to be
+ * kept in place until native support for locking is available in WordPress (estimated WordPress 5.9).
+ *
+ * @todo Remove custom Block locking support when supported natively in WordPress (5.9)
+ */
+
+/**
  * External dependencies
  */
 import {
@@ -13,15 +22,25 @@ import { MutableRefObject } from 'react';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 
 /**
- * @todo Delete hacks file when we support WP 5.9
- * This file contains hacks to lock blocks, it should be kept until we support WordPress 5.9.
+ * Toggle class on body.
  *
+ * @param {string} className CSS Class name.
+ * @param {boolean} add True to add, false to remove.
  */
+const toggleBodyClass = ( className: string, add = true ) => {
+	if ( add ) {
+		window.document.body.classList.add( className );
+	} else {
+		window.document.body.classList.remove( className );
+	}
+};
 
 /**
- * This components watchs for the currenctly selected block and adds a block to the body if that block is locked.
- * If the current block is not locked, it would remove that class.
- * We use that class in CSS to hide some UI elements that prevents the block from being deleted.
+ * addClassToBody
+ *
+ * This components watches the current selected block and adds a class name to the body if that block is locked. If the
+ * current block is not locked, it removes the class name. The appended body class is used to hide UI elements to prevent
+ * the block from being deleted.
  *
  * We use a component so we can react to changes in the store.
  */
@@ -34,31 +53,20 @@ export const addClassToBody = (): void => {
 		const { getBlockType } = _select( blocksStore );
 		const selectedBlockType = getBlockType( getSelectedBlock().name );
 
-		if ( selectedBlockType?.supports?.lock?.remove ) {
-			window.document.body.classList.add(
-				'wc-lock-selected-block-from-remove'
-			);
-		} else {
-			window.document.body.classList.remove(
-				'wc-lock-selected-block-from-remove'
-			);
-		}
-
-		if ( selectedBlockType?.supports?.lock?.move ) {
-			window.document.body.classList.add(
-				'wc-lock-selected-block-from-move'
-			);
-		} else {
-			window.document.body.classList.remove(
-				'wc-lock-selected-block-from-move'
-			);
-		}
+		toggleBodyClass(
+			'wc-lock-selected-block--remove',
+			!! selectedBlockType?.supports?.lock?.remove
+		);
+		toggleBodyClass(
+			'wc-lock-selected-block--move',
+			!! selectedBlockType?.supports?.lock?.move
+		);
 	} );
 };
 
 /**
- * This is a hook we use in conjection with useBlockProps. Its goal is to check if a block is locked (move or remove) and would stop the keydown event from propagating to stop it from being deleted via the keyboard.
- *
+ * This is a hook we use in conjunction with useBlockProps. Its goal is to check if a block is locked (move or remove)
+ * and will stop the keydown event from propagating to stop it from being deleted via the keyboard.
  */
 const useLockBlock = ( {
 	clientId,

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -5,6 +5,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { isTextField } from '@wordpress/dom';
 import { store as blocksStore } from '@wordpress/blocks';
 import { useSelect, subscribe, select as _select } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
@@ -91,7 +92,7 @@ const useLockBlock = ( {
 				return;
 			}
 
-			if ( target !== node ) {
+			if ( target !== node || isTextField( target ) ) {
 				return;
 			}
 

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -113,9 +113,11 @@ const useLockBlock = ( {
 /**
  * This hook is a light wrapper to useBlockProps, it wraps that hook plus useLockBlock to pass data between them.
  */
-export const useBlockPropsWithLocking = (): Record< string, unknown > => {
+export const useBlockPropsWithLocking = (
+	props?: Record< string, unknown > = {}
+): Record< string, unknown > => {
 	const ref = useRef< Element >();
-	const blockProps = useBlockProps( { ref } );
+	const blockProps = useBlockProps( { ref, ...props } );
 	useLockBlock( {
 		ref,
 		type: blockProps[ 'data-type' ],

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -27,7 +27,7 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
 export const addClassToBody = (): void => {
 	subscribe( () => {
 		const { getSelectedBlock } = _select( blockEditorStore );
-		if ( getSelectedBlock() ) {
+		if ( ! getSelectedBlock() ) {
 			return;
 		}
 		const { getBlockType } = _select( blocksStore );

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -90,8 +90,9 @@ const useLockBlock = ( {
 	);
 
 	const node = ref.current;
+
 	return useEffect( () => {
-		if ( ! isSelected ) {
+		if ( ! isSelected || ! node ) {
 			return;
 		}
 		function onKeyDown( event: KeyboardEvent ) {

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -3,9 +3,14 @@
  *
  * This file contains functionality to "lock" blocks i.e. to prevent blocks being moved or deleted. This needs to be
  * kept in place until native support for locking is available in WordPress (estimated WordPress 5.9).
- *
- * @todo Checkout i2: Remove custom Block locking support when supported natively in WordPress (5.9) and minimum supported version allows
- * @todo Checkout i2: Disable custom Block locking if native locking support is detected.
+ */
+
+/**
+ * @todo Checkout i2: Remove custom locking support when supported natively in WordPress (5.9)
+ */
+
+/**
+ * @todo Checkout i2: Disable custom locking support if native support is detected.
  */
 
 /**

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -1,7 +1,7 @@
 /**
  * HACKS
  *
- * @todo Checkout i2: Remove custom locking support when supported natively in WordPress (5.9)
+ * @todo Remove custom locking support when supported natively in WordPress (5.9)
  *
  * This file contains functionality to "lock" blocks i.e. to prevent blocks being moved or deleted. This needs to be
  * kept in place until native support for locking is available in WordPress (estimated WordPress 5.9).
@@ -80,7 +80,7 @@ export const addClassToBody = (): void => {
  * This is a hook we use in conjunction with useBlockProps. Its goal is to check if a block is locked (move or remove)
  * and will stop the keydown event from propagating to stop it from being deleted via the keyboard.
  *
- * @todo Checkout i2: Disable custom locking support if native support is detected.
+ * @todo Disable custom locking support if native support is detected.
  */
 const useLockBlock = ( {
 	clientId,

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -6,7 +6,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as blocksStore } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, subscribe, select as _select } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { MutableRefObject } from 'react';
 import { BACKSPACE, DELETE } from '@wordpress/keycodes';
@@ -24,16 +24,16 @@ import { BACKSPACE, DELETE } from '@wordpress/keycodes';
  *
  * We use a component so we can react to changes in the store.
  */
-export const AddCurrentlySelectedBlockClass = (): null => {
-	const selectedBlockType = useSelect( ( select ) => {
-		const { getSelectedBlock } = select( blockEditorStore );
-		const { getBlockType } = select( blocksStore );
+export const addClassToBody = (): void => {
+	subscribe( () => {
+		const { getSelectedBlock } = _select( blockEditorStore );
 		if ( getSelectedBlock() ) {
-			return getBlockType( getSelectedBlock().name );
+			return;
 		}
-	}, [] );
-	useEffect( () => {
-		if ( selectedBlockType && selectedBlockType?.supports?.lock?.remove ) {
+		const { getBlockType } = _select( blocksStore );
+		const selectedBlockType = getBlockType( getSelectedBlock().name );
+
+		if ( selectedBlockType?.supports?.lock?.remove ) {
 			window.document.body.classList.add(
 				'wc-lock-selected-block-from-remove'
 			);
@@ -43,7 +43,7 @@ export const AddCurrentlySelectedBlockClass = (): null => {
 			);
 		}
 
-		if ( selectedBlockType && selectedBlockType?.supports?.lock?.move ) {
+		if ( selectedBlockType?.supports?.lock?.move ) {
 			window.document.body.classList.add(
 				'wc-lock-selected-block-from-move'
 			);
@@ -52,8 +52,7 @@ export const AddCurrentlySelectedBlockClass = (): null => {
 				'wc-lock-selected-block-from-move'
 			);
 		}
-	}, [ selectedBlockType ] );
-	return null;
+	} );
 };
 
 /**

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -1,16 +1,10 @@
 /**
  * HACKS
  *
+ * @todo Checkout i2: Remove custom locking support when supported natively in WordPress (5.9)
+ *
  * This file contains functionality to "lock" blocks i.e. to prevent blocks being moved or deleted. This needs to be
  * kept in place until native support for locking is available in WordPress (estimated WordPress 5.9).
- */
-
-/**
- * @todo Checkout i2: Remove custom locking support when supported natively in WordPress (5.9)
- */
-
-/**
- * @todo Checkout i2: Disable custom locking support if native support is detected.
  */
 
 /**
@@ -85,6 +79,8 @@ export const addClassToBody = (): void => {
 /**
  * This is a hook we use in conjunction with useBlockProps. Its goal is to check if a block is locked (move or remove)
  * and will stop the keydown event from propagating to stop it from being deleted via the keyboard.
+ *
+ * @todo Checkout i2: Disable custom locking support if native support is detected.
  */
 const useLockBlock = ( {
 	clientId,

--- a/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/hacks.ts
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import {
+	useBlockProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { store as blocksStore } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { useEffect, useRef } from '@wordpress/element';
+import { MutableRefObject } from 'react';
+import { BACKSPACE, DELETE } from '@wordpress/keycodes';
+
+/**
+ * @todo Delete hacks file when we support WP 5.9
+ * This file contains hacks to lock blocks, it should be kept until we support WordPress 5.9.
+ *
+ */
+
+/**
+ * This components watchs for the currenctly selected block and adds a block to the body if that block is locked.
+ * If the current block is not locked, it would remove that class.
+ * We use that class in CSS to hide some UI elements that prevents the block from being deleted.
+ *
+ * We use a component so we can react to changes in the store.
+ */
+export const AddCurrentlySelectedBlockClass = (): null => {
+	const selectedBlockType = useSelect( ( select ) => {
+		const { getSelectedBlock } = select( blockEditorStore );
+		const { getBlockType } = select( blocksStore );
+		if ( getSelectedBlock() ) {
+			return getBlockType( getSelectedBlock().name );
+		}
+	}, [] );
+	useEffect( () => {
+		if ( selectedBlockType && selectedBlockType?.supports?.lock?.remove ) {
+			window.document.body.classList.add(
+				'wc-lock-selected-block-from-remove'
+			);
+		} else {
+			window.document.body.classList.remove(
+				'wc-lock-selected-block-from-remove'
+			);
+		}
+
+		if ( selectedBlockType && selectedBlockType?.supports?.lock?.move ) {
+			window.document.body.classList.add(
+				'wc-lock-selected-block-from-move'
+			);
+		} else {
+			window.document.body.classList.remove(
+				'wc-lock-selected-block-from-move'
+			);
+		}
+	}, [ selectedBlockType ] );
+	return null;
+};
+
+/**
+ * This is a hook we use in conjection with useBlockProps. Its goal is to check if a block is locked (move or remove) and would stop the keydown event from propagating to stop it from being deleted via the keyboard.
+ *
+ */
+const useLockBlock = ( {
+	clientId,
+	ref,
+	type,
+}: {
+	clientId: string;
+	ref: MutableRefObject< Element >;
+	type: string;
+} ): void => {
+	const { isSelected, blockType } = useSelect(
+		( select ) => {
+			return {
+				isSelected: select( blockEditorStore ).isBlockSelected(
+					clientId
+				),
+				blockType: select( blocksStore ).getBlockType( type ),
+			};
+		},
+		[ clientId ]
+	);
+
+	const node = ref.current;
+	return useEffect( () => {
+		if ( ! isSelected ) {
+			return;
+		}
+		function onKeyDown( event: KeyboardEvent ) {
+			const { keyCode, target } = event;
+			if ( keyCode !== BACKSPACE && keyCode !== DELETE ) {
+				return;
+			}
+
+			if ( target !== node ) {
+				return;
+			}
+
+			// Prevent the keyboard event from propogating if it supports locking.
+			if ( blockType?.supports?.lock?.remove ) {
+				event.preventDefault();
+				event.stopPropagation();
+			}
+		}
+
+		node.addEventListener( 'keydown', onKeyDown, true );
+
+		return () => {
+			node.removeEventListener( 'keydown', onKeyDown, true );
+		};
+	}, [ node, isSelected, blockType ] );
+};
+
+/**
+ * This hook is a light wrapper to useBlockProps, it wraps that hook plus useLockBlock to pass data between them.
+ */
+export const useBlockPropsWithLocking = (): Record< string, unknown > => {
+	const ref = useRef< Element >();
+	const blockProps = useBlockProps( { ref } );
+	useLockBlock( {
+		ref,
+		type: blockProps[ 'data-type' ],
+		clientId: blockProps[ 'data-block' ],
+	} );
+	return blockProps;
+};

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/edit.tsx
@@ -12,7 +12,7 @@ import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
  * Internal dependencies
  */
 import Block from './block';
-
+import { useBlockPropsWithLocking } from '../../hacks';
 export const Edit = ( {
 	attributes,
 	setAttributes,
@@ -23,7 +23,7 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockPropsWithLocking();
 	const { cartPageId = 0, showReturnToCart = true } = attributes;
 	const { current: savedCartPageId } = useRef( cartPageId );
 	const currentPostId = useSelect(

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/edit.tsx
@@ -2,14 +2,14 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-
 /**
  * Internal dependencies
  */
 import Block from './block';
+import { useBlockPropsWithLocking } from '../../hacks';
 
 export const Edit = (): JSX.Element => {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockPropsWithLocking();
 
 	return (
 		<div { ...blockProps }>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-note-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-note-block/edit.tsx
@@ -8,9 +8,9 @@ import { Disabled } from '@wordpress/components';
  * Internal dependencies
  */
 import Block from './block';
-
+import { useBlockPropsWithLocking } from '../../hacks';
 export const Edit = (): JSX.Element => {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockPropsWithLocking();
 	return (
 		<div { ...blockProps }>
 			<Disabled>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/edit.tsx
@@ -8,9 +8,9 @@ import { Disabled } from '@wordpress/components';
  * Internal dependencies
  */
 import Block from './block';
-
+import { useBlockPropsWithLocking } from '../../hacks';
 export const Edit = (): JSX.Element => {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockPropsWithLocking();
 
 	return (
 		<div { ...blockProps }>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/edit.tsx
@@ -26,7 +26,7 @@ export const Edit = (): JSX.Element => {
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
 					template={ TEMPLATE }
-					templateLock={ 'all' }
+					templateLock={ false }
 				/>
 			</div>
 		</Sidebar>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5374,6 +5374,15 @@
 						"uuid": "^7.0.2"
 					}
 				},
+				"@wordpress/dom": {
+					"version": "2.16.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.16.0.tgz",
+					"integrity": "sha512-IjXPfv9SuEkVbmxD4eaxn01zZmYUxp/4wrMcsHAHGym59k/bN6uJOQprrU/tTiSR4Zlf8Jmo22HWmuL654k8zg==",
+					"requires": {
+						"@babel/runtime": "^7.12.5",
+						"lodash": "^4.17.19"
+					}
+				},
 				"@wordpress/element": {
 					"version": "2.19.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.0.tgz",
@@ -5695,6 +5704,17 @@
 						"react-dates": "^17.2.0",
 						"react-router-dom": "5.2.0",
 						"react-transition-group": "4.4.1"
+					},
+					"dependencies": {
+						"@wordpress/dom": {
+							"version": "2.16.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.16.0.tgz",
+							"integrity": "sha512-IjXPfv9SuEkVbmxD4eaxn01zZmYUxp/4wrMcsHAHGym59k/bN6uJOQprrU/tTiSR4Zlf8Jmo22HWmuL654k8zg==",
+							"requires": {
+								"@babel/runtime": "^7.12.5",
+								"lodash": "^4.17.19"
+							}
+						}
 					}
 				},
 				"@wordpress/components": {
@@ -5747,6 +5767,15 @@
 							"requires": {
 								"@babel/runtime": "^7.13.10",
 								"@wordpress/hooks": "^2.12.3"
+							}
+						},
+						"@wordpress/dom": {
+							"version": "2.18.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+							"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"lodash": "^4.17.19"
 							}
 						}
 					}
@@ -5945,6 +5974,15 @@
 						"uuid": "^7.0.2"
 					},
 					"dependencies": {
+						"@wordpress/dom": {
+							"version": "2.18.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+							"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"lodash": "^4.17.19"
+							}
+						},
 						"@wordpress/icons": {
 							"version": "2.10.3",
 							"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
@@ -6238,6 +6276,16 @@
 						"uuid": "^7.0.2"
 					}
 				},
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
+					}
+				},
 				"@wordpress/icons": {
 					"version": "2.10.3",
 					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
@@ -6395,6 +6443,16 @@
 				"uuid": "^7.0.2"
 			},
 			"dependencies": {
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
+					}
+				},
 				"@wordpress/icons": {
 					"version": "2.10.3",
 					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
@@ -6492,6 +6550,16 @@
 					"requires": {
 						"@babel/runtime": "^7.13.10",
 						"@wordpress/hooks": "^2.12.3"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
 					}
 				},
 				"@wordpress/element": {
@@ -6595,6 +6663,15 @@
 					"requires": {
 						"@babel/runtime": "^7.13.10",
 						"@wordpress/hooks": "^2.12.3"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
 					}
 				},
 				"@wordpress/element": {
@@ -6988,12 +7065,13 @@
 			}
 		},
 		"@wordpress/dom": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.16.0.tgz",
-			"integrity": "sha512-IjXPfv9SuEkVbmxD4eaxn01zZmYUxp/4wrMcsHAHGym59k/bN6uJOQprrU/tTiSR4Zlf8Jmo22HWmuL654k8zg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.1.2.tgz",
+			"integrity": "sha512-ahY2nFqX7dktTHbuSyxnx3uz3LC5Y3g5Ji4mkoJZsA2BVAJFc8Vj7dGWnSstcPnuECGlkcEXF5FvMpIgsJB20Q==",
+			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.12.5",
-				"lodash": "^4.17.19"
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.21"
 			}
 		},
 		"@wordpress/dom-ready": {
@@ -7136,6 +7214,18 @@
 						"rememo": "^3.0.0",
 						"tinycolor2": "^1.4.1",
 						"uuid": "^7.0.2"
+					},
+					"dependencies": {
+						"@wordpress/dom": {
+							"version": "2.18.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+							"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"lodash": "^4.17.19"
+							}
+						}
 					}
 				},
 				"@wordpress/icons": {
@@ -7506,32 +7596,6 @@
 				"memize": "^1.1.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
-			}
-		},
-		"@wordpress/icons": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
-			"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
-			"requires": {
-				"@babel/runtime": "^7.13.10",
-				"@wordpress/element": "^2.20.3",
-				"@wordpress/primitives": "^1.12.3"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
-					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
-					"requires": {
-						"@babel/runtime": "^7.13.10",
-						"@types/react": "^16.9.0",
-						"@types/react-dom": "^16.9.0",
-						"@wordpress/escape-html": "^1.12.2",
-						"lodash": "^4.17.19",
-						"react": "^16.13.1",
-						"react-dom": "^16.13.1"
-					}
-				}
 			}
 		},
 		"@wordpress/is-shallow-equal": {
@@ -8689,6 +8753,15 @@
 						"uuid": "^7.0.2"
 					},
 					"dependencies": {
+						"@wordpress/dom": {
+							"version": "2.18.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+							"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"lodash": "^4.17.19"
+							}
+						},
 						"@wordpress/icons": {
 							"version": "2.10.3",
 							"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
@@ -33693,115 +33766,6 @@
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
 		},
-		"wordpress-components": {
-			"version": "npm:@wordpress/components@11.1.5",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-11.1.5.tgz",
-			"integrity": "sha512-XOVD4HgqvizuqMtY1XzppNiw2ET2VefGtdclewb3sB/eBxkNtqb2hl9mHBG547Au0QZnsOylK9AOAZI0eYhMOw==",
-			"requires": {
-				"@babel/runtime": "^7.11.2",
-				"@emotion/core": "^10.0.22",
-				"@emotion/css": "^10.0.22",
-				"@emotion/native": "^10.0.22",
-				"@emotion/styled": "^10.0.23",
-				"@wordpress/a11y": "^2.13.0",
-				"@wordpress/compose": "^3.22.0",
-				"@wordpress/date": "^3.12.0",
-				"@wordpress/deprecated": "^2.10.0",
-				"@wordpress/dom": "^2.15.0",
-				"@wordpress/element": "^2.18.0",
-				"@wordpress/hooks": "^2.10.0",
-				"@wordpress/i18n": "^3.16.0",
-				"@wordpress/icons": "^2.8.0",
-				"@wordpress/is-shallow-equal": "^2.3.0",
-				"@wordpress/keycodes": "^2.16.0",
-				"@wordpress/primitives": "^1.10.0",
-				"@wordpress/rich-text": "^3.23.0",
-				"@wordpress/warning": "^1.3.0",
-				"classnames": "^2.2.5",
-				"dom-scroll-into-view": "^1.2.1",
-				"downshift": "^5.4.0",
-				"gradient-parser": "^0.1.5",
-				"lodash": "^4.17.19",
-				"memize": "^1.1.0",
-				"moment": "^2.22.1",
-				"re-resizable": "^6.4.0",
-				"react-dates": "^17.1.1",
-				"react-merge-refs": "^1.0.0",
-				"react-resize-aware": "^3.0.1",
-				"react-spring": "^8.0.20",
-				"react-use-gesture": "^7.0.15",
-				"reakit": "^1.1.0",
-				"rememo": "^3.0.0",
-				"tinycolor2": "^1.4.1",
-				"uuid": "^7.0.2"
-			},
-			"dependencies": {
-				"@wordpress/deprecated": {
-					"version": "2.12.3",
-					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
-					"integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
-					"requires": {
-						"@babel/runtime": "^7.13.10",
-						"@wordpress/hooks": "^2.12.3"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
-					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
-					"requires": {
-						"@babel/runtime": "^7.13.10",
-						"@types/react": "^16.9.0",
-						"@types/react-dom": "^16.9.0",
-						"@wordpress/escape-html": "^1.12.2",
-						"lodash": "^4.17.19",
-						"react": "^16.13.1",
-						"react-dom": "^16.13.1"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.20.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
-					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
-					"requires": {
-						"@babel/runtime": "^7.13.10",
-						"@wordpress/hooks": "^2.12.3",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.19",
-						"memize": "^1.1.0",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.2.0"
-					}
-				},
-				"@wordpress/is-shallow-equal": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
-					"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
-					"requires": {
-						"@babel/runtime": "^7.11.2"
-					}
-				},
-				"downshift": {
-					"version": "5.4.7",
-					"resolved": "https://registry.npmjs.org/downshift/-/downshift-5.4.7.tgz",
-					"integrity": "sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==",
-					"requires": {
-						"@babel/runtime": "^7.10.2",
-						"compute-scroll-into-view": "^1.0.14",
-						"prop-types": "^15.7.2",
-						"react-is": "^16.13.1"
-					}
-				},
-				"re-resizable": {
-					"version": "6.9.0",
-					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
-					"integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
-					"requires": {
-						"fast-memoize": "^2.5.1"
-					}
-				}
-			}
-		},
 		"wordpress-compose": {
 			"version": "npm:@wordpress/compose@3.23.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.23.1.tgz",
@@ -33830,6 +33794,15 @@
 					"requires": {
 						"@babel/runtime": "^7.13.10",
 						"@wordpress/hooks": "^2.12.3"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
 					}
 				},
 				"@wordpress/element": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4638,72 +4638,6 @@
 			}
 		},
 		"@types/wordpress__blocks": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-9.0.1.tgz",
-			"integrity": "sha512-iqUO+BBuwpBKFgxbuMCWu21GuV7vQN3WuWXoqK2gVNVXPykQSBN9FCPZYwa9VBM7uFIUaqWZImlOMV15Kox+sQ==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*",
-				"@types/wordpress__components": "*",
-				"@types/wordpress__data": "*",
-				"@wordpress/element": "^3.0.0"
-			},
-			"dependencies": {
-				"@wordpress/element": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.1.1.tgz",
-					"integrity": "sha512-OaqKQVEV3CCTdrx/G7fMbmxhrxjApobHUAGAVYCCR1MIqScfluYJRLWFLx8tlkl/Qm/UbF9IfdXS1lphufvYog==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.13.10",
-						"@types/react": "^16.9.0",
-						"@types/react-dom": "^16.9.0",
-						"@wordpress/escape-html": "^2.1.1",
-						"lodash": "^4.17.21",
-						"react": "^16.13.1",
-						"react-dom": "^16.13.1"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.1.1.tgz",
-					"integrity": "sha512-ZIkLxGLBhXkZu3t0yF82/brPV5aCOGCXGiH0EMV8GCohhXCNIfQwwFrZ5gd5NyNX5Q8alTLsiA84azJd+n0XiQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.13.10"
-					}
-				}
-			}
-		},
-		"@types/wordpress__block-editor": {
-			"version": "2.2.9",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__block-editor/-/wordpress__block-editor-2.2.9.tgz",
-			"integrity": "sha512-TrmruuJFb0jplVvWki+ThQKmNGU0fkr+DXHIiwp8YN6atRNn9AJRL0FF7B4QXeoE3lHIpdZ41pFuuTgs3aqmiw==",
-			"dev": true,
-			"requires": {
-				"@types/react": "*",
-				"@types/wordpress__blocks": "*",
-				"@types/wordpress__components": "*",
-				"@types/wordpress__data": "*",
-				"@types/wordpress__keycodes": "*",
-				"@wordpress/element": "^2.14.0",
-				"react-autosize-textarea": "^7.0.0"
-			},
-			"dependencies": {
-				"react-autosize-textarea": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
-					"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
-					"dev": true,
-					"requires": {
-						"autosize": "^4.0.2",
-						"line-height": "^0.3.1",
-						"prop-types": "^15.5.6"
-					}
-				}
-			}
-		},
-		"@types/wordpress__blocks": {
 			"version": "6.4.12",
 			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-6.4.12.tgz",
 			"integrity": "sha512-ezQoo4NTfVY/KiCA8kwUXBJhgyoPq1HtfpRk6NXxQOwcDyFK0zN0knCvLn5YqVx1u8j3fSblbkW4RcFOK1xGIQ==",
@@ -7596,6 +7530,32 @@
 				"memize": "^1.1.0",
 				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
+			}
+		},
+		"@wordpress/icons": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+			"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/element": "^2.20.3",
+				"@wordpress/primitives": "^1.12.3"
+			},
+			"dependencies": {
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				}
 			}
 		},
 		"@wordpress/is-shallow-equal": {
@@ -33765,6 +33725,124 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
+		},
+		"wordpress-components": {
+			"version": "npm:@wordpress/components@11.1.5",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-11.1.5.tgz",
+			"integrity": "sha512-XOVD4HgqvizuqMtY1XzppNiw2ET2VefGtdclewb3sB/eBxkNtqb2hl9mHBG547Au0QZnsOylK9AOAZI0eYhMOw==",
+			"requires": {
+				"@babel/runtime": "^7.11.2",
+				"@emotion/core": "^10.0.22",
+				"@emotion/css": "^10.0.22",
+				"@emotion/native": "^10.0.22",
+				"@emotion/styled": "^10.0.23",
+				"@wordpress/a11y": "^2.13.0",
+				"@wordpress/compose": "^3.22.0",
+				"@wordpress/date": "^3.12.0",
+				"@wordpress/deprecated": "^2.10.0",
+				"@wordpress/dom": "^2.15.0",
+				"@wordpress/element": "^2.18.0",
+				"@wordpress/hooks": "^2.10.0",
+				"@wordpress/i18n": "^3.16.0",
+				"@wordpress/icons": "^2.8.0",
+				"@wordpress/is-shallow-equal": "^2.3.0",
+				"@wordpress/keycodes": "^2.16.0",
+				"@wordpress/primitives": "^1.10.0",
+				"@wordpress/rich-text": "^3.23.0",
+				"@wordpress/warning": "^1.3.0",
+				"classnames": "^2.2.5",
+				"dom-scroll-into-view": "^1.2.1",
+				"downshift": "^5.4.0",
+				"gradient-parser": "^0.1.5",
+				"lodash": "^4.17.19",
+				"memize": "^1.1.0",
+				"moment": "^2.22.1",
+				"re-resizable": "^6.4.0",
+				"react-dates": "^17.1.1",
+				"react-merge-refs": "^1.0.0",
+				"react-resize-aware": "^3.0.1",
+				"react-spring": "^8.0.20",
+				"react-use-gesture": "^7.0.15",
+				"reakit": "^1.1.0",
+				"rememo": "^3.0.0",
+				"tinycolor2": "^1.4.1",
+				"uuid": "^7.0.2"
+			},
+			"dependencies": {
+				"@wordpress/deprecated": {
+					"version": "2.12.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+					"integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "2.18.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+					"integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^1.12.2",
+						"lodash": "^4.17.19",
+						"react": "^16.13.1",
+						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.20.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+					"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^2.12.3",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.19",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
+					"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
+					"requires": {
+						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"downshift": {
+					"version": "5.4.7",
+					"resolved": "https://registry.npmjs.org/downshift/-/downshift-5.4.7.tgz",
+					"integrity": "sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==",
+					"requires": {
+						"@babel/runtime": "^7.10.2",
+						"compute-scroll-into-view": "^1.0.14",
+						"prop-types": "^15.7.2",
+						"react-is": "^16.13.1"
+					}
+				},
+				"re-resizable": {
+					"version": "6.9.0",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
+					"integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
+					}
+				}
+			}
 		},
 		"wordpress-compose": {
 			"version": "npm:@wordpress/compose@3.23.1",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
 		"@wordpress/components": "11.1.1",
 		"@wordpress/data-controls": "1.20.8",
 		"@wordpress/dependency-extraction-webpack-plugin": "2.8.0",
+		"@wordpress/dom": "^3.1.2",
 		"@wordpress/e2e-test-utils": "5.1.2",
 		"@wordpress/editor": "9.22.0",
 		"@wordpress/element": "2.17.1",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds an interim solution for locking blocks from being removed or moved. It does this by using the same registration system introduced in [#32457](https://github.com/WordPress/gutenberg/pull/32457) via `supports` option and locks the blocks.
- It adds a classname to the body when a locked block is selected, this is to hide the remove and drag buttons from the block toolbar.
- It intercepts the `DELETE` and `BACKSPACE` keydown events on the block and prevent them from propagating to Gutenberg.

<!-- Reference any related issues or PRs here -->
Fixes #4453


### How to test the changes in this Pull Request:

1. Currently, in this PR, only express payment methods is locked.
2. Try deleting that block or moving it, it shouldn't work.
3. Try deleting other block, they all work fine.
