### PR TITLE
Cart i2: migrate alignment options

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/attributes.js
+++ b/assets/js/blocks/cart-checkout/cart/attributes.js
@@ -27,4 +27,7 @@ export const blockAttributes = {
 		type: 'boolean',
 		default: true,
 	},
+	align: {
+		type: 'string',
+	},
 };

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -62,35 +62,44 @@ const settings = {
 					isShippingCalculatorEnabled,
 					showRateAfterTaxName,
 					checkoutPageId,
+					align,
 				} = attributes;
 				return [
 					attributes,
 					[
-						createBlock( 'woocommerce/filled-cart-block', {}, [
-							createBlock( 'woocommerce/cart-items-block' ),
-							createBlock( 'woocommerce/cart-totals-block', {}, [
+						createBlock(
+							'woocommerce/filled-cart-block',
+							{ align },
+							[
+								createBlock( 'woocommerce/cart-items-block' ),
 								createBlock(
-									'woocommerce/cart-order-summary-block',
-									{
-										isShippingCalculatorEnabled,
-										showRateAfterTaxName,
-									}
+									'woocommerce/cart-totals-block',
+									{},
+									[
+										createBlock(
+											'woocommerce/cart-order-summary-block',
+											{
+												isShippingCalculatorEnabled,
+												showRateAfterTaxName,
+											}
+										),
+										createBlock(
+											'woocommerce/cart-express-payment-block'
+										),
+										createBlock(
+											'woocommerce/proceed-to-checkout-block',
+											{ checkoutPageId }
+										),
+										createBlock(
+											'woocommerce/cart-accepted-payment-methods-block'
+										),
+									]
 								),
-								createBlock(
-									'woocommerce/cart-express-payment-block'
-								),
-								createBlock(
-									'woocommerce/proceed-to-checkout-block',
-									{ checkoutPageId }
-								),
-								createBlock(
-									'woocommerce/cart-accepted-payment-methods-block'
-								),
-							] ),
-						] ),
+							]
+						),
 						createBlock(
 							'woocommerce/empty-cart-block',
-							{},
+							{ align },
 							innerBlocks
 						),
 					],


### PR DESCRIPTION
Alignment options changed between Cart i1 and Cart i2. In Cart i2, you need to apply alignment in both Cart and filled cart/empty cart to it to be applied in the editor.

This PR migrates that.

### Testing steps
- Checkout an old tag `git checkout v6.0.0`
- Insert Cart i1.
- Change alignment to full or wide.
- Checkout this branch, refresh the cart in editor, you should see it full.
- Check frontend, it should be respected there.