### PR TITLE
Add types to legacy-events.js

### DIFF
--- a/assets/js/base/utils/legacy-events.ts
+++ b/assets/js/base/utils/legacy-events.ts
@@ -1,22 +1,21 @@
 const Event = window.Event || null;
 
-/** @typedef {import('window').HTMLNode} HTMLNode */
+interface DispatchedEventProperties {
+	// Whether the event bubbles.
+	bubbles?: boolean;
+	// Whether the event is cancelable.
+	cancelable?: boolean;
+	// Element that dispatches the event. By default, the body.
+	element?: HTMLElement;
+}
 
 /**
  * Wrapper function to dispatch an event so it's compatible with IE11.
- *
- * @param {string}    name                 Name of the event to dispatch.
- * @param {Object}    [options]            Some additional options to modify
- *                                         the event.
- * @param {boolean}   [options.bubbles]    Whether the event bubbles.
- * @param {boolean}   [options.cancelable] Whether the event is cancelable.
- * @param {HTMLNode}  [options.element]    Element that dispatches the event. By
- *                                         default, the body.
  */
 export const dispatchEvent = (
-	name,
-	{ bubbles = false, cancelable = false, element }
-) => {
+	name: string,
+	{ bubbles = false, cancelable = false, element }: DispatchedEventProperties
+): void => {
 	if ( ! element ) {
 		element = document.body;
 	}
@@ -34,12 +33,12 @@ export const dispatchEvent = (
 	}
 };
 
-let fragmentRequestTimeoutId;
+let fragmentRequestTimeoutId: ReturnType< typeof setTimeout >;
 
 // This is a hack to trigger cart updates till we migrate to block based cart
 // that relies on the store, see
 // https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1247
