### PR TITLE
Fix/price slider aria values

### DIFF
--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -250,6 +250,9 @@ const PriceSlider = ( {
 	const maxRangeStep =
 		activeElement && activeElement === maxRange.current ? stepValue : 1;
 
+	const ariaReadableMinPrice = minPriceInput / 10 ** currency.minorUnit;
+	const ariaReadableMaxPrice = maxPriceInput / 10 ** currency.minorUnit;
+
 	return (
 		<div className={ classes }>
 			<div
@@ -270,6 +273,7 @@ const PriceSlider = ( {
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
 							) }
+							aria-valuetext={ ariaReadableMinPrice }
 							value={
 								Number.isFinite( minPrice )
 									? minPrice
@@ -290,6 +294,7 @@ const PriceSlider = ( {
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
 							) }
+							aria-valuetext={ ariaReadableMaxPrice }
 							value={
 								Number.isFinite( maxPrice )
 									? maxPrice
@@ -317,6 +322,7 @@ const PriceSlider = ( {
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
 							) }
+							aria-valuetext={ ariaReadableMinPrice }
 							onValueChange={ ( value ) => {
 								if ( value === minPriceInput ) {
 									return;
@@ -335,6 +341,7 @@ const PriceSlider = ( {
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
 							) }
+							aria-valuetext={ ariaReadableMaxPrice }
 							onValueChange={ ( value ) => {
 								if ( value === maxPriceInput ) {
 									return;

--- a/assets/js/base/components/price-slider/index.js
+++ b/assets/js/base/components/price-slider/index.js
@@ -322,7 +322,6 @@ const PriceSlider = ( {
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
 							) }
-							aria-valuetext={ ariaReadableMinPrice }
 							onValueChange={ ( value ) => {
 								if ( value === minPriceInput ) {
 									return;
@@ -341,7 +340,6 @@ const PriceSlider = ( {
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
 							) }
-							aria-valuetext={ ariaReadableMaxPrice }
 							onValueChange={ ( value ) => {
 								if ( value === maxPriceInput ) {
 									return;


### PR DESCRIPTION
### Description

* Add human readable values to the aria attribute of the Price Filter slider for screen readers.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4378

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Add the Filter By Price block to your All Products page
2. Turn Voice Over on your Mac (click the power button 3 times to do this)
3. Move the slider back and fourth, the voice should say "Ninety" instead of "Nine thousand" for example.

### Changelog

> Filter By Price: Update aria values to be more representative of the actual values presented.
