### PR TITLE
Prefix the search input id with wc- instead of wp-

### DIFF
--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -71,7 +71,7 @@ class ProductSearch extends AbstractBlock {
 			'after'
 		);
 
-		$input_id           = 'wp-block-search__input-' . ( ++$instance_id );
+		$input_id           = 'wc-block-search__input-' . ( ++$instance_id );
 		$wrapper_attributes = get_block_wrapper_attributes(
 			array(
 				'class' => implode(


### PR DESCRIPTION
I propose to change the search block input id to avoid a conflict with the WordPress search block, reported by the browser console: 
```
[DOM] Found 2 elements with non-unique id #wp-block-search__input-1: (More info: https://goo.gl/9p2vKq) 
<input type=​"search" id=​"wp-block-search__input-1" class=​"wp-block-search__input" name=​"s" value placeholder required>​
<input type=​"search" id=​"wp-block-search__input-1" class=​"wc-block-product-search__field" placeholder=​"Search products…" name=​"s">​
```

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Add a WordPress search block in a page
2. Add a Product search block to tha same page
3.  Go to frontend and open the browser tools console

<!-- If you can, add the appropriate labels -->

### Performance Impact

None
