### PR TITLE
Replace new lines with empty strings when outputting category list

### DIFF
--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -305,7 +305,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
 					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
-					(' . $this->getCount( $category, $attributes ) . ')
+					' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
 				</li>
 			';

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -307,7 +307,7 @@ class ProductCategories extends AbstractDynamicBlock {
 					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">
 						' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '
 					</a>
-					' . $this->getCount( $category, $attributes ) . '
+					(' . $this->getCount( $category, $attributes ) . ')
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
 				</li>
 			';

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -304,9 +304,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
-					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">
-						' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '
-					</a>
+					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
 					(' . $this->getCount( $category, $attributes ) . ')
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
 				</li>

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -313,7 +313,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			';
 		}
 
-		return $output;
+		return preg_replace( '/\r|\n/', '', $output );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will replace new lines in the Product Category List block with empty strings before rendering it.

This is because the code is written in such a way that newlines end up in the string, these eventually end up parsing into `<br>` elements.

If the new lines are removed, no `<br>` elements are added.

This PR also moves the text within the `<a>`  onto the same line, to remove excess spaces from the string.

Finally, the product count is also enclosed in parentheses, so it matches the preview in the block editor.

<!-- Reference any related issues or PRs here -->
Fixes #4577

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/129597106-6162e3f7-d12a-4dd1-8e84-a81a69a05195.png) | ![image](https://user-images.githubusercontent.com/5656702/129597035-eb6b2f63-219e-4a49-9d77-344d369c9115.png) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:

1. Add the `Product Category List` block to a page.
2. Go to WooCommerce > Settings > Products and set the Shop Page to be the page above.
2. Visit the page and ensure the list is rendered correctly with no excess linebreaks.

<!-- If you can, add the appropriate labels -->

### Changelog

> Prevent Product Category List from displaying incorrectly when used on the shop page.
