### PR TITLE
Make All Reviews block honor 'ratings enabled' and 'show avatars' preferences

### DIFF
--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -158,6 +158,7 @@ const ReviewListItem = ( { attributes, review = {} } ) => {
 				'wc-block-components-review-list-item__item',
 				{
 					'is-loading': isLoading,
+					'wc-block-components-review-list-item__item--has-image': showReviewImage,
 				}
 			) }
 			aria-hidden={ isLoading }

--- a/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/assets/js/base/components/reviews/review-list-item/style.scss
@@ -57,7 +57,7 @@
 	grid-row: 1;
 }
 
-.has-image {
+.wc-block-components-review-list-item__item--has-image {
 	.wc-block-components-review-list-item__info {
 		grid-template-columns: calc(3em + #{$gap}) 1fr;
 	}

--- a/src/BlockTypes/AllReviews.php
+++ b/src/BlockTypes/AllReviews.php
@@ -27,4 +27,17 @@ class AllReviews extends AbstractBlock {
 		];
 		return $key ? $script[ $key ] : $script;
 	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+		$this->asset_data_registry->add( 'reviewRatingsEnabled', wc_review_ratings_enabled(), true );
+		$this->asset_data_registry->add( 'showAvatars', '1' === get_option( 'show_avatars' ), true );
+	}
 }


### PR DESCRIPTION
While investigating build sizes of Reviews blocks, I noticed that All Reviews was missing some code to honor 'ratings enabled' and 'show avatars' preferences. That same code [exists in the other Reviews blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypes/ReviewsByCategory.php#L31-L42), so it's probably a bug.

### Manual Testing

1. In wp-admin, go to _Settings_ > _Discussion_ > _Avatars_ and uncheck _Show Avatars_.
2. Add an All Reviews block and verify avatars are not shown and instead there is a warning in the sidebar:

<img src="https://user-images.githubusercontent.com/3616980/133635801-013aacf7-e6e3-48ac-978e-b36f81284c4a.png" width="298" alt="" />

3. In wp-admin, go to _WooCommerce_ > _Settings_ and uncheck _Enable star rating on reviews_.
4. In the All Reviews block, verify ratings and the _Sort by_ select aren't displayed.

### Changelog

> Update All Reviews block so it honors 'ratings enabled' and 'show avatars' preferences.
