### PR TITLE
Add E2E and Unit (PHP and JS) tests for Filter by Stock block.

### DIFF
--- a/assets/js/blocks/stock-filter/block.js
+++ b/assets/js/blocks/stock-filter/block.js
@@ -34,31 +34,24 @@ const StockStatusFilterBlock = ( {
 	attributes: blockAttributes,
 	isEditor = false,
 } ) => {
-	const hideOutOfStockItems = useMemo(
-		() => getSetting( 'hideOutOfStockItems', false ),
-		[]
+	const hideOutOfStockItems = getSetting( 'hideOutOfStockItems', false );
+	const { outofstock, ...otherStockStatusOptions } = getSetting(
+		'stockStatusOptions',
+		{}
 	);
-	const { outofstock, ...otherStockStatusOptions } = useMemo(
-		() => getSetting( 'stockStatusOptions', {} ),
-		[]
-	);
-	const STOCK_STATUS_OPTIONS = useMemo( () => {
-		return hideOutOfStockItems
-			? otherStockStatusOptions
-			: { outofstock, ...otherStockStatusOptions };
-	}, [ hideOutOfStockItems, otherStockStatusOptions, outofstock ] );
+	const STOCK_STATUS_OPTIONS = hideOutOfStockItems
+		? otherStockStatusOptions
+		: { outofstock, ...otherStockStatusOptions };
 
 	const [ checked, setChecked ] = useState( [] );
 	const [ displayedOptions, setDisplayedOptions ] = useState(
 		blockAttributes.isPreview ? previewOptions : []
 	);
 	// Filter added to handle if there are slugs without a corresponding name defined.
-	const initialOptions = useMemo( () => {
-		return Object.entries( STOCK_STATUS_OPTIONS )
-			.map( ( [ slug, name ] ) => ( { slug, name } ) )
-			.filter( ( status ) => !! status.name )
-			.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
-	}, [ STOCK_STATUS_OPTIONS ] );
+	const initialOptions = Object.entries( STOCK_STATUS_OPTIONS )
+		.map( ( [ slug, name ] ) => ( { slug, name } ) )
+		.filter( ( status ) => !! status.name )
+		.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
 
 	const [ queryState ] = useQueryStateByContext();
 	const [

--- a/assets/js/blocks/stock-filter/block.js
+++ b/assets/js/blocks/stock-filter/block.js
@@ -23,20 +23,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { previewOptions } from './preview';
 import './style.scss';
 
-const hideOutOfStockItems = getSetting( 'hideOutOfStockItems', false );
-const { outofstock, ...otherStockStatusOptions } = getSetting(
-	'stockStatusOptions',
-	{}
-);
-const STOCK_STATUS_OPTIONS = hideOutOfStockItems
-	? otherStockStatusOptions
-	: { outofstock, ...otherStockStatusOptions };
-// Filter added to handle if there are slugs without a corresponding name defined.
-const initialOptions = Object.entries( STOCK_STATUS_OPTIONS )
-	.map( ( [ slug, name ] ) => ( { slug, name } ) )
-	.filter( ( status ) => !! status.name )
-	.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
-
 /**
  * Component displaying an stock status filter.
  *
@@ -48,10 +34,31 @@ const StockStatusFilterBlock = ( {
 	attributes: blockAttributes,
 	isEditor = false,
 } ) => {
+	const hideOutOfStockItems = useMemo(
+		() => getSetting( 'hideOutOfStockItems', false ),
+		[]
+	);
+	const { outofstock, ...otherStockStatusOptions } = useMemo(
+		() => getSetting( 'stockStatusOptions', {} ),
+		[]
+	);
+	const STOCK_STATUS_OPTIONS = useMemo( () => {
+		return hideOutOfStockItems
+			? otherStockStatusOptions
+			: { outofstock, ...otherStockStatusOptions };
+	}, [ hideOutOfStockItems, otherStockStatusOptions, outofstock ] );
+
 	const [ checked, setChecked ] = useState( [] );
 	const [ displayedOptions, setDisplayedOptions ] = useState(
 		blockAttributes.isPreview ? previewOptions : []
 	);
+	// Filter added to handle if there are slugs without a corresponding name defined.
+	const initialOptions = useMemo( () => {
+		return Object.entries( STOCK_STATUS_OPTIONS )
+			.map( ( [ slug, name ] ) => ( { slug, name } ) )
+			.filter( ( status ) => !! status.name )
+			.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
+	}, [ STOCK_STATUS_OPTIONS ] );
 
 	const [ queryState ] = useQueryStateByContext();
 	const [
@@ -140,6 +147,7 @@ const StockStatusFilterBlock = ( {
 		getFilteredStock,
 		checked,
 		queryState.stock_status,
+		initialOptions,
 	] );
 
 	const onSubmit = useCallback(

--- a/assets/js/blocks/stock-filter/block.js
+++ b/assets/js/blocks/stock-filter/block.js
@@ -34,24 +34,29 @@ const StockStatusFilterBlock = ( {
 	attributes: blockAttributes,
 	isEditor = false,
 } ) => {
-	const hideOutOfStockItems = getSetting( 'hideOutOfStockItems', false );
-	const { outofstock, ...otherStockStatusOptions } = getSetting(
-		'stockStatusOptions',
-		{}
+	const [ hideOutOfStockItems ] = useState(
+		getSetting( 'hideOutOfStockItems', false )
 	);
-	const STOCK_STATUS_OPTIONS = hideOutOfStockItems
-		? otherStockStatusOptions
-		: { outofstock, ...otherStockStatusOptions };
+	const [ { outofstock, ...otherStockStatusOptions } ] = useState(
+		getSetting( 'stockStatusOptions', {} )
+	);
+	const [ STOCK_STATUS_OPTIONS ] = useState(
+		hideOutOfStockItems
+			? otherStockStatusOptions
+			: { outofstock, ...otherStockStatusOptions }
+	);
 
 	const [ checked, setChecked ] = useState( [] );
 	const [ displayedOptions, setDisplayedOptions ] = useState(
 		blockAttributes.isPreview ? previewOptions : []
 	);
 	// Filter added to handle if there are slugs without a corresponding name defined.
-	const initialOptions = Object.entries( STOCK_STATUS_OPTIONS )
-		.map( ( [ slug, name ] ) => ( { slug, name } ) )
-		.filter( ( status ) => !! status.name )
-		.sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
+	const [ initialOptions ] = useState(
+		Object.entries( STOCK_STATUS_OPTIONS )
+			.map( ( [ slug, name ] ) => ( { slug, name } ) )
+			.filter( ( status ) => !! status.name )
+			.sort( ( a, b ) => a.slug.localeCompare( b.slug ) )
+	);
 
 	const [ queryState ] = useQueryStateByContext();
 	const [

--- a/assets/js/blocks/stock-filter/edit.js
+++ b/assets/js/blocks/stock-filter/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Disabled,
@@ -110,7 +111,12 @@ const Edit = ( { attributes, setAttributes } ) => {
 		<>
 			{ getInspectorControls() }
 			{
-				<div className={ className }>
+				<div
+					className={ classnames(
+						'wc-block-stock-filter',
+						className
+					) }
+				>
 					<BlockTitle
 						headingLevel={ headingLevel }
 						heading={ heading }

--- a/assets/js/blocks/stock-filter/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/stock-filter/test/__snapshots__/block.js.snap
@@ -1,0 +1,205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing stock filter renders the stock filter block 1`] = `
+<div>
+  <div
+    class="wc-block-stock-filter"
+  >
+    <ul
+      class="wc-block-checkbox-list wc-block-components-checkbox-list wc-block-stock-filter-list"
+    >
+      <li>
+        <input
+          id="instock"
+          type="checkbox"
+          value="instock"
+        />
+        <label
+          for="instock"
+        >
+          In stock
+        </label>
+      </li>
+      <li>
+        <input
+          id="onbackorder"
+          type="checkbox"
+          value="onbackorder"
+        />
+        <label
+          for="onbackorder"
+        >
+          On backorder
+        </label>
+      </li>
+      <li>
+        <input
+          id="outofstock"
+          type="checkbox"
+          value="outofstock"
+        />
+        <label
+          for="outofstock"
+        >
+          Out of stock
+        </label>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`Testing stock filter renders the stock filter block with the filter button 1`] = `
+<div>
+  <div
+    class="wc-block-stock-filter"
+  >
+    <ul
+      class="wc-block-checkbox-list wc-block-components-checkbox-list wc-block-stock-filter-list"
+    >
+      <li>
+        <input
+          id="instock"
+          type="checkbox"
+          value="instock"
+        />
+        <label
+          for="instock"
+        >
+          In stock
+        </label>
+      </li>
+      <li>
+        <input
+          id="onbackorder"
+          type="checkbox"
+          value="onbackorder"
+        />
+        <label
+          for="onbackorder"
+        >
+          On backorder
+        </label>
+      </li>
+      <li>
+        <input
+          id="outofstock"
+          type="checkbox"
+          value="outofstock"
+        />
+        <label
+          for="outofstock"
+        >
+          Out of stock
+        </label>
+      </li>
+    </ul>
+    <button
+      class="wc-block-filter-submit-button wc-block-components-filter-submit-button wc-block-stock-filter__button"
+      type="submit"
+    >
+      <span
+        aria-hidden="true"
+      >
+        Go
+      </span>
+      <span
+        class="screen-reader-text"
+      >
+        Apply filter
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Testing stock filter renders the stock filter block with the product counts 1`] = `
+<div>
+  <div
+    class="wc-block-stock-filter"
+  >
+    <ul
+      class="wc-block-checkbox-list wc-block-components-checkbox-list wc-block-stock-filter-list"
+    >
+      <li>
+        <input
+          id="instock"
+          type="checkbox"
+          value="instock"
+        />
+        <label
+          for="instock"
+        >
+          In stock
+          <span
+            class="wc-filter-element-label-list-count"
+          >
+            <span
+              aria-hidden="true"
+            >
+              18
+            </span>
+            <span
+              class="screen-reader-text"
+            >
+              18 products
+            </span>
+          </span>
+        </label>
+      </li>
+      <li>
+        <input
+          id="onbackorder"
+          type="checkbox"
+          value="onbackorder"
+        />
+        <label
+          for="onbackorder"
+        >
+          On backorder
+          <span
+            class="wc-filter-element-label-list-count"
+          >
+            <span
+              aria-hidden="true"
+            >
+              5
+            </span>
+            <span
+              class="screen-reader-text"
+            >
+              5 products
+            </span>
+          </span>
+        </label>
+      </li>
+      <li>
+        <input
+          id="outofstock"
+          type="checkbox"
+          value="outofstock"
+        />
+        <label
+          for="outofstock"
+        >
+          Out of stock
+          <span
+            class="wc-filter-element-label-list-count"
+          >
+            <span
+              aria-hidden="true"
+            >
+              1
+            </span>
+            <span
+              class="screen-reader-text"
+            >
+              1 product
+            </span>
+          </span>
+        </label>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/assets/js/blocks/stock-filter/test/block.js
+++ b/assets/js/blocks/stock-filter/test/block.js
@@ -1,0 +1,73 @@
+/**
+ * Internal dependencies
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { default as fetchMock } from 'jest-fetch-mock';
+
+/**
+ * Internal dependencies
+ */
+import Block from '../block';
+import { allSettings } from '../../../settings/shared/settings-init';
+
+const mockResults = {
+	stock_status_counts: [
+		{ status: 'instock', count: '18' },
+		{ status: 'outofstock', count: '1' },
+		{ status: 'onbackorder', count: '5' },
+	],
+};
+
+jest.mock( '@woocommerce/base-context/hooks', () => {
+	return {
+		...jest.requireActual( '@woocommerce/base-context/hooks' ),
+		useCollectionData: () => ( { isLoading: false, results: mockResults } ),
+	};
+} );
+
+const StockFilterBlock = ( props ) => <Block { ...props } />;
+describe( 'Testing stock filter', () => {
+	beforeEach( () => {
+		allSettings.stockStatusOptions = {
+			instock: 'In stock',
+			outofstock: 'Out of stock',
+			onbackorder: 'On backorder',
+		};
+	} );
+
+	afterEach( () => {
+		fetchMock.resetMocks();
+	} );
+
+	it( 'renders the stock filter block', async () => {
+		const { container } = render(
+			<StockFilterBlock attributes={ { isPreview: false } } />
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'renders the stock filter block with the filter button', async () => {
+		const { container } = render(
+			<StockFilterBlock
+				attributes={ { isPreview: false, showFilterButton: true } }
+			/>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'renders the stock filter block with the product counts', async () => {
+		const { container } = render(
+			<StockFilterBlock
+				attributes={ {
+					isPreview: false,
+					showCounts: true,
+				} }
+			/>
+		);
+		expect( container ).toMatchSnapshot();
+	} );
+} );

--- a/tests/e2e/specs/backend/__fixtures__/filter-products-by-stock.fixture.json
+++ b/tests/e2e/specs/backend/__fixtures__/filter-products-by-stock.fixture.json
@@ -1,0 +1,1 @@
+{"title":"Filter Products by Stock Block","pageContent":"<!-- wp:woocommerce/stock-filter -->\n<div class=\"wp-block-woocommerce-stock-filter is-loading\" data-show-counts=\"true\" data-heading=\"Filter by stock status\" data-heading-level=\"3\"><span aria-hidden=\"true\" class=\"wc-block-product-stock-filter__placeholder\"></span></div>\n<!-- /wp:woocommerce/stock-filter -->"}

--- a/tests/e2e/specs/backend/filter-products-by-stock.test.js
+++ b/tests/e2e/specs/backend/filter-products-by-stock.test.js
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import { closeInserter, insertBlockDontWaitForInsertClose } from '../../utils';
+import { findLabelWithText } from '../../../utils';
+
+/**
+ * External dependencies
+ */
+import {
+	switchUserToAdmin,
+	clickButton,
+	getAllBlocks,
+	openDocumentSettingsSidebar,
+} from '@wordpress/e2e-test-utils';
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+const block = {
+	name: 'Filter Products by Stock',
+	slug: 'woocommerce/stock-filter',
+	class: '.wc-block-stock-filter',
+};
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+
+	it( 'can only be inserted once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		await closeInserter();
+		expect( await getAllBlocks() ).toHaveLength( 1 );
+	} );
+
+	describe( 'attributes', () => {
+		beforeEach( async () => {
+			await openDocumentSettingsSidebar();
+			await page.click( block.class );
+		} );
+
+		it( 'product count can be toggled', async () => {
+			const toggleLabel = await findLabelWithText( 'Product count' );
+			await expect( toggleLabel ).toToggleElement(
+				`${ block.class } .wc-filter-element-label-list-count`
+			);
+		} );
+
+		it( 'filter button can be toggled', async () => {
+			const toggleLabel = await findLabelWithText( 'Filter button' );
+			await expect( toggleLabel ).toToggleElement(
+				`${ block.class } .wc-block-filter-submit-button`
+			);
+		} );
+	} );
+} );

--- a/tests/php/StoreApi/Utilities/ProductQueryFilters.php
+++ b/tests/php/StoreApi/Utilities/ProductQueryFilters.php
@@ -1,0 +1,55 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\ProductQueryFilters;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use Automattic\WooCommerce\Blocks\Tests\Helpers\FixtureData;
+
+class ProductQueryFiltersTest extends TestCase {
+	/**
+	 * Setup test products data. Called before every test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$fixtures = new FixtureData();
+
+		add_filter( 'woocommerce_product_stock_status_options', function( $status ) {
+			$status['custom1'] = 'Custom status 1';
+			$status['custom2'] = 'Custom status 2';
+			return $status;
+		}, 10, 1 );
+
+		$this->products = [
+			$fixtures->get_simple_product( [
+				                               'name' => 'Test Product 1',
+				                               'stock_status' => 'custom1',
+				                               'regular_price' => 10,
+				                               'weight' => 10,
+			                               ] ),
+			$fixtures->get_simple_product( [
+				                               'name' => 'Test Product 2',
+				                               'stock_status' => 'custom2',
+				                               'regular_price' => 10,
+				                               'weight' => 10,
+			                               ] ),
+			$fixtures->get_simple_product( [
+				                               'name' => 'Test Product 3',
+				                               'stock_status' => 'custom2',
+				                               'regular_price' => 10,
+				                               'weight' => 10,
+			                               ] ),
+		];
+	}
+
+	/**
+	 * Test that custom stock levels are returned properly with the correct counts.
+	 */
+	public function test_custom_stock_counts() {
+		$class = new ProductQueryFilters();
+		$result = $class->get_stock_status_counts( new \WP_REST_Request( 'GET', '/wc/store/products' ) );
+		$this->assertArrayHasKey( 'custom1', $result );
+		$this->assertArrayHasKey( 'custom2', $result );
+		$this->assertEquals( 1, $result['custom1'] );
+		$this->assertEquals( 2, $result['custom2'] );
+	}
+}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR introduces E2E, JS unit, and PHP unit tests for the Filter by Stock block.

Besides the code changes to test files, there is one other important change to actual code: I have modified the way that the options for the block are derived and at what point. Originally these options were fetched outside of the component body. Because of this the code was executed as soon as the file was imported. This was not good for testing because we couldn't mock the values returned by `getSetting`. That is because the mocks were set up in the tests after importing the file. The changes made in `assets/js/blocks/stock-filter/block.js` move the options into the component ~~and add them to a `useMemo` with no deps, so this should only be calculated once.~~. 

~~I opted to do this rather than using `useState` because the implication of using this is that the values returned by `getSetting` (and therefore `STOCK_STATUS_OPTIONS`) could change over time, when they will not. I welcome any feedback on this approach though.~~

After discussing with @tjcafferkey we decided that these usages of `useMemo` were "over-optimisations". The length of `STOCK_STATUS_OPTIONS` will _usually_ be 3, so iterating over it is cheap, and not worth memoizing given the complexity this adds to the component.

Because the value of `initialOptions` is used as a dependency to the `useEffect` further down this file, setting these values as internal component state seemed the best way forward to stop this effect running every render.

<!-- Reference any related issues or PRs here -->
Fixes #4661

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->
### How to test the changes in this Pull Request:

1. Run `npm run test:php` `npm run test` `npm run test:e2e` and verify they all pass.
2. Create a page, add the `Filter by Stock`, `Filter by Price`, `Active filters`, and `All Products` blocks.
3. View the page and ensure the `Filter by Stock` block is working correctly. Verify the counts of each stock level are accurate.
4. Go to **WooCommerce > Settings > Products > Inventory** toggle `Hide out of stock products from catalogue" to be true.
5. View the page again and ensure `Out of stock` is not shown as a stock level option.
6. Wait for tests to go green in this PR.

<!-- If you can, add the appropriate labels -->
