### PR TITLE
Checkout i2: Hide tax row if tax totals are 0

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/block.tsx
@@ -88,15 +88,16 @@ const Block = ( {
 					/>
 				</TotalsWrapper>
 			) }
-			{ ! getSetting( 'displayCartPricesIncludingTax', false ) && (
-				<TotalsWrapper>
-					<TotalsTaxes
-						currency={ totalsCurrency }
-						showRateAfterTaxName={ showRateAfterTaxName }
-						values={ cartTotals }
-					/>
-				</TotalsWrapper>
-			) }
+			{ ! getSetting( 'displayCartPricesIncludingTax', false ) &&
+				parseInt( cartTotals.total_tax, 10 ) > 0 && (
+					<TotalsWrapper>
+						<TotalsTaxes
+							currency={ totalsCurrency }
+							showRateAfterTaxName={ showRateAfterTaxName }
+							values={ cartTotals }
+						/>
+					</TotalsWrapper>
+				) }
 			<TotalsWrapper>
 				<TotalsFooterItem
 					currency={ totalsCurrency }


### PR DESCRIPTION
Hides the tax row if totals are 0. This fix is directly copied from the Checkout i1 block.

Fixes #4712

### Screenshots

![Screenshot 2021-09-10 at 15 44 23](https://user-images.githubusercontent.com/90977/132872060-018cd9d9-8c99-43f8-adcf-4b95495635b1.png)

### Testing

How to test the changes in this Pull Request:

1. Turn of taxes in WC > Settings > General
2. View Checkout
3. Ensure row is hidden.