### PR TITLE
Convert CategoryList to TypeScript

### DIFF
--- a/assets/js/atomic/blocks/product-elements/category-list/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/attributes.ts
@@ -1,4 +1,4 @@
-export const blockAttributes = {
+export const blockAttributes: Record< string, Record< string, unknown > > = {
 	productId: {
 		type: 'number',
 		default: 0,

--- a/assets/js/atomic/blocks/product-elements/category-list/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/category-list/block.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
 	useInnerBlockLayoutContext,
@@ -10,11 +9,15 @@ import {
 } from '@woocommerce/shared-context';
 import { isEmpty } from 'lodash';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
+import { HTMLAttributes } from 'react';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import { Attributes } from './types';
+
+type Props = Attributes & HTMLAttributes< HTMLDivElement >;
 
 /**
  * Product Category Block Component.
@@ -23,7 +26,7 @@ import './style.scss';
  * @param {string} [props.className] CSS Class name for the component.
  * @return {*} The component.
  */
-const Block = ( { className } ) => {
+const Block = ( { className }: Props ): JSX.Element | null => {
 	const { parentClassName } = useInnerBlockLayoutContext();
 	const { product } = useProductDataContext();
 
@@ -55,10 +58,6 @@ const Block = ( { className } ) => {
 			</ul>
 		</div>
 	);
-};
-
-Block.propTypes = {
-	className: PropTypes.string,
 };
 
 export default withProductDataContext( Block );

--- a/assets/js/atomic/blocks/product-elements/category-list/constants.tsx
+++ b/assets/js/atomic/blocks/product-elements/category-list/constants.tsx
@@ -4,12 +4,12 @@
 import { __ } from '@wordpress/i18n';
 import { folder, Icon } from '@woocommerce/icons';
 
-export const BLOCK_TITLE = __(
+export const BLOCK_TITLE: string = __(
 	'Product Category List',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ folder } />;
-export const BLOCK_DESCRIPTION = __(
+export const BLOCK_ICON: JSX.Element = <Icon srcElement={ folder } />;
+export const BLOCK_DESCRIPTION: string = __(
 	'Display a list of categories belonging to a product.',
 	'woo-gutenberg-products-block'
 );

--- a/assets/js/atomic/blocks/product-elements/category-list/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/category-list/edit.tsx
@@ -11,8 +11,13 @@ import EditProductLink from '@woocommerce/editor-components/edit-product-link';
 import Block from './block';
 import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
+import { Attributes } from './types';
 
-const Edit = ( { attributes } ) => {
+interface Props {
+	attributes: Attributes;
+}
+
+const Edit = ( { attributes }: Props ): JSX.Element => {
 	return (
 		<>
 			<EditProductLink />

--- a/assets/js/atomic/blocks/product-elements/category-list/index.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/index.ts
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import { registerExperimentalBlockType } from '@woocommerce/block-settings';
+import { BlockConfiguration } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import sharedConfig from '../shared/config';
+import sharedConfig from './../shared/config';
 import attributes from './attributes';
 import edit from './edit';
 import {
@@ -15,7 +16,8 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-const blockConfig = {
+const blockConfig: BlockConfiguration = {
+	...sharedConfig,
 	title,
 	description,
 	icon: {
@@ -26,7 +28,7 @@ const blockConfig = {
 	edit,
 };
 
-registerExperimentalBlockType( 'woocommerce/product-category-list', {
-	...sharedConfig,
-	...blockConfig,
-} );
+registerExperimentalBlockType(
+	'woocommerce/product-category-list',
+	blockConfig
+);

--- a/assets/js/atomic/blocks/product-elements/category-list/types.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/types.ts
@@ -1,3 +1,3 @@
-export interface Attributes extends HTMLElement {
+export interface Attributes {
 	productId: number;
 }

--- a/assets/js/atomic/blocks/product-elements/category-list/types.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/types.ts
@@ -1,0 +1,3 @@
+export interface Attributes extends HTMLElement {
+	productId: number;
+}

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, grid } from '@woocommerce/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
 import type { BlockConfiguration } from '@wordpress/blocks';
+
 /**
  * Internal dependencies
  */

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { Icon, grid } from '@woocommerce/icons';
 import { isExperimentalBuild } from '@woocommerce/block-settings';
 import type { BlockConfiguration } from '@wordpress/blocks';
-
 /**
  * Internal dependencies
  */

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -52,6 +52,7 @@
 			"@woocommerce/knobs": [ "storybook/knobs" ],
 			"@woocommerce/settings": [ "assets/js/settings/shared" ],
 			"@woocommerce/shared-context": [ "assets/js/shared/context" ],
+		  	"@woocommerce/shared-hocs": [ "assets/js/shared/hocs" ],
 			"@woocommerce/type-defs/*": [ "assets/js/types/type-defs/*" ],
 			"@woocommerce/types": [ "assets/js/types" ]
 		}


### PR DESCRIPTION
#### Description

Converting the `<CategoryList />` component from JS to TypeScript.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

Please regression test this component to ensure it is still working as expected. You can also do this by comparing the behaviour to that on the `trunk` branch.

1. Check out and build this branch
2. Add `Single Product` block to your page
2. See the "Product Category" block within the Single Product block and observe its working as expected.

### Changelog

> CategoryList: Convert to TypeScript
