### PR TITLE
Add e2e tests for Best Selling Products

### DIFF
--- a/assets/js/blocks/product-best-sellers/block.js
+++ b/assets/js/blocks/product-best-sellers/block.js
@@ -87,7 +87,7 @@ class ProductBestSellersBlock extends Component {
 		}
 
 		return (
-			<>
+			<div className="wc-block-product-best-sellers">
 				{ this.getInspectorControls() }
 				<Disabled>
 					<ServerSideRender
@@ -95,7 +95,7 @@ class ProductBestSellersBlock extends Component {
 						attributes={ attributes }
 					/>
 				</Disabled>
-			</>
+			</div>
 		);
 	}
 }

--- a/tests/e2e/config/custom-matchers/__fixtures__/best-selling-products.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/best-selling-products.fixture.json
@@ -1,0 +1,1 @@
+{"title":"Best Selling Products Block","pageContent":"<!-- wp:woocommerce/product-best-sellers /-->"}

--- a/tests/e2e/specs/backend/product-best-sellers.test.js
+++ b/tests/e2e/specs/backend/product-best-sellers.test.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
+
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
+
+const block = {
+	name: 'Best Selling Products',
+	slug: 'woocommerce/product-best-sellers',
+	class: '.wc-block-product-best-sellers',
+};
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+
+	it( 'can be inserted more than once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 2 );
+	} );
+} );


### PR DESCRIPTION
### Note

Currently, not every block is covered by e2e tests. This PR aims to add e2e tests for the Best Selling Products block.

Part of #4643 

### Testing

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env start && npm run test:e2e`.
4. The e2e test suite shows no failed tests.