### PR TITLE
Add missing checkout i2 inner block icons

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, card } from '@woocommerce/icons';
+import { Icon, fields } from '@woocommerce/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 import { createBlock } from '@wordpress/blocks';
 
@@ -16,7 +16,7 @@ import './inner-blocks';
 const settings = {
 	title: __( 'Checkout i2', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ card } />,
+		src: <Icon srcElement={ fields } />,
 		foreground: '#874FB9',
 	},
 	category: 'woocommerce',

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/index.tsx
@@ -15,7 +15,7 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-actions-block', {
 	title: __( 'Actions', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Contains the Place Order button and other actions.',
+		'Allow customers to place their order.',
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon, button } from '@wordpress/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
@@ -14,9 +15,13 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-actions-block', {
 	title: __( 'Actions', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Checkout actions buttons block.',
+		'Contains the Place Order button and other actions.',
 		'woo-gutenberg-products-block'
 	),
+	icon: {
+		src: <Icon icon={ button } />,
+		foreground: '#874FB9',
+	},
 	supports: {
 		align: false,
 		html: false,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/index.tsx
@@ -15,7 +15,7 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-billing-address-block', {
 	title: __( 'Billing Address', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Manage your address requirements.',
+		"Collect your customer's billing address.",
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/index.tsx
@@ -17,7 +17,7 @@ registerFeaturePluginBlockType(
 		title: __( 'Contact Information', 'woo-gutenberg-products-block' ),
 		category: 'woocommerce',
 		description: __(
-			"Get your customer's contact email.",
+			"Collect your customer's contact information.",
 			'woo-gutenberg-products-block'
 		),
 		icon: {

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-fields-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-fields-block/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon, column } from '@wordpress/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
@@ -13,9 +14,13 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-fields-block', {
 	title: __( 'Checkout Fields Block', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Wrapper block for checkout fields',
+		'Column containing checkout address fields.',
 		'woo-gutenberg-products-block'
 	),
+	icon: {
+		src: <Icon icon={ column } />,
+		foreground: '#874FB9',
+	},
 	supports: {
 		align: false,
 		html: false,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/index.tsx
@@ -15,7 +15,7 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-order-summary-block', {
 	title: __( 'Order Summary', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Displays the order summary and totals.',
+		'Show customers a summary of their order.',
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon, totals } from '@woocommerce/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
@@ -17,6 +18,10 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-order-summary-block', {
 		'Displays the order summary and totals.',
 		'woo-gutenberg-products-block'
 	),
+	icon: {
+		src: <Icon srcElement={ totals } />,
+		foreground: '#874FB9',
+	},
 	supports: {
 		align: false,
 		html: false,

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/index.tsx
@@ -15,7 +15,7 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-payment-block', {
 	title: __( 'Payment Options', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Manage your payment options.',
+		'Payment options for your store.',
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/index.tsx
@@ -15,7 +15,7 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-shipping-address-block', {
 	title: __( 'Shipping Address', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Manage your address requirements.',
+		"Collect your customer's shipping address.",
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/index.tsx
@@ -12,7 +12,7 @@ import { Edit, Save } from './edit';
 import attributes from './attributes';
 
 registerFeaturePluginBlockType( 'woocommerce/checkout-shipping-methods-block', {
-	title: __( 'Shipping Methods', 'woo-gutenberg-products-block' ),
+	title: __( 'Shipping Options', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
 		'Shipping options for your store.',

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon, column } from '@wordpress/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
@@ -13,9 +14,13 @@ registerFeaturePluginBlockType( 'woocommerce/checkout-totals-block', {
 	title: __( 'Checkout Totals Block', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	description: __(
-		'Wrapper block for checkout totals',
+		'Column containing the checkout totals.',
 		'woo-gutenberg-products-block'
 	),
+	icon: {
+		src: <Icon icon={ column } />,
+		foreground: '#874FB9',
+	},
 	supports: {
 		align: false,
 		html: false,

--- a/assets/js/icons/index.js
+++ b/assets/js/icons/index.js
@@ -47,6 +47,7 @@ export { default as tag } from './library/tag';
 export { default as tags } from './library/tags';
 export { default as thumbUp } from './library/thumb-up';
 export { default as toggle } from './library/toggle';
+export { default as totals } from './library/totals';
 export { default as truck } from './library/truck';
 export { default as widgets } from './library/widgets';
 export { default as woo } from './library/woo';

--- a/assets/js/icons/index.js
+++ b/assets/js/icons/index.js
@@ -22,6 +22,7 @@ export { default as done } from './library/done';
 export { default as discussion } from './library/discussion';
 export { default as exclamation } from './library/exclamation';
 export { default as external } from './library/external';
+export { default as fields } from './library/fields';
 export { default as folderStarred } from './library/folder-starred';
 export { default as folder } from './library/folder';
 export { default as formStep } from './library/form-step';

--- a/assets/js/icons/library/fields.js
+++ b/assets/js/icons/library/fields.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const fields = (
+	<SVG xmlns="http://www.w3.org/2000/SVG" viewBox="0 0 24 24" fill="none">
+		<path
+			stroke="currentColor"
+			strokeWidth="1.5"
+			fill="none"
+			d="M5 3.75h14c.69 0 1.25.56 1.25 1.25v14c0 .69-.56 1.25-1.25 1.25H5c-.69 0-1.25-.56-1.25-1.25V5c0-.69.56-1.25 1.25-1.25z"
+		/>
+		<path
+			fill="currentColor"
+			fillRule="evenodd"
+			d="M6.4 10.75c0-.47.38-.85.85-.85h9.5c.47 0 .85.38.85.85v1.5c0 .47-.38.85-.85.85h-9.5a.85.85 0 01-.85-.85v-1.5zm1.2.35v.8h8.8v-.8H7.6zM12.4 15.25c0-.47.38-.85.85-.85h3.5c.47 0 .85.38.85.85v1.5c0 .47-.38.85-.85.85h-3.5a.85.85 0 01-.85-.85v-1.5zm1.2.35v.8h2.8v-.8h-2.8zM6.5 15.9a.6.6 0 01.6-.6h2.8a.6.6 0 010 1.2H7.1a.6.6 0 01-.6-.6zM6.5 7.9a.6.6 0 01.6-.6h9.8a.6.6 0 110 1.2H7.1a.6.6 0 01-.6-.6z"
+			clipRule="evenodd"
+		/>
+	</SVG>
+);
+
+export default fields;

--- a/assets/js/icons/library/totals.js
+++ b/assets/js/icons/library/totals.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { SVG } from 'wordpress-components';
+
+const totals = (
+	<SVG xmlns="http://www.w3.org/2000/SVG" viewBox="0 0 24 24" fill="none">
+		<path
+			stroke="currentColor"
+			strokeWidth="1.5"
+			fill="none"
+			d="M6 3.75h12c.69 0 1.25.56 1.25 1.25v14c0 .69-.56 1.25-1.25 1.25H6c-.69 0-1.25-.56-1.25-1.25V5c0-.69.56-1.25 1.25-1.25z"
+		/>
+		<path
+			fill="currentColor"
+			fillRule="evenodd"
+			d="M6.9 7.5A1.1 1.1 0 018 6.4h8a1.1 1.1 0 011.1 1.1v2a1.1 1.1 0 01-1.1 1.1H8a1.1 1.1 0 01-1.1-1.1v-2zm1.2.1v1.8h7.8V7.6H8.1z"
+			clipRule="evenodd"
+		/>
+		<path
+			fill="currentColor"
+			d="M8.5 12h1v1h-1v-1zM8.5 14h1v1h-1v-1zM8.5 16h1v1h-1v-1zM11.5 12h1v1h-1v-1zM11.5 14h1v1h-1v-1zM11.5 16h1v1h-1v-1zM14.5 12h1v1h-1v-1zM14.5 14h1v1h-1v-1zM14.5 16h1v1h-1v-1z"
+		/>
+	</SVG>
+);
+
+export default totals;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6445,6 +6445,32 @@
 						"tannin": "^1.2.0"
 					}
 				},
+				"@wordpress/icons": {
+					"version": "2.10.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+					"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/primitives": "^1.12.3"
+					},
+					"dependencies": {
+						"@wordpress/element": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+							"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
+								"@wordpress/escape-html": "^1.12.2",
+								"lodash": "^4.17.19",
+								"react": "^16.13.1",
+								"react-dom": "^16.13.1"
+							}
+						}
+					}
+				},
 				"@wordpress/is-shallow-equal": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
@@ -6873,6 +6899,32 @@
 						"tannin": "^1.2.0"
 					}
 				},
+				"@wordpress/icons": {
+					"version": "2.10.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+					"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/primitives": "^1.12.3"
+					},
+					"dependencies": {
+						"@wordpress/element": {
+							"version": "2.20.3",
+							"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
+							"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@types/react": "^16.9.0",
+								"@types/react-dom": "^16.9.0",
+								"@wordpress/escape-html": "^1.12.2",
+								"lodash": "^4.17.19",
+								"react": "^16.13.1",
+								"react-dom": "^16.13.1"
+							}
+						}
+					}
+				},
 				"@wordpress/is-shallow-equal": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-2.3.0.tgz",
@@ -6997,6 +7049,18 @@
 						"rememo": "^3.0.0",
 						"tinycolor2": "^1.4.1",
 						"uuid": "^7.0.2"
+					},
+					"dependencies": {
+						"@wordpress/icons": {
+							"version": "2.10.3",
+							"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+							"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@wordpress/element": "^2.20.3",
+								"@wordpress/primitives": "^1.12.3"
+							}
+						}
 					}
 				},
 				"@wordpress/dom": {
@@ -7344,6 +7408,17 @@
 						"tannin": "^1.2.0"
 					}
 				},
