### PR TITLE
Update canMakePayment to receive cart as argument and make it react to changes in billingData.

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -26,7 +26,7 @@ import type {
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
 	CartResponseCouponItem,
-	CartResponseCouponItemWithLabel,
+	CartResponseCoupons,
 } from '@woocommerce/types';
 import {
 	emptyHiddenAddressFields,
@@ -129,6 +129,7 @@ export const defaultCartData: StoreCart = {
  *
  * @return {StoreCart} Object containing cart data.
  */
+
 export const useStoreCart = (
 	options: { shouldSelect: boolean } = { shouldSelect: true }
 ): StoreCart => {
@@ -136,7 +137,6 @@ export const useStoreCart = (
 	const previewCart = previewData?.previewCart;
 	const { shouldSelect } = options;
 	const currentResults = useRef();
-
 	const results: StoreCart = useSelect(
 		( select, { dispatch } ) => {
 			if ( ! shouldSelect ) {
@@ -194,7 +194,7 @@ export const useStoreCart = (
 			// Add a text property to the coupon to allow extensions to modify
 			// the text used to display the coupon, without affecting the
 			// functionality when it comes to removing the coupon.
-			const cartCoupons: CartResponseCouponItemWithLabel[] =
+			const cartCoupons: CartResponseCoupons =
 				cartData.coupons.length > 0
 					? cartData.coupons.map(
 							( coupon: CartResponseCouponItem ) => ( {

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
@@ -52,11 +52,13 @@ const usePaymentMethodRegistration = (
 	const selectedShippingMethods = useShallowEqual( selectedRates );
 	const paymentMethodsOrder = useShallowEqual( paymentMethodsSortOrder );
 	const {
+		cartCoupons,
 		cartTotals,
 		cartNeedsShipping,
 		paymentRequirements,
 	} = useStoreCart();
 	const canPayArgument = useRef( {
+		cartCoupons,
 		cartTotals,
 		cartNeedsShipping,
 		billingData,
@@ -68,6 +70,7 @@ const usePaymentMethodRegistration = (
 
 	useEffect( () => {
 		canPayArgument.current = {
+			cartCoupons,
 			cartTotals,
 			cartNeedsShipping,
 			billingData,
@@ -76,6 +79,7 @@ const usePaymentMethodRegistration = (
 			paymentRequirements,
 		};
 	}, [
+		cartCoupons,
 		cartTotals,
 		cartNeedsShipping,
 		billingData,

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
@@ -15,6 +15,7 @@ import type {
 	PaymentMethodConfigInstance,
 	ExpressPaymentMethodConfigInstance,
 } from '@woocommerce/type-defs/payments';
+import { useDebouncedCallback } from 'use-debounce';
 
 /**
  * Internal dependencies
@@ -160,12 +161,22 @@ const usePaymentMethodRegistration = (
 		registeredPaymentMethods,
 	] );
 
+	const [ debouncedRefreshCanMakePayments ] = useDebouncedCallback(
+		refreshCanMakePayments,
+		500
+	);
+
 	// Determine which payment methods are available initially and whenever
 	// shipping methods, cart or the billing data change.
 	// Some payment methods (e.g. COD) can be disabled for specific shipping methods.
 	useEffect( () => {
-		refreshCanMakePayments();
-	}, [ refreshCanMakePayments, cart, selectedShippingMethods, billingData ] );
+		debouncedRefreshCanMakePayments();
+	}, [
+		debouncedRefreshCanMakePayments,
+		cart,
+		selectedShippingMethods,
+		billingData,
+	] );
 
 	return isInitialized;
 };

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
@@ -51,14 +51,10 @@ const usePaymentMethodRegistration = (
 	const { billingData, shippingAddress } = useCustomerDataContext();
 	const selectedShippingMethods = useShallowEqual( selectedRates );
 	const paymentMethodsOrder = useShallowEqual( paymentMethodsSortOrder );
-	const {
-		cartCoupons,
-		cartTotals,
-		cartNeedsShipping,
-		paymentRequirements,
-	} = useStoreCart();
+	const cart = useStoreCart();
+	const { cartTotals, cartNeedsShipping, paymentRequirements } = cart;
 	const canPayArgument = useRef( {
-		cartCoupons,
+		cart,
 		cartTotals,
 		cartNeedsShipping,
 		billingData,
@@ -70,7 +66,7 @@ const usePaymentMethodRegistration = (
 
 	useEffect( () => {
 		canPayArgument.current = {
-			cartCoupons,
+			cart,
 			cartTotals,
 			cartNeedsShipping,
 			billingData,
@@ -79,7 +75,7 @@ const usePaymentMethodRegistration = (
 			paymentRequirements,
 		};
 	}, [
-		cartCoupons,
+		cart,
 		cartTotals,
 		cartNeedsShipping,
 		billingData,
@@ -165,16 +161,11 @@ const usePaymentMethodRegistration = (
 	] );
 
 	// Determine which payment methods are available initially and whenever
-	// shipping methods or cart totals change.
+	// shipping methods, cart or the billing data change.
 	// Some payment methods (e.g. COD) can be disabled for specific shipping methods.
 	useEffect( () => {
 		refreshCanMakePayments();
-	}, [
-		refreshCanMakePayments,
-		cartTotals,
-		selectedShippingMethods,
-		paymentRequirements,
-	] );
+	}, [ refreshCanMakePayments, cart, selectedShippingMethods, billingData ] );
 
 	return isInitialized;
 };

--- a/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
@@ -2,6 +2,9 @@
  * External dependencies
  */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { previewCart } from '@woocommerce/resource-previews';
+import { dispatch } from '@wordpress/data';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import {
 	registerPaymentMethod,
 	__experimentalDeRegisterPaymentMethod,
@@ -15,6 +18,7 @@ import {
  * Internal dependencies
  */
 import PaymentMethods from '../payment-methods';
+import { defaultCartState } from '../../../../data/default-states';
 
 jest.mock( '../saved-payment-method-options', () => ( { onChange } ) => {
 	return (
@@ -63,6 +67,22 @@ const resetMockPaymentMethods = () => {
 };
 
 describe( 'PaymentMethods', () => {
+	beforeEach( async () => {
+		fetchMock.mockResponse( ( req ) => {
+			if ( req.url.match( /wc\/store\/cart/ ) ) {
+				return Promise.resolve( JSON.stringify( previewCart ) );
+			}
+			return Promise.resolve( '' );
+		} );
+		// need to clear the store resolution state between tests.
+		await dispatch( storeKey ).invalidateResolutionForStore();
+		await dispatch( storeKey ).receiveCart( defaultCartState.cartData );
+	} );
+
+	afterEach( () => {
+		fetchMock.resetMocks();
+	} );
+
 	test( 'should show no payment methods component when there are no payment methods', async () => {
 		render(
 			<PaymentMethodDataProvider>
@@ -78,6 +98,8 @@ describe( 'PaymentMethods', () => {
 			// creates an extra `div` with the notice contents used for a11y.
 			expect( noPaymentMethods.length ).toBeGreaterThanOrEqual( 1 );
 		} );
+		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
+		expect( console ).toHaveWarned();
 	} );
 
 	test( 'selecting new payment method', async () => {

--- a/assets/js/types/type-defs/cart-response.ts
+++ b/assets/js/types/type-defs/cart-response.ts
@@ -26,6 +26,8 @@ export interface CartResponseCouponItemWithLabel
 	label: string;
 }
 
+export type CartResponseCoupons = CartResponseCouponItemWithLabel[];
+
 export interface ResponseFirstNameLastName {
 	first_name: string;
 	last_name: string;

--- a/assets/js/types/type-defs/hooks.ts
+++ b/assets/js/types/type-defs/hooks.ts
@@ -11,6 +11,7 @@ import type {
 	CartResponseBillingAddress,
 	CartResponseShippingRate,
 	CartResponse,
+	CartResponseCoupons,
 } from './cart-response';
 import type { ResponseError } from '../../data/types';
 export interface StoreCartItemQuantity {
@@ -31,7 +32,7 @@ export interface StoreCartCoupon {
 }
 
 export interface StoreCart {
-	cartCoupons: Array< CartResponseCouponItem >;
+	cartCoupons: CartResponseCoupons;
 	cartItems: Array< CartResponseItem >;
 	cartFees: Array< CartResponseFeeItem >;
 	cartItemsCount: number;

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /**
  * Internal dependencies
  */
-import type { CartTotals } from './cart';
+import type { CartTotals, Cart } from './cart';
 import {
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
@@ -28,6 +28,7 @@ export interface Supports extends SupportsConfiguration {
 }
 
 export interface CanMakePaymentArgument {
+	cart: Cart;
 	cartCoupons: CartResponseCoupons;
 	cartTotals: CartTotals;
 	cartNeedsShipping: boolean;

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -10,6 +10,7 @@ import type { CartTotals } from './cart';
 import {
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
+	CartResponseCoupons,
 } from './cart-response';
 import type { EmptyObjectType } from './objects';
 
@@ -27,6 +28,7 @@ export interface Supports extends SupportsConfiguration {
 }
 
 export interface CanMakePaymentArgument {
+	cartCoupons: CartResponseCoupons;
 	cartTotals: CartTotals;
 	cartNeedsShipping: boolean;
 	billingData: CartResponseBillingAddress;

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -10,7 +10,6 @@ import type { CartTotals, Cart } from './cart';
 import {
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
-	CartResponseCoupons,
 } from './cart-response';
 import type { EmptyObjectType } from './objects';
 
@@ -29,7 +28,6 @@ export interface Supports extends SupportsConfiguration {
 
 export interface CanMakePaymentArgument {
 	cart: Cart;
-	cartCoupons: CartResponseCoupons;
 	cartTotals: CartTotals;
 	cartNeedsShipping: boolean;
 	billingData: CartResponseBillingAddress;

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -87,6 +87,7 @@ A callback to determine whether the payment method should be available as an opt
 
 ```
 canMakePayment( {
+    cart: Cart,
     cartCoupons: CartCoupons,
     cartTotals: CartTotals,
     cartNeedsShipping: boolean,

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -88,7 +88,6 @@ A callback to determine whether the payment method should be available as an opt
 ```
 canMakePayment( {
     cart: Cart,
-    cartCoupons: CartCoupons,
     cartTotals: CartTotals,
     cartNeedsShipping: boolean,
     shippingAddress: CartShippingAddress,

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -4,21 +4,21 @@ The checkout block has an API interface for payment methods to integrate that co
 
 ## Table of Contents <!-- omit in toc -->
 
-- [Client Side integration](#client-side-integration)
-  - [Express payment methods - `registerExpressPaymentMethod( options )`](#express-payment-methods---registerexpresspaymentmethod-options-)
-    - [`name` (required)](#name-required)
-    - [`content` (required)](#content-required)
-    - [`edit` (required)](#edit-required)
-    - [`canMakePayment` (required):](#canmakepayment-required)
-    - [`paymentMethodId`](#paymentmethodid)
-    - [`supports:features`](#supportsfeatures)
-  - [Payment Methods - `registerPaymentMethod( options )`](#payment-methods---registerpaymentmethod-options-)
-  - [Props Fed to Payment Method Nodes](#props-fed-to-payment-method-nodes)
-- [Server Side Integration](#server-side-integration)
-  - [Processing Payment](#processing-payment)
-  - [Registering Assets](#registering-assets)
-  - [Hooking into the Checkout processing by the Store API.](#hooking-into-the-checkout-processing-by-the-store-api)
-  - [Putting it all together](#putting-it-all-together)
+-   [Client Side integration](#client-side-integration)
+    -   [Express payment methods - `registerExpressPaymentMethod( options )`](#express-payment-methods---registerexpresspaymentmethod-options-)
+        -   [`name` (required)](#name-required)
+        -   [`content` (required)](#content-required)
+        -   [`edit` (required)](#edit-required)
+        -   [`canMakePayment` (required):](#canmakepayment-required)
+        -   [`paymentMethodId`](#paymentmethodid)
+        -   [`supports:features`](#supportsfeatures)
+    -   [Payment Methods - `registerPaymentMethod( options )`](#payment-methods---registerpaymentmethod-options-)
+    -   [Props Fed to Payment Method Nodes](#props-fed-to-payment-method-nodes)
+-   [Server Side Integration](#server-side-integration)
+    -   [Processing Payment](#processing-payment)
+    -   [Registering Assets](#registering-assets)
+    -   [Hooking into the Checkout processing by the Store API.](#hooking-into-the-checkout-processing-by-the-store-api)
+    -   [Putting it all together](#putting-it-all-together)
 
 ## Client Side integration
 
@@ -52,7 +52,7 @@ The registry function expects a JavaScript object with options specific to the p
 registerExpressPaymentMethod( options );
 ```
 
-The options you feed the configuration instance should be an object in this shape (see `ExpressPaymentMethodRegistrationOptions` typedef):
+The options you feed the configuration instance should be an object in this shape (see `ExpressPaymentMethodConfiguration` typedef):
 
 ```js
 const options = {
@@ -87,11 +87,12 @@ A callback to determine whether the payment method should be available as an opt
 
 ```
 canMakePayment( {
+    cartCoupons: CartCoupons,
     cartTotals: CartTotals,
     cartNeedsShipping: boolean,
     shippingAddress: CartShippingAddress,
     billingData: BillingData,
-    selectedShippingMethods: string[],
+    selectedShippingMethods: Record<string,unknown>,
     paymentRequirements: string[],
 } )
 ```


### PR DESCRIPTION
This PR 
- adds the  `cart` object to the argument we pass to the `canMakePayment` callback
- it adds `billingData` to the dependencies list of the effect that calls `refresCanMakePayment` and closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4766. 
- It improves the performance of calculating if a payment method is still active after changes in the Checkout block:
   - it debounces refreshMakePayment for the reasons from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4775#issuecomment-923958392. Debounced was chosen instead of throttle because we want to call refreshCanMakePayments once the change event has stopped, with the final value.
- it adds some types related to coupon data made while investigating #4670 
<!-- Reference any related issues or PRs here -->
Fixes: 
#4670 
#4766


A new ticket has been created for deprecating cart-derived values from the `canMakePayment` argument https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4809

How to test the changes in this Pull Request:

1. Go to `assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts` and edit for the purpose of testing only:

- add `registerPaymentMethodExtensionCallbacks` to the existing import from `'@woocommerce/blocks-registry'`
- register a callback for COD at the top of the file, after the imports
```
registerPaymentMethodExtensionCallbacks( 'woocommerce-marketplace-extension', {
	cod: ( arg ) => {
		console.log( 'checking COD' );
		return arg.billingData.first_name === 'Alexandra';
	},
} );
```
2. Make the console visible
2. Go to Checkout block and notice that COD payment method is missing and that an initial check was made COD (see console.log())
3. Deselect `Use same address for billing` and write "Alexandra" for First Name in the Billing Address section. Cash on Delivery option should be available as a payment method.
3. Notice that the check for COD is done only after the user finished typing


### Changelog

> Update canMakePayment to receive cart as argument and make it react to changes in billingData.  Improve the performance of calculating canMakePayment after changes in the Checkout block.