-export const triggerFragmentRefresh = () => {
+export const triggerFragmentRefresh = (): void => {
 	if ( fragmentRequestTimeoutId ) {
 		clearTimeout( fragmentRequestTimeoutId );
 	}
@@ -55,21 +54,19 @@ export const triggerFragmentRefresh = () => {
  * Function that listens to a jQuery event and dispatches a native JS event.
  * Useful to convert WC Core events into events that can be read by blocks.
  *
- * @param {string}  jQueryEventName Name of the jQuery event to listen to.
- * @param {string}  nativeEventName Name of the native event to dispatch.
- * @param {boolean} bubbles         Whether the event bubbles.
- * @param {boolean} cancelable      Whether the event is cancelable.
- *
- * @return {Function} Function to remove the jQuery event handler. Ideally it
- * should be used when the component is unmounted.
+ * Returns a function to remove the jQuery event handler. Ideally it should be
+ * used when the component is unmounted.
  */
 export const translateJQueryEventToNative = (
-	jQueryEventName,
-	nativeEventName,
+	// Name of the jQuery event to listen to.
+	jQueryEventName: string,
+	// Name of the native event to dispatch.
+	nativeEventName: string,
+	// Whether the event bubbles.
 	bubbles = false,
+	// Whether the event is cancelable.
 	cancelable = false
-) => {
-	// @ts-ignore -- jQuery is window global
+): ( () => void ) => {
 	if ( typeof jQuery !== 'function' ) {
 		return () => void null;
 	}
@@ -78,8 +75,6 @@ export const translateJQueryEventToNative = (
 		dispatchEvent( nativeEventName, { bubbles, cancelable } );
 	};
 
-	// @ts-ignore -- jQuery is window global
 	jQuery( document ).on( jQueryEventName, eventDispatcher );
-	// @ts-ignore -- jQuery is window global
 	return () => jQuery( document ).off( jQueryEventName, eventDispatcher );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5831,6 +5831,15 @@
 				"pretty-format": "^26.0.0"
 			}
 		},
+		"@types/jquery": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.6.tgz",
+			"integrity": "sha512-SmgCQRzGPId4MZQKDj9Hqc6kSXFNWZFHpELkyK8AQhf8Zr6HKfCzFv9ZC1Fv3FyQttJZOlap3qYb12h61iZAIg==",
+			"dev": true,
+			"requires": {
+				"@types/sizzle": "*"
+			}
+		},
 		"@types/json-schema": {
 			"version": "7.0.8",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
@@ -6045,6 +6054,12 @@
 			"version": "0.16.2",
 			"resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
 			"integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+		},
+		"@types/sizzle": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+			"integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
+			"dev": true
 		},
 		"@types/source-list-map": {
 			"version": "0.1.2",
@@ -6926,6 +6941,7 @@
 				"@woocommerce/date": "^3.0.0",
 				"@woocommerce/experimental": "^1.2.0",
 				"@woocommerce/navigation": "^6.0.1",
+				"@wordpress/api-fetch": "^3.21.5",
 				"@wordpress/components": "10.2.0",
 				"@wordpress/compose": "3.23.1",
 				"@wordpress/date": "3.13.0",
@@ -6967,6 +6983,32 @@
 						"@types/prop-types": "*",
 						"@types/scheduler": "*",
 						"csstype": "^3.0.2"
+					}
+				},
+				"@wordpress/api-fetch": {
+					"version": "3.23.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.1.tgz",
+					"integrity": "sha512-dmeigLuvqYAzpQ2hWUQT1P5VQAjkj9hS1z7PgNi1CcULFPbY8BWW+KiBETUu6Wm+rlSbUL2dC8qrA4JDv9ja5A==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^3.19.2",
+						"@wordpress/url": "^2.22.2"
+					},
+					"dependencies": {
+						"@wordpress/i18n": {
+							"version": "3.20.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+							"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@wordpress/hooks": "^2.12.3",
+								"gettext-parser": "^1.3.1",
+								"lodash": "^4.17.19",
+								"memize": "^1.1.0",
+								"sprintf-js": "^1.1.1",
+								"tannin": "^1.2.0"
+							}
+						}
 					}
 				},
 				"@wordpress/components": {
@@ -7096,6 +7138,16 @@
 					"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
 					"requires": {
 						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.22.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.22.2.tgz",
+					"integrity": "sha512-aqpYKQXzyzkCOm+GzZRYlLb+wh58g0cwR1PaKAl0UXaBS4mdS+X6biMriylb4P8CVC/RR7CSw5XI20JC24KDwQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19",
+						"react-native-url-polyfill": "^1.1.2"
 					}
 				},
 				"core-js": {
@@ -7333,6 +7385,7 @@
 						"@woocommerce/data": "^1.3.2",
 						"@woocommerce/date": "^3.0.0",
 						"@woocommerce/navigation": "^6.0.1",
+						"@wordpress/api-fetch": "^3.21.5",
 						"@wordpress/components": "10.2.0",
 						"@wordpress/compose": "3.23.1",
 						"@wordpress/date": "3.13.0",
@@ -7365,6 +7418,32 @@
 						"react-dates": "^17.2.0",
 						"react-router-dom": "5.2.0",
 						"react-transition-group": "4.4.1"
+					}
+				},
+				"@wordpress/api-fetch": {
+					"version": "3.23.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.1.tgz",
+					"integrity": "sha512-dmeigLuvqYAzpQ2hWUQT1P5VQAjkj9hS1z7PgNi1CcULFPbY8BWW+KiBETUu6Wm+rlSbUL2dC8qrA4JDv9ja5A==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^3.19.2",
+						"@wordpress/url": "^2.22.2"
+					},
+					"dependencies": {
+						"@wordpress/i18n": {
+							"version": "3.20.0",
+							"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+							"integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+							"requires": {
+								"@babel/runtime": "^7.13.10",
+								"@wordpress/hooks": "^2.12.3",
+								"gettext-parser": "^1.3.1",
+								"lodash": "^4.17.19",
+								"memize": "^1.1.0",
+								"sprintf-js": "^1.1.1",
+								"tannin": "^1.2.0"
+							}
+						}
 					}
 				},
 				"@wordpress/components": {
@@ -7524,6 +7603,16 @@
 					"integrity": "sha512-BUVCYZNDoT5fRJGoam/nI2Sn8QELu5z/pFe7UL+szFqQqNnMibdWqN/KoW/YO7WLJqqqTRhAs/Fa51g4oXRyHQ==",
 					"requires": {
 						"@babel/runtime": "^7.11.2"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.22.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.22.2.tgz",
+					"integrity": "sha512-aqpYKQXzyzkCOm+GzZRYlLb+wh58g0cwR1PaKAl0UXaBS4mdS+X6biMriylb4P8CVC/RR7CSw5XI20JC24KDwQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.19",
+						"react-native-url-polyfill": "^1.1.2"
 					}
 				},
 				"core-js": {
@@ -10121,6 +10210,7 @@
 			"integrity": "sha512-qF/rJk1u6qh1wlpgUoUn40b5uT6erNUlZYVY0sSa6z1BB/99jaYE6bdlmi1SYkXCOoh2vfs9bn/R5v848Mk2yA==",
 			"requires": {
 				"@babel/runtime": "^7.11.2",
+				"@wordpress/api-fetch": "^3.20.0",
 				"@wordpress/components": "^11.1.3",
 				"@wordpress/data": "^4.25.0",
 				"@wordpress/deprecated": "^2.10.0",
@@ -10138,6 +10228,16 @@
 						"@types/prop-types": "*",
 						"@types/scheduler": "*",
 						"csstype": "^3.0.2"
+					}
+				},
+				"@wordpress/api-fetch": {
+					"version": "3.23.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.23.1.tgz",
+					"integrity": "sha512-dmeigLuvqYAzpQ2hWUQT1P5VQAjkj9hS1z7PgNi1CcULFPbY8BWW+KiBETUu6Wm+rlSbUL2dC8qrA4JDv9ja5A==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^3.19.2",
+						"@wordpress/url": "^2.22.2"
 					}
 				},
 				"@wordpress/components": {

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"@types/dinero.js": "1.8.1",
 		"@types/gtag.js": "0.0.7",
 		"@types/jest": "26.0.24",
+		"@types/jquery": "^3.5.6",
 		"@types/lodash": "4.14.172",
 		"@types/react": "16.14.15",
 		"@types/wordpress__block-editor": "2.2.9",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -20,7 +20,7 @@
 		"composite": true,
 		"rootDir": ".",
 		"typeRoots": [ "./node_modules/@types" ],
-		"types": ["jest"],
+		"types": [ "jest", "jquery" ],
 		"paths": {
 			"@woocommerce/atomic-blocks": [ "assets/js/base/atomic/blocks" ],
 			"@woocommerce/atomic-blocks/*": [


### PR DESCRIPTION
Refactor `legacy-events.js` so it uses TypeScript (part of working on #4688).

### Manual Testing

1. One way to test that `legacy-events.js` works as expected is to go to a page with the Cart block and remove all items.
2. Once you see the empty cart template, add an item to the Cart.
3. Verify contents update and the full cart template appears.

https://user-images.githubusercontent.com/3616980/133256791-a95802f0-2980-464d-8c1b-01be8ccd1d72.mp4
