### PR TITLE
Add E2E test for Products by Tag block

### DIFF
--- a/tests/e2e/specs/backend/__fixtures__/product-tag.fixture.json
+++ b/tests/e2e/specs/backend/__fixtures__/product-tag.fixture.json
@@ -1,0 +1,1 @@
+{"title":"Products by Tag Block","pageContent":"<!-- wp:woocommerce/product-tag /-->"}

--- a/tests/e2e/specs/backend/product-tag.test.js
+++ b/tests/e2e/specs/backend/product-tag.test.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
+
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
+
+const block = {
+	name: 'Products by Tag',
+	slug: 'woocommerce/product-tag',
+	class: '.wc-block-product-tag',
+};
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'can be inserted more than once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 2 );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+} );


### PR DESCRIPTION
### Note

Currently, not every block is covered by e2e tests. This PR aims to add e2e tests for the Products by Tag block.

Part of #4643

### Testing

1. Check out this PR.
2. Run `npm run wp-env start && npm run test:e2e`.
3. The e2e test suite shows no failed tests.