### PR TITLE
Show message if user has not yet calculated shipping and no shipping rates exist

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -61,32 +61,44 @@ const Block = (): JSX.Element | null => {
 		return null;
 	}
 
+	const shippingRatesPackageCount = getShippingRatesPackageCount(
+		shippingRates
+	);
+
+	if (
+		! isEditor &&
+		! hasCalculatedShipping &&
+		! shippingRatesPackageCount
+	) {
+		return (
+			<p>
+				{ __(
+					'Shipping options will be displayed here after entering your full shipping address.',
+					'woo-gutenberg-products-block'
+				) }
+			</p>
+		);
+	}
+
 	return (
 		<>
-			{ isEditor && ! getShippingRatesPackageCount( shippingRates ) ? (
+			{ isEditor && ! shippingRatesPackageCount ? (
 				<NoShippingPlaceholder />
 			) : (
 				<ShippingRatesControl
 					noResultsMessage={
-						hasCalculatedShipping ? (
-							<Notice
-								isDismissible={ false }
-								className={ classnames(
-									'wc-block-components-shipping-rates-control__no-results-notice',
-									'woocommerce-error'
-								) }
-							>
-								{ __(
-									'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.',
-									'woo-gutenberg-products-block'
-								) }
-							</Notice>
-						) : (
-							__(
-								'Shipping options will appear here after entering your full shipping address.',
+						<Notice
+							isDismissible={ false }
+							className={ classnames(
+								'wc-block-components-shipping-rates-control__no-results-notice',
+								'woocommerce-error'
+							) }
+						>
+							{ __(
+								'There are no shipping options available. Please check your shipping address.',
 								'woo-gutenberg-products-block'
-							)
-						)
+							) }
+						</Notice>
 					}
 					renderOption={ renderShippingRatesControlOption }
 					shippingRates={ shippingRates }


### PR DESCRIPTION
When the user has not yet calculated shipping, and there are no rates, the shipping options step shows no content. I think this may have been broken when we introduced slot fills in this area. There was a "no results message", but this is only shown if there are no rates within a package.

Fixes #4752

### Screenshots

Before:
![Screenshot 2021-09-16 at 16 13 52](https://user-images.githubusercontent.com/90977/133638394-882eeecd-3236-407b-869d-f1453f2451e0.png)

After:
![Screenshot 2021-09-16 at 16 11 47](https://user-images.githubusercontent.com/90977/133638413-54f68e44-910e-4b1a-85b6-707ca223c1e7.png)

### Testing

How to test the changes in this Pull Request:

1. In WooCommerce Shipping Settings, enable _"Hide shipping until an address is entered"_
2. Open checkout in a new incognito window as a guest
3. Add an item to the cart and go to the checkout
4. Confirm the shipping section shows a message: "Shipping options will be displayed here after entering your full shipping address."

### Changelog

> Show placeholder message in the shipping section when there are no rates.
