### PR TITLE
Add e2e tests for Product Categories List

### DIFF
--- a/tests/e2e/config/custom-matchers/__fixtures__/product-categories-list.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/product-categories-list.fixture.json
@@ -1,0 +1,1 @@
+{"title":"Product Categories List Block","pageContent":"<!-- wp:woocommerce/product-categories /-->"}

--- a/tests/e2e/specs/backend/product-categories.test.js
+++ b/tests/e2e/specs/backend/product-categories.test.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
+
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
+
+const block = {
+	name: 'Product Categories List',
+	slug: 'woocommerce/product-categories',
+	class: '.wc-block-product-categories',
+};
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'can be inserted more than once', async () => {
+		await insertBlockDontWaitForInsertClose( block.name );
+		expect( await getAllBlocks() ).toHaveLength( 2 );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+} );


### PR DESCRIPTION
### Note

Currently, not every block is covered by e2e tests. This PR aims to add e2e tests for the Product Categories List block.

Part of #4643 

### Testing

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env start && npm run test:e2e`.
4. The e2e test suite shows no failed tests.