+				"@wordpress/icons": {
+					"version": "2.10.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+					"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/primitives": "^1.12.3"
+					}
+				},
 				"@wordpress/is-shallow-equal": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",
@@ -7517,6 +7592,17 @@
 						"memize": "^1.1.0",
 						"sprintf-js": "^1.1.1",
 						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/icons": {
+					"version": "2.10.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+					"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/primitives": "^1.12.3"
 					}
 				},
 				"@wordpress/is-shallow-equal": {
@@ -8430,43 +8516,74 @@
 			}
 		},
 		"@wordpress/icons": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
-			"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.1.tgz",
+			"integrity": "sha512-rejB1UpA0PP5dLWG5JJP6urM7oESph6eLF6KD1UEdANNiwQmTiPZoLzCHaDYQ0k5P69LYz2oZQ2lvASRkXuwzQ==",
 			"requires": {
 				"@babel/runtime": "^7.13.10",
-				"@wordpress/element": "^2.20.3",
-				"@wordpress/primitives": "^1.12.3"
+				"@wordpress/element": "^4.0.0",
+				"@wordpress/primitives": "^3.0.0"
 			},
 			"dependencies": {
-				"@types/react": {
-					"version": "16.14.12",
-					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.12.tgz",
-					"integrity": "sha512-7nOJgNsRbARhZhvwPm7cnzahtzEi5VJ9OvcQk8ExEEb1t+zaFklwLVkJz7G1kfxX4X/mDa/icTmzE0vTmqsqBg==",
-					"requires": {
-						"@types/prop-types": "*",
-						"@types/scheduler": "*",
-						"csstype": "^3.0.2"
-					}
-				},
 				"@wordpress/element": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.20.3.tgz",
-					"integrity": "sha512-f4ZPTDf9CxiiOXiMxc4v1K7jcBMT4dsiehVOpkKzCDKboNXp4qVf8oe5PE23VGZNEjcOj5Mkg9hB57R0nqvMTw==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.0.tgz",
+					"integrity": "sha512-jGQ+9Q/Ml36xmYMa5wqSDRNkmHL1/HqzjLIV91TkqURHSorul9o53ze5go0tYjeY6s8C97K1Alg4gi8V+Hu7hw==",
 					"requires": {
 						"@babel/runtime": "^7.13.10",
 						"@types/react": "^16.9.0",
 						"@types/react-dom": "^16.9.0",
-						"@wordpress/escape-html": "^1.12.2",
-						"lodash": "^4.17.19",
-						"react": "^16.13.1",
-						"react-dom": "^16.13.1"
+						"@wordpress/escape-html": "^2.2.1",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
 					}
 				},
