### PR TITLE
Increase error message spacing

### DIFF
--- a/assets/js/base/context/providers/validation/components/validation-input-error/style.scss
+++ b/assets/js/base/context/providers/validation/components/validation-input-error/style.scss
@@ -6,7 +6,7 @@
 
 	> p {
 		margin: 0;
-		padding: 0;
+		padding: $gap-smallest 0 0 0;
 	}
 }
 


### PR DESCRIPTION
## Note

Currently, the spacing of error messages for required/invalid form fields is very narrow, which decreases the readability. This PR aims to increase the readability by increasing the spacing between the error message and the form fields.

Fixes #4865 


### Screenshots

<table>
<tr>
<td valign="top">Before:
<br><br>

![#4865-before](https://user-images.githubusercontent.com/3323310/136011622-785e353a-7144-422b-8123-7fe826b51139.png)
</td>
<td valign="top">After:
<br><br>

![#4865-after](https://user-images.githubusercontent.com/3323310/136012028-d5ed478e-9b36-4395-b5e1-a70932bf35ba.png)
</td>
</tr>
</table>

### Testing

### Manual Testing

1. Check out this PR.
2. Create a test page and add the checkout block to it.
3. Open the frontend in incognito mode.
4. Add a product to the cart and go to the checkout.
5. Click on `Place Order` without filling out the form fields.
6. See that the error message spacing increased.

### Changelog

> Fix: Increase the spacing between the error message and the form fields to improve the readability.
