### PR TITLE
Update dependency @woocommerce/e2e-utils to v0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7150,13 +7150,13 @@
 			}
 		},
 		"@woocommerce/e2e-utils": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/@woocommerce/e2e-utils/-/e2e-utils-0.1.5.tgz",
-			"integrity": "sha512-2dD3ZTyMhbQT8YXUYWF9rwmosieo6kE9zgYA7W8h2GmZVcluDvET9i5yUw5MmTq4y5MVhGf5xWZOjZLzNlwjUA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@woocommerce/e2e-utils/-/e2e-utils-0.1.6.tgz",
+			"integrity": "sha512-gWSEgFIjMqaqiiIyrpa1epIHkmBBAfk6WfRojva1f5ZmffSJCc0VbX2jQQRdFm1BuEYr8KGCCYo+q8NIjlMZ7g==",
 			"dev": true,
 			"requires": {
 				"@wordpress/deprecated": "^2.10.0",
-				"@wordpress/e2e-test-utils": "^4.6.0",
+				"@wordpress/e2e-test-utils": "^4.16.1",
 				"config": "3.3.3",
 				"faker": "^5.1.0",
 				"fishery": "^1.2.0"
@@ -7206,10 +7206,35 @@
 					}
 				},
 				"node-fetch": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-					"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+					"version": "2.6.5",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.5.tgz",
+					"integrity": "sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==",
+					"dev": true,
+					"requires": {
+						"whatwg-url": "^5.0.0"
+					}
+				},
+				"tr46": {
+					"version": "0.0.3",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+					"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
 					"dev": true
+				},
+				"webidl-conversions": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+					"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+					"dev": true
+				},
+				"whatwg-url": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+					"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+					"dev": true,
+					"requires": {
+						"tr46": "~0.0.3",
+						"webidl-conversions": "^3.0.0"
+					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"@typescript-eslint/eslint-plugin": "4.14.1",
 		"@typescript-eslint/parser": "4.14.1",
 		"@woocommerce/api": "0.2.0",
-		"@woocommerce/e2e-utils": "0.1.5",
+		"@woocommerce/e2e-utils": "^0.1.6",
 		"@woocommerce/eslint-plugin": "1.2.0",
 		"@woocommerce/woocommerce-rest-api": "1.0.1",
 		"@wordpress/api-fetch": "5.2.1",

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -16,7 +16,8 @@
 		},
 		"variable": {
 			"name": "Variable Product with Three Variations"
-		}
+		},
+		"grouped": {}
 	},
 	"addresses": {
 		"admin": {


### PR DESCRIPTION
Updating e2e utils manually.

Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4693

(check tests pass before merging)