### PR TITLE
Reviews by Category: Show review count instead of product count

### DIFF
--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -90,6 +90,7 @@ const ReviewsByCategoryEditor = ( {
 						} }
 						renderItem={ renderCategoryControlItem }
 						isCompact={ true }
+						showReviewCount={ true }
 					/>
 				</PanelBody>
 				<PanelBody


### PR DESCRIPTION
Fixes #4069 

#### Accessibility

n/a

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#4069-before](https://user-images.githubusercontent.com/3323310/128381756-94d85b5e-46c6-42cf-8e87-01ea62628f69.png)
</td>
<td>After:
<br><br>

![#4069-after](https://user-images.githubusercontent.com/3323310/128382107-9bf2e8a1-6c14-4175-84db-69dfdc8ec9ab.png)
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

1. Install and activate the WooCommerce plugin
2. Install and activate this plugin
3. Create one test product
4. Add one review to the test product
5. Create one test post
6. Add the _Reviews by Category_ block
7. Open the sidebar of the block and open the section _Category_
8. See that the count refers to products
9. Check out this PR
10. See that the count refers to reviews 

### Changelog

> Reviews by Category: Show review count instead of product count