-				"csstype": {
-					"version": "3.0.8",
-					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-					"integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+				"@wordpress/escape-html": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.2.1.tgz",
+					"integrity": "sha512-+5hMa+1BLYgHdOxPK7TF+hfAaKJY1UE6osZL8s4boYeaq/O23PFv4aCPQF+z9/4cIKyvOJPGk26Z1Op6DwJLGA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/primitives": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.0.tgz",
+					"integrity": "sha512-GwBlY4Bb5yBoEpjzBvs65lfaI9+hYWByW8FmgvibdGZt1/BjKLIStifwMxOOdwhMis0AwtNxiwDLEScmy/nLBQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^4.0.0",
+						"classnames": "^2.3.1"
+					}
+				},
+				"react": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+					"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"react-dom": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+					"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"scheduler": "^0.20.2"
+					}
+				},
+				"scheduler": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+					"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
 				}
 			}
 		},
@@ -8580,6 +8697,16 @@
 						"lodash": "^4.17.19",
 						"react": "^16.13.1",
 						"react-dom": "^16.13.1"
+					}
+				},
+				"@wordpress/icons": {
+					"version": "2.10.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+					"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/primitives": "^1.12.3"
 					}
 				},
 				"csstype": {
@@ -9417,6 +9544,18 @@
 						"rememo": "^3.0.0",
 						"tinycolor2": "^1.4.1",
 						"uuid": "^7.0.2"
+					},
+					"dependencies": {
+						"@wordpress/icons": {
+							"version": "2.10.3",
+							"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+							"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@wordpress/element": "^2.20.3",
+								"@wordpress/primitives": "^1.12.3"
+							}
+						}
 					}
 				},
 				"@wordpress/deprecated": {
@@ -34496,6 +34635,16 @@
 						"memize": "^1.1.0",
 						"sprintf-js": "^1.1.1",
 						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/icons": {
+					"version": "2.10.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.10.3.tgz",
+					"integrity": "sha512-hVXArGOHLE5pL1G3rHNzsUEuTR4/G6lB+enKYwhYSSIqWuSbyXbZq3nvibxpepPrLy9B3d5t6aR6QUmjMVzIcQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^2.20.3",
+						"@wordpress/primitives": "^1.12.3"
 					}
 				},
 				"@wordpress/is-shallow-equal": {

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
 		"@woocommerce/components": "6.2.0",
 		"@wordpress/autop": "2.9.0",
 		"@wordpress/deprecated": "2.9.0",
+		"@wordpress/icons": "^5.0.1",
 		"@wordpress/notices": "2.9.1",
 		"@wordpress/plugins": "2.23.0",
 		"@wordpress/server-side-render": "1.19.3",


### PR DESCRIPTION
Ensures all inner blocks have an icon. This applies column icons to the fields/totals areas, a button icon for checkout actions, and uses the "fields" icon for checkout itself to distinguish it from payments. Custom icons are taken from Figma.

Fixes #4573

### Screenshots

![Screenshot 2021-08-31 at 11 10 54](https://user-images.githubusercontent.com/90977/131484813-ae2ba4e4-ecab-4bca-8d1f-8c9480e6c189.png)
![Screenshot 2021-08-31 at 11 10 48](https://user-images.githubusercontent.com/90977/131484820-6e974dd8-f5da-44a1-b317-5d55b552328f.png)
![Screenshot 2021-08-31 at 11 10 43](https://user-images.githubusercontent.com/90977/131484821-14cf8ca3-b0e9-4e83-97dd-697f29ac6b55.png)
