### PR TITLE
Checkout i2: Enable shipping toggle in the editor

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/block.tsx
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useEffect, Fragment } from '@wordpress/element';
+import { Disabled } from '@wordpress/components';
 import {
-	useStoreEvents,
 	useCheckoutAddress,
-} from '@woocommerce/base-context/hooks';
+	useStoreEvents,
+	useEditorContext,
+} from '@woocommerce/base-context';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
 
 /**
@@ -33,6 +35,7 @@ const Block = ( {
 		setPhone,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
+	const { isEditor } = useEditorContext();
 
 	// Clears data if fields are hidden.
 	useEffect( () => {
@@ -53,8 +56,10 @@ const Block = ( {
 		};
 	}, [ showCompanyField, requireCompanyField, showApartmentField ] );
 
+	const AddressFormWrapperComponent = isEditor ? Disabled : Fragment;
+
 	return (
-		<>
+		<AddressFormWrapperComponent>
 			<AddressForm
 				id="billing"
 				type="billing"
@@ -79,7 +84,7 @@ const Block = ( {
 					} }
 				/>
 			) }
-		</>
+		</AddressFormWrapperComponent>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/edit.tsx
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { Disabled } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
+import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 
 /**
  * Internal dependencies
@@ -30,10 +30,16 @@ export const Edit = ( {
 		'woocommerce/requirePhoneField': boolean;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
-} ): JSX.Element => {
+} ): JSX.Element | null => {
 	const { controls: FieldControls } = useContext(
 		CheckoutFieldsBlockContext
 	);
+	const { showBillingFields } = useCheckoutAddress();
+
+	if ( ! showBillingFields ) {
+		return null;
+	}
+
 	return (
 		<FormStepBlock
 			setAttributes={ setAttributes }
@@ -41,23 +47,17 @@ export const Edit = ( {
 			className="wc-block-checkout__billing-fields"
 		>
 			<FieldControls />
-			<Disabled>
-				<Block
-					showCompanyField={
-						context[ 'woocommerce/showCompanyField' ]
-					}
-					showApartmentField={
-						context[ 'woocommerce/showApartmentField' ]
-					}
-					requireCompanyField={
-						context[ 'woocommerce/requireCompanyField' ]
-					}
-					showPhoneField={ context[ 'woocommerce/showPhoneField' ] }
-					requirePhoneField={
-						context[ 'woocommerce/requirePhoneField' ]
-					}
-				/>
-			</Disabled>
+			<Block
+				showCompanyField={ context[ 'woocommerce/showCompanyField' ] }
+				showApartmentField={
+					context[ 'woocommerce/showApartmentField' ]
+				}
+				requireCompanyField={
+					context[ 'woocommerce/requireCompanyField' ]
+				}
+				showPhoneField={ context[ 'woocommerce/showPhoneField' ] }
+				requirePhoneField={ context[ 'woocommerce/requirePhoneField' ] }
+			/>
 		</FormStepBlock>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -2,9 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useEffect, Fragment } from '@wordpress/element';
+import { Disabled } from '@wordpress/components';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
-import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
+import {
+	useCheckoutAddress,
+	useStoreEvents,
+	useEditorContext,
+} from '@woocommerce/base-context';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 
 /**
@@ -34,6 +39,7 @@ const Block = ( {
 		setShippingPhone,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
+	const { isEditor } = useEditorContext();
 
 	// Clears data if fields are hidden.
 	useEffect( () => {
@@ -54,32 +60,36 @@ const Block = ( {
 		};
 	}, [ showCompanyField, requireCompanyField, showApartmentField ] );
 
+	const AddressFormWrapperComponent = isEditor ? Disabled : Fragment;
+
 	return (
 		<>
-			<AddressForm
-				id="shipping"
-				type="shipping"
-				onChange={ ( values: Record< string, unknown > ) => {
-					setShippingFields( values );
-					dispatchCheckoutEvent( 'set-shipping-address' );
-				} }
-				values={ shippingFields }
-				fields={ Object.keys( defaultAddressFields ) }
-				fieldConfig={ addressFieldsConfig }
-			/>
-			{ showPhoneField && (
-				<PhoneNumber
-					id="shipping-phone"
-					isRequired={ requirePhoneField }
-					value={ shippingFields.phone }
-					onChange={ ( value ) => {
-						setShippingPhone( value );
-						dispatchCheckoutEvent( 'set-phone-number', {
-							step: 'shipping',
-						} );
+			<AddressFormWrapperComponent>
+				<AddressForm
+					id="shipping"
+					type="shipping"
+					onChange={ ( values: Record< string, unknown > ) => {
+						setShippingFields( values );
+						dispatchCheckoutEvent( 'set-shipping-address' );
 					} }
+					values={ shippingFields }
+					fields={ Object.keys( defaultAddressFields ) }
+					fieldConfig={ addressFieldsConfig }
 				/>
-			) }
+				{ showPhoneField && (
+					<PhoneNumber
+						id="shipping-phone"
+						isRequired={ requirePhoneField }
+						value={ shippingFields.phone }
+						onChange={ ( value ) => {
+							setShippingPhone( value );
+							dispatchCheckoutEvent( 'set-phone-number', {
+								step: 'shipping',
+							} );
+						} }
+					/>
+				) }
+			</AddressFormWrapperComponent>
 			<CheckboxControl
 				className="wc-block-checkout__use-address-for-billing"
 				label={ __(

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { Disabled } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -41,23 +40,17 @@ export const Edit = ( {
 			className="wc-block-checkout__shipping-fields"
 		>
 			<FieldControls />
-			<Disabled>
-				<Block
-					showCompanyField={
-						context[ 'woocommerce/showCompanyField' ]
-					}
-					showApartmentField={
-						context[ 'woocommerce/showApartmentField' ]
-					}
-					requireCompanyField={
-						context[ 'woocommerce/requireCompanyField' ]
-					}
-					showPhoneField={ context[ 'woocommerce/showPhoneField' ] }
-					requirePhoneField={
-						context[ 'woocommerce/requirePhoneField' ]
-					}
-				/>
-			</Disabled>
+			<Block
+				showCompanyField={ context[ 'woocommerce/showCompanyField' ] }
+				showApartmentField={
+					context[ 'woocommerce/showApartmentField' ]
+				}
+				requireCompanyField={
+					context[ 'woocommerce/requireCompanyField' ]
+				}
+				showPhoneField={ context[ 'woocommerce/showPhoneField' ] }
+				requirePhoneField={ context[ 'woocommerce/requirePhoneField' ] }
+			/>
 		</FormStepBlock>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/phone-number/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/phone-number/index.tsx
@@ -18,7 +18,7 @@ const PhoneNumber = ( {
 	isRequired: boolean;
 	value: string;
 	onChange: ( value: string ) => void;
-	readonly: boolean;
+	readonly?: boolean;
 } ): JSX.Element => {
 	return (
 		<ValidatedTextInput


### PR DESCRIPTION
For Checkout i2, to make the editor better reflect the frontend, this re-enables the "Use same address" checkbox so that you can preview how it looks with this on and off.

When the billing section is visible, everything remains editable, so the toggle is not persisted and does not affect saving. Since the billing and shipping sections now **share** address field configs, it doesn't matter if billing is hidden by default.

Note; whilst the sections can be moved right now, this will be disabled in the final version, so the position of the billing and shipping sections does not matter at this point if moving blocks around.

Fixes #4443

### How to test the changes in this Pull Request:

1. Add Checkout i2 to a page
2. Try toggling the "Use same address" checkbox to show/hide billing address
3. Confirm address fields are still disabled.
