### PR TITLE
Open Mini Cart block when adding a product to cart via an AJAX call

### DIFF
--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 
 interface DrawerProps {
 	children: JSX.Element;
+	className?: string;
 	isOpen: boolean;
 	onClose: () => void;
 	slideIn?: boolean;
@@ -21,6 +22,7 @@ interface DrawerProps {
 
 const Drawer = ( {
 	children,
+	className,
 	isOpen,
 	onClose,
 	slideIn = true,
@@ -39,7 +41,7 @@ const Drawer = ( {
 			title={ title }
 			focusOnMount={ true }
 			onRequestClose={ onClose }
-			className="wc-block-components-drawer"
+			className={ classNames( className, 'wc-block-components-drawer' ) }
 			overlayClassName={ classNames(
 				'wc-block-components-drawer__screen-overlay',
 				{

--- a/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/style.scss
@@ -87,7 +87,7 @@ table.wc-block-cart-items {
 
 // Loading placeholder state.
 .wc-block-cart--is-loading,
-.wc-block-mini-cart.is-loading {
+.wc-block-mini-cart__drawer.is-loading {
 	th span,
 	h2 span {
 		@include placeholder();
@@ -98,44 +98,33 @@ table.wc-block-cart-items {
 	h2 span {
 		min-width: 33%;
 	}
-	.wc-block-cart-item__price,
-	.wc-block-cart-item__individual-price,
-	.wc-block-cart-item__product-metadata,
-	.wc-block-cart-item__image > *,
+	.wc-block-components-product-price,
+	.wc-block-components-product-metadata,
 	.wc-block-components-quantity-selector {
 		@include placeholder();
 	}
-	.wc-block-cart-item__product-name {
+	.wc-block-components-product-name {
 		@include placeholder();
 		@include force-content();
 		min-width: 84px;
 		display: inline-block;
 	}
-	.wc-block-cart-item__product-metadata {
+	.wc-block-components-product-metadata {
 		margin-top: 0.25em;
 		min-width: 8em;
 	}
 	.wc-block-cart-item__remove-link {
 		visibility: hidden;
 	}
-	.wc-block-cart-item__image a {
+	.wc-block-cart-item__image > a {
+		@include placeholder();
 		display: block;
 	}
-	.wc-block-cart-item__individual-price {
+	.wc-block-components-product-price {
 		@include force-content();
 		max-width: 3em;
 		display: block;
 		margin-top: 0.25em;
-	}
-	.wc-block-cart-item__total {
-		> span,
-		> div {
-			display: none;
-		}
-		.wc-block-cart-item__price {
-			@include force-content();
-			display: block;
-		}
 	}
 	.wc-block-cart__sidebar .components-card {
 		@include placeholder();

--- a/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
@@ -4,6 +4,7 @@
 import { getSetting } from '@woocommerce/settings';
 import preloadScript from '@woocommerce/base-utils/preload-script';
 import lazyLoadScript from '@woocommerce/base-utils/lazy-load-script';
+import { translateJQueryEventToNative } from '@woocommerce/base-utils/legacy-events';
 
 interface dependencyData {
 	src: string;
@@ -16,6 +17,7 @@ interface dependencyData {
 // eslint-disable-next-line @wordpress/no-global-event-listener
 window.onload = () => {
 	const miniCartBlocks = document.querySelectorAll( '.wc-block-mini-cart' );
+	let wasLoadScriptsCalled = false;
 
 	if ( miniCartBlocks.length === 0 ) {
 		return;
@@ -35,7 +37,31 @@ window.onload = () => {
 		} );
 	}
 
+	// Make it so we can read jQuery events triggered by WC Core elements.
+	const removeJQueryAddingToCartEvent = translateJQueryEventToNative(
+		'adding_to_cart',
+		'wc-blocks_adding_to_cart'
+	);
+	const removeJQueryAddedToCartEvent = translateJQueryEventToNative(
+		'added_to_cart',
+		'wc-blocks_added_to_cart'
+	);
+
 	const loadScripts = async () => {
+		// Ensure we only call loadScripts once.
+		if ( wasLoadScriptsCalled ) {
+			return;
+		}
+		wasLoadScriptsCalled = true;
+
+		// Remove adding to cart event handler.
+		document.body.removeEventListener(
+			'wc-blocks_adding_to_cart',
+			loadScripts
+		);
+		removeJQueryAddingToCartEvent();
+
+		// Lazy load scripts.
 		for ( const dependencyHandle in dependencies ) {
 			const dependency = dependencies[ dependencyHandle ];
 			await lazyLoadScript( {
@@ -45,7 +71,9 @@ window.onload = () => {
 		}
 	};
 
-	miniCartBlocks.forEach( ( miniCartBlock ) => {
+	document.body.addEventListener( 'wc-blocks_adding_to_cart', loadScripts );
+
+	miniCartBlocks.forEach( ( miniCartBlock, i ) => {
 		if ( ! ( miniCartBlock instanceof HTMLElement ) ) {
 			return;
 		}
@@ -63,6 +91,11 @@ window.onload = () => {
 		}
 
 		const showContents = () => {
+			document.body.removeEventListener(
+				'wc-blocks_added_to_cart',
+				// eslint-disable-next-line @typescript-eslint/no-use-before-define
+				showContentsAndUpdate
+			);
 			miniCartBlock.dataset.isPlaceholderOpen = 'true';
 			miniCartDrawerPlaceholderOverlay.classList.add(
 				'wc-block-components-drawer__screen-overlay--with-slide-in'
@@ -70,10 +103,25 @@ window.onload = () => {
 			miniCartDrawerPlaceholderOverlay.classList.remove(
 				'wc-block-components-drawer__screen-overlay--is-hidden'
 			);
+			removeJQueryAddedToCartEvent();
+		};
+
+		const showContentsAndUpdate = () => {
+			miniCartBlock.dataset.isDataOutdated = 'true';
+			showContents();
 		};
 
 		miniCartButton.addEventListener( 'mouseover', loadScripts );
 		miniCartButton.addEventListener( 'focus', loadScripts );
 		miniCartButton.addEventListener( 'click', showContents );
+
+		// There might be more than one Mini Cart block in the page. Make sure
+		// only one opens when adding a product to the cart.
+		if ( i === 0 ) {
+			document.body.addEventListener(
+				'wc-blocks_added_to_cart',
+				showContentsAndUpdate
+			);
+		}
 	} );
 };

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -1,3 +1,8 @@
 .modal-open .wc-block-mini-cart__button {
 	pointer-events: none;
 }
+
+// Reset font size so it doesn't depend on drawer's ancestors.
+.wc-block-mini-cart__drawer {
+	font-size: 1rem;
+}

--- a/assets/js/blocks/cart-checkout/mini-cart/with-mini-cart-conditional-hydration.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/with-mini-cart-conditional-hydration.tsx
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import {
+	withStoreCartApiHydration,
+	withRestApiHydration,
+} from '@woocommerce/block-hocs';
+
+interface MiniCartBlockInterface {
+	// Signals whether the cart data is outdated. That happens when
+	// opening the mini cart after adding a product to the cart.
+	isDataOutdated?: boolean;
+	// Signals that the HTML placeholder drawer has been opened. Needed
+	// to know whether we have to skip the slide in animation.
+	isPlaceholderOpen?: boolean;
+}
+
+// Custom HOC to conditionally hydrate API data depending on the isDataOutdated
+// prop.
+export default (
+	OriginalComponent: ( component: MiniCartBlockInterface ) => JSX.Element
+) => {
+	return ( {
+		isDataOutdated,
+		...props
+	}: MiniCartBlockInterface ): JSX.Element => {
+		const Component = isDataOutdated
+			? OriginalComponent
+			: withStoreCartApiHydration(
+					withRestApiHydration( OriginalComponent )
+			  );
+		return <Component { ...props } />;
+	};
+};

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -182,12 +182,12 @@ class Cart extends AbstractBlock {
 						<tbody>
 							<tr class="wc-block-cart-items__row">
 								<td class="wc-block-cart-item__image">
-									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
+									<a href=""><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></a>
 								</td>
 								<td class="wc-block-cart-item__product">
-									<div class="wc-block-cart-item__product-name"></div>
-									<div class="wc-block-cart-item__individual-price"></div>
-									<div class="wc-block-cart-item__product-metadata"></div>
+									<div class="wc-block-components-product-name"></div>
+									<div class="wc-block-components-product-price"></div>
+									<div class="wc-block-components-product-metadata"></div>
 									<div class="wc-block-components-quantity-selector">
 										<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
 										<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
@@ -195,17 +195,17 @@ class Cart extends AbstractBlock {
 									</div>
 								</td>
 								<td class="wc-block-cart-item__total">
-									<div class="wc-block-cart-item__price"></div>
+									<div class="wc-block-components-product-price"></div>
 								</td>
 							</tr>
 							<tr class="wc-block-cart-items__row">
 								<td class="wc-block-cart-item__image">
-									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
+									<a href=""><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></a>
 								</td>
 								<td class="wc-block-cart-item__product">
-									<div class="wc-block-cart-item__product-name"></div>
-									<div class="wc-block-cart-item__individual-price"></div>
-									<div class="wc-block-cart-item__product-metadata"></div>
+									<div class="wc-block-components-product-name"></div>
+									<div class="wc-block-components-product-price"></div>
+									<div class="wc-block-components-product-metadata"></div>
 									<div class="wc-block-components-quantity-selector">
 										<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
 										<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
@@ -213,17 +213,17 @@ class Cart extends AbstractBlock {
 									</div>
 								</td>
 								<td class="wc-block-cart-item__total">
-									<div class="wc-block-cart-item__price"></div>
+									<div class="wc-block-components-product-price"></div>
 								</td>
 							</tr>
 							<tr class="wc-block-cart-items__row">
 								<td class="wc-block-cart-item__image">
-									<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
+									<a href=""><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></a>
 								</td>
 								<td class="wc-block-cart-item__product">
-									<div class="wc-block-cart-item__product-name"></div>
-									<div class="wc-block-cart-item__individual-price"></div>
-									<div class="wc-block-cart-item__product-metadata"></div>
+									<div class="wc-block-components-product-name"></div>
+									<div class="wc-block-components-product-price"></div>
+									<div class="wc-block-components-product-metadata"></div>
 									<div class="wc-block-components-quantity-selector">
 										<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
 										<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
@@ -231,7 +231,7 @@ class Cart extends AbstractBlock {
 									</div>
 								</td>
 								<td class="wc-block-cart-item__total">
-									<div class="wc-block-cart-item__price"></div>
+									<div class="wc-block-components-product-price"></div>
 								</td>
 							</tr>
 						</tbody>

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -220,9 +220,9 @@ class MiniCart extends AbstractBlock {
 			</div>';
 		}
 
-		return '<div class="wc-block-mini-cart is-loading">
+		return '<div class="wc-block-mini-cart">
 			<button class="wc-block-mini-cart__button">' . $button_text . '</button>
-			<div class="wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
+			<div class="wc-block-mini-cart__drawer is-loading is-mobile wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
 				<div class="components-modal__frame wc-block-components-drawer">
 					<div class="components-modal__content">
 						<div class="components-modal__header">
@@ -246,7 +246,7 @@ class MiniCart extends AbstractBlock {
 	 */
 	protected function get_cart_contents_markup( $cart_contents ) {
 		// Force mobile styles.
-		return '<div class="is-mobile"><table class="wc-block-cart-items">
+		return '<table class="wc-block-cart-items">
 			<thead>
 				<tr class="wc-block-cart-items__header">
 					<th class="wc-block-cart-items__header-image"><span /></th>
@@ -255,7 +255,7 @@ class MiniCart extends AbstractBlock {
 				</tr>
 			</thead>
 			<tbody>' . implode( array_map( array( $this, 'get_cart_item_markup' ), $cart_contents ) ) . '</tbody>
-		</table></div>';
+		</table>';
 	}
 
 	/**
@@ -266,20 +266,25 @@ class MiniCart extends AbstractBlock {
 	protected function get_cart_item_markup() {
 		return '<tr class="wc-block-cart-items__row">
 			<td class="wc-block-cart-item__image">
-				<div><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></div>
+				<a href=""><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" width="1" height="1" /></a>
 			</td>
 			<td class="wc-block-cart-item__product">
-				<div class="wc-block-cart-item__product-name"></div>
-				<div class="wc-block-cart-item__individual-price"></div>
-				<div class="wc-block-cart-item__product-metadata"></div>
-				<div class="wc-block-components-quantity-selector">
-					<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
-					<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
-					<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
+				<div class="wc-block-components-product-name"></div>
+				<div class="wc-block-components-product-price"></div>
+				<div class="wc-block-components-product-metadata"></div>
+				<div class="wc-block-cart-item__quantity">
+					<div class="wc-block-components-quantity-selector">
+						<input class="wc-block-components-quantity-selector__input" type="number" step="1" min="0" value="1" />
+						<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus">－</button>
+						<button class="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus">＋</button>
+					</div>
+					<button class="wc-block-cart-item__remove-link"></button>
 				</div>
 			</td>
 			<td class="wc-block-cart-item__total">
-				<div class="wc-block-cart-item__price"></div>
+				<div class="wc-block-cart-item__total-price-and-sale-badge-wrapper">
+					<div class="wc-block-components-product-price"></div>
+				</div>
 			</td>
 		</tr>';
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4598.

Based on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4608.

### How to test the changes in this Pull Request:

1. In the admin, go to Appearance > Widgets and add the Mini Cart block to the sidebar.
2. Now in the frontend, go to the Shop page and add one or more products to your cart.
3. Verify the Mini Cart block drawer slides in and shows the correct cart items.

https://user-images.githubusercontent.com/3616980/131683715-455b3fff-a9b8-4f74-ab93-6a3d5d8ac92d.mp4
