### PR TITLE
Twenty Twenty: Adjust font styles for filter and product grid blocks

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -60,3 +60,14 @@
 	margin: 0;
 	padding: 0;
 }
+
+.theme-twentytwenty {
+	.wp-block {
+		.wc-block-grid__product-title,
+		.wc-block-active-filters__title,
+		.wc-block-attribute-filter__title,
+		.wc-block-price-filter__title {
+			@include font-size(regular);
+		}
+	}
+}

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -66,7 +66,8 @@
 		.wc-block-grid__product-title,
 		.wc-block-active-filters__title,
 		.wc-block-attribute-filter__title,
-		.wc-block-price-filter__title {
+		.wc-block-price-filter__title,
+		.wc-block-stock-filter__title {
 			@include font-size(regular);
 		}
 	}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -287,7 +287,8 @@
 
 	.wc-block-active-filters__title,
 	.wc-block-attribute-filter__title,
-	.wc-block-price-filter__title {
+	.wc-block-price-filter__title,
+	.wc-block-stock-filter__title {
 		@include font-size(regular);
 	}
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -217,8 +217,8 @@
 	.wc-block-grid__product-title,
 	.wc-block-components-product-title {
 		font-family: $twentytwenty-headings;
-		color: #000;
-		font-size: 1.2em;
+		color: $twentytwenty-highlights-color;
+		@include font-size(regular);
 	}
 
 	.wp-block-columns .wc-block-components-product-title {
@@ -283,6 +283,21 @@
 		right: 4px;
 		top: 4px;
 		z-index: 1;
+	}
+
+	.wc-block-active-filters__title,
+	.wc-block-attribute-filter__title,
+	.wc-block-price-filter__title {
+		@include font-size(regular);
+	}
+
+	.wc-block-active-filters .wc-block-active-filters__clear-all {
+		@include font-size(smaller);
+	}
+
+	.wc-block-grid__product-add-to-cart.wp-block-button .wp-block-button__link {
+		@include font-size(smaller);
+		padding: em($gap-smaller);
 	}
 
 	@media only screen and (min-width: 768px) {

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -125,7 +125,9 @@ const ActiveFiltersBlock = ( {
 	return (
 		<>
 			{ ! isEditor && blockAttributes.heading && (
-				<TagName>{ blockAttributes.heading }</TagName>
+				<TagName className="wc-block-active-filters__title">
+					{ blockAttributes.heading }
+				</TagName>
 			) }
 			<div className="wc-block-active-filters">
 				<ul className={ listClasses }>

--- a/assets/js/blocks/active-filters/edit.js
+++ b/assets/js/blocks/active-filters/edit.js
@@ -78,6 +78,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 		<div className={ className }>
 			{ getInspectorControls() }
 			<BlockTitle
+				className="wc-block-active-filters__title"
 				headingLevel={ headingLevel }
 				heading={ heading }
 				onChange={ ( value ) => setAttributes( { heading: value } ) }

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -327,7 +327,9 @@ const AttributeFilterBlock = ( {
 	return (
 		<>
 			{ ! isEditor && blockAttributes.heading && (
-				<TagName>{ blockAttributes.heading }</TagName>
+				<TagName className="wc-block-attribute-filter__title">
+					{ blockAttributes.heading }
+				</TagName>
 			) }
 			<div className="wc-block-attribute-filter">
 				{ blockAttributes.displayStyle === 'dropdown' ? (

--- a/assets/js/blocks/attribute-filter/edit.js
+++ b/assets/js/blocks/attribute-filter/edit.js
@@ -386,6 +386,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak } ) => {
 			) : (
 				<div className={ className }>
 					<BlockTitle
+						className="wc-block-attribute-filter__title"
 						headingLevel={ headingLevel }
 						heading={ heading }
 						onChange={ ( value ) =>

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -151,7 +151,9 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 	return (
 		<>
 			{ ! isEditor && attributes.heading && (
-				<TagName>{ attributes.heading }</TagName>
+				<TagName className="wc-block-price-filter__title">
+					{ attributes.heading }
+				</TagName>
 			) }
 			<div className="wc-block-price-slider">
 				<PriceSlider

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -158,6 +158,7 @@ export default function ( { attributes, setAttributes } ) {
 				<div className={ className }>
 					{ getInspectorControls() }
 					<BlockTitle
+						className="wc-block-price-filter__title"
 						headingLevel={ headingLevel }
 						heading={ heading }
 						onChange={ ( value ) =>

--- a/assets/js/blocks/stock-filter/block.js
+++ b/assets/js/blocks/stock-filter/block.js
@@ -252,7 +252,9 @@ const StockStatusFilterBlock = ( {
 	return (
 		<>
 			{ ! isEditor && blockAttributes.heading && (
-				<TagName>{ blockAttributes.heading }</TagName>
+				<TagName className="wc-block-stock-filter__title">
+					{ blockAttributes.heading }
+				</TagName>
 			) }
 			<div className="wc-block-stock-filter">
 				<CheckboxList

--- a/assets/js/blocks/stock-filter/edit.js
+++ b/assets/js/blocks/stock-filter/edit.js
@@ -112,6 +112,7 @@ const Edit = ( { attributes, setAttributes } ) => {
 			{
 				<div className={ className }>
 					<BlockTitle
+						className="wc-block-stock-filter__title"
 						headingLevel={ headingLevel }
 						heading={ heading }
 						onChange={ ( value ) =>

--- a/assets/js/editor-components/block-title/index.js
+++ b/assets/js/editor-components/block-title/index.js
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import { PlainText } from '@wordpress/block-editor';
-import classnames from 'classnames';
 import { withInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
@@ -21,7 +20,7 @@ const BlockTitle = ( {
 } ) => {
 	const TagName = `h${ headingLevel }`;
 	return (
-		<TagName>
+		<TagName className={ className }>
 			<label
 				className="screen-reader-text"
 				htmlFor={ `block-title-${ instanceId }` }
@@ -30,10 +29,7 @@ const BlockTitle = ( {
 			</label>
 			<PlainText
 				id={ `block-title-${ instanceId }` }
-				className={ classnames(
-					'wc-block-editor-components-title',
-					className
-				) }
+				className="wc-block-editor-components-title"
 				value={ heading }
 				onChange={ onChange }
 			/>


### PR DESCRIPTION
Fixes #2630 

#### Accessibility

n/a

### Screenshots

<table>
<tr>
<td>Editor before:
<br><br>

![#2630-editor-before](https://user-images.githubusercontent.com/3323310/128177253-29760c2e-05df-4f65-800d-071bc33534f5.png)
</td>
<td>Editor after:
<br><br>

![#2630-editor-after](https://user-images.githubusercontent.com/3323310/128177189-2c749dcb-dae8-429b-8f81-20da3ec6b1b1.png)
</td>
</tr>
</table>

<table>
<tr>
<td>Frontend before:
<br><br>

![#2630-frontend-before](https://user-images.githubusercontent.com/3323310/128176355-e2680e23-1d30-4f7b-8ca9-35e04119cdf5.png)
</td>
<td>Frontend after:
<br><br>

![#2630-frontend-after](https://user-images.githubusercontent.com/3323310/128176352-884eff43-ec7c-4c38-9d79-618528635173.png)
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

1. Install and activate the WooCommerce plugin
2. Install and activate this plugin
3. Create a new page
4. Add the column block (1/3 + 2/3) to the created page
5. Add the _Active Product Filters_, _Filter Products by Price_ & _Filter Products by Attribute_ blocks to the 1/3 column
6. Add the _All Products_ & _Products by Category_ blocks to the 2/3 column
7. Check the font sizes of the elements in the editor
8. Check the font sizes of the elements in the frontend
9. Check out this PR
10. Check the font sizes of the elements in the editor again
11. Check the font sizes of the elements in the frontend again

### Changelog

> Adjust font styles for filter and product grid blocks for the Twenty Twenty theme.
