### PR TITLE
Make SortSelect components controlled

### DIFF
--- a/assets/js/base/components/product-list/product-sort-select/index.js
+++ b/assets/js/base/components/product-list/product-sort-select/index.js
@@ -10,11 +10,10 @@ import SortSelect from '@woocommerce/base-components/sort-select';
  */
 import './style.scss';
 
-const ProductSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {
+const ProductSortSelect = ( { onChange, readOnly, value } ) => {
 	return (
 		<SortSelect
 			className="wc-block-product-sort-select wc-block-components-product-sort-select"
-			defaultValue={ defaultValue }
 			name="orderby"
 			onChange={ onChange }
 			options={ [
@@ -66,14 +65,6 @@ const ProductSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 };
 
 ProductSortSelect.propTypes = {
-	defaultValue: PropTypes.oneOf( [
-		'menu_order',
-		'popularity',
-		'rating',
-		'date',
-		'price',
-		'price-desc',
-	] ),
 	onChange: PropTypes.func,
 	readOnly: PropTypes.bool,
 	value: PropTypes.oneOf( [

--- a/assets/js/base/components/reviews/review-sort-select/index.js
+++ b/assets/js/base/components/reviews/review-sort-select/index.js
@@ -10,11 +10,10 @@ import SortSelect from '@woocommerce/base-components/sort-select';
  */
 import './style.scss';
 
-const ReviewSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {
+const ReviewSortSelect = ( { onChange, readOnly, value } ) => {
 	return (
 		<SortSelect
 			className="wc-block-review-sort-select wc-block-components-review-sort-select"
-			defaultValue={ defaultValue }
 			label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
 			onChange={ onChange }
 			options={ [
@@ -48,11 +47,6 @@ const ReviewSortSelect = ( { defaultValue, onChange, readOnly, value } ) => {
 };
 
 ReviewSortSelect.propTypes = {
-	defaultValue: PropTypes.oneOf( [
-		'most-recent',
-		'highest-rating',
-		'lowest-rating',
-	] ),
 	onChange: PropTypes.func,
 	readOnly: PropTypes.bool,
 	value: PropTypes.oneOf( [

--- a/assets/js/base/components/sort-select/index.js
+++ b/assets/js/base/components/sort-select/index.js
@@ -18,7 +18,6 @@ import './style.scss';
  * @param {Object} props Incoming props for the component.
  * @param {string} props.className CSS class used.
  * @param {string} props.instanceId Unique id for component instance.
- * @param {string} props.defaultValue Default value for the select.
  * @param {string} props.label Label for the select.
  * @param {function():any} props.onChange Function to call on the change event.
  * @param {Array} props.options Option values for the select.
@@ -29,7 +28,6 @@ import './style.scss';
 const SortSelect = ( {
 	className,
 	instanceId,
-	defaultValue,
 	label,
 	onChange,
 	options,
@@ -60,7 +58,6 @@ const SortSelect = ( {
 			<select // eslint-disable-line jsx-a11y/no-onchange
 				id={ selectId }
 				className="wc-block-sort-select__select wc-block-components-sort-select__select"
-				defaultValue={ defaultValue }
 				onChange={ onChange }
 				readOnly={ readOnly }
 				value={ value }
@@ -76,7 +73,6 @@ const SortSelect = ( {
 };
 
 SortSelect.propTypes = {
-	defaultValue: PropTypes.string,
 	label: PropTypes.string,
 	onChange: PropTypes.func,
 	options: PropTypes.arrayOf(

--- a/assets/js/blocks/reviews/frontend-block.js
+++ b/assets/js/blocks/reviews/frontend-block.js
@@ -19,6 +19,7 @@ import withReviews from '@woocommerce/base-hocs/with-reviews';
  * @param {function(any):any} props.onAppendReviews Function called when appending review.
  * @param {function(any):any} props.onChangeOrderby
  * @param {Array} props.reviews
+ * @param {string} props.sortSelectValue
  * @param {number} props.totalReviews
  */
 const FrontendBlock = ( {
@@ -26,10 +27,9 @@ const FrontendBlock = ( {
 	onAppendReviews,
 	onChangeOrderby,
 	reviews,
+	sortSelectValue,
 	totalReviews,
 } ) => {
-	const { orderby } = attributes;
-
 	if ( reviews.length === 0 ) {
 		return null;
 	}
@@ -40,7 +40,7 @@ const FrontendBlock = ( {
 		<>
 			{ attributes.showOrderby !== 'false' && reviewRatingsEnabled && (
 				<ReviewSortSelect
-					defaultValue={ orderby }
+					value={ sortSelectValue }
 					onChange={ onChangeOrderby }
 				/>
 			) }

--- a/assets/js/blocks/reviews/frontend-container-block.js
+++ b/assets/js/blocks/reviews/frontend-container-block.js
@@ -95,6 +95,7 @@ class FrontendContainerBlock extends Component {
 				orderby={ orderby }
 				productId={ productId }
 				reviewsToDisplay={ reviewsToDisplay }
+				sortSelectValue={ this.state.orderby }
 			/>
 		);
 	}


### PR DESCRIPTION
Now that #4463 is closed, I wanted to extract the changes from one commit which I think is a nice clean up: making the `ReviewSortSelect` component controlled, so it doesn't have a `defaultValue` and a `value` props, which is always confusing. I also took the chance to remove the `defaultValue` prop from `SortSelect` and `ProductSortSelect` given that they were never used.

### How to test the changes in this Pull Request:

#### Reviews blocks
1. Make sure you have at least a couple of reviews in your store.
2. Create a post or page with the All Reviews, Reviews by Product and Reviews by Category blocks.
3. In the editor, make sure you can change the `Order Product Reviews by` value under `List Settings` and blocks are updated accordingly.
4. In the frontend, make sure you can change the order reviews are displayed in.

#### All Products block
1. Create a post or page with the All Products block.
3. In the editor, make sure you can change the `Order Products By` value under `Content Settings` and the block is updated accordingly.
4. In the frontend, make sure you can change the order products are displayed in.