### PR TITLE
Fix calculation of number of reviews in Reviews by Category block

### DIFF
--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import {
 	Button,
@@ -10,11 +10,9 @@ import {
 	ToggleControl,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { SearchListItem } from '@woocommerce/components';
 import PropTypes from 'prop-types';
 import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
 import { Icon, review } from '@woocommerce/icons';
-import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -42,39 +40,6 @@ const ReviewsByCategoryEditor = ( {
 } ) => {
 	const { editMode, categoryIds } = attributes;
 
-	const renderCategoryControlItem = ( args ) => {
-		const { item, search, depth = 0 } = args;
-
-		const accessibleName = ! item.breadcrumbs.length
-			? item.name
-			: `${ item.breadcrumbs.join( ', ' ) }, ${ item.name }`;
-
-		return (
-			<SearchListItem
-				className={ classNames(
-					'woocommerce-product-categories__item',
-					'has-count',
-					{
-						'is-searching': search.length > 0,
-						'is-skip-level': depth === 0 && item.parent !== 0,
-					}
-				) }
-				{ ...args }
-				aria-label={ sprintf(
-					/* translators: %1$s is the search term name, %2$d is the number of products returned for search query. */
-					_n(
-						'%1$s, has %2$d product',
-						'%1$s, has %2$d products',
-						item.count,
-						'woo-gutenberg-products-block'
-					),
-					accessibleName,
-					item.count
-				) }
-			/>
-		);
-	};
-
 	const getInspectorControls = () => {
 		return (
 			<InspectorControls key="inspector">
@@ -88,7 +53,6 @@ const ReviewsByCategoryEditor = ( {
 							const ids = value.map( ( { id } ) => id );
 							setAttributes( { categoryIds: ids } );
 						} }
-						renderItem={ renderCategoryControlItem }
 						isCompact={ true }
 						showReviewCount={ true }
 					/>

--- a/src/StoreApi/Schemas/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/ProductCategorySchema.php
@@ -102,13 +102,18 @@ class ProductCategorySchema extends TermSchema {
 	protected function get_category_review_count( $term ) {
 		global $wpdb;
 
+		$term_children_ids = get_term_children( $term->term_id, 'product_cat' );
+		$term_ids          = array_map( 'intval', array_merge( array( $term->term_id ), $term_children_ids ) );
+		$term_ids_str      = implode( ',', $term_ids );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$products_of_category_sql = $wpdb->prepare(
-			"SELECT SUM( DISTINCT comment_count) as review_count
+			"SELECT SUM(comment_count) as review_count
 			FROM {$wpdb->posts} AS posts
 			INNER JOIN {$wpdb->term_relationships} AS term_relationships ON posts.ID = term_relationships.object_id
-			WHERE term_relationships.term_taxonomy_id=%d",
-			$term->term_id
+			WHERE term_relationships.term_taxonomy_id IN ({$term_ids_str})"
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$review_count = $wpdb->get_var( $products_of_category_sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 


### PR DESCRIPTION
This PR includes two commits:
* 20978544cad3bd295ebba16d0eec2d1afadcf9d2: removes an unused method from Reviews by Category block.
* 47ce7699012b98a0506cbb55271287ba4374d288: changes how the reviews count is calculated. Fixes #4669.

### Screenshots

| Before | After |
| --- | --- |
| ![Before screenshot](https://user-images.githubusercontent.com/3616980/132999205-923856f1-47f7-4a34-b3e4-c823ec9c5623.png) | ![After screenshot](https://user-images.githubusercontent.com/3616980/132999179-691761f0-1396-459d-a3f8-f79261bcd9b4.png) |

### Manual Testing

1. Add some reviews to some of your products.
2. Create a page and add the Reviews by Category block.
3. Verify the counter shows the correct number of reviews. Take special attention to categories with more than one review and categories with subcategories

### Changelog

> Fix calculation of number of reviews in the Reviews by Category block
