### PR TITLE
#4625 fixing product categories list block display

### DIFF
--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -80,13 +80,25 @@ const Edit = ( {
 			</InspectorControls>
 			<div className={ classes }>
 				{ !! hasLabel && (
-					<PlainText
-						className="wc-block-product-search__label"
-						value={ label }
-						onChange={ ( value ) =>
-							setAttributes( { label: value } )
-						}
-					/>
+					<>
+						<label
+							className="screen-reader-text"
+							htmlFor="wc-block-product-search__label"
+						>
+							{ __(
+								'Search Label',
+								'woo-gutenberg-products-block'
+							) }
+						</label>
+						<PlainText
+							className="wc-block-product-search__label"
+							id="wc-block-product-search__label"
+							value={ label }
+							onChange={ ( value ) =>
+								setAttributes( { label: value } )
+							}
+						/>
+					</>
 				) }
 				<div className="wc-block-product-search__fields">
 					<TextControl

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -83,6 +83,7 @@ const Edit = ( {
 					<>
 						<label
 							className="screen-reader-text"
+							aria-hidden="true"
 							htmlFor="wc-block-product-search__label"
 						>
 							{ __(

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -1,144 +1,144 @@
 /**
  * External dependencies
  */
- import { __ } from '@wordpress/i18n';
- import classnames from 'classnames';
- import PropTypes from 'prop-types';
- import { InspectorControls, PlainText } from '@wordpress/block-editor';
- import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
- import { withInstanceId } from '@wordpress/compose';
- import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { InspectorControls, PlainText } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
 
- /**
-  * Internal dependencies
-  */
- import './editor.scss';
- import './style.scss';
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import './style.scss';
 
- /**
-  * Component displaying a product search form.
-  *
-  * @param {Object} props Incoming props for the component.
-  * @param {Object} props.attributes Incoming block attributes.
-  * @param {string} props.attributes.label
-  * @param {string} props.attributes.placeholder
-  * @param {string} props.attributes.formId
-  * @param {string} props.attributes.className
-  * @param {boolean} props.attributes.hasLabel
-  * @param {string} props.attributes.align
-  * @param {string} props.instanceId
-  * @param {function(any):any} props.setAttributes Setter for block attributes.
-  */
- const Edit = ( {
-	 attributes: { label, placeholder, formId, className, hasLabel, align },
-	 instanceId,
-	 setAttributes,
- } ) => {
-	 const classes = classnames(
-		 'wc-block-product-search',
-		 align ? 'align' + align : '',
-		 className
-	 );
+/**
+ * Component displaying a product search form.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {Object} props.attributes Incoming block attributes.
+ * @param {string} props.attributes.label
+ * @param {string} props.attributes.placeholder
+ * @param {string} props.attributes.formId
+ * @param {string} props.attributes.className
+ * @param {boolean} props.attributes.hasLabel
+ * @param {string} props.attributes.align
+ * @param {string} props.instanceId
+ * @param {function(any):any} props.setAttributes Setter for block attributes.
+ */
+const Edit = ( {
+	attributes: { label, placeholder, formId, className, hasLabel, align },
+	instanceId,
+	setAttributes,
+} ) => {
+	const classes = classnames(
+		'wc-block-product-search',
+		align ? 'align' + align : '',
+		className
+	);
 
-	 useEffect( () => {
-		 if ( ! formId ) {
-			 setAttributes( {
-				 formId: `wc-block-product-search-${ instanceId }`,
-			 } );
-		 }
-	 }, [ formId, setAttributes, instanceId ] );
+	useEffect( () => {
+		if ( ! formId ) {
+			setAttributes( {
+				formId: `wc-block-product-search-${ instanceId }`,
+			} );
+		}
+	}, [ formId, setAttributes, instanceId ] );
 
-	 return (
-		 <>
-			 <InspectorControls key="inspector">
-				 <PanelBody
-					 title={ __( 'Content', 'woo-gutenberg-products-block' ) }
-					 initialOpen
-				 >
-					 <ToggleControl
-						 label={ __(
-							 'Show search field label',
-							 'woo-gutenberg-products-block'
-						 ) }
-						 help={
-							 hasLabel
-								 ? __(
-										 'Label is visible.',
-										 'woo-gutenberg-products-block'
-								   )
-								 : __(
-										 'Label is hidden.',
-										 'woo-gutenberg-products-block'
-								   )
-						 }
-						 checked={ hasLabel }
-						 onChange={ () =>
-							 setAttributes( { hasLabel: ! hasLabel } )
-						 }
-					 />
-				 </PanelBody>
-			 </InspectorControls>
-			 <div className={ classes }>
-				 { !! hasLabel && (
-					 <PlainText
-						 className="wc-block-product-search__label"
-						 value={ label }
-						 onChange={ ( value ) =>
-							 setAttributes( { label: value } )
-						 }
-					 />
-				 ) }
-				 <div className="wc-block-product-search__fields">
-					 <TextControl
-						 className="wc-block-product-search__field input-control"
-						 value={ placeholder }
-						 onChange={ ( value ) =>
-							 setAttributes( { placeholder: value } )
-						 }
-					 />
-					 <button
-						 type="submit"
-						 className="wc-block-product-search__button"
-						 label={ __( 'Search', 'woo-gutenberg-products-block' ) }
-						 onClick={ ( e ) => e.preventDefault() }
-						 tabIndex="-1"
-					 >
-						 <svg
-							 aria-hidden="true"
-							 role="img"
-							 focusable="false"
-							 className="dashicon dashicons-arrow-right-alt2"
-							 xmlns="http://www.w3.org/2000/svg"
-							 width="20"
-							 height="20"
-							 viewBox="0 0 20 20"
-						 >
-							 <path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
-						 </svg>
-					 </button>
-				 </div>
-			 </div>
-		 </>
-	 );
- };
+	return (
+		<>
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<ToggleControl
+						label={ __(
+							'Show search field label',
+							'woo-gutenberg-products-block'
+						) }
+						help={
+							hasLabel
+								? __(
+										'Label is visible.',
+										'woo-gutenberg-products-block'
+								  )
+								: __(
+										'Label is hidden.',
+										'woo-gutenberg-products-block'
+								  )
+						}
+						checked={ hasLabel }
+						onChange={ () =>
+							setAttributes( { hasLabel: ! hasLabel } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div className={ classes }>
+				{ !! hasLabel && (
+					<PlainText
+						className="wc-block-product-search__label"
+						value={ label }
+						onChange={ ( value ) =>
+							setAttributes( { label: value } )
+						}
+					/>
+				) }
+				<div className="wc-block-product-search__fields">
+					<TextControl
+						className="wc-block-product-search__field input-control"
+						value={ placeholder }
+						onChange={ ( value ) =>
+							setAttributes( { placeholder: value } )
+						}
+					/>
+					<button
+						type="submit"
+						className="wc-block-product-search__button"
+						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
+						onClick={ ( e ) => e.preventDefault() }
+						tabIndex="-1"
+					>
+						<svg
+							aria-hidden="true"
+							role="img"
+							focusable="false"
+							className="dashicon dashicons-arrow-right-alt2"
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 20 20"
+						>
+							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
+						</svg>
+					</button>
+				</div>
+			</div>
+		</>
+	);
+};
 
- Edit.propTypes = {
-	 /**
-	  * The attributes for this block.
-	  */
-	 attributes: PropTypes.object.isRequired,
-	 /**
-	  * A unique ID for identifying the label for the select dropdown.
-	  */
-	 instanceId: PropTypes.number,
-	 /**
-	  * Whether it's in the editor or frontend display.
-	  */
-	 isEditor: PropTypes.bool,
-	 /**
-	  * A callback to update attributes.
-	  */
-	 setAttributes: PropTypes.func,
- };
+Edit.propTypes = {
+	/**
+	 * The attributes for this block.
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * A unique ID for identifying the label for the select dropdown.
+	 */
+	instanceId: PropTypes.number,
+	/**
+	 * Whether it's in the editor or frontend display.
+	 */
+	isEditor: PropTypes.bool,
+	/**
+	 * A callback to update attributes.
+	 */
+	setAttributes: PropTypes.func,
+};
 
- export default withInstanceId( Edit );
+export default withInstanceId( Edit );

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -1,157 +1,144 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import classnames from 'classnames';
-import PropTypes from 'prop-types';
-import { InspectorControls, PlainText } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
-import { withInstanceId } from '@wordpress/compose';
-import { useEffect } from '@wordpress/element';
+ import { __ } from '@wordpress/i18n';
+ import classnames from 'classnames';
+ import PropTypes from 'prop-types';
+ import { InspectorControls, PlainText } from '@wordpress/block-editor';
+ import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
+ import { withInstanceId } from '@wordpress/compose';
+ import { useEffect } from '@wordpress/element';
 
-/**
- * Internal dependencies
- */
-import './editor.scss';
-import './style.scss';
+ /**
+  * Internal dependencies
+  */
+ import './editor.scss';
+ import './style.scss';
 
-/**
- * Component displaying a product search form.
- *
- * @param {Object} props Incoming props for the component.
- * @param {Object} props.attributes Incoming block attributes.
- * @param {string} props.attributes.label
- * @param {string} props.attributes.placeholder
- * @param {string} props.attributes.formId
- * @param {string} props.attributes.className
- * @param {boolean} props.attributes.hasLabel
- * @param {string} props.attributes.align
- * @param {string} props.instanceId
- * @param {function(any):any} props.setAttributes Setter for block attributes.
- */
-const Edit = ( {
-	attributes: { label, placeholder, formId, className, hasLabel, align },
-	instanceId,
-	setAttributes,
-} ) => {
-	const classes = classnames(
-		'wc-block-product-search',
-		align ? 'align' + align : '',
-		className
-	);
+ /**
+  * Component displaying a product search form.
+  *
+  * @param {Object} props Incoming props for the component.
+  * @param {Object} props.attributes Incoming block attributes.
+  * @param {string} props.attributes.label
+  * @param {string} props.attributes.placeholder
+  * @param {string} props.attributes.formId
+  * @param {string} props.attributes.className
+  * @param {boolean} props.attributes.hasLabel
+  * @param {string} props.attributes.align
+  * @param {string} props.instanceId
+  * @param {function(any):any} props.setAttributes Setter for block attributes.
+  */
+ const Edit = ( {
+	 attributes: { label, placeholder, formId, className, hasLabel, align },
+	 instanceId,
+	 setAttributes,
+ } ) => {
+	 const classes = classnames(
+		 'wc-block-product-search',
+		 align ? 'align' + align : '',
+		 className
+	 );
 
-	useEffect( () => {
-		if ( ! formId ) {
-			setAttributes( {
-				formId: `wc-block-product-search-${ instanceId }`,
-			} );
-		}
-	}, [ formId, setAttributes, instanceId ] );
+	 useEffect( () => {
+		 if ( ! formId ) {
+			 setAttributes( {
+				 formId: `wc-block-product-search-${ instanceId }`,
+			 } );
+		 }
+	 }, [ formId, setAttributes, instanceId ] );
 
-	return (
-		<>
-			<InspectorControls key="inspector">
-				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
-					initialOpen
-				>
-					<ToggleControl
-						label={ __(
-							'Show search field label',
-							'woo-gutenberg-products-block'
-						) }
-						help={
-							hasLabel
-								? __(
-										'Label is visible.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Label is hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
-						checked={ hasLabel }
-						onChange={ () =>
-							setAttributes( { hasLabel: ! hasLabel } )
-						}
-					/>
-				</PanelBody>
-			</InspectorControls>
-			<div className={ classes }>
-				{ !! hasLabel && (
-					<>
-						<label
-							className="screen-reader-text"
-							aria-hidden="true"
-							htmlFor="wc-block-product-search__label"
-						>
-							{ __(
-								'Search Label',
-								'woo-gutenberg-products-block'
-							) }
-						</label>
-						<PlainText
-							className="wc-block-product-search__label"
-							id="wc-block-product-search__label"
-							value={ label }
-							onChange={ ( value ) =>
-								setAttributes( { label: value } )
-							}
-						/>
-					</>
-				) }
-				<div className="wc-block-product-search__fields">
-					<TextControl
-						className="wc-block-product-search__field input-control"
-						value={ placeholder }
-						onChange={ ( value ) =>
-							setAttributes( { placeholder: value } )
-						}
-					/>
-					<button
-						type="submit"
-						className="wc-block-product-search__button"
-						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
-						onClick={ ( e ) => e.preventDefault() }
-						tabIndex="-1"
-					>
-						<svg
-							aria-hidden="true"
-							role="img"
-							focusable="false"
-							className="dashicon dashicons-arrow-right-alt2"
-							xmlns="http://www.w3.org/2000/svg"
-							width="20"
-							height="20"
-							viewBox="0 0 20 20"
-						>
-							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
-						</svg>
-					</button>
-				</div>
-			</div>
-		</>
-	);
-};
+	 return (
+		 <>
+			 <InspectorControls key="inspector">
+				 <PanelBody
+					 title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					 initialOpen
+				 >
+					 <ToggleControl
+						 label={ __(
+							 'Show search field label',
+							 'woo-gutenberg-products-block'
+						 ) }
+						 help={
+							 hasLabel
+								 ? __(
+										 'Label is visible.',
+										 'woo-gutenberg-products-block'
+								   )
+								 : __(
+										 'Label is hidden.',
+										 'woo-gutenberg-products-block'
+								   )
+						 }
+						 checked={ hasLabel }
+						 onChange={ () =>
+							 setAttributes( { hasLabel: ! hasLabel } )
+						 }
+					 />
+				 </PanelBody>
+			 </InspectorControls>
+			 <div className={ classes }>
+				 { !! hasLabel && (
+					 <PlainText
+						 className="wc-block-product-search__label"
+						 value={ label }
+						 onChange={ ( value ) =>
+							 setAttributes( { label: value } )
+						 }
+					 />
+				 ) }
+				 <div className="wc-block-product-search__fields">
+					 <TextControl
+						 className="wc-block-product-search__field input-control"
+						 value={ placeholder }
+						 onChange={ ( value ) =>
+							 setAttributes( { placeholder: value } )
+						 }
+					 />
+					 <button
+						 type="submit"
+						 className="wc-block-product-search__button"
+						 label={ __( 'Search', 'woo-gutenberg-products-block' ) }
+						 onClick={ ( e ) => e.preventDefault() }
+						 tabIndex="-1"
+					 >
+						 <svg
+							 aria-hidden="true"
+							 role="img"
+							 focusable="false"
+							 className="dashicon dashicons-arrow-right-alt2"
+							 xmlns="http://www.w3.org/2000/svg"
+							 width="20"
+							 height="20"
+							 viewBox="0 0 20 20"
+						 >
+							 <path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
+						 </svg>
+					 </button>
+				 </div>
+			 </div>
+		 </>
+	 );
+ };
 
-Edit.propTypes = {
-	/**
-	 * The attributes for this block.
-	 */
-	attributes: PropTypes.object.isRequired,
-	/**
-	 * A unique ID for identifying the label for the select dropdown.
-	 */
-	instanceId: PropTypes.number,
-	/**
-	 * Whether it's in the editor or frontend display.
-	 */
-	isEditor: PropTypes.bool,
-	/**
-	 * A callback to update attributes.
-	 */
-	setAttributes: PropTypes.func,
-};
+ Edit.propTypes = {
+	 /**
+	  * The attributes for this block.
+	  */
+	 attributes: PropTypes.object.isRequired,
+	 /**
+	  * A unique ID for identifying the label for the select dropdown.
+	  */
+	 instanceId: PropTypes.number,
+	 /**
+	  * Whether it's in the editor or frontend display.
+	  */
+	 isEditor: PropTypes.bool,
+	 /**
+	  * A callback to update attributes.
+	  */
+	 setAttributes: PropTypes.func,
+ };
 
-export default withInstanceId( Edit );
+ export default withInstanceId( Edit );

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -256,7 +256,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		foreach ( $categories as $category ) {
 			$output .= '
 				<option value="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">
-					' . str_repeat( '-', $depth ) . '
+					' . str_repeat( '&minus;', $depth ) . '
 					' . esc_html( $category->name ) . '
 					' . $this->getCount( $category, $attributes ) . '
 				</option>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes #4625 product categories list block display by HTML encoding the minus sign, which is the hierarchy prefix.

<!-- Reference any related issues or PRs here -->
Fixes #4625

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
<img width="677" alt="Screenshot 2021-10-07 at 14 29 24" src="https://user-images.githubusercontent.com/537751/136376225-5201a1d5-5052-4479-9718-e64211fcde07.png">

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Create 4 WooCommerce product categories, each one nested under the previous one created, like follows:
 - Level 1
   - Level 2
     - Level 3
       - Level 4
2. Add a product to the last category
3. To a page, add the block Product Categories List
4. Under the block settings > List settings > Display style, pick "Dropdown"
5. Again under the block settings > Content, switch On "Show hierarchy"
6. Save and view page


<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> fixed the Product Category List Block frontend hierarchy display by HTML encoding the hierarchy prefix
