### PR TITLE
Add cart item classname filter

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { sprintf, _n } from '@wordpress/i18n';
 import Label from '@woocommerce/base-components/label';
 import ProductPrice from '@woocommerce/base-components/product-price';
@@ -108,8 +109,20 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		validation: productPriceValidation,
 	} );
 
+	const cartItemClassNameFilter = __experimentalApplyCheckoutFilter( {
+		filterName: 'cartItemClass',
+		defaultValue: '',
+		extensions,
+		arg,
+	} );
+
 	return (
-		<div className="wc-block-components-order-summary-item">
+		<div
+			className={ classnames(
+				'wc-block-components-order-summary-item',
+				cartItemClassNameFilter
+			) }
+		>
 			<div className="wc-block-components-order-summary-item__image">
 				<div className="wc-block-components-order-summary-item__quantity">
 					<Label

--- a/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
@@ -162,9 +162,6 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 		const isProductHiddenFromCatalog =
 			catalogVisibility === 'hidden' || catalogVisibility === 'search';
 
-		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
-		// Allow extensions to add extra cart item classes.
-
 		const cartItemClassNameFilter = __experimentalApplyCheckoutFilter( {
 			filterName: 'cartItemClass',
 			defaultValue: '',
@@ -172,6 +169,7 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 			arg,
 		} );
 
+		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
 		const productPriceFormat = __experimentalApplyCheckoutFilter( {
 			filterName: 'cartItemPrice',
 			defaultValue: '<price/>',

--- a/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
@@ -163,6 +163,14 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 			catalogVisibility === 'hidden' || catalogVisibility === 'search';
 
 		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
+		// Allow extensions to add extra cart item classes.
+
+		const cartItemClassNameFilter = __experimentalApplyCheckoutFilter( {
+			filterName: 'cartItemClass',
+			defaultValue: '',
+			extensions,
+			arg,
+		} );
 
 		const productPriceFormat = __experimentalApplyCheckoutFilter( {
 			filterName: 'cartItemPrice',
@@ -190,9 +198,13 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 
 		return (
 			<tr
-				className={ classnames( 'wc-block-cart-items__row', {
-					'is-disabled': isPendingDelete,
-				} ) }
+				className={ classnames(
+					'wc-block-cart-items__row',
+					cartItemClassNameFilter,
+					{
+						'is-disabled': isPendingDelete,
+					}
+				) }
 				ref={ ref }
 				tabIndex={ tabIndex }
 			>

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -35,6 +35,7 @@ The sale badges are not shown here, so those filters are not applied in the Orde
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `itemName`            | Used to change the name of the item before it is rendered onto the page                                                                | `string`                                                                              |
 | `cartItemPrice`       | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
+| `cartItemClass`        | This is the className of the item cell.                                                          | `string` |
 | `subtotalPriceFormat` | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
 
 Each of these filters has the following additional arguments passed to it: `{ context: 'summary', cartItem: CartItem }` ([CartItem](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L113))

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -16,6 +16,7 @@ The following filters are available for line items:
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `itemName`             | Used to change the name of the item before it is rendered onto the page                                                                | `string`                                                                              |
 | `cartItemPrice`        | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
+| `cartItemClass`        | This is the className of the item cell.                                                          | `string` |
 | `subtotalPriceFormat`  | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
 | `saleBadgePriceFormat` | This is amount of money saved when buying this item. It is the difference between the item's regular price and its sale price.         | `string` and **must** contain the substring `<price/>` where the price should appear. |
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds cartItemClass filter, to allow cart items classes to be customized depending on context.
<!-- Reference any related issues or PRs here -->
Cherry-picked from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4241

### Testing

How to test the changes in this Pull Request:

1. Not much to test given this is a filter, but you can insert this code somewhere.
```js
const { __experimentalRegisterCheckoutFilters } = window.wc.blocksCheckout;
__experimentalRegisterCheckoutFilters( 'my-hypothetical-deposit-plugin', {
	cartItemClass: () => 'my-class',
} );

```
2. You should see `my-class` on all cart items.

### Changelog

> Introduce `cartItemClass` filter for cart items in Cart and Checkout blocks.
