### PR TITLE
Switch to external icon for shipping/payment methods

### DIFF
--- a/assets/js/editor-components/external-link-card/index.tsx
+++ b/assets/js/editor-components/external-link-card/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, chevronRight } from '@woocommerce/icons';
+import { Icon, external } from '@wordpress/icons';
 import { VisuallyHidden } from '@wordpress/components';
 
 /**
@@ -46,7 +46,7 @@ const ExternalLinkCard = ( {
 				}
 			</VisuallyHidden>
 			<Icon
-				srcElement={ chevronRight }
+				icon={ external }
 				className="wc-block-editor-components-external-link-card__icon"
 			/>
 		</a>


### PR DESCRIPTION
Switches icons to make it clear links open a different page.

Fixes #4722

### Screenshots

Before:

![Screenshot 2021-09-16 at 13 52 45](https://user-images.githubusercontent.com/90977/133615382-63f4cd38-564a-481c-ab96-21d50dd2126e.png)

After:

![Screenshot 2021-09-16 at 13 51 17](https://user-images.githubusercontent.com/90977/133615335-fcd90352-2f18-4ec3-87bd-ac0e6b2d358e.png)

How to test the changes in this Pull Request:

1. View the Checkout block in the editor
2. Select the "Shipping Options" or "Payment Methods" inner block
3. See icons in the sidebar