### PR TITLE
AttributePicker: Set default values if they exist

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/attribute-picker.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/attribute-picker.js
@@ -11,6 +11,7 @@ import AttributeSelectControl from './attribute-select-control';
 import {
 	getVariationMatchingSelectedAttributes,
 	getActiveSelectControlOptions,
+	getDefaultAttributes,
 } from './utils';
 
 /**
@@ -27,6 +28,7 @@ const AttributePicker = ( {
 	const currentVariationAttributes = useShallowEqual( variationAttributes );
 	const [ variationId, setVariationId ] = useState( 0 );
 	const [ selectedAttributes, setSelectedAttributes ] = useState( {} );
+	const [ hasSetDefaults, setHasSetDefaults ] = useState( false );
 
 	// Get options for each attribute picker.
 	const filteredAttributeOptions = useMemo( () => {
@@ -36,6 +38,19 @@ const AttributePicker = ( {
 			selectedAttributes
 		);
 	}, [ selectedAttributes, currentAttributes, currentVariationAttributes ] );
+
+	// Set default attributes as selected.
+	useEffect( () => {
+		if ( ! hasSetDefaults ) {
+			const defaultAttributes = getDefaultAttributes( attributes );
+			if ( defaultAttributes ) {
+				setSelectedAttributes( {
+					...defaultAttributes,
+				} );
+			}
+			setHasSetDefaults( true );
+		}
+	}, [ selectedAttributes, attributes, hasSetDefaults ] );
 
 	// Select variations when selections are change.
 	useEffect( () => {

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/index.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/index.js
@@ -13,10 +13,7 @@ import { getAttributes, getVariationAttributes } from './utils';
  * @param {Object} props.dispatchers An object where values are dispatching functions.
  */
 const VariationAttributes = ( { product, dispatchers } ) => {
-	const attributes = getAttributes(
-		product.attributes,
-		product.default_attributes
-	);
+	const attributes = getAttributes( product.attributes );
 	const variationAttributes = getVariationAttributes( product.variations );
 	if (
 		Object.keys( attributes ).length === 0 ||

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/index.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/index.js
@@ -13,9 +13,11 @@ import { getAttributes, getVariationAttributes } from './utils';
  * @param {Object} props.dispatchers An object where values are dispatching functions.
  */
 const VariationAttributes = ( { product, dispatchers } ) => {
-	const attributes = getAttributes( product.attributes );
+	const attributes = getAttributes(
+		product.attributes,
+		product.default_attributes
+	);
 	const variationAttributes = getVariationAttributes( product.variations );
-
 	if (
 		Object.keys( attributes ).length === 0 ||
 		variationAttributes.length === 0

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/test/index.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/test/index.js
@@ -7,6 +7,7 @@ import {
 	getVariationsMatchingSelectedAttributes,
 	getVariationMatchingSelectedAttributes,
 	getActiveSelectControlOptions,
+	getDefaultAttributes,
 } from '../utils';
 
 const rawAttributeData = [
@@ -20,16 +21,19 @@ const rawAttributeData = [
 				id: 22,
 				name: 'Blue',
 				slug: 'blue',
+				default: true,
 			},
 			{
 				id: 23,
 				name: 'Green',
 				slug: 'green',
+				default: false,
 			},
 			{
 				id: 24,
 				name: 'Red',
 				slug: 'red',
+				default: false,
 			},
 		],
 	},
@@ -43,11 +47,13 @@ const rawAttributeData = [
 				id: 0,
 				name: 'Yes',
 				slug: 'Yes',
+				default: true,
 			},
 			{
 				id: 0,
 				name: 'No',
 				slug: 'No',
+				default: false,
 			},
 		],
 	},
@@ -61,11 +67,13 @@ const rawAttributeData = [
 				id: 0,
 				name: 'Test',
 				slug: 'Test',
+				default: false,
 			},
 			{
 				id: 0,
 				name: 'Test 2',
 				slug: 'Test 2',
+				default: false,
 			},
 		],
 	},
@@ -126,6 +134,61 @@ const rawVariations = [
 	},
 ];
 
