### PR TITLE
Update checkout block registration API to consume Block Metadata

### DIFF
--- a/assets/js/atomic/utils/render-parent-block.tsx
+++ b/assets/js/atomic/utils/render-parent-block.tsx
@@ -50,12 +50,12 @@ const getBlockComponentFromMap = (
  * @see registerCheckoutBlock
  */
 const renderForcedBlocks = (
-	blockName: string,
+	parentBlockName: string,
 	blockMap: Record< string, React.ReactNode >,
 	// Current children from the parent (siblings of the forced block)
 	blockChildren: HTMLCollection | null
 ) => {
-	if ( ! isInnerBlockArea( blockName ) ) {
+	if ( ! isInnerBlockArea( parentBlockName ) ) {
 		return null;
 	}
 
@@ -69,16 +69,16 @@ const renderForcedBlocks = (
 				.filter( Boolean ) as string[] )
 		: [];
 
-	const forcedBlocks = getRegisteredBlocks( blockName ).filter(
-		( { block, force } ) =>
-			force === true && ! currentBlocks.includes( block )
+	const forcedBlocks = getRegisteredBlocks( parentBlockName ).filter(
+		( { blockName, force } ) =>
+			force === true && ! currentBlocks.includes( blockName )
 	);
 
 	return forcedBlocks.map(
-		( { block, component }, index: number ): JSX.Element | null => {
+		( { blockName, component }, index: number ): JSX.Element | null => {
 			const ForcedComponent = component
 				? component
-				: getBlockComponentFromMap( block, blockMap );
+				: getBlockComponentFromMap( blockName, blockMap );
 			return ForcedComponent ? (
 				<ForcedComponent key={ `${ blockName }_forced_${ index }` } />
 			) : null;

--- a/assets/js/atomic/utils/render-parent-block.tsx
+++ b/assets/js/atomic/utils/render-parent-block.tsx
@@ -11,7 +11,7 @@ import {
 import parse from 'html-react-parser';
 import {
 	getRegisteredBlocks,
-	isInnerBlockArea,
+	hasInnerBlocks,
 } from '@woocommerce/blocks-checkout';
 
 /**
@@ -32,11 +32,11 @@ import {
  * Gets a component from the block map for a given block name, or returns null if a component is not registered.
  */
 const getBlockComponentFromMap = (
-	blockName: string,
+	block: string,
 	blockMap: Record< string, React.ReactNode >
 ): React.ElementType | null => {
-	return blockName && blockMap[ blockName ]
-		? ( blockMap[ blockName ] as React.ElementType )
+	return block && blockMap[ block ]
+		? ( blockMap[ block ] as React.ElementType )
 		: null;
 };
 
@@ -50,12 +50,12 @@ const getBlockComponentFromMap = (
  * @see registerCheckoutBlock
  */
 const renderForcedBlocks = (
-	parentBlockName: string,
+	block: string,
 	blockMap: Record< string, React.ReactNode >,
 	// Current children from the parent (siblings of the forced block)
 	blockChildren: HTMLCollection | null
 ) => {
-	if ( ! isInnerBlockArea( parentBlockName ) ) {
+	if ( ! hasInnerBlocks( block ) ) {
 		return null;
 	}
 
@@ -69,7 +69,7 @@ const renderForcedBlocks = (
 				.filter( Boolean ) as string[] )
 		: [];
 
-	const forcedBlocks = getRegisteredBlocks( parentBlockName ).filter(
+	const forcedBlocks = getRegisteredBlocks( block ).filter(
 		( { blockName, force } ) =>
 			force === true && ! currentBlocks.includes( blockName )
 	);
@@ -91,7 +91,7 @@ const renderForcedBlocks = (
  */
 const renderInnerBlocks = ( {
 	// This is the parent block we're working within (see renderParentBlock)
-	blockName: parentBlockName,
+	block,
 	// This is the map of blockNames->components
 	blockMap,
 	// Component which inner blocks are wrapped with.
@@ -101,8 +101,8 @@ const renderInnerBlocks = ( {
 	// Current depth of the children. Used to ensure keys are unique.
 	depth = 1,
 }: {
-	// Parent Block Name. Used for inner block component mapping.
-	blockName: string;
+	// Block (parent) being rendered. Used for inner block component mapping.
+	block: string;
 	// Map of block names to block components for children.
 	blockMap: Record< string, React.ReactNode >;
 	// Wrapper for inner components.
@@ -121,7 +121,7 @@ const renderInnerBlocks = ( {
 		 * convert the HTMLElement to a React component.
 		 */
 		const { blockName = '', ...componentProps } = {
-			key: `${ parentBlockName }_${ depth }_${ index }`,
+			key: `${ block }_${ depth }_${ index }`,
 			...( element instanceof HTMLElement ? element.dataset : {} ),
 		};
 
@@ -141,9 +141,9 @@ const renderInnerBlocks = ( {
 				const elementChildren =
 					element.children && element.children.length
 						? renderInnerBlocks( {
-								children: element.children,
-								blockName: parentBlockName,
+								block,
 								blockMap,
+								children: element.children,
 								depth: depth + 1,
 								blockWrapper,
 						  } )
@@ -166,7 +166,7 @@ const renderInnerBlocks = ( {
 
 		return (
 			<Suspense
-				key={ `${ parentBlockName }_${ depth }_${ index }_suspense` }
+				key={ `${ block }_${ depth }_${ index }_suspense` }
 				fallback={ <div className="wc-block-placeholder" /> }
 			>
 				<InnerBlockComponentWrapper>
@@ -178,9 +178,9 @@ const renderInnerBlocks = ( {
 							 * children from this element.
 							 */
 							renderInnerBlocks( {
-								children: element.children,
-								blockName: parentBlockName,
+								block,
 								blockMap,
+								children: element.children,
 								depth: depth + 1,
 								blockWrapper,
 							} )
@@ -246,7 +246,7 @@ export const renderParentBlock = ( {
 		const children =
 			element.children && element.children.length
 				? renderInnerBlocks( {
-						blockName,
+						block: blockName,
 						blockMap,
 						children: element.children,
 						blockWrapper,

--- a/assets/js/blocks/cart-checkout/checkout-i2/editor-utils.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/editor-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+import { getBlockTypes } from '@wordpress/blocks';
+
+export const getRegisteredBlockNamesByParent = (
+	parentBlockName: string
+): string[] =>
+	getBlockTypes()
+		.filter( ( blockType ) =>
+			( blockType?.parent || [] ).includes( parentBlockName )
+		)
+		.map( ( { name } ) => name );

--- a/assets/js/blocks/cart-checkout/checkout-i2/editor-utils.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/editor-utils.ts
@@ -3,11 +3,22 @@
  */
 import { getBlockTypes } from '@wordpress/blocks';
 
-export const getRegisteredBlockNamesByParent = (
-	parentBlockName: string
-): string[] =>
-	getBlockTypes()
+// List of core block types to allow in inner block areas.
+const coreBlockTypes = [
+	'core/paragraph',
+	'core/paragraph',
+	'core/image',
+	'core/separator',
+];
+
+/**
+ * Gets a list of allowed blocks types under a specific parent block type.
+ */
+export const getAllowedBlocks = ( block: string ): string[] => [
+	...getBlockTypes()
 		.filter( ( blockType ) =>
-			( blockType?.parent || [] ).includes( parentBlockName )
+			( blockType?.parent || [] ).includes( block )
 		)
-		.map( ( { name } ) => name );
+		.map( ( { name } ) => name ),
+	...coreBlockTypes,
+];

--- a/assets/js/blocks/cart-checkout/checkout-i2/editor-utils.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/editor-utils.ts
@@ -4,12 +4,7 @@
 import { getBlockTypes } from '@wordpress/blocks';
 
 // List of core block types to allow in inner block areas.
-const coreBlockTypes = [
-	'core/paragraph',
-	'core/paragraph',
-	'core/image',
-	'core/separator',
-];
+const coreBlockTypes = [ 'core/paragraph', 'core/image', 'core/separator' ];
 
 /**
  * Gets a list of allowed blocks types under a specific parent block type.

--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/additional-fields.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/additional-fields.tsx
@@ -2,27 +2,19 @@
  * External dependencies
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
-import {
-	RegisteredBlocks,
-	getRegisteredBlockTemplate,
-} from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
 import { useForcedLayout } from '../use-forced-layout';
+import { getRegisteredBlockNamesByParent } from '../editor-utils';
 
-export const AdditionalFields = ( {
-	area,
-}: {
-	area: keyof RegisteredBlocks;
-} ): JSX.Element => {
-	const registeredBlocks = getRegisteredBlockTemplate( area );
+export const AdditionalFields = ( { area }: { area: string } ): JSX.Element => {
 	const { 'data-block': clientId } = useBlockProps();
 	const template = useForcedLayout( {
 		clientId,
-		template: registeredBlocks,
+		template: getRegisteredBlockNamesByParent( area ),
 	} );
 	return (
 		<div className="wc-block-checkout__additional_fields">

--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/additional-fields.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/additional-fields.tsx
@@ -8,17 +8,25 @@ import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
  */
 import './editor.scss';
 import { useForcedLayout } from '../use-forced-layout';
-import { getRegisteredBlockNamesByParent } from '../editor-utils';
+import { getAllowedBlocks } from '../editor-utils';
 
-export const AdditionalFields = ( { area }: { area: string } ): JSX.Element => {
+export const AdditionalFields = ( {
+	block,
+}: {
+	// Name of the parent block.
+	block: string;
+} ): JSX.Element => {
 	const { 'data-block': clientId } = useBlockProps();
-	const template = useForcedLayout( {
+	const allowedBlocks = getAllowedBlocks( block );
+
+	useForcedLayout( {
 		clientId,
-		template: getRegisteredBlockNamesByParent( area ),
+		template: allowedBlocks,
 	} );
+
 	return (
 		<div className="wc-block-checkout__additional_fields">
-			<InnerBlocks allowedBlocks={ template } />
+			<InnerBlocks allowedBlocks={ allowedBlocks } />
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-billing-address-block/edit.tsx
@@ -60,7 +60,7 @@ export const Edit = ( {
 				showPhoneField={ showPhoneField }
 				requirePhoneField={ requirePhoneField }
 			/>
-			<AdditionalFields area={ innerBlockAreas.BILLING_ADDRESS } />
+			<AdditionalFields block={ innerBlockAreas.BILLING_ADDRESS } />
 		</FormStepBlock>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-contact-information-block/edit.tsx
@@ -41,7 +41,7 @@ export const Edit = ( {
 			<Disabled>
 				<Block allowCreateAccount={ allowCreateAccount } />
 			</Disabled>
-			<AdditionalFields area={ innerBlockAreas.CONTACT_INFORMATION } />
+			<AdditionalFields block={ innerBlockAreas.CONTACT_INFORMATION } />
 		</FormStepBlock>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-fields-block/edit.tsx
@@ -10,38 +10,19 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
  */
 import { useCheckoutBlockControlsContext } from '../../context';
 import { useForcedLayout } from '../../use-forced-layout';
-import { getRegisteredBlockNamesByParent } from '../../editor-utils';
-
-const ALLOWED_BLOCKS = [
-	'woocommerce/checkout-express-payment-block',
-	'woocommerce/checkout-shipping-address-block',
-	'woocommerce/checkout-shipping-methods-block',
-	'woocommerce/checkout-contact-information-block',
-	'woocommerce/checkout-billing-address-block',
-	'woocommerce/checkout-payment-block',
-	'woocommerce/checkout-order-note-block',
-	'woocommerce/checkout-actions-block',
-	'woocommerce/checkout-terms-block',
-	'core/paragraph',
-	'core/heading',
-	'core/separator',
-];
+import { getAllowedBlocks } from '../../editor-utils';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
+	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CHECKOUT_FIELDS );
 
 	const {
 		addressFieldControls: Controls,
 	} = useCheckoutBlockControlsContext();
 
-	const template = useForcedLayout( {
+	useForcedLayout( {
 		clientId,
-		template: [
-			...ALLOWED_BLOCKS,
-			...getRegisteredBlockNamesByParent(
-				innerBlockAreas.CHECKOUT_FIELDS
-			),
-		],
+		template: allowedBlocks,
 	} );
 	return (
 		<Main className="wc-block-checkout__main">
@@ -49,7 +30,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 				<Controls />
 				<form className="wc-block-components-form wc-block-checkout__form">
 					<InnerBlocks
-						allowedBlocks={ template }
+						allowedBlocks={ allowedBlocks }
 						templateLock={ false }
 						renderAppender={ InnerBlocks.ButtonBlockAppender }
 					/>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-fields-block/edit.tsx
@@ -3,15 +3,14 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
-import {
-	getRegisteredBlockTemplate,
-	innerBlockAreas,
-} from '@woocommerce/blocks-checkout';
+import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+
 /**
  * Internal dependencies
  */
 import { useCheckoutBlockControlsContext } from '../../context';
 import { useForcedLayout } from '../../use-forced-layout';
+import { getRegisteredBlockNamesByParent } from '../../editor-utils';
 
 const ALLOWED_BLOCKS = [
 	'woocommerce/checkout-express-payment-block',
@@ -34,12 +33,15 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const {
 		addressFieldControls: Controls,
 	} = useCheckoutBlockControlsContext();
-	const registeredBlocks = getRegisteredBlockTemplate(
-		innerBlockAreas.CHECKOUT_FIELDS
-	);
+
 	const template = useForcedLayout( {
 		clientId,
-		template: [ ...ALLOWED_BLOCKS, ...registeredBlocks ],
+		template: [
+			...ALLOWED_BLOCKS,
+			...getRegisteredBlockNamesByParent(
+				innerBlockAreas.CHECKOUT_FIELDS
+			),
+		],
 	} );
 	return (
 		<Main className="wc-block-checkout__main">

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/edit.tsx
@@ -73,7 +73,7 @@ export const Edit = ( props: FormStepBlockProps ): JSX.Element => {
 			<Disabled>
 				<Block />
 			</Disabled>
-			<AdditionalFields area={ innerBlockAreas.PAYMENT_METHODS } />
+			<AdditionalFields block={ innerBlockAreas.PAYMENT_METHODS } />
 		</FormStepBlock>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/block.json
@@ -1,0 +1,30 @@
+{
+	"name": "woocommerce/checkout-sample-block",
+	"version": "1.0.0",
+	"title": "Checkout Sample Block",
+	"category": "woocommerce",
+	"description": "An example block showing how to integrate with Checkout i2.",
+	"supports": {
+		"html": false,
+		"align": true,
+		"multiple": true,
+		"reusable": false
+	},
+	"attributes": {
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": true
+			}
+		}
+	},
+	"parent": [
+		"woocommerce/checkout-shipping-address-block",
+		"woocommerce/checkout-billing-address-block",
+		"woocommerce/checkout-contact-information-block",
+		"woocommerce/checkout-fields-block",
+		"woocommerce/checkout-totals-block"
+	],
+	"textdomain": "woo-gutenberg-products-block",
+	"editorScript": "file:../../../../../../../build/checkout-blocks/sample.js"
+}

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/block.json
@@ -25,6 +25,5 @@
 		"woocommerce/checkout-fields-block",
 		"woocommerce/checkout-totals-block"
 	],
-	"textdomain": "woo-gutenberg-products-block",
-	"editorScript": "file:../../../../../../../build/checkout-blocks/sample.js"
+	"textdomain": "woo-gutenberg-products-block"
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/block.json
@@ -21,7 +21,6 @@
 	"parent": [
 		"woocommerce/checkout-shipping-address-block",
 		"woocommerce/checkout-billing-address-block",
-		"woocommerce/checkout-contact-information-block",
 		"woocommerce/checkout-fields-block",
 		"woocommerce/checkout-totals-block"
 	],

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/index.tsx
@@ -1,55 +1,20 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Icon, asterisk } from '@woocommerce/icons';
-import {
-	registerCheckoutBlock,
-	innerBlockAreas,
-} from '@woocommerce/blocks-checkout';
-import { lazy } from '@wordpress/element';
-import { WC_BLOCKS_BUILD_URL } from '@woocommerce/block-settings';
-
-// Modify webpack publicPath at runtime based on location of WordPress Plugin.
-// eslint-disable-next-line no-undef,camelcase
-__webpack_public_path__ = WC_BLOCKS_BUILD_URL;
+import { registerExperimentalBlockType } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
+import metadata from './block.json';
 
-registerCheckoutBlock( 'woocommerce/checkout-sample-block', {
-	component: lazy( () =>
-		import( /* webpackChunkName: "checkout-blocks/sample" */ './frontend' )
-	),
-	areas: [
-		innerBlockAreas.SHIPPING_ADDRESS,
-		innerBlockAreas.BILLING_ADDRESS,
-		innerBlockAreas.CONTACT_INFORMATION,
-		innerBlockAreas.CHECKOUT_FIELDS,
-		innerBlockAreas.CHECKOUT_TOTALS,
-	],
-	force: true,
-	configuration: {
-		title: __( 'Sample Block', 'woo-gutenberg-products-block' ),
-		category: 'woocommerce',
-		description: __(
-			'A sample block showing how to integrate with Checkout i2.',
-			'woo-gutenberg-products-block'
-		),
-		icon: {
-			src: <Icon srcElement={ asterisk } />,
-			foreground: '#874FB9',
-		},
-		supports: {
-			align: false,
-			html: false,
-			multiple: true,
-			reusable: false,
-		},
-		attributes: {},
-		edit: Edit,
-		save: Save,
+registerExperimentalBlockType( metadata, {
+	icon: {
+		src: <Icon srcElement={ asterisk } />,
+		foreground: '#874FB9',
 	},
+	edit: Edit,
+	save: Save,
 } );

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-address-block/edit.tsx
@@ -53,7 +53,7 @@ export const Edit = ( {
 				showPhoneField={ showPhoneField }
 				requirePhoneField={ requirePhoneField }
 			/>
-			<AdditionalFields area={ innerBlockAreas.SHIPPING_ADDRESS } />
+			<AdditionalFields block={ innerBlockAreas.SHIPPING_ADDRESS } />
 		</FormStepBlock>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/edit.tsx
@@ -116,7 +116,7 @@ export const Edit = ( {
 			<Disabled>
 				<Block />
 			</Disabled>
-			<AdditionalFields area={ innerBlockAreas.SHIPPING_METHODS } />
+			<AdditionalFields block={ innerBlockAreas.SHIPPING_METHODS } />
 		</FormStepBlock>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/edit.tsx
@@ -8,32 +8,23 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 /**
  * Internal dependencies
  */
-import type { InnerBlockTemplate } from '../../types';
 import { useForcedLayout } from '../../use-forced-layout';
-import { getRegisteredBlockNamesByParent } from '../../editor-utils';
-
-const ALLOWED_BLOCKS: string[] = [ 'woocommerce/checkout-order-summary-block' ];
-const TEMPLATE: InnerBlockTemplate[] = [
-	[ 'woocommerce/checkout-order-summary-block', {}, [] ],
-];
+import { getAllowedBlocks } from '../../editor-utils';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const template = useForcedLayout( {
+	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CHECKOUT_TOTALS );
+
+	useForcedLayout( {
 		clientId,
-		template: [
-			...ALLOWED_BLOCKS,
-			...getRegisteredBlockNamesByParent(
-				innerBlockAreas.CHECKOUT_TOTALS
-			),
-		],
+		template: allowedBlocks,
 	} );
+
 	return (
 		<Sidebar className="wc-block-checkout__sidebar">
 			<div { ...blockProps }>
 				<InnerBlocks
-					allowedBlocks={ template }
-					template={ TEMPLATE }
+					allowedBlocks={ allowedBlocks }
 					templateLock={ false }
 				/>
 			</div>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-totals-block/edit.tsx
@@ -3,15 +3,14 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
-import {
-	getRegisteredBlockTemplate,
-	innerBlockAreas,
-} from '@woocommerce/blocks-checkout';
+import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+
 /**
  * Internal dependencies
  */
 import type { InnerBlockTemplate } from '../../types';
 import { useForcedLayout } from '../../use-forced-layout';
+import { getRegisteredBlockNamesByParent } from '../../editor-utils';
 
 const ALLOWED_BLOCKS: string[] = [ 'woocommerce/checkout-order-summary-block' ];
 const TEMPLATE: InnerBlockTemplate[] = [
@@ -20,12 +19,14 @@ const TEMPLATE: InnerBlockTemplate[] = [
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const registeredBlocks = getRegisteredBlockTemplate(
-		innerBlockAreas.CHECKOUT_TOTALS
-	);
 	const template = useForcedLayout( {
 		clientId,
-		template: [ ...ALLOWED_BLOCKS, ...registeredBlocks ],
+		template: [
+			...ALLOWED_BLOCKS,
+			...getRegisteredBlockNamesByParent(
+				innerBlockAreas.CHECKOUT_TOTALS
+			),
+		],
 	} );
 	return (
 		<Sidebar className="wc-block-checkout__sidebar">

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/register-components.ts
@@ -4,6 +4,7 @@
 import { lazy } from '@wordpress/element';
 import { registerBlockComponent } from '@woocommerce/blocks-registry';
 import { WC_BLOCKS_BUILD_URL } from '@woocommerce/block-settings';
+import { registerCheckoutBlock } from '@woocommerce/blocks-checkout';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -12,7 +13,16 @@ __webpack_public_path__ = WC_BLOCKS_BUILD_URL;
 /**
  * Internal dependencies
  */
-import './checkout-sample-block';
+import sampleBlockMetaData from './checkout-sample-block/block.json';
+
+registerCheckoutBlock( {
+	metadata: sampleBlockMetaData,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "checkout-blocks/sample" */ './checkout-sample-block/frontend'
+		)
+	),
+} );
 
 registerBlockComponent( {
 	blockName: 'woocommerce/checkout-fields-block',

--- a/assets/js/blocks/cart-checkout/checkout-i2/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout/checkout-i2/use-forced-layout.ts
@@ -22,7 +22,7 @@ export const useForcedLayout = ( {
 }: {
 	clientId: string;
 	template: Array< string >;
-} ): Array< string > => {
+} ): void => {
 	const currentTemplate = useRef( template );
 	const { insertBlock } = useDispatch( 'core/block-editor' );
 	const { innerBlocks, templateTypes } = useSelect(
@@ -60,6 +60,4 @@ export const useForcedLayout = ( {
 			}
 		} );
 	}, [ clientId, innerBlocks, insertBlock, templateTypes ] );
-
-	return currentTemplate.current;
 };

--- a/assets/js/settings/blocks/feature-flags.ts
+++ b/assets/js/settings/blocks/feature-flags.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import {
+	registerBlockType,
+	Block,
+	BlockConfiguration,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -14,11 +18,11 @@ import { WC_BLOCKS_PHASE } from './constants';
  * editor interface where blocks are implemented.
  */
 export const registerExperimentalBlockType = (
-	name: string,
+	blockNameOrMetadata: string | BlockConfiguration,
 	settings: Record< string, unknown >
-): Record< string, unknown > | undefined => {
+): Block | undefined => {
 	if ( WC_BLOCKS_PHASE > 2 ) {
-		return registerBlockType( name, settings );
+		return registerBlockType( blockNameOrMetadata, settings );
 	}
 };
 
@@ -28,11 +32,11 @@ export const registerExperimentalBlockType = (
  * option to any editor interface where blocks are implemented.
  */
 export const registerFeaturePluginBlockType = (
-	name: string,
+	blockNameOrMetadata: string | BlockConfiguration,
 	settings: Record< string, unknown >
-): Record< string, unknown > | undefined => {
+): Block | undefined => {
 	if ( WC_BLOCKS_PHASE > 1 ) {
-		return registerBlockType( name, settings );
+		return registerBlockType( blockNameOrMetadata, settings );
 	}
 };
 

--- a/packages/checkout/blocks-registry/README.md
+++ b/packages/checkout/blocks-registry/README.md
@@ -8,14 +8,31 @@ The Checkout Block has a function based interface for registering custom Blocks 
 
 ## Table of Contents <!-- omit in toc -->
 
-- [Registering a block - `registerCheckoutBlock( block, options )`](#registering-a-block---registercheckoutblock-block-options-)
+- [Registering a block](#registering-a-block)
+- [Registering a block component - `registerCheckoutBlock( options )`](#registering-a-block-component---registercheckoutblock-options-)
+  - [`metadata` (required)](#metadata-required)
   - [`component` (required)](#component-required)
-  - [`areas` (required)](#areas-required)
-  - [`configuration`](#configuration)
 
-## Registering a block - `registerCheckoutBlock( block, options )`
+## Registering a block
 
-To register a checkout block, you use the registerCheckoutBlock function from the checkout blocks registry. An example of importing this for use in your JavaScript file is:
+To register a checkout block, first, register your Block Type with WordPress using https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/. We recommend using the blocks.json method to avoid
+repetition.
+
+When registering your block, you should:
+
+1. Define the `parent` property to include a list of areas where your block will be available. See the `innerBlockAreas` typedef for available areas. Valid values at time of writing include:
+
+-   `woocommerce/checkout-totals-block` - The right side of the checkout containing order totals.
+-   `woocommerce/checkout-fields-block` - The left side of the checkout containing checkout form steps.
+-   `woocommerce/checkout-contact-information-block` - Within the contact information form step.
+-   `woocommerce/checkout-shipping-address-block` - Within the shipping address form step.
+-   `woocommerce/checkout-billing-address-block` - Within the billing address form step.
+-   `woocommerce/checkout-shipping-methods-block` - Within the shipping methods form step.
+-   `woocommerce/checkout-payment-methods-block` - Within the payment methods form step.
+
+## Registering a block component - `registerCheckoutBlock( options )`
+
+After registering your block, you need to define which component will replace your block on the frontend. To do this, use the registerCheckoutBlock function from the checkout blocks registry. An example of importing this for use in your JavaScript file is:
 
 _Aliased import_
 
@@ -29,46 +46,32 @@ _wc global_
 const { registerCheckoutBlock } = wc.blocksCheckout;
 ```
 
-The register function expects a block name string, and a JavaScript object with options specific to the block you are registering:
+The register function expects a JavaScript object with options specific to the block you are registering:
 
 ```js
-registerCheckoutBlock( blockName, options );
+registerCheckoutBlock( options );
 ```
 
 The options you feed the configuration instance should be an object in this shape (see `CheckoutBlockOptions` typedef):
 
 ```js
 const options = {
+	metadata: {
+		name: 'namespace/block-name',
+		parent: [ 'woocommerce/checkout-totals-block' ],
+	},
 	component: () => <div>A Function Component</div>,
-	areas: [ 'areaName' ],
-	configuration: {},
 };
 ```
 
 Here's some more details on the _configuration_ options:
+
+### `metadata` (required)
+
+This is a your blocks metadata (from blocks.json). It needs to define at least a `name` (block name), and `parent` (the areas on checkout) to be valid.
 
 ### `component` (required)
 
 This is a React component that should replace the Block on the frontend. It will be fed any attributes from the Block and have access to any public context providers in the Checkout context.
 
 You should provide either a _React Component_ or a `React.lazy()` component if you wish to lazy load for performance reasons.
-
-### `areas` (required)
-
-This is an array of string based area names which define when the custom block can be inserted within the Checkout.
-
-See the `RegisteredBlocks` typedef for available areas. Valid values at time of writing include:
-
--   `totals` - The right side of the checkout containing order totals.
--   `fields` - The left side of the checkout containing checkout form steps.
--   `contactInformation` - Within the contact information form step.
--   `shippingAddress` - Within the shipping address form step.
--   `billingAddress` - Within the billing address form step.
--   `shippingMethods` - Within the shipping methods form step.
--   `paymentMethods` - Within the payment methods form step.
-
-### `configuration`
-
-This is where a standard `BlockConfiguration` should be provided. This matches the [Block Registration Configuration in Gutenberg](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/).
-
-If a `BlockConfiguration` is not provided, your Block Type will not be registered in WordPress unless you manually register the block using `registerBlockType` (this is what `registerCheckoutBlock` does for you behind the scenes).

--- a/packages/checkout/blocks-registry/get-registered-blocks.ts
+++ b/packages/checkout/blocks-registry/get-registered-blocks.ts
@@ -10,18 +10,10 @@ import { registeredBlocks } from './registered-blocks';
 export const getRegisteredBlocks = (
 	area: innerBlockAreas
 ): Array< RegisteredBlock > => {
-	return [ ...( registeredBlocks[ area ] || [] ) ];
-};
-
-/**
- * Get a list of blocks names in inner block template format.
- */
-export const getRegisteredBlockTemplate = (
-	area: innerBlockAreas
-): Array< string > =>
-	getRegisteredBlocks( area ).map(
-		( block: RegisteredBlock ) => block.block
+	return Object.values( registeredBlocks ).filter( ( { metadata } ) =>
+		( metadata?.parent || [] ).includes( area )
 	);
+};
 
 /**
  * Check area is valid.

--- a/packages/checkout/blocks-registry/get-registered-blocks.ts
+++ b/packages/checkout/blocks-registry/get-registered-blocks.ts
@@ -5,19 +5,23 @@ import { innerBlockAreas, RegisteredBlock } from './types';
 import { registeredBlocks } from './registered-blocks';
 
 /**
- * Get a list of blocks available within a specific area.
+ * Check area is valid.
  */
-export const getRegisteredBlocks = (
-	area: innerBlockAreas
-): Array< RegisteredBlock > => {
-	return Object.values( registeredBlocks ).filter( ( { metadata } ) =>
-		( metadata?.parent || [] ).includes( area )
+export const hasInnerBlocks = ( block: string ): block is innerBlockAreas => {
+	return Object.values( innerBlockAreas ).includes(
+		block as innerBlockAreas
 	);
 };
 
 /**
- * Check area is valid.
+ * Get a list of blocks available within a specific area.
  */
-export const isInnerBlockArea = ( area: string ): area is innerBlockAreas => {
-	return Object.values( innerBlockAreas ).includes( area as innerBlockAreas );
+export const getRegisteredBlocks = (
+	block: string
+): Array< RegisteredBlock > => {
+	return hasInnerBlocks( block )
+		? Object.values( registeredBlocks ).filter( ( { metadata } ) =>
+				( metadata?.parent || [] ).includes( block )
+		  )
+		: [];
 };

--- a/packages/checkout/blocks-registry/register-checkout-block.ts
+++ b/packages/checkout/blocks-registry/register-checkout-block.ts
@@ -2,80 +2,39 @@
  * External dependencies
  */
 import { registerBlockComponent } from '@woocommerce/blocks-registry';
-import { registerExperimentalBlockType } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
  */
 import type { CheckoutBlockOptions } from './types';
-import {
-	assertBlockName,
-	assertOption,
-	assertBlockComponent,
-	assertValidArea,
-} from './utils';
+import { assertBlockName, assertOption, assertBlockComponent } from './utils';
 import { registeredBlocks } from './registered-blocks';
 
 /**
  * Main API for registering a new checkout block within areas.
  */
 export const registerCheckoutBlock = (
-	blockName: string,
 	options: CheckoutBlockOptions
 ): void => {
-	assertBlockName( blockName );
-	assertOption( options, 'areas', 'array' );
+	assertOption( options, 'metadata', 'object' );
+	assertBlockName( options.metadata.name );
 	assertBlockComponent( options, 'component' );
 
 	/**
 	 * This ensures the frontend component for the checkout block is available.
 	 */
 	registerBlockComponent( {
-		blockName,
+		blockName: options.metadata.name as string,
 		component: options.component,
 	} );
 
 	/**
-	 * If provided with a configuration object, this registers the block with WordPress.
+	 * Store block metadata for later lookup.
 	 */
-	if ( options?.configuration ) {
-		assertOption( options, 'configuration', 'object' );
-
-		const blockConfiguration = {
-			category: 'woocommerce',
-			parent: [],
-			...options.configuration,
-		};
-
-		if ( options.force ) {
-			blockConfiguration.attributes = {
-				...( options.configuration?.attributes || {} ),
-				lock: {
-					...( options.configuration?.attributes?.lock || {
-						type: 'object',
-						default: {
-							remove: true,
-						},
-					} ),
-				},
-			};
-		}
-
-		registerExperimentalBlockType( blockName, blockConfiguration );
-	}
-
-	/**
-	 * This enables the inner block within specific areas of the checkout. An area maps to the parent block name.
-	 */
-	options.areas.forEach( ( area ) => {
-		assertValidArea( area );
-		registeredBlocks[ area ] = [
-			...registeredBlocks[ area ],
-			{
-				block: blockName,
-				component: options.component,
-				force: options?.force || false,
-			},
-		];
-	} );
+	registeredBlocks[ options.metadata.name ] = {
+		blockName: options.metadata.name,
+		metadata: options.metadata,
+		component: options.component,
+		force: !! options.metadata?.attributes?.lock?.default?.remove,
+	};
 };

--- a/packages/checkout/blocks-registry/register-checkout-block.ts
+++ b/packages/checkout/blocks-registry/register-checkout-block.ts
@@ -7,7 +7,12 @@ import { registerBlockComponent } from '@woocommerce/blocks-registry';
  * Internal dependencies
  */
 import type { CheckoutBlockOptions } from './types';
-import { assertBlockName, assertOption, assertBlockComponent } from './utils';
+import {
+	assertBlockName,
+	assertBlockParent,
+	assertOption,
+	assertBlockComponent,
+} from './utils';
 import { registeredBlocks } from './registered-blocks';
 
 /**
@@ -18,6 +23,7 @@ export const registerCheckoutBlock = (
 ): void => {
 	assertOption( options, 'metadata', 'object' );
 	assertBlockName( options.metadata.name );
+	assertBlockParent( options.metadata.parent );
 	assertBlockComponent( options, 'component' );
 
 	/**

--- a/packages/checkout/blocks-registry/registered-blocks.ts
+++ b/packages/checkout/blocks-registry/registered-blocks.ts
@@ -3,44 +3,6 @@
  */
 import type { RegisteredBlocks } from './types';
 
-const registeredBlocks: RegisteredBlocks = {
-	'woocommerce/checkout-fields-block': [],
-	'woocommerce/checkout-totals-block': [],
-	'woocommerce/checkout-contact-information-block': [
-		{
-			block: 'core/paragraph',
-			component: null,
-			force: false,
-		},
-	],
-	'woocommerce/checkout-shipping-address-block': [
-		{
-			block: 'core/paragraph',
-			component: null,
-			force: false,
-		},
-	],
-	'woocommerce/checkout-billing-address-block': [
-		{
-			block: 'core/paragraph',
-			component: null,
-			force: false,
-		},
-	],
-	'woocommerce/checkout-shipping-methods-block': [
-		{
-			block: 'core/paragraph',
-			component: null,
-			force: false,
-		},
-	],
-	'woocommerce/checkout-payment-methods-block': [
-		{
-			block: 'core/paragraph',
-			component: null,
-			force: false,
-		},
-	],
-};
+const registeredBlocks: RegisteredBlocks = {};
 
 export { registeredBlocks };

--- a/packages/checkout/blocks-registry/test/index.js
+++ b/packages/checkout/blocks-registry/test/index.js
@@ -18,17 +18,63 @@ describe( 'checkout blocks registry', () => {
 		};
 		it( 'throws an error when registered block is missing `blockName`', () => {
 			expect(
-				invokeTest( { metadata: { name: null }, component } )
+				invokeTest( {
+					metadata: {
+						name: null,
+						parent: innerBlockAreas.CHECKOUT_FIELDS,
+					},
+					component,
+				} )
 			).toThrowError( /blockName/ );
 			expect(
-				invokeTest( { metadata: { name: '' }, component } )
+				invokeTest( {
+					metadata: {
+						name: '',
+						parent: innerBlockAreas.CHECKOUT_FIELDS,
+					},
+					component,
+				} )
 			).toThrowError( /blockName/ );
+		} );
+		it( 'throws an error when registered block is missing a valid parent', () => {
+			expect(
+				invokeTest( {
+					metadata: {
+						name: 'test/block-name',
+						parent: [],
+					},
+					component,
+				} )
+			).toThrowError( /parent/ );
+			expect(
+				invokeTest( {
+					metadata: {
+						name: 'test/block-name',
+						parent: 'invalid-parent',
+					},
+					component,
+				} )
+			).toThrowError( /parent/ );
+			expect(
+				invokeTest( {
+					metadata: {
+						name: 'test/block-name',
+						parent: [
+							'invalid-parent',
+							innerBlockAreas.CHECKOUT_FIELDS,
+						],
+					},
+					component,
+				} )
+			).not.toThrowError( /parent/ );
 		} );
 		it( 'throws an error when registered block is missing `component`', () => {
 			expect(
 				invokeTest( {
-					metadata: { name: 'test/block-name' },
-					component,
+					metadata: {
+						name: 'test/block-name',
+						parent: innerBlockAreas.CHECKOUT_FIELDS,
+					},
 				} )
 			).toThrowError( /component/ );
 		} );
@@ -37,7 +83,7 @@ describe( 'checkout blocks registry', () => {
 	describe( 'getRegisteredBlocks', () => {
 		it( 'gets an empty array when checkout area has no registered blocks', () => {
 			expect(
-				getRegisteredBlocks( innerBlockAreas.CHECKOUT_FIELDS )
+				getRegisteredBlocks( innerBlockAreas.CONTACT_INFORMATION )
 			).toEqual( [] );
 		} );
 		it( 'gets an empty array when the area is not defined', () => {

--- a/packages/checkout/blocks-registry/test/index.js
+++ b/packages/checkout/blocks-registry/test/index.js
@@ -18,25 +18,17 @@ describe( 'checkout blocks registry', () => {
 		};
 		it( 'throws an error when registered block is missing `blockName`', () => {
 			expect(
-				invokeTest( null, { areas: [ 'fields' ], component } )
+				invokeTest( { metadata: { name: null }, component } )
 			).toThrowError( /blockName/ );
 			expect(
-				invokeTest( '', { areas: [ 'fields' ], component } )
+				invokeTest( { metadata: { name: '' }, component } )
 			).toThrowError( /blockName/ );
-		} );
-		it( 'throws an error when area is invalid', () => {
-			expect(
-				invokeTest( 'test/block-name', {
-					areas: [ 'invalid-area' ],
-					component,
-				} )
-			).toThrowError( /area/ );
 		} );
 		it( 'throws an error when registered block is missing `component`', () => {
 			expect(
-				invokeTest( 'test/block-name', {
-					areas: [ 'fields' ],
-					component: null,
+				invokeTest( {
+					metadata: { name: 'test/block-name' },
+					component,
 				} )
 			).toThrowError( /component/ );
 		} );
@@ -50,21 +42,6 @@ describe( 'checkout blocks registry', () => {
 		} );
 		it( 'gets an empty array when the area is not defined', () => {
 			expect( getRegisteredBlocks( 'not-defined' ) ).toEqual( [] );
-		} );
-		it( 'gets a block that was successfully registered', () => {
-			registerCheckoutBlock( 'test/block-name', {
-				areas: [ innerBlockAreas.CHECKOUT_FIELDS ],
-				component,
-			} );
-			expect(
-				getRegisteredBlocks( innerBlockAreas.CHECKOUT_FIELDS )
-			).toEqual( [
-				{
-					block: 'test/block-name',
-					component,
-					force: false,
-				},
-			] );
 		} );
 	} );
 } );

--- a/packages/checkout/blocks-registry/types.ts
+++ b/packages/checkout/blocks-registry/types.ts
@@ -14,28 +14,27 @@ export enum innerBlockAreas {
 	PAYMENT_METHODS = 'woocommerce/checkout-payment-methods-block',
 }
 
-export type RegisteredBlockComponent =
-	| LazyExoticComponent< React.ComponentType< unknown > >
-	| ( () => JSX.Element | null );
+interface CheckoutBlockOptionsMetadata extends Partial< BlockConfiguration > {
+	name: string;
+	parent: string[];
+}
 
 export type RegisteredBlock = {
-	block: string;
-	component: RegisteredBlockComponent | null;
+	blockName: string;
+	metadata: CheckoutBlockOptionsMetadata;
+	component:
+		| LazyExoticComponent< React.ComponentType< unknown > >
+		| ( () => JSX.Element | null )
+		| null;
 	force: boolean;
 };
 
-export type RegisteredBlocks = Record<
-	innerBlockAreas,
-	Array< RegisteredBlock >
->;
+export type RegisteredBlocks = Record< string, RegisteredBlock >;
 
 export type CheckoutBlockOptions = {
-	// This is a component to render on the frontend in place of this block, when used.
-	component: RegisteredBlockComponent;
-	// Area(s) to add the block to. This can be a single area (string) or an array of areas.
-	areas: Array< innerBlockAreas >;
-	// Should this block be forced? If true, it cannot be removed from the editor interface, and will be rendered in defined areas automatically.
-	force?: boolean;
-	// Standard block configuration object. If not passed, the block will not be registered with WordPress and must be done manually.
-	configuration?: Partial< BlockConfiguration >;
+	metadata: CheckoutBlockOptionsMetadata;
+	component:
+		| LazyExoticComponent< React.ComponentType< unknown > >
+		| ( () => JSX.Element | null )
+		| null;
 };

--- a/packages/checkout/blocks-registry/utils.ts
+++ b/packages/checkout/blocks-registry/utils.ts
@@ -4,11 +4,6 @@
 import { isObject } from '@woocommerce/types';
 
 /**
- * Internal dependencies
- */
-import { innerBlockAreas } from './types';
-
-/**
  * Asserts that an option is of the given type. Otherwise, throws an error.
  *
  * @throws Will throw an error if the type of the option doesn't match the expected type.
@@ -22,21 +17,6 @@ export const assertType = (
 	if ( actualType !== expectedType ) {
 		throw new Error(
 			`Incorrect value for the ${ optionName } argument when registering a checkout block. It was a ${ actualType }, but must be a ${ expectedType }.`
-		);
-	}
-};
-
-/**
- * Validation to ensure an area exists.
- */
-export const assertValidArea = ( area: string ): void => {
-	if (
-		! Object.values( innerBlockAreas ).includes( area as innerBlockAreas )
-	) {
-		throw new Error(
-			`Incorrect value for the "area" argument. It was a ${ area }, but must be one of ${ Object.values(
-				innerBlockAreas
-			).join( ', ' ) }.`
 		);
 	}
 };
@@ -60,23 +40,22 @@ export const assertBlockName = ( blockName: string ): void => {
  * Asserts that an option is of the given type. Otherwise, throws an error.
  *
  * @throws Will throw an error if the type of the option doesn't match the expected type.
+ * @param {Object} options      Object containing the option to validate.
+ * @param {string} optionName   Name of the option to validate.
+ * @param {string} expectedType Type expected for the option.
  */
 export const assertOption = (
-	options: Record< string, unknown >,
+	options: unknown,
 	optionName: string,
-	expectedType: 'array' | 'object' | 'string' | 'boolean' | 'number'
+	expectedType: string
 ): void => {
+	if ( ! isObject( options ) ) {
+		return;
+	}
 	const actualType = typeof options[ optionName ];
-
-	if ( expectedType === 'array' ) {
-		if ( ! Array.isArray( options[ optionName ] ) ) {
-			throw new Error(
-				`Incorrect value for the ${ optionName } argument when registering a checkout block component. It was a ${ actualType }, but must be an array.`
-			);
-		}
-	} else if ( actualType !== expectedType ) {
+	if ( actualType !== expectedType ) {
 		throw new Error(
-			`Incorrect value for the ${ optionName } argument when registering a checkout block component. It was a ${ actualType }, but must be a ${ expectedType }.`
+			`Incorrect value for the ${ optionName } argument when registering a block component. It was a ${ actualType }, but must be a ${ expectedType }.`
 		);
 	}
 };

--- a/packages/checkout/blocks-registry/utils.ts
+++ b/packages/checkout/blocks-registry/utils.ts
@@ -4,6 +4,11 @@
 import { isObject } from '@woocommerce/types';
 
 /**
+ * Internal dependencies
+ */
+import { hasInnerBlocks } from './get-registered-blocks';
+
+/**
  * Asserts that an option is of the given type. Otherwise, throws an error.
  *
  * @throws Will throw an error if the type of the option doesn't match the expected type.
@@ -32,6 +37,34 @@ export const assertBlockName = ( blockName: string ): void => {
 	if ( ! blockName ) {
 		throw new Error(
 			`Value for the blockName argument must not be empty.`
+		);
+	}
+};
+
+/**
+ * Validate the block parent.
+ *
+ * @throws Will throw an error if the block name is invalid.
+ */
+export const assertBlockParent = ( blockParent: string | string[] ): void => {
+	if ( typeof blockParent !== 'string' && ! Array.isArray( blockParent ) ) {
+		throw new Error(
+			`Incorrect value for the parent argument when registering a checkout block. It was a ${ typeof blockParent }, but must be a string or array of strings.`
+		);
+	}
+
+	if ( typeof blockParent === 'string' && ! hasInnerBlocks( blockParent ) ) {
+		throw new Error(
+			`When registering a checkout block, the parent must be a valid inner block area.`
+		);
+	}
+
+	if (
+		Array.isArray( blockParent ) &&
+		! blockParent.some( ( parent ) => hasInnerBlocks( parent ) )
+	) {
+		throw new Error(
+			`When registering a checkout block, the parent must be a valid inner block area.`
 		);
 	}
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
 	"extends": "./tsconfig.base.json",
-	"include": [ "./assets/js/**/*" ],
+	"include": [
+		"./assets/js/**/*",
+		"./assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-sample-block/block.json"
+	],
 	"exclude": [ "./assets/js/data" ],
 	"references": [
 		{ "path": "./assets/js/data" },


### PR DESCRIPTION
This PR updates our Block Registration API for the Checkout to use Block Metadata. Doing so greatly simplifies the API and avoids frontend components being registered in the editor where they are not needed.

Additionally, this PR moves away from registered "areas" in favour of the "parent" API that already exists in Gutenberg. This is used to define where a block should be available without another form of registration.

The API is simplified down to this:

```js
registerCheckoutBlock( {
	metadata: sampleBlockMetaData,
	component: lazy( () =>
		import(
			/* webpackChunkName: "checkout-blocks/sample" */ './checkout-sample-block/frontend'
		)
	),
} );
```

With this, we have enough information to handle component registration without needing to also register the block. Block registration should be taken care of by the consumer. 