### PR TITLE
Add inbox notification to surface cart and checkout blocks to select merchants

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -76,7 +76,7 @@ class Bootstrap {
 		$this->register_payment_methods();
 
 		add_action(
-			'woocommerce_init',
+			'admin_init',
 			function() {
 				InboxNotifications::create_surface_cart_checkout_blocks_notification();
 			},

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -74,7 +74,15 @@ class Bootstrap {
 		}
 		$this->register_dependencies();
 		$this->register_payment_methods();
-		InboxNotifications::create_surface_cart_checkout_blocks_notification();
+
+		add_action(
+			'woocommerce_init',
+			function() {
+				InboxNotifications::create_surface_cart_checkout_blocks_notification();
+			},
+			10,
+			0
+		);
 
 		$is_rest = wc()->is_rest_api_request();
 

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -5,6 +5,7 @@ use Automattic\WooCommerce\Blocks\AssetsController as AssetsController;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\BlockTypesController;
+use Automattic\WooCommerce\Blocks\InboxNotifications;
 use Automattic\WooCommerce\Blocks\Installer;
 use Automattic\WooCommerce\Blocks\Registry\Container;
 use Automattic\WooCommerce\Blocks\RestApi;
@@ -73,6 +74,7 @@ class Bootstrap {
 		}
 		$this->register_dependencies();
 		$this->register_payment_methods();
+		InboxNotifications::create_surface_cart_checkout_blocks_notification();
 
 		$is_rest = wc()->is_rest_api_request();
 

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -14,7 +14,7 @@ class InboxNotifications {
 
 	const SURFACE_CART_CHECKOUT_NOTE_NAME          = 'surface_cart_checkout';
 	const SURFACE_CART_CHECKOUT_PROBABILITY_OPTION = 'wc_blocks_surface_cart_checkout_probability';
-	const PERCENT_USERS_TO_TARGET                  = 40;
+	const PERCENT_USERS_TO_TARGET                  = 10;
 	const INELIGIBLE_EXTENSIONS                    = [
 		'automatewoo',
 		'mailchimp-for-woocommerce',
@@ -123,7 +123,7 @@ class InboxNotifications {
 		$note->add_action(
 			'learn_more',
 			'Learn More',
-			'https://woocommerce.com'
+			'https://woocommerce.com/woocommerce-checkout'
 		);
 		$note->save();
 

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -49,6 +49,14 @@ class InboxNotifications {
 		'US',
 	];
 
+
+	/**
+	 * Deletes the note.
+	 */
+	public static function delete_surface_cart_checkout_blocks_notification() {
+		Notes::delete_notes_with_name( self::SURFACE_CART_CHECKOUT_NOTE_NAME );
+	}
+
 	/**
 	 * Creates a notification letting merchants know about the Cart and Checkout Blocks.
 	 */

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -19,16 +19,26 @@ class InboxNotifications {
 		'automatewoo',
 		'mailchimp-for-woocommerce',
 		'mailpoet',
+		'klarna-payments-for-woocommerce',
+		'klarna-checkout-for-woocommerce',
+		// @todo Uncomment woocommerce-gutenberg-products-block before launch.
 		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 		// 'woocommerce-gutenberg-products-block', // Disallow the notification if the store is using the feature plugin already.
+		'woocommerce-all-products-for-subscriptions',
 		'woocommerce-bookings',
 		'woocommerce-box-office',
 		'woocommerce-cart-add-ons',
 		'woocommerce-checkout-add-ons',
+		'woocommerce-checkout-field-editor',
 		'woocommerce-conditional-shipping-and-payments',
+		'woocommerce-dynamic-pricing',
 		'woocommerce-eu-vat-number',
+		'woocommerce-follow-up-emails',
 		'woocommerce-gateway-amazon-payments-advanced',
+		'woocommerce-gateway-authorize-net-cim',
+		'woocommerce-google-analytics-pro',
 		'woocommerce-memberships',
+		'woocommerce-paypal-payments',
 		'woocommerce-points-and-rewards',
 		'woocommerce-pre-orders',
 		'woocommerce-product-bundles',
@@ -67,6 +77,7 @@ class InboxNotifications {
 
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( self::SURFACE_CART_CHECKOUT_NOTE_NAME );
+
 		foreach ( (array) $note_ids as $note_id ) {
 			$note         = Notes::get_note( $note_id );
 			$content_data = $note->get_content_data();
@@ -123,7 +134,7 @@ class InboxNotifications {
 		$note->add_action(
 			'learn_more',
 			'Learn More',
-			'https://woocommerce.com/woocommerce-checkout'
+			'https://woocommerce.com/checkout-blocks/'
 		);
 		$note->save();
 

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -21,9 +21,7 @@ class InboxNotifications {
 		'mailpoet',
 		'klarna-payments-for-woocommerce',
 		'klarna-checkout-for-woocommerce',
-		// @todo Uncomment woocommerce-gutenberg-products-block before launch.
-		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		// 'woocommerce-gutenberg-products-block', // Disallow the notification if the store is using the feature plugin already.
+		'woocommerce-gutenberg-products-block', // Disallow the notification if the store is using the feature plugin already.
 		'woocommerce-all-products-for-subscriptions',
 		'woocommerce-bookings',
 		'woocommerce-box-office',
@@ -61,9 +59,10 @@ class InboxNotifications {
 	 * Creates a notification letting merchants know about the Cart and Checkout Blocks.
 	 */
 	public static function create_surface_cart_checkout_blocks_notification() {
+
 		// If this is the feature plugin, then we don't need to do this. This should only show when Blocks is bundled
 		// with WooCommerce Core.
-		if ( false && Package::feature()->is_feature_plugin_build() ) {
+		if ( Package::feature()->is_feature_plugin_build() ) {
 			return;
 		}
 

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -20,7 +20,7 @@ class InboxNotifications {
 		'mailchimp-for-woocommerce',
 		'mailpoet',
 		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		// 'woo-gutenberg-products-block', // Disallow the notification if the store is using the feature plugin already.
+		// 'woocommerce-gutenberg-products-block', // Disallow the notification if the store is using the feature plugin already.
 		'woocommerce-bookings',
 		'woocommerce-box-office',
 		'woocommerce-cart-add-ons',
@@ -108,7 +108,7 @@ class InboxNotifications {
 		);
 		$note->set_content(
 			__(
-				'WooCommerce Blocks cart and checkout blocks surfacing copy... Lorem ipsum dolor sit amet.',
+				'Increase your stores revenue with the conversion optimized Cart & Checkout WooCommerce blocks available in the WooCommerce Blocks extension.',
 				'woo-gutenberg-products-block'
 			)
 		);

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -78,11 +78,10 @@ class InboxNotifications {
 		$note_ids   = $data_store->get_notes_with_name( self::SURFACE_CART_CHECKOUT_NOTE_NAME );
 
 		foreach ( (array) $note_ids as $note_id ) {
-			$note         = Notes::get_note( $note_id );
-			$content_data = $note->get_content_data();
+			$note = Notes::get_note( $note_id );
 
 			// Return now because the note already exists.
-			if ( property_exists( $content_data, 'getting_started' ) ) {
+			if ( $note->get_name() === self::SURFACE_CART_CHECKOUT_NOTE_NAME ) {
 				return;
 			}
 		}

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -109,7 +109,6 @@ class InboxNotifications {
 
 		// At this point, the store meets all the criteria to be shown the notice! Woo!
 		$note = new Note();
-		$note->set_date_created( time() );
 		$note->set_title(
 			__(
 				'Introducing the Cart and Checkout blocks!',
@@ -120,11 +119,6 @@ class InboxNotifications {
 			__(
 				"Increase your store's revenue with the conversion optimized Cart & Checkout WooCommerce blocks available in the WooCommerce Blocks extension.",
 				'woo-gutenberg-products-block'
-			)
-		);
-		$note->set_content_data(
-			(object) array(
-				'getting_started' => true,
 			)
 		);
 		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -1,0 +1,131 @@
+<?php
+namespace Automattic\WooCommerce\Blocks;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+
+/**
+ * A class used to display inbox messages to merchants in the WooCommerce Admin dashboard.
+ *
+ * @package Automattic\WooCommerce\Blocks
+ * @since x.x.x
+ */
+class InboxNotifications {
+
+	const SURFACE_CART_CHECKOUT_NOTE_NAME          = 'surface_cart_checkout';
+	const SURFACE_CART_CHECKOUT_PROBABILITY_OPTION = 'wc_blocks_surface_cart_checkout_probability';
+	const PERCENT_USERS_TO_TARGET                  = 40;
+	const INELIGIBLE_EXTENSIONS                    = [
+		'automatewoo',
+		'mailchimp-for-woocommerce',
+		'mailpoet',
+		// phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+		// 'woo-gutenberg-products-block', // Disallow the notification if the store is using the feature plugin already.
+		'woocommerce-bookings',
+		'woocommerce-box-office',
+		'woocommerce-cart-add-ons',
+		'woocommerce-checkout-add-ons',
+		'woocommerce-conditional-shipping-and-payments',
+		'woocommerce-eu-vat-number',
+		'woocommerce-gateway-amazon-payments-advanced',
+		'woocommerce-memberships',
+		'woocommerce-points-and-rewards',
+		'woocommerce-pre-orders',
+		'woocommerce-product-bundles',
+		'woocommerce-shipping-fedex',
+		'woocommerce-smart-coupons',
+	];
+	const ELIGIBLE_COUNTRIES                       = [
+		'GB',
+		'US',
+	];
+
+	/**
+	 * Creates a notification letting merchants know about the Cart and Checkout Blocks.
+	 */
+	public static function create_surface_cart_checkout_blocks_notification() {
+		// If this is the feature plugin, then we don't need to do this. This should only show when Blocks is bundled
+		// with WooCommerce Core.
+		if ( false && Package::feature()->is_feature_plugin_build() ) {
+			return;
+		}
+
+		// Pick a random number between 1 and 100 and add this to the wp_options table. This can then be used to target
+		// a percentage of users.
+		$existing_probability = get_option( self::SURFACE_CART_CHECKOUT_PROBABILITY_OPTION );
+		if ( false === $existing_probability ) {
+			$existing_probability = wp_rand( 0, 100 );
+			add_option( self::SURFACE_CART_CHECKOUT_PROBABILITY_OPTION, $existing_probability );
+		}
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
+			return;
+		}
+
+		if ( ! class_exists( 'WC_Data_Store' ) ) {
+			return;
+		}
+
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( self::SURFACE_CART_CHECKOUT_NOTE_NAME );
+		foreach ( (array) $note_ids as $note_id ) {
+			$note         = Notes::get_note( $note_id );
+			$content_data = $note->get_content_data();
+
+			// Return now because the note already exists.
+			if ( property_exists( $content_data, 'getting_started' ) ) {
+				return;
+			}
+		}
+
+		// Calculate store's eligibility to be shown the notice, starting with whether they have any plugins we know to
+		// be incompatible with Blocks.
+		foreach ( self::INELIGIBLE_EXTENSIONS as $extension ) {
+			if ( is_plugin_active( $extension . '/' . $extension . '.php' ) ) {
+				return;
+			}
+		}
+
+		// Next check the store is located in one of the eligible countries.
+		$raw_country = get_option( 'woocommerce_default_country' );
+		$country     = explode( ':', $raw_country )[0];
+		if ( ! in_array( $country, self::ELIGIBLE_COUNTRIES, true ) ) {
+			return;
+		}
+
+		// Finally, check if the store's generated % chance is below the % of users we want to surface this to.
+		if ( $existing_probability > self::PERCENT_USERS_TO_TARGET ) {
+			return;
+		}
+
+		// At this point, the store meets all the criteria to be shown the notice! Woo!
+		$note = new Note();
+		$note->set_date_created( time() );
+		$note->set_title(
+			__(
+				'Introducing the Cart and Checkout blocks!',
+				'woo-gutenberg-products-block'
+			)
+		);
+		$note->set_content(
+			__(
+				'WooCommerce Blocks cart and checkout blocks surfacing copy... Lorem ipsum dolor sit amet.',
+				'woo-gutenberg-products-block'
+			)
+		);
+		$note->set_content_data(
+			(object) array(
+				'getting_started' => true,
+			)
+		);
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_source( 'woo-gutenberg-products-block' );
+		$note->set_name( self::SURFACE_CART_CHECKOUT_NOTE_NAME );
+		$note->add_action(
+			'learn_more',
+			'Learn More',
+			'https://woocommerce.com'
+		);
+		$note->save();
+
+	}
+}

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -39,7 +39,6 @@ class InboxNotifications {
 		'woocommerce-google-analytics-pro',
 		'woocommerce-memberships',
 		'woocommerce-paypal-payments',
-		'woocommerce-points-and-rewards',
 		'woocommerce-pre-orders',
 		'woocommerce-product-bundles',
 		'woocommerce-shipping-fedex',

--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -108,7 +108,7 @@ class InboxNotifications {
 		);
 		$note->set_content(
 			__(
-				'Increase your stores revenue with the conversion optimized Cart & Checkout WooCommerce blocks available in the WooCommerce Blocks extension.',
+				"Increase your store's revenue with the conversion optimized Cart & Checkout WooCommerce blocks available in the WooCommerce Blocks extension.",
 				'woo-gutenberg-products-block'
 			)
 		);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will add the code necessary to show an inbox message in WooCommerce Admin's dashboard letting merchants know about the Cart and Checkout blocks.

To enable us to target only a percentage of users (and to keep the users we _do_ target consistent) I have used a `wp_options` entry to give each merchant a randomly generated "probability" of being chosen, this number is between 0-100. When the code runs, if this option doesn't exist in the database, the random number will be added. We can then use this for percentage-based targeting since only 10% of users will have numbers 0-10, 50% will have 0-50 etc.

I have also included a list of extensions that will preclude the merchant from being shown the notification (based on [the list of known incompatible extensions](https://docs.woocommerce.com/document/cart-checkout-blocks-support-status/#section-7)). We need to include `woocommerce-gutenberg-products-block` here too because we don't want to show the notification to merchants already running the feature plugin. At the moment this is commented out for testing purposes.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
![image](https://user-images.githubusercontent.com/5656702/132216173-bc5bda5b-aced-41e6-8681-f7f64cc46f12.png)


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Ensure your store is set to US or UK (or add your country locale to the `ELIGIBLE_COUNTRIES` array in `InboxNotifications.php`
1. Open the WooCommerce Admin dashboard (`/wp-admin/admin.php?page=wc-admin`)
2. Check `wp_options` table and verify an entry has been made for `wc_blocks_surface_cart_checkout_probability` - if the number is above 10, change it to be below 10. (This ensures we only target 10% of users)
2. If you've got any of the incompatible plugins active, then you should not see the notification in your inbox.
3. Disable any incompatible plugins and refresh the admin page, you should see a notification about the Cart and Checkout.
4. To delete the notification, add this code to the top of `create_surface_cart_checkout_blocks_notification` ` Notes::delete_notes_with_name( self::SURFACE_CART_CHECKOUT_NOTE_NAME );`
5. Re-test with a store in an ineligible location, or with incompatible plugins active.

<!-- If you can, add the appropriate labels -->
