### PR TITLE
Add checkout term field validation

### DIFF
--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -45,6 +45,26 @@
 		}
 	}
 
+	&.has-error {
+		color: $alert-red;
+
+		a {
+			color: $alert-red;
+		}
+		.wc-block-components-checkbox__input {
+			&,
+			&:hover,
+			&:focus,
+			&:active {
+				border-color: $alert-red;
+			}
+			&:focus {
+				outline: 1px dotted $alert-red;
+				outline-offset: 2px;
+			}
+		}
+	}
+
 	.wc-block-components-checkbox__mark {
 		fill: #000;
 		position: absolute;

--- a/assets/js/base/context/hooks/use-store-notices.ts
+++ b/assets/js/base/context/hooks/use-store-notices.ts
@@ -37,18 +37,14 @@ type NoticeCreator = ( text: string, noticeProps: NoticeOptions ) => void;
 
 export const useStoreNotices = (): {
 	notices: WPNotice[];
-	noticesApi: {
-		hasNoticesOfType: ( type: string ) => boolean;
-		removeNotices: ( status: string | null ) => void;
-		removeNotice: ( id: string, context: string ) => void;
-	};
-	noticeCreators: {
-		addDefaultNotice: NoticeCreator;
-		addErrorNotice: NoticeCreator;
-		addWarningNotice: NoticeCreator;
-		addInfoNotice: NoticeCreator;
-		addSuccessNotice: NoticeCreator;
-	};
+	hasNoticesOfType: ( type: string ) => boolean;
+	removeNotices: ( status: string | null ) => void;
+	removeNotice: ( id: string, context: string ) => void;
+	addDefaultNotice: NoticeCreator;
+	addErrorNotice: NoticeCreator;
+	addWarningNotice: NoticeCreator;
+	addInfoNotice: NoticeCreator;
+	addSuccessNotice: NoticeCreator;
 	setIsSuppressed: ( isSuppressed: boolean ) => void;
 } => {
 	const {

--- a/assets/js/base/context/hooks/use-store-notices.ts
+++ b/assets/js/base/context/hooks/use-store-notices.ts
@@ -8,7 +8,49 @@ import { useMemo, useRef, useEffect } from '@wordpress/element';
  */
 import { useStoreNoticesContext } from '../providers/store-notices/context';
 
-export const useStoreNotices = () => {
+type WPNoticeAction = {
+	label: string;
+	url?: string;
+	onClick?: () => void;
+};
+
+type WPNotice = {
+	id: string;
+	status: 'success' | 'info' | 'error' | 'warning';
+	content: string;
+	spokenMessage: string;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	__unstableHTML: string;
+	isDismissible: boolean;
+	type: 'default' | 'snackbar';
+	speak: boolean;
+	actions: WPNoticeAction[];
+};
+
+type NoticeOptions = {
+	id: string;
+	type: string;
+	isDismissible: boolean;
+};
+
+type NoticeCreator = ( text: string, noticeProps: NoticeOptions ) => void;
+
+export const useStoreNotices = (): {
+	notices: WPNotice[];
+	noticesApi: {
+		hasNoticesOfType: ( type: string ) => boolean;
+		removeNotices: ( status: string | null ) => void;
+		removeNotice: ( id: string, context: string ) => void;
+	};
+	noticeCreators: {
+		addDefaultNotice: NoticeCreator;
+		addErrorNotice: NoticeCreator;
+		addWarningNotice: NoticeCreator;
+		addInfoNotice: NoticeCreator;
+		addSuccessNotice: NoticeCreator;
+	};
+	setIsSuppressed: ( isSuppressed: boolean ) => void;
+} => {
 	const {
 		notices,
 		createNotice,
@@ -26,7 +68,7 @@ export const useStoreNotices = () => {
 
 	const noticesApi = useMemo(
 		() => ( {
-			hasNoticesOfType: ( type ) => {
+			hasNoticesOfType: ( type: 'default' | 'snackbar' ): boolean => {
 				return currentNotices.current.some(
 					( notice ) => notice.type === type
 				);
@@ -45,23 +87,23 @@ export const useStoreNotices = () => {
 
 	const noticeCreators = useMemo(
 		() => ( {
-			addDefaultNotice: ( text, noticeProps = {} ) =>
+			addDefaultNotice: ( text: string, noticeProps = {} ) =>
 				void createNotice( 'default', text, {
 					...noticeProps,
 				} ),
-			addErrorNotice: ( text, noticeProps = {} ) =>
+			addErrorNotice: ( text: string, noticeProps = {} ) =>
 				void createNotice( 'error', text, {
 					...noticeProps,
 				} ),
-			addWarningNotice: ( text, noticeProps = {} ) =>
+			addWarningNotice: ( text: string, noticeProps = {} ) =>
 				void createNotice( 'warning', text, {
 					...noticeProps,
 				} ),
-			addInfoNotice: ( text, noticeProps = {} ) =>
+			addInfoNotice: ( text: string, noticeProps = {} ) =>
 				void createNotice( 'info', text, {
 					...noticeProps,
 				} ),
-			addSuccessNotice: ( text, noticeProps = {} ) =>
+			addSuccessNotice: ( text: string, noticeProps = {} ) =>
 				void createNotice( 'success', text, {
 					...noticeProps,
 				} ),

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
@@ -179,6 +179,7 @@ export const CheckoutStateProvider = ( {
 						);
 					}
 					dispatch( actions.setIdle() );
+					dispatch( actions.setHasError() );
 				} else {
 					dispatch( actions.setProcessing() );
 				}

--- a/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout/processor/index.js
@@ -111,12 +111,7 @@ const CheckoutProcessor = () => {
 
 	const checkValidation = useCallback( () => {
 		if ( hasValidationErrors ) {
-			return {
-				errorMessage: __(
-					'Some input fields are invalid.',
-					'woo-gutenberg-products-block'
-				),
-			};
+			return false;
 		}
 		if ( currentPaymentStatus.hasError ) {
 			return {

--- a/assets/js/base/hocs/with-scroll-to-top/index.tsx
+++ b/assets/js/base/hocs/with-scroll-to-top/index.tsx
@@ -21,7 +21,7 @@ const maybeScrollToTop = ( scrollPoint: HTMLElement ): void => {
 	}
 };
 
-const moveFocusToTop = (
+const moveFocusToElement = (
 	scrollPoint: HTMLElement,
 	focusableSelector: string
 ): void => {
@@ -29,7 +29,10 @@ const moveFocusToTop = (
 		scrollPoint.parentElement?.querySelectorAll( focusableSelector ) || [];
 
 	if ( focusableElements.length ) {
+		( focusableElements[ 0 ] as HTMLElement )?.scrollIntoView();
 		( focusableElements[ 0 ] as HTMLElement )?.focus();
+	} else {
+		maybeScrollToTop( scrollPoint );
 	}
 };
 
@@ -41,10 +44,13 @@ const scrollToHTMLElement = (
 		return;
 	}
 
-	maybeScrollToTop( scrollPoint );
-
 	if ( focusableSelector ) {
-		moveFocusToTop( scrollPoint, focusableSelector );
+		// Scroll after a short timeout to allow a re-render. This will allow focusableSelector to match updated components.
+		setTimeout( () => {
+			moveFocusToElement( scrollPoint, focusableSelector );
+		}, 50 );
+	} else {
+		maybeScrollToTop( scrollPoint );
 	}
 };
 
@@ -58,10 +64,7 @@ const withScrollToTop = (
 		const scrollPointRef = useRef< HTMLDivElement >( null );
 		const scrollToTop = ( args: ScrollToTopProps ) => {
 			if ( scrollPointRef.current !== null ) {
-				// Scroll after a short timeout to allow a re-render. This will allow focusableSelector to match updated components.
-				setTimeout( () => {
-					scrollToHTMLElement( scrollPointRef.current, args );
-				}, 50 );
+				scrollToHTMLElement( scrollPointRef.current, args );
 			}
 		};
 		return (

--- a/assets/js/base/hocs/with-scroll-to-top/index.tsx
+++ b/assets/js/base/hocs/with-scroll-to-top/index.tsx
@@ -58,7 +58,10 @@ const withScrollToTop = (
 		const scrollPointRef = useRef< HTMLDivElement >( null );
 		const scrollToTop = ( args: ScrollToTopProps ) => {
 			if ( scrollPointRef.current !== null ) {
-				scrollToHTMLElement( scrollPointRef.current, args );
+				// Scroll after a short timeout to allow a re-render. This will allow focusableSelector to match updated components.
+				setTimeout( () => {
+					scrollToHTMLElement( scrollPointRef.current, args );
+				}, 50 );
 			}
 		};
 		return (

--- a/assets/js/blocks/cart-checkout/checkout-i2/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/block.tsx
@@ -120,7 +120,9 @@ const ScrollOnError = ( {
 	useEffect( () => {
 		if ( hasErrorsToDisplay ) {
 			showAllValidationErrors();
-			scrollToTop( { focusableSelector: 'input:invalid' } );
+			scrollToTop( {
+				focusableSelector: 'input:invalid, .has-error input',
+			} );
 		}
 	}, [ hasErrorsToDisplay, scrollToTop, showAllValidationErrors ] );
 

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -25,6 +25,8 @@ const FrontendBlock = ( {
 	instanceId: string;
 } ): JSX.Element => {
 	const [ checked, setChecked ] = useState( false );
+
+	// @todo Checkout i2: Pass validation context to Inner Blocks to avoid exporting in a public package.
 	const { isDisabled } = useCheckoutSubmit();
 	const {
 		getValidationError,
@@ -60,25 +62,6 @@ const FrontendBlock = ( {
 		clearValidationError,
 		setValidationErrors,
 	] );
-
-	/* Throw an error on submit. This code is not needed here but it shows as an example how to do it.
-	const { onCheckoutValidationBeforeProcessing } = useCheckoutContext();
-
-	useEffect( () => {
-		const unsubscribe = onCheckoutValidationBeforeProcessing( () => {
-			if ( ! checked ) {
-				return {
-					errorMessage: __(
-						'Please read and accept the terms and conditions to proceed with your order.',
-						'woo-gutenberg-products-block'
-					),
-				};
-			}
-		} );
-		return () => {
-			unsubscribe();
-		};
-	}, [ onCheckoutValidationBeforeProcessing, checked ] );*/
 
 	return (
 		<div

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -26,7 +26,7 @@ const FrontendBlock = ( {
 } ): JSX.Element => {
 	const [ checked, setChecked ] = useState( false );
 
-	// @todo Checkout i2: Pass validation context to Inner Blocks to avoid exporting in a public package.
+	// @todo Checkout i2 - Pass validation context to Inner Blocks to avoid exporting in a public package.
 	const { isDisabled } = useCheckoutSubmit();
 	const {
 		getValidationError,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -1,8 +1,10 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
-import { useState } from '@wordpress/element';
+import { useCheckoutContext, useStoreNotices } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -18,6 +20,34 @@ const FrontendBlock = ( {
 	checkbox: boolean;
 } ): JSX.Element => {
 	const [ checked, setChecked ] = useState( false );
+	const {
+		dispatchActions,
+		onCheckoutValidationBeforeProcessing,
+	} = useCheckoutContext();
+	const { addErrorNotice, removeNotice } = useStoreNotices();
+
+	useEffect( () => {
+		const unsubscribe = onCheckoutValidationBeforeProcessing( () => {
+			if ( ! checked ) {
+				return {
+					errorMessage: __(
+						'Please read and accept the terms and conditions to proceed with your order.',
+						'woo-gutenberg-products-block'
+					),
+				};
+			}
+		} );
+		return () => {
+			unsubscribe();
+		};
+	}, [
+		onCheckoutValidationBeforeProcessing,
+		addErrorNotice,
+		removeNotice,
+		checked,
+		dispatchActions,
+	] );
+
 	return (
 		<div className="wc-block-checkout__terms">
 			{ checkbox ? (

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -40,6 +40,9 @@ const FrontendBlock = ( {
 
 	// Track validation errors for this input.
 	useEffect( () => {
+		if ( ! checkbox ) {
+			return;
+		}
 		if ( checked ) {
 			clearValidationError( validationErrorId );
 		} else {
@@ -57,6 +60,7 @@ const FrontendBlock = ( {
 			clearValidationError( validationErrorId );
 		};
 	}, [
+		checkbox,
 		checked,
 		validationErrorId,
 		clearValidationError,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/style.scss
@@ -5,4 +5,8 @@
 		top: -5px;
 		position: relative;
 	}
+
+	&.wc-block-checkout__terms--disabled {
+		opacity: 0.6;
+	}
 }

--- a/assets/js/types/type-defs/contexts.js
+++ b/assets/js/types/type-defs/contexts.js
@@ -190,9 +190,18 @@
  */
 
 /**
+ * @typedef {Object} ValidationContextError
+ *
+ * @property {number} id Error ID.
+ * @property {string} message Error message.
+ * @property {boolean} hidden Error visibility.
+ *
+ */
+
+/**
  * @typedef {Object} ValidationContext
  *
- * @property {function(string):Object}  getValidationError       Return validation error for the given property.
+ * @property {(id:string)=>ValidationContextError} getValidationError     Return validation error for the given property.
  * @property {function(Object)}         setValidationErrors      Receive an object of properties and  error messages as
  *                                                               strings and adds to the validation error state.
  * @property {function(string)}         clearValidationError     Clears a validation error for the given property name.


### PR DESCRIPTION
Adds client-side validation to the terms and conditions block in Checkout i2.

Closes #4319

2 supporting changes were needed to make it scroll to the correct element on error; setting the error state, and making it scroll to elements with the `has-error` class name. I added TypeScript to the `useStoreNotices` hook to clarify some confusing naming.

### Screenshots

![Screenshot 2021-07-22 at 16 06 02](https://user-images.githubusercontent.com/90977/126662503-4c163c1b-573e-486e-aa62-06818012ac6d.png)

### How to test the changes in this Pull Request:

1. Setup Checkout i2 on a page and ensure the terms and conditions block is present
2. Go to the frontend and submit the checkout without checking the box
3. Checkout should jump to the input and focus it. The styling is red.