### PR TITLE
Fix broken input styles in Cart shipping calculator

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -12,39 +12,42 @@
 .is-small,
 .is-medium,
 .is-large {
-	.wc-block-components-address-form {
-		margin-left: #{-$gap-small * 0.5};
-		margin-right: #{-$gap-small * 0.5};
+	.wc-block-checkout__shipping-fields,
+	.wc-block-checkout__billing-fields {
+		.wc-block-components-address-form {
+			margin-left: #{-$gap-small * 0.5};
+			margin-right: #{-$gap-small * 0.5};
 
-		&::after {
-			content: "";
-			clear: both;
-			display: block;
-		}
-
-		.wc-block-components-text-input,
-		.wc-block-components-country-input,
-		.wc-block-components-state-input {
-			float: left;
-			margin-left: #{$gap-small * 0.5};
-			margin-right: #{$gap-small * 0.5};
-			position: relative;
-			width: calc(50% - #{$gap-small});
-
-			&:nth-of-type(2),
-			&:first-of-type {
-				margin-top: 0;
+			&::after {
+				content: "";
+				clear: both;
+				display: block;
 			}
-		}
 
-		.wc-block-components-address-form__company,
-		.wc-block-components-address-form__address_1,
-		.wc-block-components-address-form__address_2 {
-			width: calc(100% - #{$gap-small});
-		}
+			.wc-block-components-text-input,
+			.wc-block-components-country-input,
+			.wc-block-components-state-input {
+				float: left;
+				margin-left: #{$gap-small * 0.5};
+				margin-right: #{$gap-small * 0.5};
+				position: relative;
+				width: calc(50% - #{$gap-small});
 
-		.wc-block-components-checkbox {
-			clear: both;
+				&:nth-of-type(2),
+				&:first-of-type {
+					margin-top: 0;
+				}
+			}
+
+			.wc-block-components-address-form__company,
+			.wc-block-components-address-form__address_1,
+			.wc-block-components-address-form__address_2 {
+				width: calc(100% - #{$gap-small});
+			}
+
+			.wc-block-components-checkbox {
+				clear: both;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This fixes an issue with Cart shipping calculator form. Styles previously only scoped to Checkout leaked out and got applied to Cart, this PR changes that back.
<!-- Reference any related issues or PRs here -->
Fixes #4824

### Testing
- Insert Cart and visit frontend.
- Open shipping calculator.
- Fields shoul take 100%

### Screenshots

| before      | after |
| ----------- | ----------- |
|  ![image](https://user-images.githubusercontent.com/6165348/134539307-76ca85c6-3f3c-4fdc-8055-8f9a2542f4fe.png)      | ![image](https://user-images.githubusercontent.com/6165348/134539348-f21fa508-6064-4509-90bb-a71e9c705e05.png)       |

