### PR TITLE
Convert product elements shared config to TypeScript

### DIFF
--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -27,7 +27,14 @@ const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 		? undefined
 		: [ '@woocommerce/all-products', '@woocommerce/single-product' ],
 	save,
-	deprecated: [],
+	deprecated: [
+		{
+			attributes: {},
+			save(): null {
+				return null;
+			},
+		},
+	],
 };
 
 export default sharedConfig;

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -12,6 +12,7 @@ import save from '../save';
 
 /**
  * Holds default config for this collection of blocks.
+ * attributes and title are omitted here as these are added on an individual block level.
  */
 const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	category: 'woocommerce-product-elements',

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, grid } from '@woocommerce/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
-import { BlockConfiguration } from '@wordpress/blocks';
+import type { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Icon, grid } from '@woocommerce/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { BlockConfiguration } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -12,7 +13,7 @@ import save from '../save';
 /**
  * Holds default config for this collection of blocks.
  */
-export default {
+const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	category: 'woocommerce-product-elements',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	icon: {
@@ -23,12 +24,10 @@ export default {
 		html: false,
 	},
 	parent: isExperimentalBuild()
-		? null
+		? undefined
 		: [ '@woocommerce/all-products', '@woocommerce/single-product' ],
 	save,
-	deprecated: [
-		{
-			save() {},
-		},
-	],
+	deprecated: [],
 };
+
+export default sharedConfig;


### PR DESCRIPTION
#### Description

Converting the product elements shared config from JS to TypeScript.

This PR simply extracts the shared config change suggested in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4891 into its own PR so it can be reviewed independently. We have a few product element PRs coming up that depend on this shared config change.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

### Manual Testing

Please regression test this component to ensure it is still working as expected. You can also do this by comparing the behavior to that on the `trunk` branch.

1. Check out the branch and check that the compiler reports no TS errors associated with the converted files.
2. Add block(s) to your page which uses product elements Such as the `Single Product` or `All Products` block for example (the more variety the better).
2. Test no regressions with the product elements' behavior have been introduced.
