### PR TITLE
Fix free trial subscriptions orders missing payment method meta

### DIFF
--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -461,7 +461,7 @@ class Checkout extends AbstractCartRoute {
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
-		$this->order->set_payment_method( $this->order->needs_payment() ? $this->get_request_payment_method( $request ) : '' );
+		$this->order->set_payment_method( $this->get_request_payment_method( $request ) );
 
 		/**
 		 * WooCommerce Blocks Checkout Update Order From Request (experimental).


### PR DESCRIPTION
Fixes #4853

Issue in Stripe: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1964

When debugging the issue above in the Stripe plugin, I found that free trial subscriptions purchased via the blocks checkout didn't have the payment method post meta. This caused free trial subscriptions to always require manual renewals after the trial period ended.

This is possibly affecting pre-orders and other types of off-session based orders, although I only tested the issue with the subscriptions extension.

I reproduced the issue in Stripe and WooCommerce Payments, but this is probably happening in all payment gateways that support free trial subscriptions.

Apparently when the code got refactored, it wasn't refactored into its [equivalent previous functionality](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3454/files#diff-af2c90fa556cc086b780c8fad99b68373d87fd6007e6e2ff1b4c68ebe9ccb551L434-L436), so it led to the inconsistency mentioned above.

### Screenshots

**Before: Payment method didn't get saved and required manual renewals**

<img width="736" alt="Free trial subscriptions purchased via checkout block - Before fix" src="https://user-images.githubusercontent.com/5509901/135028187-e458e114-e572-4f57-aee4-872e5cce5237.png">

**After: Payment method gets saved and supports automatic renewals**

<img width="736" alt="Free trial subscriptions purchased via checkout block - After fix" src="https://user-images.githubusercontent.com/5509901/135028195-ba6c9ce0-0b5e-48b7-a48f-9e28261cdc6e.png">

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Ensure you have [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/) and [Stripe](https://woocommerce.com/products/stripe/) installed and activated.
2. Sign up for a stripe.com account
3. Enable test mode and add test API private and secret keys to your account under **WooCommerce > Settings > Payments > Stripe**.
4. Navigate to **Products > Add new** and type a product name: e.g "Free trial subscription".
5. Set the product data to **Simple subscription**.
6. Add a subscription price and a free trial period.
7. Save the product.
8. As a shopper, add the newly created free trial subscription to the cart and proceed to the checkout block.
9. Complete the purchase with a Stripe test card: `4242424242424242` and any valid CVC and expiration date.
10. Navigate to **WooCommerce > Subscriptions** and notice the newly created subscription is renewable "Via Credit card / debit card".

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix missing payment method meta data for free orders
