### PR TITLE
Improve mocking of useStoreCart

### DIFF
--- a/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
@@ -2,9 +2,6 @@
  * External dependencies
  */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { previewCart } from '@woocommerce/resource-previews';
-import { dispatch } from '@wordpress/data';
-import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
 import {
 	registerPaymentMethod,
 	__experimentalDeRegisterPaymentMethod,
@@ -17,8 +14,17 @@ import {
 /**
  * Internal dependencies
  */
+import * as useStoreCartHook from '../../../../base/context/hooks/cart/use-store-cart';
+
+// Somewhere in your test case or test suite
+useStoreCartHook.useStoreCart = jest
+	.fn()
+	.mockReturnValue( useStoreCartHook.defaultCartData );
+
+/**
+ * Internal dependencies
+ */
 import PaymentMethods from '../payment-methods';
-import { defaultCartState } from '../../../../data/default-states';
 
 jest.mock( '../saved-payment-method-options', () => ( { onChange } ) => {
 	return (
@@ -67,22 +73,6 @@ const resetMockPaymentMethods = () => {
 };
 
 describe( 'PaymentMethods', () => {
-	beforeEach( async () => {
-		fetchMock.mockResponse( ( req ) => {
-			if ( req.url.match( /wc\/store\/cart/ ) ) {
-				return Promise.resolve( JSON.stringify( previewCart ) );
-			}
-			return Promise.resolve( '' );
-		} );
-		// need to clear the store resolution state between tests.
-		await dispatch( storeKey ).invalidateResolutionForStore();
-		await dispatch( storeKey ).receiveCart( defaultCartState.cartData );
-	} );
-
-	afterEach( () => {
-		fetchMock.resetMocks();
-	} );
-
 	test( 'should show no payment methods component when there are no payment methods', async () => {
 		render(
 			<PaymentMethodDataProvider>
@@ -98,8 +88,6 @@ describe( 'PaymentMethods', () => {
 			// creates an extra `div` with the notice contents used for a11y.
 			expect( noPaymentMethods.length ).toBeGreaterThanOrEqual( 1 );
 		} );
-		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
-		expect( console ).toHaveWarned();
 	} );
 
 	test( 'selecting new payment method', async () => {


### PR DESCRIPTION
This is a missing commit mentioned in this comment https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4776#discussion_r714857353