### PR TITLE
Return an element instead of a component in useViewSwitcher

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -157,7 +157,7 @@ export const Edit = ( { className, attributes, setAttributes, clientId } ) => {
 						setAttributes={ setAttributes }
 					/>
 					<BlockControls __experimentalShareWithChildBlocks>
-						<ViewSwitcherComponent />
+						{ ViewSwitcherComponent }
 					</BlockControls>
 					<CartBlockContext.Provider
 						value={ {

--- a/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
@@ -19,14 +19,14 @@ export const useViewSwitcher = (
 	views: View[]
 ): {
 	currentView: string;
-	component: () => JSX.Element;
+	component: JSX.Element;
 } => {
 	const initialView = views[ 0 ];
 	const [ currentView, setCurrentView ] = useState( initialView );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const { getBlock } = select( blockEditorStore );
 
-	const ViewSwitcherComponent = () => (
+	const ViewSwitcherComponent = (
 		<Toolbar>
 			<ToolbarDropdownMenu
 				label={ __( 'Switch view', 'woo-gutenberg-products-block' ) }
@@ -37,6 +37,7 @@ export const useViewSwitcher = (
 				controls={ views.map( ( view ) => ( {
 					...view,
 					title: view.label,
+					isActive: view.view === currentView.view,
 					onClick: () => {
 						setCurrentView( view );
 						selectBlock(

--- a/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
-import { Toolbar, ToolbarDropdownMenu } from '@wordpress/components';
+import { ToolbarGroup, ToolbarDropdownMenu } from '@wordpress/components';
 import { Icon, eye } from '@woocommerce/icons';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
@@ -27,7 +27,7 @@ export const useViewSwitcher = (
 	const { getBlock } = select( blockEditorStore );
 
 	const ViewSwitcherComponent = (
-		<Toolbar>
+		<ToolbarGroup>
 			<ToolbarDropdownMenu
 				label={ __( 'Switch view', 'woo-gutenberg-products-block' ) }
 				text={ currentView.label }
@@ -49,7 +49,7 @@ export const useViewSwitcher = (
 					},
 				} ) ) }
 			/>
-		</Toolbar>
+		</ToolbarGroup>
 	);
 
 	return {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Returns an element instead of a component in useViewSwitcher.
Returning a component from a hook causes the reconciler to rebuild the component several times, losing reference to it. Returning a element keeps that reference stable.
I also sneaked a couple of fixes:
- Added `isActive` prop to dropdown elements.
- Switched to `ToolbarGroup` because using `Toolbar` without a label is deprecated.
<!-- Reference any related issues or PRs here -->
Fixes #5012

### Manual Testing

How to test the changes in this Pull Request:

1. In the empty cart view, open the view switcher. It shouldn't flicker if it loses hover.
2. The currently active view icon should be highlighted.
3. There shouldn't be a console warning about using Toolbar.
