### PR TITLE
Fix infinite recursion when removing an attribute filter from the Active filters block

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -178,8 +178,17 @@ const AttributeFilterBlock = ( {
 			! isShallowEqual( checked, currentCheckedQuery ) // checked query doesn't match the UI
 		) {
 			setChecked( currentCheckedQuery );
+			if ( ! blockAttributes.showFilterButton ) {
+				onSubmit( currentCheckedQuery );
+			}
 		}
-	}, [ checked, currentCheckedQuery, previousCheckedQuery ] );
+	}, [
+		checked,
+		currentCheckedQuery,
+		previousCheckedQuery,
+		onSubmit,
+		blockAttributes.showFilterButton,
+	] );
 
 	/**
 	 * Returns an array of term objects that have been chosen via the checkboxes.
@@ -219,13 +228,6 @@ const AttributeFilterBlock = ( {
 			blockAttributes.queryType,
 		]
 	);
-
-	// Track checked STATE changes - if state changes, update the query.
-	useEffect( () => {
-		if ( ! blockAttributes.showFilterButton ) {
-			onSubmit( checked );
-		}
-	}, [ blockAttributes.showFilterButton, checked, onSubmit ] );
 
 	const multiple =
 		blockAttributes.displayStyle !== 'dropdown' ||
@@ -312,8 +314,17 @@ const AttributeFilterBlock = ( {
 			}
 
 			setChecked( newChecked );
+			if ( ! blockAttributes.showFilterButton ) {
+				onSubmit( newChecked );
+			}
 		},
-		[ checked, displayedOptions, multiple ]
+		[
+			checked,
+			displayedOptions,
+			multiple,
+			onSubmit,
+			blockAttributes.showFilterButton,
+		]
 	);
 
 	if ( displayedOptions.length === 0 && ! attributeTermsLoading ) {


### PR DESCRIPTION
Fixes #4813.

As described in #4813, it was not possible to remove attribute filters from the Active filters blocks (infinite recursion that hangs the page). While I wasn't able to understand why that issue appeared suddenly, I could fix it simplifying the logic and removing one unnecessary `useEffect()`.

This issue has been present since WC Blocks 5.7 and affects the functionality of some blocks released in WC core. Thoughts on whether this deserves a point release? cc @opr who is the 5.9.0 release lead.

### Screenshots

https://user-images.githubusercontent.com/3616980/134488167-72d34a1f-e671-46be-9459-bfda8e6ad559.mp4

### Manual Testing

From https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4813:

1. Insert All Products, Filter Products by Attribute and Active filter blocks into a page.
1. Publish the page.
1. Go to Frontend on same page which created in above step.
1. Apply filter for any attribute.
1. Verify you can remove attribute filters either using the cross icon next to it or pressing Clear All.

### Changelog

> Fix infinite recursion when removing an attribute filter from the Active filters block.
