### PR TITLE
Handle `process_payment` errors the same way as validation

### DIFF
--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -161,6 +161,9 @@ class Api {
 		// Process Payment.
 		$gateway_result = $payment_method_object->process_payment( $context->order->get_id() );
 
+		// If errors were thrown while processing the payment, we need to abort as well.
+		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
+
 		// Restore $_POST data.
 		$_POST = $post_data;
 


### PR DESCRIPTION
`Api::process_legacy_payment` already has functionality to convert notices to exceptions, but it was
only called before the gateway's `process_payment`. That call should remain there, but `process_payment`
might add its own notices later (see PR https://github.com/Automattic/woocommerce-payments/pull/2872), which is why another conversion of notices to exceptions is required.

### Screenshots

<img width="819" alt="image" src="https://user-images.githubusercontent.com/5311119/132699031-f5937cdb-30d8-446a-a68b-43b5c428de0f.png">

### Testing

#### Automated Tests

This functionality already exists and is now simply called again a couple of lines later. Additional tests should not be needed.

### Manual Testing

How to test the changes in this Pull Request:

1. Checkout https://github.com/Automattic/woocommerce-payments/pull/2872 for WCPay
2. Try purchasing a product with less than $0.50 USD order total (incl. shipping)
3. See a generic message about something going wrong.
4. Checkout this PR
5. Try checkout again. A full message should be displayed like the screenshot above.

### Performance Impact

The performance impact here is minimal (iterating over a normally empty array).

### Changelog

No changelog entry required.