### PR TITLE
Revert "Display the notices registered by the payment gateway's process_payment() method (#4871)"

### DIFF
--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -164,8 +164,9 @@ class Api {
 		// Restore $_POST data.
 		$_POST = $post_data;
 
-		// Display the notices added by `process_payment` and abort.
-		NoticeHandler::convert_notices_to_exceptions( 'woocommerce_rest_payment_error' );
+		// If `process_payment` added notices, clear them. Notices are not displayed from the API -- payment should fail,
+		// and a generic notice will be shown instead if payment failed.
+		wc_clear_notices();
 
 		// Handle result.
 		$result->set_status( isset( $gateway_result['result'] ) && 'success' === $gateway_result['result'] ? 'success' : 'failure' );


### PR DESCRIPTION
This PR reverts https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4871

The PR is previously introduced here https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4700.
We originally discussed the approach there and decided not to merge it.

@mikejolley outlined in #4871 why this might be a problem

> If a legacy gateway (or any extension for that matter) creates a notice, but payment status is successful, the client would have no knowledge of the payment status which could result in multiple payments or duplicate orders.
>
> We have no way to know that an error notice is coming from a gateway. All notices share the same system.

