### PR TITLE
Some PR template improvements

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,11 @@ Fixes #
 - [ ] I've tested using a screen reader
 - [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
 - [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
+
+#### Other Checks
+
 - [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
+- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.
 
 ### Screenshots
 
@@ -29,6 +33,14 @@ Fixes #
 ### Manual Testing
 
 How to test the changes in this Pull Request:
+
+1.
+2.
+3.
+### User Facing Testing
+These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
+* [ ] Same as above, or
+* [ ] See steps below.
 
 1.
 2.


### PR DESCRIPTION
While I was hoping to use the new [GitHub issue form syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) for more precise template setup (including forms!), it's not available yet for pull request templates. 

The changes I've made here include:

- Adding an "Other Checks" section to split off from the accessibility section.
- Adding a checkbox for reviews that have two reviewers assigned because of the potential security impact of the changes.
- Added a section for User testing notes if that needs to be different from the other testing notes in scenarios where we want to account for non-developer type testing. This will be useful for inclusion with what gets included in the testing notes saved to the docs folder. This came up in some team discussion around reducing release lead friction during the release process.

This has no impact on production code so mostly just needs a grammar check and any feedback on whether these changes make sense or not.