### PR TITLE
Don't fire woocommerce_blocks_loaded if WC version is not met

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -58,20 +58,19 @@ class Bootstrap {
 	public function __construct( Container $container ) {
 		$this->container = $container;
 		$this->package   = $container->get( Package::class );
-		$this->init();
-		/**
-		 * Usable as a safe event hook for when the plugin has been loaded.
-		 */
-		do_action( 'woocommerce_blocks_loaded' );
+		if ( $this->has_core_dependencies() ) {
+			$this->init();
+			/**
+			 * Usable as a safe event hook for when the plugin has been loaded.
+			 */
+			do_action( 'woocommerce_blocks_loaded' );
+		}
 	}
 
 	/**
 	 * Init the package - load the blocks library and define constants.
 	 */
 	protected function init() {
-		if ( ! $this->has_core_dependencies() ) {
-			return;
-		}
 		$this->register_dependencies();
 		$this->register_payment_methods();
 


### PR DESCRIPTION
We fire `woocommerce_blocks_loaded` for 3P plugins that integrate with us as a safe way to signal that WooCommerce Blocks has loaded. However, we didn't properly bail out from firing it if the WooCommerce required version is not met.

This PR changes that so we only fire init and woocommerce_blocks_loaded if the version is met. I also scanned the rest of the code in that file to make sure we're not returning when we should be bailing.


### Testing steps
- Install WooCommerce 5.6.0 or earlier.
- Install WooCommerce Subscriptions, or AutomateWoo.
- Load this branch, the website should load fine without any fatal about `SchemaController` not being available.

### Changelog

> Fix fatal error when loading WooCommerce Blocks and one of its integration on an earlier version of WooCommerce Core.