### PR TITLE
Checkout i2: Handle text nodes in inner block rendering

### DIFF
--- a/assets/js/atomic/utils/render-parent-block.tsx
+++ b/assets/js/atomic/utils/render-parent-block.tsx
@@ -140,28 +140,34 @@ const renderInnerBlocks = ( {
 			const parsedElement = parse(
 				element?.outerHTML || element?.textContent || ''
 			);
-			if ( isValidElement( parsedElement ) ) {
-				const elementChildren = renderInnerBlocks( {
-					block,
-					blockMap,
-					children: element.childNodes || [],
-					depth: depth + 1,
-					blockWrapper,
-				} );
-				return elementChildren
-					? cloneElement(
-							parsedElement,
-							componentProps,
-							elementChildren
-					  )
-					: cloneElement( parsedElement, componentProps );
-			}
 
-			if ( typeof parsedElement === 'string' ) {
+			// Returns text nodes without manipulation.
+			if ( typeof parsedElement === 'string' && !! parsedElement ) {
 				return parsedElement;
 			}
 
-			return null;
+			// Do not render invalid elements.
+			if ( ! isValidElement( parsedElement ) ) {
+				return null;
+			}
+
+			const renderedChildren = element.childNodes.length
+				? renderInnerBlocks( {
+						block,
+						blockMap,
+						children: element.childNodes,
+						depth: depth + 1,
+						blockWrapper,
+				  } )
+				: undefined;
+
+			return renderedChildren
+				? cloneElement(
+						parsedElement,
+						componentProps,
+						renderedChildren
+				  )
+				: cloneElement( parsedElement, componentProps );
 		}
 
 		// This will wrap inner blocks with the provided wrapper. If no wrapper is provided, we default to Fragment.

--- a/assets/js/atomic/utils/render-parent-block.tsx
+++ b/assets/js/atomic/utils/render-parent-block.tsx
@@ -108,7 +108,7 @@ const renderInnerBlocks = ( {
 	// Wrapper for inner components.
 	blockWrapper?: React.ElementType;
 	// Elements from the DOM being converted to components.
-	children: HTMLCollection;
+	children: HTMLCollection | NodeList;
 	// Depth within the DOM hierarchy.
 	depth?: number;
 } ): ( JSX.Element | null )[] | null => {
@@ -133,15 +133,18 @@ const renderInnerBlocks = ( {
 		/**
 		 * If the component cannot be found, or blockName is missing, return the original element. This also ensures
 		 * that children within the element are processed also, since it may be an element containing block markup.
+		 *
+		 * Note we use childNodes rather than children so that text nodes are also rendered.
 		 */
 		if ( ! InnerBlockComponent ) {
-			const parsedElement = parse( element.outerHTML );
-
+			const parsedElement = parse(
+				element?.outerHTML || element?.textContent || ''
+			);
 			if ( isValidElement( parsedElement ) ) {
 				const elementChildren = renderInnerBlocks( {
 					block,
 					blockMap,
-					children: element.children || [],
+					children: element.childNodes || [],
 					depth: depth + 1,
 					blockWrapper,
 				} );
@@ -153,6 +156,11 @@ const renderInnerBlocks = ( {
 					  )
 					: cloneElement( parsedElement, componentProps );
 			}
+
+			if ( typeof parsedElement === 'string' ) {
+				return parsedElement;
+			}
+
 			return null;
 		}
 


### PR DESCRIPTION
`renderInnerBlocks` iterates over Block markup and converts Blocks into Components. If it comes across some HTML that is not recognised as a block, it's just returned. This however is broken for text nodes, because text nodes are not returned by `element.children`,

This PR switches to `element.childNodes` which returns text nodes too. For those we just render them as-is.

Fixes #4830

## Testing:

1. Create a paragraph block within the content of the Checkout Block. Add some text, as well as some bold text inside.
2. Check that the full paragraph is rendered on the frontend.

![Screenshot 2021-09-24 at 14 03 09](https://user-images.githubusercontent.com/90977/134678687-7a5eb25f-a8f3-4a46-91fe-a2d7f75e3d6f.png)
 