### PR TITLE
Twenty Twenty: Fix broken sale badge left alignment

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -268,14 +268,6 @@
 		text-transform: uppercase;
 	}
 
-	// These styles are not applied to the All Products atomic block, so it can be positioned normally.
-	.wc-block-grid__products .wc-block-grid__product-onsale {
-		position: absolute;
-		right: 4px;
-		top: 4px;
-		z-index: 1;
-	}
-
 	// Override style from WC Core that set its position to absolute.
 	// These rulesets can be removed once https://github.com/woocommerce/woocommerce/pull/26516 is released.
 	.wc-block-grid__products .wc-block-components-product-sale-badge {

--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -22,7 +22,7 @@
 		}
 	}
 
-	.wc-block-components-product-sale-badge {
+	.wc-block-grid__product-onsale.wc-block-components-product-sale-badge {
 		&--align-left {
 			position: absolute;
 			left: $gap-smaller/2;

--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -22,7 +22,7 @@
 		}
 	}
 
-	.wc-block-grid__product-onsale.wc-block-components-product-sale-badge {
+	.wc-block-components-product-sale-badge {
 		&--align-left {
 			position: absolute;
 			left: $gap-smaller/2;


### PR DESCRIPTION
Fixes #3097 

#### Accessibility

n/a

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#3097-before](https://user-images.githubusercontent.com/3323310/128196639-39369cc7-af8e-4e41-929c-2bce28010e99.png)
</td>
<td>After:
<br><br>

![#3097-after](https://user-images.githubusercontent.com/3323310/128197197-e9bbaa63-c71e-485e-8c40-abe14e1b9919.png)
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

1. Install and activate the WooCommerce plugin
2. Install and activate this plugin
3. Create one test product with sales price
4. Create one test page
5. Add the _All Products_ block to the created page
6. Mark the _All Products_ block and select the _Edit_ icon
7. Select the _Product Image_ block
8. Set the _Sale Badge Alignment_ to _Left_ in the sidebar
9. Save and look up the page
10. See that the sale badge appears in full width
11. Check out this PR
12. See that the sale badge appears left aligned

### Changelog

> Twenty Twenty: Fix broken sale badge left alignment
