### PR TITLE
Define parent in registerCheckoutBlock

### DIFF
--- a/packages/checkout/blocks-registry/index.ts
+++ b/packages/checkout/blocks-registry/index.ts
@@ -175,18 +175,28 @@ export const registerCheckoutBlock = (
 	assertOption( options, 'areas', 'array' );
 	assertBlockComponent( options, 'component' );
 
+	/**
+	 * If provided with a configuration object, this registers the block with WordPress.
+	 */
 	if ( options?.configuration ) {
 		assertOption( options, 'configuration', 'object' );
 		registerExperimentalBlockType( blockName, {
 			...options.configuration,
 			category: 'woocommerce',
+			parent: [],
 		} );
 	}
 
+	/**
+	 * This enables the inner block within specific areas. See RegisteredBlocks.
+	 */
 	options.areas.forEach( ( area ) =>
 		registerBlockForArea( area, blockName )
 	);
 
+	/**
+	 * This ensures the frontend component for the checkout block is available.
+	 */
 	registerBlockComponent( {
 		blockName,
 		component: options.component,


### PR DESCRIPTION
Update `registerCheckoutBlock` to include an empty `parent` property. This ensures a block registered via `registerCheckoutBlock` is only available in defined areas, not globally.

Fixes #4492

### How to test the changes in this Pull Request:

1. Dev build only (`npm start`).
2. "sample block" should not be available in the block inspector at top level.
3. Insert checkout i2.
4. "sample block" should be available in the contact information section as an inner block.
