### PR TITLE
Add abstract legacy template block

### DIFF
--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { registerExperimentalBlockType } from '@woocommerce/block-settings';
-import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
-import { Placeholder } from 'wordpress-components';
+import { Placeholder } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 
 interface Props {
 	attributes: {
@@ -17,7 +17,14 @@ const Edit = ( { attributes }: Props ) => {
 	return (
 		<div { ...blockProps }>
 			<Placeholder
-				label={ `Wireframe template for ${ attributes.template } will be rendered here` }
+				label={ sprintf(
+					/* translators: %s is the template name */
+					__(
+						'Wireframe template for %s will be rendered here.',
+						'woo-gutenberg-products-block'
+					),
+					attributes.template
+				) }
 			/>
 		</div>
 	);

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -59,6 +59,12 @@ registerExperimentalBlockType( 'woocommerce/legacy-template', {
 			type: 'string',
 			default: 'any',
 		},
+		lock: {
+			type: 'object',
+			default: {
+				remove: true,
+			},
+		},
 	},
 	edit: Edit,
 	save: () => null,

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import { registerExperimentalBlockType } from '@woocommerce/block-settings';
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+import { Placeholder } from 'wordpress-components';
+
+interface Props {
+	attributes: {
+		template: string;
+	};
+}
+
+const Edit = ( { attributes }: Props ) => {
+	const blockProps = useBlockProps();
+	return (
+		<div { ...blockProps }>
+			<Placeholder
+				label={ `Wireframe template for ${ attributes.template } will be rendered here` }
+			/>
+		</div>
+	);
+};
+
+registerExperimentalBlockType( 'woocommerce/legacy-template', {
+	title: __( 'Legacy Template', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce',
+	apiVersion: 2,
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	description: __(
+		'Renders legacy PHP templates.',
+		'woo-gutenberg-products-block'
+	),
+	supports: {
+		align: false,
+		html: false,
+		multiple: false,
+		reusable: false,
+		inserter: false,
+	},
+	example: {
+		attributes: {
+			isPreview: true,
+		},
+	},
+	attributes: {
+		/**
+		 * Template attribute is used to determine which core PHP template gets rendered.
+		 */
+		template: {
+			type: 'string',
+			default: 'any',
+		},
+	},
+	edit: Edit,
+	save: () => null,
+} );

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -31,12 +31,12 @@ const Edit = ( { attributes }: Props ) => {
 };
 
 registerExperimentalBlockType( 'woocommerce/legacy-template', {
-	title: __( 'Legacy Template', 'woo-gutenberg-products-block' ),
+	title: __( 'WooCommerce Legacy Template', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	apiVersion: 2,
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Renders legacy PHP templates.',
+		'Renders legacy WooCommerce PHP templates.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -53,6 +53,7 @@ const blocks = {
 	'single-product': {
 		isExperimental: true,
 	},
+	'legacy-template': {},
 };
 
 // Returns the entries for each block given a relative path (ie: `index.js`,

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -176,16 +176,22 @@ abstract class AbstractBlock {
 	 * Registers the block type with WordPress.
 	 */
 	protected function register_block_type() {
+		$block_settings = [
+			'render_callback' => $this->get_block_type_render_callback(),
+			'editor_script'   => $this->get_block_type_editor_script( 'handle' ),
+			'editor_style'    => $this->get_block_type_editor_style(),
+			'style'           => $this->get_block_type_style(),
+			'attributes'      => $this->get_block_type_attributes(),
+			'supports'        => $this->get_block_type_supports(),
+		];
+
+		if ( isset( $this->api_version ) && '2' === $this->api_version ) {
+			$block_settings['api_version'] = 2;
+		}
+
 		register_block_type(
 			$this->get_block_type(),
-			array(
-				'render_callback' => $this->get_block_type_render_callback(),
-				'editor_script'   => $this->get_block_type_editor_script( 'handle' ),
-				'editor_style'    => $this->get_block_type_editor_style(),
-				'style'           => $this->get_block_type_style(),
-				'attributes'      => $this->get_block_type_attributes(),
-				'supports'        => $this->get_block_type_supports(),
-			)
+			$block_settings
 		);
 	}
 

--- a/src/BlockTypes/LegacyTemplate.php
+++ b/src/BlockTypes/LegacyTemplate.php
@@ -1,0 +1,64 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * Legacy Single Product class
+ *
+ * @internal
+ */
+class LegacyTemplate extends AbstractDynamicBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'legacy-template';
+
+	/**
+	 * API version.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Render method for the Legacy Template block. This method will determine which template to render.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block content.
+	 *
+	 * @return string | void Rendered block type output.
+	 */
+	protected function render( $attributes, $content ) {
+		if ( null === $attributes['template'] ) {
+			return;
+		}
+
+		ob_start();
+
+		if ( 'single-product' === $attributes['template'] ) {
+			$this->render_single_product();
+		} else {
+			ob_start();
+
+			echo "You're using the LegacyTemplate block";
+
+			wp_reset_postdata();
+			return ob_get_clean();
+		}
+	}
+
+	/**
+	 * Render method for the single product template and parts.
+	 *
+	 * @return string Rendered block type output.
+	 */
+	protected function render_single_product() {
+		ob_start();
+
+		echo 'This method will render the single product template';
+
+		wp_reset_postdata();
+		return ob_get_clean();
+	}
+}

--- a/src/BlockTypes/LegacyTemplate.php
+++ b/src/BlockTypes/LegacyTemplate.php
@@ -34,10 +34,8 @@ class LegacyTemplate extends AbstractDynamicBlock {
 			return;
 		}
 
-		ob_start();
-
 		if ( 'single-product' === $attributes['template'] ) {
-			$this->render_single_product();
+			return $this->render_single_product();
 		} else {
 			ob_start();
 

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -174,6 +174,7 @@ final class BlockTypesController {
 			'AttributeFilter',
 			'StockFilter',
 			'ActiveFilters',
+			'LegacyTemplate',
 		];
 
 		if ( Package::feature()->is_feature_plugin_build() ) {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4972

### Description
This will add a block which given a `template` attribute will enable us to render a specific core PHP template.

#### Whats not included
This PR does not include any visual placeholder UI work, or individual template work which will be done as part of the PR for that specific template (e.g. `single-product.php`). This is purely an abstract block which will enable us to render those templates in future PRs

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Checkout and build this branch
2. If [this PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4984) hasn't been merged, temporarily copy the changes to your dev environment. (If it has been merged, please ping so we can rebase this PR)
2. Add the below snippet to `woo-blocks/templates/block-templates/single-product.html`
3. Go to Site Editor and switch to the Single Product template. You should see the placeholder block there.
4. Go to a product page on the frontend of your website and it should render "This method will render the single product template"

```html
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true} /-->
<!-- wp:woocommerce/legacy-template { "template": "single-product" } /-->
<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true} /-->
```

### Changelog

> FSE: Add abstract block legacy template for core PHP templates.
