### PR TITLE
Create a NoExpressPaymentMethodsPlaceholder component

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/edit.tsx
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder, Button } from 'wordpress-components';
+import { useExpressPaymentMethods } from '@woocommerce/base-context/hooks';
+import { Icon, card } from '@woocommerce/icons';
+import { ADMIN_URL } from '@woocommerce/settings';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -9,6 +15,38 @@ import { useBlockProps } from '@wordpress/block-editor';
 import Block from './block';
 import './editor.scss';
 import { useBlockPropsWithLocking } from '../../hacks';
+
+/**
+ * Renders a placeholder in the editor.
+ */
+const NoExpressPaymentMethodsPlaceholder = () => {
+	return (
+		<Placeholder
+			icon={ <Icon srcElement={ card } /> }
+			label={ __( 'Express Checkout', 'woo-gutenberg-products-block' ) }
+			className="wp-block-woocommerce-checkout-express-payment-block-placeholder"
+		>
+			<span className="wp-block-woocommerce-checkout-express-payment-block-placeholder__description">
+				{ __(
+					"Your store doesn't have any Payment Methods that support the Express Checkout Block. If they are added, they will be shown here.",
+					'woo-gutenberg-products-block'
+				) }
+			</span>
+			<Button
+				isPrimary
+				href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=checkout` }
+				target="_blank"
+				rel="noopener noreferrer"
+				className="wp-block-woocommerce-checkout-express-payment-block-placeholder__button"
+			>
+				{ __(
+					'Configure Payment Methods',
+					'woo-gutenberg-products-block'
+				) }
+			</Button>
+		</Placeholder>
+	);
+};
 
 export const Edit = ( {
 	attributes,
@@ -19,12 +57,27 @@ export const Edit = ( {
 			remove: boolean;
 		};
 	};
-} ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking( { attributes } );
+} ): JSX.Element | null => {
+	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
+	const hasExpressPaymentMethods = Object.keys( paymentMethods ).length > 0;
+	const blockProps = useBlockPropsWithLocking( {
+		className: classnames( {
+			'wp-block-woocommerce-checkout-express-payment-block--has-express-payment-methods': hasExpressPaymentMethods,
+		} ),
+		attributes,
+	} );
+
+	if ( ! isInitialized ) {
+		return null;
+	}
 
 	return (
 		<div { ...blockProps }>
-			<Block />
+			{ hasExpressPaymentMethods ? (
+				<Block />
+			) : (
+				<NoExpressPaymentMethodsPlaceholder />
+			) }
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/editor.scss
@@ -1,11 +1,28 @@
 // Adjust padding and margins in the editor to improve selected block outlines.
 .wp-block-woocommerce-checkout-express-payment-block {
-	margin-top: 14px;
-	margin-bottom: 14px;
-	padding-top: 14px;
-	padding-bottom: 14px;
+	margin: 14px 0 28px;
+
+	.components-placeholder__label svg {
+		font-size: 1em;
+	}
 
 	.wc-block-components-express-payment-continue-rule--checkout {
 		margin-bottom: 0;
+	}
+
+	&.wp-block-woocommerce-checkout-express-payment-block--has-express-payment-methods {
+		padding: 14px 0;
+		margin: 14px 0;
+	}
+}
+
+.wp-block-woocommerce-checkout-express-payment-block-placeholder {
+	* {
+		pointer-events: all; // Overrides parent disabled component in editor context
+	}
+
+	.wp-block-woocommerce-checkout-express-payment-block-placeholder__description {
+		display: block;
+		margin: 0 0 1em;
 	}
 }


### PR DESCRIPTION
Inner Blocks need content otherwise they cannot be interacted with. This PR introduces a placeholder element for express payments if none are present in the editor.

Fixes #4575

### Screenshots

With Stripe enabled:
![Screenshot 2021-08-18 at 12 42 27](https://user-images.githubusercontent.com/90977/129892381-23840d0e-e4b0-4cb7-9022-feb6e7446cd7.png)

Without:
![Screenshot 2021-08-18 at 12 42 15](https://user-images.githubusercontent.com/90977/129892382-9254701a-aa59-4f57-ab79-b7a66bc76df6.png)

### How to test the changes in this Pull Request:

1. Turn off all express payment methods.
2. View checkout i2 in the editor.
3. Confirm placeholder is rendered.
