### PR TITLE
Remove duplicate data attributes

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -320,39 +320,6 @@ abstract class AbstractBlock {
 	}
 
 	/**
-	 * Injects block attributes into the block.
-	 *
-	 * @param string $content HTML content to inject into.
-	 * @param array  $attributes Key value pairs of attributes.
-	 * @return string Rendered block with data attributes.
-	 */
-	protected function inject_html_data_attributes( $content, array $attributes ) {
-		return preg_replace( '/<div /', '<div ' . $this->get_html_data_attributes( $attributes ) . ' ', $content, 1 );
-	}
-
-	/**
-	 * Converts block attributes to HTML data attributes.
-	 *
-	 * @param array $attributes Key value pairs of attributes.
-	 * @return string Rendered HTML attributes.
-	 */
-	protected function get_html_data_attributes( array $attributes ) {
-		$data = [];
-
-		foreach ( $attributes as $key => $value ) {
-			if ( is_bool( $value ) ) {
-				$value = $value ? 'true' : 'false';
-			}
-			if ( ! is_scalar( $value ) ) {
-				$value = wp_json_encode( $value );
-			}
-			$data[] = 'data-' . esc_attr( strtolower( preg_replace( '/(?<!\ )[A-Z]/', '-$0', $key ) ) ) . '="' . esc_attr( $value ) . '"';
-		}
-
-		return implode( ' ', $data );
-	}
-
-	/**
 	 * Data passed through from server to client for block.
 	 *
 	 * @param array $attributes  Any attributes that currently are available from the block.

--- a/src/BlockTypes/AtomicBlock.php
+++ b/src/BlockTypes/AtomicBlock.php
@@ -8,17 +8,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
  */
 class AtomicBlock extends AbstractBlock {
 	/**
-	 * Inject attributes and block name.
-	 *
-	 * @param array  $attributes Block attributes.
-	 * @param string $content    Block content.
-	 * @return string Rendered block type output.
-	 */
-	protected function render( $attributes, $content ) {
-		return $this->inject_html_data_attributes( $content, $attributes );
-	}
-
-	/**
 	 * Get the editor script data for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.
@@ -54,16 +43,5 @@ class AtomicBlock extends AbstractBlock {
 	 */
 	protected function get_block_type_style() {
 		return null;
-	}
-
-	/**
-	 * Converts block attributes to HTML data attributes.
-	 *
-	 * @param array $attributes Key value pairs of attributes.
-	 * @return string Rendered HTML attributes.
-	 */
-	protected function get_html_data_attributes( array $attributes ) {
-		$data = parent::get_html_data_attributes( $attributes );
-		return trim( $data . ' data-block-name="' . esc_attr( $this->namespace . '/' . $this->block_name ) . '"' );
 	}
 }

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -80,7 +80,7 @@ class Cart extends AbstractBlock {
 		wp_dequeue_script( 'selectWoo' );
 		wp_dequeue_style( 'select2' );
 
-		return $this->inject_html_data_attributes( $content . $this->get_skeleton(), $attributes );
+		return $content . $this->get_skeleton();
 	}
 
 	/**

--- a/src/BlockTypes/CartI2.php
+++ b/src/BlockTypes/CartI2.php
@@ -80,7 +80,7 @@ class CartI2 extends AbstractBlock {
 		wp_dequeue_script( 'selectWoo' );
 		wp_dequeue_style( 'select2' );
 
-		return $this->inject_html_data_attributes( $content, $attributes );
+		return $content;
 	}
 
 	/**

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -93,7 +93,7 @@ class Checkout extends AbstractBlock {
 			$content = str_replace( '</div>', $inner_blocks_html . '</div>', $content );
 		}
 
-		return $this->inject_html_data_attributes( $content, $attributes );
+		return $content;
 	}
 
 	/**

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -183,7 +183,7 @@ class MiniCart extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content ) {
-		return $this->inject_html_data_attributes( $content . $this->get_markup(), $attributes );
+		return $content . $this->get_markup();
 	}
 
 	/**

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -26,15 +26,4 @@ class SingleProduct extends AbstractBlock {
 		];
 		return $key ? $script[ $key ] : $script;
 	}
-
-	/**
-	 * Render the block on the frontend.
-	 *
-	 * @param array  $attributes Block attributes.
-	 * @param string $content    Block content.
-	 * @return string Rendered block type output.
-	 */
-	protected function render( $attributes, $content ) {
-		return $this->inject_html_data_attributes( $content, $attributes );
-	}
 }

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -101,11 +101,15 @@ final class BlockTypesController {
 		}
 
 		$attributes              = (array) $block['attrs'];
+		$exclude_attributes      = [ 'className', 'align' ];
 		$escaped_data_attributes = [
 			'data-block-name="' . esc_attr( $block['blockName'] ) . '"',
 		];
 
 		foreach ( $attributes as $key => $value ) {
+			if ( in_array( $key, $exclude_attributes, true ) ) {
+				continue;
+			}
 			if ( is_bool( $value ) ) {
 				$value = $value ? 'true' : 'false';
 			}


### PR DESCRIPTION
We seem to have duplicate data attributes in the saved HTML markup. This is due to `inject_html_data_attributes()` code, as well as the new render filter which applies to all blocks in our namespace:

```php
add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );
```

Since `add_data_attributes` applies to all `woocommerce` blocks, we can remove `inject_html_data_attributes`.

Fixes #4867

### Testing

1. Smoke test that the core set of WooCommerce Blocks render on the frontend. I tested product, reviews, checkout, cart.
2. Save the checkout block. View page source. Confirm there are no data-class-name and data-align attributes on the main div.

### Changelog

> Remove duplicate attributes in saved block HTML
