### PR TITLE
Experiment: POC of rendering legacy Woo templates in a block for use with a block template.

### DIFF
--- a/assets/js/blocks/legacy/single-product/block.json
+++ b/assets/js/blocks/legacy/single-product/block.json
@@ -1,0 +1,17 @@
+{
+	"name": "woocommerce/legacy-single-product",
+	"version": "1.0.0",
+	"title": "Legacy Single Product",
+	"description": "Outputs the legacy single product view from php template.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false
+	},
+	"attributes": {},
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2
+}

--- a/assets/js/blocks/legacy/single-product/index.tsx
+++ b/assets/js/blocks/legacy/single-product/index.tsx
@@ -11,7 +11,6 @@ const Edit = ( { name } ) => {
 		</div>
 	);
 };
-console.log( metadata );
 registerFeaturePluginBlockType( metadata, {
 	title: metadata.title,
 	edit: Edit,

--- a/assets/js/blocks/legacy/single-product/index.tsx
+++ b/assets/js/blocks/legacy/single-product/index.tsx
@@ -1,0 +1,19 @@
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+import metadata from './block.json';
+import ServerSideRender from '@wordpress/server-side-render';
+import { useBlockProps } from '@wordpress/block-editor';
+
+const Edit = ( { name } ) => {
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<ServerSideRender block={ name } />
+		</div>
+	);
+};
+console.log( metadata );
+registerFeaturePluginBlockType( metadata, {
+	title: metadata.title,
+	edit: Edit,
+	save: () => null,
+} );

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -57,6 +57,9 @@ const blocks = {
 	'single-product': {
 		isExperimental: true,
 	},
+	'legacy-single-product': {
+		customDir: 'legacy/single-product',
+	},
 };
 
 // Returns the entries for each block given a relative path (ie: `index.js`,

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -156,16 +156,21 @@ abstract class AbstractBlock {
 	 * Registers the block type with WordPress.
 	 */
 	protected function register_block_type() {
+		$block_settings = [
+			'render_callback' => $this->get_block_type_render_callback(),
+			'editor_script'   => $this->get_block_type_editor_script( 'handle' ),
+			'editor_style'    => $this->get_block_type_editor_style(),
+			'style'           => $this->get_block_type_style(),
+			'attributes'      => $this->get_block_type_attributes(),
+			'supports'        => $this->get_block_type_supports(),
+
+		];
+		if ( isset( $this->api_version ) && '2' === $this->api_version ) {
+			$block_settings['api_version'] = 2;
+		}
 		register_block_type(
 			$this->get_block_type(),
-			array(
-				'render_callback' => $this->get_block_type_render_callback(),
-				'editor_script'   => $this->get_block_type_editor_script( 'handle' ),
-				'editor_style'    => $this->get_block_type_editor_style(),
-				'style'           => $this->get_block_type_style(),
-				'attributes'      => $this->get_block_type_attributes(),
-				'supports'        => $this->get_block_type_supports(),
-			)
+			$block_settings
 		);
 	}
 

--- a/src/BlockTypes/LegacySingleProduct.php
+++ b/src/BlockTypes/LegacySingleProduct.php
@@ -1,0 +1,41 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+class LegacySingleProduct extends AbstractDynamicBlock {
+	protected $block_name  = 'legacy-single-product';
+	protected $api_version = '2';
+
+	protected function render( $attributed, $content ) {
+		ob_start();
+		global $wp_query;
+		$original_query = $wp_query;
+		// using this to detect if in editor context
+		if ( ! is_singular( 'product' ) ) {
+			// hacky need to include frontend template hooks when in editor.
+			require_once WC_ABSPATH . 'includes/wc-template-functions.php';
+			require_once WC_ABSPATH . 'includes/wc-template-hooks.php';
+			// hacky need to remove notices because there's more dependencies in the notices output - probably could just do this in the editor context.
+			remove_action( 'woocommerce_before_single_product', 'woocommerce_output_all_notices', 10 );
+			// fudge a single product for previewing template.
+			$wp_query = new \WP_Query(
+				[
+					'posts_per_page'      => 1,
+					'post_type'           => 'product',
+					'post_status'         => 'publish',
+					'ignore_sticky_posts' => 1,
+					'no_found_rows'       => 1,
+
+				]
+			);
+		}
+			do_action( 'woocommerce_before_main_content' );
+		while ( have_posts() ) :
+			the_post();
+			wc_get_template_part( 'content', 'single-product' );
+		endwhile;
+		do_action( 'woocommerce_after_main_content' );
+			$wp_query = $original_query;
+			wp_reset_postdata();
+		return ob_get_clean();
+	}
+}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -154,6 +154,7 @@ final class BlockTypesController {
 			'FeaturedCategory',
 			'FeaturedProduct',
 			'HandpickedProducts',
+			'LegacySingleProduct',
 			'ProductBestSellers',
 			'ProductCategories',
 			'ProductCategory',


### PR DESCRIPTION
**Note: I just did this really quickly to avoid sinking too much time into it, so it isn't following any code style standards and is also very rough. This is for reference and not review or merge.**

One of the things that would be good to explore in providing support for block templates _now_ (as opposed to waiting for building multiple blocks for various Woo views), is to create temporary block wrappers over existing Woo Core templates and template parts for use in block templates and template parts. These block wrappers would essentially be used for encapsulating whatever granular elements of a template that can be and then only exposed for use in block templates (not in the default block picker). Potentially these special bridge blocks would be locked to certain templates.

The idea here is that we can just render the content server side using existing PHP code as a quicker way of bringing WooCommerce compatibility to block themes (and of use to merchants and extension developers) while we work longer term over enhancing the Store editor experience with new blocks to accommodate even more customizable layout and design.

As a proof of concept, I hacked together a `LegacySingleProductBlock` that encapsulates the `single-product.php` template (without the header and footer). This seems to work reasonably well.

![CleanShot 2021-10-04 at 04 57 03](https://user-images.githubusercontent.com/1429108/135828486-c8df14b1-49be-4e58-ab24-6d5da57ac00f.gif)

## To try this out on your WooCommerce test site (assuming you already have demo products etc setup):

1. Install and activate the Gutenberg plugin.
2. Create a build of Woo Blocks in this branch (`npm install & npm run build`);
2. Install a block theme (I did this with [Quadrat](https://github.com/Automattic/themes/tree/trunk/quadrat) - you'll need to install [BlockBase](https://github.com/Automattic/themes/tree/trunk/blockbase) too because Quadrat is a child theme). The theme will need to have `add_theme_support( 'woocommerce' )` defined in order for this to work on the frontend.
3. Create a `single-product.html` template in the theme (make sure it's in the right directory – `block-templates`) with the following content:

```html
<!-- wp:template-part {"slug":"header"} /-->
<!-- wp:woocommerce/legacy-single-product /-->
<!-- wp:template-part {"slug":"footer","className":"site-footer-container"} /-->
```

4. Load the `site-product` template in the site editor and you should see the block render the equivalent single product php template!
5. You can also add more blocks and save etc and then view things on the frontend.


## Caveats with this experiment.

- I didn't work on loading the styles in the block editor - so it's not a 1:1 view.
- I implemented a really hacky way to get a sample product show up for the block in the template editor context to account for  the reliance on the existing php code on the server expecting a populated `$wp_query` global for rendering the content.
- This revealed some difficulty there will be with rendering a good match for frontend view because of how and when certain hooks fire on the frontend. So this could impact things like:
    - extensions not injecting content in the editor. This could also impact things like extensions using jQuery or some other JavaScript code to manipulate layout/content after page load (which likely won't render in the editor context).
    - unexpected fatals because something hooks into an action or filter and implements a function that isn't loaded in the editor context.
- Might need to work out a way to disable fields and interactivity in the editor to prevent poor UX for the merchant in that context.
-  This feels pretty fragile and hacky. I'm on the fence about whether this is something that should be pursued or not. Likely any actual implementation would have to be with a narrower slice of templates as opposed to an entire file to help reduce the fragility.
- The experiment still requires the template to be defined in the theme, we’d want to work out how to have Woo provide the default block templates (should be fairly trivial).


