### PR TITLE
Add documentation for registerPaymentMethodExtensionCallbacks

### DIFF
--- a/assets/js/blocks-registry/payment-methods/extensions-config.ts
+++ b/assets/js/blocks-registry/payment-methods/extensions-config.ts
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import { CanMakePaymentCallback } from '@woocommerce/type-defs/payments';
+import { CanMakePaymentExtensionCallback } from '@woocommerce/type-defs/payments';
 
 type CanMakePaymentExtensionCallbacks = Record<
 	string,
-	CanMakePaymentCallback
+	CanMakePaymentExtensionCallback
 >;
 export type NamespacedCanMakePaymentExtensionsCallbacks = Record<
 	string,

--- a/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import type { CanMakePaymentCallback } from '@woocommerce/type-defs/payments';
+import type {
+	CanMakePaymentCallback,
+	CanMakePaymentExtensionCallback,
+} from '@woocommerce/type-defs/payments';
 
 /**
  * Internal dependencies
@@ -38,7 +41,7 @@ export const canMakePaymentWithExtensions = (
 		// Gather all callbacks for paymentMethodName.
 		const namespacedCallbacks: Record<
 			ExtensionNamespace,
-			CanMakePaymentCallback
+			CanMakePaymentExtensionCallback
 		> = {};
 
 		Object.entries( extensionsCallbacks ).forEach(

--- a/assets/js/blocks-registry/payment-methods/registry.ts
+++ b/assets/js/blocks-registry/payment-methods/registry.ts
@@ -5,7 +5,7 @@ import deprecated from '@wordpress/deprecated';
 import type {
 	PaymentMethodConfiguration,
 	ExpressPaymentMethodConfiguration,
-	CanMakePaymentCallback,
+	CanMakePaymentExtensionCallback,
 	PaymentMethodConfigInstance,
 	PaymentMethods,
 	ExpressPaymentMethods,
@@ -81,7 +81,7 @@ export const registerExpressPaymentMethod = (
  */
 export const registerPaymentMethodExtensionCallbacks = (
 	namespace: string,
-	callbacks: Record< string, CanMakePaymentCallback >
+	callbacks: Record< string, CanMakePaymentExtensionCallback >
 ): void => {
 	if ( canMakePaymentExtensionsCallbacks[ namespace ] ) {
 		// eslint-disable-next-line no-console

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -43,6 +43,10 @@ export type CanMakePaymentCallback = (
 	cartData: CanMakePaymentArgument
 ) => CanMakePaymentReturnType;
 
+export type CanMakePaymentExtensionCallback = (
+	cartData: CanMakePaymentArgument
+) => boolean;
+
 export interface PaymentMethodIcon {
 	id: string;
 	src: string | null;

--- a/docs/extensibility/README.md
+++ b/docs/extensibility/README.md
@@ -4,15 +4,16 @@ These documents are all dealing with extensibility in the various WooCommerce Bl
 
 ## Checkout Block
 
-| Document | Description |
-| ---------- | ---------- |
-[Payment Method Integration](./payment-method-integration.md) | Information about implementing payment methods.
-[Checkout Flow and Events](./checkout-flow-and-events.md) | All about the checkout flow in the checkout block and the various emitted events that can be subscribed to.
-[Available Filters](./available-filters.md) | All about the filters that you may use to change values of certain elements of WooCommerce Blocks.
-[Exposing your data in the Store API.](./extend-rest-api-add-data.md) | Explains how you can add additional data to Store API endpoints.
-[Available endpoints to extend with ExtendRestAPI.](./available-endpoints-to-extend.md) | A list of all available endpoints to extend.
-[Adding an endpoint to ExtendRestAPI.](./extend-rest-api-new-endpoint.md) | A step by step process for contributors to expose a new endpoint via ExtendRestApi.
-[Slots and Fills.](./slot-fills.md) | Explains Slot Fills and how to use them to render your own components in Cart and Checkout.
-[Available Slot Fills.](./available-slot-fills.md) | Available Slots that you can use and their positions in Cart and Checkout.
-[Available Formatters](./extend-rest-api-formatters.md) | Available `Formatters` to format data for use in the Store API.
-[IntegrationInterface](./integration-interface.md) | The `IntegrationInterface` class and how to use it to register scripts, styles, and data with WooCommerce Blocks.
+| Document                                                                                | Description                                                                                                       |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| [Payment Method Integration](./payment-method-integration.md)                           | Information about implementing payment methods.                                                                   |
+| [Filtering Payment Methods](./filtering-payment-methods.md)                             | Information about filtering the payment methods available in the Checkout Block.                                  |
+| [Checkout Flow and Events](./checkout-flow-and-events.md)                               | All about the checkout flow in the checkout block and the various emitted events that can be subscribed to.       |
+| [Available Filters](./available-filters.md)                                             | All about the filters that you may use to change values of certain elements of WooCommerce Blocks.                |
+| [Exposing your data in the Store API.](./extend-rest-api-add-data.md)                   | Explains how you can add additional data to Store API endpoints.                                                  |
+| [Available endpoints to extend with ExtendRestAPI.](./available-endpoints-to-extend.md) | A list of all available endpoints to extend.                                                                      |
+| [Adding an endpoint to ExtendRestAPI.](./extend-rest-api-new-endpoint.md)               | A step by step process for contributors to expose a new endpoint via ExtendRestApi.                               |
+| [Slots and Fills.](./slot-fills.md)                                                     | Explains Slot Fills and how to use them to render your own components in Cart and Checkout.                       |
+| [Available Slot Fills.](./available-slot-fills.md)                                      | Available Slots that you can use and their positions in Cart and Checkout.                                        |
+| [Available Formatters](./extend-rest-api-formatters.md)                                 | Available `Formatters` to format data for use in the Store API.                                                   |
+| [IntegrationInterface](./integration-interface.md)                                      | The `IntegrationInterface` class and how to use it to register scripts, styles, and data with WooCommerce Blocks. |

--- a/docs/extensibility/filtering-payment-methods.md
+++ b/docs/extensibility/filtering-payment-methods.md
@@ -1,0 +1,75 @@
+# Filtering payment methods in the Checkout block
+
+## The problem
+
+You're an extension developer, and your extension is conditionally hiding payment gateways on the checkout step. You need to be able to hide payment gateways on the Checkout block using a front-end extensibility point.
+
+## The solution
+
+WooCommerce Blocks provides a function called `registerPaymentMethodExtensionCallbacks` which allows extensions to register callbacks for specific payment methods to determine if they can make payments.
+
+## Importing
+
+_Aliased import_
+
+```js
+import { registerPaymentMethodExtensionCallbacks } from '@woocommerce/blocks-registry';
+```
+
+_wc global_
+
+```js
+const { registerPaymentMethodExtensionCallbacks } = wc.wcBlocksRegistry;
+```
+
+## Signature
+
+| Parameter   | Description                                                                                                         | Type                                              |
+| ----------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `name`      | Unique string to identify your extension. Choose something that eliminates a name collision with another extension. | `string`                                          |
+| `callbacks` | An object containing callbacks registered for different payment methods                                             | Record< string, CanMakePaymentExtensionCallback > |
+
+Read more below about [callbacks](#callbacks-registered-for-payment-methods).
+
+### Extension name collision
+
+When trying to register callbacks under an extension namespace already used with `registerPaymentMethodExtensionCallbacks`, the registration will be aborted and you will be noticed that you are not using a unique namespace.
+
+## Usage example
+
+```js
+registerPaymentMethodExtensionCallbacks( 'my-hypothetical-extension', {
+	cod: ( arg ) => {
+		return arg.shippingAddress.city === 'Berlin';
+	},
+	cheque: ( arg ) => {
+		return false;
+	},
+} );
+```
+
+## Callbacks registered for payment methods
+
+The registered callbacks are used to determine whether the corresponding payment method should be available as an option for the shopper. The function will be passed an object containing data about the current order.
+
+```typescript
+type CanMakePaymentExtensionCallback = (
+	cartData: CanMakePaymentArgument
+) => boolean;
+```
+
+Each callback will have access to the information bellow
+
+```typescript
+interface CanMakePaymentArgument {
+	cart: Cart;
+	cartTotals: CartTotals;
+	cartNeedsShipping: boolean;
+	billingData: CartResponseBillingAddress;
+	shippingAddress: CartResponseShippingAddress;
+	selectedShippingMethods: Record< string, unknown >;
+	paymentRequirements: Array< string >;
+}
+```
+
+If you need data that is not available in the parameter received by the callback you can consider [exposing your data in the Store API](extend-rest-api-add-data.md).

--- a/docs/extensibility/filtering-payment-methods.md
+++ b/docs/extensibility/filtering-payment-methods.md
@@ -26,12 +26,12 @@ const { registerPaymentMethodExtensionCallbacks } = wc.wcBlocksRegistry;
 
 | Parameter   | Description                                                                                                         | Type                                              |
 | ----------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| `name`      | Unique string to identify your extension. Choose something that eliminates a name collision with another extension. | `string`                                          |
+| `namespace` | Unique string to identify your extension. Choose something that eliminates a name collision with another extension. | `string`                                          |
 | `callbacks` | An object containing callbacks registered for different payment methods                                             | Record< string, CanMakePaymentExtensionCallback > |
 
 Read more below about [callbacks](#callbacks-registered-for-payment-methods).
 
-### Extension name collision
+### Extension namespace collision
 
 When trying to register callbacks under an extension namespace already used with `registerPaymentMethodExtensionCallbacks`, the registration will be aborted and you will be notified that you are not using a unique namespace. This will be shown in the JavaScript console.
 
@@ -49,6 +49,14 @@ registerPaymentMethodExtensionCallbacks( 'my-hypothetical-extension', {
 ```
 
 ## Callbacks registered for payment methods
+
+Extensions can register only one callback per payment method:
+
+```
+payment_method_name: ( arg ) => {...}
+```
+
+`payment_method_name` is the value of the [name](payment-method-integration.md#name-required) property used when the payment method was registered with WooCommerce Blocks.
 
 The registered callbacks are used to determine whether the corresponding payment method should be available as an option for the shopper. The function will be passed an object containing data about the current order.
 

--- a/docs/extensibility/filtering-payment-methods.md
+++ b/docs/extensibility/filtering-payment-methods.md
@@ -33,7 +33,7 @@ Read more below about [callbacks](#callbacks-registered-for-payment-methods).
 
 ### Extension name collision
 
-When trying to register callbacks under an extension namespace already used with `registerPaymentMethodExtensionCallbacks`, the registration will be aborted and you will be noticed that you are not using a unique namespace.
+When trying to register callbacks under an extension namespace already used with `registerPaymentMethodExtensionCallbacks`, the registration will be aborted and you will be notified that you are not using a unique namespace. This will be shown in the JavaScript console.
 
 ## Usage example
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds documentation for the `registerPaymentMethodExtensionCallbacks` introduced in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4621
<!-- Reference any related issues or PRs here -->
Fixes #4623 

It also improves the type for callbacks registered by extensions in commit https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/86f74afed56c113ab94aed118421c207aa385337: the previous type was CanMakePaymentCallback, used for the payment methods's own `canMakePayment` configuration parameter, that returned true || a Promise. In order to eliminate the confusion, a new type has been created to define the extension callbacks that only return true or false.


### Changelog

> Add documentation for registerPaymentMethodExtensionCallbacks
