### PR TITLE
Correct WooCommerce branding color

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/index.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit,
 	attributes,

--- a/assets/js/atomic/blocks/product-elements/button/index.js
+++ b/assets/js/atomic/blocks/product-elements/button/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/category-list/index.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/index.ts
@@ -22,7 +22,7 @@ const blockConfig: BlockConfiguration = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/image/index.js
+++ b/assets/js/atomic/blocks/product-elements/image/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/rating/index.js
+++ b/assets/js/atomic/blocks/product-elements/rating/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	supports: {
 		html: false,

--- a/assets/js/atomic/blocks/product-elements/sku/index.js
+++ b/assets/js/atomic/blocks/product-elements/sku/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/index.js
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/summary/index.js
+++ b/assets/js/atomic/blocks/product-elements/summary/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/tag-list/index.js
+++ b/assets/js/atomic/blocks/product-elements/tag-list/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/title/index.js
+++ b/assets/js/atomic/blocks/product-elements/title/index.js
@@ -20,7 +20,7 @@ const blockConfig = {
 	description,
 	icon: {
 		src: icon,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-express-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-express-payment-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ card } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-items-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-items-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon icon={ column } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-line-items-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-line-items-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon icon={ column } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-order-summary-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-order-summary-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ totals } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/cart-totals-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon icon={ column } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/empty-cart-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ removeCart } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/filled-cart-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ filledCart } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/proceed-to-checkout-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart-i2/inner-blocks/proceed-to-checkout-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerExperimentalBlockType( metadata, {
 	icon: {
 		src: <Icon icon={ button } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/index.tsx
@@ -17,7 +17,7 @@ const settings = {
 	title: __( 'Checkout', 'woo-gutenberg-products-block' ),
 	icon: {
 		src: <Icon srcElement={ fields } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon icon={ button } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ address } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ contact } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ card } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon icon={ column } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ notes } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ totals } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ card } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ address } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/index.tsx
@@ -14,7 +14,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ truck } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/index.tsx
@@ -12,7 +12,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon srcElement={ asterisk } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/index.tsx
@@ -13,7 +13,7 @@ import metadata from './block.json';
 registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: <Icon icon={ column } />,
-		foreground: '#874FB9',
+		foreground: '#7f54b3',
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -29,6 +29,6 @@ setCategories( [
 			'WooCommerce Product Elements',
 			'woo-gutenberg-products-block'
 		),
-		icon: <Icon srcElement={ atom } style={ { fill: '#874FB9' } } />,
+		icon: <Icon srcElement={ atom } style={ { fill: '#7f54b3' } } />,
 	},
 ] );


### PR DESCRIPTION
**Note**

Similar to #4878, I found more components that were using an incorrect branding color. Instead of `#7f54b3`, these components were still using `#874FB9`. This PR shall ensure that the correct WooCommerce branding color, as defined in the [WooCommerce Brand and Logo Guidelines](https://woocommerce.com/brand-and-logo-guidelines/), is used across the entire plugin.

**Steps to test**

1. Check out this PR.
2. Create a test page.
3. Add the checkout block.
4. Open the list view.
5. Check the color code of the icons.
6. Ensure that all icons use `rgb(127, 84, 179)` resp. `#7f54b3`.

<table>
<tr>
<td>Before:
<br><br>

![branding-colors-before](https://user-images.githubusercontent.com/3323310/137853332-aa0c81cd-fd36-49c6-aaa2-047fb3e2016e.png)
</td>
<td>After:
<br><br>

![branding-colors-after](https://user-images.githubusercontent.com/3323310/137853325-8b487049-9a63-43c7-aac7-c887b1d4fc18.png)
</td>
</tr>
</table>