### PR TITLE
Fix duplicate queries in product grids #4695

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -306,13 +306,37 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		// Remove ordering query arguments which may have been added by get_catalog_ordering_args.
 		WC()->query->remove_ordering_args();
 
-		// Prime caches to reduce future queries.
+		// Prime caches to reduce future queries. Note _prime_post_caches is private--we could replace this with our own
+		// query if it becomes unavailable.
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $results );
-			$this->prime_product_variations( $results );
 		}
 
+		$this->prime_product_variations( $results );
+
 		return $results;
+	}
+
+	/**
+	 * Retrieve IDs that are not already present in the cache.
+	 *
+	 * Based on WordPress function: _get_non_cached_ids
+	 *
+	 * @param int[]  $product_ids Array of IDs.
+	 * @param string $cache_key  The cache bucket to check against.
+	 * @return int[] Array of IDs not present in the cache.
+	 */
+	protected function get_non_cached_ids( $product_ids, $cache_key ) {
+		$non_cached_ids = array();
+		$cache_values   = wp_cache_get_multiple( $product_ids, $cache_key );
+
+		foreach ( $cache_values as $id => $value ) {
+			if ( ! $value ) {
+				$non_cached_ids[] = (int) $id;
+			}
+		}
+
+		return $non_cached_ids;
 	}
 
 	/**
@@ -324,64 +348,47 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @param int[] $product_ids Product ids to prime variation cache for.
 	 */
 	protected function prime_product_variations( $product_ids ) {
-		global $wpdb;
-		static $primed_product_ids = [];
-
-		$prime_product_ids = array_diff( wp_parse_id_list( $product_ids ), $primed_product_ids );
+		$cache_group       = 'product_variation_meta_data';
+		$prime_product_ids = $this->get_non_cached_ids( wp_parse_id_list( $product_ids ), $cache_group );
 
 		if ( ! $prime_product_ids ) {
 			return;
 		}
 
+		global $wpdb;
+
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$product_variations      = array_map(
-			function( $row ) {
-				$row['product_id']   = absint( $row['product_id'] );
-				$row['variation_id'] = absint( $row['variation_id'] );
-				return $row;
-			},
-			$wpdb->get_results( "SELECT ID as variation_id, post_parent as product_id from {$wpdb->posts} WHERE post_parent IN ( " . implode( ',', $prime_product_ids ) . ' )', ARRAY_A )
-		);
+		$product_variations      = $wpdb->get_results( "SELECT ID as variation_id, post_parent as product_id from {$wpdb->posts} WHERE post_parent IN ( " . implode( ',', $prime_product_ids ) . ' )', ARRAY_A );
 		$prime_variation_ids     = array_column( $product_variations, 'variation_id' );
 		$variation_ids_by_parent = array_column( $product_variations, 'product_id', 'variation_id' );
 		$all_variation_meta_data = $wpdb->get_results(
 			$wpdb->prepare(
-				"
-					SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value
-					FROM {$wpdb->postmeta}
-					WHERE post_id IN (" . implode( ',', array_map( 'esc_sql', $prime_variation_ids ) ) . ')
-					AND meta_key LIKE %s
-				',
+				"SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value FROM {$wpdb->postmeta} WHERE post_id IN (" . implode( ',', array_map( 'esc_sql', $prime_variation_ids ) ) . ') AND meta_key LIKE %s',
 				$wpdb->esc_like( 'attribute_' ) . '%'
 			)
 		);
 		// phpcs:enable
 
+		// Prepare the data to cache by indexing by the parent product.
 		$primed_data = array_reduce(
 			$all_variation_meta_data,
 			function( $values, $data ) use ( $variation_ids_by_parent ) {
-				$product_id = isset( $variation_ids_by_parent[ (int) $data->variation_id ] ) ? $variation_ids_by_parent[ (int) $data->variation_id ] : 0;
-
-				if ( $product_id ) {
-					$values[ $product_id ][] = $data;
-				}
+				$values[ $variation_ids_by_parent[ $data->variation_id ] ?? 0 ][] = $data;
 				return $values;
 			},
 			array_fill_keys( $prime_product_ids, [] )
 		);
 
+		// Cache everything.
 		foreach ( $primed_data as $product_id => $variation_meta_data ) {
-			$cache_key   = 'product_' . $product_id . '_variation_meta_data';
-			$cache_group = 'store_api';
 			wp_cache_set(
-				$cache_key,
+				$product_id,
 				[
 					'last_modified' => get_the_modified_date( 'U', $product_id ),
 					'data'          => $variation_meta_data,
 				],
 				$cache_group
 			);
-			$primed_product_ids[] = $product_id;
 		}
 	}
 

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -593,9 +593,8 @@ class ProductSchema extends AbstractSchema {
 		/**
 		 * Gets individual variation data from the database, using cache where possible.
 		 */
-		$cache_key     = 'product_' . $product->get_id() . '_variation_meta_data';
-		$cache_group   = 'store_api';
-		$cache_value   = wp_cache_get( $cache_key, $cache_group );
+		$cache_group   = 'product_variation_meta_data';
+		$cache_value   = wp_cache_get( $product->get_id(), $cache_group );
 		$last_modified = get_the_modified_date( 'U', $product->get_id() );
 
 		if ( false === $cache_value || $last_modified !== $cache_value['last_modified'] ) {
@@ -612,7 +611,7 @@ class ProductSchema extends AbstractSchema {
 			// phpcs:enable
 
 			wp_cache_set(
-				$cache_key,
+				$product->get_id(),
 				[
 					'last_modified' => $last_modified,
 					'data'          => $variation_meta_data,

--- a/src/StoreApi/Schemas/ProductSchema.php
+++ b/src/StoreApi/Schemas/ProductSchema.php
@@ -628,8 +628,10 @@ class ProductSchema extends AbstractSchema {
 		$attributes_by_variation = array_reduce(
 			$variation_meta_data,
 			function( $values, $data ) use ( $default_variation_meta_keys ) {
-				// Whilst the query above only includes keys of $default_variation_meta_data, the cache may have been
-				// primed elsewhere.
+				// The query above only includes the keys of $default_variation_meta_data so we know all of the attributes
+				// being processed here apply to this product. However, we need an additional check here because the
+				// cache may have been primed elsewhere and include keys from other products.
+				// @see AbstractProductGrid::prime_product_variations.
 				if ( in_array( $data->attribute_key, $default_variation_meta_keys, true ) ) {
 					$values[ $data->variation_id ][ $data->attribute_key ] = $data->attribute_value;
 				}


### PR DESCRIPTION
Adds caching (and cache priming) to the product grid to prevent duplicate queries.

Fixes #4695

The issue here was the [`get_variations` method in the `ProductSchema` class](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/961c0c476d4228a218859c658c42f9b6eebfdec4/src/StoreApi/Schemas/ProductSchema.php#L568) queries all product variations per product, and that custom query is uncached. If the same product is queried multiple times (for instance, if showing multiple product grids) the query will repeat. This results in duplicate queries.

To test this, I added 2 product grids to a page, both containing variable products. This is an example from Query Monitor:

![Screenshot 2021-10-27 at 12 14 00](https://user-images.githubusercontent.com/90977/139055226-a271c4e1-a2cd-4255-9efa-d8f2176dc3cf.png)
![Screenshot 2021-10-27 at 12 13 48](https://user-images.githubusercontent.com/90977/139055198-0f055c24-203a-4cd7-9da3-669d81ffb2de.png)

Notice (1), there are 2 calls to each set of variations (duplicate queries). This needs fixing with cache.

Notice (2), there is a separate query for each variable product. This is expected, but could be fixed by priming the cache.

This PR implements both. A cache for each products `$variation_meta_data` query (1), and a cache priming function once the results of the product grid query are returned (2). This eliminates duplicate queries, and  reduces the overall total number of queries on the page:

![Screenshot 2021-10-27 at 12 16 49](https://user-images.githubusercontent.com/90977/139055602-24112f4d-eb1d-47be-9ffd-28b6586fe88c.png)

**Testing**

User facing:

1. Add multiple product grid blocks to a page e.g. `Products by Category`. Ensure there are some variable products visible, or add some new ones
2. Check the Grid Block renders correctly on the frontend.

Dev:

1. Install Query Monitor
2. Check the total number of queries for the above scenario before and after this patch
3. Confirm total number of queries is reduced and there are no duplicate queries for this grid block shown in query monitor
4. Make an API request to a variable product by ID, e.g. `https://store.local/wp-json/wc/store/products/11`. Confirm the `variations` section is still populated.

**Changelog**

> Improved performance of Product Grid Blocks and Products Store API endpoint by caching product variations.
