### PR TITLE
Delete unneeded double spaces in text strings

### DIFF
--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -268,7 +268,7 @@ class CartController {
 			'not_purchasable'      => [
 				/* translators: %s: product name. */
 				'singular' => __(
-					'%s cannot be purchased.  Please remove it from your cart.',
+					'%s cannot be purchased. Please remove it from your cart.',
 					'woo-gutenberg-products-block'
 				),
 				/* translators: %s: product names. */


### PR DESCRIPTION
Deleted an unneeded double space in a string on line 271.

https://github.com/woocommerce/woocommerce/issues/30486