+const formattedAttributes = {
+	Color: {
+		id: 1,
+		name: 'Color',
+		taxonomy: 'pa_color',
+		has_variations: true,
+		terms: [
+			{
+				id: 22,
+				name: 'Blue',
+				slug: 'blue',
+				default: true,
+			},
+			{
+				id: 23,
+				name: 'Green',
+				slug: 'green',
+				default: false,
+			},
+			{
+				id: 24,
+				name: 'Red',
+				slug: 'red',
+				default: false,
+			},
+		],
+	},
+	Size: {
+		id: 2,
+		name: 'Size',
+		taxonomy: 'pa_size',
+		has_variations: true,
+		terms: [
+			{
+				id: 25,
+				name: 'Large',
+				slug: 'large',
+				default: false,
+			},
+			{
+				id: 26,
+				name: 'Medium',
+				slug: 'medium',
+				default: true,
+			},
+			{
+				id: 27,
+				name: 'Small',
+				slug: 'small',
+				default: false,
+			},
+		],
+	},
+};
+
 describe( 'Testing utils', () => {
 	describe( 'Testing getAttributes()', () => {
 		it( 'returns empty object if there are no attributes', () => {
@@ -145,16 +208,19 @@ describe( 'Testing utils', () => {
 							id: 22,
 							name: 'Blue',
 							slug: 'blue',
+							default: true,
 						},
 						{
 							id: 23,
 							name: 'Green',
 							slug: 'green',
+							default: false,
 						},
 						{
 							id: 24,
 							name: 'Red',
 							slug: 'red',
+							default: false,
 						},
 					],
 				},
@@ -168,11 +234,13 @@ describe( 'Testing utils', () => {
 							id: 0,
 							name: 'Yes',
 							slug: 'Yes',
+							default: true,
 						},
 						{
 							id: 0,
 							name: 'No',
 							slug: 'No',
+							default: false,
 						},
 					],
 				},
@@ -390,6 +458,22 @@ describe( 'Testing utils', () => {
 					},
 				],
 			} );
+		} );
+	} );
+	describe( 'Testing getDefaultAttributes()', () => {
+		const defaultAttributes = getDefaultAttributes( formattedAttributes );
+
+		it( 'should return default attributes in the format that is ready for setting state', () => {
+			expect( defaultAttributes ).toStrictEqual( {
+				Color: 'blue',
+				Size: 'medium',
+			} );
+		} );
+
+		it( 'should return an empty object if given unexpected values', () => {
+			expect( getDefaultAttributes( [] ) ).toStrictEqual( {} );
+			expect( getDefaultAttributes( null ) ).toStrictEqual( {} );
+			expect( getDefaultAttributes( undefined ) ).toStrictEqual( {} );
 		} );
 	} );
 } );

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/utils.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/utils.js
@@ -206,3 +206,19 @@ export const getActiveSelectControlOptions = (
 
 	return options;
 };
+
+export const getDefaultAttributes = ( attributes ) => {
+	const attributeNames = Object.keys( attributes );
+	const defaultsToSet = {};
+	attributeNames.forEach( ( attributeName ) => {
+		const currentAttribute = attributes[ attributeName ];
+		const defaultValue = currentAttribute.terms.filter(
+			( term ) => term.default
+		);
+		if ( defaultValue.length > 0 ) {
+			defaultsToSet[ currentAttribute.name ] = defaultValue[ 0 ]?.slug;
+		}
+	} );
+
+	return defaultsToSet;
+};

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/utils.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/utils.js
@@ -3,6 +3,7 @@
  */
 import { keyBy } from 'lodash';
 import { decodeEntities } from '@wordpress/html-entities';
