### PR TITLE
Update notices documentation to reflect changes to Snackbar Notices

### DIFF
--- a/docs/block-client-apis/notices.md
+++ b/docs/block-client-apis/notices.md
@@ -94,7 +94,7 @@ Whether notices are suppressed. If true, it will hide the notices from the front
 
 ## StoreNoticesProvider
 
-The `StoreNoticesProvider` allows managing notices in the frontend. Notices are rendered on top of the children.
+The `StoreNoticesProvider` allows managing notices in the frontend. Notices are rendered before React Children.
 
 Internally, it uses the `StoreNoticesContext` which relies on the [`notices` package](https://github.com/WordPress/gutenberg/tree/master/packages/notices) from Gutenberg.
 

--- a/docs/block-client-apis/notices.md
+++ b/docs/block-client-apis/notices.md
@@ -4,6 +4,8 @@
 
 The `useStoreNotices()` hook allows reading and manipulating notices in the frontend.
 
+Please refer to the `useStoreSnackbarNotices()` section for information on handling snackbar notices.
+
 ### API
 
 > _Note: if the context is not specified in `noticeProps` or `ctxt` params (depending on the method), the current context is used._
@@ -53,15 +55,6 @@ Create a new success notice.
 | `text`        | string | Text to be displayed in the notice.                |
 | `noticeProps` | Object | Object with the [notice options](#notice-options). |
 
-#### `addSnackbarNotice( text = '', noticeProps = {} )`
-
-Create a new snackbar notice.
-
-| Argument      | Type   | Description                                        |
-| ------------- | ------ | -------------------------------------------------- |
-| `text`        | string | Text to be displayed in the notice.                |
-| `noticeProps` | Object | Object with the [notice options](#notice-options). |
-
 #### `hasNoticesOfType( type )`
 
 Check whether there are notices of the provided type in the current context.
@@ -101,7 +94,7 @@ Whether notices are suppressed. If true, it will hide the notices from the front
 
 ## StoreNoticesProvider
 
-The `StoreNoticesProvider` allows managing notices in the frontend. Notices are rendered on top of the children, except notices of type snackbars, which are displayed in the bottom left corner and disappear after a certain time.
+The `StoreNoticesProvider` allows managing notices in the frontend. Notices are rendered on top of the children.
 
 Internally, it uses the `StoreNoticesContext` which relies on the [`notices` package](https://github.com/WordPress/gutenberg/tree/master/packages/notices) from Gutenberg.
 
@@ -154,12 +147,79 @@ Object of the form:
 ```JS
 {
 	id: 'checkout',
-	type: 'snackbar',
+	type: string,
 	isDismissible: false,
 }
 ```
 
 Refer to the [Gutenberg docs](https://github.com/WordPress/gutenberg/blob/master/packages/notices/src/store/actions.js#L46) to know the available options.
+
+## useStoreSnackbarNotices()
+
+The `useStoreNotices()` hook allows reading and manipulating snackbar notices in the frontend.
+
+The snackbar is a small toast-like notification that appears at the bottom of a user's screen.
+
+<img width="300" src="https://user-images.githubusercontent.com/5656702/124294673-dd803b80-db4f-11eb-81ec-02fb962d04ed.png" />
+
+### API
+
+#### `addSnackbarNotice( text = '', noticeProps = {} )`
+
+Create a new snackbar notice.
+
+| Argument      | Type   | Description                                        |
+| ------------- | ------ | -------------------------------------------------- |
+| `text`        | string | Text to be displayed in the notice.                |
+| `noticeProps` | Object | Object with the [notice options](#notice-options). |
+
+#### `notices`
+
+An array of the notices in the current context.
+
+#### `removeNotices( status = null )`
+
+Remove all notices from the current context. If a `status` is provided, only the notices with that status are removed.
+
+| Argument | Type   | Description                                                                                           |
+| -------- | ------ | ----------------------------------------------------------------------------------------------------- |
+| `status` | string | Status that notices must match to be removed. If not provided, all notices of any status are removed. |
+
+
+## StoreSnackbarNoticesProvider
+
+The `StoreSnackbarNoticesProvider` allows managing snackbar notices in the frontend. Snackbar notices are displayed in the bottom left corner and disappear after a certain time.
+
+Internally, it uses the `StoreNoticesContext` which relies on the [`notices` package](https://github.com/WordPress/gutenberg/tree/master/packages/notices) from Gutenberg.
+
+### Actions
+
+#### `createSnackbarNotice( content = '', options = {} )`
+
+This action creates a new snackbar notice. If the context is not specified in the `options` object, the current context is used.
+
+| Argument  | Type   | Description                                        |
+| --------- | ------ | -------------------------------------------------- |
+| `content` | string | Text to be displayed in the notice.                |
+| `options` | Object | Object with the [notice options](#notice-options). |
+
+#### `removeSnackbarNotice( id, ctx )`
+
+This action removes an existing notice. If the context is not specified, the current context is used.
+
+| Argument | Type   | Description                                                                                                 |
+| -------- | ------ | ----------------------------------------------------------------------------------------------------------- |
+| `id`     | string | Id of the notice to remove.                                                                                 |
+| `ctx`    | string | Context where the notice to remove is stored. If the context is not specified, the current context is used. |
+
+#### `setIsSuppressed( val )`
+
+Whether notices are suppressed. If true, it will hide the notices from the frontend.
+
+| Argument | Type    | Description                 |
+| -------- | ------- | --------------------------- |
+| `val`    | boolean | Id of the notice to remove. |
+
 
 ## Example usage
 
@@ -167,7 +227,8 @@ The following example shows a `CheckoutProcessor` component that displays an err
 
 ```JSX
 const CheckoutProcessor = () => {
-	const { addErrorNotice, addSnackbarNotice, removeNotice } = useStoreNotices();
+	const { addErrorNotice, removeNotice } = useStoreNotices();
+	const { addSnackbarNotice } = useStoreSnackbarNotices();
 	// ...
 	const paymentFail = () => {
 		addErrorNotice( 'Something went wrong.', { id: 'checkout' } );
@@ -183,8 +244,10 @@ const CheckoutProcessor = () => {
 ```
 
 ```JSX
-<StoreNoticesProvider context="wc/checkout">
-	// ...
-	<CheckoutProcessor />
-</StoreNoticesProvider>
+<StoreNoticesSnackbarProvider context="wc/checkout">
+  <StoreNoticesProvider context="wc/checkout">
+      // ...
+      <CheckoutProcessor />
+  </StoreNoticesProvider>
+</StoreSnackbarNoticesProvider>
 ```


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will update the notices documentation because it is outdated following a change where we split the snackbar functionality out of `StoreNoticesProvider` into `StoreSnackbarNoticesProvider` in #4407.

### How to test the changes in this Pull Request:

1. Please read the documentation from the perspective of someone who is new to the team. Check for typographical or formatting errors.
2. Ensure the changes make sense and accurately reflect the current API based on what we changed in #4407.

<!-- If you can, add the appropriate labels -->
