### PR TITLE
Enforce valid states from the API

### DIFF
--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -93,6 +93,14 @@ class BillingAddressSchema extends AbstractAddressSchema {
 	 */
 	public function get_item_response( $address ) {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
+			$billing_country = $address->get_billing_country();
+			$billing_state   = $address->get_billing_state();
+			$valid_states    = wc()->countries->get_states( $billing_country );
+
+			if ( ! empty( $billing_state ) && count( $valid_states ) && ! in_array( $billing_state, $valid_states, true ) ) {
+				$billing_state = '';
+			}
+
 			return (object) $this->prepare_html_response(
 				[
 					'first_name' => $address->get_billing_first_name(),
@@ -101,9 +109,9 @@ class BillingAddressSchema extends AbstractAddressSchema {
 					'address_1'  => $address->get_billing_address_1(),
 					'address_2'  => $address->get_billing_address_2(),
 					'city'       => $address->get_billing_city(),
-					'state'      => $address->get_billing_state(),
+					'state'      => $billing_state,
 					'postcode'   => $address->get_billing_postcode(),
-					'country'    => $address->get_billing_country(),
+					'country'    => $billing_country,
 					'email'      => $address->get_billing_email(),
 					'phone'      => $address->get_billing_phone(),
 				]

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -42,6 +42,14 @@ class ShippingAddressSchema extends AbstractAddressSchema {
 				$shipping_phone = $address->get_meta( $address instanceof \WC_Customer ? 'shipping_phone' : '_shipping_phone', true );
 			}
 
+			$shipping_country = $address->get_shipping_country();
+			$shipping_state   = $address->get_shipping_state();
+			$valid_states     = wc()->countries->get_states( $shipping_country );
+
+			if ( ! empty( $shipping_state ) && count( $valid_states ) && ! in_array( $shipping_state, $valid_states, true ) ) {
+				$shipping_state = '';
+			}
+
 			return (object) $this->prepare_html_response(
 				[
 					'first_name' => $address->get_shipping_first_name(),
@@ -50,9 +58,9 @@ class ShippingAddressSchema extends AbstractAddressSchema {
 					'address_1'  => $address->get_shipping_address_1(),
 					'address_2'  => $address->get_shipping_address_2(),
 					'city'       => $address->get_shipping_city(),
-					'state'      => $address->get_shipping_state(),
+					'state'      => $shipping_state,
 					'postcode'   => $address->get_shipping_postcode(),
-					'country'    => $address->get_shipping_country(),
+					'country'    => $shipping_country,
 					'phone'      => $shipping_phone,
 				]
 			);

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -150,12 +150,6 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await expect( page ).toClick(
 			'.wc-block-components-payment-method-label',
 			{
-				alt: 'PayPal',
-			}
-		);
-		await expect( page ).toClick(
-			'.wc-block-components-payment-method-label',
-			{
 				text: 'Direct bank transfer',
 			}
 		);


### PR DESCRIPTION
I came across an issue similar to https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4753 (which was fixed in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4761) where state validation was breaking requests. In this case, I had an invalid billing address in the client state when using the shipping calculator (which only posts shipping addresses). 

Turns out this was because I had an invalid address state coming from the Rest API and then being stored in the client. We should fix this at API level and only return the address state if valid.

### How to test the changes in this Pull Request:

Tricky to test this one. You need to have somehow had an invalid state stored in your session. Probably need to just smoke test the customer responses from the API and ensure shipping and billing states are still returned.

### Changelog

> Store API - Ensure returned customer address state is valid.
