### PR TITLE
Add a class name to the filter by product attribute block heading

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -327,7 +327,9 @@ const AttributeFilterBlock = ( {
 	return (
 		<>
 			{ ! isEditor && blockAttributes.heading && (
-				<TagName>{ blockAttributes.heading }</TagName>
+				<TagName className="wc-block-attribute-filter__heading">
+					{ blockAttributes.heading }
+				</TagName>
 			) }
 			<div className="wc-block-attribute-filter">
 				{ blockAttributes.displayStyle === 'dropdown' ? (

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -386,6 +386,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			) : (
 				<div className={ className }>
 					<BlockTitle
+						className="wc-block-attribute-filter__heading"
 						headingLevel={ headingLevel }
 						heading={ heading }
 						onChange={ ( value ) =>

--- a/assets/js/editor-components/block-title/index.js
+++ b/assets/js/editor-components/block-title/index.js
@@ -21,7 +21,7 @@ const BlockTitle = ( {
 } ) => {
 	const TagName = `h${ headingLevel }`;
 	return (
-		<TagName>
+		<TagName className={ className }>
 			<label
 				className="screen-reader-text"
 				htmlFor={ `block-title-${ instanceId }` }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3612

#### What
* This PR adds a class to the Filter Products by Attribute block heading.
* `className` prop in `<BlockTitle  />` component gets added to the `<TagName />` element

#### Why
This avoids the need to use a more complex selector to target this heading element. See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3612 for more context on this.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

_Removed non-relevant checklist items_

### Screenshots

N/A

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Add "Filter Products by Attribute" block in the Editor and select an attribute to filter by
2. Observe in the Editor the class added to the block heading should be `wc-block-attribute-filter__heading`
3. Save the page, and observe the changes on the frontend. The heading of the block should have a class name `wc-block-attribute-filter__heading`
4. No visual regressions should be introduced

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Filter Products by Attribute: Class added to the heading element of the block.
