### PR TITLE
Add `register_payment_requirements` documentation

### DIFF
--- a/docs/extensibility/filtering-payment-methods.md
+++ b/docs/extensibility/filtering-payment-methods.md
@@ -101,5 +101,86 @@ If you need data that is not available in the parameter received by the callback
 # Filtering payment methods using requirements
 
 ## The problem
-Your extension has registered a payment method that is capable of taking 
+Your extension has added functionality to your store in such a way that only specific payment gateways can process
+orders that contain certain products.
 
+Using the example of `Bookings` if the shopper adds a `Bookable` product to their cart, for example a stay in a hotel,
+and you, the merchant, want to confirm all bookings before taking payment. You would still need to capture the customer's
+checkout details but not their payment method at that point.
+
+## The solution
+To allow the shopper to check out without entering payment details, but still require them to fill in the other
+checkout details it is possible to create a new payment method which will handle carts containing a `Bookable` item.
+
+Using the `supports` configuration of payment methods it is possible to prevent other payment methods
+(such as credit card, PayPal etc.) from being used to check out, and only allow the one your extension has added to
+appear in the Checkout block.
+
+For more information on how to register a payment method with WooCommerce Blocks, please refer to the
+[Payment method integration](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/extensibility/payment-method-integration.md)
+documentation.
+
+## Basic usage
+Following the documentation for registering payment methods linked above, you should register your payment method with a
+unique `supports` feature, for example `booking_availability`. This will be used to isolate it and prevent other methods
+from displaying.
+
+First you will need to create a function that will perform the checks on the cart to determine what the specific payment
+requirements of the cart are. Below is an example of doing this for our `Bookable` products. 
+
+Then you will need to use the `register_payment_requirements` on the `ExtendRestApi` class to tell the Checkout block
+to execute a callback to check for requirements.
+
+## Putting it all together
+
+This code example assumes there is some class called `Pseudo_Booking_Class` that has the `cart_contains_bookable_product`
+method available. The implementation of this method is not relevant here.
+
+```php
+/**
+ * Check the content of the cart and add required payment methods.
+ *
+ *
+ * @return array list of features required by cart items.
+ */
+function inject_payment_feature_requirements_for_cart_api() {
+
+	// Cart contains a bookable product, so return an array containing our requirement of booking_availability.
+	if ( Pseudo_Booking_Class::cart_contains_bookable_product() ) {
+		return array( 'booking_availability' );
+	}
+
+    // No bookable products in the cart, no need to add anything.
+	return array()
+}
+```
+
+To summarise the above: if there's a bookable product in the cart then this function will return an array containing
+`booking_availability`, otherwise it will return an empty array.
+
+The next step will tell the `ExtendRestApi` to execute this callback when checking which payment methods to display.
+
+To do this you could use the following code:
+```php
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+
+add_action('woocommerce_blocks_loaded', function() {
+ // ExtendRestApi is stored in the container as a shared instance between the API and consumers.
+ // You shouldn't initiate your own ExtendRestApi instance using `new ExtendRestApi` but should
+ // always use the shared instance from the Package dependency injection container.
+ $extend = Package::container()->get( ExtendRestApi::class );
+
+ $extend->register_payment_requirements(
+	array(
+		'data_callback' => 'inject_payment_feature_requirements_for_cart_api',
+		)
+	);
+});
+```
+
+It is important to note the comment in this code block, you must not instantiate your own version of `ExtendRestApi`.
+
+If you've added your payment method correctly with the correct `supports` values then when you reach the checkout page
+with a `Bookable` item in your cart, any method that does not `supports` the `booking_availability` requirement should
+not display, while yours, the one that _does_ support this requirement _will_ display.

--- a/docs/extensibility/filtering-payment-methods.md
+++ b/docs/extensibility/filtering-payment-methods.md
@@ -1,3 +1,17 @@
+- [Filtering payment methods in the Checkout block](#filtering-payment-methods-in-the-checkout-block)
+  - [The problem](#the-problem)
+  - [The solution](#the-solution)
+  - [Importing](#importing)
+  - [Signature](#signature)
+    - [Extension namespace collision](#extension-namespace-collision)
+  - [Usage example](#usage-example)
+  - [Callbacks registered for payment methods](#callbacks-registered-for-payment-methods)
+- [Filtering payment methods using requirements](#filtering-payment-methods-using-requirements)
+  - [The problem](#the-problem-1)
+  - [The solution](#the-solution-1)
+  - [Basic usage](#basic-usage)
+  - [Putting it all together](#putting-it-all-together)
+
 # Filtering payment methods in the Checkout block
 
 ## The problem
@@ -7,6 +21,8 @@ You're an extension developer, and your extension is conditionally hiding paymen
 ## The solution
 
 WooCommerce Blocks provides a function called `registerPaymentMethodExtensionCallbacks` which allows extensions to register callbacks for specific payment methods to determine if they can make payments.
+
+
 
 ## Importing
 
@@ -81,3 +97,9 @@ interface CanMakePaymentArgument {
 ```
 
 If you need data that is not available in the parameter received by the callback you can consider [exposing your data in the Store API](extend-rest-api-add-data.md).
+
+# Filtering payment methods using requirements
+
+## The problem
+Your extension has registered a payment method that is capable of taking 
+


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds documentation about how `register_payment_requirements` can be used and uses the example of WooCommerce bookings (though simplified somewhat) to do so.

To test this PR please read the documentation and ensure it makes sense from a developer's point of view.

<!-- Reference any related issues or PRs here -->
Fixes #4940