### PR TITLE
Remove top rule so validation messages are positioned correctly below

### DIFF
--- a/assets/js/base/context/providers/validation/components/validation-input-error/style.scss
+++ b/assets/js/base/context/providers/validation/components/validation-input-error/style.scss
@@ -3,7 +3,6 @@
 	color: $alert-red;
 	max-width: 100%;
 	position: absolute;
-	top: calc(100% - 1px);
 	white-space: normal;
 
 	> p {


### PR DESCRIPTION
At some point validation message styling was broken causing it to overlap the fields below. This could be due to a style change in the parent. Removing the `calc` rule fixes it.

### Screenshots

![Screenshot 2021-08-16 at 13 14 25](https://user-images.githubusercontent.com/90977/129562137-ab877114-a2cf-408a-a74a-76ec57079f7c.png)

### How to test the changes in this Pull Request:

1. Cause a validation error on checkout
2. Confirm the error notice is shown below the field
