### PR TITLE
Enqueue frontend assets on frontend only

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/index.tsx
@@ -13,3 +13,4 @@ import './checkout-order-summary-block';
 import './checkout-payment-block';
 import './checkout-express-payment-block';
 import './checkout-shipping-methods-block';
+import './checkout-sample-block';

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -81,7 +81,9 @@ abstract class AbstractBlock {
 	 */
 	public function render_callback( $attributes = [], $content = '' ) {
 		$render_callback_attributes = $this->parse_render_callback_attributes( $attributes );
-		$this->enqueue_assets( $render_callback_attributes );
+		if ( ! is_admin() ) {
+			$this->enqueue_assets( $render_callback_attributes );
+		}
 		return $this->render( $render_callback_attributes, $content );
 	}
 


### PR DESCRIPTION
Some blocks (including checkout and checkout i2) were loading both frontend and editor assets in the admin area due to this line:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/341be1f56071fbd4b5ff975e8788d65a09512df2/src/BlockTypes/AbstractBlock.php#L84

This is there to ensure assets are loaded in time for block rendering, but this doesn't seem to be needed in the editor. Adding an `is_admin()` check fixes this.

This did break checkout-i2 sample-block but this was due to missing import. Also resolved.

Fixes #4609

### How to test the changes in this Pull Request:

1. Before patching:
  - Load a page containing checkout-i2 in the editor.
  - View source and search for a script named `wc-checkout-i2-block-frontend`
2. Apply the patch and repeat. No `wc-checkout-i2-block-frontend` should be present in the editor.
3. Confirm the block still renders in admin and frontend without regression
4. Smoke test the original cart/checkout blocks are also unaffected by the patch
