### PR TITLE
Allows product grid block contents to be limited by stock level

### DIFF
--- a/assets/js/blocks/product-new/block.js
+++ b/assets/js/blocks/product-new/block.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { getSetting } from '@woocommerce/settings';
 
@@ -26,6 +27,7 @@ class ProductNewestBlock extends Component {
 			contentVisibility,
 			rows,
 			alignButtons,
+			stockStatus,
 		} = attributes;
 
 		return (
@@ -54,6 +56,18 @@ class ProductNewestBlock extends Component {
 						onChange={ ( value ) =>
 							setAttributes( { contentVisibility: value } )
 						}
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Filter by stock status',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductStockControl
+						setAttributes={ setAttributes }
+						value={ stockStatus }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -11,6 +11,7 @@ import GridContentControl from '@woocommerce/editor-components/grid-content-cont
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
 import ProductOrderbyControl from '@woocommerce/editor-components/product-orderby-control';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { Icon, tag } from '@woocommerce/icons';
 import { getSetting } from '@woocommerce/settings';
@@ -42,6 +43,7 @@ class ProductOnSaleBlock extends Component {
 			rows,
 			orderby,
 			alignButtons,
+			stockStatus,
 		} = attributes;
 
 		return (
@@ -98,6 +100,18 @@ class ProductOnSaleBlock extends Component {
 						onOperatorChange={ ( value = 'any' ) =>
 							setAttributes( { catOperator: value } )
 						}
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Stock level',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductStockControl
+						setAttributes={ setAttributes }
+						value={ stockStatus }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -18,6 +18,7 @@ import GridContentControl from '@woocommerce/editor-components/grid-content-cont
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
 import ProductTagControl from '@woocommerce/editor-components/product-tag-control';
 import ProductOrderbyControl from '@woocommerce/editor-components/product-orderby-control';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { Icon, more } from '@woocommerce/icons';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { getSetting } from '@woocommerce/settings';
@@ -91,6 +92,7 @@ class ProductsByTagBlock extends Component {
 			orderby,
 			rows,
 			alignButtons,
+			stockStatus,
 		} = attributes;
 
 		return (
@@ -148,6 +150,18 @@ class ProductsByTagBlock extends Component {
 					<ProductOrderbyControl
 						setAttributes={ setAttributes }
 						value={ orderby }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Stock level',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductStockControl
+						setAttributes={ setAttributes }
+						value={ stockStatus }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -109,6 +109,14 @@ registerBlockType( 'woocommerce/product-tag', {
 			type: 'boolean',
 			default: false,
 		},
+
+		/**
+		 * Whether to display in stock, out of stock or backorder products.
+		 */
+		stockStatus: {
+			type: 'array',
+			default: getSetting( 'stockStatusOptions', [] ),
+		},
 	},
 
 	/**

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { getSetting } from '@woocommerce/settings';
 
@@ -26,6 +27,7 @@ class ProductTopRatedBlock extends Component {
 			contentVisibility,
 			rows,
 			alignButtons,
+			stockStatus,
 		} = attributes;
 
 		return (
@@ -73,6 +75,18 @@ class ProductTopRatedBlock extends Component {
 						onOperatorChange={ ( value = 'any' ) =>
 							setAttributes( { catOperator: value } )
 						}
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Stock level',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductStockControl
+						setAttributes={ setAttributes }
+						value={ stockStatus }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -19,6 +19,7 @@ import GridContentControl from '@woocommerce/editor-components/grid-content-cont
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
 import ProductAttributeTermControl from '@woocommerce/editor-components/product-attribute-term-control';
 import ProductOrderbyControl from '@woocommerce/editor-components/product-orderby-control';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { getSetting } from '@woocommerce/settings';
 
@@ -36,6 +37,7 @@ class ProductsByAttributeBlock extends Component {
 			orderby,
 			rows,
 			alignButtons,
+			stockStatus,
 		} = this.props.attributes;
 
 		return (
@@ -98,6 +100,18 @@ class ProductsByAttributeBlock extends Component {
 					<ProductOrderbyControl
 						setAttributes={ setAttributes }
 						value={ orderby }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Stock level',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductStockControl
+						setAttributes={ setAttributes }
+						value={ stockStatus }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -116,6 +116,14 @@ registerBlockType( blockTypeName, {
 			type: 'boolean',
 			default: false,
 		},
+
+		/**
+		 * Whether to display in stock, out of stock or backorder products.
+		 */
+		stockStatus: {
+			type: 'string',
+			default: getSetting( 'stockStatusOptions', [] ),
+		},
 	},
 
 	/**

--- a/assets/js/blocks/products/attributes.js
+++ b/assets/js/blocks/products/attributes.js
@@ -18,6 +18,7 @@ export const defaults = {
 	orderby: 'date',
 	layoutConfig: DEFAULT_PRODUCT_LIST_LAYOUT,
 	isPreview: false,
+	stockStatus: 'any',
 };
 
 export const attributes = {
@@ -63,5 +64,13 @@ export const attributes = {
 	isPreview: {
 		type: 'boolean',
 		default: false,
+	},
+
+	/**
+	 * Whether to display in stock, out of stock or backorder products.
+	 */
+	stockStatus: {
+		type: 'string',
+		default: 'any',
 	},
 };

--- a/assets/js/blocks/products/edit.js
+++ b/assets/js/blocks/products/edit.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToggleControl, SelectControl } from '@wordpress/components';
+import { PanelBody, ToggleControl, SelectControl } from '@wordpress/components';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 
 export const getSharedContentControls = ( attributes, setAttributes ) => {
 	const { contentVisibility } = attributes;
@@ -27,48 +28,65 @@ export const getSharedContentControls = ( attributes, setAttributes ) => {
 
 export const getSharedListControls = ( attributes, setAttributes ) => {
 	return (
-		<SelectControl
-			label={ __( 'Order Products By', 'woo-gutenberg-products-block' ) }
-			value={ attributes.orderby }
-			options={ [
-				{
-					label: __(
-						'Default sorting (menu order)',
-						'woo-gutenberg-products-block'
-					),
-					value: 'menu_order',
-				},
-				{
-					label: __( 'Popularity', 'woo-gutenberg-products-block' ),
-					value: 'popularity',
-				},
-				{
-					label: __(
-						'Average rating',
-						'woo-gutenberg-products-block'
-					),
-					value: 'rating',
-				},
-				{
-					label: __( 'Latest', 'woo-gutenberg-products-block' ),
-					value: 'date',
-				},
-				{
-					label: __(
-						'Price: low to high',
-						'woo-gutenberg-products-block'
-					),
-					value: 'price',
-				},
-				{
-					label: __(
-						'Price: high to low',
-						'woo-gutenberg-products-block'
-					),
-					value: 'price-desc',
-				},
-			] }
-			onChange={ ( orderby ) => setAttributes( { orderby } ) }
-		/>
+		<div>
+			<SelectControl
+				label={ __(
+					'Order Products By',
+					'woo-gutenberg-products-block'
+				) }
+				value={ attributes.orderby }
+				options={ [
+					{
+						label: __(
+							'Default sorting (menu order)',
+							'woo-gutenberg-products-block'
+						),
+						value: 'menu_order',
+					},
+					{
+						label: __(
+							'Popularity',
+							'woo-gutenberg-products-block'
+						),
+						value: 'popularity',
+					},
+					{
+						label: __(
+							'Average rating',
+							'woo-gutenberg-products-block'
+						),
+						value: 'rating',
+					},
+					{
+						label: __( 'Latest', 'woo-gutenberg-products-block' ),
+						value: 'date',
+					},
+					{
+						label: __(
+							'Price: low to high',
+							'woo-gutenberg-products-block'
+						),
+						value: 'price',
+					},
+					{
+						label: __(
+							'Price: high to low',
+							'woo-gutenberg-products-block'
+						),
+						value: 'price-desc',
+					},
+				] }
+				onChange={ ( orderby ) => setAttributes( { orderby } ) }
+			/>
+			<PanelBody
+				title={ __( 'Stock level', 'woo-gutenberg-products-block' ) }
+				initialOpen={ false }
+			>
+				<ProductStockControl
+					setAttributes={ setAttributes }
+					value={ attributes.stockStatus }
+				/>
+			</PanelBody>
+		</div>
 	);
 };

--- a/assets/js/editor-components/product-stock-control/index.tsx
+++ b/assets/js/editor-components/product-stock-control/index.tsx
@@ -1,0 +1,85 @@
+/**
+ * External dependencies
+ */
+import CheckboxList from '@woocommerce/base-components/checkbox-list';
+import { getSetting } from '@woocommerce/settings';
+import { useCallback, useState } from '@wordpress/element';
+
+export interface ProductStockControlProps {
+	value: Array< string >;
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+}
+
+/**
+ * A pre-configured SelectControl for product stock settings.
+ */
+const ProductStockControl = ( {
+	value,
+	setAttributes,
+}: ProductStockControlProps ): JSX.Element => {
+	// Should out of stock items be hidden?
+	const [ hideOutOfStockItems ] = useState(
+		getSetting( 'hideOutOfStockItems', false )
+	);
+
+	// Get the stock status options.
+	const [ { outofstock, ...otherStockStatusOptions } ] = useState(
+		getSetting( 'stockStatusOptions', {} )
+	);
+
+	// Determine whether or not to use the out of stock status.
+	const [ STOCK_STATUS_OPTIONS ] = useState(
+		hideOutOfStockItems
+			? otherStockStatusOptions
+			: { outofstock, ...otherStockStatusOptions }
+	);
+
+	// Set the initial state to the default or saved value.
+	const [ checkedOptions, setChecked ] = useState( value );
+
+	/**
+	 * Valid options must be in an array of [ 'value' : 'mystatus', 'label' : 'My label' ] format.
+	 * stockStatusOptions are returned as [ 'mystatus' : 'My label' ].
+	 * Formatting is corrected here.
+	 */
+	const [ displayOptions ] = useState(
+		Object.entries( STOCK_STATUS_OPTIONS )
+			.map( ( [ slug, name ] ) => ( { value: slug, label: name } ) )
+			.filter( ( status ) => !! status.label )
+			.sort( ( a, b ) => a.value.localeCompare( b.value ) )
+	);
+
+	/**
+	 * When a checkbox in the list changes, update state.
+	 */
+	const onChange = useCallback(
+		( checkedValue: string ) => {
+			const previouslyChecked = checkedOptions.includes( checkedValue );
+
+			const newChecked = checkedOptions.filter(
+				( filteredValue ) => filteredValue !== checkedValue
+			);
+
+			if ( ! previouslyChecked ) {
+				newChecked.push( checkedValue );
+				newChecked.sort();
+			}
+
+			setChecked( newChecked );
+			setAttributes( {
+				stockStatus: newChecked,
+			} );
+		},
+		[ checkedOptions, setAttributes ]
+	);
+
+	return (
+		<CheckboxList
+			checked={ checkedOptions }
+			options={ displayOptions }
+			onChange={ onChange }
+		/>
+	);
+};
+
+export default ProductStockControl;

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -72,4 +72,12 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+
+	/**
+	 * Whether to display in stock, out of stock or backorder products.
+	 */
+	stockStatus: {
+		type: 'array',
+		default: Object.keys( getSetting( 'stockStatusOptions', [] ) ),
+	},
 };

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -32,6 +32,13 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	protected $query_args = array();
 
 	/**
+	 * Meta query args.
+	 *
+	 * @var array
+	 */
+	protected $meta_query = array();
+
+	/**
 	 * Get a set of attributes shared across most of the grid blocks.
 	 *
 	 * @return array List of block attributes with type and defaults.
@@ -50,6 +57,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'align'             => $this->get_schema_align(),
 			'alignButtons'      => $this->get_schema_boolean( false ),
 			'isPreview'         => $this->get_schema_boolean( false ),
+			'stockStatus'       => array_keys( wc_get_product_stock_status_options() ),
 		);
 	}
 
@@ -161,6 +169,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 				'rating' => true,
 				'button' => true,
 			),
+			'stockStatus'       => array_keys( wc_get_product_stock_status_options() ),
 		);
 
 		return wp_parse_args( $attributes, $defaults );
@@ -172,6 +181,9 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @return array
 	 */
 	protected function parse_query_args() {
+		// Store the original meta query.
+		$this->meta_query = WC()->query->get_meta_query();
+
 		$query_args = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -180,7 +192,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'no_found_rows'       => false,
 			'orderby'             => '',
 			'order'               => '',
-			'meta_query'          => WC()->query->get_meta_query(), // phpcs:ignore WordPress.DB.SlowDBQuery
+			'meta_query'          => $this->meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery
 			'tax_query'           => array(), // phpcs:ignore WordPress.DB.SlowDBQuery
 			'posts_per_page'      => $this->get_products_limit(),
 		);
@@ -189,6 +201,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		$this->set_ordering_query_args( $query_args );
 		$this->set_categories_query_args( $query_args );
 		$this->set_visibility_query_args( $query_args );
+		$this->set_stock_status_query_args( $query_args );
 
 		return $query_args;
 	}
@@ -270,6 +283,29 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'terms'    => $product_visibility_not_in,
 			'operator' => 'NOT IN',
 		);
+	}
+
+	/**
+	 * Set which stock status to use when displaying products.
+	 *
+	 * @param array $query_args Query args.
+	 * @return void
+	 */
+	protected function set_stock_status_query_args( &$query_args ) {
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		if ( isset( $this->attributes['stockStatus'] ) &&
+			( array_keys( wc_get_product_stock_status_options() ) !== $this->attributes['stockStatus'] || [] !== $this->attributes['stockStatus'] )
+		) {
+			// Reset meta_query then update with our stock status.
+			$query_args['meta_query']   = $this->meta_query;
+			$query_args['meta_query'][] = array(
+				'key'   => '_stock_status',
+				'value' => $this->attributes['stockStatus'],
+			);
+		} else {
+			$query_args['meta_query'] = $this->meta_query;
+		}
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 	}
 
 	/**
@@ -498,6 +534,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		if ( empty( $this->attributes['contentVisibility']['title'] ) ) {
 			return '';
 		}
+
 		return '<div class="wc-block-grid__product-title">' . wp_kses_post( $product->get_title() ) . '</div>';
 	}
 
@@ -621,5 +658,6 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		$this->asset_data_registry->add( 'min_rows', wc_get_theme_support( 'product_blocks::min_rows', 1 ), true );
 		$this->asset_data_registry->add( 'max_rows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
 		$this->asset_data_registry->add( 'default_rows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
+		$this->asset_data_registry->add( 'stock_status_options', wc_get_product_stock_status_options(), true );
 	}
 }

--- a/src/BlockTypes/ProductTag.php
+++ b/src/BlockTypes/ProductTag.php
@@ -48,6 +48,7 @@ class ProductTag extends AbstractProductGrid {
 				'default' => 'any',
 			),
 			'isPreview'         => $this->get_schema_boolean( false ),
+			'stockStatus'       => array_keys( wc_get_product_stock_status_options() ),
 		);
 	}
 

--- a/src/BlockTypes/ProductsByAttribute.php
+++ b/src/BlockTypes/ProductsByAttribute.php
@@ -67,6 +67,7 @@ class ProductsByAttribute extends AbstractProductGrid {
 			'orderby'           => $this->get_schema_orderby(),
 			'rows'              => $this->get_schema_number( wc_get_theme_support( 'product_blocks::default_rows', 3 ) ),
 			'isPreview'         => $this->get_schema_boolean( false ),
+			'stockStatus'       => array_keys( wc_get_product_stock_status_options() ),
 		);
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Adds a product stock dropdown to Product Grid blocks. This allows admin users to filter products by their stock status (in stock, out of stock, on back order or any status).

If the site has the 'Hide out of stock items from the catalog' WooCommerce setting enabled, this filter does not display.

The blocks effected are:
* Products by Attribute
* Products by Tag
* Top Rated Products
* Products by Attribute
* On Sale Products
* Newest Products

This has come from a client requesting Product Grid blocks that show only products in stock or on back order, without hiding all out of stock items across the site. This change should allow admin users more control over which products display in the above blocks. For example, creating a product block of products on back order could be used to drive pre-sales or draw attention to products that are due back in stock soon.

This work could also be extendable to include low stock products, allowing for users to create blocks of products that will sell out soon.

<!-- Reference any related issues or PRs here -->
Fixes #2739 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

Interactions added in this PR are duplicates of existing interactions used on product grid blocks.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

https://user-images.githubusercontent.com/53259768/137306957-d2e77691-7f30-4528-914e-103c43f3d7d4.mov

Very important note: the debug string visible in this video is to give a quick and easy visual indicator of what products are in stock and out of stock. It is not included in this PR.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. On a Gutenberg page, add a new product grid block (namely, Products by Attribute, Products by Tag, Top Rated Products, Products by Attribute, On Sale Products or Newest Products)
2. In the right hand edit column, open the 'Stock level' panel
3. Change the drop down menu setting and observe the product list changing to match the new filter
4. Repeat with any variations and combinations of settings

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

When filtering by stock `meta_query` is used by WP_Query to return the selected products. This can product slow queries. 

### Changelog

> Added controls to product grid blocks for filtering by stock levels
