### PR TITLE
Cart i2: remove duplicate context on frontend

### DIFF
--- a/assets/js/blocks/cart-checkout/cart-i2/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart-i2/frontend.js
@@ -5,12 +5,6 @@ import {
 	withStoreCartApiHydration,
 	withRestApiHydration,
 } from '@woocommerce/block-hocs';
-import {
-	StoreNoticesProvider,
-	StoreSnackbarNoticesProvider,
-	CartProvider,
-} from '@woocommerce/base-context/providers';
-import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import { getValidBlockAttributes } from '@woocommerce/base-utils';
 import { Children, cloneElement, isValidElement } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context';
@@ -25,25 +19,6 @@ import { renderParentBlock } from '@woocommerce/atomic-utils';
 import './inner-blocks/register-components';
 import Block from './block';
 import { blockName, blockAttributes } from './attributes';
-
-/**
- * Wrapper component to supply API data and show empty cart view as needed.
- *
- * @param {*} props
- */
-const CartFrontend = ( props ) => {
-	return (
-		<StoreSnackbarNoticesProvider context="wc/cart">
-			<StoreNoticesProvider context="wc/cart">
-				<SlotFillProvider>
-					<CartProvider>
-						<Block { ...props } />
-					</CartProvider>
-				</SlotFillProvider>
-			</StoreNoticesProvider>
-		</StoreSnackbarNoticesProvider>
-	);
-};
 
 const getProps = ( el ) => {
 	return {
@@ -73,7 +48,7 @@ const Wrapper = ( { children } ) => {
 };
 
 renderParentBlock( {
-	Block: withStoreCartApiHydration( withRestApiHydration( CartFrontend ) ),
+	Block: withStoreCartApiHydration( withRestApiHydration( Block ) ),
 	blockName,
 	selector: '.wp-block-woocommerce-cart-i2',
 	getProps,


### PR DESCRIPTION
Fixes #4825

Frontend.js in Cart i2 had duplicate contexts as block.js (my fault 🤦🏼 ), which caused double everything (errors, slotfills...). This fixes it.


### How to test
- Insert Cart 2 and save.
- On frontend, open shipping calculator and enter a wrong zipcode.
- Get an error on the top of the page, but only 1.