### PR TITLE
Fix positioning of default locked blocks in the editor and frontend

### DIFF
--- a/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/edit.tsx
@@ -166,27 +166,8 @@ export const Edit = ( {
 	const cartClassName = classnames( {
 		'has-dark-controls': attributes.hasDarkControls,
 	} );
-	const defaultInnerBlocksTemplate = [
-		[
-			'woocommerce/filled-cart-block',
-			{},
-			[
-				[
-					'woocommerce/cart-items-block',
-					{},
-					[ [ 'woocommerce/cart-line-items-block', {}, [] ] ],
-				],
-				[
-					'woocommerce/cart-totals-block',
-					{},
-					[
-						[ 'woocommerce/cart-order-summary-block', {}, [] ],
-						[ 'woocommerce/cart-express-payment-block', {}, [] ],
-						[ 'woocommerce/proceed-to-checkout-block', {}, [] ],
-					],
-				],
-			],
-		],
+	const defaultTemplate = [
+		[ 'woocommerce/filled-cart-block', {}, [] ],
 		[ 'woocommerce/empty-cart-block', {}, [] ],
 	];
 	const blockProps = useBlockPropsWithLocking( {
@@ -229,7 +210,7 @@ export const Edit = ( {
 							<div className={ cartClassName }>
 								<InnerBlocks
 									allowedBlocks={ ALLOWED_BLOCKS }
-									template={ defaultInnerBlocksTemplate }
+									template={ defaultTemplate }
 									templateLock="insert"
 								/>
 							</div>

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-items-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-items-block/edit.tsx
@@ -4,7 +4,7 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
-
+import type { TemplateArray } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -14,16 +14,21 @@ import { getAllowedBlocks } from '../../editor-utils';
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CART_ITEMS );
+	const defaultTemplate = [
+		[ 'woocommerce/cart-line-items-block', {}, [] ],
+	] as TemplateArray;
 
 	useForcedLayout( {
 		clientId,
-		template: allowedBlocks,
+		registeredBlocks: allowedBlocks,
+		defaultTemplate,
 	} );
 	return (
 		<Main className="wc-block-cart__main">
 			<div { ...blockProps }>
 				<InnerBlocks
 					allowedBlocks={ allowedBlocks }
+					template={ defaultTemplate }
 					templateLock={ false }
 					renderAppender={ InnerBlocks.ButtonBlockAppender }
 				/>

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/edit.tsx
@@ -4,6 +4,7 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+import type { TemplateArray } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -15,10 +16,16 @@ import { getAllowedBlocks } from '../../editor-utils';
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CART_TOTALS );
+	const defaultTemplate = [
+		[ 'woocommerce/cart-order-summary-block', {}, [] ],
+		[ 'woocommerce/cart-express-payment-block', {}, [] ],
+		[ 'woocommerce/proceed-to-checkout-block', {}, [] ],
+	] as TemplateArray;
 
 	useForcedLayout( {
 		clientId,
-		template: allowedBlocks,
+		registeredBlocks: allowedBlocks,
+		defaultTemplate,
 	} );
 
 	return (
@@ -26,6 +33,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 			<div { ...blockProps }>
 				<InnerBlocks
 					allowedBlocks={ allowedBlocks }
+					template={ defaultTemplate }
 					templateLock={ false }
 				/>
 			</div>

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+import type { TemplateArray } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -15,10 +16,12 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
 	const { currentView } = useCartBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.EMPTY_CART );
+	const defaultTemplate = [] as TemplateArray;
 
 	useForcedLayout( {
 		clientId,
-		template: allowedBlocks,
+		registeredBlocks: allowedBlocks,
+		defaultTemplate,
 	} );
 
 	return (
@@ -29,6 +32,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 			This is the empty cart block.
 			<InnerBlocks
 				allowedBlocks={ allowedBlocks }
+				template={ defaultTemplate }
 				templateLock={ false }
 			/>
 		</div>

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
@@ -4,6 +4,7 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { SidebarLayout } from '@woocommerce/base-components/sidebar-layout';
+import type { TemplateArray } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -18,10 +19,15 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
 	const { currentView } = useCartBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.FILLED_CART );
+	const defaultTemplate = [
+		[ 'woocommerce/cart-items-block', {}, [] ],
+		[ 'woocommerce/cart-totals-block', {}, [] ],
+	] as TemplateArray;
 
 	useForcedLayout( {
 		clientId,
-		template: allowedBlocks,
+		registeredBlocks: allowedBlocks,
+		defaultTemplate,
 	} );
 	return (
 		<div
@@ -32,6 +38,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 				<SidebarLayout className={ 'wc-block-cart' }>
 					<InnerBlocks
 						allowedBlocks={ allowedBlocks }
+						template={ defaultTemplate }
 						templateLock={ false }
 					/>
 				</SidebarLayout>

--- a/assets/js/blocks/cart-checkout/cart-i2/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout/cart-i2/use-forced-layout.ts
@@ -1,14 +1,22 @@
 /**
  * External dependencies
  */
-import { useLayoutEffect, useRef } from '@wordpress/element';
+import {
+	useLayoutEffect,
+	useRef,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	createBlock,
 	getBlockType,
 	Block,
 	AttributeSource,
+	synchronizeBlocksWithTemplate,
+	TemplateArray,
 } from '@wordpress/blocks';
+import { isEqual } from 'lodash';
 
 const isBlockLocked = ( {
 	attributes,
@@ -16,48 +24,131 @@ const isBlockLocked = ( {
 	attributes: Record< string, AttributeSource.Attribute >;
 } ) => Boolean( attributes.lock?.remove || attributes.lock?.default?.remove );
 
+/**
+ * useForcedLayout hook
+ *
+ * Responsible for ensuring FORCED blocks exist in the inner block layout. Forced blocks cannot be removed.
+ */
 export const useForcedLayout = ( {
 	clientId,
-	template,
+	registeredBlocks,
+	defaultTemplate = [],
 }: {
+	// Client ID of the parent block.
 	clientId: string;
-	template: Array< string >;
+	// An array of registered blocks that may be forced in this particular layout.
+	registeredBlocks: Array< string >;
+	// The default template for the inner blocks in this layout.
+	defaultTemplate: TemplateArray;
 } ): void => {
-	const currentTemplate = useRef( template );
-	const { insertBlock } = useDispatch( 'core/block-editor' );
-	const { innerBlocks, templateTypes } = useSelect(
+	const currentRegisteredBlocks = useRef( registeredBlocks );
+	const currentDefaultTemplate = useRef( defaultTemplate );
+
+	const { insertBlock, replaceInnerBlocks } = useDispatch(
+		'core/block-editor'
+	);
+
+	const { innerBlocks, registeredBlockTypes } = useSelect(
 		( select ) => {
 			return {
 				innerBlocks: select( 'core/block-editor' ).getBlocks(
 					clientId
 				),
-				templateTypes: currentTemplate.current.map( ( blockName ) =>
-					getBlockType( blockName )
+				registeredBlockTypes: currentRegisteredBlocks.current.map(
+					( blockName ) => getBlockType( blockName )
 				),
 			};
 		},
-		[ clientId, currentTemplate ]
+		[ clientId, currentRegisteredBlocks.current ]
 	);
+
+	const appendBlock = useCallback(
+		( block, position ) => {
+			const newBlock = createBlock( block.name );
+			insertBlock( newBlock, position, clientId, false );
+		},
+		[ clientId, insertBlock ]
+	);
+
+	const lockedBlockTypes = useMemo(
+		() =>
+			registeredBlockTypes.filter(
+				( block: Block | undefined ) => block && isBlockLocked( block )
+			),
+		[ registeredBlockTypes ]
+	) as Block[];
+
 	/**
 	 * If the current inner blocks differ from the registered blocks, push the differences.
-	 *
 	 */
 	useLayoutEffect( () => {
 		if ( ! clientId ) {
 			return;
 		}
-		// Missing check to see if registered block is 'forced'
-		templateTypes.forEach( ( block: Block | undefined ) => {
+
+		// If there are NO inner blocks, sync with the given template.
+		if (
+			innerBlocks.length === 0 &&
+			currentDefaultTemplate.current.length > 0
+		) {
+			const nextBlocks = synchronizeBlocksWithTemplate(
+				innerBlocks,
+				currentDefaultTemplate.current
+			);
+			if ( ! isEqual( nextBlocks, innerBlocks ) ) {
+				replaceInnerBlocks( clientId, nextBlocks );
+				return;
+			}
+		}
+
+		// Find registered locked blocks missing from Inner Blocks and append them.
+		lockedBlockTypes.forEach( ( block ) => {
+			// If the locked block type is already in the layout, we can skip this one.
 			if (
-				block &&
-				isBlockLocked( block ) &&
-				! innerBlocks.find(
+				innerBlocks.find(
 					( { name }: { name: string } ) => name === block.name
 				)
 			) {
-				const newBlock = createBlock( block.name );
-				insertBlock( newBlock, innerBlocks.length, clientId, false );
+				return;
+			}
+
+			// Is the forced block part of the default template, find it's original position.
+			const defaultTemplatePosition = currentDefaultTemplate.current.findIndex(
+				( [ blockName ] ) => blockName === block.name
+			);
+
+			switch ( defaultTemplatePosition ) {
+				case -1:
+					// The block is not part of the default template so we append it to the current layout.
+					appendBlock( block, innerBlocks.length );
+					break;
+				case 0:
+					// The block was the first block in the default layout, so prepend it to the current layout.
+					appendBlock( block, 0 );
+					break;
+				default:
+					// The new layout may have extra blocks compared to the default template, so rather than insert
+					// at the default position, we should append it after another default block.
+					const adjacentBlock =
+						currentDefaultTemplate.current[
+							defaultTemplatePosition - 1
+						];
+					const position = innerBlocks.findIndex(
+						( { name: blockName } ) =>
+							blockName === adjacentBlock[ 0 ]
+					);
+					appendBlock(
+						block,
+						position === -1 ? defaultTemplatePosition : position + 1
+					);
+					break;
 			}
 		} );
-	}, [ clientId, innerBlocks, insertBlock, templateTypes ] );
+	}, [
+		clientId,
+		innerBlocks,
+		lockedBlockTypes,
+		replaceInnerBlocks,
+		appendBlock,
+	] );
 };

--- a/assets/js/blocks/cart-checkout/checkout/context.ts
+++ b/assets/js/blocks/cart-checkout/checkout/context.ts
@@ -13,6 +13,11 @@ export type CheckoutBlockContextProps = {
 	showPhoneField: boolean;
 	requireCompanyField: boolean;
 	requirePhoneField: boolean;
+	showOrderNotes: boolean;
+	showPolicyLinks: boolean;
+	showReturnToCart: boolean;
+	cartPageId: number;
+	showRateAfterTaxName: boolean;
 };
 
 export type CheckoutBlockControlsContextProps = {
@@ -28,6 +33,11 @@ export const CheckoutBlockContext = createContext< CheckoutBlockContextProps >(
 		showPhoneField: false,
 		requireCompanyField: false,
 		requirePhoneField: false,
+		showOrderNotes: true,
+		showPolicyLinks: true,
+		showReturnToCart: true,
+		cartPageId: 0,
+		showRateAfterTaxName: false,
 	}
 );
 

--- a/assets/js/blocks/cart-checkout/checkout/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/edit.tsx
@@ -130,46 +130,9 @@ export const Edit = ( {
 		cartPageId,
 	} = attributes;
 
-	const defaultInnerBlocksTemplate = [
-		[
-			'woocommerce/checkout-fields-block',
-			{},
-			[
-				[ 'woocommerce/checkout-express-payment-block', {}, [] ],
-				[ 'woocommerce/checkout-contact-information-block', {}, [] ],
-				[ 'woocommerce/checkout-shipping-address-block', {}, [] ],
-				[ 'woocommerce/checkout-billing-address-block', {}, [] ],
-				[ 'woocommerce/checkout-shipping-methods-block', {}, [] ],
-				[ 'woocommerce/checkout-payment-block', {}, [] ],
-				showOrderNotes
-					? [ 'woocommerce/checkout-order-note-block', {}, [] ]
-					: false,
-				showPolicyLinks
-					? [ 'woocommerce/checkout-terms-block', {}, [] ]
-					: false,
-				[
-					'woocommerce/checkout-actions-block',
-					{
-						showReturnToCart,
-						cartPageId,
-					},
-					[],
-				],
-			].filter( Boolean ),
-		],
-		[
-			'woocommerce/checkout-totals-block',
-			{},
-			[
-				[
-					'woocommerce/checkout-order-summary-block',
-					{
-						showRateAfterTaxName,
-					},
-					[],
-				],
-			],
-		],
+	const defaultTemplate = [
+		[ 'woocommerce/checkout-fields-block', {}, [] ],
+		[ 'woocommerce/checkout-totals-block', {}, [] ],
 	];
 
 	const toggleAttribute = ( key: keyof Attributes ): void => {
@@ -291,11 +254,16 @@ export const Edit = ( {
 										showApartmentField,
 										showPhoneField,
 										requirePhoneField,
+										showOrderNotes,
+										showPolicyLinks,
+										showReturnToCart,
+										cartPageId,
+										showRateAfterTaxName,
 									} }
 								>
 									<InnerBlocks
 										allowedBlocks={ ALLOWED_BLOCKS }
-										template={ defaultInnerBlocksTemplate }
+										template={ defaultTemplate }
 										templateLock="insert"
 									/>
 								</CheckoutBlockContext.Provider>

--- a/assets/js/blocks/cart-checkout/checkout/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/edit.tsx
@@ -29,6 +29,7 @@ import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
 import { createInterpolateElement } from '@wordpress/element';
 import { getAdminLink } from '@woocommerce/settings';
 import { CartCheckoutCompatibilityNotice } from '@woocommerce/editor-components/compatibility-notices';
+import type { TemplateArray } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -133,7 +134,7 @@ export const Edit = ( {
 	const defaultTemplate = [
 		[ 'woocommerce/checkout-fields-block', {}, [] ],
 		[ 'woocommerce/checkout-totals-block', {}, [] ],
-	];
+	] as TemplateArray;
 
 	const toggleAttribute = ( key: keyof Attributes ): void => {
 		const newAttributes = {} as Partial< Attributes >;

--- a/assets/js/blocks/cart-checkout/checkout/form-step/additional-fields.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/form-step/additional-fields.tsx
@@ -21,7 +21,7 @@ export const AdditionalFields = ( {
 
 	useForcedLayout( {
 		clientId,
-		template: allowedBlocks,
+		registeredBlocks: allowedBlocks,
 	} );
 
 	return (

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -8,24 +8,57 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 /**
  * Internal dependencies
  */
-import { useCheckoutBlockControlsContext } from '../../context';
+import {
+	useCheckoutBlockControlsContext,
+	useCheckoutBlockContext,
+} from '../../context';
 import { useForcedLayout } from '../../use-forced-layout';
 import { getAllowedBlocks } from '../../editor-utils';
 import './style.scss';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
+	const {
+		showOrderNotes,
+		showPolicyLinks,
+		showReturnToCart,
+		cartPageId,
+	} = useCheckoutBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CHECKOUT_FIELDS );
 
 	const {
 		addressFieldControls: Controls,
 	} = useCheckoutBlockControlsContext();
 
+	const defaultTemplate = [
+		[ 'woocommerce/checkout-express-payment-block', {}, [] ],
+		[ 'woocommerce/checkout-contact-information-block', {}, [] ],
+		[ 'woocommerce/checkout-shipping-address-block', {}, [] ],
+		[ 'woocommerce/checkout-billing-address-block', {}, [] ],
+		[ 'woocommerce/checkout-shipping-methods-block', {}, [] ],
+		[ 'woocommerce/checkout-payment-block', {}, [] ],
+		showOrderNotes
+			? [ 'woocommerce/checkout-order-note-block', {}, [] ]
+			: false,
+		showPolicyLinks
+			? [ 'woocommerce/checkout-terms-block', {}, [] ]
+			: false,
+		[
+			'woocommerce/checkout-actions-block',
+			{
+				showReturnToCart,
+				cartPageId,
+			},
+			[],
+		],
+	].filter( Boolean );
+
 	useForcedLayout( {
 		clientId,
 		registeredBlocks: allowedBlocks,
 		defaultTemplate,
 	} );
+
 	return (
 		<Main className="wc-block-checkout__main">
 			<div { ...blockProps }>
@@ -34,6 +67,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 					<InnerBlocks
 						allowedBlocks={ allowedBlocks }
 						templateLock={ false }
+						template={ defaultTemplate }
 						renderAppender={ InnerBlocks.ButtonBlockAppender }
 					/>
 				</form>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -23,7 +23,8 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 
 	useForcedLayout( {
 		clientId,
-		template: allowedBlocks,
+		registeredBlocks: allowedBlocks,
+		defaultTemplate,
 	} );
 	return (
 		<Main className="wc-block-checkout__main">

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -4,6 +4,7 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+import type { TemplateArray } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -30,7 +31,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 		addressFieldControls: Controls,
 	} = useCheckoutBlockControlsContext();
 
-	const defaultTemplate = [
+	const defaultTemplate = ( [
 		[ 'woocommerce/checkout-express-payment-block', {}, [] ],
 		[ 'woocommerce/checkout-contact-information-block', {}, [] ],
 		[ 'woocommerce/checkout-shipping-address-block', {}, [] ],
@@ -51,7 +52,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 			},
 			[],
 		],
-	].filter( Boolean );
+	].filter( Boolean ) as unknown ) as TemplateArray;
 
 	useForcedLayout( {
 		clientId,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
@@ -11,10 +11,22 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import './style.scss';
 import { useForcedLayout } from '../../use-forced-layout';
 import { getAllowedBlocks } from '../../editor-utils';
+import { useCheckoutBlockContext } from '../../context';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
+	const { showRateAfterTaxName } = useCheckoutBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CHECKOUT_TOTALS );
+
+	const defaultTemplate = [
+		[
+			'woocommerce/checkout-order-summary-block',
+			{
+				showRateAfterTaxName,
+			},
+			[],
+		],
+	];
 
 	useForcedLayout( {
 		clientId,
@@ -28,6 +40,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 				<InnerBlocks
 					allowedBlocks={ allowedBlocks }
 					templateLock={ false }
+					template={ defaultTemplate }
 				/>
 			</div>
 		</Sidebar>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
@@ -18,7 +18,8 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 
 	useForcedLayout( {
 		clientId,
-		template: allowedBlocks,
+		registeredBlocks: allowedBlocks,
+		defaultTemplate,
 	} );
 
 	return (

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
@@ -4,6 +4,7 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+import type { TemplateArray } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -26,7 +27,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 			},
 			[],
 		],
-	];
+	] as TemplateArray;
 
 	useForcedLayout( {
 		clientId,

--- a/assets/js/blocks/cart-checkout/checkout/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout/checkout/use-forced-layout.ts
@@ -1,14 +1,22 @@
 /**
  * External dependencies
  */
-import { useLayoutEffect, useRef } from '@wordpress/element';
+import {
+	useLayoutEffect,
+	useRef,
+	useCallback,
+	useMemo,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	createBlock,
 	getBlockType,
 	Block,
 	AttributeSource,
+	synchronizeBlocksWithTemplate,
+	TemplateArray,
 } from '@wordpress/blocks';
+import { isEqual } from 'lodash';
 
 const isBlockLocked = ( {
 	attributes,
@@ -16,48 +24,131 @@ const isBlockLocked = ( {
 	attributes: Record< string, AttributeSource.Attribute >;
 } ) => Boolean( attributes.lock?.remove || attributes.lock?.default?.remove );
 
+/**
+ * useForcedLayout hook
+ *
+ * Responsible for ensuring FORCED blocks exist in the inner block layout. Forced blocks cannot be removed.
+ */
 export const useForcedLayout = ( {
 	clientId,
-	template,
+	registeredBlocks,
+	defaultTemplate = [],
 }: {
+	// Client ID of the parent block.
 	clientId: string;
-	template: Array< string >;
+	// An array of registered blocks that may be forced in this particular layout.
+	registeredBlocks: Array< string >;
+	// The default template for the inner blocks in this layout.
+	defaultTemplate: TemplateArray;
 } ): void => {
-	const currentTemplate = useRef( template );
-	const { insertBlock } = useDispatch( 'core/block-editor' );
-	const { innerBlocks, templateTypes } = useSelect(
+	const currentRegisteredBlocks = useRef( registeredBlocks );
+	const currentDefaultTemplate = useRef( defaultTemplate );
+
+	const { insertBlock, replaceInnerBlocks } = useDispatch(
+		'core/block-editor'
+	);
+
+	const { innerBlocks, registeredBlockTypes } = useSelect(
 		( select ) => {
 			return {
 				innerBlocks: select( 'core/block-editor' ).getBlocks(
 					clientId
 				),
-				templateTypes: currentTemplate.current.map( ( blockName ) =>
-					getBlockType( blockName )
+				registeredBlockTypes: currentRegisteredBlocks.current.map(
+					( blockName ) => getBlockType( blockName )
 				),
 			};
 		},
-		[ clientId, currentTemplate ]
+		[ clientId, currentRegisteredBlocks.current ]
 	);
+
+	const appendBlock = useCallback(
+		( block, position ) => {
+			const newBlock = createBlock( block.name );
+			insertBlock( newBlock, position, clientId, false );
+		},
+		[ clientId, insertBlock ]
+	);
+
+	const lockedBlockTypes = useMemo(
+		() =>
+			registeredBlockTypes.filter(
+				( block: Block | undefined ) => block && isBlockLocked( block )
+			),
+		[ registeredBlockTypes ]
+	) as Block[];
+
 	/**
 	 * If the current inner blocks differ from the registered blocks, push the differences.
-	 *
 	 */
 	useLayoutEffect( () => {
 		if ( ! clientId ) {
 			return;
 		}
-		// Missing check to see if registered block is 'forced'
-		templateTypes.forEach( ( block: Block | undefined ) => {
+
+		// If there are NO inner blocks, sync with the given template.
+		if (
+			innerBlocks.length === 0 &&
+			currentDefaultTemplate.current.length > 0
+		) {
+			const nextBlocks = synchronizeBlocksWithTemplate(
+				innerBlocks,
+				currentDefaultTemplate.current
+			);
+			if ( ! isEqual( nextBlocks, innerBlocks ) ) {
+				replaceInnerBlocks( clientId, nextBlocks );
+				return;
+			}
+		}
+
+		// Find registered locked blocks missing from Inner Blocks and append them.
+		lockedBlockTypes.forEach( ( block ) => {
 			if (
-				block &&
-				isBlockLocked( block ) &&
-				! innerBlocks.find(
+				innerBlocks.find(
 					( { name }: { name: string } ) => name === block.name
 				)
 			) {
-				const newBlock = createBlock( block.name );
-				insertBlock( newBlock, innerBlocks.length, clientId, false );
+				return;
 			}
+
+			// Is the forced block part of the default template?
+			const defaultTemplatePosition = currentDefaultTemplate.current.findIndex(
+				( [ blockName ] ) => blockName === block.name
+			);
+
+			// Not part of the default template, so append at the end.
+			if ( defaultTemplatePosition === -1 ) {
+				appendBlock( block, innerBlocks.length );
+				return;
+			}
+
+			// If in position 0, just prepend it.
+			if ( defaultTemplatePosition === 0 ) {
+				appendBlock( block, 0 );
+				return;
+			}
+
+			// Looking at the default template, whats in the previous position?
+			const previousBlock =
+				currentDefaultTemplate.current[ defaultTemplatePosition - 1 ];
+
+			// Find the previous block in the current layout and use it's position if possible.
+			const previousBlockPosition = innerBlocks.findIndex(
+				( { name }: { name: string } ) => name === previousBlock[ 0 ]
+			);
+
+			appendBlock(
+				block,
+				previousBlockPosition > -1
+					? previousBlockPosition + 1
+					: defaultTemplatePosition
+			);
 		} );
-	}, [ clientId, innerBlocks, insertBlock, templateTypes ] );
+	}, [
+		clientId,
+		innerBlocks,
+		lockedBlockTypes,
+		replaceInnerBlocks,
+		appendBlock,
+	] );
 };

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -100,7 +100,6 @@ class Checkout extends AbstractBlock {
 					<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>
 					<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>
 					<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
-					<p>Hi</p>
 				</div>
 				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">
 					<div data-block-name="woocommerce/checkout-order-summary-block" class="wp-block-woocommerce-checkout-order-summary-block"></div>

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -88,7 +88,24 @@ class Checkout extends AbstractBlock {
 		$is_empty = preg_match( $regex_for_empty_block, $content );
 
 		if ( $is_empty ) {
-			$inner_blocks_html = '<div data-block-name="woocommerce/checkout-fields-block" class="wp-block-woocommerce-checkout-fields-block"></div><div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block"></div>';
+			// This fallback needs to match the default templates defined in our Blocks.
+			$inner_blocks_html = '
+				<div data-block-name="woocommerce/checkout-fields-block" class="wp-block-woocommerce-checkout-fields-block">
+					<div data-block-name="woocommerce/checkout-express-payment-block" class="wp-block-woocommerce-checkout-express-payment-block"></div>
+					<div data-block-name="woocommerce/checkout-contact-information-block" class="wp-block-woocommerce-checkout-contact-information-block"></div>
+					<div data-block-name="woocommerce/checkout-shipping-address-block" class="wp-block-woocommerce-checkout-shipping-address-block"></div>
+					<div data-block-name="woocommerce/checkout-billing-address-block" class="wp-block-woocommerce-checkout-billing-address-block"></div>
+					<div data-block-name="woocommerce/checkout-shipping-methods-block" class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
+					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>
+					<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>
+					<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>
+					<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
+					<p>Hi</p>
+				</div>
+				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">
+					<div data-block-name="woocommerce/checkout-order-summary-block" class="wp-block-woocommerce-checkout-order-summary-block"></div>
+				</div>
+			';
 
 			$content = str_replace( '</div>', $inner_blocks_html . '</div>', $content );
 		}


### PR DESCRIPTION
Requesting @senadir to look at this given his familiarity with block locking.

This PR updates the frontend handling of locked blocks to include all core/default blocks in the template. This removes the risk that forced blocks could be appended in a random order, because they will instead be inserted in template order. Fixes #4757 (Test Case 1)

On the editor side, this PR fixes the positioning of forced blocks if they are removed (Test Case 2) by comparing the default template to the inner blocks.

Fixes #4757

### Testing

How to test the changes in this Pull Request:

#### Test Case 1

For the frontend blocks, we need to have no HTML saved.  For the purpose of testing, you can cheat by adding some code on this line:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypes/Checkout.php#L87

Add:

```php
$content = '<div class="wp-block-woocommerce-checkout"></div>';
```

Then view the checkout block on the frontend. Confirm all default blocks are visible/inserted in the correct positions.

#### Test Case 2

1. In the editor, go to a page with the Checkout block
2. Switch to code view
3. Delete the "contact information" block by removing the HTML for that block
4. Switch back to the visual editor. 
5. The contact information block should be back, in the correct position

Before this fix, it would be appended at the end of the layout in the incorrect position.
