### PR TITLE
Store API - Force states to an array type

### DIFF
--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -95,7 +95,7 @@ class BillingAddressSchema extends AbstractAddressSchema {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
 			$billing_country = $address->get_billing_country();
 			$billing_state   = $address->get_billing_state();
-			$valid_states    = wc()->countries->get_states( $billing_country );
+			$valid_states    = array_filter( (array) wc()->countries->get_states( $billing_country ) );
 
 			if ( ! empty( $billing_state ) && count( $valid_states ) && ! in_array( $billing_state, $valid_states, true ) ) {
 				$billing_state = '';

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -44,7 +44,7 @@ class ShippingAddressSchema extends AbstractAddressSchema {
 
 			$shipping_country = $address->get_shipping_country();
 			$shipping_state   = $address->get_shipping_state();
-			$valid_states     = wc()->countries->get_states( $shipping_country );
+			$valid_states     = array_filter( (array) wc()->countries->get_states( $shipping_country ) );
 
 			if ( ! empty( $shipping_state ) && count( $valid_states ) && ! in_array( $shipping_state, $valid_states, true ) ) {
 				$shipping_state = '';


### PR DESCRIPTION
Found an issue with notices being thrown in the Store API when testing on @ralucaStan's install. When a country has no states, `wc()->countries->get_states` returns a boolean. `count()` returns 1 which breaks the logic. 

This PR casts the boolean to an array so `count()` works as expected.

Introduced in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4844

### Testing

How to test the changes in this Pull Request:

If you checkout and set the address to a country with no states, e.g. United Kindom, you'll see warnings in your logs:

![Screenshot 2021-10-20 at 12 30 40](https://user-images.githubusercontent.com/90977/138084833-24a1f26a-06b4-4049-9e33-0ee522e418ab.png)

Clear the logs after applying this fix and retest. Check logs are clean.