### PR TITLE
Remove absolute positioning on validation error messages

### DIFF
--- a/assets/js/base/context/providers/validation/components/validation-input-error/style.scss
+++ b/assets/js/base/context/providers/validation/components/validation-input-error/style.scss
@@ -2,15 +2,10 @@
 	@include font-size(smaller);
 	color: $alert-red;
 	max-width: 100%;
-	position: absolute;
 	white-space: normal;
 
 	> p {
-		align-items: center;
-		display: flex;
-		line-height: 12px; // This allows two lines in a 24px bottom margin.
 		margin: 0;
-		min-height: 24px;
 		padding: 0;
 	}
 }


### PR DESCRIPTION
This PR removes the absolute positioning on error messages and fixes #4715. This reverts a change in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3968 which did this to prevent the button press issue. After making this change I did the testing steps in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3968 and could no longer replicate the issue on Chrome or Edge, so this may have been a browser issue that has since been resolved?
 
Fixes #4583
Fixes #4715

### Testing

See steps in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3968 for button issue (test for regression)
See steps in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4715 for styling issue

@ralucaStan can you test this your side and confirm it no longer occurs?

### Changelog

> Fix validation message styling so they never overlap other elements.
