### PR TITLE
Fix Checkout i2 mobile styling

### DIFF
--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -5,7 +5,6 @@
 .wc-block-components-form .wc-block-components-checkout-step {
 	position: relative;
 	border: none;
-	// This makes the padding equal on both sides and aligned with elements like checkboxes.
 	padding: 0 0 0 $gap-large;
 	background: none;
 	margin: 0;

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -5,22 +5,14 @@
 .wc-block-components-form .wc-block-components-checkout-step {
 	position: relative;
 	border: none;
-	padding: 0 0 0 $gap-larger;
+	// This makes the padding equal on both sides and aligned with elements like checkboxes.
+	padding: 0 0 0 $gap-large;
 	background: none;
 	margin: 0;
 
-	.is-large & {
-		padding-right: $gap-large;
-	}
-
-	.wc-block-components-checkout-step__heading::after {
-		content: "";
-		border-left: 1px solid;
-		opacity: 0.3;
-		position: absolute;
-		left: -$gap-larger*0.5;
-		top: 2.5em;
-		bottom: em($gap) * -1;
+	.is-mobile &,
+	.is-small & {
+		padding-left: 0;
 	}
 }
 
@@ -49,6 +41,10 @@
 	position: relative;
 	align-items: center;
 	gap: em($gap);
+
+	.wc-block-components-express-payment-continue-rule + .wc-block-components-checkout-step & {
+		margin-top: 0;
+	}
 }
 
 .wc-block-components-checkout-step:first-child .wc-block-components-checkout-step__heading {
@@ -82,11 +78,21 @@
 		content: "\00a0" counter(checkout-step) ".";
 		content: "\00a0" counter(checkout-step) "." / "";
 		position: absolute;
-		width: $gap-larger;
-		left: -$gap-larger*0.5;
+		width: $gap-large;
+		left: -$gap-large;
 		top: 0;
 		text-align: center;
 		transform: translateX(-50%);
+
+		.is-mobile &,
+		.is-small & {
+			position: static;
+			transform: none;
+			left: auto;
+			top: auto;
+			content: counter(checkout-step) ".\00a0";
+			content: counter(checkout-step) ".\00a0" / "";
+		}
 	}
 
 	.wc-block-components-checkout-step__container::after {
@@ -95,7 +101,22 @@
 		border-left: 1px solid;
 		opacity: 0.3;
 		position: absolute;
-		left: -$gap-larger*0.5;
+		left: -$gap-large;
 		top: 0;
+	}
+
+	.is-mobile &,
+	.is-small & {
+		.wc-block-components-checkout-step__title::before {
+			position: static;
+			transform: none;
+			left: auto;
+			top: auto;
+			content: counter(checkout-step) ".\00a0";
+			content: counter(checkout-step) ".\00a0" / "";
+		}
+		.wc-block-components-checkout-step__container::after {
+			content: unset;
+		}
 	}
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/editor.scss
@@ -2,3 +2,6 @@
 .wc-block-checkout__additional_fields {
 	margin: 1.5em 0 -1.5em;
 }
+.wc-block-components-checkout-step__description-placeholder {
+	opacity: 0.5;
+}

--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/editor.scss
@@ -5,3 +5,7 @@
 .wc-block-components-checkout-step__description-placeholder {
 	opacity: 0.5;
 }
+
+.wc-block-components-checkout-step__title {
+	display: flex;
+}

--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/form-step-block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/form-step-block.tsx
@@ -35,7 +35,6 @@ export const FormStepBlock = ( {
 		} ),
 		attributes,
 	} );
