### PR TITLE
Add a label to the textarea from the editor view of the Product search block

### DIFF
--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -80,13 +80,25 @@ const Edit = ( {
 			</InspectorControls>
 			<div className={ classes }>
 				{ !! hasLabel && (
-					<PlainText
-						className="wc-block-product-search__label"
-						value={ label }
-						onChange={ ( value ) =>
-							setAttributes( { label: value } )
-						}
-					/>
+					<>
+						<label
+							className="screen-reader-text"
+							htmlFor="wc-block-product-search__label"
+						>
+							{ __(
+								'Search Label',
+								'woo-gutenberg-products-block'
+							) }
+						</label>
+						<PlainText
+							className="wc-block-product-search__label"
+							id="wc-block-product-search__label"
+							value={ label }
+							onChange={ ( value ) =>
+								setAttributes( { label: value } )
+							}
+						/>
+					</>
 				) }
 				<div className="wc-block-product-search__fields">
 					<TextControl

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -83,6 +83,7 @@ const Edit = ( {
 					<>
 						<label
 							className="screen-reader-text"
+							aria-hidden="true"
 							htmlFor="wc-block-product-search__label"
 						>
 							{ __(

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -83,7 +83,6 @@ const Edit = ( {
 					<>
 						<label
 							className="screen-reader-text"
-							aria-hidden="true"
 							htmlFor="wc-block-product-search__label"
 						>
 							{ __(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixes #1682  by adding a label field on top of the Label textarea edit field from the Product Search block.

The label text is announced when moving over the textarea field, so to avoid a duplicate announcement from the label tag, a combination of `className="screen-reader-text" aria-hidden="true"` was used on the label tag.

<!-- Reference any related issues or PRs here -->
Fixes #1682 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

<img width="1017" alt="Screenshot 2021-10-06 at 14 53 51" src="https://user-images.githubusercontent.com/537751/136197397-0b8a8dfe-3ac1-4a52-9049-91f8e150510a.png">
<img width="767" alt="Screenshot 2021-10-06 at 14 58 47" src="https://user-images.githubusercontent.com/537751/136197986-11a2c7d8-e623-4a82-90e3-ce6bc6dd15ff.png">


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. create a post and add the search block
2. start Screen reader
3. Move over search label block

### Changelog

> Improve accessibility for the editor view of the Product search block
