### PR TITLE
Add missing class to Cart skeleton title

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -170,7 +170,7 @@ class Cart extends AbstractBlock {
 		return '
 			<div class="wc-block-skeleton wc-block-components-sidebar-layout wc-block-cart wc-block-cart--is-loading wc-block-cart--skeleton hidden" aria-hidden="true">
 				<div class="wc-block-components-main wc-block-cart__main">
-					<h2><span></span></h2>
+					<h2 class="wc-block-components-title"><span></span></h2>
 					<table class="wc-block-cart-items">
 						<thead>
 							<tr class="wc-block-cart-items__header">


### PR DESCRIPTION
Adds a missing class to the `<h2>` title of the Cart skeleton so it has the same margin as the rendered block.

### How to test the changes in this Pull Request:

1. Load the Cart block and verify the margin under the `Your cart` title doesn't change between the rendered block and the loading skeleton.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/3616980/126756563-6771d730-1379-4eef-99b5-0d4823ba969f.gif) | ![After](https://user-images.githubusercontent.com/3616980/126756468-3b2f898d-c60f-46a8-bfbb-8c716f6c11a5.gif) |

### Changelog

> Remove unnecessary margin from Cart block loading skeleton to avoid content jump.
