### PR TITLE
Products by Category: Move renderEmptyResponsePlaceholder to separate method

### DIFF
--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -22,6 +22,19 @@ import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { Icon, folder } from '@woocommerce/icons';
 import { getSetting } from '@woocommerce/settings';
 
+const EmptyPlaceholder = () => (
+	<Placeholder
+		icon={ <Icon srcElement={ folder } /> }
+		label={ __( 'Products by Category', 'woo-gutenberg-products-block' ) }
+		className="wc-block-products-grid wc-block-products-category"
+	>
+		{ __(
+			'No products were found that matched your selection.',
+			'woo-gutenberg-products-block'
+		) }
+	</Placeholder>
+);
+
 /**
  * Component to handle edit mode of "Products by Category".
  */
@@ -240,24 +253,6 @@ class ProductByCategoryBlock extends Component {
 		);
 	}
 
-	renderEmptyResponsePlaceholder() {
-		return (
-			<Placeholder
-				icon={ <Icon srcElement={ folder } /> }
-				label={ __(
-					'Products by Category',
-					'woo-gutenberg-products-block'
-				) }
-				className="wc-block-products-grid wc-block-products-category"
-			>
-				{ __(
-					'No products were found that matched your selection.',
-					'woo-gutenberg-products-block'
-				) }
-			</Placeholder>
-		);
-	}
-
 	renderViewMode() {
 		const { attributes, name } = this.props;
 		const hasCategories = attributes.categories.length;
@@ -268,9 +263,7 @@ class ProductByCategoryBlock extends Component {
 					<ServerSideRender
 						block={ name }
 						attributes={ attributes }
-						EmptyResponsePlaceholder={
-							this.renderEmptyResponsePlaceholder
-						}
+						EmptyResponsePlaceholder={ EmptyPlaceholder }
 					/>
 				) : (
 					__(

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -240,6 +240,24 @@ class ProductByCategoryBlock extends Component {
 		);
 	}
 
+	renderEmptyResponsePlaceholder() {
+		return (
+			<Placeholder
+				icon={ <Icon srcElement={ folder } /> }
+				label={ __(
+					'Products by Category',
+					'woo-gutenberg-products-block'
+				) }
+				className="wc-block-products-grid wc-block-products-category"
+			>
+				{ __(
+					'No products were found that matched your selection.',
+					'woo-gutenberg-products-block'
+				) }
+			</Placeholder>
+		);
+	}
+
 	renderViewMode() {
 		const { attributes, name } = this.props;
 		const hasCategories = attributes.categories.length;
@@ -250,21 +268,9 @@ class ProductByCategoryBlock extends Component {
 					<ServerSideRender
 						block={ name }
 						attributes={ attributes }
-						EmptyResponsePlaceholder={ () => (
-							<Placeholder
-								icon={ <Icon srcElement={ folder } /> }
-								label={ __(
-									'Products by Category',
-									'woo-gutenberg-products-block'
-								) }
-								className="wc-block-products-grid wc-block-products-category"
-							>
-								{ __(
-									'No products were found that matched your selection.',
-									'woo-gutenberg-products-block'
-								) }
-							</Placeholder>
-						) }
+						EmptyResponsePlaceholder={
+							this.renderEmptyResponsePlaceholder
+						}
 					/>
 				) : (
 					__(


### PR DESCRIPTION
### Description

Moved `renderEmptyResponsePlaceholder` to a separate method instead of an inline function to prevent a rerender that was happening due to inequality of the callback function being passed to prop `EmptyResponsePlaceholder`. This was being treated as a new function every time.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4746

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Go to a new or existing page and add the "Products by Category" block
2. Select a category with products in
3. Click on and off the block to select/unselect the recently added "Products by Category" block
4. The issue observed [here](https://www.loom.com/share/2580dbc894c1474584c9ad5be36937db) which triggers a rerender should no longer be happening

### Performance Impact

Improved performance as unnecessary fetches are no longer happening.

### Changelog

> Products by Category: Moved renderEmptyResponsePlaceholder to separate method to prevent unnecessary rerender
