### PR TITLE
Don't allow opening the Mini Cart in the Cart and Checkout pages

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -49,6 +49,10 @@ class MiniCart extends AbstractBlock {
 	 * @return array|string
 	 */
 	protected function get_block_type_script( $key = null ) {
+		if ( is_cart() || is_checkout() ) {
+			return;
+		}
+
 		$script = [
 			'handle'       => 'wc-' . $this->block_name . '-block-frontend',
 			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name . '-frontend' ),
@@ -65,6 +69,10 @@ class MiniCart extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
+		if ( is_cart() || is_checkout() ) {
+			return;
+		}
+
 		parent::enqueue_data( $attributes );
 
 		// Hydrate the following data depending on admin or frontend context.
@@ -206,6 +214,12 @@ class MiniCart extends AbstractBlock {
 			$cart_contents_count
 		);
 
+		if ( is_cart() || is_checkout() ) {
+			return '<div class="wc-block-mini-cart">
+				<button class="wc-block-mini-cart__button" disabled>' . $button_text . '</button>
+			</div>';
+		}
+
 		return '<div class="wc-block-mini-cart is-loading">
 			<button class="wc-block-mini-cart__button">' . $button_text . '</button>
 			<div class="wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
@@ -215,9 +229,9 @@ class MiniCart extends AbstractBlock {
 							<div class="components-modal__header-heading-container">
 								<h1 id="components-modal-header-1" class="components-modal__header-heading">' . $title . '</h1>
 							</div>
-						</div>
-						' . $this->get_cart_contents_markup( $cart_contents ) . '
-					</div>
+						</div>'
+						. $this->get_cart_contents_markup( $cart_contents ) .
+					'</div>
 				</div>
 			</div>
 		</div>';


### PR DESCRIPTION
Fixes #4602.

### How to test the changes in this Pull Request:

1. In the admin, go to Appearance > Widgets and add the Mini Cart block to a widget area (ie: the sidebar).
2. In the frontend, go to the Cart or Checkout pages and verify you can't open the Mini Cart (button is disabled). Verify also `mini-cart-frontend.js` and `mini-cart-component-frontend.js` scripts are not loaded.
3. In the frontend, go to any other page which is not Cart or Checkout and verify the Mini Cart can be opened as usual.
