### PR TITLE
update Checkout i2 locks to attributes.

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/form-step-block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/form-step-block.tsx
@@ -16,21 +16,24 @@ export interface FormStepBlockProps {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 	className?: string;
 	children?: React.ReactNode;
+	lock?: { move: boolean; remove: boolean };
 }
 
 /**
  * Form Step Block for use in the editor.
  */
 export const FormStepBlock = ( {
-	attributes: { title = '', description = '', showStepNumber = true },
+	attributes,
 	setAttributes,
 	className = '',
 	children,
 }: FormStepBlockProps ): JSX.Element => {
+	const { title = '', description = '', showStepNumber = true } = attributes;
 	const blockProps = useBlockPropsWithLocking( {
 		className: classnames( 'wc-block-components-checkout-step', className, {
 			'wc-block-components-checkout-step--with-step-number': showStepNumber,
 		} ),
+		attributes,
 	} );
 
 	return (

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/attributes.tsx
@@ -7,4 +7,11 @@ export default {
 		type: 'boolean',
 		default: true,
 	},
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/edit.tsx
@@ -23,7 +23,7 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking();
+	const blockProps = useBlockPropsWithLocking( { attributes } );
 	const { cartPageId = 0, showReturnToCart = true } = attributes;
 	const { current: savedCartPageId } = useRef( cartPageId );
 	const currentPostId = useSelect(

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/index.tsx
@@ -23,10 +23,6 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-actions-block', {
 		multiple: false,
 		reusable: false,
 		inserter: false,
-		lock: {
-			remove: true,
-			move: true,
-		},
 	},
 	parent: [ 'woocommerce/checkout-fields-block' ],
 	attributes,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/attributes.tsx
@@ -16,4 +16,11 @@ export default {
 			'woo-gutenberg-products-block'
 		),
 	} ),
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/index.tsx
@@ -28,10 +28,6 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-billing-address-block', {
 		multiple: false,
 		reusable: false,
 		inserter: false,
-		lock: {
-			remove: true,
-			move: true,
-		},
 	},
 	parent: [ 'woocommerce/checkout-fields-block' ],
 	attributes,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/attributes.tsx
@@ -19,4 +19,11 @@ export default {
 			'woo-gutenberg-products-block'
 		),
 	} ),
+	lock: {
+		type: 'object',
+		default: {
+			remove: true,
+			move: true,
+		},
+	},
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/index.tsx
@@ -30,10 +30,6 @@ registerFeaturePluginBlockType(
 			multiple: false,
 			reusable: false,
 			inserter: false,
-			lock: {
-				remove: true,
-				move: true,
-			},
 		},
 		parent: [ 'woocommerce/checkout-fields-block' ],
 		attributes,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/edit.tsx
@@ -10,8 +10,17 @@ import Block from './block';
 import './editor.scss';
 import { useBlockPropsWithLocking } from '../../hacks';
 
