### PR TITLE
Debounce billingData to be used as a dependency on the useEffect hook

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
@@ -15,6 +15,7 @@ import type {
 	PaymentMethodConfigInstance,
 	ExpressPaymentMethodConfigInstance,
 } from '@woocommerce/type-defs/payments';
+import { useDebounce } from 'use-debounce';
 
 /**
  * Internal dependencies
@@ -49,6 +50,9 @@ const usePaymentMethodRegistration = (
 	const { isEditor } = useEditorContext();
 	const { selectedRates } = useShippingDataContext();
 	const { billingData, shippingAddress } = useCustomerDataContext();
+
+	// Debouncing billingData to use as a dependency on refreshCanMakePayments and prevent excessive useEffect executions.
+	const [ debouncedBillingData ] = useDebounce( billingData, 750 );
 	const selectedShippingMethods = useShallowEqual( selectedRates );
 	const paymentMethodsOrder = useShallowEqual( paymentMethodsSortOrder );
 	const {
@@ -170,6 +174,7 @@ const usePaymentMethodRegistration = (
 		cartTotals,
 		selectedShippingMethods,
 		paymentRequirements,
+		debouncedBillingData,
 	] );
 
 	return isInitialized;


### PR DESCRIPTION
## Description

Debounce `billingData` to be used as a dependency in the useEffect hook. Debouncing is necessary to prevent an excessive amount of useEffect executions.

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4766

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add the following snippet to the top of the changed file (`assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts`) for the purpose of testing only.

```
registerPaymentMethodExtensionCallbacks( 'woocommerce-marketplace-extension', {
	cod: ( arg ) => arg.billingData.first_name === 'Tom',
} );
```

and add `registerPaymentMethodExtensionCallbacks` to the existing import of `'@woocommerce/blocks-registry'`

2. On the checkout input a first name which _is not_ "Tom" in the Billing Address section. Cash on Delivery option should not be available as a payment method.
3. Update this to be "Tom" and observe the change to the payment methods which now should show Cash on Delivery as a valid option.

### Changelog

> usePaymentMethodRegistration: Debounce billingData updates.
