### PR TITLE
Add Drawer component

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -6,7 +6,8 @@ $fontSizes: (
 	"larger": 2,
 );
 
-// Maps a named font-size to its em equivalent.
+// Maps a named font-size to its predefined size. Units default to em, but can
+// be changed using the multiplier parameter.
 @mixin font-size($sizeName, $multiplier: 1em) {
 	font-size: map-get($fontSizes, $sizeName) * $multiplier;
 }

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -7,8 +7,8 @@ $fontSizes: (
 );
 
 // Maps a named font-size to its em equivalent.
-@mixin font-size($sizeName) {
-	font-size: map-get($fontSizes, $sizeName) * 1em;
+@mixin font-size($sizeName, $multiplier: 1em) {
+	font-size: map-get($fontSizes, $sizeName) * $multiplier;
 }
 
 @keyframes loading-fade {

--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -39,11 +39,16 @@ const Drawer = ( {
 			title={ title }
 			focusOnMount={ true }
 			onRequestClose={ onClose }
-			overlayClassName={ classNames( 'wc-block-components-drawer', {
+			className={ classNames( 'wc-block-components-drawer', {
 				'wc-block-components-drawer--with-slide-in': slideIn,
 				'wc-block-components-drawer--with-slide-out': slideOut,
-				'wc-block-components-drawer--is-hidden': ! isOpen,
 			} ) }
+			overlayClassName={ classNames(
+				'wc-block-components-drawer__screen-overlay',
+				{
+					'wc-block-components-drawer__screen-overlay--is-hidden': ! isOpen,
+				}
+			) }
 		>
 			{ children }
 		</Modal>

--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -39,14 +39,13 @@ const Drawer = ( {
 			title={ title }
 			focusOnMount={ true }
 			onRequestClose={ onClose }
-			className={ classNames( 'wc-block-components-drawer', {
-				'wc-block-components-drawer--with-slide-in': slideIn,
-				'wc-block-components-drawer--with-slide-out': slideOut,
-			} ) }
+			className="wc-block-components-drawer"
 			overlayClassName={ classNames(
 				'wc-block-components-drawer__screen-overlay',
 				{
 					'wc-block-components-drawer__screen-overlay--is-hidden': ! isOpen,
+					'wc-block-components-drawer__screen-overlay--with-slide-in': slideIn,
+					'wc-block-components-drawer__screen-overlay--with-slide-out': slideOut,
 				}
 			) }
 		>

--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { useDebounce } from 'use-debounce';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+interface DrawerProps {
+	children: JSX.Element;
+	isOpen: boolean;
+	onClose: () => void;
+	slideIn?: boolean;
+	slideOut?: boolean;
+	title: string;
+}
+
+const Drawer = ( {
+	children,
+	isOpen,
+	onClose,
+	slideIn = true,
+	slideOut = true,
+	title,
+}: DrawerProps ): JSX.Element | null => {
+	const [ debouncedIsOpen ] = useDebounce< boolean >( isOpen, 300 );
+	const isClosing = ! isOpen && debouncedIsOpen;
+
+	if ( ! isOpen && ! isClosing ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			title={ title }
+			focusOnMount={ true }
+			onRequestClose={ onClose }
+			overlayClassName={ classNames( 'wc-block-components-drawer', {
+				'wc-block-components-drawer--with-slide-in': slideIn,
+				'wc-block-components-drawer--with-slide-out': slideOut,
+				'wc-block-components-drawer--is-hidden': ! isOpen,
+			} ) }
+		>
+			{ children }
+		</Modal>
+	);
+};
+
+export default Drawer;

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -1,5 +1,21 @@
 $drawer-width: 480px;
 
+.wc-block-components-drawer__screen-overlay {
+	background-color: rgba(0, 0, 0, 0.15);
+	bottom: 0;
+	left: 0;
+	position: fixed;
+	right: 0;
+	top: 0;
+	transition: all 0.3s;
+	z-index: 999;
+}
+
+.wc-block-components-drawer__screen-overlay--is-hidden {
+	background: rgba(0, 0, 0, 0);
+	pointer-events: none;
+}
+
 .wc-block-components-drawer {
 	@include with-translucent-border(0 0 0 1px);
 	background: #fff;
@@ -12,7 +28,6 @@ $drawer-width: 480px;
 	top: 0;
 	transform: translateX(-$drawer-width);
 	width: $drawer-width;
-	z-index: 999;
 }
 
 .wc-block-components-drawer--with-slide-out {
@@ -61,7 +76,7 @@ $drawer-width: 480px;
 	}
 }
 
-.wc-block-components-drawer--is-hidden {
+.wc-block-components-drawer__screen-overlay--is-hidden .wc-block-components-drawer {
 	transform: translateX(0);
 }
 

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -107,6 +107,7 @@ $drawer-width: 480px;
 // Same styles as `Title` component.
 .wc-block-components-drawer .components-modal__header-heading {
 	@include reset-box();
-	@include font-size(large);
+	// We need the font size to be in rem so it doesn't change depending on the parent element.
+	@include font-size(large, 1rem);
 	word-break: break-word;
 }

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -1,0 +1,97 @@
+$drawer-width: 480px;
+
+.wc-block-components-drawer {
+	@include with-translucent-border(0 0 0 1px);
+	background: #fff;
+	display: block;
+	height: 100%;
+	left: 100%;
+	overflow: auto;
+	position: fixed;
+	right: 0;
+	top: 0;
+	transform: translateX(-$drawer-width);
+	width: $drawer-width;
+	z-index: 999;
+}
+
+.wc-block-components-drawer--with-slide-out {
+	transition: all 0.3s;
+}
+
+.wc-block-components-drawer--with-slide-in {
+	animation-duration: 0.3s;
+	animation-name: slidein;
+}
+
+@keyframes slidein {
+	from {
+		transform: translateX(0);
+	}
+
+	to {
+		transform: translateX(-$drawer-width);
+	}
+}
+
+@media only screen and (max-width: 480px) {
+	.wc-block-components-drawer {
+		transform: translateX(-100vw);
+		width: 100vw;
+	}
+
+	@keyframes slidein {
+		from {
+			transform: translateX(0);
+		}
+
+		to {
+			transform: translateX(-100vw);
+		}
+	}
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+	.wc-block-components-drawer--with-slide-out {
+		transition: none;
+	}
+
+	.wc-block-components-drawer--with-slide-in {
+		animation-name: none;
+	}
+}
+
+.wc-block-components-drawer--is-hidden {
+	transform: translateX(0);
+}
+
+.wc-block-components-drawer .components-modal__content {
+	padding: $gap-largest $gap;
+}
+
+.wc-block-components-drawer .components-modal__header {
+	position: relative;
+
+	// Close button.
+	.components-button {
+		@include reset-box();
+		background: transparent;
+		position: absolute;
+		right: 0;
+		top: 0;
+		// Increase clickable area.
+		padding: 1em;
+		margin: -1em;
+
+		> span {
+			@include visually-hidden();
+		}
+	}
+}
+
+// Same styles as `Title` component.
+.wc-block-components-drawer .components-modal__header-heading {
+	@include reset-box();
+	@include font-size(large);
+	word-break: break-word;
+}

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -34,6 +34,9 @@ $drawer-width: 480px;
 	transition: all 0.3s;
 }
 
+// We can't use transition for the slide-in animation because the element
+// doesn't exist in the DOM when not open. Instead, use an animation that
+// is triggered when the element is appended to the DOM.
 .wc-block-components-drawer--with-slide-in {
 	animation-duration: 0.3s;
 	animation-name: slidein;

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -1,4 +1,38 @@
+$drawer-animation-duration: 0.3s;
 $drawer-width: 480px;
+$drawer-width-mobile: 100vw;
+
+@keyframes fadein {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+@keyframes slidein {
+	from {
+		transform: translateX(0);
+	}
+
+	to {
+		transform: translateX(-$drawer-width);
+	}
+}
+
+@media only screen and (max-width: 480px) {
+	@keyframes slidein {
+		from {
+			transform: translateX(0);
+		}
+
+		to {
+			transform: translateX(-$drawer-width-mobile);
+		}
+	}
+}
 
 .wc-block-components-drawer__screen-overlay {
 	background-color: rgba(95, 95, 95, 0.35);
@@ -7,13 +41,26 @@ $drawer-width: 480px;
 	position: fixed;
 	right: 0;
 	top: 0;
-	transition: all 0.3s;
+	transition: opacity $drawer-animation-duration;
 	z-index: 999;
+	opacity: 1;
+}
+
+.wc-block-components-drawer__screen-overlay--with-slide-out {
+	transition: opacity $drawer-animation-duration;
+}
+
+// We can't use transition for the slide-in animation because the element
+// doesn't exist in the DOM when not open. Instead, use an animation that
+// is triggered when the element is appended to the DOM.
+.wc-block-components-drawer__screen-overlay--with-slide-in {
+	animation-duration: $drawer-animation-duration;
+	animation-name: fadein;
 }
 
 .wc-block-components-drawer__screen-overlay--is-hidden {
-	background: rgba(95, 95, 95, 0);
 	pointer-events: none;
+	opacity: 0;
 }
 
 .wc-block-components-drawer {
@@ -28,59 +75,35 @@ $drawer-width: 480px;
 	top: 0;
 	transform: translateX(-$drawer-width);
 	width: $drawer-width;
+
+	@media only screen and (max-width: 480px) {
+		transform: translateX(-$drawer-width-mobile);
+		width: $drawer-width-mobile;
+	}
 }
 
-.wc-block-components-drawer--with-slide-out {
-	transition: all 0.3s;
+.wc-block-components-drawer__screen-overlay--with-slide-out .wc-block-components-drawer {
+	transition: transform $drawer-animation-duration;
 }
 
-// We can't use transition for the slide-in animation because the element
-// doesn't exist in the DOM when not open. Instead, use an animation that
-// is triggered when the element is appended to the DOM.
-.wc-block-components-drawer--with-slide-in {
-	animation-duration: 0.3s;
+.wc-block-components-drawer__screen-overlay--with-slide-in .wc-block-components-drawer {
+	animation-duration: $drawer-animation-duration;
 	animation-name: slidein;
-}
-
-@keyframes slidein {
-	from {
-		transform: translateX(0);
-	}
-
-	to {
-		transform: translateX(-$drawer-width);
-	}
-}
-
-@media only screen and (max-width: 480px) {
-	.wc-block-components-drawer {
-		transform: translateX(-100vw);
-		width: 100vw;
-	}
-
-	@keyframes slidein {
-		from {
-			transform: translateX(0);
-		}
-
-		to {
-			transform: translateX(-100vw);
-		}
-	}
-}
-
-@media screen and (prefers-reduced-motion: reduce) {
-	.wc-block-components-drawer--with-slide-out {
-		transition: none;
-	}
-
-	.wc-block-components-drawer--with-slide-in {
-		animation-name: none;
-	}
 }
 
 .wc-block-components-drawer__screen-overlay--is-hidden .wc-block-components-drawer {
 	transform: translateX(0);
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+	.wc-block-components-drawer__screen-overlay {
+		animation-name: none !important;
+		transition: none !important;
+	}
+	.wc-block-components-drawer {
+		animation-name: none !important;
+		transition: none !important;
+	}
 }
 
 .wc-block-components-drawer .components-modal__content {

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -1,7 +1,7 @@
 $drawer-width: 480px;
 
 .wc-block-components-drawer__screen-overlay {
-	background-color: rgba(0, 0, 0, 0.15);
+	background-color: rgba(95, 95, 95, 0.35);
 	bottom: 0;
 	left: 0;
 	position: fixed;
@@ -12,7 +12,7 @@ $drawer-width: 480px;
 }
 
 .wc-block-components-drawer__screen-overlay--is-hidden {
-	background: rgba(0, 0, 0, 0);
+	background: rgba(95, 95, 95, 0);
 	pointer-events: none;
 }
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -87,7 +87,7 @@ table.wc-block-cart-items {
 
 // Loading placeholder state.
 .wc-block-cart--is-loading,
-.wc-block-mini-cart-items--is-loading {
+.wc-block-mini-cart--is-loading {
 	th span,
 	h2 span {
 		@include placeholder();

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -87,7 +87,7 @@ table.wc-block-cart-items {
 
 // Loading placeholder state.
 .wc-block-cart--is-loading,
-.wc-block-mini-cart--is-loading {
+.wc-block-mini-cart.is-loading {
 	th span,
 	h2 span {
 		@include placeholder();

--- a/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
@@ -123,13 +123,6 @@ const renderMiniCartFrontend = () => {
 			innerButton.focus();
 		}
 	}
-
-	// Remove is-loading class.
-	document
-		.querySelectorAll( '.wc-block-mini-cart' )
-		.forEach( ( miniCartEl ) => {
-			miniCartEl.classList.remove( 'wc-block-mini-cart--is-loading' );
-		} );
 };
 
 renderMiniCartFrontend();

--- a/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
@@ -85,16 +85,51 @@ const MiniCartBlock = ( { isPlaceholderOpen = false } ): JSX.Element => {
 	);
 };
 
-const getProps = ( el: HTMLElement ) => ( {
-	isPlaceholderOpen: el.dataset.isPlaceholderOpen,
-} );
+const renderMiniCartFrontend = () => {
+	// Check if button is focused. In that case, we want to refocus it after we
+	// replace it with the React equivalent.
+	let focusedMiniCartBlock: HTMLElement | null = null;
+	/* eslint-disable @wordpress/no-global-active-element */
+	if (
+		document.activeElement &&
+		document.activeElement.classList.contains(
+			'wc-block-mini-cart__button'
+		) &&
+		document.activeElement.parentNode instanceof HTMLElement
+	) {
+		focusedMiniCartBlock = document.activeElement.parentNode;
+	}
+	/* eslint-enable @wordpress/no-global-active-element */
 
-renderFrontend( {
-	selector: '.wc-block-mini-cart',
-	Block: withStoreCartApiHydration( withRestApiHydration( MiniCartBlock ) ),
-	getProps,
-} );
+	renderFrontend( {
+		selector: '.wc-block-mini-cart',
+		Block: withStoreCartApiHydration(
+			withRestApiHydration( MiniCartBlock )
+		),
+		getProps: ( el: HTMLElement ) => ( {
+			isPlaceholderOpen: el.dataset.isPlaceholderOpen,
+		} ),
+	} );
 
-document.querySelectorAll( '.wc-block-mini-cart' ).forEach( ( miniCartEl ) => {
-	miniCartEl.classList.remove( 'wc-block-mini-cart--is-loading' );
-} );
+	// Refocus previously focused button if drawer is not open.
+	if (
+		focusedMiniCartBlock instanceof HTMLElement &&
+		! focusedMiniCartBlock.dataset.isPlaceholderOpen
+	) {
+		const innerButton = focusedMiniCartBlock.querySelector(
+			'.wc-block-mini-cart__button'
+		);
+		if ( innerButton instanceof HTMLElement ) {
+			innerButton.focus();
+		}
+	}
+
+	// Remove is-loading class.
+	document
+		.querySelectorAll( '.wc-block-mini-cart' )
+		.forEach( ( miniCartEl ) => {
+			miniCartEl.classList.remove( 'wc-block-mini-cart--is-loading' );
+		} );
+};
+
+renderMiniCartFrontend();

--- a/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
@@ -17,15 +17,17 @@ import {
 import CartLineItemsTable from '../cart/full-cart/cart-line-items-table';
 import './style.scss';
 
-const MiniCartBlock = () => {
+interface MiniCartBlock {
+	isPlaceholderOpen?: boolean;
+}
+
+const MiniCartBlock = ( { isPlaceholderOpen = false } ): JSX.Element => {
 	const { cartItems, cartItemsCount, cartIsLoading } = useStoreCart();
-	const [ isOpen, setIsOpen ] = useState< boolean >(
-		window.wcBlocksMiniCartDrawerOpen
-	);
+	const [ isOpen, setIsOpen ] = useState< boolean >( isPlaceholderOpen );
 	// We already rendered the HTML drawer placeholder, so we want to skip the
 	// slide in animation.
 	const [ skipSlideIn, setSkipSlideIn ] = useState< boolean >(
-		window.wcBlocksMiniCartDrawerOpen
+		isPlaceholderOpen
 	);
 
 	const contents =
@@ -83,9 +85,14 @@ const MiniCartBlock = () => {
 	);
 };
 
+const getProps = ( el: HTMLElement ) => ( {
+	isPlaceholderOpen: el.dataset.isPlaceholderOpen,
+} );
+
 renderFrontend( {
 	selector: '.wc-block-mini-cart',
 	Block: withStoreCartApiHydration( withRestApiHydration( MiniCartBlock ) ),
+	getProps,
 } );
 
 document.querySelectorAll( '.wc-block-mini-cart' ).forEach( ( miniCartEl ) => {

--- a/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
@@ -47,8 +47,10 @@ const MiniCartBlock = ( { isPlaceholderOpen = false } ): JSX.Element => {
 			<button
 				className="wc-block-mini-cart__button"
 				onClick={ () => {
-					setIsOpen( true );
-					setSkipSlideIn( false );
+					if ( ! isOpen ) {
+						setIsOpen( true );
+						setSkipSlideIn( false );
+					}
 				} }
 			>
 				{ sprintf(

--- a/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
@@ -1,9 +1,11 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import { renderFrontend } from '@woocommerce/base-utils';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
+import Drawer from '@woocommerce/base-components/drawer';
 import {
 	withStoreCartApiHydration,
 	withRestApiHydration,
@@ -13,25 +15,79 @@ import {
  * Internal dependencies
  */
 import CartLineItemsTable from '../cart/full-cart/cart-line-items-table';
+import './style.scss';
 
-const MiniCartContents = () => {
-	const { cartItems, cartIsLoading } = useStoreCart();
+const MiniCartBlock = () => {
+	const { cartItems, cartItemsCount, cartIsLoading } = useStoreCart();
+	const [ isOpen, setIsOpen ] = useState< boolean >(
+		window.wcBlocksMiniCartDrawerOpen
+	);
+	// We already rendered the HTML drawer placeholder, so we want to skip the
+	// slide in animation.
+	const [ skipSlideIn, setSkipSlideIn ] = useState< boolean >(
+		window.wcBlocksMiniCartDrawerOpen
+	);
 
-	if ( cartItems.length === 0 ) {
-		return <>{ __( 'Cart is empty', 'woo-gutenberg-products-block' ) }</>;
-	}
+	const contents =
+		cartItems.length === 0 ? (
+			<>{ __( 'Cart is empty', 'woo-gutenberg-products-block' ) }</>
+		) : (
+			<div className="is-mobile">
+				<CartLineItemsTable
+					lineItems={ cartItems }
+					isLoading={ cartIsLoading }
+				/>
+			</div>
+		);
 
 	return (
-		<CartLineItemsTable
-			lineItems={ cartItems }
-			isLoading={ cartIsLoading }
-		/>
+		<>
+			<button
+				className="wc-block-mini-cart__button"
+				onClick={ () => {
+					setIsOpen( true );
+					setSkipSlideIn( false );
+				} }
+			>
+				{ sprintf(
+					/* translators: %d is the count of items in the cart. */
+					_n(
+						'%d item',
+						'%d items',
+						cartItemsCount,
+						'woo-gutenberg-products-block'
+					),
+					cartItemsCount
+				) }
+			</button>
+			<Drawer
+				title={ sprintf(
+					/* translators: %d is the count of items in the cart. */
+					_n(
+						'Your cart (%d item)',
+						'Your cart (%d items)',
+						cartItemsCount,
+						'woo-gutenberg-products-block'
+					),
+					cartItemsCount
+				) }
+				isOpen={ isOpen }
+				onClose={ () => {
+					setIsOpen( false );
+				} }
+				slideIn={ ! skipSlideIn }
+			>
+				{ contents }
+			</Drawer>
+		</>
 	);
 };
 
 renderFrontend( {
-	selector: '.wc-block-mini-cart__contents',
-	Block: withStoreCartApiHydration(
-		withRestApiHydration( MiniCartContents )
-	),
+	selector: '.wc-block-mini-cart',
+	Block: withStoreCartApiHydration( withRestApiHydration( MiniCartBlock ) ),
+} );
+
+document.querySelectorAll( '.wc-block-mini-cart' ).forEach( ( miniCartEl ) => {
+	miniCartEl.classList.remove( 'wc-block-mini-cart--is-loading' );
 } );

--- a/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
@@ -56,23 +56,16 @@ window.onload = () => {
 		const miniCartDrawerPlaceholderOverlay = miniCartBlock.querySelector(
 			'.wc-block-components-drawer__screen-overlay'
 		);
-		const miniCartDrawerPlaceholder = miniCartBlock.querySelector(
-			'.wc-block-components-drawer'
-		);
 
-		if (
-			! miniCartButton ||
-			! miniCartDrawerPlaceholderOverlay ||
-			! miniCartDrawerPlaceholder
-		) {
+		if ( ! miniCartButton || ! miniCartDrawerPlaceholderOverlay ) {
 			// Markup is not correct, abort.
 			return;
 		}
 
 		const showContents = () => {
 			miniCartBlock.dataset.isPlaceholderOpen = 'true';
-			miniCartDrawerPlaceholder.classList.add(
-				'wc-block-components-drawer--with-slide-in'
+			miniCartDrawerPlaceholderOverlay.classList.add(
+				'wc-block-components-drawer__screen-overlay--with-slide-in'
 			);
 			miniCartDrawerPlaceholderOverlay.classList.remove(
 				'wc-block-components-drawer__screen-overlay--is-hidden'

--- a/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
@@ -53,21 +53,21 @@ window.onload = () => {
 		const miniCartButton = miniCartBlock.querySelector(
 			'.wc-block-mini-cart__button'
 		);
-		const miniCartOverlay = miniCartBlock.querySelector(
+		const miniCartDrawerPlaceholder = miniCartBlock.querySelector(
 			'.wc-block-components-drawer'
 		);
 
-		if ( ! miniCartButton || ! miniCartOverlay ) {
+		if ( ! miniCartButton || ! miniCartDrawerPlaceholder ) {
 			// Markup is not correct, abort.
 			return;
 		}
 
 		const showContents = () => {
 			miniCartBlock.dataset.isPlaceholderOpen = 'true';
-			miniCartOverlay.classList.add(
+			miniCartDrawerPlaceholder.classList.add(
 				'wc-block-components-drawer--with-slide-in'
 			);
-			miniCartOverlay.classList.remove(
+			miniCartDrawerPlaceholder.classList.remove(
 				'wc-block-components-drawer--is-hidden'
 			);
 		};

--- a/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
@@ -13,8 +13,6 @@ interface dependencyData {
 	translations?: string;
 }
 
-window.wcBlocksMiniCartDrawerOpen = false;
-
 // eslint-disable-next-line @wordpress/no-global-event-listener
 window.onload = () => {
 	const miniCartBlocks = document.querySelectorAll( '.wc-block-mini-cart' );
@@ -48,6 +46,10 @@ window.onload = () => {
 	};
 
 	miniCartBlocks.forEach( ( miniCartBlock ) => {
+		if ( ! ( miniCartBlock instanceof HTMLElement ) ) {
+			return;
+		}
+
 		const miniCartButton = miniCartBlock.querySelector(
 			'.wc-block-mini-cart__button'
 		);
@@ -60,14 +62,14 @@ window.onload = () => {
 			return;
 		}
 
-		const showContents = async () => {
+		const showContents = () => {
+			miniCartBlock.dataset.isPlaceholderOpen = 'true';
 			miniCartOverlay.classList.add(
 				'wc-block-components-drawer--with-slide-in'
 			);
 			miniCartOverlay.classList.remove(
 				'wc-block-components-drawer--is-hidden'
 			);
-			window.wcBlocksMiniCartDrawerOpen = true;
 		};
 
 		miniCartButton.addEventListener( 'mouseover', loadScripts );

--- a/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
@@ -13,6 +13,8 @@ interface dependencyData {
 	translations?: string;
 }
 
+window.wcBlocksMiniCartDrawerOpen = false;
+
 // eslint-disable-next-line @wordpress/no-global-event-listener
 window.onload = () => {
 	const miniCartBlocks = document.querySelectorAll( '.wc-block-mini-cart' );
@@ -35,41 +37,41 @@ window.onload = () => {
 		} );
 	}
 
+	const loadScripts = async () => {
+		for ( const dependencyHandle in dependencies ) {
+			const dependency = dependencies[ dependencyHandle ];
+			await lazyLoadScript( {
+				handle: dependencyHandle,
+				...dependency,
+			} );
+		}
+	};
+
 	miniCartBlocks.forEach( ( miniCartBlock ) => {
 		const miniCartButton = miniCartBlock.querySelector(
 			'.wc-block-mini-cart__button'
 		);
-		const miniCartContents = miniCartBlock.querySelector(
-			'.wc-block-mini-cart__contents'
+		const miniCartOverlay = miniCartBlock.querySelector(
+			'.wc-block-components-drawer'
 		);
 
-		if ( ! miniCartButton || ! miniCartContents ) {
+		if ( ! miniCartButton || ! miniCartOverlay ) {
 			// Markup is not correct, abort.
 			return;
 		}
 
 		const showContents = async () => {
-			miniCartContents.removeAttribute( 'hidden' );
-
-			// Load scripts
-			for ( const dependencyHandle in dependencies ) {
-				const dependency = dependencies[ dependencyHandle ];
-				await lazyLoadScript( {
-					handle: dependencyHandle,
-					...dependency,
-				} );
-			}
+			miniCartOverlay.classList.add(
+				'wc-block-components-drawer--with-slide-in'
+			);
+			miniCartOverlay.classList.remove(
+				'wc-block-components-drawer--is-hidden'
+			);
+			window.wcBlocksMiniCartDrawerOpen = true;
 		};
-		const hideContents = () =>
-			miniCartContents.setAttribute( 'hidden', 'true' );
 
-		miniCartButton.addEventListener( 'mouseover', showContents );
-		miniCartButton.addEventListener( 'mouseleave', hideContents );
-
-		miniCartContents.addEventListener( 'mouseover', showContents );
-		miniCartContents.addEventListener( 'mouseleave', hideContents );
-
-		miniCartButton.addEventListener( 'focus', showContents );
-		miniCartButton.addEventListener( 'blur', hideContents );
+		miniCartButton.addEventListener( 'mouseover', loadScripts );
+		miniCartButton.addEventListener( 'focus', loadScripts );
+		miniCartButton.addEventListener( 'click', showContents );
 	} );
 };

--- a/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
@@ -53,11 +53,18 @@ window.onload = () => {
 		const miniCartButton = miniCartBlock.querySelector(
 			'.wc-block-mini-cart__button'
 		);
+		const miniCartDrawerPlaceholderOverlay = miniCartBlock.querySelector(
+			'.wc-block-components-drawer__screen-overlay'
+		);
 		const miniCartDrawerPlaceholder = miniCartBlock.querySelector(
 			'.wc-block-components-drawer'
 		);
 
-		if ( ! miniCartButton || ! miniCartDrawerPlaceholder ) {
+		if (
+			! miniCartButton ||
+			! miniCartDrawerPlaceholderOverlay ||
+			! miniCartDrawerPlaceholder
+		) {
 			// Markup is not correct, abort.
 			return;
 		}
@@ -67,8 +74,8 @@ window.onload = () => {
 			miniCartDrawerPlaceholder.classList.add(
 				'wc-block-components-drawer--with-slide-in'
 			);
-			miniCartDrawerPlaceholder.classList.remove(
-				'wc-block-components-drawer--is-hidden'
+			miniCartDrawerPlaceholderOverlay.classList.remove(
+				'wc-block-components-drawer__screen-overlay--is-hidden'
 			);
 		};
 

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -1,0 +1,3 @@
+.modal-open .wc-block-mini-cart__button {
+	pointer-events: none;
+}

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -208,14 +208,16 @@ class MiniCart extends AbstractBlock {
 
 		return '<div class="wc-block-mini-cart wc-block-mini-cart--is-loading">
 			<button class="wc-block-mini-cart__button">' . $button_text . '</button>
-			<div class="wc-block-components-drawer wc-block-components-drawer--is-hidden" aria-hidden="true">
-				<div class="components-modal__content">
-					<div class="components-modal__header">
-						<div class="components-modal__header-heading-container">
-							<h1 id="components-modal-header-1" class="components-modal__header-heading">' . $title . '</h1>
+			<div class="wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
+				<div class="components-modal__frame wc-block-components-drawer">
+					<div class="components-modal__content">
+						<div class="components-modal__header">
+							<div class="components-modal__header-heading-container">
+								<h1 id="components-modal-header-1" class="components-modal__header-heading">' . $title . '</h1>
+							</div>
 						</div>
+						' . $this->get_cart_contents_markup( $cart_contents ) . '
 					</div>
-					' . $this->get_cart_contents_markup( $cart_contents ) . '
 				</div>
 			</div>
 		</div>';

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -185,20 +185,39 @@ class MiniCart extends AbstractBlock {
 		$cart_contents_count = $cart->get_cart_contents_count();
 		$cart_contents       = $cart->get_cart();
 
-		// Force mobile styles.
-		return '<div class="wc-block-mini-cart is-mobile">
-			<button class="wc-block-mini-cart__button">' .
-				sprintf(
-					/* translators: %d is the number of products in the cart. */
-					_n(
-						'%d product',
-						'%d products',
-						$cart_contents_count,
-						'woo-gutenberg-products-block'
-					),
-					$cart_contents_count
-				) . '</button>
-			<div class="wc-block-mini-cart__contents" hidden>' . $this->get_cart_contents_markup( $cart_contents ) . '</div>
+		$button_text = sprintf(
+			/* translators: %d is the number of products in the cart. */
+			_n(
+				'%d item',
+				'%d items',
+				$cart_contents_count,
+				'woo-gutenberg-products-block'
+			),
+			$cart_contents_count
+		);
+		$title = sprintf(
+			/* translators: %d is the count of items in the cart. */
+			_n(
+				'Your cart (%d item)',
+				'Your cart (%d items)',
+				$cart_contents_count,
+				'woo-gutenberg-products-block'
+			),
+			$cart_contents_count
+		);
+
+		return '<div class="wc-block-mini-cart wc-block-mini-cart--is-loading">
+			<button class="wc-block-mini-cart__button">' . $button_text . '</button>
+			<div class="wc-block-components-drawer wc-block-components-drawer--is-hidden" aria-hidden="true">
+				<div class="components-modal__content">
+					<div class="components-modal__header">
+						<div class="components-modal__header-heading-container">
+							<h1 id="components-modal-header-1" class="components-modal__header-heading">' . $title . '</h1>
+						</div>
+					</div>
+					' . $this->get_cart_contents_markup( $cart_contents ) . '
+				</div>
+			</div>
 		</div>';
 	}
 
@@ -210,7 +229,8 @@ class MiniCart extends AbstractBlock {
 	 * @return string The HTML markup.
 	 */
 	protected function get_cart_contents_markup( $cart_contents ) {
-		return '<table class="wc-block-cart-items wc-block-mini-cart-items--is-loading" aria-hidden="true">
+		// Force mobile styles.
+		return '<div class="is-mobile"><table class="wc-block-cart-items">
 			<thead>
 				<tr class="wc-block-cart-items__header">
 					<th class="wc-block-cart-items__header-image"><span /></th>
@@ -219,7 +239,7 @@ class MiniCart extends AbstractBlock {
 				</tr>
 			</thead>
 			<tbody>' . implode( array_map( array( $this, 'get_cart_item_markup' ), $cart_contents ) ) . '</tbody>
-		</table>';
+		</table></div>';
 	}
 
 	/**

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -206,7 +206,7 @@ class MiniCart extends AbstractBlock {
 			$cart_contents_count
 		);
 
-		return '<div class="wc-block-mini-cart wc-block-mini-cart--is-loading">
+		return '<div class="wc-block-mini-cart is-loading">
 			<button class="wc-block-mini-cart__button">' . $button_text . '</button>
 			<div class="wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
 				<div class="components-modal__frame wc-block-components-drawer">


### PR DESCRIPTION
Fixes #4597.
Fixes #4600.

Follow-up of #4510.

This PR introduces a `Drawer` component to be used by the Mini Cart block. Styles are not final yet, but the interaction should be mostly done.

According to the designs, the `<body>` contents should move along the drawer. However, I had some issues adding `transform: translateX()` to the `<body>` element (admin bar appeared displaced, transitions seemed to be clunky...). I think we can leave it for a follow-up or reconsider the designs if we see it gives too many problems.

### Screenshots

https://user-images.githubusercontent.com/3616980/130203163-500d6d14-b347-40f7-a4a4-66f80e66ce2c.mp4

### How to test the changes in this Pull Request:

1. Create a post or page and add a Mini Cart block.
2. Visit that post or page in the frontend and verify the Mini Cart button appears.
3. Click on the Mini Cart button and verify the Drawer slides in from the right side of the screen. Press <kbd>Tab</kbd> several times to ensure the focus is inside the Drawer.
4. Reload the page and try clicking the button quickly (without hovering it for too long) and verify the 'skeleton' appears.
5. Reload the page again and try hovering the button, waiting for a couple of seconds, and then clicking it. Verify the 'skeleton' doesn't show up and instead Mini Cart contents appear directly because they were pre-loaded while the button was hovered.

### Known issues
* #4618: leaving it for a follow-up because it might require debugging some Gutenberg components/hooks.