### PR TITLE
Twenty Twenty-One: Adjust removable chip background color

### DIFF
--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -51,6 +51,20 @@
 	}
 }
 
+.theme-twentytwentyone {
+	// Adjust removable chip background color.
+	// @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4404
+	.wc-block-components-chip,
+	.wc-block-components-chip:active,
+	.wc-block-components-chip:focus,
+	.wc-block-components-chip:hover {
+		background: #fff;
+		button.wc-block-components-chip__remove:not(:hover):not(:active):not(.has-background) {
+			background: transparent;
+		}
+	}
+}
+
 button.wc-block-components-chip:hover > .wc-block-components-chip__remove,
 button.wc-block-components-chip:focus > .wc-block-components-chip__remove,
 .wc-block-components-chip__remove:hover,

--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -52,8 +52,6 @@
 }
 
 .theme-twentytwentyone {
-	// Adjust removable chip background color.
-	// @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4404
 	.wc-block-components-chip,
 	.wc-block-components-chip:active,
 	.wc-block-components-chip:focus,


### PR DESCRIPTION
Fixes #4404

#### Accessibility

n/a

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#4404-before](https://user-images.githubusercontent.com/3323310/128184619-030aecf6-1496-43c8-b649-c7e513d9a377.png)
</td>
<td>After:
<br><br>

![#4404-after](https://user-images.githubusercontent.com/3323310/128184613-fb17fd6c-c7c4-401c-9628-5337f1b24082.png)
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

1. Install and activate the WooCommerce plugin
2. Install and activate this plugin
3. Create one test product
4. Create one test coupon
5. Create one test page
6. Add the cart block to the created page
7. Look up the created page
8. Add a product to the cart
9. Apply the test coupon
10. See the incorrect removable chip background color
11. Apply this PR
12. See the correct removable chip background color

### Changelog

> Twenty Twenty-One: Adjust removable chip background color