### PR TITLE
Update percent of users who will see inbox notification in WooCommerce Core

### DIFF
--- a/src/InboxNotifications.php
+++ b/src/InboxNotifications.php
@@ -14,7 +14,7 @@ class InboxNotifications {
 
 	const SURFACE_CART_CHECKOUT_NOTE_NAME          = 'surface_cart_checkout';
 	const SURFACE_CART_CHECKOUT_PROBABILITY_OPTION = 'wc_blocks_surface_cart_checkout_probability';
-	const PERCENT_USERS_TO_TARGET                  = 10;
+	const PERCENT_USERS_TO_TARGET                  = 50;
 	const INELIGIBLE_EXTENSIONS                    = [
 		'automatewoo',
 		'mailchimp-for-woocommerce',


### PR DESCRIPTION
Following a request from @garymurray in pca54o-1OJ-p2#comment-2806 this PR will increase the percentage of users who see the inbox notification surfacing the Cart and Checkout blocks to 50%.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Remove `'woocommerce-gutenberg-products-block'` from the list of ineligible extensions.
2. Deactivate any other extensions that appear in the list on your site.
3. Find the 
```php
if ( Package::feature()->is_feature_plugin_build() ) {
			return;
		}
```
code and comment it out.
3. Check your `wp_options` table and verify the value of the `wc_blocks_surface_cart_checkout_probability` is below 50
4. Visit the WooCommerce dashboard on your site, and verify that the inbox message is shown directing you to the WooCommerce checkout blocks page.
5. If you need to clear the notice then add `self::delete_surface_cart_checkout_blocks_notification();` to the top of the class