### PR TITLE
Remove assets/js/settings/blocks from sideEffects list

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
 		"*.scss",
 		"./assets/js/atomic/blocks/**",
 		"./assets/js/filters/**",
-		"./assets/js/settings/blocks/**",
 		"./assets/js/middleware/**",
 		"./assets/js/blocks/cart-checkout/checkout/inner-blocks/**/index.tsx",
 		"./assets/js/blocks/cart-checkout/checkout/inner-blocks/register-components.ts",


### PR DESCRIPTION
Cherry-picks the third commit from #4463.

After some investigation, I noticed that having `./assets/js/settings/blocks/**` listed as scripts with side effects caused several frontend scripts to include the `wp-blocks` dependency even if it was not directly used. Affected blocks are:

* Active filters
* Cart
* Checkout
* Mini Cart
* Price filter
* Reviews

`wp-blocks` has [several other dependencies](https://github.com/WordPress/gutenberg/blob/trunk/packages/blocks/package.json#L30-L52), so avoiding it helps in reducing the total downloaded size when rendering those blocks in the frontend.

For reference, `./assets/js/settings/blocks/**` was added to `sideEffects` in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2042, but I tried to reproduce the issues mentioned there, and I couldn't. In addition, I took a look at the code under `/assets/js/settings/blocks/` and I couldn't find anything that would require it being listed as having side effects.

### Manual Testing

Note: Make sure to test it on a product build (running `npm run build`).

Unfortunately, it's difficult to predict the effect this change will have. In theory, any block that imports from `block-settings` might be affected, so I would suggest [adding all blocks into a page](https://gist.github.com/Aljullu/d9c76ed510ae6973bd41dcc4184e8eb2) and verifying they load correctly in the editor and the frontend.

Smoke testing the Checkout flow would also be great (validation, payment with some payment methods, etc.).

### Performance Impact

A dependency has been removed from several frontend scripts, so it should cause a performance improvement on pages loading those blocks.

### Changelog

> Removed `wp-blocks` dependency from several frontend scripts.
