### PR TITLE
Improve accessibility when removing items from cart

### DIFF
--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -52,7 +52,7 @@ const Drawer = ( {
 				}
 			) }
 			closeButtonLabel={ __(
-				'Close mini cart.',
+				'Close mini cart',
 				'woo-gutenberg-products-block'
 			) }
 		>

--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { Modal } from '@wordpress/components';
 import { useDebounce } from 'use-debounce';
 import classNames from 'classnames';
@@ -49,6 +50,10 @@ const Drawer = ( {
 					'wc-block-components-drawer__screen-overlay--with-slide-in': slideIn,
 					'wc-block-components-drawer__screen-overlay--with-slide-out': slideOut,
 				}
+			) }
+			closeButtonLabel={ __(
+				'Close mini cart.',
+				'woo-gutenberg-products-block'
 			) }
 		>
 			{ children }

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -123,10 +123,6 @@ $drawer-width-mobile: 100vw;
 		// Increase clickable area.
 		padding: 1em;
 		margin: -1em;
-
-		> span {
-			@include visually-hidden();
-		}
 	}
 }
 

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -123,6 +123,10 @@ $drawer-width-mobile: 100vw;
 		// Increase clickable area.
 		padding: 1em;
 		margin: -1em;
+
+		> span {
+			@include visually-hidden();
+		}
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 import QuantitySelector from '@woocommerce/base-components/quantity-selector';
 import ProductPrice from '@woocommerce/base-components/product-price';
 import ProductName from '@woocommerce/base-components/product-name';
@@ -275,6 +276,16 @@ const CartLineItemRow = ( {
 								product: lineItem,
 								quantity,
 							} );
+							speak(
+								sprintf(
+									/* translators: %s refers to the item name in the cart. */
+									__(
+										'%s has been removed from your cart.',
+										'woo-gutenberg-products-block'
+									),
+									name
+								)
+							);
 						} }
 						disabled={ isPendingDelete }
 					>

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -28,10 +28,11 @@ import {
 	mustContain,
 } from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
