### PR TITLE
Cart i2: view switcher shared to children

### DIFF
--- a/assets/js/blocks/cart-checkout/cart-i2/context.ts
+++ b/assets/js/blocks/cart-checkout/cart-i2/context.ts
@@ -6,22 +6,14 @@ import { createContext, useContext } from '@wordpress/element';
 /**
  * Context consumed by inner blocks.
  */
-export type CartBlockControlsContextProps = {
-	viewSwitcher: {
-		component: () => JSX.Element | null;
-		currentView: string;
-	};
+export type CartBlockContextProps = {
+	currentView: string;
 };
 
-export const CartBlockControlsContext = createContext<
-	CartBlockControlsContextProps
->( {
-	viewSwitcher: {
-		component: () => null,
-		currentView: 'filledCart',
-	},
+export const CartBlockContext = createContext< CartBlockContextProps >( {
+	currentView: '',
 } );
 
-export const useCartBlockControlsContext = (): CartBlockControlsContextProps => {
-	return useContext( CartBlockControlsContext );
+export const useCartBlockContext = (): CartBlockContextProps => {
+	return useContext( CartBlockContext );
 };

--- a/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
@@ -152,15 +152,15 @@ export const Edit = ( {
 		clientId,
 		[
 			{
-				view: 'emptyCart',
-				label: __( 'Empty Cart', 'woo-gutenberg-products-block' ),
-				icon: <Icon srcElement={ removeCart } />,
-			},
-			{
 				view: 'filledCart',
 				label: __( 'Filled Cart', 'woo-gutenberg-products-block' ),
 				icon: <Icon srcElement={ filledCart } />,
 				default: true,
+			},
+			{
+				view: 'emptyCart',
+				label: __( 'Empty Cart', 'woo-gutenberg-products-block' ),
+				icon: <Icon srcElement={ removeCart } />,
 			},
 		]
 	);

--- a/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
@@ -152,12 +152,12 @@ export const Edit = ( {
 		clientId,
 		[
 			{
-				view: 'filledCart',
+				view: 'woocommerce/filled-cart-block',
 				label: __( 'Filled Cart', 'woo-gutenberg-products-block' ),
 				icon: <Icon srcElement={ filledCart } />,
 			},
 			{
-				view: 'emptyCart',
+				view: 'woocommerce/empty-cart-block',
 				label: __( 'Empty Cart', 'woo-gutenberg-products-block' ),
 				icon: <Icon srcElement={ removeCart } />,
 			},

--- a/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
@@ -141,24 +141,29 @@ export const Edit = ( {
 	className,
 	attributes,
 	setAttributes,
+	clientId,
 }: {
 	className: string;
 	attributes: Attributes;
 	setAttributes: ( attributes: Record< string, unknown > ) => undefined;
+	clientId: string;
 } ): JSX.Element => {
-	const { currentView, component: ViewSwitcherComponent } = useViewSwitcher( [
-		{
-			view: 'emptyCart',
-			label: __( 'Empty Cart', 'woo-gutenberg-products-block' ),
-			icon: <Icon srcElement={ removeCart } />,
-		},
-		{
-			view: 'filledCart',
-			label: __( 'Filled Cart', 'woo-gutenberg-products-block' ),
-			icon: <Icon srcElement={ filledCart } />,
-			default: true,
-		},
-	] );
+	const { currentView, component: ViewSwitcherComponent } = useViewSwitcher(
+		clientId,
+		[
+			{
+				view: 'emptyCart',
+				label: __( 'Empty Cart', 'woo-gutenberg-products-block' ),
+				icon: <Icon srcElement={ removeCart } />,
+			},
+			{
+				view: 'filledCart',
+				label: __( 'Filled Cart', 'woo-gutenberg-products-block' ),
+				icon: <Icon srcElement={ filledCart } />,
+				default: true,
+			},
+		]
+	);
 	const cartClassName = classnames( {
 		'has-dark-controls': attributes.hasDarkControls,
 	} );

--- a/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
@@ -6,9 +6,10 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { CartCheckoutFeedbackPrompt } from '@woocommerce/editor-components/feedback-prompt';
 import {
-	InnerBlocks,
 	useBlockProps,
+	InnerBlocks,
 	InspectorControls,
+	BlockControls,
 } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl, Notice } from '@wordpress/components';
 import { CartCheckoutCompatibilityNotice } from '@woocommerce/editor-components/compatibility-notices';
@@ -31,7 +32,7 @@ import './editor.scss';
 import { addClassToBody, useBlockPropsWithLocking } from './hacks';
 import { useViewSwitcher } from './use-view-switcher';
 import type { Attributes } from './types';
-import { CartBlockControlsContext } from './context';
+import { CartBlockContext } from './context';
 
 // This is adds a class to body to signal if the selected block is locked
 addClassToBody();
@@ -212,13 +213,12 @@ export const Edit = ( {
 						attributes={ attributes }
 						setAttributes={ setAttributes }
 					/>
-					<ViewSwitcherComponent />
-					<CartBlockControlsContext.Provider
+					<BlockControls __experimentalShareWithChildBlocks>
+						<ViewSwitcherComponent />
+					</BlockControls>
+					<CartBlockContext.Provider
 						value={ {
-							viewSwitcher: {
-								component: ViewSwitcherComponent,
-								currentView,
-							},
+							currentView,
 						} }
 					>
 						<CartProvider>
@@ -230,7 +230,7 @@ export const Edit = ( {
 								/>
 							</div>
 						</CartProvider>
-					</CartBlockControlsContext.Provider>
+					</CartBlockContext.Provider>
 				</EditorProvider>
 			</BlockErrorBoundary>
 			<CartCheckoutCompatibilityNotice blockName="cart" />

--- a/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
@@ -155,7 +155,6 @@ export const Edit = ( {
 				view: 'filledCart',
 				label: __( 'Filled Cart', 'woo-gutenberg-products-block' ),
 				icon: <Icon srcElement={ filledCart } />,
-				default: true,
 			},
 			{
 				view: 'emptyCart',

--- a/assets/js/blocks/cart-checkout/cart-i2/index.js
+++ b/assets/js/blocks/cart-checkout/cart-i2/index.js
@@ -29,6 +29,7 @@ const settings = {
 		align: false,
 		html: false,
 		multiple: false,
+		__experimentalExposeControlsToChildren: true,
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
@@ -22,7 +22,10 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	} );
 
 	return (
-		<div { ...blockProps } hidden={ currentView !== 'emptyCart' }>
+		<div
+			{ ...blockProps }
+			hidden={ currentView !== 'woocommerce/empty-cart-block' }
+		>
 			This is the empty cart block.
 			<InnerBlocks
 				allowedBlocks={ allowedBlocks }

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
@@ -9,20 +9,17 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
  */
 import { useForcedLayout } from '../../use-forced-layout';
 import { getAllowedBlocks } from '../../editor-utils';
-import { useCartBlockControlsContext } from '../../context';
+import { useCartBlockContext } from '../../context';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
+	const { currentView } = useCartBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.EMPTY_CART );
 
 	useForcedLayout( {
 		clientId,
 		template: allowedBlocks,
 	} );
-
-	const {
-		viewSwitcher: { currentView, component: ViewSwitcherComponent },
-	} = useCartBlockControlsContext();
 
 	return (
 		<div { ...blockProps } hidden={ currentView !== 'emptyCart' }>
@@ -31,7 +28,6 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 				allowedBlocks={ allowedBlocks }
 				templateLock={ false }
 			/>
-			<ViewSwitcherComponent />
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
@@ -12,21 +12,17 @@ import { useForcedLayout } from '../../use-forced-layout';
 import { getAllowedBlocks } from '../../editor-utils';
 import { Columns } from './../../columns';
 import './editor.scss';
-import { useCartBlockControlsContext } from '../../context';
+import { useCartBlockContext } from '../../context';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
+	const { currentView } = useCartBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.FILLED_CART );
 
 	useForcedLayout( {
 		clientId,
 		template: allowedBlocks,
 	} );
-
-	const {
-		viewSwitcher: { currentView, component: ViewSwitcherComponent },
-	} = useCartBlockControlsContext();
-
 	return (
 		<div { ...blockProps } hidden={ currentView !== 'filledCart' }>
 			<Columns>
@@ -37,7 +33,6 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 					/>
 				</SidebarLayout>
 			</Columns>
-			<ViewSwitcherComponent />
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
@@ -24,7 +24,10 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 		template: allowedBlocks,
 	} );
 	return (
-		<div { ...blockProps } hidden={ currentView !== 'filledCart' }>
+		<div
+			{ ...blockProps }
+			hidden={ currentView !== 'woocommerce/filled-cart-block' }
+		>
 			<Columns>
 				<SidebarLayout className={ 'wc-block-cart' }>
 					<InnerBlocks

--- a/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
 import { Toolbar, ToolbarDropdownMenu } from '@wordpress/components';
 import { Icon, eye } from '@woocommerce/icons';
 
@@ -14,6 +15,7 @@ interface View {
 }
 
 export const useViewSwitcher = (
+	clientId: string,
 	views: View[]
 ): {
 	currentView: string;
@@ -22,6 +24,7 @@ export const useViewSwitcher = (
 	const initialView =
 		views?.find( ( view ) => view.default === true ) || views[ 0 ];
 	const [ currentView, setCurrentView ] = useState( initialView );
+	const { selectBlock } = useDispatch( 'core/block-editor' );
 
 	const ViewSwitcherComponent = () => (
 		<Toolbar>
@@ -34,7 +37,10 @@ export const useViewSwitcher = (
 				controls={ views.map( ( view ) => ( {
 					...view,
 					title: view.label,
-					onClick: () => setCurrentView( view ),
+					onClick: () => {
+						setCurrentView( view );
+						selectBlock( clientId );
+					},
 				} ) ) }
 			/>
 		</Toolbar>

--- a/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
@@ -4,7 +4,6 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { Toolbar, ToolbarDropdownMenu } from '@wordpress/components';
-import { BlockControls } from '@wordpress/block-editor';
 import { Icon, eye } from '@woocommerce/icons';
 
 interface View {
@@ -25,28 +24,20 @@ export const useViewSwitcher = (
 	const [ currentView, setCurrentView ] = useState( initialView );
 
 	const ViewSwitcherComponent = () => (
-		<BlockControls>
-			<Toolbar>
-				<ToolbarDropdownMenu
-					label={ __(
-						'Switch view',
-						'woo-gutenberg-products-block'
-					) }
-					text={ currentView.label }
-					icon={
-						<Icon
-							srcElement={ eye }
-							style={ { marginRight: '8px' } }
-						/>
-					}
-					controls={ views.map( ( view ) => ( {
-						...view,
-						title: view.label,
-						onClick: () => setCurrentView( view ),
-					} ) ) }
-				/>
-			</Toolbar>
-		</BlockControls>
+		<Toolbar>
+			<ToolbarDropdownMenu
+				label={ __( 'Switch view', 'woo-gutenberg-products-block' ) }
+				text={ currentView.label }
+				icon={
+					<Icon srcElement={ eye } style={ { marginRight: '8px' } } />
+				}
+				controls={ views.map( ( view ) => ( {
+					...view,
+					title: view.label,
+					onClick: () => setCurrentView( view ),
+				} ) ) }
+			/>
+		</Toolbar>
 	);
 
 	return {

--- a/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
@@ -11,7 +11,6 @@ interface View {
 	view: string;
 	label: string;
 	icon: string | JSX.Element;
-	default?: boolean;
 }
 
 export const useViewSwitcher = (
@@ -21,8 +20,7 @@ export const useViewSwitcher = (
 	currentView: string;
 	component: () => JSX.Element;
 } => {
-	const initialView =
-		views?.find( ( view ) => view.default === true ) || views[ 0 ];
+	const initialView = views[ 0 ];
 	const [ currentView, setCurrentView ] = useState( initialView );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 

--- a/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/use-view-switcher.tsx
@@ -3,9 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, select } from '@wordpress/data';
 import { Toolbar, ToolbarDropdownMenu } from '@wordpress/components';
 import { Icon, eye } from '@woocommerce/icons';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 interface View {
 	view: string;
@@ -23,6 +24,7 @@ export const useViewSwitcher = (
 	const initialView = views[ 0 ];
 	const [ currentView, setCurrentView ] = useState( initialView );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { getBlock } = select( blockEditorStore );
 
 	const ViewSwitcherComponent = () => (
 		<Toolbar>
@@ -37,7 +39,12 @@ export const useViewSwitcher = (
 					title: view.label,
 					onClick: () => {
 						setCurrentView( view );
-						selectBlock( clientId );
+						selectBlock(
+							getBlock( clientId ).innerBlocks.find(
+								( block: { name: string } ) =>
+									block.name === view.view
+							)?.clientId || clientId
+						);
 					},
 				} ) ) }
 			/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -446,8 +446,7 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
-			"dev": true
+			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
 		},
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.14.5",
@@ -1109,7 +1108,6 @@
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
 			"integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.14.5"
 			}
@@ -2057,6 +2055,54 @@
 				"minimist": "^1.2.0"
 			}
 		},
+		"@emotion/babel-plugin": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.3.0.tgz",
+			"integrity": "sha512-UZKwBV2rADuhRp+ZOGgNWg2eYgbzKzQXfQPtJbu/PLy8onurxlNCLvxMQEvlr1/GudguPI5IU9qIY1+2z1M5bA==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/plugin-syntax-jsx": "^7.12.13",
+				"@babel/runtime": "^7.13.10",
+				"@emotion/hash": "^0.8.0",
+				"@emotion/memoize": "^0.7.5",
+				"@emotion/serialize": "^1.0.2",
+				"babel-plugin-macros": "^2.6.1",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "^4.0.3"
+			},
+			"dependencies": {
+				"@emotion/memoize": {
+					"version": "0.7.5",
+					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+					"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+				}
+			}
+		},
 		"@emotion/cache": {
 			"version": "10.0.29",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -2123,6 +2169,56 @@
 			"integrity": "sha512-fRBEDNPSFFOrBJ0OcheuElayrNTNdLF9DzMxtL0sFgsCFvvadlzwJHhJMSwEJuxwARm9GhVLr1p8G8JGkK98lQ==",
 			"requires": {
 				"css-to-react-native": "^2.2.1"
+			}
+		},
+		"@emotion/react": {
+			"version": "11.4.1",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.1.tgz",
+			"integrity": "sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@emotion/cache": "^11.4.0",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/sheet": "^1.0.2",
+				"@emotion/utils": "^1.0.0",
+				"@emotion/weak-memoize": "^0.2.5",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"dependencies": {
+				"@emotion/cache": {
+					"version": "11.4.0",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
+					"integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.0.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "^4.0.3"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.2.tgz",
+					"integrity": "sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				}
 			}
 		},
 		"@emotion/serialize": {
@@ -5857,8 +5953,7 @@
 		"@types/lodash": {
 			"version": "4.14.173",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
-			"integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg==",
-			"dev": true
+			"integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg=="
 		},
 		"@types/markdown-to-jsx": {
 			"version": "6.11.3",
@@ -5898,6 +5993,11 @@
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
 			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
 			"dev": true
+		},
+		"@types/mousetrap": {
+			"version": "1.6.8",
+			"resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.8.tgz",
+			"integrity": "sha512-zTqjvgCUT5EoXqbqmd8iJMb4NJqyV/V7pK7AIKq7qcaAsJIpGlTVJS1HQM6YkdHCdnkNSbhcQI7MXYxFfE3iCA=="
 		},
 		"@types/node": {
 			"version": "16.3.1",
@@ -9175,7 +9275,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.1.tgz",
 			"integrity": "sha512-DHuIQ7MMyAcmkMM/VY8RibIcLiIcstk6Og09f4EWQegOgage6yMgnG7eI0nf2LBe65mttnda1EL51slc7XjaXg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.13.10"
 			}
@@ -9282,7 +9381,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.2.0.tgz",
 			"integrity": "sha512-9Oy7f3HFLMNfry4LLwYmfx4tROmusPAOfanv9F/MgzSBfMH7eyxU2JZd4KrP7IbPb59UfoUa8GhaLsnqKm66og==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.13.10"
 			}
@@ -9309,6 +9407,183 @@
 				"enzyme": "^3.11.0",
 				"enzyme-adapter-react-16": "^1.15.2",
 				"enzyme-to-json": "^3.4.4"
+			}
+		},
+		"@wordpress/keyboard-shortcuts": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-3.0.2.tgz",
+			"integrity": "sha512-G+Cw8nagEos8Tm11jXC1YMtK6yt2yVT/J+lx6tgiHJ6d/S3CH9E7vFUNucOIIO/6f/4iSgPPXW5XoJVZveyNyA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/compose": "^5.0.2",
+				"@wordpress/data": "^6.1.0",
+				"@wordpress/element": "^4.0.1",
+				"@wordpress/keycodes": "^3.2.2",
+				"lodash": "^4.17.21",
+				"rememo": "^3.0.0"
+			},
+			"dependencies": {
+				"@wordpress/compose": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.2.tgz",
+					"integrity": "sha512-NI7jbcAOTqCaTnrSVo7tZ/Zm59mg/Bo4ZjofYP5y+dUXC0ntoHcWuZJYttfXFrA/npeRxCGKHKxe10FRz6h4ow==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/lodash": "^4.14.172",
+						"@types/mousetrap": "^1.6.8",
+						"@wordpress/deprecated": "^3.2.1",
+						"@wordpress/dom": "^3.2.3",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/keycodes": "^3.2.2",
+						"@wordpress/priority-queue": "^2.2.1",
+						"clipboard": "^2.0.8",
+						"lodash": "^4.17.21",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.1.0",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.1.0.tgz",
+					"integrity": "sha512-eQR5afybHXMfy1Ol2oWy7BlTAUZJrw0ATZZuUZ4OWUsSuugKGHdX4cBuYqx6r2vCj59MSN670xfzfmTMwCcKdQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/compose": "^5.0.2",
+						"@wordpress/deprecated": "^3.2.1",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/priority-queue": "^2.2.1",
+						"@wordpress/redux-routine": "^4.2.1",
+						"equivalent-key-map": "^0.2.2",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"turbo-combine-reducers": "^1.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.2.1.tgz",
+					"integrity": "sha512-+mSpxeu0za9cNw30x9n0kZY/IUhmd9vhEzjZzLfT92lY3dDPXCEaE4IOSdPevcLpWTcKd7RhRMj2zXmaU5MA2g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^3.2.0"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.3.tgz",
+					"integrity": "sha512-0n1zGTKYt8lCxS5Q3fsFBUzDx+VjysrPX0Q/trE5b68NxJk4tIrQ9BeFa2wSZAmd1GPer0l/ZTbIGppgdtNUIg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.21"
+					}
+				},
+				"@wordpress/element": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.1.tgz",
+					"integrity": "sha512-Woi8Vh6anJgCt0AHvhUexiL+3TrhUk1EiLCN9vRahd9k5gvNQ6FzrQr60TagONmQXbe0CHACmWksZaVvQmsA/g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.1",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.2.1.tgz",
+					"integrity": "sha512-+5hMa+1BLYgHdOxPK7TF+hfAaKJY1UE6osZL8s4boYeaq/O23PFv4aCPQF+z9/4cIKyvOJPGk26Z1Op6DwJLGA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.0.tgz",
+					"integrity": "sha512-nVR6V9kPxl8+aYQzQJdoDt+aKBKHHD0zplcYZbu2MHxjmHMvppAeL9mjzVhQZj/3n10NR2Ftk94mHQzHWfhCCg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.2.tgz",
+					"integrity": "sha512-6PrfTDpeW5dfWyuqUx4Z5ApKFbh45CAbCs/G3PuZLlKJlXs/8p2Oq6Zxs0gLZk1QfHkw0t5qMx61lDlxWQhuPw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^3.2.0",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.2.2.tgz",
+					"integrity": "sha512-z4B4vby+iGciJ9gvUBIozsseDkdQXDNuWm5szMnG5g1Nn7UGDWmfCNc9IHNs3alXySmAFev6d0T/o/zgm9BBvQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^4.2.2",
+						"lodash": "^4.17.21"
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.2.1.tgz",
+					"integrity": "sha512-ou3dbfnWvIsTH6fZJhveobOxO0VH09XpIoKalDPVB9TD65LP5Zuy5KTn0ASV5V/+5KEdMNRxQ1U/9uPJc6wIXw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/redux-routine": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.2.1.tgz",
+					"integrity": "sha512-u//4vdeKzYvu4YBRmSUsIbnUazai+PybEnquLPqxQdaF4JqVN1D5OPWHSeFtmaXR1c78I+lUf40Q7dnmA2waXw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.21",
+						"redux": "^4.1.0",
+						"rungen": "^0.3.2"
+					}
+				},
+				"react": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+					"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"react-dom": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+					"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"scheduler": "^0.20.2"
+					}
+				},
+				"scheduler": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+					"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				}
 			}
 		},
 		"@wordpress/keycodes": {
@@ -10409,6 +10684,15 @@
 				"stylelint-scss": "^3.17.2"
 			}
 		},
+		"@wordpress/token-list": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.2.0.tgz",
+			"integrity": "sha512-0z6MhRv/pqxQcvTSeMAL69vcaxJ2J8U1Q5VeavHWnhtZ+nRglYNoE0yMLrEaeutoHeXOfWpY6baC91AgLDKE8A==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"lodash": "^4.17.21"
+			}
+		},
 		"@wordpress/url": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.1.1.tgz",
@@ -11271,8 +11555,7 @@
 		"autosize": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.4.tgz",
-			"integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ==",
-			"dev": true
+			"integrity": "sha512-5yxLQ22O0fCRGoxGfeLSNt3J8LB1v+umtpMnPW6XjkTWXKoN0AmXAIhelJcDtFT/Y/wYWmfE+oqU10Q0b8FhaQ=="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -11995,6 +12278,16 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true,
 			"optional": true
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
 		},
 		"bl": {
 			"version": "4.1.0",
@@ -13719,8 +14012,7 @@
 		"computed-style": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/computed-style/-/computed-style-0.1.4.tgz",
-			"integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ=",
-			"dev": true
+			"integrity": "sha1-fzRP2FhLLkJb7cpKGvwOMAuwXXQ="
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -14499,6 +14791,11 @@
 					}
 				}
 			}
+		},
+		"css-mediaquery": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+			"integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
 		},
 		"css-select": {
 			"version": "4.1.3",
@@ -15379,6 +15676,11 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
 			"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
 			"dev": true
+		},
+		"diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
 		},
 		"diff-sequences": {
 			"version": "26.6.2",
@@ -17735,6 +18037,13 @@
 				}
 			}
 		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
