### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -36,7 +36,7 @@ To install dependencies, you will need the following tools installed on your mac
 -   [`npm` and `node.js`](https://nodejs.org)
 -   [`composer`](https://getcomposer.org)
 
-See [`package.json` `engines`](package.json) for details of required versions.
+See [`package.json` `engines`](../../package.json) for details of required versions.
 
 Once you have `node` and `composer` setup, install the dependencies from the command line:
 


### PR DESCRIPTION
While checking https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/contributors/getting-started.md, I noticed that the link to `package.json engines` isn't working as expected.

**Expected result**

`package.json engines` links to https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/package.json and shows the content of the package.json file.

**Current result**

`package.json engines` links to https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/contributors/package.json and shows 404 page.