### PR TITLE
Add Accepted Payment Methods Block 

### DIFF
--- a/assets/js/blocks/cart-checkout/cart-i2/checkout-button/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/checkout-button/index.tsx
@@ -3,29 +3,15 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
 import Button from '@woocommerce/base-components/button';
 import { CHECKOUT_URL } from '@woocommerce/block-settings';
 import { useCheckoutContext } from '@woocommerce/base-context';
-import { usePaymentMethods } from '@woocommerce/base-context/hooks';
 import { usePositionRelativeToViewport } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import type PaymentMethodConfig from '../../../../blocks-registry/payment-methods/payment-method-config';
-
-const getIconsFromPaymentMethods = (
-	paymentMethods: PaymentMethodConfig[]
-) => {
-	return Object.values( paymentMethods ).reduce( ( acc, paymentMethod ) => {
-		if ( paymentMethod.icons !== null ) {
-			acc = acc.concat( paymentMethod.icons );
-		}
-		return acc;
-	}, [] );
-};
 
 /**
  * Checkout button rendered in the full cart page.
@@ -40,7 +26,6 @@ const CheckoutButton = ( { link }: { link: string } ): JSX.Element => {
 		positionRelativeToViewport,
 	] = usePositionRelativeToViewport();
 	const [ showSpinner, setShowSpinner ] = useState( false );
-	const { paymentMethods } = usePaymentMethods();
 
 	useEffect( () => {
 		// Add a listener to remove the spinner on the checkout button, so the saved page snapshot does not
@@ -65,20 +50,15 @@ const CheckoutButton = ( { link }: { link: string } ): JSX.Element => {
 	}, [] );
 
 	const submitContainerContents = (
-		<>
-			<Button
-				className="wc-block-cart__submit-button"
-				href={ link || CHECKOUT_URL }
-				disabled={ isCalculating }
-				onClick={ () => setShowSpinner( true ) }
-				showSpinner={ showSpinner }
-			>
-				{ __( 'Proceed to Checkout', 'woo-gutenberg-products-block' ) }
-			</Button>
-			<PaymentMethodIcons
-				icons={ getIconsFromPaymentMethods( paymentMethods ) }
-			/>
-		</>
+		<Button
+			className="wc-block-cart__submit-button"
+			href={ link || CHECKOUT_URL }
+			disabled={ isCalculating }
+			onClick={ () => setShowSpinner( true ) }
+			showSpinner={ showSpinner }
+		>
+			{ __( 'Proceed to Checkout', 'woo-gutenberg-products-block' ) }
+		</Button>
 	);
 
 	return (

--- a/assets/js/blocks/cart-checkout/cart-i2/checkout-button/style.scss
+++ b/assets/js/blocks/cart-checkout/cart-i2/checkout-button/style.scss
@@ -1,38 +1,27 @@
 .wc-block-cart__submit {
 	position: relative;
-}
-
-.wc-block-cart__submit-container {
-	padding-bottom: $gap;
+	margin: 0 0 $gap 0;
 }
 
 .wc-block-cart__submit-button {
 	width: 100%;
-	margin: 0 0 $gap;
-
-	&:last-child {
-		margin-bottom: 0;
-	}
+	margin: 0;
 }
 
-.is-mobile,
-.is-small,
-.is-medium {
-	.wc-block-cart__submit-container:not(.wc-block-cart__submit-container--sticky) {
-		padding-left: 0;
-		padding-right: 0;
-		padding-top: 0;
+.wc-block-cart {
+	.wc-block-cart__submit-container {
+		padding: 0;
 	}
 }
 
 @include breakpoint(">782px") {
-	.wc-block-cart__submit-container--sticky {
+	.wc-block-cart .wc-block-cart__submit-container--sticky {
 		display: none;
 	}
 }
 
 @include breakpoint("<782px") {
-	.wc-block-cart__submit-container--sticky {
+	.wc-block-cart .wc-block-cart__submit-container--sticky {
 		background: $white;
 		bottom: 0;
 		left: 0;

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/attributes.tsx
@@ -1,0 +1,13 @@
+export default {
+	checkoutPageId: {
+		type: 'number',
+		default: 0,
+	},
+	lock: {
+		type: 'object',
+		default: {
+			move: true,
+			remove: true,
+		},
+	},
+};

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/attributes.tsx
@@ -1,9 +1,0 @@
-export default {
-	lock: {
-		type: 'object',
-		default: {
-			move: true,
-			remove: true,
-		},
-	},
-};

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/attributes.tsx
@@ -1,8 +1,4 @@
 export default {
-	checkoutPageId: {
-		type: 'number',
-		default: 0,
-	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/block.json
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/block.json
@@ -9,15 +9,7 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false,
-		"inserter": false
-	},
-	"attributes": {
-		"lock": {
-			"default": {
-				"remove": true,
-				"move": true
-			}
-		}
+		"inserter": true
 	},
 	"parent": [ "woocommerce/cart-totals-block" ],
 	"textdomain": "woo-gutenberg-products-block",

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/block.json
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/block.json
@@ -1,0 +1,25 @@
+{
+	"name": "woocommerce/cart-accepted-payment-methods-block",
+	"version": "1.0.0",
+	"title": "Accepted Payment Methods",
+	"description": "Display accepted payment methods.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false
+	},
+	"attributes": {
+		"lock": {
+			"default": {
+				"remove": true,
+				"move": true
+			}
+		}
+	},
+	"parent": [ "woocommerce/cart-totals-block" ],
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2
+}

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/block.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
+import { usePaymentMethods } from '@woocommerce/base-context/hooks';
+
+/**
+ * Internal dependencies
+ */
+import type PaymentMethodConfig from '../../../../../blocks-registry/payment-methods/payment-method-config';
+
+const getIconsFromPaymentMethods = (
+	paymentMethods: PaymentMethodConfig[]
+) => {
+	return Object.values( paymentMethods ).reduce( ( acc, paymentMethod ) => {
+		if ( paymentMethod.icons !== null ) {
+			acc = acc.concat( paymentMethod.icons );
+		}
+		return acc;
+	}, [] );
+};
+
+const Block = (): JSX.Element => {
+	const { paymentMethods } = usePaymentMethods();
+
+	return (
+		<PaymentMethodIcons
+			icons={ getIconsFromPaymentMethods( paymentMethods ) }
+		/>
+	);
+};
+
+export default Block;

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/edit.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<Block />
+		</div>
+	);
+};
+
+export const Save = (): JSX.Element => {
+	return <div { ...useBlockProps.save() } />;
+};

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/frontend.tsx
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import attributes from './attributes';
+
+export default withFilteredAttributes( attributes )( Block );

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/frontend.tsx
@@ -1,12 +1,6 @@
 /**
- * External dependencies
- */
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
-
-/**
  * Internal dependencies
  */
 import Block from './block';
