### PR TITLE
Display the notices registered by the payment gateway's process_payment() method

### DIFF
--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -164,9 +164,8 @@ class Api {
 		// Restore $_POST data.
 		$_POST = $post_data;
 
-		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
-		// and a generic notice will be shown instead if payment failed.
-		wc_clear_notices();
+		// Display the notices added by `process_payment` and abort.
+		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
 
 		// Handle result.
 		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );


### PR DESCRIPTION
Call `NoticeHandler::convert_notices_to_exceptions()` after `$payment_method_object->process_payment()` when processing a payment.

This way the notices added by this method are actually displayed. We were displaying a generic error and clearing the notices before. 

<!-- Reference any related issues or PRs here -->
Fixes #4870 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

Error message before:
![before](https://user-images.githubusercontent.com/13835680/116463974-e6584680-a85a-11eb-85a8-9f9431803fea.png)

Error message after:
![after](https://user-images.githubusercontent.com/41606954/135299237-a4ffce12-5acc-4881-9e4c-9cf5b465ec4a.png)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Make sure you're using the Blocks checkout and WCPay.
2. Add 1 or more products to your cart.
3. Go to the blocks checkout page
4. Pay through the credit card form with a card that will be declined, e.g. 4000 0000 0000 0002.
5. Now the error should say "Error: Card declined" instead of the generic message mentioned in the issue.

### Changelog

> Fix: Payment gateway's error messages not being displayed during checkout.
