### PR TITLE
Add e2e tests for Featured Category

### DIFF
--- a/tests/e2e/config/custom-matchers/__fixtures__/featured-category.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/featured-category.fixture.json
@@ -1,0 +1,1 @@
+{"title":"Featured Category Block","pageContent":"<!-- wp:woocommerce/featured-category /-->"}

--- a/tests/e2e/specs/backend/featured-category.test.js
+++ b/tests/e2e/specs/backend/featured-category.test.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
+
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
+
+const block = {
+	name: 'Featured Category',
+	slug: 'woocommerce/featured-category',
+	class: '.wc-block-featured-category',
+};
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'can be inserted more than once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 2 );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+} );


### PR DESCRIPTION
### Note

Currently, not every block is covered by e2e tests. This PR aims to add e2e tests for the Featured Category block.

Part of #4643 

### Testing

1. Check out this PR.
2. Run `npm run wp-env start && npm run test:e2e`.
3. The e2e test suite shows no failed tests.