### PR TITLE
Add cart item data to cart and validator cart data

### DIFF
--- a/src/StoreApi/Routes/CartAddItem.php
+++ b/src/StoreApi/Routes/CartAddItem.php
@@ -87,9 +87,10 @@ class CartAddItem extends AbstractCartRoute {
 		$cart   = $this->cart_controller->get_cart_instance();
 		$result = $this->cart_controller->add_to_cart(
 			[
-				'id'        => $request['id'],
-				'quantity'  => $request['quantity'],
-				'variation' => $request['variation'],
+				'id'             => $request['id'],
+				'quantity'       => $request['quantity'],
+				'variation'      => $request['variation'],
+				'cart_item_data' => $request['cart_item_data'],
 			]
 		);
 

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -204,7 +204,8 @@ class CartController {
 			$this->get_product_id( $product ),
 			$request['quantity'],
 			$this->get_variation_id( $product ),
-			$request['variation']
+			$request['variation'],
+			$request['cart_item_data']
 		);
 
 		if ( ! $passed_validation ) {


### PR DESCRIPTION
I'm building the Mobile app and using /store/cart API and [Product Add-Ons](https://woocommerce.com/products/product-add-ons/)

**The problem "cart_item_data" is not used also the filter hook does not pass cart item data.**

I try fixed and there are 2 points that need update.

The payload:

![image](https://user-images.githubusercontent.com/4260689/127638389-4316af88-046c-4afa-afcf-c09f929c2ace.png)
