### PR TITLE
Fix store notice classes

### DIFF
--- a/assets/js/base/context/providers/store-notices/components/store-notices-container.js
+++ b/assets/js/base/context/providers/store-notices/components/store-notices-container.js
@@ -15,7 +15,7 @@ const getWooClassName = ( { status = 'default' } ) => {
 		case 'error':
 			return 'woocommerce-error';
 		case 'success':
-			return 'woocommerce-success';
+			return 'woocommerce-message';
 		case 'info':
 		case 'warning':
 			return 'woocommerce-info';
@@ -42,7 +42,6 @@ const StoreNoticesContainer = ( { className, notices, removeNotice } ) => {
 					{ ...props }
 					className={ classnames(
 						'wc-block-components-notices__notice',
-						'woocommerce-message',
 						getWooClassName( props )
 					) }
 					onRemove={ () => {


### PR DESCRIPTION
The `StoreNoticesContainer` component is using an incorrect class name for a "success" notice and also applying the general `woocommerce-message` (what's used by WC core for the "success" notice) to all notices. In some instances, this could cause the general `woocommerce-message` styles to be applied instead of the `woocommerce-error` or `woocommerce-info` styles.

This PR changes the use of `woocommerce-success` to `woocommerce-message` and prevents `woocommerce-message` from being applied to all notices.

More info about this issue can be found in https://github.com/Automattic/woocommerce-payments/issues/2494 but, essentially what we've found is that when this plugin and WooCommerce Payments are being used on Storefront, the notices displayed in the Checkout block in the credit card section show the incorrect icons. For example, the failed payment notice has the correct red background color but still has the white checkmark icon, which is incorrect for the `woocommerce-error` type of notice.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes # https://github.com/Automattic/woocommerce-payments/issues/2494

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
**Before**
![126348588-b74d9d93-aa4e-46ef-b53c-c6c588ca626d](https://user-images.githubusercontent.com/1558827/129184772-371e9fc8-49d8-4b70-bede-fad0772328a5.png)

**After**
<img width="487" alt="Screen Shot 2021-08-12 at 6 50 49 AM" src="https://user-images.githubusercontent.com/1558827/129184925-6ee304cb-4540-4659-b154-fbeb7e418a55.png">


### How to test the changes in this Pull Request:

_Alternative testing instructions with WooCommerce Stripe Payment Gateway available [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4568#pullrequestreview-728544965)._
 
1. Create a test site.
2. Install and activate WooCommerce Payments and WooCommerce Blocks.
3. Install and activate the Storefront theme.
4. Create a new page with the Checkout block.
5. Add product to cart.
6. Go to the new checkout page created in step 4.
7. Try to purchase with incorrect/incomplete credit card data.
8. Ensure that the icon in the notice is correct.

<!-- If you can, add the appropriate labels -->

### Changelog

> Adjusted store notice class names so that error notices show the correct icons
