### PR TITLE
Remove `checkout-newsletter-subscription-block` from `get_atomic_blocks`

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -183,7 +183,6 @@ final class BlockTypesController {
 			'checkout-shipping-methods-block',
 			'checkout-express-payment-block',
 			'checkout-terms-block',
-			'checkout-newsletter-subscription-block',
 		];
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This block should be registered by an extension, and not in the Blocks repository. While this line is here, when https://github.com/opr/newsletter-test tries to register the block we see this notice.

`Notice: WP_Block_Type_Registry::register was called <strong>incorrectly</strong>. Block type "woocommerce/checkout-newsletter-subscription-block" is already registered.`

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/opr/newsletter-test/issues/1

### How to test the changes in this Pull Request:

1. Clone https://github.com/opr/newsletter-test/ `main` branch into a directory within `wp-content/plugins` in your wp install and run `npm run build`.
2. Activate the plugin.
3. Check the notice is not shown.

<!-- If you can, add the appropriate labels -->
