### PR TITLE
Add cart item name filter

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.js
@@ -28,6 +28,7 @@ import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
 
 const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
+const productNameValidation = ( value ) => mustContain( value, '<name/>' );
 
 const OrderSummaryItem = ( { cartItem } ) => {
 	const {
@@ -108,6 +109,15 @@ const OrderSummaryItem = ( { cartItem } ) => {
 		validation: productPriceValidation,
 	} );
 
+	// Allow extensions to filter and format product names.
+	const productNameFormat = __experimentalApplyCheckoutFilter( {
+		filterName: 'productNameFormat',
+		defaultValue: '<name/>',
+		extensions,
+		arg,
+		validation: productNameValidation,
+	} );
+
 	return (
 		<div className="wc-block-components-order-summary-item">
 			<div className="wc-block-components-order-summary-item__image">
@@ -133,6 +143,7 @@ const OrderSummaryItem = ( { cartItem } ) => {
 					disabled={ true }
 					name={ name }
 					permalink={ permalink }
+					format={ productNameFormat }
 				/>
 				<ProductPrice
 					currency={ priceCurrency }

--- a/assets/js/base/components/product-name/index.tsx
+++ b/assets/js/base/components/product-name/index.tsx
@@ -14,6 +14,7 @@ interface ProductNameProps extends AnchorHTMLAttributes< HTMLAnchorElement > {
 	disabled?: boolean;
 	name: string;
 	permalink?: string;
+	format?: string;
 	onClick?: () => void;
 }
 
@@ -30,9 +31,20 @@ export default ( {
 	rel,
 	style,
 	onClick,
+	format = '<name/>',
 	...props
 }: ProductNameProps ): JSX.Element => {
 	const classes = classnames( 'wc-block-components-product-name', className );
+	if ( ! format.includes( '<name/>' ) ) {
+		format = '<name/>';
+		// eslint-disable-next-line no-console
+		console.error(
+			'Product name formats need to include the `<name/>` tag.'
+		);
+	}
+
+	const formattedName = format.replace( '<name/>', name );
+
 	if ( disabled ) {
 		// Cast the props as type HTMLSpanElement.
 		const disabledProps = props as HTMLAttributes< HTMLSpanElement >;
@@ -41,7 +53,7 @@ export default ( {
 				className={ classes }
 				{ ...disabledProps }
 				dangerouslySetInnerHTML={ {
-					__html: decodeEntities( name ),
+					__html: decodeEntities( formattedName ),
 				} }
 			/>
 		);
@@ -53,7 +65,7 @@ export default ( {
 			rel={ rel }
 			{ ...props }
 			dangerouslySetInnerHTML={ {
-				__html: decodeEntities( name ),
+				__html: decodeEntities( formattedName ),
 			} }
 		/>
 	);

--- a/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
@@ -47,7 +47,11 @@ const getAmountFromRawPrice = (
 	return priceObject.convertPrecision( currency.minorUnit ).getAmount();
 };
 
-const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
+const productPriceValidation = ( value: string ): true | Error =>
+	mustContain( value, '<price/>' );
+
+const productNameValidation = ( value: string ): true | Error =>
+	mustContain( value, '<name/>' );
 
 interface CartLineItemRowProps {
 	lineItem: CartItem | Record< string, never >;
@@ -162,8 +166,15 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 		const isProductHiddenFromCatalog =
 			catalogVisibility === 'hidden' || catalogVisibility === 'search';
 
-		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
+		const productNameFormat = __experimentalApplyCheckoutFilter( {
+			filterName: 'productNameFormat',
+			defaultValue: '<name/>',
+			extensions,
+			arg,
+			validation: productNameValidation,
+		} );
 
+		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
 		const productPriceFormat = __experimentalApplyCheckoutFilter( {
 			filterName: 'cartItemPrice',
 			defaultValue: '<price/>',
@@ -219,6 +230,7 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 						}
 						name={ name }
 						permalink={ permalink }
+						format={ productNameFormat }
 					/>
 					{ showBackorderBadge ? (
 						<ProductBackorderBadge />

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -18,6 +18,7 @@ The following filters are available for line items:
 | `cartItemPrice`        | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
 | `subtotalPriceFormat`  | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
 | `saleBadgePriceFormat` | This is amount of money saved when buying this item. It is the difference between the item's regular price and its sale price.         | `string` and **must** contain the substring `<price/>` where the price should appear. |
+| `productNameFormat` | This is the name of a single item. before being turned to a link. | `string` and **must** contain the substring `<name/>` where the original name should appear. |
 
 Each of these filters has the following arguments passed to it: `{ context: 'cart', cartItem: CartItem }` ([CartItem](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L113))
 
@@ -35,6 +36,7 @@ The sale badges are not shown here, so those filters are not applied in the Orde
 | `itemName`            | Used to change the name of the item before it is rendered onto the page                                                                | `string`                                                                              |
 | `cartItemPrice`       | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
 | `subtotalPriceFormat` | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
+| `productNameFormat` | This is the name of a single item. before being turned to a link. | `string` and **must** contain the substring `<name/>` where the original name should appear. |
 
 Each of these filters has the following additional arguments passed to it: `{ context: 'summary', cartItem: CartItem }` ([CartItem](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L113))
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds productNameFormat filter, to allow cart items names to be customized depending on context.
<!-- Reference any related issues or PRs here -->
Cherry-picked from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4241

### Testing

How to test the changes in this Pull Request:

1. Not much to test given this is a filter, but you can insert this code somewhere.
```js
const { __experimentalRegisterCheckoutFilters } = window.wc.blocksCheckout;
__experimentalRegisterCheckoutFilters( 'my-hypothetical-deposit-plugin', {
	productNameFormat: ( name ) => `${ name } customized`,
} );
```
2. In Checkout, you should see the item name with customized at the end of it.
3. On Cart, you should see the item link with customized at the end of it, it should be included in the link.

### Changelog

> Introduce `productNameFormat` filter for cart items in Cart and Checkout blocks.