+import { isObject } from '@woocommerce/types';
 
 /**
  * Key an array of attributes by name,
@@ -207,9 +208,24 @@ export const getActiveSelectControlOptions = (
 	return options;
 };
 
-export const getDefaultAttributes = ( attributes ) => {
+/**
+ * Return the default values of the given attributes in a format ready to be set in state.
+ *
+ * @param {Object} attributes List of attribute names and terms.
+ * @return {Object} Default attributes.
+ */
+export const getDefaultAttributes = ( attributes = {} ) => {
+	if ( ! isObject( attributes ) ) {
+		return {};
+	}
+
 	const attributeNames = Object.keys( attributes );
 	const defaultsToSet = {};
+
+	if ( attributeNames.length === 0 ) {
+		return defaultsToSet;
+	}
+
 	attributeNames.forEach( ( attributeName ) => {
 		const currentAttribute = attributes[ attributeName ];
 		const defaultValue = currentAttribute.terms.filter(

--- a/assets/js/types/type-guards/index.ts
+++ b/assets/js/types/type-guards/index.ts
@@ -13,7 +13,11 @@ export const isString = < U >( term: string | U ): term is string => {
 export const isObject = < T extends Record< string, unknown >, U >(
 	term: T | U
 ): term is NonNullable< T > => {
-	return ! isNull( term ) && typeof term === 'object';
+	return (
+		! isNull( term ) &&
+		term instanceof Object &&
+		term.constructor === Object
+	);
 };
 
 export function objectHasProp< P extends PropertyKey >(

--- a/assets/js/types/type-guards/test/index.ts
+++ b/assets/js/types/type-guards/test/index.ts
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { isObject } from '@woocommerce/types';
+
+describe( 'type-guards', () => {
+	describe( 'Testing isObject()', () => {
+		it( 'Correctly identifies an object', () => {
+			expect( isObject( {} ) ).toBe( true );
+			expect( isObject( { test: 'object' } ) ).toBe( true );
+		} );
+		it( 'Correctly rejects object-like things', () => {
+			expect( isObject( [] ) ).toBe( false );
+			expect( isObject( null ) ).toBe( false );
+		} );
+	} );
+} );

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -639,11 +639,12 @@ class ProductSchema extends AbstractSchema {
 				continue;
 			}
 
-			$terms = $attribute->is_taxonomy() ? array_map( [ $this, 'prepare_product_attribute_taxonomy_value' ], $attribute->get_terms() ) : array_map( [ $this, 'prepare_product_attribute_value' ], $attribute->get_options() );
+			$terms                    = $attribute->is_taxonomy() ? array_map( [ $this, 'prepare_product_attribute_taxonomy_value' ], $attribute->get_terms() ) : array_map( [ $this, 'prepare_product_attribute_value' ], $attribute->get_options() );
+			$sanitized_attribute_name = sanitize_key( $attribute->get_name() );
 
-			if ( $attribute->is_taxonomy() && array_key_exists( $attribute->get_name(), $default_attributes ) ) {
+			if ( array_key_exists( $sanitized_attribute_name, $default_attributes ) ) {
 				foreach ( $terms as $term ) {
-					$term->default = $term->slug === $default_attributes[ $attribute->get_name() ];
+					$term->default = $term->slug === $default_attributes[ $sanitized_attribute_name ];
 				}
 			}
 

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -639,7 +639,9 @@ class ProductSchema extends AbstractSchema {
 				continue;
 			}
 
-			$terms                    = $attribute->is_taxonomy() ? array_map( [ $this, 'prepare_product_attribute_taxonomy_value' ], $attribute->get_terms() ) : array_map( [ $this, 'prepare_product_attribute_value' ], $attribute->get_options() );
+			$terms = $attribute->is_taxonomy() ? array_map( [ $this, 'prepare_product_attribute_taxonomy_value' ], $attribute->get_terms() ) : array_map( [ $this, 'prepare_product_attribute_value' ], $attribute->get_options() );
+			// Custom attribute names are sanitized to be the array keys.
+			// So when we do the array_key_exists check below we also need to sanitize the attribute names.
 			$sanitized_attribute_name = sanitize_key( $attribute->get_name() );
 
 			if ( array_key_exists( $sanitized_attribute_name, $default_attributes ) ) {


### PR DESCRIPTION
### Description
* Set a new `default` key with a boolean value on each attribute in the API response to determine whether it should be set as the default attribute or not.
* Set default selections as selected if there are any on the frontend.
* Modified the `isObject` type-guard utility function so it doesn't pass for object-like values (e.g. array)

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2758

### Screenshots
**Before**
![Screenshot 2021-09-23 at 09 26 43](https://user-images.githubusercontent.com/8639742/134476238-c70b23de-d005-4ff5-adae-6220b7b80f90.png)

**After**
![Screenshot 2021-09-23 at 09 26 28](https://user-images.githubusercontent.com/8639742/134476197-95531178-6093-450e-b256-03c742074d54.png)

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Find a variable product in your store and set its default attributes under Form Variations > Default Form Values.
2. Add All Products block to a page
3. Click the edit button on the block (the pencil) and replace the “Add to cart button” block with the “Add to cart” block. On this block enable “Display form elements”.
3. On the frontend your variable product should have the correct default attributes already set
4. Add to basket to ensure the correct product selection gets added.

### Changelog

> AttributePicker: Set default values if they exist.
