### PR TITLE
Replace deprecated divisions with math.div($size, $base)

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 $fontSizes: (
 	"smaller": 0.75,
 	"small": 0.875,

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $fontSizes: (
 	"smaller": 0.75,
 	"small": 0.875,
@@ -179,7 +181,7 @@ $fontSizes: (
 
 // Converts a px unit to em.
 @function em($size, $base: 16px) {
-	@return $size / $base * 1em;
+	@return math.div($size, $base) * 1em;
 }
 
 // Encodes hex colors so they can be used in URL content.

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -18,7 +18,7 @@
 	.wc-block-grid {
 		.wc-block-grid__products {
 			list-style: none;
-			margin: 0 (-$gap/2) $gap;
+			margin: 0 (-$gap*0.5) $gap;
 			padding: 0;
 
 			.wc-block-grid__product {

--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -25,14 +25,14 @@
 	.wc-block-components-product-sale-badge {
 		&--align-left {
 			position: absolute;
-			left: $gap-smaller/2;
-			top: $gap-smaller/2;
+			left: $gap-smaller*0.5;
+			top: $gap-smaller*0.5;
 			right: auto;
 			margin: 0;
 		}
 		&--align-center {
 			position: absolute;
-			top: $gap-smaller/2;
+			top: $gap-smaller*0.5;
 			left: 50%;
 			right: auto;
 			transform: translateX(-50%);
@@ -40,8 +40,8 @@
 		}
 		&--align-right {
 			position: absolute;
-			right: $gap-smaller/2;
-			top: $gap-smaller/2;
+			right: $gap-smaller*0.5;
+			top: $gap-smaller*0.5;
 			left: auto;
 			margin: 0;
 		}

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -18,7 +18,7 @@
 		border-left: 1px solid;
 		opacity: 0.3;
 		position: absolute;
-		left: -$gap-larger/2;
+		left: -$gap-larger*0.5;
 		top: 2.5em;
 		bottom: em($gap) * -1;
 	}
@@ -83,7 +83,7 @@
 		content: "\00a0" counter(checkout-step) "." / "";
 		position: absolute;
 		width: $gap-larger;
-		left: -$gap-larger/2;
+		left: -$gap-larger*0.5;
 		top: 0;
 		text-align: center;
 		transform: translateX(-50%);
@@ -95,7 +95,7 @@
 		border-left: 1px solid;
 		opacity: 0.3;
 		position: absolute;
-		left: -$gap-larger/2;
+		left: -$gap-larger*0.5;
 		top: 0;
 	}
 }

--- a/assets/js/base/components/cart-checkout/order-summary/style.scss
+++ b/assets/js/base/components/cart-checkout/order-summary/style.scss
@@ -88,7 +88,7 @@
 	p,
 	.wc-block-components-product-metadata {
 		line-height: 1.375;
-		margin-top: #{ ( $gap-large - $gap ) / 2 };
+		margin-top: #{ ( $gap-large - $gap ) * 0.5 };
 	}
 }
 

--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	border: 0;
 	display: inline-flex;
-	padding: em($gap-smallest / 2) 0.5em em($gap-smallest);
+	padding: em($gap-smallest * 0.5) 0.5em em($gap-smallest);
 	margin: 0 0.365em 0.365em 0;
 	border-radius: 0;
 	line-height: 1;

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -1,6 +1,8 @@
 // 18px is the minimum input field line-height and 14px is the font-size of
 // the drop down selector elements.
-$dropdown-selector-line-height: 18/14;
+@use "sass:math";
+
+$dropdown-selector-line-height: math.div(18, 14);
 
 .wc-block-components-dropdown-selector {
 	max-width: 300px;
@@ -35,7 +37,7 @@ $dropdown-selector-line-height: 18/14;
 .wc-block-components-dropdown-selector__input {
 	@include font-size(small);
 	line-height: $dropdown-selector-line-height;
-	margin: em($gap-small/4) 0;
+	margin: em($gap-small*0.25) 0;
 	min-width: 0;
 	padding: em($gap-smallest * 0.75) 0 em($gap-smallest * 0.75);
 
@@ -104,7 +106,7 @@ $dropdown-selector-line-height: 18/14;
 		align-items: center;
 		color: $gray-700;
 		display: inline-flex;
-		margin: em($gap-small/4) 0;
+		margin: em($gap-small*0.25) 0;
 		padding: em($gap-smallest * 0.75) 0 em($gap-smallest * 0.75);
 		width: 100%;
 	}
@@ -130,8 +132,8 @@ $dropdown-selector-line-height: 18/14;
 
 	.wc-block-components-dropdown-selector__selected-chip {
 		@include font-size(small);
-		margin-top: em($gap-small/4);
-		margin-bottom: em($gap-small/4);
+		margin-top: em($gap-small*0.25);
+		margin-bottom: em($gap-small*0.25);
 		line-height: $dropdown-selector-line-height;
 	}
 }

--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -1,6 +1,5 @@
 // 18px is the minimum input field line-height and 14px is the font-size of
 // the drop down selector elements.
-@use "sass:math";
 
 $dropdown-selector-line-height: math.div(18, 14);
 

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @keyframes spin {
 	from {
 		transform: rotate(0deg);
@@ -37,7 +39,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	padding: 0;
-	margin: 0 (-$gap/2) $gap;
+	margin: 0 (-$gap*0.5) $gap;
 	background-clip: padding-box;
 }
 
@@ -49,8 +51,8 @@
 	width: auto;
 	position: relative;
 	text-align: center;
-	border-left: $gap/2 solid transparent;
-	border-right: $gap/2 solid transparent;
+	border-left: $gap*0.5 solid transparent;
+	border-right: $gap*0.5 solid transparent;
 	border-bottom: $gap solid transparent;
 	list-style: none;
 }
@@ -75,8 +77,8 @@
 	}
 	@for $i from 1 to 9 {
 		&.has-#{$i}-columns .wc-block-grid__product {
-			flex: 1 0 calc(#{ 100% / $i });
-			max-width: 100% / $i;
+			flex: 1 0 calc(#{ math.div(100%, $i) });
+			max-width: math.div(100%, $i);
 		}
 	}
 	// Adjust font size as more cols are added.
@@ -130,12 +132,12 @@
 					margin: 0 0 $gap-large 0;
 				}
 				.wc-block-grid__product:nth-child(odd) {
-					padding-right: $gap/2;
+					padding-right: $gap*0.5;
 				}
 				.wc-block-grid__product:nth-child(even) {
-					padding-left: $gap/2;
+					padding-left: $gap*0.5;
 					.wc-block-grid__product-onsale {
-						left: $gap/2;
+						left: $gap*0.5;
 					}
 				}
 			}

--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 @keyframes spin {
 	from {
 		transform: rotate(0deg);

--- a/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/assets/js/base/components/reviews/review-list-item/style.scss
@@ -122,14 +122,14 @@
 	display: block;
 	font-weight: bold;
 	order: 1;
-	margin-right: $gap/2;
+	margin-right: $gap*0.5;
 }
 
 .wc-block-components-review-list-item__author {
 	display: block;
 	font-weight: bold;
 	order: 1;
-	margin-right: $gap/2;
+	margin-right: $gap*0.5;
 }
 
 .wc-block-components-review-list-item__product + .wc-block-components-review-list-item__author {
@@ -147,7 +147,7 @@
 	&::before {
 		content: "";
 		display: inline-block;
-		margin-right: $gap/2;
+		margin-right: $gap*0.5;
 		border-right: 1px solid #ddd;
 		height: 1em;
 		vertical-align: middle;

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 .wc-block-components-sidebar-layout {
 	display: flex;
 	flex-wrap: wrap;

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .wc-block-components-sidebar-layout {
 	display: flex;
 	flex-wrap: wrap;
@@ -7,7 +9,7 @@
 	.wc-block-components-main {
 		box-sizing: border-box;
 		margin: 0;
-		padding-right: percentage($gap-largest / 1060px); // ~1060px is the default width of the content area in Storefront.
+		padding-right: percentage(math.div($gap-largest, 1060px)); // ~1060px is the default width of the content area in Storefront.
 		width: 65%;
 	}
 }
@@ -15,7 +17,7 @@
 .wc-block-components-sidebar {
 	box-sizing: border-box;
 	margin: 0;
-	padding-left: percentage($gap-large / 1060px);
+	padding-left: percentage(math.div($gap-large, 1060px));
 	width: 35%;
 
 	.wc-block-components-panel > h2 {

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -91,8 +91,8 @@
 
 		.wc-block-components-chip {
 			@include font-size(small);
-			margin-top: em($gap-small/4);
-			margin-bottom: em($gap-small/4);
+			margin-top: em($gap-small*0.25);
+			margin-bottom: em($gap-small*0.25);
 		}
 	}
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/styles/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/styles/style.scss
@@ -1,5 +1,4 @@
 // Loading skeleton.
-@use "sass:math";
 
 .is-loading.wp-block-woocommerce-checkout-i2 {
 	.wp-block-woocommerce-checkout-totals-block,

--- a/assets/js/blocks/cart-checkout/checkout-i2/styles/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/styles/style.scss
@@ -1,4 +1,6 @@
 // Loading skeleton.
+@use "sass:math";
+
 .is-loading.wp-block-woocommerce-checkout-i2 {
 	.wp-block-woocommerce-checkout-totals-block,
 	.wp-block-woocommerce-checkout-fields-block {
@@ -39,13 +41,13 @@
 		.wp-block-woocommerce-checkout-fields-block {
 			box-sizing: border-box;
 			margin: 0;
-			padding-right: percentage($gap-largest / 1060px); // ~1060px is the default width of the content area in Storefront.
+			padding-right: percentage(math.div($gap-largest, 1060px)); // ~1060px is the default width of the content area in Storefront.
 			width: 65%;
 		}
 		.wp-block-woocommerce-checkout-totals-block {
 			box-sizing: border-box;
 			margin: 0;
-			padding-left: percentage($gap-large / 1060px);
+			padding-left: percentage(math.div($gap-large, 1060px));
 			width: 35%;
 
 			.wc-block-components-panel > h2 {

--- a/assets/js/blocks/cart-checkout/checkout/form/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/form/style.scss
@@ -25,8 +25,8 @@
 	.wc-block-checkout__billing-fields,
 	.wc-block-checkout__shipping-fields {
 		.wc-block-components-address-form {
-			margin-left: #{-$gap-small / 2};
-			margin-right: #{-$gap-small / 2};
+			margin-left: #{-$gap-small * 0.5};
+			margin-right: #{-$gap-small * 0.5};
 
 			&::after {
 				content: "";
@@ -38,8 +38,8 @@
 			.wc-block-components-country-input,
 			.wc-block-components-state-input {
 				float: left;
-				margin-left: #{$gap-small / 2};
-				margin-right: #{$gap-small / 2};
+				margin-left: #{$gap-small * 0.5};
+				margin-right: #{$gap-small * 0.5};
 				position: relative;
 				width: calc(50% - #{$gap-small});
 

--- a/assets/js/blocks/featured-category/style.scss
+++ b/assets/js/blocks/featured-category/style.scss
@@ -107,7 +107,7 @@
 	// Apply max-width to floated items that have no intrinsic width
 	&.alignleft,
 	&.alignright {
-		max-width: $content-width / 2;
+		max-width: $content-width * 0.5;
 		width: 100%;
 	}
 

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -119,7 +119,7 @@
 	// Apply max-width to floated items that have no intrinsic width
 	&.alignleft,
 	&.alignright {
-		max-width: $content-width / 2;
+		max-width: $content-width * 0.5;
 		width: 100%;
 	}
 

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -747,6 +747,7 @@ const getStylingConfig = ( options = {} ) => {
 									}
 
 									return (
+										'@use "sass:math";' +
 										'@import "_colors"; ' +
 										'@import "_variables"; ' +
 										'@import "_breakpoints"; ' +


### PR DESCRIPTION
Fixes #4286 

#### Accessibility

n/a

### Screenshots

n/a

### How to test the changes in this Pull Request:

1. Check out this plugin
2. Run `npm i` and `npm run build`
3. See deprecation warnings both for this plugin and external dependencies
4. Apply this PR
5. Run `npm run build` again
5. See only deprecation warnings for external dependencies

### Changelog

> Replace deprecated divisions with math.div($size, $base)
