### PR TITLE
Add Filter Products by Stock block to the readme.txt list of blocks

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ Use this plugin if you want access to the bleeding edge of available blocks for 
 - **All Products**
 - **Filter Products by Price**
 - **Filter Products by Attribute**
+- **Filter Products by Stock**
 - **Active Product Filters**
 - **Cart**
 - **Checkout**


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4145, the Filter Products by Stock block was added, but it was missing from `readme.txt`. This PR is adding it there so it's listed along the other blocks.