### PR TITLE
Add initial e2e tests to Mini Cart block

### DIFF
--- a/tests/e2e/specs/backend/__fixtures__/mini-cart.fixture.json
+++ b/tests/e2e/specs/backend/__fixtures__/mini-cart.fixture.json
@@ -1,0 +1,1 @@
+{"title":"Mini Cart Block","pageContent":"<!-- wp:woocommerce/mini-cart /-->"}

--- a/tests/e2e/specs/backend/mini-cart.test.js
+++ b/tests/e2e/specs/backend/mini-cart.test.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { switchUserToAdmin, getAllBlocks } from '@wordpress/e2e-test-utils';
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
+
+const block = {
+	name: 'Mini Cart',
+	slug: 'woocommerce/mini-cart',
+	class: '.wc-block-mini-cart',
+};
+
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
+	// eslint-disable-next-line jest/no-focused-tests
+	test.only( `skipping ${ block.name } tests`, () => {} );
+}
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'can only be inserted once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 1 );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+} );


### PR DESCRIPTION
Part of #4643.

PR adding some basic e2e tests to the Mini Cart block.

### How to test the changes in this Pull Request:

1. Verify tests pass in this PR.