### PR TITLE
Checkout i2: support odd classes when transforming from Checkout i1 to Checkout i2

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -77,7 +77,9 @@ class Checkout extends AbstractBlock {
 		wp_dequeue_style( 'select2' );
 
 		// If the content is empty, we may have transformed from an older checkout block. Insert the default list of blocks.
-		$is_empty = strstr( $content, '<div class="wp-block-woocommerce-checkout is-loading"></div>' );
+		$regex_for_empty_block = '/<div class="wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*"><\/div>/mi';
+
+		$is_empty = preg_match( $regex_for_empty_block, $content );
 
 		if ( $is_empty ) {
 			$content = '<div class="wp-block-woocommerce-checkout is-loading">

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -82,10 +82,9 @@ class Checkout extends AbstractBlock {
 		$is_empty = preg_match( $regex_for_empty_block, $content );
 
 		if ( $is_empty ) {
-			$content = '<div class="wp-block-woocommerce-checkout is-loading">
-				<div data-block-name="woocommerce/checkout-fields-block" class="wp-block-woocommerce-checkout-fields-block"></div>
-				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block"></div>
-			</div>';
+			$inner_blocks_html = '<div data-block-name="woocommerce/checkout-fields-block" class="wp-block-woocommerce-checkout-fields-block"></div><div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block"></div>';
+
+			$content = str_replace( '</div>', $inner_blocks_html . '</div>', $content );
 		}
 
 		return $this->inject_html_data_attributes( $content, $attributes );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -77,7 +77,7 @@ class Checkout extends AbstractBlock {
 		wp_dequeue_style( 'select2' );
 
 		// If the content is empty, we may have transformed from an older checkout block. Insert the default list of blocks.
-		$regex_for_empty_block = '/<div class="wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*"><\/div>/mi';
+		$regex_for_empty_block = '/<div class="[a-zA-Z0-9_\- ]*wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*"><\/div>/mi';
 
 		$is_empty = preg_match( $regex_for_empty_block, $content );
 


### PR DESCRIPTION
When someone updates his WooCommerce Blocks version from Checkout i1 to Checkout i2, without updating the block on the editor, we do a php run to update it for him in the frontend. This is required because we longer have the old block code.

The check we do didn't account for extra classes that might come from alignment or custom classes, this PR fixs it.

### Testing instructions:
- Checkout `release/5.9.0`
- Run `npm run build` `composer install`
- In a page, named simple Checkout, Insert Checkout block, save.
- In a new page, named Complex Checkout, insert Checkout, change alignment, add custom classes from the sidebar advanced panel, save.
- Checkout this branch.
- Run `npm run build` `composer install`
- Visit both pages on frontend, both of them should work.
- Your alignment should be honored.
- Your custom className should persist
- You might see `data-align` and `data-class-name` as well, this is a known bug https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4867

### Changelog

> Fix: support custom classNames when updating Checkout i1 to Checkout i2 on frontend.