### PR TITLE
Handle translations in lazy loaded files by injecting them into the page

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -178,6 +178,11 @@ const getMainConfig = ( options = {} ) => {
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksJsonp',
+			// Putting a cache buster in the query string is not documented, but confirmed by the author of Webpack.
+			// `But better use the hash in filename and use no query parameter.`
+			// The reason probably is because it's not the best way to do cache busting.
+			// More information: https://github.com/webpack/webpack/issues/2329
+			chunkFilename: `[name].chunk.js?ver=[contenthash]`,
 		},
 		module: {
 			rules: [
@@ -285,6 +290,11 @@ const getFrontConfig = ( options = {} ) => {
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksJsonp',
+			// Putting a cache buster in the query string is not documented, but confirmed by the author of Webpack.
+			// `But better use the hash in filename and use no query parameter.`
+			// The reason probably is because it's not the best way to do cache busting.
+			// More information: https://github.com/webpack/webpack/issues/2329
+			chunkFilename: `[name]-frontend.chunk.js?ver=[contenthash]`,
 		},
 		module: {
 			rules: [

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -182,7 +182,7 @@ const getMainConfig = ( options = {} ) => {
 			// `But better use the hash in filename and use no query parameter.`
 			// The reason probably is because it's not the best way to do cache busting.
 			// More information: https://github.com/webpack/webpack/issues/2329
-			chunkFilename: `[name].chunk.js?ver=[contenthash]`,
+			chunkFilename: `[name]${ fileSuffix }.chunk.js?ver=[contenthash]`,
 		},
 		module: {
 			rules: [
@@ -294,7 +294,7 @@ const getFrontConfig = ( options = {} ) => {
 			// `But better use the hash in filename and use no query parameter.`
 			// The reason probably is because it's not the best way to do cache busting.
 			// More information: https://github.com/webpack/webpack/issues/2329
-			chunkFilename: `[name]-frontend.chunk.js?ver=[contenthash]`,
+			chunkFilename: `[name]-frontend${ fileSuffix }.chunk.js?ver=[contenthash]`,
 		},
 		module: {
 			rules: [

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -178,11 +178,6 @@ const getMainConfig = ( options = {} ) => {
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksJsonp',
-			// Putting a cache buster in the query string is not documented, but confirmed by the author of Webpack.
-			// `But better use the hash in filename and use no query parameter.`
-			// The reason probably is because it's not the best way to do cache busting.
-			// More information: https://github.com/webpack/webpack/issues/2329
-			chunkFilename: `[name]${ fileSuffix }.chunk.js?ver=[contenthash]`,
 		},
 		module: {
 			rules: [
@@ -290,11 +285,6 @@ const getFrontConfig = ( options = {} ) => {
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
 			jsonpFunction: 'webpackWcBlocksJsonp',
-			// Putting a cache buster in the query string is not documented, but confirmed by the author of Webpack.
-			// `But better use the hash in filename and use no query parameter.`
-			// The reason probably is because it's not the best way to do cache busting.
-			// More information: https://github.com/webpack/webpack/issues/2329
-			chunkFilename: `[name]-frontend${ fileSuffix }.chunk.js?ver=[contenthash]`,
 		},
 		module: {
 			rules: [

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -153,6 +153,26 @@ abstract class AbstractBlock {
 	}
 
 	/**
+	 * Injects Chunk Translations into the page so translations work for lazy loaded components.
+	 *
+	 * The chunk names are defined when creating lazy loaded components using webpackChunkName. The '.chunk'
+	 * suffix comes from our webpack-config where chunkFilename is defined.
+	 *
+	 * A random temporary script handle is generated to load translations, and then they are inserted inline before the
+	 * main script handle.
+	 *
+	 * @param string[] $chunks Array of chunk names.
+	 */
+	protected function register_chunk_translations( $chunks ) {
+		foreach ( $chunks as $chunk ) {
+			$chunk_name = $chunk . '.chunk';
+			$this->asset_api->register_script( $chunk_name, $this->asset_api->get_block_asset_build_path( $chunk_name ), [], true );
+			wp_add_inline_script( $this->get_block_type_script( 'handle' ), wp_scripts()->print_translations( $chunk_name, false ), 'before' );
+			wp_deregister_script( $chunk_name );
+		}
+	}
+
+	/**
 	 * Registers the block type with WordPress.
 	 */
 	protected function register_block_type() {

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -158,17 +158,18 @@ abstract class AbstractBlock {
 	 * The chunk names are defined when creating lazy loaded components using webpackChunkName. The '.chunk'
 	 * suffix comes from our webpack-config where chunkFilename is defined.
 	 *
-	 * A random temporary script handle is generated to load translations, and then they are inserted inline before the
-	 * main script handle.
-	 *
 	 * @param string[] $chunks Array of chunk names.
 	 */
 	protected function register_chunk_translations( $chunks ) {
 		foreach ( $chunks as $chunk ) {
-			$chunk_name = $chunk . '.chunk';
-			$this->asset_api->register_script( $chunk_name, $this->asset_api->get_block_asset_build_path( $chunk_name ), [], true );
-			wp_add_inline_script( $this->get_block_type_script( 'handle' ), wp_scripts()->print_translations( $chunk_name, false ), 'before' );
-			wp_deregister_script( $chunk_name );
+			$handle = 'wc-blocks-' . $chunk . '-chunk';
+			$this->asset_api->register_script( $handle, $this->asset_api->get_block_asset_build_path( $chunk . '.chunk' ), [], true );
+			wp_add_inline_script(
+				$this->get_block_type_script( 'handle' ),
+				wp_scripts()->print_translations( $handle, false ),
+				'before'
+			);
+			wp_deregister_script( $handle );
 		}
 	}
 

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -155,15 +155,14 @@ abstract class AbstractBlock {
 	/**
 	 * Injects Chunk Translations into the page so translations work for lazy loaded components.
 	 *
-	 * The chunk names are defined when creating lazy loaded components using webpackChunkName. The '.chunk'
-	 * suffix comes from our webpack-config where chunkFilename is defined.
+	 * The chunk names are defined when creating lazy loaded components using webpackChunkName.
 	 *
 	 * @param string[] $chunks Array of chunk names.
 	 */
 	protected function register_chunk_translations( $chunks ) {
 		foreach ( $chunks as $chunk ) {
 			$handle = 'wc-blocks-' . $chunk . '-chunk';
-			$this->asset_api->register_script( $handle, $this->asset_api->get_block_asset_build_path( $chunk . '.chunk' ), [], true );
+			$this->asset_api->register_script( $handle, $this->asset_api->get_block_asset_build_path( $chunk ), [], true );
 			wp_add_inline_script(
 				$this->get_block_type_script( 'handle' ),
 				wp_scripts()->print_translations( $handle, false ),

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -28,4 +28,29 @@ class AllProducts extends AbstractBlock {
 		$this->asset_data_registry->add( 'max_rows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
 		$this->asset_data_registry->add( 'default_rows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
 	}
+
+	/**
+	 * Register script and style assets for the block type before it is registered.
+	 *
+	 * This registers the scripts; it does not enqueue them.
+	 */
+	protected function register_block_type_assets() {
+		parent::register_block_type_assets();
+		$this->register_chunk_translations(
+			[
+				'atomic-block-components/price',
+				'atomic-block-components/image',
+				'atomic-block-components/title',
+				'atomic-block-components/rating',
+				'atomic-block-components/button',
+				'atomic-block-components/summary',
+				'atomic-block-components/sale-badge',
+				'atomic-block-components/sku',
+				'atomic-block-components/category-list',
+				'atomic-block-components/tag-list',
+				'atomic-block-components/stock-indicator',
+				'atomic-block-components/add-to-cart',
+			]
+		);
+	}
 }


### PR DESCRIPTION
This is an alternative, simpler fix for #4019 (replaces https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4392) inspired by https://github.com/Automattic/jetpack/pull/20926.

https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4392 worked, however, it introduced complex webpack plugins, the need to calculate translation hashes to get the correct translation files, and ultimately I think would be difficult to maintain without a more in-depth knowledge of webpack.

Therefore, I've created this alternative approach which injects translations before the blocks script is output to the page. 

Where #4392 required a list of `$translated_chunks`, this one just needs a list of `webpackChunkName` as defined when initializing the lazy components. Everything else is derived from that.

Fixes #4019
Closes #4392

### Screenshots

![Screenshot 2021-10-05 at 14 17 49](https://user-images.githubusercontent.com/90977/136031320-425348d9-232f-44b7-b372-072225ff91f8.png)

### Testing

1. Switch to Brailian Portuguese translation.
2. Find the file wp-content/languages/woo-gutenberg-products-block-pt_BR-e330894bce4582a6969137e88a76105c.json
3. Note that `e330894bce4582a6969137e88a76105c` is generated from the path to the chunk script. This PR changes the chunk name, so change `e330894bce4582a6969137e88a76105c` to `bff28bb492f099ecaf7494b1201c4e46`. This is the md5 hash of `build/atomic-block-components/sale-badge.chunk.js`.
4. View the all products block. Confirm sale badges are translated like in the screenshot above.

### Changelog

> Fixed string translations within the All Products Block.
