### PR TITLE
Throw an exception if there is no selected shipping method on an item…

### DIFF
--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -426,7 +426,7 @@ class OrderController {
 			if ( false === $chosen_shipping_method ) {
 				throw new RouteException(
 					'woocommerce_rest_invalid_shipping_option',
-					__( 'Sorry, this order requires a shipping option', 'woo-gutenberg-products-block' ),
+					__( 'Sorry, this order requires a shipping option.', 'woo-gutenberg-products-block' ),
 					400,
 					[]
 				);

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -116,8 +116,12 @@ class OrderController {
 	 * @param \WC_Order $order Order object.
 	 */
 	public function validate_order_before_payment( \WC_Order $order ) {
+		$needs_shipping          = wc()->cart->needs_shipping();
+		$chosen_shipping_methods = wc()->session->get( 'chosen_shipping_methods' );
+
 		$this->validate_coupons( $order );
 		$this->validate_email( $order );
+		$this->validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods );
 		$this->validate_addresses( $order );
 	}
 
@@ -402,6 +406,30 @@ class OrderController {
 
 			if ( $usage_count >= $coupon_usage_limit ) {
 				throw new Exception( $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED ) );
+			}
+		}
+	}
+
+	/**
+	 * Check there is a shipping method if it requires shipping.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 * @param boolean $needs_shipping Current order needs shipping.
+	 * @param array   $chosen_shipping_methods Array of shipping methods.
+	 */
+	public function validate_selected_shipping_methods( $needs_shipping, $chosen_shipping_methods = array() ) {
+		if ( ! $needs_shipping || ! is_array( $chosen_shipping_methods ) ) {
+			return;
+		}
+
+		foreach ( $chosen_shipping_methods as $chosen_shipping_method ) {
+			if ( false === $chosen_shipping_method ) {
+				throw new RouteException(
+					'woocommerce_rest_invalid_shipping_option',
+					__( 'Sorry, this order requires a shipping option', 'woo-gutenberg-products-block' ),
+					400,
+					[]
+				);
 			}
 		}
 	}

--- a/tests/php/StoreApi/Routes/ControllerTestCase.php
+++ b/tests/php/StoreApi/Routes/ControllerTestCase.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * OrderController Tests.
+ * ControllerTestCase Tests.
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Routes;

--- a/tests/php/StoreApi/Utilities/CartController.php
+++ b/tests/php/StoreApi/Utilities/CartController.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * OrderController Tests.
+ * CartController Tests.
  */
 
 namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;
@@ -9,7 +9,7 @@ use Automattic\WooCommerce\Blocks\Tests\Helpers\FixtureData;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
-class OrderControllerTests extends TestCase {
+class CartControllerTests extends TestCase {
 
 	public function test_get_cart_item_errors()    {
 		$class    = new CartController();

--- a/tests/php/StoreApi/Utilities/OrderController.php
+++ b/tests/php/StoreApi/Utilities/OrderController.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * OrderController Tests.
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Utilities;
+
+use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\OrderController;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class OrderControllerTests extends TestCase {
+	use ExpectException;
+
+	public function test_validate_selected_shipping_methods_throws() {
+		$class = new OrderController();
+
+		$this->expectException( RouteException::class );
+		$class->validate_selected_shipping_methods( true, array( false ) );
+	}
+
+	public function test_validate_selected_shipping_methods() {
+		$class = new OrderController();
+
+		// By running this method we assert that it doesn't error because if it does this test will fail.
+		$class->validate_selected_shipping_methods( true, array( 'free-shipping' ) );
+		$class->validate_selected_shipping_methods( false, array( 'free-shipping' ) );
+		$class->validate_selected_shipping_methods( true, null );
+	}
+}


### PR DESCRIPTION
### Description

Throw an exception if there is a shipping method required and one isn't selected at the time of placing an order.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4705

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Set a shipping zone in a country of your choice
2. Add a physical product to your cart and enter a country that **isn't covered** by the shipping zone
3. Clicking "Place Order" should throw an exception which should be displayed in the checkout, whilst preventing you from placing an order.

### Changelog

> Checkout: Throw an exception if there is a shipping method required and one isn't selected at the time of placing an order.