-export const Edit = (): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking();
+export const Edit = ( {
+	attributes,
+}: {
+	attributes: {
+		lock: {
+			move: boolean;
+			remove: boolean;
+		};
+	};
+} ): JSX.Element => {
+	const blockProps = useBlockPropsWithLocking( { attributes } );
 
 	return (
 		<div { ...blockProps }>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/index.tsx
@@ -27,13 +27,17 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-express-payment-block', {
 		multiple: false,
 		reusable: false,
 		inserter: false,
-		lock: {
-			remove: true,
-			move: true,
-		},
 	},
 	parent: [ 'woocommerce/checkout-fields-block' ],
-	attributes: {},
+	attributes: {
+		lock: {
+			type: 'object',
+			default: {
+				remove: true,
+				move: true,
+			},
+		},
+	},
 	apiVersion: 2,
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-note-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-note-block/edit.tsx
@@ -11,8 +11,17 @@ import Block from './block';
 import './editor.scss';
 import { useBlockPropsWithLocking } from '../../hacks';
 
-export const Edit = (): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking();
+export const Edit = ( {
+	attributes,
+}: {
+	attributes: {
+		lock: {
+			move: boolean;
+			remove: boolean;
+		};
+	};
+} ): JSX.Element => {
+	const blockProps = useBlockPropsWithLocking( { attributes } );
 	return (
 		<div { ...blockProps }>
 			<Disabled>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-note-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-note-block/index.tsx
@@ -28,7 +28,15 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-order-note-block', {
 		reusable: false,
 	},
 	parent: [ 'woocommerce/checkout-fields-block' ],
-	attributes: {},
+	attributes: {
+		lock: {
+			type: 'object',
+			default: {
+				move: true,
+				remove: true,
+			},
+		},
+	},
 	apiVersion: 2,
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/attributes.tsx
@@ -8,4 +8,11 @@ export default {
 		type: 'boolean',
 		default: getSetting( 'displayCartPricesIncludingTax', false ),
 	},
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/edit.tsx
@@ -18,10 +18,14 @@ export const Edit = ( {
 }: {
 	attributes: {
 		showRateAfterTaxName: boolean;
+		lock: {
+			move: boolean;
+			remove: boolean;
+		};
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking();
+	const blockProps = useBlockPropsWithLocking( { attributes } );
 	const taxesEnabled = getSetting( 'taxesEnabled' ) as boolean;
 	const displayItemizedTaxes = getSetting(
 		'displayItemizedTaxes',

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/index.tsx
@@ -23,10 +23,6 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-order-summary-block', {
 		multiple: false,
 		reusable: false,
 		inserter: false,
-		lock: {
-			remove: true,
-			move: true,
-		},
 	},
 	parent: [ 'woocommerce/checkout-totals-block' ],
 	attributes,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/attributes.tsx
@@ -16,4 +16,11 @@ export default {
 			'woo-gutenberg-products-block'
 		),
 	} ),
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/index.tsx
@@ -28,10 +28,6 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-payment-block', {
 		multiple: false,
 		reusable: false,
 		inserter: false,
-		lock: {
-			remove: true,
-			move: true,
-		},
 	},
 	parent: [ 'woocommerce/checkout-fields-block' ],
 	attributes,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/attributes.tsx
@@ -16,4 +16,11 @@ export default {
 			'woo-gutenberg-products-block'
 		),
 	} ),
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/index.tsx
@@ -28,10 +28,6 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-shipping-address-block', {
 		multiple: false,
 		reusable: false,
 		inserter: false,
-		lock: {
-			remove: true,
-			move: true,
-		},
 	},
 	parent: [ 'woocommerce/checkout-fields-block' ],
 	attributes,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/attributes.tsx
@@ -20,4 +20,11 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/index.tsx
@@ -28,10 +28,6 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-shipping-methods-block', {
 		multiple: false,
 		reusable: false,
 		inserter: false,
-		lock: {
-			remove: true,
-			move: true,
-		},
 	},
 	parent: [ 'woocommerce/checkout-fields-block' ],
 	attributes,

--- a/assets/js/blocks/cart-checkout/checkout-i2/styles/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/styles/editor.scss
@@ -27,11 +27,11 @@
 
 body.wc-lock-selected-block--move {
 	.block-editor-block-mover__move-button-container,
-	.block-editor-block-mover,
-	.block-editor-block-settings-menu {
+	.block-editor-block-mover {
 		display: none;
 	}
 }
+
 
 body.wc-lock-selected-block--remove {
 	.block-editor-block-settings-menu__popover {


### PR DESCRIPTION
Following the discussion in https://github.com/WordPress/gutenberg/pull/32457 I moved block locking to `attributes` instead of `support`.
I also updated the hack file to better detect if we have lock implemented in GB or not.
Closes #4459

### Testing instructions
- Checkout this branch with a default GB, insert Checkout i2. You shouldn't be able to remove or move core blocks.
- Checkout https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4570, behavior should persist anyway.