### PR TITLE
Mini Cart block: add 'ver' query param to script URLs

### DIFF
--- a/assets/js/base/utils/lazy-load-script.ts
+++ b/assets/js/base/utils/lazy-load-script.ts
@@ -123,7 +123,7 @@ const lazyLoadScript = ( {
 			id: `${ handle }-js`,
 			onerror: reject,
 			onload,
-			src: version ? `${ src }?${ version }` : src,
+			src: version ? `${ src }?ver=${ version }` : src,
 		} );
 	} );
 };

--- a/assets/js/base/utils/preload-script.ts
+++ b/assets/js/base/utils/preload-script.ts
@@ -19,7 +19,7 @@ const preloadScript = ( {
 
 	if ( handleScriptElements.length === 0 ) {
 		const prefetchLink = document.createElement( 'link' );
-		prefetchLink.href = version ? `${ src }?${ version }` : src;
+		prefetchLink.href = version ? `${ src }?ver=${ version }` : src;
 		prefetchLink.rel = 'preload';
 		prefetchLink.as = 'script';
 		prefetchLink.id = `${ handle }-js-prefetch`;


### PR DESCRIPTION
This is a small PR fixing a flaw in the `preloadScript` and the `lazyLoadScript` utils. They were generating script URLs different from the ones generated by WP.

Ie:
`/wp-content/plugins/gutenberg/build/element/index.min.js?51b038d0a9e09d863ec01732ed923941` instead of
`/wp-content/plugins/gutenberg/build/element/index.min.js?ver=51b038d0a9e09d863ec01732ed923941` (notice the missing `ver=`).

That would make the browser cache to consider both scripts different.

### How to test the changes in this Pull Request:

1. Create a page with the Mini Cart block. Go to the frontend and click on the button. In your browser devtools, go to the Network tab and search for a script with the word `element`, for example. Write down its location.
Ie: `/wp-content/plugins/gutenberg/build/element/index.min.js?ver=51b038d0a9e09d863ec01732ed923941`
2. Now, create a page with the Cart block. Go to the frontend and in your browser devtools, go to the Network tab and search for a script with the same word as the step before. Compare its location with the one from step 1 and verify they are exactly the same.
