### PR TITLE
Checkout i2: Add focus styles to form elements

### DIFF
--- a/assets/js/base/components/checkbox-control/index.tsx
+++ b/assets/js/base/components/checkbox-control/index.tsx
@@ -16,6 +16,7 @@ type CheckboxControlProps = {
 	instanceId: string;
 	onChange: ( value: boolean ) => void;
 	children: React.ReactChildren;
+	hasError: boolean;
 };
 
 /**
@@ -28,6 +29,7 @@ const CheckboxControl = ( {
 	instanceId,
 	onChange,
 	children,
+	hasError = false,
 	...rest
 }: CheckboxControlProps ): JSX.Element => {
 	const checkboxId = id || `checkbox-control-${ instanceId }`;
@@ -36,6 +38,9 @@ const CheckboxControl = ( {
 		<label
 			className={ classNames(
 				'wc-block-components-checkbox',
+				{
+					'has-error': hasError,
+				},
 				className
 			) }
 			htmlFor={ checkboxId }
@@ -45,6 +50,7 @@ const CheckboxControl = ( {
 				className="wc-block-components-checkbox__input"
 				type="checkbox"
 				onChange={ ( event ) => onChange( event.target.checked ) }
+				aria-invalid={ hasError === true }
 				{ ...rest }
 			/>
 			<svg

--- a/assets/js/base/components/checkbox-control/style.scss
+++ b/assets/js/base/components/checkbox-control/style.scss
@@ -25,6 +25,11 @@
 			border-color: $input-border-gray;
 		}
 
+		&:focus {
+			outline: 2px solid $input-border-gray;
+			outline-offset: 2px;
+		}
+
 		&::before,
 		&::after {
 			content: "";
@@ -42,11 +47,18 @@
 				background: $input-background-dark;
 				border-color: $controls-border-dark;
 			}
+
+			&:focus {
+				outline: 2px solid $controls-border-dark;
+				outline-offset: 2px;
+			}
 		}
 	}
 
 	&.has-error {
 		color: $alert-red;
+		outline: 2px solid $alert-red;
+		outline-offset: 0.5em;
 
 		a {
 			color: $alert-red;
@@ -59,7 +71,7 @@
 				border-color: $alert-red;
 			}
 			&:focus {
-				outline: 1px dotted $alert-red;
+				outline: 2px solid $alert-red;
 				outline-offset: 2px;
 			}
 		}

--- a/assets/js/base/components/combobox/index.tsx
+++ b/assets/js/base/components/combobox/index.tsx
@@ -142,6 +142,7 @@ const Combobox = ( {
 				value={ value || '' }
 				allowReset={ false }
 				autoComplete={ autoComplete }
+				aria-invalid={ error.message && ! error.hidden }
 			/>
 			<ValidationInputError propertyName={ errorId } />
 		</div>

--- a/assets/js/base/components/combobox/style.scss
+++ b/assets/js/base/components/combobox/style.scss
@@ -40,6 +40,8 @@
 			&:focus {
 				background-color: #fff;
 				color: $input-text-active;
+				outline: 0;
+				box-shadow: 0 0 0 1px $input-border-gray;
 			}
 
 			&[aria-expanded="true"] {
@@ -55,6 +57,7 @@
 				&:focus {
 					background-color: $input-background-dark;
 					color: $input-text-dark;
+					box-shadow: 0 0 0 1px $input-border-dark;
 				}
 			}
 		}
@@ -147,8 +150,7 @@
 					border-color: $alert-red;
 				}
 				&:focus {
-					outline: 1px dotted $alert-red;
-					outline-offset: 2px;
+					box-shadow: 0 0 0 1px $alert-red;
 				}
 			}
 		}

--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -59,6 +59,8 @@
 		&:focus {
 			background-color: #fff;
 			color: $input-text-active;
+			outline: 0;
+			box-shadow: 0 0 0 1px $input-border-gray;
 		}
 
 		.has-dark-controls & {
@@ -69,6 +71,7 @@
 			&:focus {
 				background-color: $input-background-dark;
 				color: $input-text-dark;
+				box-shadow: 0 0 0 1px $input-border-dark;
 			}
 		}
 	}
@@ -99,8 +102,7 @@
 			border-color: $alert-red;
 		}
 		&:focus {
-			outline: 1px dotted $alert-red;
-			outline-offset: 2px;
+			box-shadow: 0 0 0 1px $alert-red;
 		}
 	}
 

--- a/assets/js/base/components/text-input/validated-text-input.tsx
+++ b/assets/js/base/components/text-input/validated-text-input.tsx
@@ -151,6 +151,7 @@ const ValidatedTextInput = ( {
 			className={ classnames( className, {
 				'has-error': hasError,
 			} ) }
+			aria-invalid={ hasError === true }
 			id={ textInputId }
 			onBlur={ () => {
 				validateInput( false );

--- a/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout-i2/inner-blocks/checkout-terms-block/frontend.tsx
@@ -80,9 +80,7 @@ const FrontendBlock = ( {
 						id="terms-and-conditions"
 						checked={ checked }
 						onChange={ () => setChecked( ( value ) => ! value ) }
-						className={ classnames( {
-							'has-error': hasError,
-						} ) }
+						hasError={ hasError }
 						disabled={ isDisabled }
 					>
 						<span


### PR DESCRIPTION
Adds consistent focus styles to form elements on the checkout and styles error messages with a more visible outline. See screenshots below.

Fixes #4714

#### Accessibility

Added `aria-invalid` to invalid form elements.

### Screenshots

![Screenshot 2021-09-10 at 16 42 15](https://user-images.githubusercontent.com/90977/132880687-cd471392-876c-4f77-8078-2c55566736bf.png)
![Screenshot 2021-09-10 at 16 42 10](https://user-images.githubusercontent.com/90977/132880690-1fe50262-98d1-4cfb-ba4b-f2ab7b29d884.png)
![Screenshot 2021-09-10 at 16 41 58](https://user-images.githubusercontent.com/90977/132880692-67871f4e-ccbc-40b6-ae7a-969f6658d8a8.png)

### Testing

How to test the changes in this Pull Request:

1. Leave checkout fields blank
2. Place order and view error styling
3. Click within fields to check focus styles match above screenshots
