### PR TITLE
Fix Product Search block displaying incorrectly.

### DIFF
--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -97,13 +97,13 @@ class ProductSearch extends AbstractBlock {
 		);
 
 		$input_markup  = sprintf(
-			'<input type="search" id="%s" className="wc-block-product-search__field" placeholder="%s" name="s" />',
+			'<input type="search" id="%s" class="wc-block-product-search__field" placeholder="%s" name="s" />',
 			esc_attr( $input_id ),
 			esc_attr( $attributes['placeholder'] )
 		);
 		$button_markup = sprintf(
-			'<button type="submit" className="wc-block-product-search__button" aria-label="%s">
-				<svg aria-hidden="true" role="img" focusable="false" className="dashicon dashicons-arrow-right-alt2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+			'<button type="submit" class="wc-block-product-search__button" aria-label="%s">
+				<svg aria-hidden="true" role="img" focusable="false" class="dashicon dashicons-arrow-right-alt2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
 					<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
 				</svg>
 			</button>',
@@ -111,7 +111,7 @@ class ProductSearch extends AbstractBlock {
 		);
 
 		$field_markup = '
-			<div className="wc-block-product-search__fields">
+			<div class="wc-block-product-search__fields">
 				' . $input_markup . $button_markup . '
 				<input type="hidden" name="post_type" value="product" />
 			</div>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR renames the instances of `className` to `class` in the `ProductSearch.php` file. The incorrect attribute was causing the classes not to be applied resulting in incorrect styling.

<!-- Reference any related issues or PRs here -->
Fixes #4738 

### Screenshots

| Before | After |
|---|---|
| <img src="https://user-images.githubusercontent.com/3616980/133223981-f31f54ff-2a4d-4652-a8e8-599c7942b7ce.png" /> | ![image](https://user-images.githubusercontent.com/5656702/133245602-8751a6fd-9bad-40b2-aad0-4d91e09afdd7.png) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
  
Not covered by tests as this is a style change, visual inspection is required.
### Manual Testing

How to test the changes in this Pull Request:

1. Add the Product Search block to a page.
2. Ensure it renders at full width with a gap between the input and the button.

<!-- If you can, add the appropriate labels -->

### Performance Impact
Nil.
<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