-import { useMemo } from '@wordpress/element';
+import { useRef, useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/type-defs/cart';
 import { objectHasProp } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
+import type { TdHTMLAttributes } from 'react';
 
 /**
  * Convert a Dinero object with precision to store currency minor unit.
@@ -49,17 +50,20 @@ const getAmountFromRawPrice = (
 
 const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
 
+interface CartLineItemRowProps
+	extends TdHTMLAttributes< HTMLTableDataCellElement > {
+	lineItem: CartItem | Record< string, never >;
+	onRemove?: ( removedRow: HTMLElement | null ) => void;
+}
+
 /**
  * Cart line item table row component.
- *
- * @param {Object} props
- * @param {CartItem|Object} props.lineItem
  */
 const CartLineItemRow = ( {
 	lineItem,
-}: {
-	lineItem: CartItem | Record< string, never >;
-} ): JSX.Element => {
+	onRemove = ( removedRow: HTMLElement | null ) => void removedRow,
+	...props
+}: CartLineItemRowProps ): JSX.Element => {
 	const {
 		name: initialName = '',
 		catalog_visibility: catalogVisibility = 'visible',
@@ -185,11 +189,15 @@ const CartLineItemRow = ( {
 		validation: productPriceValidation,
 	} );
 
+	const tableRowRef = useRef( null );
+
 	return (
 		<tr
 			className={ classnames( 'wc-block-cart-items__row', {
 				'is-disabled': isPendingDelete,
 			} ) }
+			ref={ tableRowRef }
+			{ ...props }
 		>
 			{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
 			<td
@@ -271,6 +279,7 @@ const CartLineItemRow = ( {
 					<button
 						className="wc-block-cart-item__remove-link"
 						onClick={ () => {
+							onRemove( tableRowRef.current );
 							removeItem();
 							dispatchStoreEvent( 'cart-remove-item', {
 								product: lineItem,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-item-row.tsx
@@ -28,11 +28,10 @@ import {
 	mustContain,
 } from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
-import { useRef, useMemo } from '@wordpress/element';
+import { forwardRef, useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/type-defs/cart';
 import { objectHasProp } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
-import type { TdHTMLAttributes } from 'react';
 
 /**
  * Convert a Dinero object with precision to store currency minor unit.
@@ -50,280 +49,284 @@ const getAmountFromRawPrice = (
 
 const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
 
-interface CartLineItemRowProps
-	extends TdHTMLAttributes< HTMLTableDataCellElement > {
+interface CartLineItemRowProps {
 	lineItem: CartItem | Record< string, never >;
-	onRemove?: ( removedRow: HTMLElement | null ) => void;
+	onRemove?: () => void;
+	tabIndex?: number;
 }
 
 /**
  * Cart line item table row component.
  */
-const CartLineItemRow = ( {
-	lineItem,
-	onRemove = ( removedRow: HTMLElement | null ) => void removedRow,
-	...props
-}: CartLineItemRowProps ): JSX.Element => {
-	const {
-		name: initialName = '',
-		catalog_visibility: catalogVisibility = 'visible',
-		short_description: shortDescription = '',
-		description: fullDescription = '',
-		low_stock_remaining: lowStockRemaining = null,
-		show_backorder_badge: showBackorderBadge = false,
-		quantity_limit: quantityLimit = 99,
-		permalink = '',
-		images = [],
-		variation = [],
-		item_data: itemData = [],
-		prices = {
-			currency_code: 'USD',
-			currency_minor_unit: 2,
-			currency_symbol: '$',
-			currency_prefix: '$',
-			currency_suffix: '',
-			currency_decimal_separator: '.',
-			currency_thousand_separator: ',',
-			price: '0',
-			regular_price: '0',
-			sale_price: '0',
-			price_range: null,
-			raw_prices: {
-				precision: 6,
+const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
+	(
+		{ lineItem, onRemove = () => void null, tabIndex = null },
+		ref
+	): JSX.Element => {
+		const {
+			name: initialName = '',
+			catalog_visibility: catalogVisibility = 'visible',
+			short_description: shortDescription = '',
+			description: fullDescription = '',
+			low_stock_remaining: lowStockRemaining = null,
+			show_backorder_badge: showBackorderBadge = false,
+			quantity_limit: quantityLimit = 99,
+			permalink = '',
+			images = [],
+			variation = [],
+			item_data: itemData = [],
+			prices = {
+				currency_code: 'USD',
+				currency_minor_unit: 2,
+				currency_symbol: '$',
+				currency_prefix: '$',
+				currency_suffix: '',
+				currency_decimal_separator: '.',
+				currency_thousand_separator: ',',
 				price: '0',
 				regular_price: '0',
 				sale_price: '0',
+				price_range: null,
+				raw_prices: {
+					precision: 6,
+					price: '0',
+					regular_price: '0',
+					sale_price: '0',
+				},
 			},
-		},
-		totals = {
-			currency_code: 'USD',
-			currency_minor_unit: 2,
-			currency_symbol: '$',
-			currency_prefix: '$',
-			currency_suffix: '',
-			currency_decimal_separator: '.',
-			currency_thousand_separator: ',',
-			line_subtotal: '0',
-			line_subtotal_tax: '0',
-		},
-		extensions,
-	} = lineItem;
+			totals = {
+				currency_code: 'USD',
+				currency_minor_unit: 2,
+				currency_symbol: '$',
+				currency_prefix: '$',
+				currency_suffix: '',
+				currency_decimal_separator: '.',
+				currency_thousand_separator: ',',
+				line_subtotal: '0',
+				line_subtotal_tax: '0',
+			},
+			extensions,
+		} = lineItem;
 
-	const {
-		quantity,
-		setItemQuantity,
-		removeItem,
-		isPendingDelete,
-	} = useStoreCartItemQuantity( lineItem );
-	const { dispatchStoreEvent } = useStoreEvents();
+		const {
+			quantity,
+			setItemQuantity,
+			removeItem,
+			isPendingDelete,
+		} = useStoreCartItemQuantity( lineItem );
+		const { dispatchStoreEvent } = useStoreEvents();
 
-	// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
-	// We need to pluck out receiveCart.
-	// eslint-disable-next-line no-unused-vars
-	const { receiveCart, ...cart } = useStoreCart();
-	const arg = useMemo(
-		() => ( {
-			context: 'cart',
-			cartItem: lineItem,
-			cart,
-		} ),
-		[ lineItem, cart ]
-	);
-	const priceCurrency = getCurrencyFromPriceResponse( prices );
-	const name = __experimentalApplyCheckoutFilter( {
-		filterName: 'itemName',
-		defaultValue: initialName,
-		extensions,
-		arg,
-	} );
+		// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
+		// We need to pluck out receiveCart.
+		// eslint-disable-next-line no-unused-vars
+		const { receiveCart, ...cart } = useStoreCart();
+		const arg = useMemo(
+			() => ( {
+				context: 'cart',
+				cartItem: lineItem,
+				cart,
+			} ),
+			[ lineItem, cart ]
+		);
+		const priceCurrency = getCurrencyFromPriceResponse( prices );
+		const name = __experimentalApplyCheckoutFilter( {
+			filterName: 'itemName',
+			defaultValue: initialName,
+			extensions,
+			arg,
+		} );
 
-	const regularAmountSingle = Dinero( {
-		amount: parseInt( prices.raw_prices.regular_price, 10 ),
-		precision: prices.raw_prices.precision,
-	} );
-	const purchaseAmountSingle = Dinero( {
-		amount: parseInt( prices.raw_prices.price, 10 ),
-		precision: prices.raw_prices.precision,
-	} );
-	const saleAmountSingle = regularAmountSingle.subtract(
-		purchaseAmountSingle
-	);
-	const saleAmount = saleAmountSingle.multiply( quantity );
-	const totalsCurrency = getCurrencyFromPriceResponse( totals );
-	let lineSubtotal = parseInt( totals.line_subtotal, 10 );
-	if ( getSetting( 'displayCartPricesIncludingTax', false ) ) {
-		lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
-	}
-	const subtotalPrice = Dinero( {
-		amount: lineSubtotal,
-		precision: totalsCurrency.minorUnit,
-	} );
+		const regularAmountSingle = Dinero( {
+			amount: parseInt( prices.raw_prices.regular_price, 10 ),
+			precision: prices.raw_prices.precision,
+		} );
+		const purchaseAmountSingle = Dinero( {
+			amount: parseInt( prices.raw_prices.price, 10 ),
+			precision: prices.raw_prices.precision,
+		} );
+		const saleAmountSingle = regularAmountSingle.subtract(
+			purchaseAmountSingle
+		);
+		const saleAmount = saleAmountSingle.multiply( quantity );
+		const totalsCurrency = getCurrencyFromPriceResponse( totals );
+		let lineSubtotal = parseInt( totals.line_subtotal, 10 );
+		if ( getSetting( 'displayCartPricesIncludingTax', false ) ) {
+			lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
+		}
+		const subtotalPrice = Dinero( {
+			amount: lineSubtotal,
+			precision: totalsCurrency.minorUnit,
+		} );
 
-	const firstImage = images.length ? images[ 0 ] : {};
-	const isProductHiddenFromCatalog =
-		catalogVisibility === 'hidden' || catalogVisibility === 'search';
+		const firstImage = images.length ? images[ 0 ] : {};
+		const isProductHiddenFromCatalog =
+			catalogVisibility === 'hidden' || catalogVisibility === 'search';
 
-	// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
+		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
 
-	const productPriceFormat = __experimentalApplyCheckoutFilter( {
-		filterName: 'cartItemPrice',
-		defaultValue: '<price/>',
-		extensions,
-		arg,
-		validation: productPriceValidation,
-	} );
+		const productPriceFormat = __experimentalApplyCheckoutFilter( {
+			filterName: 'cartItemPrice',
+			defaultValue: '<price/>',
+			extensions,
+			arg,
+			validation: productPriceValidation,
+		} );
 
-	const subtotalPriceFormat = __experimentalApplyCheckoutFilter( {
-		filterName: 'subtotalPriceFormat',
-		defaultValue: '<price/>',
-		extensions,
-		arg,
-		validation: productPriceValidation,
-	} );
+		const subtotalPriceFormat = __experimentalApplyCheckoutFilter( {
+			filterName: 'subtotalPriceFormat',
+			defaultValue: '<price/>',
+			extensions,
+			arg,
+			validation: productPriceValidation,
+		} );
 
-	const saleBadgePriceFormat = __experimentalApplyCheckoutFilter( {
-		filterName: 'saleBadgePriceFormat',
-		defaultValue: '<price/>',
-		extensions,
-		arg,
-		validation: productPriceValidation,
-	} );
+		const saleBadgePriceFormat = __experimentalApplyCheckoutFilter( {
+			filterName: 'saleBadgePriceFormat',
+			defaultValue: '<price/>',
+			extensions,
+			arg,
+			validation: productPriceValidation,
+		} );
 
-	const tableRowRef = useRef( null );
-
-	return (
-		<tr
-			className={ classnames( 'wc-block-cart-items__row', {
-				'is-disabled': isPendingDelete,
-			} ) }
-			ref={ tableRowRef }
-			{ ...props }
-		>
-			{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
-			<td
-				className="wc-block-cart-item__image"
-				aria-hidden={
-					! objectHasProp( firstImage, 'alt' ) || ! firstImage.alt
-				}
+		return (
+			<tr
+				className={ classnames( 'wc-block-cart-items__row', {
+					'is-disabled': isPendingDelete,
+				} ) }
+				ref={ ref }
+				tabIndex={ tabIndex }
 			>
-				{ /* We don't need to make it focusable, because product name has the same link. */ }
-				{ isProductHiddenFromCatalog ? (
-					<ProductImage image={ firstImage } />
-				) : (
-					<a href={ permalink } tabIndex={ -1 }>
+				{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
+				<td
+					className="wc-block-cart-item__image"
+					aria-hidden={
+						! objectHasProp( firstImage, 'alt' ) || ! firstImage.alt
+					}
+				>
+					{ /* We don't need to make it focusable, because product name has the same link. */ }
+					{ isProductHiddenFromCatalog ? (
 						<ProductImage image={ firstImage } />
-					</a>
-				) }
-			</td>
-			<td className="wc-block-cart-item__product">
-				<ProductName
-					disabled={ isPendingDelete || isProductHiddenFromCatalog }
-					name={ name }
-					permalink={ permalink }
-				/>
-				{ showBackorderBadge ? (
-					<ProductBackorderBadge />
-				) : (
-					!! lowStockRemaining && (
-						<ProductLowStockBadge
-							lowStockRemaining={ lowStockRemaining }
-						/>
-					)
-				) }
-
-				<div className="wc-block-cart-item__prices">
-					<ProductPrice
-						currency={ priceCurrency }
-						regularPrice={ getAmountFromRawPrice(
-							regularAmountSingle,
-							priceCurrency
-						) }
-						price={ getAmountFromRawPrice(
-							purchaseAmountSingle,
-							priceCurrency
-						) }
-						format={ subtotalPriceFormat }
-					/>
-				</div>
-
-				<ProductSaleBadge
-					currency={ priceCurrency }
-					saleAmount={ getAmountFromRawPrice(
-						saleAmountSingle,
-						priceCurrency
+					) : (
+						<a href={ permalink } tabIndex={ -1 }>
+							<ProductImage image={ firstImage } />
+						</a>
 					) }
-					format={ saleBadgePriceFormat }
-				/>
-
-				<ProductMetadata
-					shortDescription={ shortDescription }
-					fullDescription={ fullDescription }
-					itemData={ itemData }
-					variation={ variation }
-				/>
-
-				<div className="wc-block-cart-item__quantity">
-					<QuantitySelector
-						disabled={ isPendingDelete }
-						quantity={ quantity }
-						maximum={ quantityLimit }
-						onChange={ ( newQuantity ) => {
-							setItemQuantity( newQuantity );
-							dispatchStoreEvent( 'cart-set-item-quantity', {
-								product: lineItem,
-								quantity: newQuantity,
-							} );
-						} }
-						itemName={ name }
+				</td>
+				<td className="wc-block-cart-item__product">
+					<ProductName
+						disabled={
+							isPendingDelete || isProductHiddenFromCatalog
+						}
+						name={ name }
+						permalink={ permalink }
 					/>
-					<button
-						className="wc-block-cart-item__remove-link"
-						onClick={ () => {
-							onRemove( tableRowRef.current );
-							removeItem();
-							dispatchStoreEvent( 'cart-remove-item', {
-								product: lineItem,
-								quantity,
-							} );
-							speak(
-								sprintf(
-									/* translators: %s refers to the item name in the cart. */
-									__(
-										'%s has been removed from your cart.',
-										'woo-gutenberg-products-block'
-									),
-									name
-								)
-							);
-						} }
-						disabled={ isPendingDelete }
-					>
-						{ __( 'Remove item', 'woo-gutenberg-products-block' ) }
-					</button>
-				</div>
-			</td>
-			<td className="wc-block-cart-item__total">
-				<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
-					<ProductPrice
-						currency={ totalsCurrency }
-						format={ productPriceFormat }
-						price={ subtotalPrice.getAmount() }
-					/>
+					{ showBackorderBadge ? (
+						<ProductBackorderBadge />
+					) : (
+						!! lowStockRemaining && (
+							<ProductLowStockBadge
+								lowStockRemaining={ lowStockRemaining }
+							/>
+						)
+					) }
 
-					{ quantity > 1 && (
-						<ProductSaleBadge
+					<div className="wc-block-cart-item__prices">
+						<ProductPrice
 							currency={ priceCurrency }
-							saleAmount={ getAmountFromRawPrice(
-								saleAmount,
+							regularPrice={ getAmountFromRawPrice(
+								regularAmountSingle,
 								priceCurrency
 							) }
-							format={ saleBadgePriceFormat }
+							price={ getAmountFromRawPrice(
+								purchaseAmountSingle,
+								priceCurrency
+							) }
+							format={ subtotalPriceFormat }
 						/>
-					) }
-				</div>
-			</td>
-		</tr>
-	);
-};
+					</div>
+
+					<ProductSaleBadge
+						currency={ priceCurrency }
+						saleAmount={ getAmountFromRawPrice(
+							saleAmountSingle,
+							priceCurrency
+						) }
+						format={ saleBadgePriceFormat }
+					/>
+
+					<ProductMetadata
+						shortDescription={ shortDescription }
+						fullDescription={ fullDescription }
+						itemData={ itemData }
+						variation={ variation }
+					/>
+
+					<div className="wc-block-cart-item__quantity">
+						<QuantitySelector
+							disabled={ isPendingDelete }
+							quantity={ quantity }
+							maximum={ quantityLimit }
+							onChange={ ( newQuantity ) => {
+								setItemQuantity( newQuantity );
+								dispatchStoreEvent( 'cart-set-item-quantity', {
+									product: lineItem,
+									quantity: newQuantity,
+								} );
+							} }
+							itemName={ name }
+						/>
+						<button
+							className="wc-block-cart-item__remove-link"
+							onClick={ () => {
+								onRemove();
+								removeItem();
+								dispatchStoreEvent( 'cart-remove-item', {
+									product: lineItem,
+									quantity,
+								} );
+								speak(
+									sprintf(
+										/* translators: %s refers to the item name in the cart. */
+										__(
+											'%s has been removed from your cart.',
+											'woo-gutenberg-products-block'
+										),
+										name
+									)
+								);
+							} }
+							disabled={ isPendingDelete }
+						>
+							{ __(
+								'Remove item',
+								'woo-gutenberg-products-block'
+							) }
+						</button>
+					</div>
+				</td>
+				<td className="wc-block-cart-item__total">
+					<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
+						<ProductPrice
+							currency={ totalsCurrency }
+							format={ productPriceFormat }
+							price={ subtotalPrice.getAmount() }
+						/>
+
+						{ quantity > 1 && (
+							<ProductSaleBadge
+								currency={ priceCurrency }
+								saleAmount={ getAmountFromRawPrice(
+									saleAmount,
+									priceCurrency
+								) }
+								format={ saleBadgePriceFormat }
+							/>
+						) }
+					</div>
+				</td>
+			</tr>
+		);
+	}
+);
 
 export default CartLineItemRow;

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
@@ -29,6 +29,20 @@ const CartLineItemsTable = ( {
 					<CartLineItemRow
 						key={ lineItem.key }
 						lineItem={ lineItem }
+						onRemove={ ( removedRow: HTMLElement | null ) => {
+							if (
+								removedRow?.nextElementSibling instanceof
+								HTMLElement
+							) {
+								removedRow.nextElementSibling.focus();
+							} else if (
+								removedRow?.previousElementSibling instanceof
+								HTMLElement
+							) {
+								removedRow.previousElementSibling.focus();
+							}
+						} }
+						tabIndex={ -1 }
 					/>
 				);
 		  } );

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
@@ -35,11 +35,6 @@ const CartLineItemsTable = ( {
 								HTMLElement
 							) {
 								removedRow.nextElementSibling.focus();
-							} else if (
-								removedRow?.previousElementSibling instanceof
-								HTMLElement
-							) {
-								removedRow.previousElementSibling.focus();
 							}
 						} }
 						tabIndex={ -1 }

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
@@ -35,6 +35,13 @@ const CartLineItemsTable = ( {
 								HTMLElement
 							) {
 								removedRow.nextElementSibling.focus();
+							} else {
+								const tableElement = removedRow?.closest(
+									'.wc-block-cart-items'
+								);
+								if ( tableElement instanceof HTMLElement ) {
+									tableElement.focus();
+								}
 							}
 						} }
 						tabIndex={ -1 }
@@ -43,7 +50,7 @@ const CartLineItemsTable = ( {
 		  } );
 
 	return (
-		<table className="wc-block-cart-items">
+		<table className="wc-block-cart-items" tabIndex={ -1 }>
 			<thead>
 				<tr className="wc-block-cart-items__header">
 					<th className="wc-block-cart-items__header-image">

--- a/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/cart-line-items-table.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { CartResponseItem } from '@woocommerce/type-defs/cart-response';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ const CartLineItemsTable = ( {
 	lineItems = [],
 	isLoading = false,
 }: CartLineItemsTableProps ): JSX.Element => {
+	const tableRef = useRef< HTMLTableElement | null >( null );
 	const products = isLoading
 		? placeholderRows
 		: lineItems.map( ( lineItem ) => {
@@ -35,13 +37,10 @@ const CartLineItemsTable = ( {
 								HTMLElement
 							) {
 								removedRow.nextElementSibling.focus();
-							} else {
-								const tableElement = removedRow?.closest(
-									'.wc-block-cart-items'
-								);
-								if ( tableElement instanceof HTMLElement ) {
-									tableElement.focus();
-								}
+							} else if (
+								tableRef.current instanceof HTMLElement
+							) {
+								tableRef.current.focus();
 							}
 						} }
 						tabIndex={ -1 }
@@ -50,7 +49,7 @@ const CartLineItemsTable = ( {
 		  } );
 
 	return (
-		<table className="wc-block-cart-items" tabIndex={ -1 }>
+		<table className="wc-block-cart-items" ref={ tableRef } tabIndex={ -1 }>
 			<thead>
 				<tr className="wc-block-cart-items__header">
 					<th className="wc-block-cart-items__header-image">

--- a/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
@@ -64,6 +64,7 @@ exports[`Testing cart Contains a Taxes section if Core options are set to show i
             <tbody>
               <tr
                 class="wc-block-cart-items__row"
+                tabindex="-1"
               >
                 <td
                   aria-hidden="true"
@@ -210,6 +211,7 @@ exports[`Testing cart Contains a Taxes section if Core options are set to show i
               </tr>
               <tr
                 class="wc-block-cart-items__row"
+                tabindex="-1"
               >
                 <td
                   aria-hidden="true"
@@ -746,6 +748,7 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
             <tbody>
               <tr
                 class="wc-block-cart-items__row"
+                tabindex="-1"
               >
                 <td
                   aria-hidden="true"
@@ -892,6 +895,7 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
               </tr>
               <tr
                 class="wc-block-cart-items__row"
+                tabindex="-1"
               >
                 <td
                   aria-hidden="true"
@@ -1433,6 +1437,7 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
             <tbody>
               <tr
                 class="wc-block-cart-items__row"
+                tabindex="-1"
               >
                 <td
                   aria-hidden="true"
@@ -1579,6 +1584,7 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
               </tr>
               <tr
                 class="wc-block-cart-items__row"
+                tabindex="-1"
               >
                 <td
                   aria-hidden="true"

--- a/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/cart-checkout/cart/test/__snapshots__/block.js.snap
@@ -33,6 +33,7 @@ exports[`Testing cart Contains a Taxes section if Core options are set to show i
         >
           <table
             class="wc-block-cart-items"
+            tabindex="-1"
           >
             <thead>
               <tr
@@ -717,6 +718,7 @@ exports[`Testing cart Shows individual tax lines if the store is set to do so 1`
         >
           <table
             class="wc-block-cart-items"
+            tabindex="-1"
           >
             <thead>
               <tr
@@ -1406,6 +1408,7 @@ exports[`Testing cart Shows rate percentages after tax lines if the block is set
         >
           <table
             class="wc-block-cart-items"
+            tabindex="-1"
           >
             <thead>
               <tr

--- a/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
@@ -3,7 +3,7 @@
  */
 import classNames from 'classnames';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
 import {
 	translateJQueryEventToNative,
@@ -29,6 +29,7 @@ const MiniCartBlock = ( {
 }: MiniCartBlockProps ): JSX.Element => {
 	const { cartItems, cartItemsCount, cartIsLoading } = useStoreCart();
 	const [ isOpen, setIsOpen ] = useState< boolean >( isPlaceholderOpen );
+	const emptyCartRef = useRef< HTMLDivElement | null >( null );
 	// We already rendered the HTML drawer placeholder, so we want to skip the
 	// slide in animation.
 	const [ skipSlideIn, setSkipSlideIn ] = useState< boolean >(
@@ -63,9 +64,25 @@ const MiniCartBlock = ( {
 		};
 	}, [] );
 
+	useEffect( () => {
+		// If the cart has been completely emptied, move focus to empty cart
+		// element.
+		if ( isOpen && ! cartIsLoading && cartItems.length === 0 ) {
+			if ( emptyCartRef.current instanceof HTMLElement ) {
+				emptyCartRef.current.focus();
+			}
+		}
+	}, [ isOpen, cartIsLoading, cartItems.length, emptyCartRef ] );
+
 	const contents =
 		! cartIsLoading && cartItems.length === 0 ? (
-			<>{ __( 'Cart is empty', 'woo-gutenberg-products-block' ) }</>
+			<div
+				className="wc-block-mini-cart__empty-cart"
+				tabIndex={ -1 }
+				ref={ emptyCartRef }
+			>
+				{ __( 'Cart is empty', 'woo-gutenberg-products-block' ) }
+			</div>
 		) : (
 			<CartLineItemsTable
 				lineItems={ cartItems }
@@ -150,7 +167,7 @@ const renderMiniCartFrontend = () => {
 		Block: withMiniCartConditionalHydration( MiniCartBlock ),
 		getProps: ( el: HTMLElement ) => ( {
 			isDataOutdated: el.dataset.isDataOutdated,
-			isPlaceholderOpen: el.dataset.isPlaceholderOpen,
+			isPlaceholderOpen: el.dataset.isPlaceholderOpen === 'true',
 		} ),
 	} );
 

--- a/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/component-frontend.tsx
@@ -103,16 +103,20 @@ const MiniCartBlock = ( {
 						'is-loading': cartIsLoading,
 					}
 				) }
-				title={ sprintf(
-					/* translators: %d is the count of items in the cart. */
-					_n(
-						'Your cart (%d item)',
-						'Your cart (%d items)',
-						cartItemsCount,
-						'woo-gutenberg-products-block'
-					),
-					cartItemsCount
-				) }
+				title={
+					cartIsLoading
+						? __( 'Your cart', 'woo-gutenberg-products-block' )
+						: sprintf(
+								/* translators: %d is the count of items in the cart. */
+								_n(
+									'Your cart (%d item)',
+									'Your cart (%d items)',
+									cartItemsCount,
+									'woo-gutenberg-products-block'
+								),
+								cartItemsCount
+						  )
+				}
 				isOpen={ isOpen }
 				onClose={ () => {
 					setIsOpen( false );


### PR DESCRIPTION
This PR introduces several accessibility improvements to the Cart and Mini Cart blocks:

* fdc92d2165bb43204849fcd9bce4c52f970c1cd1: adds a custom label to the Mini Cart drawer close button, so instead of the generic `Close dialog` now it will read `Close mini cart`.
* 4c831c51a502c210034e6769c8e360f0f2e84332: adds a screen reader notice when a product is removed from the cart.
* c6911d497b950472e75b15f12b1c0c7761007839: makes it so when an item is removed from cart, the next item is automatically focused. Until now, focus was going to the `<body>`, and that caused screen readers to read unnecessary data again. In parallel, that was causing the issue in #4618.

Fixes #4618.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### How to test the changes in this Pull Request:

For a better experience, you can test with the changes in Gutenberg from this PR: https://github.com/WordPress/gutenberg/pull/34684. It improves several focus flows when interacting with cart items and navigating with the keyboard.

**Cart block:**
1. Add several products to your cart and go to a page with the Cart block.
2. With a screen reader + using the keyboard to move around the page try to remove a couple of items.
3. Verify you can successfully remove them and when a product is removed, the screen reader announces it.

**Mini Cart block (you can skip these testing instructions from the release docs):**

1. Add several products to your cart and go to a page with the Mini Cart block.
2. With a screen reader + using the keyboard to move around the page try to remove a couple of items.
3. Verify you can successfully remove them and when a product is removed, the screen reader announces it.
4. Verify that right after clicking the `Remove item` button, you can click on the screen overlay to close the Mini Cart (fix for #4618).

### Changelog

> Accessibility improvements when removing items from cart.
