### PR TITLE
Update blocks-registry docs

### DIFF
--- a/assets/js/blocks/cart-checkout/cart-i2/frontend.js
+++ b/assets/js/blocks/cart-checkout/cart-i2/frontend.js
@@ -8,7 +8,6 @@ import {
 import { getValidBlockAttributes } from '@woocommerce/base-utils';
 import { Children, cloneElement, isValidElement } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context';
-import { useValidation } from '@woocommerce/base-context/hooks';
 import { getRegisteredBlockComponents } from '@woocommerce/blocks-registry';
 
 import { renderParentBlock } from '@woocommerce/atomic-utils';
@@ -33,13 +32,11 @@ const Wrapper = ( { children } ) => {
 	// we need to pluck out receiveCart.
 	// eslint-disable-next-line no-unused-vars
 	const { extensions, receiveCart, ...cart } = useStoreCart();
-	const validation = useValidation();
 	return Children.map( children, ( child ) => {
 		if ( isValidElement( child ) ) {
 			const componentProps = {
 				extensions,
 				cart,
-				validation,
 			};
 			return cloneElement( child, componentProps );
 		}

--- a/packages/checkout/README.md
+++ b/packages/checkout/README.md
@@ -6,7 +6,7 @@ Components and utilities making it possible to integrate with the WooCommerce Ca
 
 - [Installation](#installation)
 - [Usage](#usage)
-  - [Aliased imports](#aliased-imports)
+	- [Aliased imports](#aliased-imports)
 - [Folder Structure Overview](#folder-structure-overview)
 
 ## Installation
@@ -33,6 +33,10 @@ const dependencyMap = {
 	'@woocommerce/blocks-checkout': [ 'wc', 'blocksCheckout' ],
 };
 
+const handleMap = {
+	'@woocommerce/blocks-checkout': 'wc-blocks-checkout',
+};
+
 module.exports = {
 	// …snip
 	plugins: [
@@ -41,6 +45,11 @@ module.exports = {
 			requestToExternal( request ) {
 				if ( dependencyMap[ request ] ) {
 					return dependencyMap[ request ];
+				}
+			},
+			requestToHandle( request ) {
+				if ( handleMap[ request ] ) {
+					return handleMap[ request ];
 				}
 			},
 		} ),

--- a/packages/checkout/blocks-registry/README.md
+++ b/packages/checkout/blocks-registry/README.md
@@ -91,7 +91,7 @@ If you want your block to appear within the layout of the Checkout without merch
 In the above example, the inner block would be inserted automatically, and would not be movable or removable by the merchant.
 
 ### Passing attributes to your frontend block
-For your block to dynamically render on the frontend, and for you to access your attributes, you need to pass them in the frontend.
+For your block to dynamically render on the frontend and have access to its own attributes, both the block name and the list of block attributes need to be passed via HTML `data-` attributes.
 
 - To render the block on the frontend, you need a `data-block-name` attribute on the HTML with your block name `namespace/block-name`.
 - To access your attributes on frontend, you need to save them as `data-*` attributes on the HTML.

--- a/packages/checkout/blocks-registry/README.md
+++ b/packages/checkout/blocks-registry/README.md
@@ -102,7 +102,7 @@ This function registers a block and it's corresponding component with WooCommerc
 ### Passing attributes to your frontend block
 In order to access your attributes on your frontend component, you need to append them to your saved html.
 
-Blocks whose namespace is `woocommerce` or `woocommerce-checkout` would have this applied to them automaticly.
+Blocks whose namespace is `woocommerce` or `woocommerce-checkout` will have this applied to them automatically, but you can also add this behaviour to your own namespace or individual blocks.
 
 To add this behavior to your namespace, you can use the `__experimental_woocommerce_blocks_add_data_attributes_to_namespace` filter:
 

--- a/packages/checkout/blocks-registry/README.md
+++ b/packages/checkout/blocks-registry/README.md
@@ -10,9 +10,9 @@ Registered Inner Blocks can either be forced within the layout of the Cart/Check
 - [Inner Block Areas](#inner-block-areas)
 - [Registering a Block](#registering-a-block)
 	- [Registering a Forced Block](#registering-a-forced-block)
+	- [Passing attributes to your frontend block](#passing-attributes-to-your-frontend-block)
 	- [Registering a Block Component](#registering-a-block-component)
 - [`registerCheckoutBlock( options )`](#registercheckoutblock-options-)
-	- [Passing attributes to your frontend block](#passing-attributes-to-your-frontend-block)
 	- [Usage](#usage)
 	- [Options](#options)
 		- [`metadata` (object, required)](#metadata-object-required)
@@ -90,17 +90,11 @@ If you want your block to appear within the layout of the Checkout without merch
 
 In the above example, the inner block would be inserted automatically, and would not be movable or removable by the merchant.
 
-### Registering a Block Component
-
-After registering your block, you need to define which component will replace your block on the frontend of the store. To do this, use the `registerCheckoutBlock` function from the checkout blocks registry.
-
-## `registerCheckoutBlock( options )`
-
-This function registers a block and it's corresponding component with WooCommerce. The register function expects a JavaScript object with options specific to the block you are registering.
-
-
 ### Passing attributes to your frontend block
-In order to access your attributes on your frontend component, you need to append them to your saved html.
+For your block to dynamically render on the frontend, and for you to access your attributes, you need to pass them in the frontend.
+
+- To render the block on the frontend, you need a `data-block-name` attribute on the HTML with your block name `namespace/block-name`.
+- To access your attributes on frontend, you need to save them as `data-*` attributes on the HTML.
 
 Blocks whose namespace is `woocommerce` or `woocommerce-checkout` will have this applied to them automatically, but you can also add this behaviour to your own namespace or individual blocks.
 
@@ -131,6 +125,14 @@ add_filter(
 	1
 );
 ```
+### Registering a Block Component
+
+After registering your block, you need to define which component will replace your block on the frontend of the store. To do this, use the `registerCheckoutBlock` function from the checkout blocks registry.
+
+## `registerCheckoutBlock( options )`
+
+This function registers a block and it's corresponding component with WooCommerce. The register function expects a JavaScript object with options specific to the block you are registering.
+
 ### Usage
 
 ```js

--- a/packages/checkout/blocks-registry/README.md
+++ b/packages/checkout/blocks-registry/README.md
@@ -9,17 +9,18 @@ Registered Inner Blocks can either be forced within the layout of the Cart/Check
 - [How Inner Blocks Work](#how-inner-blocks-work)
 - [Inner Block Areas](#inner-block-areas)
 - [Registering a Block](#registering-a-block)
-  - [Registering a Forced Block](#registering-a-forced-block)
-  - [Registering a Block Component](#registering-a-block-component)
+	- [Registering a Forced Block](#registering-a-forced-block)
+	- [Registering a Block Component](#registering-a-block-component)
 - [`registerCheckoutBlock( options )`](#registercheckoutblock-options-)
-  - [Usage](#usage)
-  - [Options](#options)
-    - [`metadata` (object, required)](#metadata-object-required)
-    - [`component` (function, required)](#component-function-required)
+	- [Passing attributes to your frontend block](#passing-attributes-to-your-frontend-block)
+	- [Usage](#usage)
+	- [Options](#options)
+		- [`metadata` (object, required)](#metadata-object-required)
+		- [`component` (function, required)](#component-function-required)
 - [`getRegisteredBlocks( blockName )`](#getregisteredblocks-blockname-)
-  - [Usage](#usage-1)
+	- [Usage](#usage-1)
 - [`hasInnerBlocks( blockName )`](#hasinnerblocks-blockname-)
-  - [Usage](#usage-2)
+	- [Usage](#usage-2)
 
 ## How Inner Blocks Work
 
@@ -97,6 +98,39 @@ After registering your block, you need to define which component will replace yo
 
 This function registers a block and it's corresponding component with WooCommerce. The register function expects a JavaScript object with options specific to the block you are registering.
 
+
+### Passing attributes to your frontend block
+In order to access your attributes on your frontend component, you need to append them to your saved html.
+
+Blocks whose namespace is `woocommerce` or `woocommerce-checkout` would have this applied to them automaticly.
+
+To add this behavior to your namespace, you can use the `__experimental_woocommerce_blocks_add_data_attributes_to_namespace` filter:
+
+```php
+add_filter(
+	'__experimental_woocommerce_blocks_add_data_attributes_to_namespace',
+	function ( $allowed_namespaces ) {
+		$allowed_namespaces[] = 'namespace';
+		return $allowed_namespaces;
+	},
+	10,
+	1
+);
+```
+
+To add just a single block, you can use `__experimental_woocommerce_blocks_add_data_attributes_to_block` filter:
+
+```php
+add_filter(
+	'__experimental_woocommerce_blocks_add_data_attributes_to_block',
+	function ( $allowed_blocks ) {
+		$allowed_blocks[] = 'namespace/block-name';
+		return $allowed_blocks;
+	},
+	10,
+	1
+);
+```
 ### Usage
 
 ```js


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds some missing pieces to our docs and removes the validation script from Cart inner blocks.
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4799
