### PR TITLE
move SlotFillProvider before pluginArea in Checkout i2

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/block.tsx
@@ -157,8 +157,9 @@ const Block = ( {
 		<StoreSnackbarNoticesProvider context="wc/checkout">
 			<StoreNoticesProvider context="wc/checkout">
 				<ValidationContextProvider>
-					<CheckoutProvider>
-						<SlotFillProvider>
+					{ /* SlotFillProvider need to be defined before CheckoutProvider so fills have the SlotFill context ready when they mount. */ }
+					<SlotFillProvider>
+						<CheckoutProvider>
 							<SidebarLayout
 								className={ classnames( 'wc-block-checkout', {
 									'has-dark-controls':
@@ -170,8 +171,8 @@ const Block = ( {
 								</Checkout>
 								<ScrollOnError scrollToTop={ scrollToTop } />
 							</SidebarLayout>
-						</SlotFillProvider>
-					</CheckoutProvider>
+						</CheckoutProvider>
+					</SlotFillProvider>
 				</ValidationContextProvider>
 			</StoreNoticesProvider>
 		</StoreSnackbarNoticesProvider>


### PR DESCRIPTION
This PR fixes the issue of SlotFillProvider being called too late, causing slots to not load on the frontend.

The issue was that `SlotFillProvider` must run before `PluginArea` is initiated. `PluginArea` is inside `CheckoutProvider` so the slot provider must be before it.

### Why?
By having PluginArea before the Slot Provider, fills would initiate and mount before the slot provider is present, causing them to not find a slot to hook into and not rendering. By switching, we guarantee the context is there.


### How to test
- Using WooCommerce Subscriptions, make sure you're registered to Checkout i2 https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4500
- Load the checkout i2 block after adding subs products to your cart.
- Make sure recurring totals and shipping methods are showing.