### PR TITLE
Fix Store API cart links in main readme

### DIFF
--- a/src/StoreApi/README.md
+++ b/src/StoreApi/README.md
@@ -88,13 +88,13 @@ Available resources in the Store API are listed below, with links to more detail
 | Resource                                                     | Available endpoints                                                                   |
 | :----------------------------------------------------------- | :------------------------------------------------------------------------------------ |
 | [`Cart`](docs/cart.md)                                       | [`/wc/store/cart`](docs/cart.md#get-cart)                                             |
-|                                                              | [`/wc/store/cart/add-item`](#add-item)                                                |
-|                                                              | [`/wc/store/cart/remove-item`](#remove-item)                                          |
-|                                                              | [`/wc/store/cart/update-item`](#update-item)                                          |
-|                                                              | [`/wc/store/cart/apply-coupon`](#apply-coupon)                                        |
-|                                                              | [`/wc/store/cart/remove-coupon`](#remove-coupon)                                      |
-|                                                              | [`/wc/store/cart/update-customer`](#update-customer)                                  |
-|                                                              | [`/wc/store/cart/select-shipping-rate`](#select-shipping-rate)                        |
+|                                                              | [`/wc/store/cart/add-item`](docs/cart.md#add-item)                                    |
+|                                                              | [`/wc/store/cart/remove-item`](docs/cart.md#remove-item)                              |
+|                                                              | [`/wc/store/cart/update-item`](docs/cart.md#update-item)                              |
+|                                                              | [`/wc/store/cart/apply-coupon`](docs/cart.md#apply-coupon)                            |
+|                                                              | [`/wc/store/cart/remove-coupon`](docs/cart.md#remove-coupon)                          |
+|                                                              | [`/wc/store/cart/update-customer`](docs/cart.md#update-customer)                      |
+|                                                              | [`/wc/store/cart/select-shipping-rate`](docs/cart.md#select-shipping-rate)            |
 | [`Cart Items`](docs/cart-items.md)                           | [`/wc/store/cart/items`](docs/cart-items.md#list-cart-items)                          |
 | [`Cart Coupons`](docs/cart-coupons.md)                       | [`/wc/store/cart/coupons`](docs/cart-coupons.md#list-cart-coupons)                    |
 | [`Checkout`](docs/checkout.md)                               | [`/wc/store/checkout`](docs/checkout.md)                                              |


### PR DESCRIPTION
This small PR fixes broken links from the main Store API readme page.