-import attributes from './attributes';
 
-export default withFilteredAttributes( attributes )( Block );
+export default Block;

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/index.tsx
@@ -7,7 +7,6 @@ import { Icon, card } from '@woocommerce/icons';
 /**
  * Internal dependencies
  */
-import attributes from './attributes';
 import { Edit, Save } from './edit';
 import metadata from './block.json';
 
@@ -16,7 +15,6 @@ registerFeaturePluginBlockType( metadata, {
 		src: <Icon srcElement={ card } />,
 		foreground: '#874FB9',
 	},
-	attributes,
 	edit: Edit,
 	save: Save,
 } );

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-accepted-payment-methods-block/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+import { Icon, card } from '@woocommerce/icons';
+
+/**
+ * Internal dependencies
+ */
+import attributes from './attributes';
+import { Edit, Save } from './edit';
+import metadata from './block.json';
+
+registerFeaturePluginBlockType( metadata, {
+	icon: {
+		src: <Icon srcElement={ card } />,
+		foreground: '#874FB9',
+	},
+	attributes,
+	edit: Edit,
+	save: Save,
+} );

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/edit.tsx
@@ -20,6 +20,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 		[ 'woocommerce/cart-order-summary-block', {}, [] ],
 		[ 'woocommerce/cart-express-payment-block', {}, [] ],
 		[ 'woocommerce/proceed-to-checkout-block', {}, [] ],