-
 	return (
 		<div { ...blockProps }>
 			<InspectorControls>
@@ -69,10 +68,20 @@ export const FormStepBlock = ( {
 			<div className="wc-block-components-checkout-step__container">
 				<p className="wc-block-components-checkout-step__description">
 					<PlainText
-						className={ '' }
+						className={
+							! description
+								? 'wc-block-components-checkout-step__description-placeholder'
+								: ''
+						}
 						value={ description }
+						placeholder={ __(
+							'Optional text for this form step.',
+							'woo-gutenberg-products-block'
+						) }
 						onChange={ ( value ) =>
-							setAttributes( { description: value } )
+							setAttributes( {
+								description: value,
+							} )
 						}
 					/>
 				</p>

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-actions-block/style.scss
@@ -2,7 +2,6 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-left: 9px;
 
 	.wc-block-components-checkout-place-order-button {
 		width: 50%;
@@ -35,7 +34,6 @@
 .is-large {
 	.wc-block-checkout__actions {
 		@include with-translucent-border(1px 0 0);
-		margin-right: $gap-large;
 		padding: em($gap-large) 0;
 	}
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-express-payment-block/editor.scss
@@ -12,7 +12,8 @@
 
 	&.wp-block-woocommerce-checkout-express-payment-block--has-express-payment-methods {
 		padding: 14px 0;
-		margin: 14px 0;
+		margin: -14px 0 14px 0 !important;
+		position: relative;
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-payment-block/attributes.tsx
@@ -10,11 +10,8 @@ import formStepAttributes from '../../form-step/attributes';
 
 export default {
 	...formStepAttributes( {
-		defaultTitle: __( 'Payment Method', 'woo-gutenberg-products-block' ),
-		defaultDescription: __(
-			'Select a payment method below.',
-			'woo-gutenberg-products-block'
-		),
+		defaultTitle: __( 'Payment options', 'woo-gutenberg-products-block' ),
+		defaultDescription: '',
 	} ),
 	lock: {
 		type: 'object',

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-shipping-methods-block/attributes.tsx
@@ -11,10 +11,7 @@ import formStepAttributes from '../../form-step/attributes';
 export default {
 	...formStepAttributes( {
 		defaultTitle: __( 'Shipping options', 'woo-gutenberg-products-block' ),
-		defaultDescription: __(
-			'Select shipping options below.',
-			'woo-gutenberg-products-block'
-		),
+		defaultDescription: '',
 	} ),
 	allowCreateAccount: {
 		type: 'boolean',

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/editor.scss
@@ -1,22 +1,17 @@
 // Adjust padding and margins in the editor to improve selected block outlines.
 .wc-block-checkout__terms {
-	margin: 20px 0 20px 9px;
+	margin: 20px 0;
 	padding-top: 4px;
 	padding-bottom: 4px;
 	display: flex;
 	align-items: flex-start;
 
 	.block-editor-rich-text__editable {
-		padding-left: $gap;
 		vertical-align: middle;
 		line-height: em(24px);
 	}
 }
 
-.wc-block-checkout__terms_notice {
-	margin-left: 9px;
-
-	.components-notice__action {
-		margin-left: 0;
-	}
+.wc-block-checkout__terms_notice .components-notice__action {
+	margin-left: 0;
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/editor.scss
@@ -12,6 +12,10 @@
 	}
 }
 
+.wc-block-components-checkbox {
+	margin-right: $gap;
+}
+
 .wc-block-checkout__terms_notice .components-notice__action {
 	margin-left: 0;
 }

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/style.scss
@@ -1,5 +1,6 @@
 .wc-block-checkout__terms {
-	margin: 1.5em 0 1.5em 9px;
+	margin: 1.5em 0;
+	text-align: justify;
 
 	textarea {
 		top: -5px;

--- a/assets/js/blocks/cart-checkout/checkout-i2/styles/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/styles/editor.scss
@@ -1,23 +1,32 @@
-[data-type="woocommerce/checkout-i2"] {
+.wp-block-woocommerce-checkout-i2 {
+	margin-top: 0;
+
 	.wc-block-components-sidebar-layout {
 		display: block;
 	}
 	.block-editor-block-list__layout {
 		display: flex;
 		flex-flow: row wrap;
-		align-items: baseline;
-	}
-}
+		align-items: flex-start;
 
-[data-type="woocommerce/checkout-fields-block"] {
-	.block-editor-block-list__layout {
-		display: block;
+		.wc-block-checkout__additional_fields {
+			padding: 0;
+		}
 	}
-}
 
-[data-type="woocommerce/checkout-totals-block"] {
+	.wc-block-components-main,
+	.wc-block-components-sidebar,
 	.block-editor-block-list__layout {
-		display: block;
+		> :first-child {
+			margin-top: 0;
+		}
+	}
+
+	.wp-block-woocommerce-checkout-totals-block,
+	.wp-block-woocommerce-checkout-fields-block {
+		.block-editor-block-list__layout {
+			display: block;
+		}
 	}
 }
 
@@ -32,7 +41,6 @@ body.wc-lock-selected-block--move {
 	}
 }
 
-
 body.wc-lock-selected-block--remove {
 	.block-editor-block-settings-menu__popover {
 		.components-menu-group:last-child {
@@ -41,5 +49,13 @@ body.wc-lock-selected-block--remove {
 		.components-menu-group:nth-last-child(2) {
 			margin-bottom: -12px;
 		}
+	}
+}
+
+.is-mobile,
+.is-small,
+.is-medium {
+	.wc-block-checkout__sidebar {
+		margin-bottom: 0;
 	}
 }

--- a/assets/js/blocks/cart-checkout/checkout/form/order-notes/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/form/order-notes/style.scss
@@ -1,5 +1,5 @@
 .wc-block-checkout__add-note {
-	margin: em($gap-large) 0 em($gap-large) 9px;
+	margin: em($gap-large) 0;
 }
 
 .is-mobile,

--- a/assets/js/blocks/cart-checkout/checkout/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/style.scss
@@ -21,7 +21,6 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	margin-left: 9px;
 
 	.wc-block-components-checkout-place-order-button {
 		width: 50%;
@@ -144,7 +143,7 @@
 	}
 
 	.wc-block-checkout__sidebar {
-		margin-bottom: $gap-largest;
+		margin-bottom: $gap-large;
 		order: 0;
 	}
 }
@@ -152,7 +151,6 @@
 .is-large {
 	.wc-block-checkout__actions {
 		@include with-translucent-border(1px 0 0);
-		margin-right: $gap-large;
 		padding-top: em($gap-large);
 	}
 }

--- a/assets/js/blocks/cart-checkout/payment-methods/express-payment/checkout-express-payment.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/express-payment/checkout-express-payment.js
@@ -86,7 +86,7 @@ const CheckoutExpressPayment = () => {
 						>
 							<p>
 								{ __(
-									'In a hurry? Use one of our express checkout options below:',
+									'In a hurry? Use one of our express checkout options:',
 									'woo-gutenberg-products-block'
 								) }
 							</p>

--- a/assets/js/blocks/cart-checkout/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout/payment-methods/express-payment/style.scss
@@ -28,6 +28,8 @@ $border-radius: 5px;
 }
 
 .wc-block-components-express-payment--checkout {
+	margin-top: $border-radius;
+
 	.wc-block-components-express-payment__title-container {
 		display: flex;
 		flex-direction: row;
@@ -48,7 +50,7 @@ $border-radius: 5px;
 			margin-right: $gap-small;
 			opacity: 0.3;
 			pointer-events: none;
-			width: #{$gap-larger - $gap-small - $border-width * 2};
+			width: #{$gap-large - $gap-small - $border-width * 2};
 		}
 
 		&::after {
@@ -72,8 +74,7 @@ $border-radius: 5px;
 
 	.wc-block-components-express-payment__content {
 		@include with-translucent-border(0 $border-width $border-width);
-		margin-top: calc(0.75em + #{$border-radius});
-		padding: em($gap-large) #{$gap-larger - $border-width} em($gap) #{$gap-larger - $border-width};
+		padding: em($gap-large) #{$gap-large - $border-width};
 
 		&::after {
 			border-radius: 0 0 $border-radius $border-radius;
@@ -118,7 +119,7 @@ $border-radius: 5px;
 	display: flex;
 	align-items: center;
 	text-align: center;
-	padding: 0 $gap-larger;
+	padding: 0 $gap-large;
 	margin: $gap-large 0;
 
 	&::before {


### PR DESCRIPTION
The goal of this PR is to improve the appearance of Checkout i2 on mobile, as well as adding some consistency with the Desktop views. This includes better alignment of fields in the column, and removal of the indentation when viewing on a mobile device or small screen.

Fixes #4576

### Screenshots

Here are some side by side views showing what has changed:

**Mobile appearance:**

| Before | After |
| ------------- | ------------- |
|  ![Screenshot 2021-09-09 at 14 41 11](https://user-images.githubusercontent.com/90977/132696866-7f20f02a-2c95-4698-a544-5ef5401d9ab6.png) |  ![Screenshot 2021-09-09 at 13 45 25](https://user-images.githubusercontent.com/90977/132692714-546b1819-1f59-4070-ba2a-91a4148a8a0e.png) |
|  ![Screenshot 2021-09-09 at 14 41 18](https://user-images.githubusercontent.com/90977/132696876-bee0e392-64d1-4c2a-ad60-abc31b0889a2.png) |  ![Screenshot 2021-09-09 at 13 45 40](https://user-images.githubusercontent.com/90977/132692758-2a2ffbf4-3df5-445e-9cad-7472cbdf32fb.png) |

**Desktop appearance:**

| Before | After |
| ------------- | ------------- |
|  ![Screenshot 2021-09-09 at 14 41 42](https://user-images.githubusercontent.com/90977/132696914-83adbead-df10-4756-aac3-fcd2b7b3dc79.png) |  ![Screenshot 2021-09-09 at 13 46 10](https://user-images.githubusercontent.com/90977/132694894-7e8c3588-73cc-4551-8b35-7f8c3aaab0c6.png) |
| ![Screenshot 2021-09-09 at 14 41 47](https://user-images.githubusercontent.com/90977/132696922-a38aab18-9899-476d-8ba1-0abd058a4524.png)  |  ![Screenshot 2021-09-09 at 13 46 18](https://user-images.githubusercontent.com/90977/132694905-670bdd48-e33a-420b-af46-a1af462d39f7.png) |

**Editor appearance:**

| Before | After |
| ------------- | ------------- |
| ![Screenshot 2021-09-09 at 14 41 54](https://user-images.githubusercontent.com/90977/132696960-6264c492-6fd7-4606-8d1a-8153f82d95eb.png)  |  ![Screenshot 2021-09-09 at 14 10 38](https://user-images.githubusercontent.com/90977/132694942-9cd54e5d-0ba0-4ac5-abe6-d00379d10ea2.png) |
|  ![Screenshot 2021-09-09 at 14 41 35](https://user-images.githubusercontent.com/90977/132696972-508b3837-ad94-4cd6-973e-946f11a66f18.png) | ![Screenshot 2021-09-09 at 14 10 48](https://user-images.githubusercontent.com/90977/132694947-84a6696b-6dcf-4879-8c2e-79b0623868cb.png)  |

### Manual Testing

How to test the changes in this Pull Request:

1. View checkout i2 block
2. Confirm elements are styled as shown above on both desktop, and mobile (using browser tools)
3. Repeat for i1. This will also reflect the changes above

### Changelog

> Updated checkout styling to reduce margins in the mobile layout
