### PR TITLE
Use Cart's needs payment check instead of Order's

### DIFF
--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -464,7 +464,7 @@ class Checkout extends AbstractCartRoute {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
 
 		$cart = $this->cart_controller->get_cart_instance();
-		$this->order->set_payment_method( $cart->needs_payment() ? $this->get_request_payment_method( $request ) : '' );
+		$this->order->set_payment_method( $request['payment_method'] ?? '' );
 
 		/**
 		 * Fires when the Checkout Block/Store API updates an order's from the API request data.

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -462,8 +462,6 @@ class Checkout extends AbstractCartRoute {
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
-
-		$cart = $this->cart_controller->get_cart_instance();
 		$this->order->set_payment_method( $request['payment_method'] ?? '' );
 
 		/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -462,7 +462,9 @@ class Checkout extends AbstractCartRoute {
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
-		$this->order->set_payment_method( $this->order->needs_payment() ? $this->get_request_payment_method( $request ) : '' );
+
+		$cart = $this->cart_controller->get_cart_instance();
+		$this->order->set_payment_method( $cart->needs_payment() ? $this->get_request_payment_method( $request ) : '' );
 
 		/**
 		 * Fires when the Checkout Block/Store API updates an order's from the API request data.

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -462,7 +462,7 @@ class Checkout extends AbstractCartRoute {
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
-		$this->order->set_payment_method( $this->get_request_payment_method( $request ) );
+		$this->order->set_payment_method( $this->order->needs_payment() ? $this->get_request_payment_method( $request ) : '' );
 
 		/**
 		 * Fires when the Checkout Block/Store API updates an order's from the API request data.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
#4854 Removed a check to see if the order needs payment before setting the payment ID on the order. This caused a regression (#4948) In which free orders didn't pass because there are no payment method.

Reverting #4854 fixes #4948 but regresses #4853 , so this PR reverts it and fixes the original issue in both cases.

### What happened?

- We show the payment setup on Checkout based on `$cart->needs_payment()`. Plugins (like WC Subscriptions) hooks into `needs_payment` and sets it to true based on conditions like trial and such. However, when setting a payment method, we check `$order->needs_payment`.

WooCommerce Subscriptions[ does hook into `$order->needs_payment`](https://github.com/woocommerce/woocommerce-subscriptions/blob/d0f64e5e23b8fcc5bdb2fd422a3e7da6a9d76a78/includes/class-wc-subscriptions-order.php#L658-L704) but that didn't work, because that value is false, causing the subscription recurring payment method to be `Manual renewal` even if a payment was still captured.

This PR changes that check into `$cart->needs_payment` instead, why?

I believe, at that moment in the checkout lifecycle, using `$cart->needs_payment` makes more sense than order given that we still didn't submit the order, and that we use that exact check to decide if we should capture payment or not, so they should be consistent.

### Question

There are several other instances in `Routes/Checkout.php` that uses `$order->needs_payment`, should I evaluate them to see if they should be `$cart->needs_payment` or not? In total, there are two other instances left.

<!-- Reference any related issues or PRs here -->
Fixes #4948
Reverts #4854 
Fixes #4853

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

We're testing two issues here, #4948, and #4853

#4948
1. Create a free order ($0), Add to Cart.
2. Make sure you have a free shipping method or it's a virtual product.
2. Visit Checkout, Payment and Express Payment steps shouldn't render.
3. Place order, you should not see an error.

#4853
1. Install WC Subscriptions and enable a payment gateway like Stripe or WCPay.
2. Create a product with a trial.
2. Visit Checkout, Payment and Express Payment steps **should render.**
3. Place order, you should not see an error.
4. Visit wp-admin->WooCommerce->Subscriptions
5. See the latest created subscription, it should have Via Credit Card or any payment gateway you did, not vial Manual Renewals.
![image](https://user-images.githubusercontent.com/6165348/137723042-662d2913-de63-4b62-ad0b-fd86721ae54b.png)


### Changelog

> Fix a bug in free orders and trial subscription products.
