### PR TITLE
Add custom className support to Checkout Inner Blocks

### DIFF
--- a/assets/js/atomic/utils/render-parent-block.tsx
+++ b/assets/js/atomic/utils/render-parent-block.tsx
@@ -123,6 +123,7 @@ const renderInnerBlocks = ( {
 		const { blockName = '', ...componentProps } = {
 			key: `${ block }_${ depth }_${ index }`,
 			...( element instanceof HTMLElement ? element.dataset : {} ),
+			className: element.className || '',
 		};
 
 		const InnerBlockComponent = getBlockComponentFromMap(

--- a/assets/js/base/components/sidebar-layout/main.js
+++ b/assets/js/base/components/sidebar-layout/main.js
@@ -1,19 +1,18 @@
 /**
  * External dependencies
  */
+import { forwardRef } from 'react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
-const Main = ( { children, className } ) => {
+const Main = forwardRef( ( { children, className = '' }, ref ) => {
 	return (
-		<div className={ classNames( 'wc-block-components-main', className ) }>
+		<div
+			ref={ ref }
+			className={ classNames( 'wc-block-components-main', className ) }
+		>
 			{ children }
 		</div>
 	);
-};
-
-Main.propTypes = {
-	className: PropTypes.string,
-};
+} );
 
 export default Main;

--- a/assets/js/base/components/sidebar-layout/sidebar.js
+++ b/assets/js/base/components/sidebar-layout/sidebar.js
@@ -1,21 +1,18 @@
 /**
  * External dependencies
  */
+import { forwardRef } from 'react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
-const Sidebar = ( { children, className } ) => {
+const Sidebar = forwardRef( ( { children, className = '' }, ref ) => {
 	return (
 		<div
+			ref={ ref }
 			className={ classNames( 'wc-block-components-sidebar', className ) }
 		>
 			{ children }
 		</div>
 	);
-};
-
-Sidebar.propTypes = {
-	className: PropTypes.string,
-};
+} );
 
 export default Sidebar;

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/attributes.tsx
@@ -7,6 +7,10 @@ export default {
 		type: 'boolean',
 		default: true,
 	},
+	className: {
+		type: 'string',
+		default: '',
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/block.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { getSetting } from '@woocommerce/settings';
 import {
 	PlaceOrderButton,
@@ -15,12 +16,16 @@ import './style.scss';
 const Block = ( {
 	cartPageId,
 	showReturnToCart,
+	className,
 }: {
 	cartPageId: number;
 	showReturnToCart: boolean;
+	className?: string;
 } ): JSX.Element => {
 	return (
-		<div className="wc-block-checkout__actions">
+		<div
+			className={ classnames( 'wc-block-checkout__actions', className ) }
+		>
 			{ showReturnToCart && (
 				<ReturnToCartButton
 					link={ getSetting( 'page-' + cartPageId, false ) }

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -24,7 +24,11 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const { cartPageId = 0, showReturnToCart = true } = attributes;
+	const {
+		cartPageId = 0,
+		showReturnToCart = true,
+		className = '',
+	} = attributes;
 	const { current: savedCartPageId } = useRef( cartPageId );
 	const currentPostId = useSelect(
 		( select ) => {
@@ -86,6 +90,7 @@ export const Edit = ( {
 				<Block
 					showReturnToCart={ showReturnToCart }
 					cartPageId={ cartPageId }
+					className={ className }
 				/>
 			</Disabled>
 		</div>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -24,11 +24,7 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const {
-		cartPageId = 0,
-		showReturnToCart = true,
-		className = '',
-	} = attributes;
+	const { cartPageId = 0, showReturnToCart = true } = attributes;
 	const { current: savedCartPageId } = useRef( cartPageId );
 	const currentPostId = useSelect(
 		( select ) => {
@@ -90,7 +86,6 @@ export const Edit = ( {
 				<Block
 					showReturnToCart={ showReturnToCart }
 					cartPageId={ cartPageId }
-					className={ className }
 				/>
 			</Disabled>
 		</div>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/attributes.tsx
@@ -16,6 +16,10 @@ export default {
 			'woo-gutenberg-products-block'
 		),
 	} ),
+	className: {
+		type: 'string',
+		default: '',
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useBlockProps } from '@wordpress/block-editor';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
@@ -27,6 +28,7 @@ export const Edit = ( {
 		title: string;
 		description: string;
 		showStepNumber: boolean;
+		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element | null => {
@@ -50,7 +52,10 @@ export const Edit = ( {
 		<FormStepBlock
 			setAttributes={ setAttributes }
 			attributes={ attributes }
-			className="wc-block-checkout__billing-fields"
+			className={ classnames(
+				'wc-block-checkout__billing-fields',
+				attributes?.className
+			) }
 		>
 			<Controls />
 			<Block

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
@@ -18,11 +19,13 @@ const FrontendBlock = ( {
 	description,
 	showStepNumber,
 	children,
+	className,
 }: {
 	title: string;
 	description: string;
 	showStepNumber: boolean;
 	children: JSX.Element;
+	className?: string;
 } ): JSX.Element | null => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { showBillingFields } = useCheckoutAddress();
@@ -42,7 +45,10 @@ const FrontendBlock = ( {
 		<FormStep
 			id="billing-fields"
 			disabled={ checkoutIsProcessing }
-			className="wc-block-checkout__billing-fields"
+			className={ classnames(
+				'wc-block-checkout__billing-fields',
+				className
+			) }
 			title={ title }
 			description={ description }
 			showStepNumber={ showStepNumber }

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/attributes.tsx
@@ -19,6 +19,10 @@ export default {
 			'woo-gutenberg-products-block'
 		),
 	} ),
+	className: {
+		type: 'string',
+		default: '',
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
@@ -27,6 +28,7 @@ export const Edit = ( {
 		title: string;
 		description: string;
 		showStepNumber: boolean;
+		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
@@ -36,6 +38,10 @@ export const Edit = ( {
 		<FormStepBlock
 			attributes={ attributes }
 			setAttributes={ setAttributes }
+			className={ classnames(
+				'wc-block-checkout__contact-fields',
+				attributes?.className
+			) }
 		>
 			<Controls />
 			<Disabled>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
@@ -18,12 +19,14 @@ const FrontendBlock = ( {
 	description,
 	showStepNumber,
 	children,
+	className,
 }: {
 	title: string;
 	description: string;
 	allowCreateAccount: boolean;
 	showStepNumber: boolean;
 	children: JSX.Element;
+	className?: string;
 } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { allowCreateAccount } = useCheckoutBlockContext();
@@ -32,7 +35,10 @@ const FrontendBlock = ( {
 		<FormStep
 			id="contact-fields"
 			disabled={ checkoutIsProcessing }
-			className="wc-block-checkout__contact-fields"
+			className={ classnames(
+				'wc-block-checkout__contact-fields',
+				className
+			) }
 			title={ title }
 			description={ description }
 			showStepNumber={ showStepNumber }

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/block.json
@@ -12,6 +12,10 @@
 		"inserter": false
 	},
 	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
 		"lock": {
 			"type": "object",
 			"default": {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/block.tsx
@@ -8,14 +8,18 @@ import { useStoreCart } from '@woocommerce/base-context/hooks';
  */
 import { CheckoutExpressPayment } from '../../../payment-methods';
 
-const Block = (): JSX.Element | null => {
+const Block = ( { className }: { className?: string } ): JSX.Element | null => {
 	const { cartNeedsPayment } = useStoreCart();
 
 	if ( ! cartNeedsPayment ) {
 		return null;
 	}
 
-	return <CheckoutExpressPayment />;
+	return (
+		<div className={ className }>
+			<CheckoutExpressPayment />
+		</div>
+	);
 };
 
 export default Block;

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/edit.tsx
@@ -51,6 +51,7 @@ export const Edit = ( {
 	attributes,
 }: {
 	attributes: {
+		className?: string;
 		lock: {
 			move: boolean;
 			remove: boolean;
@@ -60,9 +61,12 @@ export const Edit = ( {
 	const { paymentMethods, isInitialized } = useExpressPaymentMethods();
 	const hasExpressPaymentMethods = Object.keys( paymentMethods ).length > 0;
 	const blockProps = useBlockProps( {
-		className: classnames( {
-			'wp-block-woocommerce-checkout-express-payment-block--has-express-payment-methods': hasExpressPaymentMethods,
-		} ),
+		className: classnames(
+			{
+				'wp-block-woocommerce-checkout-express-payment-block--has-express-payment-methods': hasExpressPaymentMethods,
+			},
+			attributes?.className
+		),
 		attributes,
 	} );
 

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/block.json
@@ -12,6 +12,10 @@
 		"inserter": false
 	},
 	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
 		"lock": {
 			"type": "object",
 			"default": {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
@@ -16,8 +17,21 @@ import {
 import { useForcedLayout, getAllowedBlocks } from '../../../shared';
 import './style.scss';
 
-export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
-	const blockProps = useBlockProps();
+export const Edit = ( {
+	clientId,
+	attributes,
+}: {
+	clientId: string;
+	attributes: {
+		className?: string;
+	};
+} ): JSX.Element => {
+	const blockProps = useBlockProps( {
+		className: classnames(
+			'wc-block-checkout__main',
+			attributes?.className
+		),
+	} );
 	const {
 		showOrderNotes,
 		showPolicyLinks,
@@ -60,18 +74,16 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	} );
 
 	return (
-		<Main className="wc-block-checkout__main">
-			<div { ...blockProps }>
-				<Controls />
-				<form className="wc-block-components-form wc-block-checkout__form">
-					<InnerBlocks
-						allowedBlocks={ allowedBlocks }
-						templateLock={ false }
-						template={ defaultTemplate }
-						renderAppender={ InnerBlocks.ButtonBlockAppender }
-					/>
-				</form>
-			</div>
+		<Main { ...blockProps }>
+			<Controls />
+			<form className="wc-block-components-form wc-block-checkout__form">
+				<InnerBlocks
+					allowedBlocks={ allowedBlocks }
+					templateLock={ false }
+					template={ defaultTemplate }
+					renderAppender={ InnerBlocks.ButtonBlockAppender }
+				/>
+			</form>
 		</Main>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 
 /**
@@ -10,11 +11,13 @@ import './style.scss';
 
 const FrontendBlock = ( {
 	children,
+	className,
 }: {
 	children: JSX.Element;
+	className?: string;
 } ): JSX.Element => {
 	return (
-		<Main className="wc-block-checkout__main">
+		<Main className={ classnames( 'wc-block-checkout__main', className ) }>
 			<form className="wc-block-components-form wc-block-checkout__form">
 				{ children }
 			</form>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
@@ -12,6 +12,10 @@
 		"inserter": false
 	},
 	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
 		"lock": {
 			"type": "object",
 			"default": {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import {
@@ -13,7 +14,7 @@ import {
  */
 import CheckoutOrderNotes from '../../order-notes';
 
-const Block = (): JSX.Element => {
+const Block = ( { className }: { className?: string } ): JSX.Element => {
 	const { needsShipping } = useShippingDataContext();
 	const {
 		isProcessing: checkoutIsProcessing,
@@ -26,7 +27,10 @@ const Block = (): JSX.Element => {
 		<FormStep
 			id="order-notes"
 			showStepNumber={ false }
-			className="wc-block-checkout__order-notes"
+			className={ classnames(
+				'wc-block-checkout__order-notes',
+				className
+			) }
 			disabled={ checkoutIsProcessing }
 		>
 			<CheckoutOrderNotes

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/attributes.tsx
@@ -8,6 +8,10 @@ export default {
 		type: 'boolean',
 		default: getSetting( 'displayCartPricesIncludingTax', false ),
 	},
+	className: {
+		type: 'string',
+		default: '',
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
@@ -30,8 +30,10 @@ import { getSetting } from '@woocommerce/settings';
 
 const Block = ( {
 	showRateAfterTaxName = false,
+	className,
 }: {
 	showRateAfterTaxName: boolean;
+	className?: string;
 } ): JSX.Element => {
 	const { cartItems, cartTotals, cartCoupons, cartFees } = useStoreCart();
 	const {
@@ -54,7 +56,7 @@ const Block = ( {
 	};
 
 	return (
-		<>
+		<div className={ className }>
 			<TotalsWrapper>
 				<OrderSummary cartItems={ cartItems } />
 			</TotalsWrapper>
@@ -105,7 +107,7 @@ const Block = ( {
 				/>
 			</TotalsWrapper>
 			<ExperimentalOrderMeta.Slot { ...slotFillProps } />
-		</>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/attributes.tsx
@@ -13,6 +13,10 @@ export default {
 		defaultTitle: __( 'Payment options', 'woo-gutenberg-products-block' ),
 		defaultDescription: '',
 	} ),
+	className: {
+		type: 'string',
+		default: '',
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, Disabled, ExternalLink } from '@wordpress/components';
@@ -13,7 +14,6 @@ import { innerBlockAreas } from '@woocommerce/blocks-checkout';
  */
 import {
 	FormStepBlock,
-	FormStepBlockProps,
 	AdditionalFields,
 	AdditionalFieldsContent,
 } from '../../form-step';
@@ -25,15 +25,30 @@ type paymentAdminLink = {
 	description: string;
 };
 
-export const Edit = ( props: FormStepBlockProps ): JSX.Element => {
+export const Edit = ( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: {
+		title: string;
+		description: string;
+		showStepNumber: boolean;
+		className: string;
+	};
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+} ): JSX.Element => {
 	const globalPaymentMethods = getSetting(
 		'globalPaymentMethods'
 	) as paymentAdminLink[];
 
 	return (
 		<FormStepBlock
-			{ ...props }
-			className="wc-block-checkout__payment-method"
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+			className={ classnames(
+				'wc-block-checkout__payment-method',
+				attributes?.className
+			) }
 		>
 			<InspectorControls>
 				{ globalPaymentMethods.length > 0 && (

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useStoreCart, useEmitResponse } from '@woocommerce/base-context/hooks';
 import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
@@ -20,11 +21,13 @@ const FrontendBlock = ( {
 	description,
 	showStepNumber,
 	children,
+	className,
 }: {
 	title: string;
 	description: string;
 	showStepNumber: boolean;
 	children: JSX.Element;
+	className?: string;
 } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { cartNeedsPayment } = useStoreCart();
@@ -37,7 +40,10 @@ const FrontendBlock = ( {
 		<FormStep
 			id="payment-method"
 			disabled={ checkoutIsProcessing }
-			className="wc-block-checkout__payment-method"
+			className={ classnames(
+				'wc-block-checkout__payment-method',
+				className
+			) }
 			title={ title }
 			description={ description }
 			showStepNumber={ showStepNumber }

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/attributes.tsx
@@ -16,6 +16,10 @@ export default {
 			'woo-gutenberg-products-block'
 		),
 	} ),
+	className: {
+		type: 'string',
+		default: '',
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useBlockProps } from '@wordpress/block-editor';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 
@@ -26,6 +27,7 @@ export const Edit = ( {
 		title: string;
 		description: string;
 		showStepNumber: boolean;
+		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
@@ -43,7 +45,10 @@ export const Edit = ( {
 		<FormStepBlock
 			setAttributes={ setAttributes }
 			attributes={ attributes }
-			className="wc-block-checkout__shipping-fields"
+			className={ classnames(
+				'wc-block-checkout__shipping-fields',
+				attributes?.className
+			) }
 		>
 			<Controls />
 			<Block

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
@@ -18,11 +19,13 @@ const FrontendBlock = ( {
 	description,
 	showStepNumber,
 	children,
+	className,
 }: {
 	title: string;
 	description: string;
 	showStepNumber: boolean;
 	children: JSX.Element;
+	className?: string;
 } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { showShippingFields } = useCheckoutAddress();
@@ -42,7 +45,10 @@ const FrontendBlock = ( {
 		<FormStep
 			id="shipping-fields"
 			disabled={ checkoutIsProcessing }
-			className="wc-block-checkout__shipping-fields"
+			className={ classnames(
+				'wc-block-checkout__shipping-fields',
+				className
+			) }
 			title={ title }
 			description={ description }
 			showStepNumber={ showStepNumber }

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/attributes.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/attributes.tsx
@@ -17,6 +17,10 @@ export default {
 		type: 'boolean',
 		default: false,
 	},
+	className: {
+		type: 'string',
+		default: '',
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { PanelBody, Disabled, ExternalLink } from '@wordpress/components';
@@ -33,6 +34,7 @@ export const Edit = ( {
 		description: string;
 		showStepNumber: boolean;
 		allowCreateAccount: boolean;
+		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
@@ -47,6 +49,10 @@ export const Edit = ( {
 		<FormStepBlock
 			attributes={ attributes }
 			setAttributes={ setAttributes }
+			className={ classnames(
+				'wc-block-checkout__shipping-option',
+				attributes?.className
+			) }
 		>
 			<InspectorControls>
 				{ globalShippingMethods.length > 0 && (

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
@@ -17,6 +18,7 @@ const FrontendBlock = ( {
 	description,
 	showStepNumber,
 	children,
+	className,
 }: {
 	title: string;
 	description: string;
@@ -27,6 +29,7 @@ const FrontendBlock = ( {
 	showPhoneField: boolean;
 	showStepNumber: boolean;
 	children: JSX.Element;
+	className?: string;
 } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { showShippingFields } = useCheckoutAddress();
@@ -39,7 +42,10 @@ const FrontendBlock = ( {
 		<FormStep
 			id="shipping-option"
 			disabled={ checkoutIsProcessing }
-			className="wc-block-checkout__shipping-option"
+			className={ classnames(
+				'wc-block-checkout__shipping-option',
+				className
+			) }
 			title={ title }
 			description={ description }
 			showStepNumber={ showStepNumber }

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/block.json
@@ -11,6 +11,10 @@
 		"reusable": false
 	},
 	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
 		"checkbox": {
 			"type": "boolean",
 			"default": false

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/frontend.tsx
@@ -19,11 +19,13 @@ const FrontendBlock = ( {
 	checkbox,
 	instanceId,
 	validation,
+	className,
 }: {
 	text: string;
 	checkbox: boolean;
 	instanceId: string;
 	validation: ValidationData;
+	className?: string;
 } ): JSX.Element => {
 	const [ checked, setChecked ] = useState( false );
 
@@ -70,9 +72,13 @@ const FrontendBlock = ( {
 
 	return (
 		<div
-			className={ classnames( 'wc-block-checkout__terms', {
-				'wc-block-checkout__terms--disabled': isDisabled,
-			} ) }
+			className={ classnames(
+				'wc-block-checkout__terms',
+				{
+					'wc-block-checkout__terms--disabled': isDisabled,
+				},
+				className
+			) }
 		>
 			{ checkbox ? (
 				<>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/block.json
@@ -12,6 +12,10 @@
 		"inserter": false
 	},
 	"attributes": {
+		"className": {
+			"type": "string",
+			"default": ""
+		},
 		"checkbox": {
 			"type": "boolean",
 			"default": false

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
@@ -13,8 +14,21 @@ import './style.scss';
 import { useForcedLayout, getAllowedBlocks } from '../../../shared';
 import { useCheckoutBlockContext } from '../../context';
 
-export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
-	const blockProps = useBlockProps();
+export const Edit = ( {
+	clientId,
+	attributes,
+}: {
+	clientId: string;
+	attributes: {
+		className?: string;
+	};
+} ): JSX.Element => {
+	const blockProps = useBlockProps( {
+		className: classnames(
+			'wc-block-checkout__sidebar',
+			attributes?.className
+		),
+	} );
 	const { showRateAfterTaxName } = useCheckoutBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CHECKOUT_TOTALS );
 
@@ -35,15 +49,13 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	} );
 
 	return (
-		<Sidebar className="wc-block-checkout__sidebar">
-			<div { ...blockProps }>
-				<InnerBlocks
-					allowedBlocks={ allowedBlocks }
-					templateLock={ false }
-					template={ defaultTemplate }
-					renderAppender={ InnerBlocks.ButtonBlockAppender }
-				/>
-			</div>
+		<Sidebar { ...blockProps }>
+			<InnerBlocks
+				allowedBlocks={ allowedBlocks }
+				templateLock={ false }
+				template={ defaultTemplate }
+				renderAppender={ InnerBlocks.ButtonBlockAppender }
+			/>
 		</Sidebar>
 	);
 };

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/frontend.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
 
 /**
@@ -10,11 +11,17 @@ import './style.scss';
 
 const FrontendBlock = ( {
 	children,
+	className,
 }: {
 	children: JSX.Element;
+	className?: string;
 } ): JSX.Element => {
 	return (
-		<Sidebar className="wc-block-checkout__sidebar">{ children }</Sidebar>
+		<Sidebar
+			className={ classnames( 'wc-block-checkout__sidebar', className ) }
+		>
+			{ children }
+		</Sidebar>
 	);
 };
 


### PR DESCRIPTION
Updates `renderInnerBlocks` to pass the className to our components, and then adds classname support to all checkout inner blocks.

Fixes #4963

### Testing

How to test the changes in this Pull Request:

1. Smoke test checkout
2. Confirm you can add classnames to checkout inner blocks and then are shown on the frontend
   - Select inner block e.g. shipping address
   - Toggle open the advanced section in the inspector
   - Add custom CSS class
   - View frontend
   - Inspect the element using browser tools and confirm the class is present

### Changelog

> Fix custom classname support for inner checkout blocks
