### PR TITLE
Update Cart & Checkout i2 temporarily locking to be on the parent block

### DIFF
--- a/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
@@ -28,7 +28,7 @@ import { Icon, filledCart, removeCart } from '@woocommerce/icons';
  * Internal dependencies
  */
 import './editor.scss';
-import { addClassToBody } from './hacks';
+import { addClassToBody, useBlockPropsWithLocking } from './hacks';
 import { useViewSwitcher } from './use-view-switcher';
 import type { Attributes } from './types';
 import { CartBlockControlsContext } from './context';
@@ -184,12 +184,14 @@ export const Edit = ( {
 		],
 		[ 'woocommerce/empty-cart-block', {}, [] ],
 	];
+	const blockProps = useBlockPropsWithLocking( {
+		className: classnames( className, 'wp-block-woocommerce-cart', {
+			'is-editor-preview': attributes.isPreview,
+		} ),
+	} );
+
 	return (
-		<div
-			className={ classnames( className, 'wp-block-woocommerce-cart', {
-				'is-editor-preview': attributes.isPreview,
-			} ) }
-		>
+		<div { ...blockProps }>
 			<BlockErrorBoundary
 				header={ __(
 					'Cart Block Error',

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-express-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-express-payment-block/edit.tsx
@@ -14,7 +14,6 @@ import classnames from 'classnames';
  */
 import Block from './block';
 import './editor.scss';
-import { useBlockPropsWithLocking } from '../../hacks';
 
 /**
  * Renders a placeholder in the editor.
@@ -48,23 +47,13 @@ const NoExpressPaymentMethodsPlaceholder = () => {
 	);
 };
 
-export const Edit = ( {
-	attributes,
-}: {
-	attributes: {
-		lock: {
-			move: boolean;
-			remove: boolean;
-		};
-	};
-} ): JSX.Element | null => {
+export const Edit = (): JSX.Element | null => {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
 	const hasExpressPaymentMethods = Object.keys( paymentMethods ).length > 0;
-	const blockProps = useBlockPropsWithLocking( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			'wp-block-woocommerce-cart-express-payment-block--has-express-payment-methods': hasExpressPaymentMethods,
 		} ),
-		attributes,
 	} );
 
 	if ( ! isInitialized ) {

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-line-items-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-line-items-block/edit.tsx
@@ -6,21 +6,10 @@ import { useBlockProps } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { useBlockPropsWithLocking } from '../../hacks';
-
 import Block from './block';
 
-export const Edit = ( {
-	attributes,
-}: {
-	attributes: {
-		lock: {
-			move: boolean;
-			remove: boolean;
-		};
-	};
-} ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking( { attributes } );
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
 
 	return (
 		<div { ...blockProps }>

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-order-summary-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-order-summary-block/edit.tsx
@@ -10,7 +10,6 @@ import { getSetting } from '@woocommerce/settings';
  * Internal dependencies
  */
 import Block from './block';
-import { useBlockPropsWithLocking } from '../../hacks';
 
 export const Edit = ( {
 	attributes,
@@ -27,7 +26,7 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
 	const { showRateAfterTaxName, isShippingCalculatorEnabled } = attributes;
-	const blockProps = useBlockPropsWithLocking( { attributes } );
+	const blockProps = useBlockProps();
 	const taxesEnabled = getSetting( 'taxesEnabled' ) as boolean;
 	const displayItemizedTaxes = getSetting(
 		'displayItemizedTaxes',

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/proceed-to-checkout-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/proceed-to-checkout-block/edit.tsx
@@ -12,7 +12,6 @@ import { CART_PAGE_ID } from '@woocommerce/block-settings';
  * Internal dependencies
  */
 import Block from './block';
-import { useBlockPropsWithLocking } from '../../hacks';
 export const Edit = ( {
 	attributes,
 	setAttributes,
@@ -22,7 +21,7 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking( { attributes } );
+	const blockProps = useBlockProps();
 	const { checkoutPageId = 0 } = attributes;
 	const { current: savedCheckoutPageId } = useRef( checkoutPageId );
 	const currentPostId = useSelect(

--- a/assets/js/blocks/cart-checkout/checkout/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/edit.tsx
@@ -35,7 +35,7 @@ import { CartCheckoutCompatibilityNotice } from '@woocommerce/editor-components/
  */
 import './styles/editor.scss';
 import { Columns } from './columns';
-import { addClassToBody } from './hacks';
+import { addClassToBody, useBlockPropsWithLocking } from './hacks';
 import { CheckoutBlockContext, CheckoutBlockControlsContext } from './context';
 import type { Attributes } from './types';
 
@@ -260,9 +260,9 @@ export const Edit = ( {
 			</PanelBody>
 		</InspectorControls>
 	);
-
+	const blockProps = useBlockPropsWithLocking();
 	return (
-		<>
+		<div { ...blockProps }>
 			<EditorProvider
 				previewData={ { previewCart, previewSavedPaymentMethods } }
 			>
@@ -305,7 +305,7 @@ export const Edit = ( {
 				</CheckoutProvider>
 			</EditorProvider>
 			<CartCheckoutCompatibilityNotice blockName="checkout" />
-		</>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/form-step/form-step-block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/form-step/form-step-block.tsx
@@ -3,14 +3,17 @@
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
-import { PlainText, InspectorControls } from '@wordpress/block-editor';
+import {
+	PlainText,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import FormStepHeading from './form-step-heading';
-import { useBlockPropsWithLocking } from '../hacks';
 export interface FormStepBlockProps {
 	attributes: { title: string; description: string; showStepNumber: boolean };
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
@@ -29,11 +32,10 @@ export const FormStepBlock = ( {
 	children,
 }: FormStepBlockProps ): JSX.Element => {
 	const { title = '', description = '', showStepNumber = true } = attributes;
-	const blockProps = useBlockPropsWithLocking( {
+	const blockProps = useBlockProps( {
 		className: classnames( 'wc-block-components-checkout-step', className, {
 			'wc-block-components-checkout-step--with-step-number': showStepNumber,
 		} ),
-		attributes,
 	} );
 	return (
 		<div { ...blockProps }>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -12,7 +12,7 @@ import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
  * Internal dependencies
  */
 import Block from './block';
-import { useBlockPropsWithLocking } from '../../hacks';
+
 export const Edit = ( {
 	attributes,
 	setAttributes,
@@ -23,7 +23,7 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking( { attributes } );
+	const blockProps = useBlockProps();
 	const { cartPageId = 0, showReturnToCart = true } = attributes;
 	const { current: savedCartPageId } = useRef( cartPageId );
 	const currentPostId = useSelect(

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/edit.tsx
@@ -14,7 +14,6 @@ import classnames from 'classnames';
  */
 import Block from './block';
 import './editor.scss';
-import { useBlockPropsWithLocking } from '../../hacks';
 
 /**
  * Renders a placeholder in the editor.
@@ -60,7 +59,7 @@ export const Edit = ( {
 } ): JSX.Element | null => {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
 	const hasExpressPaymentMethods = Object.keys( paymentMethods ).length > 0;
-	const blockProps = useBlockPropsWithLocking( {
+	const blockProps = useBlockProps( {
 		className: classnames( {
 			'wp-block-woocommerce-checkout-express-payment-block--has-express-payment-methods': hasExpressPaymentMethods,
 		} ),

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/edit.tsx
@@ -9,19 +9,9 @@ import { Disabled } from '@wordpress/components';
  */
 import Block from './block';
 import './editor.scss';
-import { useBlockPropsWithLocking } from '../../hacks';
 
-export const Edit = ( {
-	attributes,
-}: {
-	attributes: {
-		lock: {
-			move: boolean;
-			remove: boolean;
-		};
-	};
-} ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking( { attributes } );
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
 			<Disabled>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/edit.tsx
@@ -10,7 +10,6 @@ import { getSetting } from '@woocommerce/settings';
  * Internal dependencies
  */
 import Block from './block';
-import { useBlockPropsWithLocking } from '../../hacks';
 
 export const Edit = ( {
 	attributes,
@@ -25,7 +24,7 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const blockProps = useBlockPropsWithLocking( { attributes } );
+	const blockProps = useBlockProps();
 	const taxesEnabled = getSetting( 'taxesEnabled' ) as boolean;
 	const displayItemizedTaxes = getSetting(
 		'displayItemizedTaxes',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Until we reach WordPress 5.9 support, we have our temporary locking mechanism that is a hack. One of its method is catching the `DELETE` and variant keyboard events to prevent a block from being deleted.

It does that by listening to the `keydown` event and preventing it from reaching Gutenberg. This works fine in Chrome/Safari/Edge but not Firefox, as Firefox event run first.

This PR changes that so we listen to locking on the parent block (Cart i2, Checkout i2) instead of inner block, and would prevent locking if the block being deleted is locked.
<!-- Reference any related issues or PRs here -->
Fixes #4831

### Testing

How to test the changes in this Pull Request:

Do this on 2-3 browsers, mainly Firefox.
1. Insert Checkout block.
2. Try deleting a core block like billing fields, it shouldn't work.
3. Insert a block like sample block, try deleting it, it should work fine.
4. Do it again in another browser.
