### PR TITLE
Fix SKU search in the Store API

### DIFF
--- a/tests/php/StoreApi/Routes/Products.php
+++ b/tests/php/StoreApi/Routes/Products.php
@@ -114,6 +114,24 @@ class Products extends TestCase {
 	}
 
 	/**
+	 * Test searching by SKU
+	 */
+	public function test_search_by_sku() {
+		ProductHelper::create_simple_product( true, [ 'sku' => 'search-for-this-value' ] );
+
+		$request = new WP_REST_Request( 'GET', '/wc/store/products' );
+		$request->set_param( 'search', 'search-for-this' );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $data ) );
+		$this->assertArrayHasKey( 'sku', $data[0] );
+		$this->assertEquals( 'search-for-this-value', $data[0]['sku'] );
+	}
+
+	/**
 	 * Test conversion of prdouct to rest response.
 	 */
 	public function test_prepare_item_for_response() {


### PR DESCRIPTION
I discovered that the SKU searching code in the Store API **was never ran**. This is due to using the wrong variable name (WP Query uses `s`, but we were looking for `search` ).

Since we actually want to control the search, we should map this to `search` so we can search on the product title and SKU without WP_Query interfering with things.

I have added a test to check SKU search is functional.

### How to test the changes in this Pull Request:

Try some search requests via the Store API, for example:

`https://store.local/wp-json/wc/store/products?search=woo-album`

Ensure matched results match your query. Try searching for both titles and SKUs.

### Changelog

> Fixed the SKU search on the /wc/store/products endpoint.
