### PR TITLE
Update documentation to describe updated snackbar filter

### DIFF
--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -127,26 +127,24 @@ There is a snackbar at the bottom of the page used to display notices to the cus
 
 <img src="https://user-images.githubusercontent.com/5656702/120882329-d573c100-c5ce-11eb-901b-d7f206f74a66.png" width=300 />
 
-It may be desirable to hide this (by removing it from the array) or to change the text in the notice.
+It may be desirable to hide this if there's a notice you don't want the shopper to see.
 
 | Filter name  | Description | Return type  |
 |---|---|---|
-| `snackbarNotices`  | An array of notices waiting to be shown in the snackbar | `SnackbarNotice[]`
+| `snackbarNoticeVisibility`  | An object keyed by the content of the notices slated to be displayed. The value of each member of this object will initially be true. | `object`
 
-These are the relevant members of a `SnackbarNotice` object.
+The filter passes an object whose keys are the `content` of each notice.
 
-```typescript
-SnackbarNotice {
-  content: string;
-  explicitDismiss: boolean;
-  icon: string | null;
-  isDismissable: boolean;
-  onDismiss: Function;
-  spokenMessage: string;
-  status: string;
-  type: string
+If there are two notices slated to be displayed ('Coupon code "10off" has been applied to your basket.', and 'Coupon
+code "50off" has been removed from your basket.'), the value passed to the filter would look like so:
+
+```javascript
+{
+  'Coupon code "10off" has been applied to your basket.': true, 
+  'Coupon code "50off" has been removed from your basket.': true
 }
 ```
+To reiterate, the _value_ here will determine whether this notice gets displayed or not. It will display if true.
 
 ## Examples
 
@@ -243,6 +241,26 @@ __experimentalRegisterCheckoutFilters( 'automatic-coupon-extension', {
 |---|---|
 | <img src="https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png" /> | ![image](https://user-images.githubusercontent.com/5656702/124126048-2c57a380-da72-11eb-9b45-b2cae0cffc37.png) |
 
+### Hide a snackbar notice containing a certain string
+Let's say we want to hide all notices that contain the string `auto-generated-coupon`.
+
+We would do this by setting the value of the `snackbarNoticeVisibility` to false for the notices we want to hide.
+
+```typescript
+import { __experimentalRegisterCheckoutFilters } from '@woocommerce/blocks-checkout';
+
+__experimentalRegisterCheckoutFilters( 'automatic-coupon-extension', {
+    snackbarNoticeVisibility: (value) => {
+      // Copy the value so we don't mutate what is being passed by the filter.
+      const valueCopy = Object.assign({}, value);
+      Object.keys(value).forEach((key) => {
+        valueCopy[key] = key.indexOf( 'auto-generated-coupon' ) === -1;
+      });
+      return valueCopy;
+    },
+  }
+);
+```
 
 ## Troubleshooting
 If you are logged in to the store as an administrator, you should be shown an error like this if your filter is not

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -127,7 +127,7 @@ There is a snackbar at the bottom of the page used to display notices to the cus
 
 <img src="https://user-images.githubusercontent.com/5656702/120882329-d573c100-c5ce-11eb-901b-d7f206f74a66.png" width=300 />
 
-It may be desirable to hide this if there's a notice you don't want the shopper to see.
+It may be desirable to hide this if there's a notice that should not be displayed to the shopper.
 
 | Filter name  | Description | Return type  |
 |---|---|---|
@@ -242,9 +242,9 @@ __experimentalRegisterCheckoutFilters( 'automatic-coupon-extension', {
 | <img src="https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png" /> | ![image](https://user-images.githubusercontent.com/5656702/124126048-2c57a380-da72-11eb-9b45-b2cae0cffc37.png) |
 
 ### Hide a snackbar notice containing a certain string
-Let's say we want to hide all notices that contain the string `auto-generated-coupon`.
-
-We would do this by setting the value of the `snackbarNoticeVisibility` to false for the notices we want to hide.
+Hiding notices that contain a string can be achieved by using this filter. For example: To hide all notices that contain
+the string `auto-generated-coupon`, the value in the object returned by the `snackbarNoticeVisibility` filter needs to
+be set to false for the notices that should be hidden.
 
 ```typescript
 import { __experimentalRegisterCheckoutFilters } from '@woocommerce/blocks-checkout';

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -127,7 +127,7 @@ There is a snackbar at the bottom of the page used to display notices to the cus
 
 <img src="https://user-images.githubusercontent.com/5656702/120882329-d573c100-c5ce-11eb-901b-d7f206f74a66.png" width=300 />
 
-It may be desirable to hide this if there's a notice that should not be displayed to the shopper.
+It may be desirable to hide this if there's a notice you don't want the shopper to see.
 
 | Filter name  | Description | Return type  |
 |---|---|---|
@@ -242,9 +242,9 @@ __experimentalRegisterCheckoutFilters( 'automatic-coupon-extension', {
 | <img src="https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png" /> | ![image](https://user-images.githubusercontent.com/5656702/124126048-2c57a380-da72-11eb-9b45-b2cae0cffc37.png) |
 
 ### Hide a snackbar notice containing a certain string
-Hiding notices that contain a string can be achieved by using this filter. For example: To hide all notices that contain
-the string `auto-generated-coupon`, the value in the object returned by the `snackbarNoticeVisibility` filter needs to
-be set to false for the notices that should be hidden.
+Let's say we want to hide all notices that contain the string `auto-generated-coupon`.
+
+We would do this by setting the value of the `snackbarNoticeVisibility` to false for the notices we want to hide.
 
 ```typescript
 import { __experimentalRegisterCheckoutFilters } from '@woocommerce/blocks-checkout';


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In #4417 I updated how the snackbar filter works. This PR updates the related documentation and adds an example of how the filter can be used.

### How to test the changes in this Pull Request:

1. Please read the documentation and ensure it makes sense and reads well.
2. Feel free to try out the example if you like! I would recommend trying to filter notices based on a specific coupon value.

### Changelog

> Update documentation for the snackbarNoticeVisibility filter.
