### PR TITLE
Rename productLink to showProductLink

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/attributes.js
+++ b/assets/js/atomic/blocks/product-elements/image/attributes.js
@@ -1,5 +1,5 @@
 export const blockAttributes = {
-	productLink: {
+	showProductLink: {
 		type: 'boolean',
 		default: true,
 	},

--- a/assets/js/atomic/blocks/product-elements/image/block.js
+++ b/assets/js/atomic/blocks/product-elements/image/block.js
@@ -25,7 +25,7 @@ import './style.scss';
  * @param {Object} props                  Incoming props.
  * @param {string} [props.className]      CSS Class name for the component.
  * @param {string} [props.imageSizing]    Size of image to use.
- * @param {boolean} [props.productLink]   Whether or not to display a link to the product page.
+ * @param {boolean} [props.showProductLink]   Whether or not to display a link to the product page.
  * @param {boolean} [props.showSaleBadge] Whether or not to display the on sale badge.
  * @param {string} [props.saleBadgeAlign] How should the sale badge be aligned if displayed.
  * @return {*} The component.
@@ -33,7 +33,7 @@ import './style.scss';
 export const Block = ( {
 	className,
 	imageSizing = 'full-size',
-	productLink: showProductLink = true,
+	showProductLink = true,
 	showSaleBadge,
 	saleBadgeAlign = 'right',
 } ) => {
@@ -136,7 +136,7 @@ const Image = ( { image, onLoad, loaded, showFullSize, fallbackAlt } ) => {
 Block.propTypes = {
 	className: PropTypes.string,
 	fallbackAlt: PropTypes.string,
-	productLink: PropTypes.bool,
+	showProductLink: PropTypes.bool,
 	showSaleBadge: PropTypes.bool,
 	saleBadgeAlign: PropTypes.string,
 };

--- a/assets/js/atomic/blocks/product-elements/image/edit.js
+++ b/assets/js/atomic/blocks/product-elements/image/edit.js
@@ -17,7 +17,7 @@ import { BLOCK_TITLE, BLOCK_ICON } from './constants';
 
 const Edit = ( { attributes, setAttributes } ) => {
 	const {
-		productLink,
+		showProductLink,
 		imageSizing,
 		showSaleBadge,
 		saleBadgeAlign,
@@ -38,10 +38,10 @@ const Edit = ( { attributes, setAttributes } ) => {
 							'Links the image to the single product listing.',
 							'woo-gutenberg-products-block'
 						) }
-						checked={ productLink }
+						checked={ showProductLink }
 						onChange={ () =>
 							setAttributes( {
-								productLink: ! productLink,
+								showProductLink: ! showProductLink,
 							} )
 						}
 					/>

--- a/assets/js/atomic/blocks/product-elements/image/test/block.test.js
+++ b/assets/js/atomic/blocks/product-elements/image/test/block.test.js
@@ -56,7 +56,7 @@ describe( 'Product Image Block', () => {
 		test( 'should render an anchor with the product image', () => {
 			const component = render(
 				<ProductDataContextProvider product={ productWithImages }>
-					<Block productLink />
+					<Block showProductLink />
 				</ProductDataContextProvider>
 			);
 
@@ -80,7 +80,7 @@ describe( 'Product Image Block', () => {
 		test( 'should render an anchor with the placeholder image', () => {
 			const component = render(
 				<ProductDataContextProvider product={ productWithoutImages }>
-					<Block productLink />
+					<Block showProductLink />
 				</ProductDataContextProvider>
 			);
 
@@ -103,7 +103,7 @@ describe( 'Product Image Block', () => {
 		test( 'should render the product image without an anchor wrapper', () => {
 			const component = render(
 				<ProductDataContextProvider product={ productWithImages }>
-					<Block productLink={ false } />
+					<Block showProductLink={ false } />
 				</ProductDataContextProvider>
 			);
 			const image = component.getByTestId( 'product-image' );
@@ -123,7 +123,7 @@ describe( 'Product Image Block', () => {
 		test( 'should render the placeholder image without an anchor wrapper', () => {
 			const component = render(
 				<ProductDataContextProvider product={ productWithoutImages }>
-					<Block productLink={ false } />
+					<Block showProductLink={ false } />
 				</ProductDataContextProvider>
 			);
 

--- a/assets/js/atomic/blocks/product-elements/image/test/block.test.js
+++ b/assets/js/atomic/blocks/product-elements/image/test/block.test.js
@@ -56,7 +56,7 @@ describe( 'Product Image Block', () => {
 		test( 'should render an anchor with the product image', () => {
 			const component = render(
 				<ProductDataContextProvider product={ productWithImages }>
-					<Block showProductLink />
+					<Block showProductLink={ true } />
 				</ProductDataContextProvider>
 			);
 
@@ -80,7 +80,7 @@ describe( 'Product Image Block', () => {
 		test( 'should render an anchor with the placeholder image', () => {
 			const component = render(
 				<ProductDataContextProvider product={ productWithoutImages }>
-					<Block showProductLink />
+					<Block showProductLink={ true } />
 				</ProductDataContextProvider>
 			);
 

--- a/assets/js/atomic/blocks/product-elements/title/attributes.js
+++ b/assets/js/atomic/blocks/product-elements/title/attributes.js
@@ -8,7 +8,7 @@ let blockAttributes = {
 		type: 'number',
 		default: 2,
 	},
-	productLink: {
+	showProductLink: {
 		type: 'boolean',
 		default: true,
 	},

--- a/assets/js/atomic/blocks/product-elements/title/block.js
+++ b/assets/js/atomic/blocks/product-elements/title/block.js
@@ -25,7 +25,7 @@ import './style.scss';
  * @param {Object}  props                  Incoming props.
  * @param {string}  [props.className]      CSS Class name for the component.
  * @param {number}  [props.headingLevel]   Heading level (h1, h2 etc)
- * @param {boolean} [props.productLink]    Whether or not to display a link to the product page.
+ * @param {boolean} [props.showProductLink]    Whether or not to display a link to the product page.
  * @param {string}  [props.align]          Title alignment.
  * @param {string}  [props.color]          Title color name.
  * @param {string}  [props.customColor]    Custom title color value.
@@ -37,7 +37,7 @@ import './style.scss';
 export const Block = ( {
 	className,
 	headingLevel = 2,
-	productLink = true,
+	showProductLink = true,
 	align,
 	color,
 	customColor,
@@ -98,10 +98,10 @@ export const Block = ( {
 				className={ classnames( {
 					[ titleClasses ]: isFeaturePluginBuild(),
 				} ) }
-				disabled={ ! productLink }
+				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ productLink ? 'nofollow' : null }
+				rel={ showProductLink ? 'nofollow' : null }
 				style={ gatedStyledText( {
 					color: customColor,
 					fontSize: customFontSize,
@@ -119,7 +119,7 @@ export const Block = ( {
 Block.propTypes = {
 	className: PropTypes.string,
 	headingLevel: PropTypes.number,
-	productLink: PropTypes.bool,
+	showProductLink: PropTypes.bool,
 	align: PropTypes.string,
 	color: PropTypes.string,
 	customColor: PropTypes.string,

--- a/assets/js/atomic/blocks/product-elements/title/edit.js
+++ b/assets/js/atomic/blocks/product-elements/title/edit.js
@@ -31,7 +31,7 @@ const TitleEdit = ( {
 	attributes,
 	setAttributes,
 } ) => {
-	const { headingLevel, productLink, align } = attributes;
+	const { headingLevel, showProductLink, align } = attributes;
 	return (
 		<>
 			<BlockControls>
@@ -66,10 +66,10 @@ const TitleEdit = ( {
 							'Links the image to the single product listing.',
 							'woo-gutenberg-products-block'
 						) }
-						checked={ productLink }
+						checked={ showProductLink }
 						onChange={ () =>
 							setAttributes( {
-								productLink: ! productLink,
+								showProductLink: ! showProductLink,
 							} )
 						}
 					/>


### PR DESCRIPTION
### Note

The atomic image and title blocks use a prop called `productLink` which has the type `boolean`. To ensure that developers understand that this prop contains a `boolean` instead of a `string`, @ralucaStan suggested renaming the prop `productLink` to `showProductLink`.

Fixes #3756

#### Accessibility

n/a

### Screenshots

n/a

### How to test the changes in this Pull Request:

#### Automated testing

1. Run `npm run test` to ensure that all test cases pass
2. Check out this PR
3. Run `npm run test` again to ensure that all test cases still pass 

#### Manual testing

1. Create a test page
2. Add the `All Products` block
3. Click the pencil icon to edit the block
4. Click on the product image
5. Activate/deactivate the `Link to Product Page` setting in the sidebar
6. Save the changes
7. Look up the test page to ensure that the `Link to Product Page` setting behaves as expected

### Changelog

n/a
