### PR TITLE
#3906 screen reader fix for order summary block accessibility 

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { sprintf, _n } from '@wordpress/i18n';
 import Label from '@woocommerce/base-components/label';
 import ProductPrice from '@woocommerce/base-components/product-price';
 import ProductName from '@woocommerce/base-components/product-name';
@@ -116,7 +116,12 @@ const OrderSummaryItem = ( { cartItem } ) => {
 						label={ quantity }
 						screenReaderLabel={ sprintf(
 							/* translators: %d number of products of the same type in the cart */
-							__( '%d items', 'woo-gutenberg-products-block' ),
+							_n(
+								'%d item',
+								'%d items',
+								quantity,
+								'woo-gutenberg-products-block'
+							),
 							quantity
 						) }
 					/>
@@ -124,27 +129,11 @@ const OrderSummaryItem = ( { cartItem } ) => {
 				<ProductImage image={ images.length ? images[ 0 ] : {} } />
 			</div>
 			<div className="wc-block-components-order-summary-item__description">
-				<span className="screen-reader-text" tabIndex={ 0 }>
-					{ sprintf(
-						/* translators: %d items of product %s */
-						__( '%1$d %2$s', 'woo-gutenberg-products-block' ),
-						quantity,
-						name
-					) }
-				</span>
 				<ProductName
 					disabled={ true }
 					name={ name }
 					permalink={ permalink }
 				/>
-
-				<span className="screen-reader-text" tabIndex={ 0 }>
-					{ sprintf(
-						/* translators: Unit Price %s */
-						__( 'Unit Price: %s', 'woo-gutenberg-products-block' ),
-						formatPrice( priceSingle, priceCurrency )
-					) }
-				</span>
 				<ProductPrice
 					currency={ priceCurrency }
 					price={ priceSingle }
@@ -170,15 +159,18 @@ const OrderSummaryItem = ( { cartItem } ) => {
 					variation={ variation }
 				/>
 			</div>
-			<span className="screen-reader-text" tabIndex={ 0 }>
+			<span className="screen-reader-text">
 				{ sprintf(
-					/* translators: Total Price for %d quantity items: %s */
-					__(
-						'Total Price for %1$d items: %2$s',
+					/* translators: %1$d is the number of items, %2$s is the total price including the currency symbol and %3$s is the item name. */
+					_n(
+						'Total price for %1$d %3$s item: %2$s',
+						'Total price for %1$d %3$s items: %2$s',
+						quantity,
 						'woo-gutenberg-products-block'
 					),
 					quantity,
-					formatPrice( subtotalPrice, totalsCurrency )
+					formatPrice( subtotalPrice, totalsCurrency ),
+					name
 				) }
 			</span>
 			<div className="wc-block-components-order-summary-item__total-price">

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -161,19 +161,22 @@ const OrderSummaryItem = ( { cartItem } ) => {
 			</div>
 			<span className="screen-reader-text">
 				{ sprintf(
-					/* translators: %1$d is the number of items, %2$s is the total price including the currency symbol and %3$s is the item name. */
+					/* translators: %1$d is the number of items, %2$s is the item name and %3$s is the total price including the currency symbol. */
 					_n(
-						'Total price for %1$d %3$s item: %2$s',
-						'Total price for %1$d %3$s items: %2$s',
+						'Total price for %1$d %2$s item: %3$s',
+						'Total price for %1$d %2$s items: %3$s',
 						quantity,
 						'woo-gutenberg-products-block'
 					),
 					quantity,
-					formatPrice( subtotalPrice, totalsCurrency ),
-					name
+					name,
+					formatPrice( subtotalPrice, totalsCurrency )
 				) }
 			</span>
-			<div className="wc-block-components-order-summary-item__total-price">
+			<div
+				className="wc-block-components-order-summary-item__total-price"
+				aria-hidden="true"
+			>
 				<ProductPrice
 					currency={ totalsCurrency }
 					format={ productPriceFormat }

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -5,7 +5,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import Label from '@woocommerce/base-components/label';
 import ProductPrice from '@woocommerce/base-components/product-price';
 import ProductName from '@woocommerce/base-components/product-name';
-import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
+import {
+	getCurrencyFromPriceResponse,
+	formatPrice,
+} from '@woocommerce/price-format';
 import {
 	__experimentalApplyCheckoutFilter,
 	mustContain,
@@ -121,11 +124,27 @@ const OrderSummaryItem = ( { cartItem } ) => {
 				<ProductImage image={ images.length ? images[ 0 ] : {} } />
 			</div>
 			<div className="wc-block-components-order-summary-item__description">
+				<span className="screen-reader-text" tabIndex={ 0 }>
+					{ sprintf(
+						/* translators: %d items of product %s */
+						__( '%1$d %2$s', 'woo-gutenberg-products-block' ),
+						quantity,
+						name
+					) }
+				</span>
 				<ProductName
 					disabled={ true }
 					name={ name }
 					permalink={ permalink }
 				/>
+
+				<span className="screen-reader-text" tabIndex={ 0 }>
+					{ sprintf(
+						/* translators: Unit Price %s */
+						__( 'Unit Price: %s', 'woo-gutenberg-products-block' ),
+						formatPrice( priceSingle, priceCurrency )
+					) }
+				</span>
 				<ProductPrice
 					currency={ priceCurrency }
 					price={ priceSingle }
@@ -151,6 +170,17 @@ const OrderSummaryItem = ( { cartItem } ) => {
 					variation={ variation }
 				/>
 			</div>
+			<span className="screen-reader-text" tabIndex={ 0 }>
+				{ sprintf(
+					/* translators: Total Price for %d quantity items: %s */
+					__(
+						'Total Price for %1$d items: %2$s',
+						'woo-gutenberg-products-block'
+					),
+					quantity,
+					formatPrice( subtotalPrice, totalsCurrency )
+				) }
+			</span>
 			<div className="wc-block-components-order-summary-item__total-price">
 				<ProductPrice
 					currency={ totalsCurrency }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #3906 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
![Screen Recording 2021-09-22 at 13 58 25](https://user-images.githubusercontent.com/537751/134335056-fd8c6c06-8a9d-4eb1-8ecc-3ba5546a2bf8.gif)


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add one or more items to your cart
2. Create a post/page add the `Checkout` block
3. Open the new page from previous step
4. Click on `Order Summary` to expand the tab, or navigate to it using TAB key
5. Navigate using the `TAB` key
6. Optionally you could enable the screen reader

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Improve the Checkout Order Summary block accessibility by making more info available to screen readers.
