### PR TITLE
Add object type to lock attributes

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true
 			}

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/block.json
@@ -13,6 +13,7 @@
 	},
 	"attributes": {
 		"lock": {
+			"type": "object",
 			"default": {
 				"remove": true,
 				"move": true


### PR DESCRIPTION
Some of the inner blocks in Checkout i2 could still be removed. This was due to missing `"type": "object",` in the block json. 

**To test:**
1. Apply patch
2. Ensure express payment block cannot be moved or removed