+		[ 'woocommerce/cart-accepted-payment-methods-block', {}, [] ],
 	] as TemplateArray;
 
 	useForcedLayout( {

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/edit.tsx
@@ -36,6 +36,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 					allowedBlocks={ allowedBlocks }
 					template={ defaultTemplate }
 					templateLock={ false }
+					renderAppender={ InnerBlocks.ButtonBlockAppender }
 				/>
 			</div>
 		</Sidebar>

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/edit.tsx
@@ -34,6 +34,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 				allowedBlocks={ allowedBlocks }
 				template={ defaultTemplate }
 				templateLock={ false }
+				renderAppender={ InnerBlocks.ButtonBlockAppender }
 			/>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/edit.tsx
@@ -46,7 +46,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 					<InnerBlocks
 						allowedBlocks={ allowedBlocks }
 						template={ defaultTemplate }
-						templateLock={ false }
+						templateLock="insert"
 					/>
 				</SidebarLayout>
 			</Columns>

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/index.tsx
@@ -9,3 +9,4 @@ import './cart-order-summary-block';
 import './cart-express-payment-block';
 import './proceed-to-checkout-block';
 import './empty-cart-block';
+import './cart-accepted-payment-methods-block';

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/register-components.ts
@@ -20,6 +20,7 @@ import cartLineItemsMetadata from './cart-line-items-block/block.json';
 import cartOrderSummaryMetadata from './cart-order-summary-block/block.json';
 import cartTotalsMetadata from './cart-totals-block/block.json';
 import cartProceedToCheckoutMetadata from './proceed-to-checkout-block/block.json';
+import cartAcceptedPaymentMethodsMetadata from './cart-accepted-payment-methods-block/block.json';
 
 registerCheckoutBlock( {
 	metadata: filledCartMetadata,
@@ -29,6 +30,7 @@ registerCheckoutBlock( {
 		)
 	),
 } );
+
 registerCheckoutBlock( {
 	metadata: emptyCartMetadata,
 	component: lazy( () =>
@@ -37,6 +39,7 @@ registerCheckoutBlock( {
 		)
 	),
 } );
+
 registerCheckoutBlock( {
 	metadata: filledCartMetadata,
 	component: lazy( () =>
@@ -45,6 +48,7 @@ registerCheckoutBlock( {
 		)
 	),
 } );
+
 registerCheckoutBlock( {
 	metadata: emptyCartMetadata,
 	component: lazy( () =>
@@ -53,6 +57,7 @@ registerCheckoutBlock( {
 		)
 	),
 } );
+
 registerCheckoutBlock( {
 	metadata: cartItemsMetadata,
 	component: lazy( () =>
@@ -103,6 +108,15 @@ registerCheckoutBlock( {
 	component: lazy( () =>
 		import(
 			/* webpackChunkName: "cart-blocks/checkout-button" */ './proceed-to-checkout-block/frontend'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
+	metadata: cartAcceptedPaymentMethodsMetadata,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "cart-blocks/accepted-payment-methods" */ './cart-accepted-payment-methods-block/frontend'
 		)
 	),
 } );

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
@@ -42,6 +42,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 					allowedBlocks={ allowedBlocks }
 					templateLock={ false }
 					template={ defaultTemplate }
+					renderAppender={ InnerBlocks.ButtonBlockAppender }
 				/>
 			</div>
 		</Sidebar>


### PR DESCRIPTION
Adds an accepted payment methods block below the proceed to checkout button.

Fixes #4833

### Screenshots

Editor:
![Screenshot 2021-10-14 at 13 29 21](https://user-images.githubusercontent.com/90977/137317713-5e916cbf-324d-4734-b759-b162992077fa.png)

Frontend:
![Screenshot 2021-10-14 at 13 28 55](https://user-images.githubusercontent.com/90977/137317746-4af6626d-0350-422a-9903-5d4a633f71cf.png)

### Testing

This is a forced block for now, so go to the editor and use Cart i2. You should see the block below the checkout button.
