### PR TITLE
Twenty Nineteen: Price slider track fix padding/border

### DIFF
--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -37,8 +37,8 @@
 }
 @mixin reset {
 	margin: 0;
-	padding: 0;
-	border: 0;
+	padding: 0 !important;
+	border: 0 !important;
 	outline: none;
 	background: transparent;
 	-webkit-appearance: none;

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -37,8 +37,7 @@
 }
 @mixin reset {
 	margin: 0;
-	/* 
-	Use !important to prevent theme input styles from breaking the component. 
+	/* Use !important to prevent theme input styles from breaking the component.
 	Reference https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3902
 	*/
 	padding: 0 !important;

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -37,6 +37,10 @@
 }
 @mixin reset {
 	margin: 0;
+	/* 
+	Use !important to prevent theme input styles from breaking the component. 
+	Reference https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3902
+	*/
 	padding: 0 !important;
 	border: 0 !important;
 	outline: none;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes the visibility of the Price Slider block reported in issue #3902 against the Twenty Nineteen theme.


<!-- Reference any related issues or PRs here -->
Fixes #3902

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

<img width="1549" alt="Screenshot 2021-10-12 at 14 39 32" src="https://user-images.githubusercontent.com/537751/136949377-3a47b98c-6067-4c2d-b94a-bab0a4a14a11.png">

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Merge this PR
2. Switch there to default WordPress Twenty Nineteen
2. Create a page with the All Products block and the Filter Products by Price block.
3. Notice that the track of the price slider in the Filter Products by Price block display is fixed, by making the 0px padding/border take precedence against the default theme style values which are:

```
border: solid 1px #ccc;
padding: 0.36rem 0.66rem;
```

for Twenty Nineteen.

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

I did not find a way to circumvent the use of `!important` flag, as the border and padding values for the input element are taking the default values from the theme style file, so it could be the case for other themes as well.

### Changelog

> Price Slider block display fix for Twenty Nineteen Theme