+		},
 		"filelist": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.2.tgz",
@@ -19266,14 +19575,12 @@
 		"hey-listen": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-			"integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-			"dev": true
+			"integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
 		},
 		"highlight-words-core": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.2.tgz",
-			"integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==",
-			"dev": true
+			"integrity": "sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg=="
 		},
 		"highlight.js": {
 			"version": "10.7.3",
@@ -22546,7 +22853,6 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/line-height/-/line-height-0.3.1.tgz",
 			"integrity": "sha1-SxIF7d4YKHKl76PI9iCzGHqcVMk=",
-			"dev": true,
 			"requires": {
 				"computed-style": "~0.1.3"
 			}
@@ -24651,6 +24957,13 @@
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
 			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
 			"dev": true
+		},
+		"nan": {
+			"version": "2.15.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+			"integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+			"dev": true,
+			"optional": true
 		},
 		"nanoid": {
 			"version": "3.1.23",
@@ -29305,11 +29618,20 @@
 				"object-assign": "^4.1.0"
 			}
 		},
+		"react-autosize-textarea": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
+			"integrity": "sha512-BHpjCDkuOlllZn3nLazY2F8oYO1tS2jHnWhcjTWQdcKiiMU6gHLNt/fzmqMSyerR0eTdKtfSIqtSeTtghNwS+g==",
+			"requires": {
+				"autosize": "^4.0.2",
+				"line-height": "^0.3.1",
+				"prop-types": "^15.5.6"
+			}
+		},
 		"react-colorful": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.4.0.tgz",
