### PR TITLE
Correct textdomain from 'woo-gutenberg-product-blocks' to 'woo-gutenberg-products-blocks'

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/constants.js
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/constants.js
@@ -7,22 +7,22 @@ import { PRIVACY_URL, TERMS_URL } from '@woocommerce/block-settings';
 const termsPageLink = TERMS_URL
 	? `<a href="${ TERMS_URL }">${ __(
 			'Terms and Conditions',
-			'woo-gutenberg-product-blocks'
+			'woo-gutenberg-products-blocks'
 	  ) }</a>`
-	: __( 'Terms and Conditions', 'woo-gutenberg-product-blocks' );
+	: __( 'Terms and Conditions', 'woo-gutenberg-products-blocks' );
 
 const privacyPageLink = PRIVACY_URL
 	? `<a href="${ PRIVACY_URL }">${ __(
 			'Privacy Policy',
-			'woo-gutenberg-product-blocks'
+			'woo-gutenberg-products-blocks'
 	  ) }</a>`
-	: __( 'Privacy Policy', 'woo-gutenberg-product-blocks' );
+	: __( 'Privacy Policy', 'woo-gutenberg-products-blocks' );
 
 export const termsConsentDefaultText = sprintf(
 	/* translators: %1$s terms page link, %2$s privacy page link. */
 	__(
 		'By proceeding with your purchase you agree to our %1$s and %2$s',
-		'woo-gutenberg-product-blocks'
+		'woo-gutenberg-products-blocks'
 	),
 	termsPageLink,
 	privacyPageLink
@@ -32,7 +32,7 @@ export const termsCheckboxDefaultText = sprintf(
 	/* translators: %1$s terms page link, %2$s privacy page link. */
 	__(
 		'You must accept our %1$s and %2$s to continue with your purchase.',
-		'woo-gutenberg-product-blocks'
+		'woo-gutenberg-products-blocks'
 	),
 	termsPageLink,
 	privacyPageLink

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/constants.js
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/constants.js
@@ -7,22 +7,22 @@ import { PRIVACY_URL, TERMS_URL } from '@woocommerce/block-settings';
 const termsPageLink = TERMS_URL
 	? `<a href="${ TERMS_URL }">${ __(
 			'Terms and Conditions',
-			'woo-gutenberg-products-blocks'
+			'woo-gutenberg-products-block'
 	  ) }</a>`
-	: __( 'Terms and Conditions', 'woo-gutenberg-products-blocks' );
+	: __( 'Terms and Conditions', 'woo-gutenberg-products-block' );
 
 const privacyPageLink = PRIVACY_URL
 	? `<a href="${ PRIVACY_URL }">${ __(
 			'Privacy Policy',
-			'woo-gutenberg-products-blocks'
+			'woo-gutenberg-products-block'
 	  ) }</a>`
-	: __( 'Privacy Policy', 'woo-gutenberg-products-blocks' );
+	: __( 'Privacy Policy', 'woo-gutenberg-products-block' );
 
 export const termsConsentDefaultText = sprintf(
 	/* translators: %1$s terms page link, %2$s privacy page link. */
 	__(
 		'By proceeding with your purchase you agree to our %1$s and %2$s',
-		'woo-gutenberg-products-blocks'
+		'woo-gutenberg-products-block'
 	),
 	termsPageLink,
 	privacyPageLink
@@ -32,7 +32,7 @@ export const termsCheckboxDefaultText = sprintf(
 	/* translators: %1$s terms page link, %2$s privacy page link. */
 	__(
 		'You must accept our %1$s and %2$s to continue with your purchase.',
-		'woo-gutenberg-products-blocks'
+		'woo-gutenberg-products-block'
 	),
 	termsPageLink,
 	privacyPageLink

--- a/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
@@ -40,7 +40,7 @@ const getCcOrEcheckPaymentMethodOption = (
 			/* translators: %1$s is referring to the payment method brand, %2$s is referring to the last 4 digits of the payment card, %3$s is referring to the expiry date.  */
 			__(
 				'%1$s ending in %2$s (expires %3$s)',
-				'woo-gutenberg-product-blocks'
+				'woo-gutenberg-products-blocks'
 			),
 			method.brand,
 			method.last4,

--- a/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
@@ -40,7 +40,7 @@ const getCcOrEcheckPaymentMethodOption = (
 			/* translators: %1$s is referring to the payment method brand, %2$s is referring to the last 4 digits of the payment card, %3$s is referring to the expiry date.  */
 			__(
 				'%1$s ending in %2$s (expires %3$s)',
-				'woo-gutenberg-products-blocks'
+				'woo-gutenberg-products-block'
 			),
 			method.brand,
 			method.last4,

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
@@ -121,7 +121,7 @@ export const CardElements = ( {
 					onBlur={ () => cardNumOnActive( isEmpty.cardNumber ) }
 				/>
 				<label htmlFor="wc-stripe-card-number-element">
-					{ __( 'Card Number', 'woo-gutenberg-products-blocks' ) }
+					{ __( 'Card Number', 'woo-gutenberg-products-block' ) }
 				</label>
 				<ValidationInputError errorMessage={ cardNumError } />
 			</div>
@@ -138,7 +138,7 @@ export const CardElements = ( {
 					id="wc-stripe-card-expiry-element"
 				/>
 				<label htmlFor="wc-stripe-card-expiry-element">
-					{ __( 'Expiry Date', 'woo-gutenberg-products-blocks' ) }
+					{ __( 'Expiry Date', 'woo-gutenberg-products-block' ) }
 				</label>
 				<ValidationInputError errorMessage={ cardExpiryError } />
 			</div>
@@ -152,7 +152,7 @@ export const CardElements = ( {
 					id="wc-stripe-card-code-element"
 				/>
 				<label htmlFor="wc-stripe-card-code-element">
-					{ __( 'CVV/CVC', 'woo-gutenberg-products-blocks' ) }
+					{ __( 'CVV/CVC', 'woo-gutenberg-products-block' ) }
 				</label>
 				<ValidationInputError errorMessage={ cardCvcError } />
 			</div>

--- a/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
@@ -121,7 +121,7 @@ export const CardElements = ( {
 					onBlur={ () => cardNumOnActive( isEmpty.cardNumber ) }
 				/>
 				<label htmlFor="wc-stripe-card-number-element">
-					{ __( 'Card Number', 'woo-gutenberg-product-blocks' ) }
+					{ __( 'Card Number', 'woo-gutenberg-products-blocks' ) }
 				</label>
 				<ValidationInputError errorMessage={ cardNumError } />
 			</div>
@@ -138,7 +138,7 @@ export const CardElements = ( {
 					id="wc-stripe-card-expiry-element"
 				/>
 				<label htmlFor="wc-stripe-card-expiry-element">
-					{ __( 'Expiry Date', 'woo-gutenberg-product-blocks' ) }
+					{ __( 'Expiry Date', 'woo-gutenberg-products-blocks' ) }
 				</label>
 				<ValidationInputError errorMessage={ cardExpiryError } />
 			</div>
@@ -152,7 +152,7 @@ export const CardElements = ( {
 					id="wc-stripe-card-code-element"
 				/>
 				<label htmlFor="wc-stripe-card-code-element">
-					{ __( 'CVV/CVC', 'woo-gutenberg-product-blocks' ) }
+					{ __( 'CVV/CVC', 'woo-gutenberg-products-blocks' ) }
 				</label>
 				<ValidationInputError errorMessage={ cardCvcError } />
 			</div>

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -233,12 +233,12 @@ const getErrorMessageForTypeAndCode = ( type, code = '' ) => {
 		case errorTypes.INVALID_EMAIL:
 			return __(
 				'Invalid email address, please correct and try again.',
-				'woo-gutenberg-products-blocks'
+				'woo-gutenberg-products-block'
 			);
 		case isNonFriendlyError( type ):
 			return __(
 				'Unable to process this payment, please try again or use alternative method.',
-				'woo-gutenberg-products-blocks'
+				'woo-gutenberg-products-block'
 			);
 		case errorTypes.CARD_ERROR:
 			return getErrorMessageForCode( code );

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -233,12 +233,12 @@ const getErrorMessageForTypeAndCode = ( type, code = '' ) => {
 		case errorTypes.INVALID_EMAIL:
 			return __(
 				'Invalid email address, please correct and try again.',
-				'woo-gutenberg-product-blocks'
+				'woo-gutenberg-products-blocks'
 			);
 		case isNonFriendlyError( type ):
 			return __(
 				'Unable to process this payment, please try again or use alternative method.',
-				'woo-gutenberg-product-blocks'
+				'woo-gutenberg-products-blocks'
 			);
 		case errorTypes.CARD_ERROR:
 			return getErrorMessageForCode( code );


### PR DESCRIPTION
Related #5005 

### Note

Some strings were using the textdomain `woo-gutenberg-product-blocks` instead of `woo-gutenberg-products-blocks` (note the missing `s` for products). Even though these strings have been translated, due to the incorrect textdomain they aren't visible in the plugin.

### Testing instructions

1. Check out the `trunk`.
2. Search for the incorrect text domain `'woo-gutenberg-product-blocks'`.
3. Verify that you get some results.
4. Check out this PR.
5. Search for the incorrect text domain `'woo-gutenberg-product-blocks'` again.
6. Verify that you no longer get results for the incorrect text domain.

### Additional notes

Issue #5005 is not entierly solved by this PR, but require a follow up PR to lazy load some missing translation files on the frontend.

### Changelog

> Replace incorrect with correct text domain.
