### PR TITLE
Add minimum quantity and step so Cart Block and Store API.

### DIFF
--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -6,6 +6,7 @@ import { speak } from '@wordpress/a11y';
 import classNames from 'classnames';
 import { useCallback } from '@wordpress/element';
 import { DOWN, UP } from '@wordpress/keycodes';
+import useDebouncedCallback from 'use-debounce/lib/useDebouncedCallback';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ interface QuantitySelectorProps {
 	quantity?: number;
 	minimum?: number;
 	maximum: number;
+	step?: number;
 	onChange: ( newQuantity: number ) => void;
 	itemName?: string;
 	disabled: boolean;
@@ -27,6 +29,7 @@ const QuantitySelector = ( {
 	quantity = 1,
 	minimum = 1,
 	maximum,
+	step = 1,
 	onChange = () => {
 		/* Do nothing. */
 	},
@@ -39,8 +42,46 @@ const QuantitySelector = ( {
 	);
 
 	const hasMaximum = typeof maximum !== 'undefined';
-	const canDecrease = quantity > minimum;
-	const canIncrease = ! hasMaximum || quantity < maximum;
+	const canDecrease = quantity - step > minimum;
+	const canIncrease = ! hasMaximum || quantity + step < maximum;
+
+	/**
+	 * The goal of this function is to normalize what was inserted,
+	 * but after the customer has stopped typing.
+	 *
+	 * It's important to wait before normalizing or we end up with
+	 * a frustrating expiernce, for example, if the minimun is 2 and
+	 * the customer is trying to type "10", premature normalizing would
+	 * always kick in at "1" and turn that into 2.
+	 */
+	const [ normalizeQuantity ] = useDebouncedCallback(
+		( initialValue: number ) => {
+			// We copy the starting value.
+			let value = initialValue;
+
+			// We check if we have a maximum value, and select the lowest between what was inserted, and the maximum.
+			if ( hasMaximum ) {
+				value = Math.min(
+					value,
+					// the maximum possible value in step increments.
+					Math.floor( maximum / step ) * step
+				);
+			}
+
+			// Select the biggest between what's inserted, the the minimum value in steps.
+			value = Math.max( value, Math.ceil( minimum / step ) * step );
+
+			// We round off the value to our steps.
+			value = Math.floor( value / step ) * step;
+
+			// Only commit if the value has changed
+			if ( value !== initialValue ) {
+				onChange( value );
+			}
+		},
+		// This value is delibrtly smaller than what's in useStoreCartItemQuantity so we don't end up with two requests.
+		300
+	);
 
 	/**
 	 * Handles keyboard up and down keys to change quantity value.
@@ -60,15 +101,15 @@ const QuantitySelector = ( {
 
 			if ( isArrowDown && canDecrease ) {
 				event.preventDefault();
-				onChange( quantity - 1 );
+				onChange( quantity - step );
 			}
 
 			if ( isArrowUp && canIncrease ) {
 				event.preventDefault();
-				onChange( quantity + 1 );
+				onChange( quantity + step );
 			}
 		},
-		[ quantity, onChange, canIncrease, canDecrease ]
+		[ quantity, onChange, canIncrease, canDecrease, step ]
 	);
 
 	return (
@@ -77,22 +118,22 @@ const QuantitySelector = ( {
 				className="wc-block-components-quantity-selector__input"
 				disabled={ disabled }
 				type="number"
-				step="1"
-				min="0"
+				step={ step }
+				min={ minimum }
 				value={ quantity }
 				onKeyDown={ quantityInputOnKeyDown }
 				onChange={ ( event ) => {
-					let value =
-						Number.isNaN( event.target.value ) ||
-						! event.target.value
-							? 0
-							: parseInt( event.target.value, 10 );
-					if ( hasMaximum ) {
-						value = Math.min( value, maximum );
-					}
-					value = Math.max( value, minimum );
+					// Inputs values are strings, we parse them here.
+					let value = parseInt( event.target.value, 10 );
+					// parseInt would throw NaN for anything not a number,
+					// so we revert value to the quantity value.
+					value = isNaN( value ) ? quantity : value;
+
 					if ( value !== quantity ) {
+						// we commit this value immideatly.
 						onChange( value );
+						// but once the customer has stopped typing, we make sure his value is respecting the bounds (maximum value, minimum value, step value), and commit the normlized value.
+						normalizeQuantity( value );
 					}
 				} }
 				aria-label={ sprintf(
@@ -112,7 +153,7 @@ const QuantitySelector = ( {
 				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
 				disabled={ disabled || ! canDecrease }
 				onClick={ () => {
-					const newQuantity = quantity - 1;
+					const newQuantity = quantity - step;
 					onChange( newQuantity );
 					speak(
 						sprintf(
@@ -136,7 +177,7 @@ const QuantitySelector = ( {
 				disabled={ disabled || ! canIncrease }
 				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
 				onClick={ () => {
-					const newQuantity = quantity + 1;
+					const newQuantity = quantity + step;
 					onChange( newQuantity );
 					speak(
 						sprintf(

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -130,7 +130,7 @@ const QuantitySelector = ( {
 					value = isNaN( value ) ? quantity : value;
 
 					if ( value !== quantity ) {
-						// we commit this value immideatly.
+						// we commit this value immediately.
 						onChange( value );
 						// but once the customer has stopped typing, we make sure his value is respecting the bounds (maximum value, minimum value, step value), and commit the normlized value.
 						normalizeQuantity( value );

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -50,7 +50,7 @@ const QuantitySelector = ( {
 	 * but after the customer has stopped typing.
 	 *
 	 * It's important to wait before normalizing or we end up with
-	 * a frustrating expiernce, for example, if the minimun is 2 and
+	 * a frustrating experience, for example, if the minimum is 2 and
 	 * the customer is trying to type "10", premature normalizing would
 	 * always kick in at "1" and turn that into 2.
 	 */

--- a/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
@@ -71,6 +71,8 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 			low_stock_remaining: lowStockRemaining = null,
 			show_backorder_badge: showBackorderBadge = false,
 			quantity_limit: quantityLimit = 99,
+			quantity_min: quantityMin = 1,
+			quantity_step: quantityStep = 1,
 			permalink = '',
 			images = [],
 			variation = [],
@@ -282,6 +284,8 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 							disabled={ isPendingDelete }
 							quantity={ quantity }
 							maximum={ quantityLimit }
+							minimum={ quantityMin }
+							step={ quantityStep }
 							onChange={ ( newQuantity ) => {
 								setItemQuantity( newQuantity );
 								dispatchStoreEvent( 'cart-set-item-quantity', {

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -118,6 +118,8 @@ export interface CartItem {
 	quantity: number;
 	catalog_visibility: CatalogVisibility;
 	quantity_limit: number;
+	quantity_min: number;
+	quantity_step: number;
 	name: string;
 	summary: string;
 	short_description: string;

--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -878,11 +878,11 @@
             }
         },
         {
-            "name": "woocommerce_store_api_item_quantity_increment",
+            "name": "woocommerce_store_api_item_quantity_minimum",
             "file": "StoreApi/Schemas/CartItemSchema.php",
             "type": "filter",
             "doc": {
-                "description": "Filters the quantity increment for a cart item in Store API.",
+                "description": "Filters the quantity minimum for a cart item in Store API.",
                 "long_description": "",
                 "tags": [
                     {
@@ -905,11 +905,11 @@
             }
         },
         {
-            "name": "woocommerce_store_api_item_quantity_minimum",
+            "name": "woocommerce_store_api_item_quantity_step",
             "file": "StoreApi/Schemas/CartItemSchema.php",
             "type": "filter",
             "doc": {
-                "description": "Filters the quantity minimum for a cart item in Store API.",
+                "description": "Filters the quantity increment for a cart item in Store API.",
                 "long_description": "",
                 "tags": [
                     {

--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -878,6 +878,60 @@
             }
         },
         {
+            "name": "woocommerce_store_api_item_quantity_increment",
+            "file": "StoreApi/Schemas/CartItemSchema.php",
+            "type": "filter",
+            "doc": {
+                "description": "Filters the quantity increment for a cart item in Store API.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "Cart item array.",
+                        "types": [
+                            "array"
+                        ],
+                        "variable": "$cart_item"
+                    },
+                    {
+                        "name": "return",
+                        "content": "",
+                        "types": [
+                            "\\Automattic\\WooCommerce\\Blocks\\StoreApi\\Schemas\\number"
+                        ]
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_store_api_item_quantity_minimum",
+            "file": "StoreApi/Schemas/CartItemSchema.php",
+            "type": "filter",
+            "doc": {
+                "description": "Filters the quantity minimum for a cart item in Store API.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "Cart item array.",
+                        "types": [
+                            "array"
+                        ],
+                        "variable": "$cart_item"
+                    },
+                    {
+                        "name": "return",
+                        "content": "",
+                        "types": [
+                            "\\Automattic\\WooCommerce\\Blocks\\StoreApi\\Schemas\\number"
+                        ]
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
             "name": "woocommerce_store_api_product_quantity_limit",
             "file": "StoreApi/Schemas/ProductSchema.php",
             "type": "filter",

--- a/docs/extensibility/filters.md
+++ b/docs/extensibility/filters.md
@@ -32,8 +32,8 @@
  - [woocommerce_shipping_package_name](#woocommerce_shipping_package_name)
  - [woocommerce_show_page_title](#woocommerce_show_page_title)
  - [woocommerce_store_api_disable_nonce_check](#woocommerce_store_api_disable_nonce_check)
- - [woocommerce_store_api_item_quantity_increment](#woocommerce_store_api_item_quantity_increment)
  - [woocommerce_store_api_item_quantity_minimum](#woocommerce_store_api_item_quantity_minimum)
+ - [woocommerce_store_api_item_quantity_step](#woocommerce_store_api_item_quantity_step)
  - [woocommerce_store_api_product_quantity_limit](#woocommerce_store_api_product_quantity_limit)
  - [woocommerce_variation_option_name](#woocommerce_variation_option_name)
 
@@ -783,13 +783,13 @@ File: [StoreApi/Routes/AbstractCartRoute.php](../src/StoreApi/Routes/AbstractCar
 
 ---
 
-## woocommerce_store_api_item_quantity_increment
+## woocommerce_store_api_item_quantity_minimum
 
 
-Filters the quantity increment for a cart item in Store API.
+Filters the quantity minimum for a cart item in Store API.
 
 ```php
-apply_filters( 'woocommerce_store_api_item_quantity_increment', array $cart_item )
+apply_filters( 'woocommerce_store_api_item_quantity_minimum', array $cart_item )
 ```
 
 ### Parameters
@@ -810,13 +810,13 @@ File: [StoreApi/Schemas/CartItemSchema.php](../src/StoreApi/Schemas/CartItemSche
 
 ---
 
-## woocommerce_store_api_item_quantity_minimum
+## woocommerce_store_api_item_quantity_step
 
 
-Filters the quantity minimum for a cart item in Store API.
+Filters the quantity increment for a cart item in Store API.
 
 ```php
-apply_filters( 'woocommerce_store_api_item_quantity_minimum', array $cart_item )
+apply_filters( 'woocommerce_store_api_item_quantity_step', array $cart_item )
 ```
 
 ### Parameters

--- a/docs/extensibility/filters.md
+++ b/docs/extensibility/filters.md
@@ -32,6 +32,8 @@
  - [woocommerce_shipping_package_name](#woocommerce_shipping_package_name)
  - [woocommerce_show_page_title](#woocommerce_show_page_title)
  - [woocommerce_store_api_disable_nonce_check](#woocommerce_store_api_disable_nonce_check)
+ - [woocommerce_store_api_item_quantity_increment](#woocommerce_store_api_item_quantity_increment)
+ - [woocommerce_store_api_item_quantity_minimum](#woocommerce_store_api_item_quantity_minimum)
  - [woocommerce_store_api_product_quantity_limit](#woocommerce_store_api_product_quantity_limit)
  - [woocommerce_variation_option_name](#woocommerce_variation_option_name)
 
@@ -778,6 +780,60 @@ apply_filters( 'woocommerce_store_api_disable_nonce_check', boolean $disable_non
 
 
 File: [StoreApi/Routes/AbstractCartRoute.php](../src/StoreApi/Routes/AbstractCartRoute.php)
+
+---
+
+## woocommerce_store_api_item_quantity_increment
+
+
+Filters the quantity increment for a cart item in Store API.
+
+```php
+apply_filters( 'woocommerce_store_api_item_quantity_increment', array $cart_item )
+```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $cart_item | array | Cart item array. |
+
+### Returns
+
+
+`\Automattic\WooCommerce\Blocks\StoreApi\Schemas\number` 
+
+### Source
+
+
+File: [StoreApi/Schemas/CartItemSchema.php](../src/StoreApi/Schemas/CartItemSchema.php)
+
+---
+
+## woocommerce_store_api_item_quantity_minimum
+
+
+Filters the quantity minimum for a cart item in Store API.
+
+```php
+apply_filters( 'woocommerce_store_api_item_quantity_minimum', array $cart_item )
+```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $cart_item | array | Cart item array. |
+
+### Returns
+
+
+`\Automattic\WooCommerce\Blocks\StoreApi\Schemas\number` 
+
+### Source
+
+
+File: [StoreApi/Schemas/CartItemSchema.php](../src/StoreApi/Schemas/CartItemSchema.php)
 
 ---
 

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -327,7 +327,7 @@ class CartItemSchema extends ProductSchema {
 			'quantity'             => wc_stock_amount( $cart_item['quantity'] ),
 			'quantity_limit'       => $this->get_product_quantity_limit( $product ),
 			'quantity_min'         => $this->get_item_quantity_min( $cart_item ),
-			'quantity_increment'   => $this->get_item_quantity_increment( $cart_item ),
+			'quantity_step'        => $this->get_item_quantity_step( $cart_item ),
 			'name'                 => $this->prepare_html_response( $product->get_title() ),
 			'short_description'    => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_short_description() ) ) ),
 			'description'          => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_description() ) ) ),
@@ -487,14 +487,14 @@ class CartItemSchema extends ProductSchema {
 	 * @param array $cart_item Cart item array.
 	 * @return number
 	 */
-	protected function get_item_quantity_increment( $cart_item ) {
+	protected function get_item_quantity_step( $cart_item ) {
 		/**
 		 * Filters the quantity increment for a cart item in Store API.
 		 *
 		 * @param array $cart_item Cart item array.
 		 * @return number
 		 */
-		return apply_filters( 'woocommerce_store_api_item_quantity_increment', 1, $cart_item );
+		return apply_filters( 'woocommerce_store_api_item_quantity_step', 1, $cart_item );
 	}
 
 	/**

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -63,7 +63,7 @@ class CartItemSchema extends ProductSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'quantity_increment'   => [
+			'quantity_step'        => [
 				'description' => __( 'The amount quantity can change with.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -57,6 +57,18 @@ class CartItemSchema extends ProductSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
+			'quantity_min'         => [
+				'description' => __( 'The minimum quantity than can be added to the cart at once.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'quantity_increment'   => [
+				'description' => __( 'The amount quantity can change with.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
 			'name'                 => [
 				'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
@@ -314,6 +326,8 @@ class CartItemSchema extends ProductSchema {
 			'id'                   => $product->get_id(),
 			'quantity'             => wc_stock_amount( $cart_item['quantity'] ),
 			'quantity_limit'       => $this->get_product_quantity_limit( $product ),
+			'quantity_min'         => $this->get_item_quantity_min( $cart_item ),
+			'quantity_increment'   => $this->get_item_quantity_increment( $cart_item ),
 			'name'                 => $this->prepare_html_response( $product->get_title() ),
 			'short_description'    => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_short_description() ) ) ),
 			'description'          => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_description() ) ) ),
@@ -449,6 +463,38 @@ class CartItemSchema extends ProductSchema {
 		 */
 		$item_data = apply_filters( 'woocommerce_get_item_data', array(), $cart_item );
 		return array_map( [ $this, 'format_item_data_element' ], $item_data );
+	}
+
+	/**
+	 * Return the minimum quantity that's allowed for this item.
+	 *
+	 * @param array $cart_item Cart item array.
+	 * @return number
+	 */
+	protected function get_item_quantity_min( $cart_item ) {
+		/**
+		 * Filters the quantity minimum for a cart item in Store API.
+		 *
+		 * @param array $cart_item Cart item array.
+		 * @return number
+		 */
+		return apply_filters( 'woocommerce_store_api_item_quantity_minimum', 1, $cart_item );
+	}
+
+	/**
+	 * Return the increment quantity that an item is allowed to change with.
+	 *
+	 * @param array $cart_item Cart item array.
+	 * @return number
+	 */
+	protected function get_item_quantity_increment( $cart_item ) {
+		/**
+		 * Filters the quantity increment for a cart item in Store API.
+		 *
+		 * @param array $cart_item Cart item array.
+		 * @return number
+		 */
+		return apply_filters( 'woocommerce_store_api_item_quantity_increment', 1, $cart_item );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds `minimum` and `step` concepts to Store API and Cart Block.

This functionality is still mainly plugin land, so we're not actually implementing a way for a merchant to setup a step or a minimum amount, but we're laying the foundation for plugins to use this, in Store API, via two new filters:

- `woocommerce_store_api_item_quantity_minimum`
- `woocommerce_store_api_item_quantity_step`

Following on the steps of `woocommerce_store_api_product_quantity_limit`.

The second addition is honoring those values in Cart Block. Cart Item quantity switcher now honors minimum and step values and would change according to them.

Based on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4241/commits/66b053424c11ca310069ec3a0883884a3e541c82

### Testing steps
1. Smoke test adding items to cart and changing quantity, either via buttons or directly via the input.
2. Keep you network tap open and make sure no extra requests are being made.
3. Add this code, which would apply to your cart items:
```php
add_filter(
	'woocommerce_store_api_item_quantity_minimum',
	function ( $value, $cart_item ) {
		return 6;
	},
	10,
	2
);

add_filter(
	'woocommerce_store_api_item_quantity_step',
	function ( $value, $cart_item ) {
		return 4;
	},
	10,
	2
);
```

4. Substitute 6 and 4 with whatever value you want.
5. Refresh your cart, change values, quantity should up and down by 4 (or whatever value you set for step).
6. If the initial value isn't a multiplier of 4, after changing the quantity, your new quantity would be a multiplier of 4.
7. Try to type a number inside the quantity selector, trying something that isn't a multiplier of 4 would change to the nearest one, for example, typing 14 would yield back 12.

### Caveats:
- I opted out for filters instead of a registration API. the surface area is very minimal (just a number).
- I decided to keep this plugin land. This means there's no verification on Store API about minimum quantity and if it follows a step or not. We do have verification for maximum quantity, but that's because maximum quantity is a core feature, handled via sold individually and stock attributes.
- @mikejolley and discussed not implementing the step part, and let plugins handle that on server side. This reduces the amount of logic we have, but I believe results in a subpar UI experience overall. I'd prefer, if we can, to handle that on our part.
- 
### Changelog

> Store API and Cart block now support defining a quantity stepper and a minimum quantity.
