### PR TITLE
Expose Validation to 3PD blocks.

### DIFF
--- a/assets/js/base/context/hooks/index.js
+++ b/assets/js/base/context/hooks/index.js
@@ -13,3 +13,4 @@ export * from './use-checkout-notices';
 export * from './use-checkout-submit';
 export * from './use-emit-response';
 export * from './use-checkout-extension-data';
+export * from './use-validation';

--- a/assets/js/base/context/hooks/use-validation.ts
+++ b/assets/js/base/context/hooks/use-validation.ts
@@ -15,9 +15,7 @@ import { useValidationContext } from '../providers/validation/';
 /**
  * Custom hook for setting for adding errors to the validation system.
  */
-export const useValidation = (): ( (
-	validationErrorId: string
-) => ValidationData ) => {
+export const useValidation = (): ValidationData => {
 	const {
 		hasValidationErrors,
 		getValidationError,
@@ -25,30 +23,38 @@ export const useValidation = (): ( (
 		hideValidationError,
 		setValidationErrors,
 	} = useValidationContext();
+	const prefix = 'extensions-errors';
 
-	return useCallback(
-		( validationErrorId: string ) => {
-			validationErrorId = `extensions-errors-${ validationErrorId }`;
-			return {
-				hasValidationErrors,
-				getValidationError: () =>
-					getValidationError( validationErrorId ),
-				clearValidationError: () =>
-					clearValidationError( validationErrorId ),
-				hideValidationError: () =>
-					hideValidationError( validationErrorId ),
-				setValidationError: ( error: ValidationContextError ) =>
-					setValidationErrors( {
-						[ validationErrorId ]: error,
-					} ),
-			};
-		},
-		[
-			clearValidationError,
-			getValidationError,
-			hasValidationErrors,
-			hideValidationError,
-			setValidationErrors,
-		]
-	);
+	return {
+		hasValidationErrors,
+		getValidationError: useCallback(
+			( validationErrorId: string ) =>
+				getValidationError( `${ prefix }-${ validationErrorId }` ),
+			[ getValidationError ]
+		),
+		clearValidationError: useCallback(
+			( validationErrorId: string ) =>
+				clearValidationError( `${ prefix }-${ validationErrorId }` ),
+			[ clearValidationError ]
+		),
+		hideValidationError: useCallback(
+			( validationErrorId: string ) =>
+				hideValidationError( `${ prefix }-${ validationErrorId }` ),
+			[ hideValidationError ]
+		),
+		setValidationErrors: useCallback(
+			( errorsObject: Record< string, ValidationContextError > ) =>
+				setValidationErrors(
+					Object.fromEntries(
+						Object.entries(
+							errorsObject
+						).map( ( [ validationErrorId, error ] ) => [
+							`${ prefix }-${ validationErrorId }`,
+							error,
+						] )
+					)
+				),
+			[ setValidationErrors ]
+		),
+	};
 };

--- a/assets/js/base/context/hooks/use-validation.ts
+++ b/assets/js/base/context/hooks/use-validation.ts
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import type {
+	ValidationData,
+	ValidationContextError,
+} from '@woocommerce/type-defs/contexts';
+
+/**
+ * Internal dependencies
+ */
+import { useValidationContext } from '../providers/validation/';
+
+/**
+ * Custom hook for setting for adding errors to the validation system.
+ */
+export const useValidation = (): ( (
+	validationErrorId: string
+) => ValidationData ) => {
+	const {
+		hasValidationErrors,
+		getValidationError,
+		clearValidationError,
+		hideValidationError,
+		setValidationErrors,
+	} = useValidationContext();
+
+	return useCallback(
+		( validationErrorId: string ) => {
+			validationErrorId = `extensions-errors-${ validationErrorId }`;
+			return {
+				hasValidationErrors,
+				getValidationError: () =>
+					getValidationError( validationErrorId ),
+				clearValidationError: () =>
+					clearValidationError( validationErrorId ),
+				hideValidationError: () =>
+					hideValidationError( validationErrorId ),
+				setValidationError: ( error: ValidationContextError ) =>
+					setValidationErrors( {
+						[ validationErrorId ]: error,
+					} ),
+			};
+		},
+		[
+			clearValidationError,
+			getValidationError,
+			hasValidationErrors,
+			hideValidationError,
+			setValidationErrors,
+		]
+	);
+};

--- a/assets/js/blocks/cart-checkout/checkout-i2/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/frontend.tsx
@@ -4,7 +4,10 @@
 import { Children, cloneElement, isValidElement } from '@wordpress/element';
 import { getValidBlockAttributes } from '@woocommerce/base-utils';
 import { useStoreCart } from '@woocommerce/base-context';
-import { useCheckoutExtensionData } from '@woocommerce/base-context/hooks';
+import {
+	useCheckoutExtensionData,
+	useValidation,
+} from '@woocommerce/base-context/hooks';
 import { getRegisteredBlockComponents } from '@woocommerce/blocks-registry';
 import {
 	withStoreCartApiHydration,
@@ -38,13 +41,14 @@ const Wrapper = ( {
 	// eslint-disable-next-line no-unused-vars
 	const { extensions, receiveCart, ...cart } = useStoreCart();
 	const checkoutExtensionData = useCheckoutExtensionData();
-
+	const validation = useValidation();
 	return Children.map( children, ( child ) => {
 		if ( isValidElement( child ) ) {
 			const componentProps = {
 				extensions,
 				cart,
 				checkoutExtensionData,
+				validation,
 			};
 			return cloneElement( child, componentProps );
 		}

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -26,7 +26,7 @@ const FrontendBlock = ( {
 	validation: ValidationData;
 } ): JSX.Element => {
 	const [ checked, setChecked ] = useState( false );
-	// @todo Checkout i2 - Pass validation context to Inner Blocks to avoid exporting in a public package.
+
 	const { isDisabled } = useCheckoutSubmit();
 
 	const validationErrorId = 'terms-and-conditions-' + instanceId;

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -5,10 +5,9 @@ import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useState, useEffect } from '@wordpress/element';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
-import { useValidationContext } from '@woocommerce/base-context';
 import { useCheckoutSubmit } from '@woocommerce/base-context/hooks';
 import { withInstanceId } from '@wordpress/compose';
-
+import type { ValidationData } from '@woocommerce/type-defs/contexts';
 /**
  * Internal dependencies
  */
@@ -19,23 +18,25 @@ const FrontendBlock = ( {
 	text,
 	checkbox,
 	instanceId,
+	validation,
 }: {
 	text: string;
 	checkbox: boolean;
 	instanceId: string;
+	validation: ( validationErrorId: string ) => ValidationData;
 } ): JSX.Element => {
 	const [ checked, setChecked ] = useState( false );
-
 	// @todo Checkout i2 - Pass validation context to Inner Blocks to avoid exporting in a public package.
 	const { isDisabled } = useCheckoutSubmit();
-	const {
-		getValidationError,
-		setValidationErrors,
-		clearValidationError,
-	} = useValidationContext();
 
 	const validationErrorId = 'terms-and-conditions-' + instanceId;
-	const error = getValidationError( validationErrorId ) || {};
+	const {
+		getValidationError,
+		setValidationError,
+		clearValidationError,
+	} = validation( validationErrorId );
+
+	const error = getValidationError() || {};
 	const hasError = error.message && ! error.hidden;
 
 	// Track validation errors for this input.
@@ -44,27 +45,25 @@ const FrontendBlock = ( {
 			return;
 		}
 		if ( checked ) {
-			clearValidationError( validationErrorId );
+			clearValidationError();
 		} else {
-			setValidationErrors( {
-				[ validationErrorId ]: {
-					message: __(
-						'Please read and accept the terms and conditions.',
-						'woo-gutenberg-products-block'
-					),
-					hidden: true,
-				},
+			setValidationError( {
+				message: __(
+					'Please read and accept the terms and conditions.',
+					'woo-gutenberg-products-block'
+				),
+				hidden: true,
 			} );
 		}
 		return () => {
-			clearValidationError( validationErrorId );
+			clearValidationError();
 		};
 	}, [
 		checkbox,
 		checked,
 		validationErrorId,
 		clearValidationError,
-		setValidationErrors,
+		setValidationError,
 	] );
 
 	return (

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -23,7 +23,7 @@ const FrontendBlock = ( {
 	text: string;
 	checkbox: boolean;
 	instanceId: string;
-	validation: ( validationErrorId: string ) => ValidationData;
+	validation: ValidationData;
 } ): JSX.Element => {
 	const [ checked, setChecked ] = useState( false );
 	// @todo Checkout i2 - Pass validation context to Inner Blocks to avoid exporting in a public package.
@@ -32,11 +32,11 @@ const FrontendBlock = ( {
 	const validationErrorId = 'terms-and-conditions-' + instanceId;
 	const {
 		getValidationError,
-		setValidationError,
+		setValidationErrors,
 		clearValidationError,
-	} = validation( validationErrorId );
+	} = validation;
 
-	const error = getValidationError() || {};
+	const error = getValidationError( validationErrorId ) || {};
 	const hasError = error.message && ! error.hidden;
 
 	// Track validation errors for this input.
@@ -45,22 +45,27 @@ const FrontendBlock = ( {
 			return;
 		}
 		if ( checked ) {
-			clearValidationError();
+			clearValidationError( validationErrorId );
 		} else {
-			setValidationError( {
-				message: __(
-					'Please read and accept the terms and conditions.',
-					'woo-gutenberg-products-block'
-				),
-				hidden: false,
+			setValidationErrors( {
+				[ validationErrorId ]: {
+					message: __(
+						'Please read and accept the terms and conditions.',
+						'woo-gutenberg-products-block'
+					),
+					hidden: true,
+				},
 			} );
 		}
+		return () => {
+			clearValidationError( validationErrorId );
+		};
 	}, [
 		checkbox,
 		checked,
 		validationErrorId,
 		clearValidationError,
-		setValidationError,
+		setValidationErrors,
 	] );
 
 	return (

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -52,12 +52,9 @@ const FrontendBlock = ( {
 					'Please read and accept the terms and conditions.',
 					'woo-gutenberg-products-block'
 				),
-				hidden: true,
+				hidden: false,
 			} );
 		}
-		return () => {
-			clearValidationError();
-		};
 	}, [
 		checkbox,
 		checked,

--- a/assets/js/types/type-defs/contexts.ts
+++ b/assets/js/types/type-defs/contexts.ts
@@ -5,8 +5,10 @@ export type ValidationContextError = {
 
 export type ValidationData = {
 	hasValidationErrors: boolean;
-	getValidationError: () => ValidationContextError;
-	clearValidationError: () => void;
-	hideValidationError: () => void;
-	setValidationError: ( error: ValidationContextError ) => void;
+	getValidationError: ( validationErrorId: string ) => ValidationContextError;
+	clearValidationError: ( validationErrorId: string ) => void;
+	hideValidationError: ( validationErrorId: string ) => void;
+	setValidationErrors: (
+		errors: Record< string, ValidationContextError >
+	) => void;
 };

--- a/assets/js/types/type-defs/contexts.ts
+++ b/assets/js/types/type-defs/contexts.ts
@@ -1,0 +1,12 @@
+export type ValidationContextError = {
+	message: string;
+	hidden: boolean;
+};
+
+export type ValidationData = {
+	hasValidationErrors: boolean;
+	getValidationError: () => ValidationContextError;
+	clearValidationError: () => void;
+	hideValidationError: () => void;
+	setValidationError: ( error: ValidationContextError ) => void;
+};


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Introduced `useValidation` which returns `validation` that we pass to plugins. Upon being executed, it returns validation related functions that 3PD can use.

<!-- Reference any related issues or PRs here -->
Fixes #4502

### How to test the changes in this Pull Request:

1. Add Terms block to Checkout i2
2. Turn it to Checkbox instead of text.
3. Visit Checkout i2, you can toggle the field, leaving it untoggled and submitting would prevent the order.
4. in `assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/index.tsx`, inside `parent` add `woocommerce/checkout-billing-address-block`.
5. Open Checkout i2 block, remove Terms block from below block. Uncheck "using same address for billing", add Terms block to billing step, save.
6. Visit checkout, placing order with  checked should work fine.
7. Unchecking "using same address for billing" would prevent the block from checking out if the Terms block isn't checked.
8. Checking "using same address for billing" would remove that requirement.

