### PR TITLE
Mini Cart block: improve button accessibility

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/block.tsx
@@ -13,6 +13,7 @@ import {
 	formatPrice,
 	getCurrencyFromPriceResponse,
 } from '@woocommerce/price-format';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -82,6 +83,11 @@ const MiniCartBlock = ( {
 		}
 	}, [ isOpen, cartIsLoading, cartItems.length, emptyCartRef ] );
 
+	const subTotal = getSetting( 'displayCartPricesIncludingTax', false )
+		? parseInt( cartTotals.total_items, 10 ) +
+		  parseInt( cartTotals.total_items_tax, 10 )
+		: cartTotals.total_items;
+
 	const ariaLabel = sprintf(
 		/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
 		_n(
@@ -91,10 +97,7 @@ const MiniCartBlock = ( {
 			'woo-gutenberg-products-block'
 		),
 		cartItemsCount,
-		formatPrice(
-			cartTotals.total_price,
-			getCurrencyFromPriceResponse( cartTotals )
-		)
+		formatPrice( subTotal, getCurrencyFromPriceResponse( cartTotals ) )
 	);
 
 	const contents =

--- a/assets/js/blocks/cart-checkout/mini-cart/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/block.tsx
@@ -9,7 +9,10 @@ import { translateJQueryEventToNative } from '@woocommerce/base-utils';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import Drawer from '@woocommerce/base-components/drawer';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
-import { formatPrice } from '@woocommerce/price-format';
+import {
+	formatPrice,
+	getCurrencyFromPriceResponse,
+} from '@woocommerce/price-format';
 
 /**
  * Internal dependencies
@@ -88,7 +91,10 @@ const MiniCartBlock = ( {
 			'woo-gutenberg-products-block'
 		),
 		cartItemsCount,
-		formatPrice( cartTotals.total_items )
+		formatPrice(
+			cartTotals.total_price,
+			getCurrencyFromPriceResponse( cartTotals )
+		)
 	);
 
 	const contents =

--- a/assets/js/blocks/cart-checkout/mini-cart/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/block.tsx
@@ -9,6 +9,7 @@ import { translateJQueryEventToNative } from '@woocommerce/base-utils';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import Drawer from '@woocommerce/base-components/drawer';
 import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { formatPrice } from '@woocommerce/price-format';
 
 /**
  * Internal dependencies
@@ -23,7 +24,12 @@ interface MiniCartBlockProps {
 const MiniCartBlock = ( {
 	isPlaceholderOpen = false,
 }: MiniCartBlockProps ): JSX.Element => {
-	const { cartItems, cartItemsCount, cartIsLoading } = useStoreCart();
+	const {
+		cartItems,
+		cartItemsCount,
+		cartIsLoading,
+		cartTotals,
+	} = useStoreCart();
 	const [ isOpen, setIsOpen ] = useState< boolean >( isPlaceholderOpen );
 	const emptyCartRef = useRef< HTMLDivElement | null >( null );
 	// We already rendered the HTML drawer placeholder, so we want to skip the
@@ -73,6 +79,18 @@ const MiniCartBlock = ( {
 		}
 	}, [ isOpen, cartIsLoading, cartItems.length, emptyCartRef ] );
 
+	const ariaLabel = sprintf(
+		/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+		_n(
+			'%1$d item in cart, total price of %2$s',
+			'%1$d items in cart, total price of %2$s',
+			cartItemsCount,
+			'woo-gutenberg-products-block'
+		),
+		cartItemsCount,
+		formatPrice( cartTotals.total_items )
+	);
+
 	const contents =
 		! cartIsLoading && cartItems.length === 0 ? (
 			<div
@@ -99,6 +117,7 @@ const MiniCartBlock = ( {
 						setSkipSlideIn( false );
 					}
 				} }
+				aria-label={ ariaLabel }
 			>
 				{ sprintf(
 					/* translators: %d is the count of items in the cart. */

--- a/packages/prices/utils/price.ts
+++ b/packages/prices/utils/price.ts
@@ -120,7 +120,7 @@ export const getCurrency = (
 export const formatPrice = (
 	// Price in minor unit, e.g. cents.
 	price: number | string,
-	currencyData: Currency
+	currencyData?: Currency
 ): string => {
 	if ( price === '' || price === undefined ) {
 		return '';

--- a/packages/prices/utils/test/price.js
+++ b/packages/prices/utils/test/price.js
@@ -25,4 +25,20 @@ describe( 'formatPrice', () => {
 			expect( formattedPrice ).toEqual( expected );
 		}
 	);
+
+	test.each`
+		value          | expected
+		${ 1000 }      | ${ '$10' }
+		${ 0 }         | ${ '$0' }
+		${ '' }        | ${ '' }
+		${ null }      | ${ '' }
+		${ undefined } | ${ '' }
+	`(
+		'correctly formats price given "$value" only',
+		( { value, expected } ) => {
+			const formattedPrice = formatPrice( value );
+
+			expect( formattedPrice ).toEqual( expected );
+		}
+	);
 } );

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -107,6 +107,12 @@ class MiniCart extends AbstractBlock {
 			true
 		);
 
+		$this->asset_data_registry->add(
+			'displayCartPricesIncludingTax',
+			'incl' === get_option( 'woocommerce_tax_display_cart' ),
+			true
+		);
+
 		do_action( 'woocommerce_blocks_cart_enqueue_data' );
 	}
 
@@ -192,7 +198,11 @@ class MiniCart extends AbstractBlock {
 		$cart                = $cart_controller->get_cart_instance();
 		$cart_contents_count = $cart->get_cart_contents_count();
 		$cart_contents       = $cart->get_cart();
-		$cart_contents_total = $cart->get_cart_subtotal();
+		$cart_contents_total = $cart->get_subtotal();
+
+		if ( $cart->display_prices_including_tax() ) {
+			$cart_contents_total += $cart->get_subtotal_tax();
+		}
 
 		$button_text = sprintf(
 			/* translators: %d is the number of products in the cart. */

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -192,6 +192,7 @@ class MiniCart extends AbstractBlock {
 		$cart                = $cart_controller->get_cart_instance();
 		$cart_contents_count = $cart->get_cart_contents_count();
 		$cart_contents       = $cart->get_cart();
+		$cart_contents_total = $cart->get_cart_contents_total();
 
 		$button_text = sprintf(
 			/* translators: %d is the number of products in the cart. */
@@ -202,6 +203,17 @@ class MiniCart extends AbstractBlock {
 				'woo-gutenberg-products-block'
 			),
 			$cart_contents_count
+		);
+		$aria_label = sprintf(
+			/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+			_n(
+				'%1$d item in cart, total price of %2$s',
+				'%1$d items in cart, total price of %2$s',
+				$cart_contents_count,
+				'woo-gutenberg-products-block'
+			),
+			$cart_contents_count,
+			wp_strip_all_tags( wc_price( $cart_contents_total ) )
 		);
 		$title = sprintf(
 			/* translators: %d is the count of items in the cart. */
@@ -221,7 +233,7 @@ class MiniCart extends AbstractBlock {
 		}
 
 		return '<div class="wc-block-mini-cart">
-			<button class="wc-block-mini-cart__button">' . $button_text . '</button>
+			<button class="wc-block-mini-cart__button" aria-label="' . $aria_label . '">' . $button_text . '</button>
 			<div class="wc-block-mini-cart__drawer is-loading is-mobile wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
 				<div class="components-modal__frame wc-block-components-drawer">
 					<div class="components-modal__content">

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -238,7 +238,7 @@ class MiniCart extends AbstractBlock {
 
 		if ( is_cart() || is_checkout() ) {
 			return '<div class="wc-block-mini-cart">
-				<button class="wc-block-mini-cart__button" disabled>' . $button_text . '</button>
+				<button class="wc-block-mini-cart__button" aria-label="' . $aria_label . '" disabled>' . $button_text . '</button>
 			</div>';
 		}
 

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -192,7 +192,7 @@ class MiniCart extends AbstractBlock {
 		$cart                = $cart_controller->get_cart_instance();
 		$cart_contents_count = $cart->get_cart_contents_count();
 		$cart_contents       = $cart->get_cart();
-		$cart_contents_total = $cart->get_cart_contents_total();
+		$cart_contents_total = $cart->get_cart_subtotal();
 
 		$button_text = sprintf(
 			/* translators: %d is the number of products in the cart. */


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR improves the Mini Cart block button a11y by adding `aria-label` used by screen readers. The label format is "X items in cart, total price of Y".

This PR also updates the `formatPrice` function, makes the second argument optional. I added unit tests to cover that change too.

<!-- Reference any related issues or PRs here -->
Fixes #4704 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

<img width="1357" alt="Screen Shot 2021-09-28 at 09 39 59" src="https://user-images.githubusercontent.com/5423135/135013788-a6c18bda-1c56-4c82-adc6-a58db03e8187.png">


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Turn on a screen reader.
2. Add Mini cart block to a page.
3. View the page on the front end, pre `Tab` to navigate to the Mini Cart button.
4. Heard/see the label from the screen reader.

<!-- If you can, add the appropriate labels -->