### PR TITLE
Call validation before submitting the order

### DIFF
--- a/assets/js/base/components/text-input/validated-text-input.tsx
+++ b/assets/js/base/components/text-input/validated-text-input.tsx
@@ -117,6 +117,9 @@ const ValidatedTextInput = ( {
 		}
 	}, [ isPristine, setIsPristine, validateOnMount, validateInput ] );
 
+	/**
+	 * @todo Remove extra validation call after refactoring the validation system.
+	 */
 	useEffect( () => {
 		if ( isBeforeProcessing ) {
 			validateInput();

--- a/assets/js/base/components/text-input/validated-text-input.tsx
+++ b/assets/js/base/components/text-input/validated-text-input.tsx
@@ -65,7 +65,7 @@ const ValidatedTextInput = ( {
 		getValidationErrorId,
 	} = useValidationContext();
 
-	const { onCheckoutValidationBeforeProcessing } = useCheckoutContext();
+	const { isBeforeProcessing } = useCheckoutContext();
 
 	const textInputId =
 		typeof id !== 'undefined' ? id : 'textinput-' + instanceId;
@@ -118,10 +118,10 @@ const ValidatedTextInput = ( {
 	}, [ isPristine, setIsPristine, validateOnMount, validateInput ] );
 
 	useEffect( () => {
-		const unsubscribe = onCheckoutValidationBeforeProcessing( () => validateInput() );
-		return unsubscribe;
-	}, [ onCheckoutValidationBeforeProcessing, validateInput ] );
-
+		if ( isBeforeProcessing ) {
+			validateInput();
+		}
+	}, [ isBeforeProcessing, validateInput ] );
 	// Remove validation errors when unmounted.
 	useEffect( () => {
 		return () => {

--- a/assets/js/base/components/text-input/validated-text-input.tsx
+++ b/assets/js/base/components/text-input/validated-text-input.tsx
@@ -65,7 +65,7 @@ const ValidatedTextInput = ( {
 		getValidationErrorId,
 	} = useValidationContext();
 
-	const { isBeforeProcessing } = useCheckoutContext();
+	const { onCheckoutValidationBeforeProcessing } = useCheckoutContext();
 
 	const textInputId =
 		typeof id !== 'undefined' ? id : 'textinput-' + instanceId;
@@ -118,10 +118,10 @@ const ValidatedTextInput = ( {
 	}, [ isPristine, setIsPristine, validateOnMount, validateInput ] );
 
 	useEffect( () => {
-		if ( isBeforeProcessing ) {
-			validateInput();
-		}
-	}, [isBeforeProcessing])
+		const unsubscribe = onCheckoutValidationBeforeProcessing( () => validateInput() );
+		return unsubscribe;
+	}, [ onCheckoutValidationBeforeProcessing, validateInput ] );
+
 	// Remove validation errors when unmounted.
 	useEffect( () => {
 		return () => {

--- a/assets/js/base/components/text-input/validated-text-input.tsx
+++ b/assets/js/base/components/text-input/validated-text-input.tsx
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import {
 	ValidationInputError,
 	useValidationContext,
+	useCheckoutContext,
 } from '@woocommerce/base-context';
 import { withInstanceId } from '@wordpress/compose';
 import { isString } from '@woocommerce/types';
@@ -64,6 +65,8 @@ const ValidatedTextInput = ( {
 		getValidationErrorId,
 	} = useValidationContext();
 
+	const { isBeforeProcessing } = useCheckoutContext();
+
 	const textInputId =
 		typeof id !== 'undefined' ? id : 'textinput-' + instanceId;
 	const errorIdString = errorId !== undefined ? errorId : textInputId;
@@ -114,6 +117,11 @@ const ValidatedTextInput = ( {
 		}
 	}, [ isPristine, setIsPristine, validateOnMount, validateInput ] );
 
+	useEffect( () => {
+		if ( isBeforeProcessing ) {
+			validateInput();
+		}
+	}, [isBeforeProcessing])
 	// Remove validation errors when unmounted.
 	useEffect( () => {
 		return () => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes the autofill issue, see #4495 for what's happening.
TL;DR, we only run validation on mount and blur, autoFill doesn't trigger blur, meaning we didn't run any validation. Additionally, all inputs mount with an error if empty, meaning when we submit an order, errors aren't cleared.

This PR runs validation on `isBeforeProcessing`.
<!-- Reference any related issues or PRs here -->
Fixes #4495

### How to test the changes in this Pull Request:

1. On a private window, autoFill the form.
2. Submit the order, it should pass fine.
3. Again, on a private window, autoFill the order.
4. Mess up the email field or postcode with an invalid value.
5. Try submitting, make sure it shows the error.
6. Fix the field, make sure there is no jumping around.
7. Submit again, it should pass.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fix autofill triggering validation errors for valid values in Checkout block