### PR TITLE
Add label for Block Title component to satisfy accessibility

### DIFF
--- a/assets/js/editor-components/block-title/index.js
+++ b/assets/js/editor-components/block-title/index.js
@@ -4,17 +4,29 @@
 import PropTypes from 'prop-types';
 import { PlainText } from '@wordpress/block-editor';
 import classnames from 'classnames';
+import { withInstanceId } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
 
-const BlockTitle = ( { className, headingLevel, onChange, heading } ) => {
+const BlockTitle = ( {
+	className,
+	headingLevel,
+	onChange,
+	heading,
+	instanceId,
+} ) => {
 	const TagName = `h${ headingLevel }`;
 	return (
 		<TagName>
+			<label className="screen-reader-text" htmlFor={ `block-title-${ instanceId }` }>
+				{ __( 'Block title', 'woo-gutenberg-products-block' ) }
+			</label>
 			<PlainText
+				id={ `block-title-${ instanceId }` }
 				className={ classnames(
 					'wc-block-editor-components-title',
 					className
@@ -45,4 +57,4 @@ BlockTitle.propTypes = {
 	headingLevel: PropTypes.number,
 };
 
-export default BlockTitle;
+export default withInstanceId( BlockTitle );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1680

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. In a new page add Filter Products By Attribute (and Price) block
2. Choose an attribute and then click "Done"
3. Inspect the blocks title within the editor
4. Observe `<label />` element which has `for` attribute value which corresponds to the `<textarea />` `id` value

<!-- If you can, add the appropriate labels -->

### Changelog

> Add label element to `<BlockTitle>` component
