### PR TITLE
Update pagination class names to match our coding guidelines

### DIFF
--- a/assets/js/base/components/pagination/index.js
+++ b/assets/js/base/components/pagination/index.js
@@ -58,7 +58,7 @@ const Pagination = ( {
 			/>
 			{ displayNextAndPreviousArrows && (
 				<button
-					className="wc-block-pagination-page wc-block-components-pagination__page wc-block-pagination-page--arrow"
+					className="wc-block-pagination-page wc-block-components-pagination__page wc-block-components-pagination-page--arrow"
 					onClick={ () => onPageChange( currentPage - 1 ) }
 					title={ __(
 						'Previous page',
@@ -175,7 +175,7 @@ const Pagination = ( {
 			) }
 			{ displayNextAndPreviousArrows && (
 				<button
-					className="wc-block-pagination-page wc-block-components-pagination__page wc-block-pagination-page--arrow"
+					className="wc-block-pagination-page wc-block-components-pagination__page wc-block-components-pagination-page--arrow"
 					onClick={ () => onPageChange( currentPage + 1 ) }
 					title={ __( 'Next page', 'woo-gutenberg-products-block' ) }
 					disabled={ currentPage >= totalPages }

--- a/assets/js/base/components/pagination/style.scss
+++ b/assets/js/base/components/pagination/style.scss
@@ -50,7 +50,7 @@
 	}
 }
 
-html[dir="rtl"] .wc-block-pagination-page--arrow span {
+html[dir="rtl"] .wc-block-components-pagination-page--arrow span {
 	display: inline-block;
 	transform: scale(-1, 1);
 }


### PR DESCRIPTION
Updates the class names added in #4364 to match our [coding guidelines](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/32e69208caf602ce772b3681cca5bda741163a93/docs/contributors/coding-guidelines.md#naming).

### How to test the changes in this Pull Request:

Same as in #4364:

> View the pagination rendered on the all products block and confirm the symbol matches the screenshot above.
