### PR TITLE
Run BlockTemplatesController filter only on templates

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -43,10 +43,12 @@ class BlockTemplatesController {
 	 * Add the block template objects to be used.
 	 *
 	 * @param array $query_result Array of template objects.
+	 * @param array $query Optional. Arguments to retrieve templates.
+	 * @param array $template_type wp_template or wp_template_part.
 	 * @return array
 	 */
-	public function add_block_templates( $query_result ) {
-		if ( ! gutenberg_supports_block_templates() ) {
+	public function add_block_templates( $query_result, $query, $template_type ) {
+		if ( ! gutenberg_supports_block_templates() || 'wp_template' !== $template_type ) {
 			return $query_result;
 		}
 


### PR DESCRIPTION
The `get_block_templates` filter can be run either on `wp_template` and `wp_template_part`, however, our implementation on `BlockTemplatesController` only needs to filter templates. This PR adds a check so the logic is not run when the filter is called for template parts.

### Manual Testing

Verify there are no regressions from #4981 (testing steps copied):

1. Ensure you're using a block enabled theme
2. Add the **second** template below to the Woo Blocks path specified above the snippet.
3. Confirm this loads in the Site Editor templates, it should say in the editor "You are using the Woo Blocks block template now"
4. Add the **first** template below to themes directory path specified above the snippet.
5. Confirm this loads in the Site Editor templates, it should say in the editor "You are using the Themes block template now"
6. This code is not yet responsible for loading the templates on the frontend. This will be done as part of https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4969

`/theme-dir/block-templates/single-product.html`
```html
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true} /-->
<!-- wp:paragraph --> <p>You are using the Themes block template now</p> <!-- /wp:paragraph -->
<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true} /-->
```

`/woo-blocks/templates/block-templates/single-product.html`
```html
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true} /-->
<!-- wp:paragraph --> <p>You are using the Woo Blocks block template now</p> <!-- /wp:paragraph -->
<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true} /-->
```