### PR TITLE
Fix Terms and Conditions block toolbar block not working because of lack of edit wrapping

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
@@ -23,10 +23,11 @@ export const Edit = ( {
 	attributes: { text: string; checkbox: boolean };
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
+	const blockProps = useBlockProps();
 	const currentText = text || termsCheckboxDefaultText;
 
 	return (
-		<>
+		<div { ...blockProps }>
 			<InspectorControls>
 				<PanelBody
 					title={ __(
@@ -100,7 +101,7 @@ export const Edit = ( {
 					</p>
 				</Notice>
 			) }
-		</>
+		</div>
 	);
 };
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Terms and Conditions blocks didn't work well (not selectable, no toolbar) because we forget to spread `useBlockProps` on it.

I audited all other inner blocks in Cart i2 and Checkout and it was the only one.
<!-- Reference any related issues or PRs here -->
Fixes #4842 

### Testing
1. In Checkout, go to T&C
2. You can select it.
3. You can see toolbar.
