### PR TITLE
Add support for extensions to filter express payment methods

### DIFF
--- a/assets/js/blocks-registry/payment-methods/express-payment-method-config.ts
+++ b/assets/js/blocks-registry/payment-methods/express-payment-method-config.ts
@@ -12,7 +12,7 @@ import type {
 /**
  * Internal dependencies
  */
-import { canMakePaymentWithFeaturesCheck } from './payment-method-config-helper';
+import { getCanMakePayment } from './payment-method-config-helper';
 import { assertConfigHasProperties, assertValidElement } from './assertions';
 
 export default class ExpressPaymentMethodConfig
@@ -22,7 +22,7 @@ export default class ExpressPaymentMethodConfig
 	public edit: ReactNode;
 	public paymentMethodId?: string;
 	public supports: Supports;
-	public canMakePayment: CanMakePaymentCallback;
+	public canMakePaymentFromConfig: CanMakePaymentCallback;
 
 	constructor( config: ExpressPaymentMethodConfiguration ) {
 		// validate config
@@ -34,9 +34,15 @@ export default class ExpressPaymentMethodConfig
 		this.supports = {
 			features: config?.supports?.features || [ 'products' ],
 		};
-		this.canMakePayment = canMakePaymentWithFeaturesCheck(
-			config.canMakePayment,
-			this.supports.features
+		this.canMakePaymentFromConfig = config.canMakePayment;
+	}
+
+	// canMakePayment is calculated each time based on data that modifies outside of the class (eg: cart data).
+	get canMakePayment(): CanMakePaymentCallback {
+		return getCanMakePayment(
+			this.canMakePaymentFromConfig,
+			this.supports.features,
+			this.name
 		);
 	}
 

--- a/assets/js/blocks-registry/payment-methods/payment-method-config.tsx
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config.tsx
@@ -14,11 +14,7 @@ import type {
 /**
  * Internal dependencies
  */
-import {
-	canMakePaymentWithFeaturesCheck,
-	canMakePaymentWithExtensions,
-} from './payment-method-config-helper';
-import { extensionsConfig, PaymentMethodName } from './extensions-config';
+import { getCanMakePayment } from './payment-method-config-helper';
 import {
 	assertConfigHasProperties,
 	assertValidElement,
@@ -68,22 +64,11 @@ export default class PaymentMethodConfig
 
 	// canMakePayment is calculated each time based on data that modifies outside of the class (eg: cart data).
 	get canMakePayment(): CanMakePaymentCallback {
-		const canPay = canMakePaymentWithFeaturesCheck(
+		return getCanMakePayment(
 			this.canMakePaymentFromConfig,
-			this.supports.features
+			this.supports.features,
+			this.name
 		);
-
-		// Loop through all callbacks to check if there are any registered for this payment method.
-		return ( Object.values( extensionsConfig.canMakePayment ) as Record<
-			PaymentMethodName,
-			CanMakePaymentCallback
-		>[] ).some( ( callbacks ) => this.name in callbacks )
-			? canMakePaymentWithExtensions(
-					canPay,
-					extensionsConfig.canMakePayment,
-					this.name
-			  )
-			: canPay;
 	}
 
 	static assertValidConfig = ( config: PaymentMethodConfiguration ): void => {

--- a/assets/js/blocks-registry/payment-methods/test/payment-method-config-helper.ts
+++ b/assets/js/blocks-registry/payment-methods/test/payment-method-config-helper.ts
@@ -2,14 +2,71 @@
  * External dependencies
  */
 import { registerPaymentMethodExtensionCallbacks } from '@woocommerce/blocks-registry';
-
 /**
  * Internal dependencies
  */
+import * as helpers from '../payment-method-config-helper';
 import { canMakePaymentExtensionsCallbacks } from '../extensions-config';
-import { canMakePaymentWithExtensions } from '../payment-method-config-helper';
 
-describe( 'canMakePaymentWithExtensions', () => {
+const canMakePaymentArgument = {
+	cartTotals: {
+		total_items: '1488',
+		total_items_tax: '312',
+		total_fees: '0',
+		total_fees_tax: '0',
+		total_discount: '0',
+		total_discount_tax: '0',
+		total_shipping: '0',
+		total_shipping_tax: '0',
+		total_price: '1800',
+		total_tax: '312',
+		tax_lines: [
+			{
+				name: 'BTW',
+				price: '312',
+				rate: '21%',
+			},
+		],
+		currency_code: 'EUR',
+		currency_symbol: '€',
+		currency_minor_unit: 2,
+		currency_decimal_separator: ',',
+		currency_thousand_separator: '.',
+		currency_prefix: '€',
+		currency_suffix: '',
+	},
+	cartNeedsShipping: true,
+	billingData: {
+		first_name: 'name',
+		last_name: 'Name',
+		company: '',
+		address_1: 'fdsfdsfdsf',
+		address_2: '',
+		city: 'Berlin',
+		state: '',
+		postcode: 'xxxxx',
+		country: 'DE',
+		email: 'name.Name@test.com',
+		phone: '1234',
+	},
+	shippingAddress: {
+		first_name: 'name',
+		last_name: 'Name',
+		company: '',
+		address_1: 'fdsfdsfdsf',
+		address_2: '',
+		city: 'Berlin',
+		state: '',
+		postcode: 'xxxxx',
+		country: 'DE',
+		phone: '1234',
+	},
+	selectedShippingMethods: {
+		'0': 'free_shipping:1',
+	},
+	paymentRequirements: [ 'products' ],
+};
+describe( 'payment-method-config-helper', () => {
 	const trueCallback = jest.fn().mockReturnValue( true );
 	const falseCallback = jest.fn().mockReturnValue( false );
 	const throwsCallback = jest.fn().mockImplementation( () => {
@@ -20,7 +77,7 @@ describe( 'canMakePaymentWithExtensions', () => {
 			'woocommerce-marketplace-extension',
 			{
 				// cod: one extension returns true, the other returns false.
-				cod: () => trueCallback,
+				cod: trueCallback,
 				// cheque: returns true only if arg.billingData.postcode is 12345.
 				cheque: ( arg ) => arg.billingData.postcode === '12345',
 				// bacs: both extensions return false.
@@ -47,53 +104,89 @@ describe( 'canMakePaymentWithExtensions', () => {
 		throwsCallback.mockClear();
 		falseCallback.mockClear();
 	} );
+	describe( 'getCanMakePayment', () => {
+		it( 'returns callback canMakePaymentWithFeaturesCheck if no extension callback is detected', () => {
+			const args = {
+				canMakePayment: jest.fn().mockImplementation( () => true ),
+				features: [ 'products' ],
+				paymentMethodName: 'missing-payment-method',
+			};
 
-	it( "Returns false without executing the registered callbacks, if the payment method's canMakePayment callback returns false.", () => {
-		const canMakePayment = () => false;
-		const canMakePaymentWithExtensionsResult = canMakePaymentWithExtensions(
-			canMakePayment,
-			canMakePaymentExtensionsCallbacks,
-			'cod'
-		)();
-		expect( canMakePaymentWithExtensionsResult ).toBe( false );
-		expect( trueCallback ).not.toHaveBeenCalled();
+			const canMakePayment = helpers.getCanMakePayment(
+				args.canMakePayment,
+				args.features,
+				args.paymentMethodName
+			)( canMakePaymentArgument );
+			expect( canMakePayment ).toEqual( args.canMakePayment() );
+		} );
+		it( 'returns callbacks from the extensions when they are defined', () => {
+			const args = {
+				canMakePaymentConfiguration: jest
+					.fn()
+					.mockImplementation( () => true ),
+				features: [ 'products' ],
+				paymentMethodName: 'bacs',
+			};
+
+			const canMakePayment = helpers.getCanMakePayment(
+				args.canMakePaymentConfiguration,
+				args.features,
+				args.paymentMethodName
+			)( canMakePaymentArgument );
+			expect( canMakePayment ).toBe( falseCallback() );
+		} );
 	} );
 
-	it( 'Returns early when a registered callback returns false, without executing all the registered callbacks', () => {
-		canMakePaymentWithExtensions(
-			() => true,
-			canMakePaymentExtensionsCallbacks,
-			'bacs'
-		)();
-		expect( falseCallback ).toHaveBeenCalledTimes( 1 );
-	} );
+	describe( 'canMakePaymentWithExtensions', () => {
+		it( "Returns false without executing the registered callbacks, if the payment method's canMakePayment callback returns false.", () => {
+			const canMakePayment = () => false;
+			const canMakePaymentWithExtensionsResult = helpers.canMakePaymentWithExtensions(
+				canMakePayment,
+				canMakePaymentExtensionsCallbacks,
+				'cod'
+			)( canMakePaymentArgument );
+			expect( canMakePaymentWithExtensionsResult ).toBe( false );
+			expect( trueCallback ).not.toHaveBeenCalled();
+		} );
 
-	it( 'Returns true if all extension callbacks return true', () => {
-		const result = canMakePaymentWithExtensions(
-			() => true,
-			canMakePaymentExtensionsCallbacks,
-			'woopay'
-		)();
-		expect( result ).toBe( true );
-	} );
+		it( 'Returns early when a registered callback returns false, without executing all the registered callbacks', () => {
+			helpers.canMakePaymentWithExtensions(
+				() => true,
+				canMakePaymentExtensionsCallbacks,
+				'bacs'
+			)( canMakePaymentArgument );
+			expect( falseCallback ).toHaveBeenCalledTimes( 1 );
+		} );
 
-	it( 'Passes canPayArg to the callback', () => {
-		canMakePaymentWithExtensions(
-			() => true,
-			canMakePaymentExtensionsCallbacks,
-			'woopay'
-		)( 'canPayArg' );
-		expect( trueCallback ).toHaveBeenCalledWith( 'canPayArg' );
-	} );
+		it( 'Returns true if all extension callbacks return true', () => {
+			const result = helpers.canMakePaymentWithExtensions(
+				() => true,
+				canMakePaymentExtensionsCallbacks,
+				'woopay'
+			)( canMakePaymentArgument );
+			expect( result ).toBe( true );
+		} );
 
-	it( 'Allows all valid callbacks to run, even if one causes an error', () => {
-		canMakePaymentWithExtensions(
-			() => true,
-			canMakePaymentExtensionsCallbacks,
-			'testpay'
-		)();
-		expect( console ).toHaveErrored();
-		expect( throwsCallback ).toHaveBeenCalledTimes( 1 );
-		expect( trueCallback ).toHaveBeenCalledTimes( 1 );
+		it( 'Passes canPayArg to the callback', () => {
+			helpers.canMakePaymentWithExtensions(
+				() => true,
+				canMakePaymentExtensionsCallbacks,
+				'woopay'
+			)( canMakePaymentArgument );
+			expect( trueCallback ).toHaveBeenCalledWith(
+				canMakePaymentArgument
+			);
+		} );
+
+		it( 'Allows all valid callbacks to run, even if one causes an error', () => {
+			helpers.canMakePaymentWithExtensions(
+				() => true,
+				canMakePaymentExtensionsCallbacks,
+				'testpay'
+			)( canMakePaymentArgument );
+			expect( console ).toHaveErrored();
+			expect( throwsCallback ).toHaveBeenCalledTimes( 1 );
+			expect( trueCallback ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 } );

--- a/assets/js/blocks-registry/payment-methods/test/payment-method-config.tsx
+++ b/assets/js/blocks-registry/payment-methods/test/payment-method-config.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { registerPaymentMethodExtensionCallbacks } from '@woocommerce/blocks-registry';
+import type { PaymentMethodConfigInstance } from '@woocommerce/type-defs/payments';
 /**
  * Internal dependencies
  */
@@ -9,13 +10,12 @@ import PaymentMethodConfig from '../payment-method-config';
 import * as paymentMethodConfigHelpers from '../payment-method-config-helper';
 
 describe( 'PaymentMethodConfig', () => {
-	let paymentMethod;
-	const spies = {};
+	let paymentMethod: PaymentMethodConfigInstance;
+	const extensionsCallbackSpy = jest.spyOn(
+		paymentMethodConfigHelpers,
+		'canMakePaymentWithExtensions'
+	);
 	beforeEach( () => {
-		spies.canMakePaymentWithExtensions = jest.spyOn(
-			paymentMethodConfigHelpers,
-			'canMakePaymentWithExtensions'
-		);
 		paymentMethod = new PaymentMethodConfig( {
 			name: 'test-payment-method',
 			label: 'Test payment method',
@@ -23,6 +23,7 @@ describe( 'PaymentMethodConfig', () => {
 			content: <div>Test payment content</div>,
 			edit: <div>Test payment edit</div>,
 			canMakePayment: () => true,
+			supports: { features: [ 'products' ] },
 		} );
 	} );
 
@@ -40,7 +41,7 @@ describe( 'PaymentMethodConfig', () => {
 		// Disable no-unused-expressions because we just want to test the getter
 		// eslint-disable-next-line no-unused-expressions
 		paymentMethod.canMakePayment;
-		expect( spies.canMakePaymentWithExtensions ).toHaveBeenCalledTimes( 0 );
+		expect( extensionsCallbackSpy ).toHaveBeenCalledTimes( 0 );
 
 		registerPaymentMethodExtensionCallbacks(
 			'other-woocommerce-marketplace-extension',
@@ -55,6 +56,6 @@ describe( 'PaymentMethodConfig', () => {
 		// Disable no-unused-expressions because we just want to test the getter
 		// eslint-disable-next-line no-unused-expressions
 		paymentMethod.canMakePayment;
-		expect( spies.canMakePaymentWithExtensions ).toHaveBeenCalledTimes( 1 );
+		expect( extensionsCallbackSpy ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -110,5 +110,6 @@ export interface ExpressPaymentMethodConfigInstance {
 	edit: ReactNode;
 	paymentMethodId?: string;
 	supports: Supports;
+	canMakePaymentFromConfig: CanMakePaymentCallback;
 	canMakePayment: CanMakePaymentCallback;
 }

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -31,7 +31,7 @@ export interface CanMakePaymentArgument {
 	cartNeedsShipping: boolean;
 	billingData: CartResponseBillingAddress;
 	shippingAddress: CartResponseShippingAddress;
-	selectedShippingMethods: Array< unknown >;
+	selectedShippingMethods: Record< string, unknown >;
 	paymentRequirements: Array< string >;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6080,9 +6080,9 @@
 			"dev": true
 		},
 		"@types/testing-library__jest-dom": {
-			"version": "5.14.0",
-			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.0.tgz",
-			"integrity": "sha512-l2P2GO+hFF4Liye+fAajT1qBqvZOiL79YMpEvgGs1xTK7hECxBI8Wz4J7ntACJNiJ9r0vXQqYovroXRLPDja6A==",
+			"version": "5.14.1",
+			"resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.1.tgz",
+			"integrity": "sha512-Gk9vaXfbzc5zCXI9eYE9BI5BNHEp4D3FWjgqBE/ePGYElLAP+KvxBcsdkwfIVvezs605oiyd/VrpiHe3Oeg+Aw==",
 			"dev": true,
 			"requires": {
 				"@types/jest": "*"


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds support for extensions to also filter express payment methods.

<!-- Reference any related issues or PRs here -->
Fixes #4733 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Make sure you use the Checkout block and that you are on https
2. In an extension register an express payment method
```
registerExpressPaymentMethod({
        name: "expressMethod",
        edit: null,
        content: <div>My express test method</div>,
        canMakePayment: () => true,
        paymentMethodId: "expressMethod",
        supports: {
          features: ["products"],
        },
 })
```
3. Go to the Checkout block and see that the express payment method appears
4. In the same extension register a callback to remove the above express method
```
 registerPaymentMethodExtensionCallbacks( 'woocommerce-marketplace-extension',
	{
		expressMethod: ( arg ) => { return false; },
	}
);
```
5. Go to the Checkout block and see that the express payment method disappears



### Changelog

> Add support for extensions to filter express payment methods
