### PR TITLE
Add automation for automatically assigning the team the pr author belongs to for reviewing

### DIFF
--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -1,0 +1,17 @@
+when:
+  - author:
+      teamIs:
+        - rubik-fp-squad
+      ignore:
+        nameIs:
+    assign:
+      teams:
+        - rubik-fp-squad
+  - author:
+      teamIs:
+        -rubik-fse-squad
+      ignore:
+        nameIs:
+    assign:
+      teams:
+        -rubik-fse-squad

--- a/.github/workflows/automate-team-review-assignment-config.yml
+++ b/.github/workflows/automate-team-review-assignment-config.yml
@@ -1,0 +1,11 @@
+name: 'Automate assigning team for review.'
+on: pull_request
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check config and assign reviews
+        uses: acq688/Request-Reviewer-For-Team-Action@v1.1
+        with:
+          config: ".github/automate-team-review-assignment-config.yml"
+          GITHUB_TOKEN: ${{ secrets.PAT_FOR_ACTIONS }}


### PR DESCRIPTION
This PR implements a new Automation that will use the check if the PR belongs to any teams in the provided configuration and assign to that team for review. Since we have the `rubik-fp-squad` and `rubik-fse-squad` setup with round robin, this then trigger GitHub automatically assigning the appropriate person in the place of the team for review.

In order to work, the existing `CODEOWNERS` file had to be removed separately from trunk (hence it's not a part of this PR). 

I'm going to go ahead and merge this and we can see how it works next week. This should scale well when multiple teams start working in this repository.