### PR TITLE
Add textdomain validation to .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,6 +59,15 @@ module.exports = {
 		'react-hooks/exhaustive-deps': 'error',
 		'react/jsx-fragments': [ 'error', 'syntax' ],
 		'@wordpress/no-global-active-element': 'warn',
+		'@wordpress/i18n-text-domain': [
+			'error',
+			{
+				allowedTextDomain: [
+					'default',
+					'woo-gutenberg-products-block',
+				],
+			},
+		],
 		camelcase: [
 			'error',
 			{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,10 +62,7 @@ module.exports = {
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{
-				allowedTextDomain: [
-					'default',
-					'woo-gutenberg-products-block',
-				],
+				allowedTextDomain: [ 'woo-gutenberg-products-block' ],
 			},
 		],
 		camelcase: [


### PR DESCRIPTION
Discovered in #5005 and #5020

### Note

At the moment, we only validate the textdomain within PHP files based on the following PHPCS rule:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/888760656a13e83562fc1e995822043c931fe339/phpcs.xml#L18-L22

However, we do not validate the textdomain within JS, TS and TSX files. This PR aims to add textdomain validation for these files.

The solution, I used, is coming from Gutenberg. The following pages provide more information:

* https://github.com/WordPress/gutenberg/tree/trunk/packages/eslint-plugin
* https://github.com/WordPress/gutenberg/blob/trunk/packages/eslint-plugin/docs/rules/i18n-text-domain.md

In my solution, I used the textdomains `default` and `woo-gutenberg-products-block`. `woo-gutenberg-products-block` validates our plugin-related textdomain, while `default` allows having strings without textdomain, such as default WordPress elements which get their translation directly from core. An example for such a string can be found here:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/20389f280acd3663f22eac3a1c0b132a64e9fd0c/assets/js/blocks/handpicked-products/block.js#L168-L178

### Demo output

<details>
  <summary>Output when allowing an empty textdomain</summary>

```shell
$ npm run lint:js                                                                                         1 ✘  took 26s  

> @woocommerce/block-library@6.2.0-dev lint:js /Users/nielslange/Plugins/woocommerce-gutenberg-products-block
> wp-scripts lint-js --ext=js,ts,tsx


/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/constants.js
   8:33  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  12:4   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  15:35  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  19:4   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  23:2   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  33:2   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
  41:4  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
  124:8  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  141:8  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  155:8  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
  193:7  error  Invalid text domain 'woocommerce-gateway-stripe'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
  167:34  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  171:40  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  175:39  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  179:31  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  183:36  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  187:37  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  191:34  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  195:37  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  199:32  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  203:33  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  207:33  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  211:44  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  215:33  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  219:27  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  223:36  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  234:11  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  239:11  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

✖ 28 problems (28 errors, 0 warnings)

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @woocommerce/block-library@6.2.0-dev lint:js: `wp-scripts lint-js --ext=js,ts,tsx`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @woocommerce/block-library@6.2.0-dev lint:js script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/nielslange/.npm/_logs/2021-10-28T03_41_34_672Z-debug.log
```

</details>

<details>
  <summary>Output when not allowing an empty textdomain</summary>

```shell
$ npm run lint:js                                                                                         1 ✘  took 28s  

> @woocommerce/block-library@6.2.0-dev lint:js /Users/nielslange/Plugins/woocommerce-gutenberg-products-block
> wp-scripts lint-js --ext=js,ts,tsx


/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/atomic/blocks/product-elements/price/edit.js
  39:13  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/constants.js
   8:33  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  12:4   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  15:35  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  19:4   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  23:2   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  33:2   error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/cart-checkout/payment-methods/saved-payment-method-options.js
  41:4  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/featured-category/block.js
  114:15  error  Missing text domain  @wordpress/i18n-text-domain
  178:18  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/featured-product/block.js
  164:15  error  Missing text domain  @wordpress/i18n-text-domain
  240:18  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/handpicked-products/block.js
  172:16  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/product-category/block.js
  293:16  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/product-tag/block.js
  275:16  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/blocks/products-by-attribute/block.js
  173:16  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/editor-components/heading-toolbar/index.js
  25:20  error  Missing text domain  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/payment-method-extensions/payment-methods/stripe/credit-card/elements.js
  124:8  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  141:8  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  155:8  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
  193:7  error  Invalid text domain 'woocommerce-gateway-stripe'  @wordpress/i18n-text-domain

/Users/nielslange/Plugins/woocommerce-gutenberg-products-block/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
  167:34  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  171:40  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  175:39  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  179:31  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  183:36  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  187:37  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  191:34  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  195:37  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  199:32  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  203:33  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  207:33  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  211:44  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  215:33  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  219:27  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  223:36  error  Invalid text domain 'woocommerce-gateway-stripe'    @wordpress/i18n-text-domain
  234:11  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain
  239:11  error  Invalid text domain 'woo-gutenberg-product-blocks'  @wordpress/i18n-text-domain

✖ 38 problems (38 errors, 0 warnings)
  38 errors and 0 warnings potentially fixable with the `--fix` option.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @woocommerce/block-library@6.2.0-dev lint:js: `wp-scripts lint-js --ext=js,ts,tsx`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @woocommerce/block-library@6.2.0-dev lint:js script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/nielslange/.npm/_logs/2021-10-28T04_38_35_417Z-debug.log
```

</details>

### Benefits

In case a change contains an incorrect textdomain, this problem then gets automatically detected as seen on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5021/files.

### Questions

#### Shall we allow the use of an empty textdomain?

As mentioned before, there are some sections in which we're not using a textdomain. However, [these strings are still listed on WordPress.org](https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/es/default/?filters%5Bterm%5D=Edit&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D&filter=Apply+Filters&sort%5Bby%5D=references&sort%5Bhow%5D=desc&page=5) and can be translated there. This might lead to confusion if a string is translated there, but this translation does not appear in our plugin.

#### Shall we allow the use of external textdomains?

Similar to the previous question, some sections use the textdomain `woocommerce-gateway-stripe`. While these sections are related to the [WooCommerce Stripe](https://woocommerce.com/products/stripe/) extension, if the upstream changes one of these strings, then it's no longer translated. Furthermore, as mentioned in the question before, it can be confusing that the strings are editable on WordPress.org, but will not show up within our plugin due to the different textdomain.