### PR TITLE
Fix Hand-picked Products block name inconsistencies

### DIFF
--- a/docs/testing/releases/260.md
+++ b/docs/testing/releases/260.md
@@ -84,7 +84,7 @@ All of these blocks share a common ancestor for the PHP side registration, so it
 - Best Selling Products
 - On Sale Products
 - Products By Attribute
-- Hand-Picked Products
+- Hand-picked Products
 - Products by Category
 - Products by Tag
 - Newest Products

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -88,13 +88,13 @@ _(Requires at least WooCommerce 4.3)_
 
 #### Product grid inconsistencies (#2428)
 - Update a product so it has a very small image (100px or less).
-- Add the All Products block and a PHP-based product grids block (Hand-picked products, for example) and verify:
+- Add the All Products block and a PHP-based product grids block (Hand-picked Products, for example) and verify:
 	- Both of them have the same styles for prices.
 	- Both of them scale up the small image.
-_Handpicked products on top, All Products below:_<br>
+_Hand-picked Products on top, All Products below:_<br>
 ![Product grid blocks by default](https://user-images.githubusercontent.com/3616980/83166453-3d1b4480-a10f-11ea-813f-2515b26dedac.png)
 - Add the [code snippets](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/theming/product-grid-270.md#product-grid-blocks-style-update-in-270) from the theming docs to undo the changes and verify:
-	- Hand-picked products block doesn't scale up the image anymore.
+	- Hand-picked Products block doesn't scale up the image anymore.
 	- All Products block shows discounted prices in two lines.
-_Handpicked products on top, All Products below:_<br>
+_Hand-picked Products on top, All Products below:_<br>
 ![Product grid blocks with the code snippets applied](https://user-images.githubusercontent.com/3616980/83164436-828a4280-a10c-11ea-81c1-b9a62cdf52b5.png)

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -35,7 +35,7 @@ This new release has a new system to generate the styles, so it would be great t
 
 -   [ ] Featured Product Block
 -   [ ] Featured Category Block
--   [ ] Hand-Picked products Block
+-   [ ] Hand-picked Products Block
 -   [ ] Best Selling Products Block
 -   [ ] Top Rated Products Block
 -   [ ] Newest Products Block

--- a/docs/testing/releases/490.md
+++ b/docs/testing/releases/490.md
@@ -8,7 +8,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 Smoke test these blocks can be inserted and render correctly:
 
-* Hand-Picked products Block
+* Hand-picked Products Block
 * Best Selling Products Block
 * Top Rated Products Block
 * Newest Products Block

--- a/docs/testing/releases/520.md
+++ b/docs/testing/releases/520.md
@@ -58,7 +58,7 @@ The controls modified in this PR are used in many blocks, so the steps below sho
 Affected blocks:
 * Featured Product Block
 * Featured Category Block
-* Hand-Picked products Block
+* Hand-picked Products Block
 * Products by Category Block
 * Products by Tag Block
 * Products by Attribute Block

--- a/docs/testing/releases/540.md
+++ b/docs/testing/releases/540.md
@@ -31,8 +31,8 @@ To test this properly you'll need Stripe setup locally in sandbox mode. You can 
 
 1. Smoke test blocks and make sure they're insertable.
 
-### Allow products to be added by SKU in the Hand-Picked Products block. ([4366](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4366))
+### Allow products to be added by SKU in the Hand-picked Products block. ([4366](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4366))
 
-1. Insert the hand picked product block
+1. Insert the Hand-picked Products block
 2. See SKUs shown for products with a SKU
 3. Try searching for a SKU. See results.

--- a/readme.txt
+++ b/readme.txt
@@ -20,7 +20,7 @@ Use this plugin if you want access to the bleeding edge of available blocks for 
 
 - **Featured Product Block**
 - **Featured Category Block**
-- **Hand-Picked products Block**
+- **Hand-picked Products Block**
 - **Best Selling Products Block**
 - **Top Rated Products Block**
 - **Newest Products Block**
@@ -79,7 +79,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 1. The Featured Product Block
 2. Selecting a product for the Featured Product Block
-3. Selecting Products for the Hand-Picked Products Block
+3. Selecting Products for the Hand-picked Products Block
 4. Selecting categories in the Products By Category block
 5. WooCommerce Product Blocks in the block inserter menu
 
@@ -123,7 +123,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 #### Various
 
-- Allow products to be added by SKU in the Hand-Picked Products block. ([4366](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4366))
+- Allow products to be added by SKU in the Hand-picked Products block. ([4366](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4366))
 - Add Slot in the Discounts section of the Checkout sidebar to allow third party extensions to render their own components there. ([4310](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4310))
 
 = 5.3.2 - 2021-06-28 =
@@ -727,7 +727,7 @@ You can read [more about the release here](https://woocommerce.wordpress.com/?p=
 - Add `getAdminLink()` utility method. #1244
 
 = 2.5.1 - 2019-11-26 =
-- Fix Products by Tag, Products by Attribute and Handpicked products blocks showing an invalid attributes error. #1254
+- Fix Products by Tag, Products by Attribute and Hand-picked Products blocks showing an invalid attributes error. #1254
 - Fix the price slider updating instantly even when filter button was enabled. #1228
 - Honor CSS classes in the editor for blocks added in 2.5. #1227
 - Fix variable products price format in All Products block. #1210
@@ -764,7 +764,7 @@ You can read [more about the release here](https://woocommerce.wordpress.com/?p=
 - Feature: Added Reviews by Category block.
 - Feature: Added a new product search block to insert a product search field on a page.
 - Enhancement: Add error handling for API requests to the featured product block.
-- Enhancement: Allow hidden products in handpicked products block.
+- Enhancement: Allow hidden products in Hand-picked Products block.
 - Fix: Prevented block settings being output on every route.  Now they are only needed when the route has blocks requiring them.
 - Dev: Introduced higher order components, global data handlers, and refactored some blocks.
 - Dev: Created new HOCs for retrieving data: `withProduct`, `withComponentId`, `withCategory`.
@@ -796,7 +796,7 @@ You can read [more about the release here](https://woocommerce.wordpress.com/?p=
 - Fix: Disable HTML editing on dynamic blocks which have no content.
 - Fix: Hide background opacity control in Featured Product settings if there is no background image.
 - Fix: Reduce CSS specificity to make styling easier.
-- Fix: Fix author access to API for handpicked products block.
+- Fix: Fix author access to API for Hand-picked Products block.
 
 = 2.2.1 - 2019-07-04 =
 


### PR DESCRIPTION
`Hand-picked Products` was written in many different ways across the docs. I unified all of them to the name used in the block registration:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/5261c4e9a733d5292ab40027a6ad6b3d61952e73/assets/js/blocks/handpicked-products/index.js#L16

### How to test the changes in this Pull Request:

Nothing to test, just make sure changes in documentation files make sense.

**Note:** these testing steps can be omitted from the release testing instructions.