### PR TITLE
Checkout i2: Add terms link check 

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/edit.tsx
@@ -1,12 +1,15 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useBlockProps, RichText } from '@wordpress/block-editor';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
+import { Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import './editor.scss';
 import { termsConsentDefaultText, termsCheckboxDefaultText } from './constants';
 
 export const Edit = ( {
@@ -16,26 +19,63 @@ export const Edit = ( {
 	attributes: { text: string; checkbox: boolean };
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
+	const currentText = text || termsCheckboxDefaultText;
+
 	return (
-		<div className="wc-block-checkout__terms">
-			{ checkbox ? (
-				<>
-					<CheckboxControl id="terms-condition" checked={ false } />
+		<>
+			<div className="wc-block-checkout__terms">
+				{ checkbox ? (
+					<>
+						<CheckboxControl
+							id="terms-condition"
+							checked={ false }
+						/>
+						<RichText
+							value={ currentText }
+							onChange={ ( value ) =>
+								setAttributes( { text: value } )
+							}
+						/>
+					</>
+				) : (
 					<RichText
-						value={ text || termsCheckboxDefaultText }
+						tagName="span"
+						value={ text || termsConsentDefaultText }
 						onChange={ ( value ) =>
 							setAttributes( { text: value } )
 						}
 					/>
-				</>
-			) : (
-				<RichText
-					tagName="span"
-					value={ text || termsConsentDefaultText }
-					onChange={ ( value ) => setAttributes( { text: value } ) }
-				/>
+				) }
+			</div>
+			{ ! currentText.includes( '<a ' ) && (
+				<Notice
+					className="wc-block-checkout__terms_notice"
+					status="warning"
+					isDismissible={ false }
+					actions={
+						termsConsentDefaultText !== text
+							? [
+									{
+										label: __(
+											'Restore default text',
+											'woo-gutenberg-products-block'
+										),
+										onClick: () =>
+											setAttributes( { text: '' } ),
+									},
+							  ]
+							: []
+					}
+				>
+					<p>
+						{ __(
+							'Ensure you add links to your policy pages in this section.',
+							'woo-gutenberg-products-block'
+						) }
+					</p>
+				</Notice>
 			) }
-		</div>
+		</>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/editor.scss
@@ -1,0 +1,7 @@
+.wc-block-checkout__terms_notice {
+	margin-left: 9px;
+
+	.components-notice__action {
+		margin-left: 0;
+	}
+}


### PR DESCRIPTION
Part of #4319, adds a notice if the text for the terms and conditions does not contain a link.

To help users fix this, I included a button to restore the default text.

### Screenshots

![Screenshot 2021-07-14 at 15 53 09](https://user-images.githubusercontent.com/90977/125643797-089935c3-cd18-4351-a72b-ef539411cf97.png)

### How to test the changes in this Pull Request:

1. Add Checkout i2 block to a page
2. Select Checkout i2 and insert a block within it (terms consent or terms checkbox block) if it's not already present
3. Default text will include a link if your store has one. Edit the terms text and remove the links.
4. Confirm notice appears.
5. Click the restore default text button.
6. Original text is restored.
