### PR TITLE
Improvements to Loading Placeholder and Skeletons

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -7,7 +7,6 @@ $low-stock-color: $alert-yellow;
 $in-stock-color: $alert-green;
 $discount-color: $alert-green;
 
-$placeholder-color: var(--global--color-primary, $gray-200);
 $input-border-gray: #50575e;
 $input-border-dark: rgba(255, 255, 255, 0.4);
 $input-disabled-dark: rgba(255, 255, 255, 0.3);

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -36,7 +36,7 @@ $fontSizes: (
 	color: transparent !important;
 	width: 100%;
 	border-radius: 0.25rem;
-	display: inline-flex !important;
+	display: block;
 	line-height: inherit;
 	position: relative !important;
 	overflow: hidden !important;
@@ -56,6 +56,7 @@ $fontSizes: (
 		position: absolute;
 		left: 0;
 		right: 0;
+		top: 0;
 		height: 100%;
 		background-repeat: no-repeat;
 		background-image: linear-gradient(90deg, #ebebeb, #f5f5f5, #ebebeb);
@@ -69,7 +70,7 @@ $fontSizes: (
 }
 
 @mixin force-content() {
-	&::after {
+	&::before {
 		content: "\00a0";
 	}
 }

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -8,40 +8,63 @@ $fontSizes: (
 
 // Maps a named font-size to its predefined size. Units default to em, but can
 // be changed using the multiplier parameter.
-@mixin font-size($sizeName, $multiplier: 1em) {
+@mixin font-size( $sizeName, $multiplier: 1em ) {
 	font-size: map-get($fontSizes, $sizeName) * $multiplier;
 }
 
-@keyframes loading-fade {
+@keyframes spinner__animation {
 	0% {
-		opacity: 0.7;
-	}
-	50% {
-		opacity: 1;
+		animation-timing-function: cubic-bezier(0.5856, 0.0703, 0.4143, 0.9297);
+		transform: rotate(0deg);
 	}
 	100% {
-		opacity: 0.7;
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes loading__animation {
+	100% {
+		transform: translateX(100%);
 	}
 }
 
 // Adds animation to placeholder section
 @mixin placeholder() {
-	animation: loading-fade 1.2s ease-in-out infinite;
-	background-color: $placeholder-color !important;
-	color: $placeholder-color !important;
 	outline: 0 !important;
 	border: 0 !important;
-	box-shadow: none;
+	background-color: #ebebeb !important;
+	color: transparent !important;
+	width: 100%;
+	border-radius: 0.25rem;
+	display: inline-flex !important;
+	line-height: inherit;
+	position: relative !important;
+	overflow: hidden !important;
+	max-width: 100% !important;
 	pointer-events: none;
-	max-width: 100%;
+	box-shadow: none;
+	z-index: 1; /* Necessary for overflow: hidden to work correctly in Safari */
 
 	// Forces direct descendants to keep layout but lose visibility.
 	> * {
 		visibility: hidden;
 	}
 
-	@media screen and (prefers-reduced-motion: reduce) {
-		animation: none;
+	&::after {
+		content: " ";
+		display: block;
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 100%;
+		background-repeat: no-repeat;
+		background-image: linear-gradient(90deg, #ebebeb, #f5f5f5, #ebebeb);
+		transform: translateX(-100%);
+		animation: loading__animation 1.5s ease-in-out infinite;
+
+		@media screen and ( prefers-reduced-motion: reduce ) {
+			animation: none;
+		}
 	}
 }
 
@@ -153,7 +176,7 @@ $fontSizes: (
 // Shows a border with the current color and a custom opacity. That can't be achieved
 // with normal border because `currentColor` doesn't allow tweaking the opacity, and
 // setting the opacity of the entire element would change the children's opacity too.
-@mixin with-translucent-border($border-width: 1px, $opacity: 0.3) {
+@mixin with-translucent-border( $border-width: 1px, $opacity: 0.3 ) {
 	position: relative;
 
 	&::after {
@@ -173,22 +196,23 @@ $fontSizes: (
 
 // Wraps the content with a media query specially targeting IE11.
 @mixin ie11() {
-	@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+	@media screen and ( -ms-high-contrast: active ),
+		( -ms-high-contrast: none ) {
 		@content;
 	}
 }
 
 // Converts a px unit to em.
-@function em($size, $base: 16px) {
-	@return math.div($size, $base) * 1em;
+@function em( $size, $base: 16px ) {
+	@return math.div( $size, $base ) * 1em;
 }
 
 // Encodes hex colors so they can be used in URL content.
-@function encode-color($color) {
-	@if type-of($color) != "color" or str-index(#{$color}, "#") != 1 {
+@function encode-color( $color ) {
+	@if type-of( $color ) != "color" or str-index( #{$color}, "#" ) != 1 {
 		@return $color;
 	}
 
 	$hex: str-slice(ie-hex-str($color), 4);
-	@return "%23" + unquote("#{$hex}");
+	@return "%23" + unquote( "#{$hex}" );
 }

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -37,7 +37,7 @@ $fontSizes: (
 	width: 100%;
 	border-radius: 0.25rem;
 	display: block;
-	line-height: inherit;
+	line-height: 1;
 	position: relative !important;
 	overflow: hidden !important;
 	max-width: 100% !important;

--- a/assets/js/base/components/cart-checkout/totals/footer-item/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/test/__snapshots__/index.js.snap
@@ -15,9 +15,6 @@ exports[`TotalsFooterItem Does not show the "including %s of tax" line if tax is
     >
       £85.00
     </span>
-    <div
-      class="wc-block-components-totals-item__description"
-    />
   </div>
 </div>
 `;
@@ -37,9 +34,6 @@ exports[`TotalsFooterItem Does not show the "including %s of tax" line if tax is
     >
       £85.00
     </span>
-    <div
-      class="wc-block-components-totals-item__description"
-    />
   </div>
 </div>
 `;

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -11,14 +11,14 @@
 }
 
 .wc-block-components-quantity-selector {
-	display: flex;
+	display: inline-flex;
 	width: 107px;
 	border: 1px solid $gray-300;
 	background: #fff;
 	border-radius: 4px;
 	// needed so that buttons fill the container.
 	box-sizing: content-box;
-	margin: 0 0 0.25em 0;
+	margin: 0 $gap 0.25em 0;
 
 	.has-dark-controls & {
 		background-color: transparent;

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -11,14 +11,14 @@
 }
 
 .wc-block-components-quantity-selector {
-	display: inline-flex;
+	display: flex;
 	width: 107px;
 	border: 1px solid $gray-300;
 	background: #fff;
 	border-radius: 4px;
 	// needed so that buttons fill the container.
 	box-sizing: content-box;
-	margin: 0 $gap 0.25em 0;
+	margin: 0 0 0.25em 0;
 
 	.has-dark-controls & {
 		background-color: transparent;

--- a/assets/js/base/components/skeleton/index.tsx
+++ b/assets/js/base/components/skeleton/index.tsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { CSSProperties, Fragment, ReactChildren } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+/**
+ * Loading skeleton/placeholder element that can be used inline.
+ */
+export const Skeleton = ( {
+	type = 'text',
+	count = 1,
+	inline = false,
+	className: customClassName = '',
+	width = '100%',
+	height = 'auto',
+	style = {},
+	children,
+}: {
+	type?: 'text' | 'img';
+	count?: number;
+	inline?: boolean;
+	className?: string;
+	width?: string;
+	height?: string;
+	style?: CSSProperties;
+	children?: ReactChildren | null;
+} ): JSX.Element => {
+	const className = classnames( 'loading-skeleton', customClassName );
+
+	if ( type === 'img' ) {
+		return (
+			<span className={ className }>
+				<img
+					src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+					alt=""
+					style={ { width, height, ...style } }
+				/>
+			</span>
+		);
+	}
+
+	return (
+		<>
+			{ [ ...Array( count ) ].map( ( _x, i ) => (
+				<Fragment key={ i }>
+					<span
+						key={ i }
+						className={ className }
+						style={ { width, height, ...style } }
+					>
+						{ children }&zwnj;
+					</span>
+					{ ! inline && <br /> }
+				</Fragment>
+			) ) }
+		</>
+	);
+};
+
+export default Skeleton;

--- a/assets/js/base/components/skeleton/style.scss
+++ b/assets/js/base/components/skeleton/style.scss
@@ -1,0 +1,4 @@
+.loading-skeleton {
+	@include placeholder();
+	display: inline-flex !important;
+}

--- a/assets/js/base/components/spinner/style.scss
+++ b/assets/js/base/components/spinner/style.scss
@@ -22,16 +22,6 @@
 		border-radius: 50%;
 		border: 0.2em solid currentColor;
 		border-left-color: transparent;
-		animation: wc-block-components-spinner__animation 1s infinite linear;
-	}
-}
-
-@keyframes wc-block-components-spinner__animation {
-	0% {
-		animation-timing-function: cubic-bezier(0.5856, 0.0703, 0.4143, 0.9297);
-		transform: rotate(0deg);
-	}
-	100% {
-		transform: rotate(360deg);
+		animation: spinner__animation 1s infinite linear;
 	}
 }

--- a/assets/js/base/utils/render-frontend.js
+++ b/assets/js/base/utils/render-frontend.js
@@ -51,8 +51,6 @@ const renderBlockInContainers = ( {
 			...el.dataset,
 			...( props.attributes || {} ),
 		};
-		el.classList.remove( 'is-loading' );
-
 		renderBlock( {
 			Block,
 			container: el,
@@ -90,7 +88,12 @@ export const renderBlock = ( {
 				<Block { ...props } attributes={ attributes } />
 			</Suspense>
 		</BlockErrorBoundary>,
-		container
+		container,
+		() => {
+			if ( container.classList ) {
+				container.classList.remove( 'is-loading' );
+			}
+		}
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/cart/cart-line-items-table/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/cart-line-items-table/index.tsx
@@ -6,15 +6,34 @@ import { __ } from '@wordpress/i18n';
 import { CartResponseItem } from '@woocommerce/type-defs/cart-response';
 import { createRef, useEffect, useRef } from '@wordpress/element';
 import type { RefObject } from 'react';
+import Skeleton from '@woocommerce/base-components/skeleton';
 
 /**
  * Internal dependencies
  */
 import CartLineItemRow from './cart-line-item-row';
 
-const placeholderRows = [ ...Array( 3 ) ].map( ( _x, i ) => (
-	<CartLineItemRow lineItem={ {} } key={ i } />
-) );
+const LoadingSkeleton = ( { count }: { count: number } ): JSX.Element => {
+	return (
+		<>
+			{ [ ...Array( count ) ].map( ( _x, i ) => (
+				<tr key={ i } className="wc-block-cart-items__row">
+					<td className="wc-block-cart-item__image">
+						<Skeleton type="img" />
+					</td>
+					<td className="wc-block-cart-item__product">
+						<Skeleton width="150px" />
+						<Skeleton />
+						<Skeleton height="34px" width="107px" />
+					</td>
+					<td className="wc-block-cart-item__total">
+						<Skeleton />
+					</td>
+				</tr>
+			) ) }
+		</>
+	);
+};
 
 interface CartLineItemsTableProps {
 	lineItems: CartResponseItem[];
@@ -53,21 +72,23 @@ const CartLineItemsTable = ( {
 		}
 	};
 
-	const products = isLoading
-		? placeholderRows
-		: lineItems.map( ( lineItem, i ) => {
-				const nextItemKey =
-					lineItems.length > i + 1 ? lineItems[ i + 1 ].key : null;
-				return (
-					<CartLineItemRow
-						key={ lineItem.key }
-						lineItem={ lineItem }
-						onRemove={ onRemoveRow( nextItemKey ) }
-						ref={ rowRefs.current[ lineItem.key ] }
-						tabIndex={ -1 }
-					/>
-				);
-		  } );
+	const products = isLoading ? (
+		<LoadingSkeleton count={ lineItems.length || 3 } />
+	) : (
+		lineItems.map( ( lineItem, i ) => {
+			const nextItemKey =
+				lineItems.length > i + 1 ? lineItems[ i + 1 ].key : null;
+			return (
+				<CartLineItemRow
+					key={ lineItem.key }
+					lineItem={ lineItem }
+					onRemove={ onRemoveRow( nextItemKey ) }
+					ref={ rowRefs.current[ lineItem.key ] }
+					tabIndex={ -1 }
+				/>
+			);
+		} )
+	);
 
 	return (
 		<table

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
@@ -9,6 +9,7 @@ import {
 	TotalsShipping,
 } from '@woocommerce/base-components/cart-checkout';
 import {
+	TotalsItem,
 	Subtotal,
 	TotalsFees,
 	TotalsTaxes,
@@ -24,6 +25,30 @@ import {
 import { getSetting } from '@woocommerce/settings';
 import Title from '@woocommerce/base-components/title';
 
+const TotalsHeading = (): JSX.Element => {
+	return (
+		<Title headingLevel="2" className="wc-block-cart__totals-title">
+			{ __( 'Cart totals', 'woo-gutenberg-products-block' ) }
+		</Title>
+	);
+};
+
+const TotalsCoupons = (): JSX.Element => {
+	const { applyCoupon, isApplyingCoupon } = useStoreCartCoupons();
+
+	if ( ! getSetting( 'couponsEnabled', true ) ) {
+		return null;
+	}
+	return (
+		<TotalsWrapper>
+			<TotalsCoupon
+				onSubmit={ applyCoupon }
+				isLoading={ isApplyingCoupon }
+			/>
+		</TotalsWrapper>
+	);
+};
+
 /**
  * Internal dependencies
  */
@@ -37,12 +62,15 @@ const Block = ( {
 	showRateAfterTaxName: boolean;
 	isShippingCalculatorEnabled: boolean;
 } ): JSX.Element => {
-	const { cartFees, cartTotals, cartNeedsShipping } = useStoreCart();
+	const {
+		cartFees,
+		cartTotals,
+		cartNeedsShipping,
+		cartIsLoading,
+	} = useStoreCart();
 
 	const {
-		applyCoupon,
 		removeCoupon,
-		isApplyingCoupon,
 		isRemovingCoupon,
 		appliedCoupons,
 	} = useStoreCartCoupons();
@@ -63,11 +91,40 @@ const Block = ( {
 		cart,
 	};
 
+	if ( cartIsLoading ) {
+		return (
+			<div className={ className }>
+				<TotalsHeading />
+				<TotalsWrapper>
+					<TotalsItem
+						label={ __(
+							'Subtotal',
+							'woo-gutenberg-products-block'
+						) }
+					/>
+				</TotalsWrapper>
+				<TotalsCoupons />
+				<TotalsWrapper>
+					<TotalsItem
+						label={ __(
+							'Shipping',
+							'woo-gutenberg-products-block'
+						) }
+					/>
+				</TotalsWrapper>
+				<TotalsWrapper>
+					<TotalsItem
+						className="wc-block-components-totals-footer-item"
+						label={ __( 'Total', 'woo-gutenberg-products-block' ) }
+					/>
+				</TotalsWrapper>
+			</div>
+		);
+	}
+
 	return (
 		<div className={ className }>
-			<Title headingLevel="2" className="wc-block-cart__totals-title">
-				{ __( 'Cart totals', 'woo-gutenberg-products-block' ) }
-			</Title>
+			<TotalsHeading />
 			<TotalsWrapper>
 				<Subtotal currency={ totalsCurrency } values={ cartTotals } />
 				<TotalsFees currency={ totalsCurrency } cartFees={ cartFees } />
@@ -79,14 +136,7 @@ const Block = ( {
 					values={ cartTotals }
 				/>
 			</TotalsWrapper>
-			{ getSetting( 'couponsEnabled', true ) && (
-				<TotalsWrapper>
-					<TotalsCoupon
-						onSubmit={ applyCoupon }
-						isLoading={ isApplyingCoupon }
-					/>
-				</TotalsWrapper>
-			) }
+			<TotalsCoupons />
 			<ExperimentalDiscountsMeta.Slot { ...discountsSlotFillProps } />
 			{ cartNeedsShipping && (
 				<TotalsWrapper>
@@ -114,7 +164,6 @@ const Block = ( {
 					values={ cartTotals }
 				/>
 			</TotalsWrapper>
-
 			<ExperimentalOrderMeta.Slot { ...slotFillProps } />
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/register-components.ts
@@ -21,77 +21,41 @@ import cartOrderSummaryMetadata from './cart-order-summary-block/block.json';
 import cartTotalsMetadata from './cart-totals-block/block.json';
 import cartProceedToCheckoutMetadata from './proceed-to-checkout-block/block.json';
 import cartAcceptedPaymentMethodsMetadata from './cart-accepted-payment-methods-block/block.json';
-
-registerCheckoutBlock( {
-	metadata: filledCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/filled-cart" */ './filled-cart-block/frontend'
-		)
-	),
-} );
+import emptyCartComponent from './empty-cart-block/frontend';
+import filledCartComponent from './filled-cart-block/frontend';
+import cartItemsComponent from './cart-items-block/frontend';
+import cartLineItemsComponent from './cart-line-items-block/block';
+import cartTotalsComponent from './cart-totals-block/frontend';
+import cartOrderSummaryComponent from './cart-order-summary-block/frontend';
 
 registerCheckoutBlock( {
 	metadata: emptyCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/empty-cart" */ './empty-cart-block/frontend'
-		)
-	),
+	component: emptyCartComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: filledCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/filled-cart" */ './filled-cart-block/frontend'
-		)
-	),
-} );
-
-registerCheckoutBlock( {
-	metadata: emptyCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/empty-cart" */ './empty-cart-block/frontend'
-		)
-	),
+	component: filledCartComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartItemsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/items" */ './cart-items-block/frontend'
-		)
-	),
+	component: cartItemsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartLineItemsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/line-items" */ './cart-line-items-block/block'
-		)
-	),
+	component: cartLineItemsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartTotalsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/totals" */ './cart-totals-block/frontend'
-		)
-	),
+	component: cartTotalsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartOrderSummaryMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/order-summary" */ './cart-order-summary-block/frontend'
-		)
-	),
+	component: cartOrderSummaryComponent,
 } );
 
 registerCheckoutBlock( {

--- a/assets/js/blocks/cart-checkout/cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/style.scss
@@ -85,60 +85,6 @@ table.wc-block-cart-items {
 	}
 }
 
-// Loading placeholder state.
-.wc-block-cart--is-loading,
-.wc-block-mini-cart__drawer.is-loading {
-	th span,
-	h2 span {
-		@include placeholder();
-		@include force-content();
-		min-width: 84px;
-		display: inline-block;
-	}
-	h2 span {
-		min-width: 33%;
-	}
-	.wc-block-components-product-price,
-	.wc-block-components-product-metadata,
-	.wc-block-components-quantity-selector {
-		@include placeholder();
-	}
-	.wc-block-components-product-name {
-		@include placeholder();
-		@include force-content();
-		min-width: 84px;
-		display: inline-block;
-	}
-	.wc-block-components-product-metadata {
-		margin-top: 0.25em;
-		min-width: 8em;
-	}
-	.wc-block-cart-item__remove-link {
-		visibility: hidden;
-	}
-	.wc-block-cart-item__image > a {
-		@include placeholder();
-		display: block;
-	}
-	.wc-block-components-product-price {
-		@include force-content();
-		max-width: 3em;
-		display: block;
-		margin-top: 0.25em;
-	}
-	.wc-block-cart__sidebar .components-card {
-		@include placeholder();
-		@include force-content();
-		min-height: 460px;
-	}
-}
-.wc-block-components-sidebar-layout.wc-block-cart--skeleton {
-	display: none;
-}
-.is-loading + .wc-block-components-sidebar-layout.wc-block-cart--skeleton {
-	display: flex;
-}
-
 .wc-block-cart-item__total-price-and-sale-badge-wrapper {
 	display: flex;
 	flex-direction: column;
@@ -267,13 +213,62 @@ table.wc-block-cart-items {
 		}
 	}
 
-	.wc-block-cart__payment-options {
-		padding: $gap 0 0;
+	.wp-block-woocommerce-cart-order-summary-block {
+		padding: 0 0 $gap;
 	}
 }
 
+
+// Loading placeholder state.
+.wc-block-mini-cart__drawer.is-loading {
+	th span,
+	h2 span {
+		@include placeholder();
+		@include force-content();
+		min-width: 84px;
+		display: inline-block;
+	}
+	h2 span {
+		min-width: 33%;
+	}
+	.wc-block-components-product-price,
+	.wc-block-components-product-metadata,
+	.wc-block-components-quantity-selector {
+		@include placeholder();
+	}
+	.wc-block-components-product-name {
+		@include placeholder();
+		@include force-content();
+		min-width: 84px;
+		display: inline-block;
+	}
+	.wc-block-components-product-metadata {
+		margin-top: 0.25em;
+		min-width: 8em;
+	}
+	.wc-block-cart-item__remove-link {
+		visibility: hidden;
+	}
+	.wc-block-cart-item__image > a {
+		@include placeholder();
+		display: block;
+	}
+	.wc-block-components-product-price {
+		@include force-content();
+		max-width: 3em;
+		display: block;
+		margin-top: 0.25em;
+	}
+	.wc-block-cart__sidebar .components-card {
+		@include placeholder();
+		@include force-content();
+		min-height: 460px;
+	}
+}
 .wp-block-woocommerce-cart.is-loading {
-	.wp-block-woocommerce-empty-cart-block {
+	.wp-block-woocommerce-empty-cart-block,
+	.wp-block-woocommerce-cart-express-payment-block,
+	.wp-block-woocommerce-cart-accepted-payment-methods-block {
 		display: none;
 	}
 	.wp-block-woocommerce-filled-cart-block {
@@ -282,7 +277,6 @@ table.wc-block-cart-items {
 		margin: 0 auto $gap;
 		position: relative;
 	}
-
 	.wp-block-woocommerce-cart-items-block {
 		box-sizing: border-box;
 		margin: 0;
@@ -290,13 +284,11 @@ table.wc-block-cart-items {
 		width: 65%;
 		min-height: 10em;
 	}
-
 	.wp-block-woocommerce-cart-line-items-block {
 		min-height: 15em;
 		display: block;
 		@include placeholder();
 	}
-
 	.wp-block-woocommerce-cart-totals-block {
 		box-sizing: border-box;
 		margin: 0;
@@ -304,17 +296,13 @@ table.wc-block-cart-items {
 		width: 35%;
 		min-height: 12em;
 	}
-
 	.wp-block-woocommerce-cart-order-summary-block,
-	.wp-block-woocommerce-cart-express-payment-block,
-	.wp-block-woocommerce-proceed-to-checkout-block,
-	.wp-block-woocommerce-cart-accepted-payment-methods-block {
+	.wp-block-woocommerce-proceed-to-checkout-block {
 		min-height: 3em;
 		display: block;
 		@include placeholder();
 		margin: 0 0 1em 0;
 	}
-
 	.wp-block-woocommerce-cart-order-summary-block {
 		height: 20em;
 	}
@@ -329,12 +317,10 @@ table.wc-block-cart-items {
 			flex-direction: column;
 			margin: 0 auto $gap;
 		}
-
 		.wp-block-woocommerce-cart-items-block {
 			padding: 0;
 			width: 100%;
 		}
-
 		.wp-block-woocommerce-cart-totals-block {
 			padding: 0;
 			width: 100%;

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/register-components.ts
@@ -24,15 +24,17 @@ import checkoutShippingAddressMetadata from './checkout-shipping-address-block/b
 import checkoutShippingMethodsMetadata from './checkout-shipping-methods-block/block.json';
 import checkoutTermsMetadata from './checkout-terms-block/block.json';
 import checkoutTotalsMetadata from './checkout-totals-block/block.json';
+import checkoutFieldsComponent from './checkout-fields-block/frontend';
+import checkoutContactInformationComponent from './checkout-contact-information-block/frontend';
+import checkoutShippingAddressComponent from './checkout-shipping-address-block/frontend';
+import checkoutActionsComponent from './checkout-actions-block/frontend';
+import checkoutOrderSummaryComponent from './checkout-order-summary-block/block';
+import checkoutTotalsComponent from './checkout-totals-block/frontend';
 
 // @todo When forcing all blocks at once, they will append based on the order they are registered. Introduce formal sorting param.
 registerCheckoutBlock( {
 	metadata: checkoutFieldsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/fields" */ './checkout-fields-block/frontend'
-		)
-	),
+	component: checkoutFieldsComponent,
 } );
 
 registerCheckoutBlock( {
@@ -46,20 +48,12 @@ registerCheckoutBlock( {
 
 registerCheckoutBlock( {
 	metadata: checkoutContactInformationMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/contact-information" */ './checkout-contact-information-block/frontend'
-		)
-	),
+	component: checkoutContactInformationComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: checkoutShippingAddressMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/shipping-address" */ './checkout-shipping-address-block/frontend'
-		)
-	),
+	component: checkoutShippingAddressComponent,
 } );
 
 registerCheckoutBlock( {
@@ -109,27 +103,15 @@ registerCheckoutBlock( {
 
 registerCheckoutBlock( {
 	metadata: checkoutActionsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/actions" */ './checkout-actions-block/frontend'
-		)
-	),
+	component: checkoutActionsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: checkoutTotalsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/totals" */ './checkout-totals-block/frontend'
-		)
-	),
+	component: checkoutTotalsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: checkoutOrderSummaryMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/order-summary" */ './checkout-order-summary-block/block'
-		)
-	),
+	component: checkoutOrderSummaryComponent,
 } );

--- a/assets/js/blocks/cart-checkout/checkout/styles/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/styles/style.scss
@@ -11,6 +11,7 @@
 	flex-wrap: wrap;
 	margin: 0 auto $gap;
 	position: relative;
+
 	.wp-block-woocommerce-checkout-totals-block {
 		width: 35%;
 		padding-left: percentage(math.div($gap-large, 1060px));
@@ -19,42 +20,42 @@
 		width: 65%;
 		padding-right: percentage(math.div($gap-largest, 1060px)); // ~1060px is the default width of the content area in Storefront.
 	}
+
 	.wp-block-woocommerce-checkout-totals-block,
 	.wp-block-woocommerce-checkout-fields-block {
 		box-sizing: border-box;
 		margin: 0;
+		display: block;
 
 		> div {
-			@include placeholder();
-			margin: 0 0 1.5em 0;
 			display: none;
 		}
-		.wp-block-woocommerce-checkout-contact-information-block,
-		.wp-block-woocommerce-checkout-payment-block {
+
+		> [class^="wp-block-"] {
+			@include placeholder();
+			@include force-content();
+			margin: 0 0 1em 0;
+			display: none;
+		}
+
+		> .wp-block-woocommerce-checkout-contact-information-block,
+		> .wp-block-woocommerce-checkout-payment-block {
 			min-height: 10em;
 			display: block;
 		}
-		.wp-block-woocommerce-checkout-shipping-address-block {
+		> .wp-block-woocommerce-checkout-shipping-address-block {
 			min-height: 24em;
 			display: block;
 		}
-		.wp-block-woocommerce-checkout-actions-block {
+		> .wp-block-woocommerce-checkout-actions-block {
 			width: 50%;
 			min-height: 4em;
 			margin-left: 50%;
 			display: block;
 		}
-		.wp-block-woocommerce-checkout-order-summary-block {
+		> .wp-block-woocommerce-checkout-order-summary-block {
 			min-height: 47em;
 			display: block;
-		}
-		.wc-block-components-panel > h2 {
-			@include font-size(regular);
-			@include reset-box();
-			@include reset-typography();
-			.wc-block-components-panel__button {
-				font-weight: 400;
-			}
 		}
 		.wc-block-components-totals-item,
 		.wc-block-components-panel {

--- a/packages/checkout/components/totals/item/index.tsx
+++ b/packages/checkout/components/totals/item/index.tsx
@@ -6,6 +6,7 @@ import { isValidElement } from '@wordpress/element';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import type { ReactElement, ReactNode } from 'react';
 import type { Currency } from '@woocommerce/price-format';
+import Skeleton from '@woocommerce/base-components/skeleton';
 
 /**
  * Internal dependencies
@@ -14,10 +15,10 @@ import './style.scss';
 
 interface TotalsItemProps {
 	className?: string;
-	currency: Currency;
+	currency?: Currency;
 	label: string;
 	// Value may be a number, or react node. Numbers are passed to FormattedMonetaryAmount.
-	value: number | ReactNode;
+	value?: number | ReactNode;
 	description?: ReactNode;
 }
 
@@ -59,10 +60,16 @@ const TotalsItem = ( {
 			<span className="wc-block-components-totals-item__label">
 				{ label }
 			</span>
-			<TotalsItemValue value={ value } currency={ currency } />
-			<div className="wc-block-components-totals-item__description">
-				{ description }
-			</div>
+			{ value === undefined ? (
+				<Skeleton width="60px" inline={ true } />
+			) : (
+				<TotalsItemValue value={ value } currency={ currency } />
+			) }
+			{ description && (
+				<div className="wc-block-components-totals-item__description">
+					{ description }
+				</div>
+			) }
 		</div>
 	);
 };

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -374,37 +374,4 @@ abstract class AbstractBlock {
 			wp_enqueue_script( $this->get_block_type_script( 'handle' ) );
 		}
 	}
-
-	/**
-	 * Script to append the correct sizing class to a block skeleton.
-	 *
-	 * @return string
-	 */
-	protected function get_skeleton_inline_script() {
-		return "<script>
-			var containers = document.querySelectorAll( 'div.wc-block-skeleton' );
-
-			if ( containers.length ) {
-				Array.prototype.forEach.call( containers, function( el, i ) {
-					var w = el.offsetWidth;
-					var classname = '';
-
-					if ( w > 700 )
-						classname = 'is-large';
-					else if ( w > 520 )
-						classname = 'is-medium';
-					else if ( w > 400 )
-						classname = 'is-small';
-					else
-						classname = 'is-mobile';
-
-					if ( ! el.classList.contains( classname ) )  {
-						el.classList.add( classname );
-					}
-
-					el.classList.remove( 'hidden' );
-				} );
-			}
-		</script>";
-	}
 }


### PR DESCRIPTION
This PR contains a few enhancements to help mitigate the problem in #5011. This includes the following changes:

- ~~**Remove lazy loading for critical inner blocks cc @senadir**  - The most important layout and/or forced blocks should not be lazy loaded. We know these blocks must render, so lazy loading just adds a delay. This was the main reason for the issue in #5011 Blocks that don't need to be visible straight away can still lazy load.~~ Moved to https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5360
- ~~Remove is-loading class after render, using a render callback.  I moved this to the callback so it's ran as late as possible to minimise the delay between skeleton showing, and the blocks.~~ Moved to https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5364
- I added a generic Skeleton component for use inline. This has been implemented in the line items block and order summary block to hide totals when loading. Currently, if the store is invalidated, you see 0 totals which is wrong.
- ~~I updated the pulsing animation to a 'loading' swipe type animation, based on the Skeleton component I adapted above.~~ Moved to https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5362
- ~~I removed some unused skeleton styles/code.~~ Moved to https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5361

Closes #5011

Whilst it fixes the loading issue, I do think our current placeholder/skeleton is poor and should be replaced with a traditional spinner, but I didn't want to go too far off tangent with this fix.

### Testing

To test the skeleton before DOM and react is finished loading:

1. Open dev tools network panel
2. Set the speed to 3g or something slow
3. View a page containing the cart and checkout blocks

You will see the skeleton loading view, and once loaded, the components will replace them.

To test the skeletons shown when the wp data store is getting data from the API:

1. View a cart page
2. Open the console
3. Enter the command `wp.data.dispatch('wc/store/cart').invalidateResolutionForStore()`
4. You should see the skeleton and loading indicator while it gets data from the server.

### Performance Impact

The bundle size may increase due to removing some lazy loading components, but the perceived speed should be improved because the cart and checkout blocks will render faster without an obvious delay.

### Changelog

> Improve the cart and checkout loading states.
