### PR TITLE
Add optimizations around checkout filter calls

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -29,18 +29,18 @@ const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
 const OrderSummaryItem = ( { cartItem } ) => {
 	const {
 		images,
-		low_stock_remaining: lowStockRemaining = null,
-		show_backorder_badge: showBackorderBadge = false,
+		low_stock_remaining: lowStockRemaining,
+		show_backorder_badge: showBackorderBadge,
 		name: initialName,
 		permalink,
 		prices,
 		quantity,
 		short_description: shortDescription,
 		description: fullDescription,
-		item_data: itemData = [],
+		item_data: itemData,
 		variation,
 		totals,
-		extensions = {},
+		extensions,
 	} = cartItem;
 
 	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -13,7 +13,7 @@ import {
 import PropTypes from 'prop-types';
 import Dinero from 'dinero.js';
 import { getSetting } from '@woocommerce/settings';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 
 /**
@@ -23,6 +23,8 @@ import ProductBackorderBadge from '../product-backorder-badge';
 import ProductImage from '../product-image';
 import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
+
+const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
 
 const OrderSummaryItem = ( { cartItem } ) => {
 	const {
@@ -45,11 +47,6 @@ const OrderSummaryItem = ( { cartItem } ) => {
 	// We need to pluck out receiveCart.
 	// eslint-disable-next-line no-unused-vars
 	const { receiveCart, ...cart } = useStoreCart();
-
-	const productPriceValidation = useCallback(
-		( value ) => mustContain( value, '<price/>' ),
-		[]
-	);
 
 	const arg = useMemo(
 		() => ( {

--- a/assets/js/base/components/cart-checkout/order-summary/test/index.js
+++ b/assets/js/base/components/cart-checkout/order-summary/test/index.js
@@ -12,7 +12,7 @@ import OrderSummary from '../index';
 jest.mock( '@woocommerce/base-context', () => ( {
 	...jest.requireActual( '@woocommerce/base-context' ),
 	useContainerWidthContext: () => ( {
-		isLarge: false,
+		isLarge: true,
 		hasContainerWidth: true,
 	} ),
 } ) );

--- a/assets/js/base/components/cart-checkout/totals/discount/index.js
+++ b/assets/js/base/components/cart-checkout/totals/discount/index.js
@@ -16,6 +16,10 @@ import { getSetting } from '@woocommerce/settings';
  */
 import './style.scss';
 
+const filteredCartCouponsFilterArg = {
+	context: 'summary',
+};
+
 const TotalsDiscount = ( {
 	cartCoupons = [],
 	currency,
@@ -42,9 +46,7 @@ const TotalsDiscount = ( {
 		: discountValue;
 
 	const filteredCartCoupons = __experimentalApplyCheckoutFilter( {
-		arg: {
-			context: 'summary',
-		},
+		arg: filteredCartCouponsFilterArg,
 		filterName: 'coupons',
 		defaultValue: cartCoupons,
 	} );

--- a/assets/js/base/components/product-name/index.tsx
+++ b/assets/js/base/components/product-name/index.tsx
@@ -21,10 +21,10 @@ export default ( {
 	permalink = '',
 	...props
 }: {
-	className: string;
-	disabled: boolean;
+	className?: string;
+	disabled?: boolean;
 	name: string;
-	permalink: string;
+	permalink?: string;
 } ): JSX.Element => {
 	const classes = classnames( 'wc-block-components-product-name', className );
 	return disabled ? (

--- a/assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js
+++ b/assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js
@@ -5,6 +5,8 @@ import { SnackbarList } from 'wordpress-components';
 import classnames from 'classnames';
 import { __experimentalApplyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
+const EMPTY_SNACKBAR_NOTICES = {};
+
 const SnackbarNoticesContainer = ( {
 	className,
 	notices,
@@ -19,10 +21,13 @@ const SnackbarNoticesContainer = ( {
 		( notice ) => notice.type === 'snackbar'
 	);
 
-	const noticeVisibility = snackbarNotices.reduce( ( acc, { content } ) => {
-		acc[ content ] = true;
-		return acc;
-	}, {} );
+	const noticeVisibility =
+		snackbarNotices.length > 0
+			? snackbarNotices.reduce( ( acc, { content } ) => {
+					acc[ content ] = true;
+					return acc;
+			  }, {} )
+			: EMPTY_SNACKBAR_NOTICES;
 
 	const filteredNotices = __experimentalApplyCheckoutFilter( {
 		filterName: 'snackbarNoticeVisibility',

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -27,7 +27,7 @@ import {
 	mustContain,
 } from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/type-defs/cart';
 import { objectHasProp } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
@@ -45,6 +45,8 @@ const getAmountFromRawPrice = (
 ) => {
 	return priceObject.convertPrecision( currency.minorUnit ).getAmount();
 };
+
+const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
 
 /**
  * Cart line item table row component.
@@ -109,11 +111,6 @@ const CartLineItemRow = ( {
 		isPendingDelete,
 	} = useStoreCartItemQuantity( lineItem );
 	const { dispatchStoreEvent } = useStoreEvents();
-
-	const productPriceValidation = useCallback(
-		( value ) => mustContain( value, '<price/>' ),
-		[]
-	);
 
 	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
 	// We need to pluck out receiveCart.

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -305,4 +305,5 @@ const CartLineItemRow = ( {
 		</tr>
 	);
 };
+
 export default CartLineItemRow;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -101,7 +101,7 @@ const CartLineItemRow = ( {
 			line_subtotal: '0',
 			line_subtotal_tax: '0',
 		},
-		extensions = {},
+		extensions,
 	} = lineItem;
 
 	const {

--- a/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
@@ -427,57 +427,6 @@ exports[`Testing cart Contains a Taxes section if Core options are set to show i
                   </span>
                 </button>
               </div>
-              <div
-                class="wc-block-components-panel__content"
-                hidden=""
-              >
-                <div
-                  class=""
-                >
-                  <div
-                    aria-hidden="false"
-                    class=""
-                  >
-                    <div
-                      class="wc-block-components-totals-coupon__content"
-                    >
-                      <form
-                        class="wc-block-components-totals-coupon__form"
-                      >
-                        <div
-                          class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
-                        >
-                          <input
-                            aria-describedby=""
-                            aria-label="Enter code"
-                            autocapitalize="off"
-                            autocomplete="off"
-                            id="wc-block-components-totals-coupon__input-1"
-                            type="text"
-                            value=""
-                          />
-                          <label
-                            for="wc-block-components-totals-coupon__input-1"
-                          >
-                            Enter code
-                          </label>
-                        </div>
-                        <button
-                          class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
-                          disabled=""
-                          type="submit"
-                        >
-                          <span
-                            class="wc-block-components-button__text"
-                          >
-                            Apply
-                          </span>
-                        </button>
-                      </form>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
           <div
@@ -1159,57 +1108,6 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
                     Apply a coupon code
                   </span>
                 </button>
-              </div>
-              <div
-                class="wc-block-components-panel__content"
-                hidden=""
-              >
-                <div
-                  class=""
-                >
-                  <div
-                    aria-hidden="false"
-                    class=""
-                  >
-                    <div
-                      class="wc-block-components-totals-coupon__content"
-                    >
-                      <form
-                        class="wc-block-components-totals-coupon__form"
-                      >
-                        <div
-                          class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
-                        >
-                          <input
-                            aria-describedby=""
-                            aria-label="Enter code"
-                            autocapitalize="off"
-                            autocomplete="off"
-                            id="wc-block-components-totals-coupon__input-2"
-                            type="text"
-                            value=""
-                          />
-                          <label
-                            for="wc-block-components-totals-coupon__input-2"
-                          >
-                            Enter code
-                          </label>
-                        </div>
-                        <button
-                          class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
-                          disabled=""
-                          type="submit"
-                        >
-                          <span
-                            class="wc-block-components-button__text"
-                          >
-                            Apply
-                          </span>
-                        </button>
-                      </form>
-                    </div>
-                  </div>
-                </div>
               </div>
             </div>
           </div>
@@ -1897,57 +1795,6 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
                     Apply a coupon code
                   </span>
                 </button>
-              </div>
-              <div
-                class="wc-block-components-panel__content"
-                hidden=""
-              >
-                <div
-                  class=""
-                >
-                  <div
-                    aria-hidden="false"
-                    class=""
-                  >
-                    <div
-                      class="wc-block-components-totals-coupon__content"
-                    >
-                      <form
-                        class="wc-block-components-totals-coupon__form"
-                      >
-                        <div
-                          class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
-                        >
-                          <input
-                            aria-describedby=""
-                            aria-label="Enter code"
-                            autocapitalize="off"
-                            autocomplete="off"
-                            id="wc-block-components-totals-coupon__input-3"
-                            type="text"
-                            value=""
-                          />
-                          <label
-                            for="wc-block-components-totals-coupon__input-3"
-                          >
-                            Enter code
-                          </label>
-                        </div>
-                        <button
-                          class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
-                          disabled=""
-                          type="submit"
-                        >
-                          <span
-                            class="wc-block-components-button__text"
-                          >
-                            Apply
-                          </span>
-                        </button>
-                      </form>
-                    </div>
-                  </div>
-                </div>
               </div>
             </div>
           </div>

--- a/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
+++ b/assets/js/blocks/cart-checkout/checkout/sidebar/test/__snapshots__/index.js.snap
@@ -63,57 +63,6 @@ exports[`Testing checkout sidebar Shows rate percentages after tax lines if the 
           </span>
         </button>
       </div>
-      <div
-        class="wc-block-components-panel__content"
-        hidden=""
-      >
-        <div
-          class=""
-        >
-          <div
-            aria-hidden="false"
-            class=""
-          >
-            <div
-              class="wc-block-components-totals-coupon__content"
-            >
-              <form
-                class="wc-block-components-totals-coupon__form"
-              >
-                <div
-                  class="wc-block-components-text-input wc-block-components-totals-coupon__input is-active"
-                >
-                  <input
-                    aria-describedby="wc-block-components-totals-coupon__input-0"
-                    aria-label="Enter code"
-                    autocapitalize="off"
-                    autocomplete="off"
-                    id="wc-block-components-totals-coupon__input-0"
-                    type="text"
-                    value=""
-                  />
-                  <label
-                    for="wc-block-components-totals-coupon__input-0"
-                  >
-                    Enter code
-                  </label>
-                </div>
-                <button
-                  class="components-button wc-block-components-button wc-block-components-totals-coupon__button"
-                  disabled=""
-                  type="submit"
-                >
-                  <span
-                    class="wc-block-components-button__text"
-                  >
-                    Apply
-                  </span>
-                </button>
-              </form>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
   <div

--- a/packages/checkout/panel/index.tsx
+++ b/packages/checkout/panel/index.tsx
@@ -50,12 +50,11 @@ const Panel = ( {
 					{ title }
 				</button>
 			</TitleTag>
-			<div
-				className="wc-block-components-panel__content"
-				hidden={ ! isOpen }
-			>
-				{ children }
-			</div>
+			{ isOpen && (
+				<div className="wc-block-components-panel__content">
+					{ children }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/packages/checkout/registry/index.ts
+++ b/packages/checkout/registry/index.ts
@@ -90,7 +90,7 @@ const getCheckoutFilters = ( filterName: string ): CheckoutFilterFunction[] => {
 export const __experimentalApplyCheckoutFilter = < T >( {
 	filterName,
 	defaultValue,
-	extensions = {},
+	extensions = null,
 	arg = null,
 	validation = returnTrue,
 }: {
@@ -99,7 +99,7 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 	/** Default value to filter. */
 	defaultValue: T;
 	/** Values extend to REST API response. */
-	extensions?: Record< string, unknown >;
+	extensions?: Record< string, unknown > | null;
 	/** Object containing arguments for the filter function. */
 	arg?: CheckoutFilterArguments;
 	/** Function that needs to return true when the filtered value is passed in order for the filter to be applied. */
@@ -111,7 +111,7 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 		let value = defaultValue;
 		filters.forEach( ( filter ) => {
 			try {
-				const newValue = filter( value, extensions, arg );
+				const newValue = filter( value, extensions || {}, arg );
 				if ( typeof newValue !== typeof value ) {
 					throw new Error(
 						sprintf(


### PR DESCRIPTION
This PR includes several optimizations to reduce the number of times `__experimentalApplyCheckoutFilter()` is called in the Cart and Checkout blocks. Each optimization is unrelated from the others, so it might be easier to review this PR commit by commit.

While there isn't any specific performance issue this PR is fixing, `__experimentalApplyCheckoutFilter` executes 3rd-party code, so I think it's good to avoid as much as possible calling it unnecessarily. In addition to that, several of the changes included in this PR are general good practices, so even if the performance impact was negligible, I still think it makes sense merging them.

I measured how many times `__experimentalApplyCheckoutFilter()` was called in these three scenarios:

**Cart block:**

| | On render | When changing a product quantity |
| --- | ---: | ---: |
| `trunk` | 230 | 251 |
| This branch | 212 | 234 |

**Checkout block (desktop):**

| | On render | When changing shipping country |
| --- | ---: | ---: |
| `trunk` | 220 | 252 |
| This branch | 197 | 220 |

**Checkout block (mobile):** (the big improvement here is because `Panel` contents are no longer rendered when collapsed, and `Order Summary` is collapsed by default on mobile)

| | On render | When changing shipping country |
| --- | ---: | ---: |
| `trunk` | 238 | 258 |
| This branch | 28 | 35 |

Note: the exact numbers will depend on the number of products you have in the cart, whether they are on sale, if you have coupons, etc. so most probably you will get different results, but the improvement should be noticeable anyway.

### How to test the changes in this Pull Request:

1. Testing means verifying there are no regressions. Try interacting with the Cart and Checkout blocks (removing products, changing quantity, adding a coupon, filling the Checkout form, etc.) and verify everything works as expected.
2. Verify extensibility still works as usual. You can test it getting WooCommerce Subscriptions and adding a subscription product to your cart.

### Changelog

> Performance improvements in the Cart and Checkout block extensibility points
