### PR TITLE
Enable re-select category for Featured Category block

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -21,6 +21,7 @@ import {
 	ResizableBox,
 	Spinner,
 	ToggleControl,
+	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
 import classnames from 'classnames';
@@ -101,6 +102,17 @@ const FeaturedCategory = ( {
 						} );
 					} }
 					allowedTypes={ [ 'image' ] }
+				/>
+				<ToolbarGroup
+					controls={ [
+						{
+							icon: 'edit',
+							title: __( 'Edit' ),
+							onClick: () =>
+								setAttributes( { editMode: ! editMode } ),
+							isActive: editMode,
+						},
+					] }
 				/>
 			</BlockControls>
 		);

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -59,7 +59,7 @@ import { withCategory } from '../../hocs';
  * @param {Object} props.overlayColor Overlay color object for content.
  * @param {function(any):any} props.setOverlayColor Setter for overlay color.
  * @param {function(any):any} props.debouncedSpeak Function for delayed speak.
- * @param {function(any):any} props.triggerUrlUpdate Function to update Shop now button Url.
+ * @param {function():void} props.triggerUrlUpdate Function to update Shop now button Url.
  */
 const FeaturedCategory = ( {
 	attributes,


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4177

It was not possible to re-select the selected category of a featured category block, This PR adds the edit button (pencil icon) to the block toolbar that allows changing the selected category.

### Screenshots

![featured-category-block](https://user-images.githubusercontent.com/69596988/128643408-d23981cc-79a7-414e-a432-2490b5b5d800.gif)


### How to test the changes in this Pull Request:

1. Insert a featured category block.
2. Select a category to be featured.
3. To re-select the category: click on the edit button (pencil button)

### Changelog

> Featured Category Block:  Allow user to re-select categories using the edit icon
