### PR TITLE
Wrap order summary block in disabled in Checkout i2

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-order-summary-block/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import { getSetting } from '@woocommerce/settings';
 
 /**
@@ -66,7 +66,11 @@ export const Edit = ( {
 						</PanelBody>
 					) }
 			</InspectorControls>
-			<Block showRateAfterTaxName={ attributes.showRateAfterTaxName } />
+			<Disabled>
+				<Block
+					showRateAfterTaxName={ attributes.showRateAfterTaxName }
+				/>
+			</Disabled>
 		</div>
 	);
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Wraps order summary block in `<Disabled>` to prevent interactions with Coupons panel or other panels.
If we're to change this block later to be an inner block, we would remove the Disabled and move it deeper.
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4711
Fixes #4710

### Testing
- In Edtitor, insert Checkout i2.
- Make sure you can't interact with Coupons panel
- Make sure you can't interact with other panels