-			"integrity": "sha512-k7QJXuQGWevr/V8hoMJ1wBW9i2CVhBdDXpBf3jy/AAtzVyYtsFqEAT+y+NOGiSG1cmnGTreqm5EFLXlVaKbPLQ==",
-			"dev": true
+			"integrity": "sha512-k7QJXuQGWevr/V8hoMJ1wBW9i2CVhBdDXpBf3jy/AAtzVyYtsFqEAT+y+NOGiSG1cmnGTreqm5EFLXlVaKbPLQ=="
 		},
 		"react-dates": {
 			"version": "17.2.0",
@@ -30139,6 +30461,11 @@
 			"requires": {
 				"@babel/runtime": "^7.9.2"
 			}
+		},
+		"redux-multi": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/redux-multi/-/redux-multi-0.1.12.tgz",
+			"integrity": "sha1-KOH+XklnLLxb2KB/Cyrq8O+DVcI="
 		},
 		"reflect.ownkeys": {
 			"version": "0.2.0",
@@ -32930,6 +33257,11 @@
 				}
 			}
 		},
+		"stylis": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
+			"integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
+		},
 		"sugarss": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
@@ -33728,6 +34060,11 @@
 			"requires": {
 				"punycode": "^2.1.1"
 			}
+		},
+		"traverse": {
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
 		"tree-kill": {
 			"version": "1.2.2",
@@ -34644,7 +34981,11 @@
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 					"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1"
+					}
 				},
 				"glob-parent": {
 					"version": "3.1.0",
@@ -35533,6 +35874,573 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
+		},
+		"wordpress-block-editor": {
+			"version": "npm:@wordpress/block-editor@7.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-7.0.2.tgz",
+			"integrity": "sha512-BqUO7s/nrqK4E5BlMJTzqzOY8p8p7rfLciyRJx5ZHA7ravV+6QlgWUzWIJk5rFp4vzyo7efawJJFVPboNyTyeA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@wordpress/a11y": "^3.2.2",
+				"@wordpress/blob": "^3.2.1",
+				"@wordpress/block-serialization-default-parser": "^4.2.1",
+				"@wordpress/blocks": "^11.1.0",
+				"@wordpress/components": "^17.0.0",
+				"@wordpress/compose": "^5.0.2",
+				"@wordpress/data": "^6.1.0",
+				"@wordpress/data-controls": "^2.2.3",
+				"@wordpress/deprecated": "^3.2.1",
+				"@wordpress/dom": "^3.2.3",
+				"@wordpress/element": "^4.0.1",
+				"@wordpress/hooks": "^3.2.0",
+				"@wordpress/html-entities": "^3.2.1",
+				"@wordpress/i18n": "^4.2.2",
+				"@wordpress/icons": "^5.0.2",
+				"@wordpress/is-shallow-equal": "^4.2.0",
+				"@wordpress/keyboard-shortcuts": "^3.0.2",
+				"@wordpress/keycodes": "^3.2.2",
+				"@wordpress/notices": "^3.2.3",
+				"@wordpress/rich-text": "^5.0.2",
+				"@wordpress/shortcode": "^3.2.1",
+				"@wordpress/token-list": "^2.2.0",
+				"@wordpress/url": "^3.2.2",
+				"@wordpress/warning": "^2.2.1",
+				"@wordpress/wordcount": "^3.2.1",
+				"classnames": "^2.3.1",
+				"css-mediaquery": "^0.1.2",
+				"diff": "^4.0.2",
+				"dom-scroll-into-view": "^1.2.1",
+				"inherits": "^2.0.3",
+				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
+				"react-autosize-textarea": "^7.1.0",
+				"react-spring": "^8.0.19",
+				"redux-multi": "^0.1.12",
+				"rememo": "^3.0.0",
+				"tinycolor2": "^1.4.2",
+				"traverse": "^0.6.6"
+			},
+			"dependencies": {
+				"@emotion/cache": {
+					"version": "11.4.0",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.4.0.tgz",
+					"integrity": "sha512-Zx70bjE7LErRO9OaZrhf22Qye1y4F7iDl+ITjet0J+i+B88PrAOBkKvaAWhxsZf72tDLajwCgfCjJ2dvH77C3g==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.0.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "^4.0.3"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.1.3",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.1.3.tgz",
+					"integrity": "sha512-RSQP59qtCNTf5NWD6xM08xsQdCZmVYnX/panPYvB6LQAPKQB6GL49Njf0EMbS3CyDtrlWsBcmqBtysFvfWT3rA==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.0.0",
+						"@emotion/cache": "^11.1.3",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.0",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/is-prop-valid": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.0.tgz",
+					"integrity": "sha512-9RkilvXAufQHsSsjQ3PIzSns+pxuX4EW8EbGeSPjZMHuMx6z/MOzb9LpqNieQX4F3mre3NWS2+X3JNRHTQztUQ==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.2.tgz",
+					"integrity": "sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw=="
+				},
+				"@emotion/styled": {
+					"version": "11.3.0",
+					"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.3.0.tgz",
+					"integrity": "sha512-fUoLcN3BfMiLlRhJ8CuPUMEyKkLEoM+n+UyAbnqGEsCd5IzKQ7VQFLtzpJOaCD2/VR2+1hXQTnSZXVJeiTNltA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@emotion/babel-plugin": "^11.3.0",
+						"@emotion/is-prop-valid": "^1.1.0",
+						"@emotion/serialize": "^1.0.2",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@wordpress/a11y": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.2.2.tgz",
+					"integrity": "sha512-7NVoisqRW0hb+lg3Dwv0SL5uDBLMwep8wXiJPrWPBFcZmOYaaDvF+4edkCRl/Qr+/dRx0IfjS7kWZ3oyxl3rew==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/dom-ready": "^3.2.1",
+						"@wordpress/i18n": "^4.2.2"
+					}
+				},
+				"@wordpress/api-fetch": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.2.tgz",
+					"integrity": "sha512-WwJHOe6qiI4Oa1BSSo+Fpietdtm/0UgaN5A9k/TlEkARqIE+Fh56sfbC3JbjJDfQxz9TsAxMm+WWO5aNapantQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^4.2.2",
+						"@wordpress/url": "^3.2.2"
+					}
+				},
+				"@wordpress/autop": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.2.1.tgz",
+					"integrity": "sha512-dp5jm72v53ygEHiPp6CTyE8AzLEZ/YpW7kRKJGQwYz4U7wwkkfpsoattc/9uaQsv06AP6rEzT/ioGFOVZRuv9g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/blob": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.2.1.tgz",
+					"integrity": "sha512-qD8wZ6n+hjoshV2dp9eGH3VismOM0kvrJn5cSe4PaoYDREqUhioJIDXktZxaohnvgWOq6xfJH6rS4Or8W0r9ew==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/block-serialization-default-parser": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.2.1.tgz",
+					"integrity": "sha512-TKLGqFiysDKtLnc0pjPD1AOU5fg0LX12XfrK9Ke6QmCP2q7e57+9ZM9SRzXQ2U8GRgsIiwhjzi31R2HQGXqYng==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/blocks": {
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-11.1.0.tgz",
+					"integrity": "sha512-6Nl1/9g4rMiI/yPNJVXxp2ZmrZ31faikeuQAv/keMBHpi48IizdCrWWmQdRlF1wxXERWrjrRnu/kPIxJaMFKjA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/autop": "^3.2.1",
+						"@wordpress/blob": "^3.2.1",
+						"@wordpress/block-serialization-default-parser": "^4.2.1",
+						"@wordpress/compose": "^5.0.2",
+						"@wordpress/data": "^6.1.0",
+						"@wordpress/deprecated": "^3.2.1",
+						"@wordpress/dom": "^3.2.3",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/hooks": "^3.2.0",
+						"@wordpress/html-entities": "^3.2.1",
+						"@wordpress/i18n": "^4.2.2",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/shortcode": "^3.2.1",
+						"hpq": "^1.3.0",
+						"lodash": "^4.17.21",
+						"rememo": "^3.0.0",
+						"showdown": "^1.9.1",
+						"simple-html-tokenizer": "^0.5.7",
+						"tinycolor2": "^1.4.2",
+						"uuid": "^8.3.0"
+					}
+				},
+				"@wordpress/components": {
+					"version": "17.0.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-17.0.0.tgz",
+					"integrity": "sha512-NW1K+n68SwN7UGvu9+AaLprD+P0K5QudHL/snjYXuJRAL+0OXh+BaOqNc+v+f4dLAIaSxUzbAJArF3CMtOvZlg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@emotion/cache": "^11.4.0",
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.1",
+						"@emotion/styled": "^11.3.0",
+						"@emotion/utils": "1.0.0",
+						"@wordpress/a11y": "^3.2.2",
+						"@wordpress/compose": "^5.0.2",
+						"@wordpress/date": "^4.2.1",
+						"@wordpress/deprecated": "^3.2.1",
+						"@wordpress/dom": "^3.2.3",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/hooks": "^3.2.0",
+						"@wordpress/i18n": "^4.2.2",
+						"@wordpress/icons": "^5.0.2",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/keycodes": "^3.2.2",
+						"@wordpress/primitives": "^3.0.1",
+						"@wordpress/rich-text": "^5.0.2",
+						"@wordpress/warning": "^2.2.1",
+						"classnames": "^2.3.1",
+						"dom-scroll-into-view": "^1.2.1",
+						"downshift": "^6.0.15",
+						"framer-motion": "^4.1.17",
+						"gradient-parser": "^0.1.5",
+						"highlight-words-core": "^1.2.2",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"moment": "^2.22.1",
+						"re-resizable": "^6.4.0",
+						"react-colorful": "^5.3.0",
+						"react-dates": "^17.1.1",
+						"react-resize-aware": "^3.1.0",
+						"react-use-gesture": "^9.0.0",
+						"reakit": "^1.3.8",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.2",
+						"uuid": "^8.3.0"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.2.tgz",
+					"integrity": "sha512-NI7jbcAOTqCaTnrSVo7tZ/Zm59mg/Bo4ZjofYP5y+dUXC0ntoHcWuZJYttfXFrA/npeRxCGKHKxe10FRz6h4ow==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/lodash": "^4.14.172",
+						"@types/mousetrap": "^1.6.8",
+						"@wordpress/deprecated": "^3.2.1",
+						"@wordpress/dom": "^3.2.3",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/keycodes": "^3.2.2",
+						"@wordpress/priority-queue": "^2.2.1",
+						"clipboard": "^2.0.8",
+						"lodash": "^4.17.21",
+						"mousetrap": "^1.6.5",
+						"react-resize-aware": "^3.1.0",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/data": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.1.0.tgz",
+					"integrity": "sha512-eQR5afybHXMfy1Ol2oWy7BlTAUZJrw0ATZZuUZ4OWUsSuugKGHdX4cBuYqx6r2vCj59MSN670xfzfmTMwCcKdQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/compose": "^5.0.2",
+						"@wordpress/deprecated": "^3.2.1",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/priority-queue": "^2.2.1",
+						"@wordpress/redux-routine": "^4.2.1",
+						"equivalent-key-map": "^0.2.2",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"turbo-combine-reducers": "^1.0.2",
+						"use-memo-one": "^1.1.1"
+					}
+				},
+				"@wordpress/data-controls": {
+					"version": "2.2.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-2.2.3.tgz",
+					"integrity": "sha512-FluBCdaGaWAHcMUvBbQ8a6/9bvYcFmaT1zUl80OKNIFi1RD1KQnUWK2Jsle7WEkzyNC0UmpvUfdZ+lVean2TIQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/api-fetch": "^5.2.2",
+						"@wordpress/data": "^6.1.0",
+						"@wordpress/deprecated": "^3.2.1"
+					}
+				},
+				"@wordpress/date": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.2.1.tgz",
+					"integrity": "sha512-1I9B+PvtdJAt5R5ON6fq3ux76GUltk/V5dYjhsN8CYzmuSNpIY7hNFbbr9LgRswSdPH1zhR+a/mqhzdDU99PRA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"moment": "^2.22.1",
+						"moment-timezone": "^0.5.31"
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.2.1.tgz",
+					"integrity": "sha512-+mSpxeu0za9cNw30x9n0kZY/IUhmd9vhEzjZzLfT92lY3dDPXCEaE4IOSdPevcLpWTcKd7RhRMj2zXmaU5MA2g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^3.2.0"
+					}
+				},
+				"@wordpress/dom": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.3.tgz",
+					"integrity": "sha512-0n1zGTKYt8lCxS5Q3fsFBUzDx+VjysrPX0Q/trE5b68NxJk4tIrQ9BeFa2wSZAmd1GPer0l/ZTbIGppgdtNUIg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.21"
+					}
+				},
+				"@wordpress/dom-ready": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.2.1.tgz",
+					"integrity": "sha512-2Tsc/SyqZMzLhJffkmgz0j9ziJKFkCpMELba9PPp8HaYYWWY67G9XxKarRbS6TSrpwpa4YI+KLc/LStDP0wpMQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/element": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-4.0.1.tgz",
+					"integrity": "sha512-Woi8Vh6anJgCt0AHvhUexiL+3TrhUk1EiLCN9vRahd9k5gvNQ6FzrQr60TagONmQXbe0CHACmWksZaVvQmsA/g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@types/react": "^16.9.0",
+						"@types/react-dom": "^16.9.0",
+						"@wordpress/escape-html": "^2.2.1",
+						"lodash": "^4.17.21",
+						"react": "^17.0.1",
+						"react-dom": "^17.0.1"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.2.1.tgz",
+					"integrity": "sha512-+5hMa+1BLYgHdOxPK7TF+hfAaKJY1UE6osZL8s4boYeaq/O23PFv4aCPQF+z9/4cIKyvOJPGk26Z1Op6DwJLGA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.0.tgz",
+					"integrity": "sha512-nVR6V9kPxl8+aYQzQJdoDt+aKBKHHD0zplcYZbu2MHxjmHMvppAeL9mjzVhQZj/3n10NR2Ftk94mHQzHWfhCCg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.2.tgz",
+					"integrity": "sha512-6PrfTDpeW5dfWyuqUx4Z5ApKFbh45CAbCs/G3PuZLlKJlXs/8p2Oq6Zxs0gLZk1QfHkw0t5qMx61lDlxWQhuPw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/hooks": "^3.2.0",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
+				"@wordpress/icons": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-5.0.2.tgz",
+					"integrity": "sha512-ckogzI/j9c+gqTA9T2zCtUiA7gjZHVWvC6USMCBHzPIVK7njQ9MD5R55vSEueA/qjhhcbcTZgz0yWrXnuE9PZw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/primitives": "^3.0.1"
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.2.2.tgz",
+					"integrity": "sha512-z4B4vby+iGciJ9gvUBIozsseDkdQXDNuWm5szMnG5g1Nn7UGDWmfCNc9IHNs3alXySmAFev6d0T/o/zgm9BBvQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/i18n": "^4.2.2",
+						"lodash": "^4.17.21"
+					}
+				},
+				"@wordpress/notices": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-3.2.3.tgz",
+					"integrity": "sha512-w6KslLN4txDHElEnMhacftBS8Cnhzmaiz+GkQaZRJbJEvyvd4GKCE5syjqeM5GRWGMcz+XeJMcptmzapoDCXgA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/a11y": "^3.2.2",
+						"@wordpress/data": "^6.1.0",
+						"lodash": "^4.17.21"
+					}
+				},
+				"@wordpress/primitives": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-3.0.1.tgz",
+					"integrity": "sha512-VgvtpFr2LA70B9yKJAA+qbMGhckADXU0klBctA9hvOGhsBMaytIpJ6sSBotIEc918Fawq0He1AsLJXJJgMBPCQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/element": "^4.0.1",
+						"classnames": "^2.3.1"
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.2.1.tgz",
+					"integrity": "sha512-ou3dbfnWvIsTH6fZJhveobOxO0VH09XpIoKalDPVB9TD65LP5Zuy5KTn0ASV5V/+5KEdMNRxQ1U/9uPJc6wIXw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@wordpress/redux-routine": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-4.2.1.tgz",
+					"integrity": "sha512-u//4vdeKzYvu4YBRmSUsIbnUazai+PybEnquLPqxQdaF4JqVN1D5OPWHSeFtmaXR1c78I+lUf40Q7dnmA2waXw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"is-promise": "^4.0.0",
+						"lodash": "^4.17.21",
+						"redux": "^4.1.0",
+						"rungen": "^0.3.2"
+					}
+				},
+				"@wordpress/rich-text": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-5.0.2.tgz",
+					"integrity": "sha512-R54Cs+oX7QCj+iX46D5z54+p/24e4F4b0Y42lQLx+XaBGS4tTe0cTM1WhCWtYA8t1N5sorTHdIMbToWAAv3k4g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@wordpress/compose": "^5.0.2",
+						"@wordpress/data": "^6.1.0",
+						"@wordpress/dom": "^3.2.3",
+						"@wordpress/element": "^4.0.1",
+						"@wordpress/escape-html": "^2.2.1",
+						"@wordpress/is-shallow-equal": "^4.2.0",
+						"@wordpress/keycodes": "^3.2.2",
+						"classnames": "^2.3.1",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0",
+						"rememo": "^3.0.0"
+					}
+				},
+				"@wordpress/shortcode": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.2.1.tgz",
+					"integrity": "sha512-nVELegRjoy/ShrKx2julCSCHiXlp8NTPfxYQCqNomUJzosdqVg7hj/LGt1STu7vZIqPayS8iVG3V7d0s2kGAkg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.21",
+						"memize": "^1.1.0"
+					}
+				},
+				"@wordpress/url": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.2.2.tgz",
+					"integrity": "sha512-TYWE7V9F8nj0ZkCJy1eFD0crdDTS7iB3cVNW2yIDOn1RTWJJtzINXQFMASokVsjuh+NetAIOu8ru2mIfoRMG8Q==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.21",
+						"react-native-url-polyfill": "^1.1.2"
+					}
+				},
+				"@wordpress/warning": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.2.1.tgz",
+					"integrity": "sha512-IlwDEcCYCMQjrHjVxPTjqx/y+aeyg0DYpNGArt30WFY/aVfZHNu25UASYjwngEahIAUfA7b3oTQbJv2o3IghGQ=="
+				},
+				"@wordpress/wordcount": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.2.1.tgz",
+					"integrity": "sha512-OBHR1QIuNC8RNrFJ1EnqWAJmaFCK71JDw8WvQWy2ZN7tAlzvKGofpmCWdOrP/JXGRhVpNzLGlyMoiGB0QmvYdw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"lodash": "^4.17.21"
+					}
+				},
+				"framer-motion": {
+					"version": "4.1.17",
+					"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
+					"integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
+					"requires": {
+						"@emotion/is-prop-valid": "^0.8.2",
+						"framesync": "5.3.0",
+						"hey-listen": "^1.0.8",
+						"popmotion": "9.3.6",
+						"style-value-types": "4.1.4",
+						"tslib": "^2.1.0"
+					},
+					"dependencies": {
+						"@emotion/is-prop-valid": {
+							"version": "0.8.8",
+							"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+							"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+							"optional": true,
+							"requires": {
+								"@emotion/memoize": "0.7.4"
+							}
+						}
+					}
+				},
+				"framesync": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
+					"integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"popmotion": {
+					"version": "9.3.6",
+					"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
+					"integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
+					"requires": {
+						"framesync": "5.3.0",
+						"hey-listen": "^1.0.8",
+						"style-value-types": "4.1.4",
+						"tslib": "^2.1.0"
+					}
+				},
+				"react": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+					"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"react-dom": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+					"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"scheduler": "^0.20.2"
+					}
+				},
+				"react-use-gesture": {
+					"version": "9.1.3",
+					"resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.1.3.tgz",
+					"integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg=="
+				},
+				"scheduler": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
+					"integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+					"requires": {
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1"
+					}
+				},
+				"style-value-types": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
+					"integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
+					"requires": {
+						"hey-listen": "^1.0.8",
+						"tslib": "^2.1.0"
+					}
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+				}
+			}
 		},
 		"wordpress-components": {
 			"version": "npm:@wordpress/components@11.1.5",


### PR DESCRIPTION
Implements `__experimentalExposeToChildren` so that the view switcher is passed down to all children toolbars. When switching, the view is changed and the parent is selected to avoid the selection of a non-visible block.

Fixes #4812

NOTE: Only the top 2 levels of inner blocks will show the toolbar item, unless you first implement https://github.com/WordPress/gutenberg/pull/35078 This makes it so all levels show the toolbar item.

### How to test the changes in this Pull Request:

1. Insert Cart i2 Block
2. Toggle between empty/full cart views
3. Select inner blocks. Confirm toolbar item is visible.
4. Toggle between empty/full cart views. Parent block should be selected after a switch.
