### PR TITLE
Checkout i2: Make h2 fill width of container in editor

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout-i2/form-step/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout-i2/form-step/editor.scss
@@ -8,4 +8,5 @@
 
 .wc-block-components-checkout-step__title {
 	display: flex;
+	width: 100%;
 }


### PR DESCRIPTION
Makes the heading full width to prevent wrapping.

Fixes #4724 

### Screenshots

![Screenshot 2021-09-13 at 14 48 58](https://user-images.githubusercontent.com/90977/133095572-db2efd2e-3edc-4799-be2a-8a1f5bd7a5d0.png)

### Testing

How to test the changes in this Pull Request:

1. Edit any step heading text and add a long line of text.
2. Ensure the text spans the full width. See screenshot.