### PR TITLE
Avoid exposing receiveCart to extensions

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -150,7 +150,7 @@ const ShippingRatesControl = ( {
 	// Prepare props to pass to the ExperimentalOrderShippingPackages slot fill.
 	// We need to pluck out receiveCart.
 	// eslint-disable-next-line no-unused-vars
-	const { extensions, ...cart } = useStoreCart();
+	const { extensions, receiveCart, ...cart } = useStoreCart();
 	const slotFillProps = {
 		className,
 		collapsible,

--- a/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/full-cart/index.tsx
@@ -107,7 +107,7 @@ const Cart = ( { attributes }: CartProps ): JSX.Element => {
 	// Prepare props to pass to the ExperimentalOrderMeta slot fill.
 	// We need to pluck out receiveCart.
 	// eslint-disable-next-line no-unused-vars
-	const { extensions, ...cart } = useStoreCart();
+	const { extensions, receiveCart, ...cart } = useStoreCart();
 	const slotFillProps = {
 		extensions,
 		cart,


### PR DESCRIPTION
While working on #4688, I found a couple of instances where we were passing `receiveCart` to slot fills so it was available by extensions. This PR fixes that.

Question: I wonder if we should create a hook that acts as a wrapper of `useStoreCart()` and automatically excludes `receiveCart`, so it can be used safely when making data available to extensions.

### Testing

1. Smoke test Cart & Checkout blocks with an extension like WC Subscriptions and verify there are no JS errors in the console and everything works as expected.

### Changelog

> Removed `receiveCart` method that was exposed in a couple of SlotFills by mistake.
