### PR TITLE
Disable Cart, Checkout, All Products & filters blocks from the widgets screen

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -134,7 +134,7 @@ final class BlockTypesController {
 		/**
 		 * This disables specific blocks in Widget Areas by not registering them.
 		 */
-		if ( in_array( $pagenow, [ 'themes.php', 'customize.php' ], true ) ) {
+		if ( in_array( $pagenow, [ 'widgets.php', 'themes.php', 'customize.php' ], true ) ) {
 			$block_types = array_diff(
 				$block_types,
 				[


### PR DESCRIPTION
Fixes #4640.

Regression from #3737. Currently, we are relying on a work-around to prevent some blocks being added to widget areas until a Gutenberg-supported solution is implemented (see https://github.com/WordPress/gutenberg/issues/28517). It works detecting which is the current screen and based on that not registering some blocks.

Adding this PR to the 5.8 milestone and with label `blocker` because I consider this regression to be important enough. I'm on the fence on whether this deserves a point release of WC Blocks 5.7 and WC core 5.7. Thoughts @nerrad @frontdevde?

I also created an issue to add automated testing for this so we can detect if this work-around stops working in the future: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4645.

### How to test the changes in this Pull Request:

With Storefront and WP 5.8:

1. Go to Appearance > Widgets and verify you can't add the Cart, Checkout, All Products & filters blocks.
2. Go to Appearance > Customizer > Widgets and verify you can't add those blocks either.
3. Create a new post or page and verify those blocks can be added without problems.

### Changelog

> Disable Cart, Checkout, All Products & filters blocks from the widgets screen