### PR TITLE
Use .hidden instead of .screen-reader-text for toggling helper texts

### DIFF
--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -176,11 +176,7 @@ const ProductAttributeTermControl = ( {
 				isHierarchical
 			/>
 			{ !! onOperatorChange && (
-				<div
-					className={
-						selected.length < 2 ? 'hidden' : ''
-					}
-				>
+				<div className={ selected.length < 2 ? 'hidden' : '' }>
 					<SelectControl
 						className="woocommerce-product-attributes__operator"
 						label={ __(

--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -176,7 +176,7 @@ const ProductAttributeTermControl = ( {
 				isHierarchical
 			/>
 			{ !! onOperatorChange && (
-				<div className={ selected.length < 2 ? 'hidden' : '' }>
+				<div hidden={ selected.length < 2 }>
 					<SelectControl
 						className="woocommerce-product-attributes__operator"
 						label={ __(

--- a/assets/js/editor-components/product-attribute-term-control/index.js
+++ b/assets/js/editor-components/product-attribute-term-control/index.js
@@ -178,7 +178,7 @@ const ProductAttributeTermControl = ( {
 			{ !! onOperatorChange && (
 				<div
 					className={
-						selected.length < 2 ? 'screen-reader-text' : ''
+						selected.length < 2 ? 'hidden' : ''
 					}
 				>
 					<SelectControl

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -149,11 +149,7 @@ const ProductCategoryControl = ( {
 				isSingle={ isSingle }
 			/>
 			{ !! onOperatorChange && (
-				<div
-					className={
-						selected.length < 2 ? 'hidden' : ''
-					}
-				>
+				<div className={ selected.length < 2 ? 'hidden' : '' }>
 					<SelectControl
 						className="woocommerce-product-categories__operator"
 						label={ __(

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -151,7 +151,7 @@ const ProductCategoryControl = ( {
 			{ !! onOperatorChange && (
 				<div
 					className={
-						selected.length < 2 ? 'screen-reader-text' : ''
+						selected.length < 2 ? 'hidden' : ''
 					}
 				>
 					<SelectControl

--- a/assets/js/editor-components/product-category-control/index.js
+++ b/assets/js/editor-components/product-category-control/index.js
@@ -149,7 +149,7 @@ const ProductCategoryControl = ( {
 				isSingle={ isSingle }
 			/>
 			{ !! onOperatorChange && (
-				<div className={ selected.length < 2 ? 'hidden' : '' }>
+				<div hidden={ selected.length < 2 }>
 					<SelectControl
 						className="woocommerce-product-categories__operator"
 						label={ __(

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -150,7 +150,7 @@ class ProductTagControl extends Component {
 					isHierarchical
 				/>
 				{ !! onOperatorChange && (
-					<div className={ selected.length < 2 ? 'hidden' : '' }>
+					<div hidden={ selected.length < 2 }>
 						<SelectControl
 							className="woocommerce-product-tags__operator"
 							label={ __(

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -152,7 +152,7 @@ class ProductTagControl extends Component {
 				{ !! onOperatorChange && (
 					<div
 						className={
-							selected.length < 2 ? 'screen-reader-text' : ''
+							selected.length < 2 ? 'hidden' : ''
 						}
 					>
 						<SelectControl

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -150,11 +150,7 @@ class ProductTagControl extends Component {
 					isHierarchical
 				/>
 				{ !! onOperatorChange && (
-					<div
-						className={
-							selected.length < 2 ? 'hidden' : ''
-						}
-					>
+					<div className={ selected.length < 2 ? 'hidden' : '' }>
 						<SelectControl
 							className="woocommerce-product-tags__operator"
 							label={ __(


### PR DESCRIPTION
Fixes #4525 

#### Accessibility

n/a

### Screenshots

<table>
<tr>
<td valign="top"><img width="633" alt="Screenshot 2021-08-02 at 14 19 28" src="https://user-images.githubusercontent.com/3323310/127860858-28922b72-774d-4c9e-95ad-946a19ce851f.png"></td>
<td valign="top"><img width="636" alt="Screenshot 2021-08-02 at 14 19 48" src="https://user-images.githubusercontent.com/3323310/127860886-3b9a4788-c89f-4cde-b365-9ad1f13025d7.png"></td>
<td valign="top"><img width="636" alt="Screenshot 2021-08-02 at 14 20 06" src="https://user-images.githubusercontent.com/3323310/127860917-d877fe34-e263-4e77-981c-a9e548315485.png"></td>
</tr>
</table>

### How to test the changes in this Pull Request:

#### Products by Tag block

1. Install and activate the WooCommerce plugin
2. Install and activate this plugin
3. Create min. 2 product tags
4. Create one test product and add the product tags to it
5. Create a test page
6. Add the **Products by Tag** block
7. Select tags
8. When >= 2 product tags are selected, the message 'Pick at least two tags to use this setting.' is visible
9. When < 2 product tags  are selected, the message 'Pick at least two tags to use this setting.' is not visible

#### Products by Category block

1. Install and activate the WooCommerce plugin
2. Install and activate this plugin
3. Create min. 2 product categories with min 
4. Create one test product and add the tags to it
5. Create a test page
6. Add the **Products by Category** block
7. Select product categories
8. When >= 2 product categories are selected, the message 'Pick at least two categories to use this setting.' is visible
9. When < 2 product categories are selected, the message 'Pick at least two categories to use this setting.' is not visible

#### Products by Attribute block

1. Install and activate the WooCommerce plugin
2. Install and activate this plugin
3. Create min. 1 product attribute with min. 2 values
4. Create one test product and add the product attribute to it
5. Create a test page
6. Add the **Products by Attribute** block
7. Select product attribute values
8. When >= 2 product attribute values are selected, the message 'Pick at least two attributes to use this setting.' is visible
9. When < 2 product attribute values are selected, the message 'Pick at least two attributes to use this setting.' is not visible

### Note

This PR only replaces `.screen-reader-text` with `.hidden`, while it does not change the existing functionality. However, the current functionality seems to be implemented the other way around. 

### Changelog

> Replace .screen-reader-text with .hidden for elements that are not relevant to screen readers