### PR TITLE
Updated has_block_template hook to use correct woocommerce_ prefix

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -136,7 +136,7 @@ class BlockTemplatesController {
 			! $this->theme_has_template( 'single-product' ) &&
 			$this->default_block_template_is_available( 'single-product' )
 		) {
-			add_filter( 'wc_has_block_template', '__return_true', 10, 0 );
+			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
 	}
 }


### PR DESCRIPTION
Updated the hook name so its correctly prefixed with `woocommerce_` as per this request https://github.com/woocommerce/woocommerce/pull/30997#discussion_r738552712

### Testing

Please follow testing instructions here https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4984
