### PR TITLE
Expose the total number of items in each shipping package in the cart response

### DIFF
--- a/assets/js/types/type-defs/cart-response.ts
+++ b/assets/js/types/type-defs/cart-response.ts
@@ -75,6 +75,7 @@ export interface CartResponseShippingRate {
 	name: string;
 	destination: ResponseBaseAddress;
 	items: Array< ShippingRateItem >;
+	total_item_count: number;
 	shipping_rates: Array< CartResponseShippingPackageShippingRate >;
 }
 
@@ -192,7 +193,6 @@ export interface CartResponseExtensionItem {
 export interface CartResponse {
 	coupons: Array< CartResponseCouponItem >;
 	shipping_rates: Array< CartResponseShippingRate >;
-	package_item_counts: Array< number >;
 	shipping_address: CartResponseShippingAddress;
 	billing_address: CartResponseBillingAddress;
 	items: Array< CartResponseItem >;

--- a/assets/js/types/type-defs/cart-response.ts
+++ b/assets/js/types/type-defs/cart-response.ts
@@ -192,6 +192,7 @@ export interface CartResponseExtensionItem {
 export interface CartResponse {
 	coupons: Array< CartResponseCouponItem >;
 	shipping_rates: Array< CartResponseShippingRate >;
+	package_item_counts: Array< number >;
 	shipping_address: CartResponseShippingAddress;
 	billing_address: CartResponseBillingAddress;
 	items: Array< CartResponseItem >;

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -60,6 +60,7 @@ export interface CartShippingRate {
 	name: string;
 	destination: BaseAddress;
 	items: Array< ShippingRateItem >;
+	total_item_count: number;
 	shipping_rates: Array< CartShippingPackageShippingRate >;
 }
 
@@ -172,7 +173,6 @@ export interface CartErrorItem {
 export interface Cart {
 	coupons: Array< CartCouponItem >;
 	shippingRates: Array< CartShippingRate >;
-	packageItemCounts: Array< number >;
 	shippingAddress: CartShippingAddress;
 	billingAddress: CartBillingAddress;
 	items: Array< CartItem >;

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -172,6 +172,7 @@ export interface CartErrorItem {
 export interface Cart {
 	coupons: Array< CartCouponItem >;
 	shippingRates: Array< CartShippingRate >;
+	packageItemCounts: Array< number >;
 	shippingAddress: CartShippingAddress;
 	billingAddress: CartBillingAddress;
 	items: Array< CartItem >;

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -136,16 +136,6 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->shipping_rate_schema->get_properties() ),
 				],
 			],
-			'package_item_counts'     => [
-				'description' => __( 'Array of packages and the number of items in each one.', 'woo-gutenberg-products-block' ),
-				'type'        => 'array',
-				'context'     => [ 'view', 'edit' ],
-				'readonly'    => true,
-				'items'       => [
-					'type'       => 'object',
-					'properties' => $this->force_schema_readonly( $this->shipping_rate_schema->get_properties() ),
-				],
-			],
 			'shipping_address'        => [
 				'description' => __( 'Current set shipping address for the customer.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
@@ -359,7 +349,6 @@ class CartSchema extends AbstractSchema {
 		return [
 			'coupons'                 => $this->get_item_responses_from_schema( $this->coupon_schema, $cart->get_applied_coupons() ),
 			'shipping_rates'          => $this->get_item_responses_from_schema( $this->shipping_rate_schema, $shipping_packages ),
-			'package_item_counts'     => $this->get_package_item_counts( $cart ),
 			'shipping_address'        => $this->shipping_address_schema->get_item_response( wc()->customer ),
 			'billing_address'         => $this->billing_address_schema->get_item_response( wc()->customer ),
 			'items'                   => $this->get_item_responses_from_schema( $this->item_schema, $cart->get_cart() ),
@@ -391,29 +380,6 @@ class CartSchema extends AbstractSchema {
 			'generated_timestamp'     => time(),
 			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
 		];
-	}
-
-	/**
-	 * Get number of items in each package.
-	 *
-	 * @param \WC_Cart $cart Cart class instance.
-	 * @return array
-	 */
-	protected function get_package_item_counts( $cart ) {
-		$packages = $cart->get_shipping_packages();
-		return array_map(
-			function( $package ) {
-				$contents = $package['contents'];
-				return array_reduce(
-					$contents,
-					function( $acc, $item ) {
-						return $acc + $item['quantity'];
-					},
-					0
-				);
-			},
-			$packages
-		);
 	}
 
 	/**

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -394,7 +394,7 @@ class CartSchema extends AbstractSchema {
 	}
 
 	/**
-	 * Get packages and the number of items in each
+	 * Get number of items in each package.
 	 *
 	 * @param \WC_Cart $cart Cart class instance.
 	 * @return array

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -136,6 +136,16 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->shipping_rate_schema->get_properties() ),
 				],
 			],
+			'package_item_counts'     => [
+				'description' => __( 'Array of packages and the number of items in each one.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->shipping_rate_schema->get_properties() ),
+				],
+			],
 			'shipping_address'        => [
 				'description' => __( 'Current set shipping address for the customer.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
@@ -349,6 +359,7 @@ class CartSchema extends AbstractSchema {
 		return [
 			'coupons'                 => $this->get_item_responses_from_schema( $this->coupon_schema, $cart->get_applied_coupons() ),
 			'shipping_rates'          => $this->get_item_responses_from_schema( $this->shipping_rate_schema, $shipping_packages ),
+			'package_item_counts'     => $this->get_package_item_counts( $cart ),
 			'shipping_address'        => $this->shipping_address_schema->get_item_response( wc()->customer ),
 			'billing_address'         => $this->billing_address_schema->get_item_response( wc()->customer ),
 			'items'                   => $this->get_item_responses_from_schema( $this->item_schema, $cart->get_cart() ),
@@ -380,6 +391,29 @@ class CartSchema extends AbstractSchema {
 			'generated_timestamp'     => time(),
 			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
 		];
+	}
+
+	/**
+	 * Get packages and the number of items in each
+	 *
+	 * @param \WC_Cart $cart Cart class instance.
+	 * @return array
+	 */
+	protected function get_package_item_counts( $cart ) {
+		$packages = $cart->get_shipping_packages();
+		return array_map(
+			function( $package ) {
+				$contents = $package['contents'];
+				return array_reduce(
+					$contents,
+					function( $acc, $item ) {
+						return $acc + $item['quantity'];
+					},
+					0
+				);
+			},
+			$packages
+		);
 	}
 
 	/**

--- a/src/StoreApi/Schemas/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/CartShippingRateSchema.php
@@ -30,19 +30,19 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'package_id'     => [
+			'package_id'       => [
 				'description' => __( 'The ID of the package the shipping rates belong to.', 'woo-gutenberg-products-block' ),
 				'type'        => [ 'integer', 'string' ],
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'name'           => [
+			'name'             => [
 				'description' => __( 'Name of the package.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'destination'    => [
+			'destination'      => [
 				'description' => __( 'Shipping destination address.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -86,7 +86,7 @@ class CartShippingRateSchema extends AbstractSchema {
 					],
 				],
 			],
-			'items'          => [
+			'items'            => [
 				'description' => __( 'List of cart items the returned shipping rates apply to.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -115,7 +115,13 @@ class CartShippingRateSchema extends AbstractSchema {
 					],
 				],
 			],
-			'shipping_rates' => [
+			'total_item_count' => [
+				'description' => __( 'Total number of items in this package.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'shipping_rates'   => [
 				'description' => __( 'List of shipping rates.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -225,12 +231,29 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $package ) {
 		return [
-			'package_id'     => $package['package_id'],
-			'name'           => $package['package_name'],
-			'destination'    => $this->prepare_package_destination_response( $package ),
-			'items'          => $this->prepare_package_items_response( $package ),
-			'shipping_rates' => $this->prepare_package_shipping_rates_response( $package ),
+			'package_id'       => $package['package_id'],
+			'name'             => $package['package_name'],
+			'destination'      => $this->prepare_package_destination_response( $package ),
+			'items'            => $this->prepare_package_items_response( $package ),
+			'total_item_count' => $this->prepare_total_item_count( $package ),
+			'shipping_rates'   => $this->prepare_package_shipping_rates_response( $package ),
 		];
+	}
+
+	/**
+	 * Get number of items in the shipping package.
+	 *
+	 * @param array $package Shipping package complete with rates from WooCommerce.
+	 * @return integer
+	 */
+	protected function prepare_total_item_count( $package ) {
+		return array_reduce(
+			$package['contents'],
+			function( $acc, $item ) {
+				return $acc + $item['quantity'];
+			},
+			0
+		);
 	}
 
 	/**

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -74,7 +74,6 @@ class Cart extends ControllerTestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 3, $data['items_count'] );
-		$this->assertEquals( [ 3 ], $data['package_item_counts'] );
 		$this->assertEquals( 2, count( $data['items'] ) );
 		$this->assertEquals( true, $data['needs_payment'] );
 		$this->assertEquals( true, $data['needs_shipping'] );
@@ -92,6 +91,9 @@ class Cart extends ControllerTestCase {
 		$this->assertEquals( '0', $data['totals']->total_shipping_tax );
 		$this->assertEquals( '0', $data['totals']->total_tax );
 		$this->assertEquals( '2900', $data['totals']->total_price );
+
+		// Check the shipping rate total item count.
+		$this->assertEquals( 3, $data['shipping_rates'][0]['total_item_count'] );
 	}
 
 	/**

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -74,6 +74,7 @@ class Cart extends ControllerTestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 3, $data['items_count'] );
+		$this->assertEquals( [ 3 ], $data['package_item_counts'] );
 		$this->assertEquals( 2, count( $data['items'] ) );
 		$this->assertEquals( true, $data['needs_payment'] );
 		$this->assertEquals( true, $data['needs_shipping'] );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Adds a key called `total_item_count` to each `shipping_rate` in the cart response. This is an integer, the value of which is the total quantity of all items in the package. This change is desirable because it will remove the need of doing this calculation on the client-side for each package.

<!-- Reference any related issues or PRs here -->
Fixes #4624 cc @ralucaStan 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### How to test the changes in this Pull Request:

1. Add some items to your cart, add several different items, including ones that are virtual!
2. Change the quantity on a few items.
2. Go to the checkout and observe the cart response in dev tools, ensure the counts in `/wc/store/cart` > `shippingRates`  are correct. The count should only be the total number of _shippable_ products, so
3. Add this plugin: https://woocommerce.com/products/woocommerce-advanced-shipping-packages/
4. Set it up like so (click each image to see the full size):
- ![image](https://user-images.githubusercontent.com/5656702/131495272-538863bb-db31-4b6a-b47f-e4946775ed25.png)
- ![image](https://user-images.githubusercontent.com/5656702/131495366-172f7fb1-f083-472e-9574-d428ff9e5670.png)
- ![image](https://user-images.githubusercontent.com/5656702/131495414-07826da5-96de-44e3-8abf-b2f98ca4b507.png)
5. Check the cart again, ensure you have products in the cart that will cause it to split into two packages (some below $10 and some above $10).
6. Check the cart response again and ensure the `shippingRates` contains the correct number of products in each package.
7. Check the PHP unit tests pass `npm run test:php`

<!-- If you can, add the appropriate labels -->

### Changelog

> Conveniently expose the total number of items in each shipping package in the cart response.
