### PR TITLE
Honor the `get_product_search_form` filter

### DIFF
--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -117,11 +117,14 @@ class ProductSearch extends AbstractBlock {
 			</div>
 		';
 
-		return sprintf(
-			'<div %s><form role="search" method="get" action="%s">%s</form></div>',
-			$wrapper_attributes,
-			esc_url( home_url( '/' ) ),
-			$label_markup . $field_markup
+		return apply_filters(
+			'get_product_search_form',
+			sprintf(
+				'<div %s><form role="search" method="get" action="%s">%s</form></div>',
+				$wrapper_attributes,
+				esc_url( home_url( '/' ) ),
+				$label_markup . $field_markup
+			)
 		);
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The legacy product search widget uses the template tag `get_product_search_form()` which allows plugins to modify the form through the `get_product_search_form` filter.

The product search block uses its own markup to render the form and no alternative filter is provided to allow plugins to modify the form output.

This causes a potential backward compatibility for users migrating from widgets to blocks.

This filter is useful, for example, for multilingual plugins like Polylang and WPML to, in fine, return search results in only one language.

#### Accessibility

No impact.

### Testing

#### Automated Tests

No impact.

<!-- If you can, add the appropriate labels -->

### Performance Impact

No impact.

