### PR TITLE
Add padding in 2020 and 2021

### DIFF
--- a/assets/js/base/context/providers/store-notices/components/style.scss
+++ b/assets/js/base/context/providers/store-notices/components/style.scss
@@ -22,3 +22,10 @@
 		margin-top: 1em;
 	}
 }
+
+.theme-twentytwentyone,
+.theme-twentytwenty {
+	.wc-block-components-notices__notice {
+		padding: 1.5rem 3rem;
+	}
+}

--- a/assets/js/base/context/providers/store-notices/components/style.scss
+++ b/assets/js/base/context/providers/store-notices/components/style.scss
@@ -23,6 +23,7 @@
 	}
 }
 
+// @todo Either move notice style fixes to Woo core, or take full control over notice component styling in blocks.
 .theme-twentytwentyone,
 .theme-twentytwenty {
 	.wc-block-components-notices__notice {


### PR DESCRIPTION
Fixes a styling regression affecting 2021 and 2020 themes caused by https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4568

These themes do not style the `woocommerce-error` container, they style an inner `li` element. We don't use lists. To fix this, we can apply the padding in the component.

We should likely take full control over notice styling in the future and deprecate core classes.

### Screenshots

Before:
![Screenshot 2021-08-17 at 11 31 23](https://user-images.githubusercontent.com/90977/129711191-6a5452a5-cda1-43ff-a23c-99b790ad98ae.png)

After:
![Screenshot 2021-08-17 at 11 27 32](https://user-images.githubusercontent.com/90977/129711197-5788529a-87b2-4a21-b910-27da92a848b0.png)

### How to test the changes in this Pull Request:

Using 2021 and 2020 themes:

1. Go to checkout
2. Enter invalid postcode and submit order
3. Check error notice styling
