### PR TITLE
Improve the engines support in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,8 +182,8 @@
 		"zenhub-api": "0.2.0"
 	},
 	"engines": {
-		"node": "12.22.6",
-		"npm": "6.14.14"
+		"node": ">=12.0.0",
+		"npm": ">=6.14.0 <7"
 	},
 	"dependencies": {
 		"@stripe/react-stripe-js": "1.4.1",


### PR DESCRIPTION
This is a better representation of the node and npm version support for Woo Blocks (more notably the NPM 7 exclusion) which can help new contributors coming into the repository.

This has no impact on actual builds for the project and is a signal for developers (and automations).
