### PR TITLE
Checkout i2: Show a notice if terms and conditions page

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/block.json
@@ -8,8 +8,7 @@
 		"align": false,
 		"html": false,
 		"multiple": false,
-		"reusable": false,
-		"inserter": false
+		"reusable": false
 	},
 	"attributes": {
 		"checkbox": {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
@@ -11,6 +11,7 @@ import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 import { PanelBody, ToggleControl, Notice } from '@wordpress/components';
 import { PRIVACY_URL, TERMS_URL } from '@woocommerce/block-settings';
 import { ADMIN_URL } from '@woocommerce/settings';
+import { Icon, external } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -83,10 +84,21 @@ export const Edit = ( {
 					isDismissible={ false }
 					actions={ [
 						! TERMS_URL && {
-							label: __(
-								'Setup a Terms and Conditions page',
-								'woo-gutenberg-products-block'
+							className: 'wc-block-checkout__terms_notice-button',
+							label: (
+								<>
+									{ __(
+										'Setup a Terms and Conditions page',
+										'woo-gutenberg-products-block'
+									) }
+									<Icon
+										icon={ external }
+										size={ 16 }
+										className="wc-block-checkout__terms_notice-button__icon"
+									/>
+								</>
 							),
+
 							onClick: () =>
 								window.open(
 									`${ ADMIN_URL }admin.php?page=wc-settings&tab=advanced`,
@@ -94,9 +106,19 @@ export const Edit = ( {
 								),
 						},
 						! PRIVACY_URL && {
-							label: __(
-								'Setup a Privacy Policy page',
-								'woo-gutenberg-products-block'
+							className: 'wc-block-checkout__terms_notice-button',
+							label: (
+								<>
+									{ __(
+										'Setup a Privacy Policy page',
+										'woo-gutenberg-products-block'
+									) }
+									<Icon
+										size={ 16 }
+										icon={ external }
+										className="wc-block-checkout__terms_notice-button__icon"
+									/>
+								</>
 							),
 							onClick: () =>
 								window.open(

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
@@ -27,8 +27,12 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const currentText =
-		text || checkbox ? termsCheckboxDefaultText : termsConsentDefaultText;
+
+	const defaultText = checkbox
+		? termsCheckboxDefaultText
+		: termsConsentDefaultText;
+
+	const currentText = text || defaultText;
 	return (
 		<div { ...blockProps }>
 			<InspectorControls>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/edit.tsx
@@ -9,6 +9,8 @@ import {
 } from '@wordpress/block-editor';
 import CheckboxControl from '@woocommerce/base-components/checkbox-control';
 import { PanelBody, ToggleControl, Notice } from '@wordpress/components';
+import { PRIVACY_URL, TERMS_URL } from '@woocommerce/block-settings';
+import { ADMIN_URL } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -24,8 +26,8 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const currentText = text || termsCheckboxDefaultText;
-
+	const currentText =
+		text || checkbox ? termsCheckboxDefaultText : termsConsentDefaultText;
 	return (
 		<div { ...blockProps }>
 			<InspectorControls>
@@ -66,41 +68,86 @@ export const Edit = ( {
 				) : (
 					<RichText
 						tagName="span"
-						value={ text || termsConsentDefaultText }
+						value={ currentText }
 						onChange={ ( value ) =>
 							setAttributes( { text: value } )
 						}
 					/>
 				) }
 			</div>
-			{ ! currentText.includes( '<a ' ) && (
+			{ /* Show this notice if a terms page or a privacy page is not setup. */ }
+			{ ( ! TERMS_URL || ! PRIVACY_URL ) && (
 				<Notice
 					className="wc-block-checkout__terms_notice"
 					status="warning"
 					isDismissible={ false }
-					actions={
-						termsConsentDefaultText !== text
-							? [
-									{
-										label: __(
-											'Restore default text',
-											'woo-gutenberg-products-block'
-										),
-										onClick: () =>
-											setAttributes( { text: '' } ),
-									},
-							  ]
-							: []
-					}
+					actions={ [
+						! TERMS_URL && {
+							label: __(
+								'Setup a Terms and Conditions page',
+								'woo-gutenberg-products-block'
+							),
+							onClick: () =>
+								window.open(
+									`${ ADMIN_URL }admin.php?page=wc-settings&tab=advanced`,
+									'_blank'
+								),
+						},
+						! PRIVACY_URL && {
+							label: __(
+								'Setup a Privacy Policy page',
+								'woo-gutenberg-products-block'
+							),
+							onClick: () =>
+								window.open(
+									`${ ADMIN_URL }options-privacy.php`,
+									'_blank'
+								),
+						},
+					].filter( Boolean ) }
 				>
 					<p>
 						{ __(
-							'Ensure you add links to your policy pages in this section.',
+							"You don't seem to have a Terms and Conditions and/or a Privacy Policy pages setup.",
 							'woo-gutenberg-products-block'
 						) }
 					</p>
 				</Notice>
 			) }
+			{ /* Show this notice if we have both a terms and privacy pages, but they're not present in the text. */ }
+			{ TERMS_URL &&
+				PRIVACY_URL &&
+				! (
+					currentText.includes( TERMS_URL ) &&
+					currentText.includes( PRIVACY_URL )
+				) && (
+					<Notice
+						className="wc-block-checkout__terms_notice"
+						status="warning"
+						isDismissible={ false }
+						actions={
+							termsConsentDefaultText !== text
+								? [
+										{
+											label: __(
+												'Restore default text',
+												'woo-gutenberg-products-block'
+											),
+											onClick: () =>
+												setAttributes( { text: '' } ),
+										},
+								  ]
+								: []
+						}
+					>
+						<p>
+							{ __(
+								'Ensure you add links to your policy pages in this section.',
+								'woo-gutenberg-products-block'
+							) }
+						</p>
+					</Notice>
+				) }
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/editor.scss
@@ -19,3 +19,14 @@
 .wc-block-checkout__terms_notice .components-notice__action {
 	margin-left: 0;
 }
+
+.wc-block-checkout__terms_notice-button {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.wc-block-checkout__terms_notice-button__icon {
+		margin-left: $gap-smallest;
+	}
+}
+

--- a/assets/js/editor-components/external-link-card/editor.scss
+++ b/assets/js/editor-components/external-link-card/editor.scss
@@ -1,5 +1,4 @@
 .wc-block-editor-components-external-link-card {
-	display: block;
 	display: flex;
 	flex-direction: row;
 	text-decoration: none;


### PR DESCRIPTION
This was discovered during releasing 6.0.0. If you don't have a terms and conditions and privacy pages, you won't see the links in the editor by default. This PR adds a new notice that tells you to set up those pages.

#### No page setup
![image](https://user-images.githubusercontent.com/6165348/135088286-b6bad8f5-84ed-4ecb-9390-785db7f653cf.png)

#### One page not setup
![image](https://user-images.githubusercontent.com/6165348/135088427-fdaf4a07-b714-43fe-9fd3-d93f9d85663a.png)

### Both pages setup
![image](https://user-images.githubusercontent.com/6165348/135088582-f9617dbc-24be-41a9-88a4-4e35ecfc6794.png)

### Testing steps
- Reset your terms and conditions page from WooCommerce -> Settings -> Advanced.
- Turn your privacy policy page to draft or delete it.
- Insert Checkout.
- You should see a warning about setting up pages.
- Setup pages.
- Refresh the checkout editor page, the warning is gone.
- Edit one of the links to something else in the editor.
- You should see a new warning telling you about a messing link.
- Remove Terms and Conditions block.
- You should be able to reinsert it.