### PR TITLE
Add e2e tests for Active Product Filters block

### DIFF
--- a/tests/e2e/specs/backend/__fixtures__/active-filters.fixture.json
+++ b/tests/e2e/specs/backend/__fixtures__/active-filters.fixture.json
@@ -1,0 +1,1 @@
+{"title":"Active Product Filters Block","pageContent":"<!-- wp:woocommerce/active-filters -->\n<div class=\"wp-block-woocommerce-active-filters is-loading\" data-display-style=\"list\" data-heading=\"Active filters\" data-heading-level=\"3\"><span aria-hidden=\"true\" class=\"wc-block-active-product-filters__placeholder\"></span></div>\n<!-- /wp:woocommerce/active-filters -->"}

--- a/tests/e2e/specs/backend/__snapshots__/active-filters.test.js.snap
+++ b/tests/e2e/specs/backend/__snapshots__/active-filters.test.js.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Active Product Filters Block can change title label in editor 1`] = `
+"<!-- wp:woocommerce/active-filters -->
+<div class=\\"wp-block-woocommerce-active-filters is-loading\\" data-display-style=\\"list\\" data-heading=\\"Active filters\\" data-heading-level=\\"3\\"><span aria-hidden=\\"true\\" class=\\"wc-block-active-product-filters__placeholder\\"></span></div>
+<!-- /wp:woocommerce/active-filters -->"
+`;

--- a/tests/e2e/specs/backend/active-filters.test.js
+++ b/tests/e2e/specs/backend/active-filters.test.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import {
+	getAllBlocks,
+	switchUserToAdmin,
+	getEditedPostContent,
+} from '@wordpress/e2e-test-utils';
+import { clearAndFillInput } from '@woocommerce/e2e-utils';
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+const block = {
+	name: 'Active Product Filters',
+	slug: 'woocommerce/active-filters',
+	class: '.wc-block-active-filters',
+};
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'can be inserted once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 1 );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+
+	it( 'can change title label in editor', async () => {
+		await expect( page ).toFill(
+			'.wc-block-active-filters__title > textarea',
+			'Current filters'
+		);
+
+		await clearAndFillInput(
+			'.wc-block-active-filters__title > textarea',
+			'Active filters'
+		);
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
### Note

Currently, not every block is covered by e2e tests. This PR aims to add e2e tests for the Active Product Filters block.

Part of #4643 

### Testing

1. Check out this PR.
2. Run `npm run wp-env start && npm run test:e2e`.
3. The e2e test suite shows no failed tests.