### PR TITLE
Add render logic to BlockTemplateController

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -37,7 +37,7 @@ class BlockTemplatesController {
 	 */
 	protected function init() {
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
-		add_action( 'wp', array( $this, 'render_block_template' ) );
+		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 	}
 
 	/**

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -37,7 +37,6 @@ class BlockTemplatesController {
 	 */
 	protected function init() {
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
-		add_action( 'wp', array( $this, 'render_block_template' ) );
 	}
 
 	/**

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -37,6 +37,7 @@ class BlockTemplatesController {
 	 */
 	protected function init() {
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+		add_action( 'wp', array( $this, 'render_block_template' ) );
 	}
 
 	/**
@@ -102,5 +103,38 @@ class BlockTemplatesController {
 	public function theme_has_template( $template_name ) {
 		return is_readable( get_template_directory() . '/block-templates/' . $template_name . '.html' ) ||
 			is_readable( get_stylesheet_directory() . '/block-templates/' . $template_name . '.html' );
+	}
+
+	/**
+	 * Checks whether a block template with that name exists in Woo Blocks
+	 *
+	 * @param string $template_name Template to check.
+	 * @return boolean
+	 */
+	public function default_block_template_is_available( $template_name ) {
+		if ( ! $template_name ) {
+			return false;
+		}
+
+		return is_readable(
+			$this->templates_directory . '/' . $template_name . '.html'
+		);
+	}
+
+	/**
+	 * Renders the default block template from Woo Blocks if no theme templates exist.
+	 */
+	public function render_block_template() {
+		if ( is_embed() || ! gutenberg_supports_block_templates() ) {
+			return;
+		}
+
+		if (
+			is_singular( 'product' ) &&
+			! $this->theme_has_template( 'single-product' ) &&
+			$this->default_block_template_is_available( 'single-product' )
+		) {
+			add_filter( 'wc_has_block_template', '__return_true', 10, 0 );
+		}
 	}
 }

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -37,6 +37,7 @@ class BlockTemplatesController {
 	 */
 	protected function init() {
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+		add_action( 'wp', array( $this, 'render_block_template' ) );
 	}
 
 	/**

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -125,7 +125,7 @@ class BlockTemplatesController {
 	 * Renders the default block template from Woo Blocks if no theme templates exist.
 	 */
 	public function render_block_template() {
-		if ( is_embed() || ! gutenberg_supports_block_templates() ) {
+		if ( is_embed() || function_exists( 'gutenberg_supports_block_templates' ) && ! gutenberg_supports_block_templates() ) {
 			return;
 		}
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -125,7 +125,7 @@ class BlockTemplatesController {
 	 * Renders the default block template from Woo Blocks if no theme templates exist.
 	 */
 	public function render_block_template() {
-		if ( is_embed() || function_exists( 'gutenberg_supports_block_templates' ) && ! gutenberg_supports_block_templates() ) {
+		if ( is_embed() || ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() ) {
 			return;
 		}
 

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -83,7 +83,7 @@ class BlockTemplateUtils {
 	 * @return WP_Block_Template Template.
 	 */
 	public static function gutenberg_build_template_result_from_file( $template_file, $template_type ) {
-		$default_template_types = gutenberg_get_default_template_types();
+		$default_template_types = function_exists( 'gutenberg_get_default_template_types' ) ? gutenberg_get_default_template_types() : array();
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$template_content = file_get_contents( $template_file['path'] );
 		$theme            = wp_get_theme()->get_stylesheet();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4971

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Amend WooCommerce Core or checkout this PR https://github.com/woocommerce/woocommerce/pull/30997
2. Add the following snippets below to template files in the correct directories specified.
3. Go to your Product Page and confirm the themes template is being rendered.
4. Delete the themes `single-product.html` template and refresh your Product Page. Confirm the Woo Blocks template is being rendered.
4. Delete Woo Blocks template file and refresh your Product Page. Confirm the Core WooCommerce PHP template is being rendered.

`/theme-dir/block-templates/single-product.html`
```html
<!-- wp:template-part {"slug":"header"} /-->
<!-- wp:paragraph --> <p>You are using the Themes block template now</p> <!-- /wp:paragraph -->
<!-- wp:template-part {"slug":"footer"} /-->
```

`/woo-blocks/templates/block-templates/single-product.html`
```html
<!-- wp:template-part {"slug":"header"} /-->
<!-- wp:paragraph --> <p>You are using the Woo Blocks block template now</p> <!-- /wp:paragraph -->
<!-- wp:template-part {"slug":"footer"} /-->
```

### Changelog

> FSE: Add render logic to BlockTemplateController.
