### PR TITLE
replace synchronizeBlocksWithTemplate with createBlocksFromInnerBlock…

### DIFF
--- a/assets/js/blocks/cart-checkout/shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout/shared/use-forced-layout.ts
@@ -13,7 +13,7 @@ import {
 	getBlockType,
 	Block,
 	AttributeSource,
-	synchronizeBlocksWithTemplate,
+	createBlocksFromInnerBlocksTemplate,
 	TemplateArray,
 } from '@wordpress/blocks';
 import { isEqual } from 'lodash';
@@ -91,8 +91,7 @@ export const useForcedLayout = ( {
 			innerBlocks.length === 0 &&
 			currentDefaultTemplate.current.length > 0
 		) {
-			const nextBlocks = synchronizeBlocksWithTemplate(
-				innerBlocks,
+			const nextBlocks = createBlocksFromInnerBlocksTemplate(
 				currentDefaultTemplate.current
 			);
 			if ( ! isEqual( nextBlocks, innerBlocks ) ) {


### PR DESCRIPTION
Replaces [`synchronizeBlocksWithTemplate`](https://github.com/WordPress/gutenberg/blob/984160d1368695f22222aea4e20527d7699b842c/packages/blocks/src/api/templates.js) with the more appropriate function [`createBlocksFromInnerBlocksTemplate`](https://github.com/WordPress/gutenberg/blob/5621a3c415c22b626b3fe5d504ecf33b75ea6223/packages/blocks/src/api/factory.js#L76).

Reason: `synchronizeBlocksWithTemplate` is useful for taking an existing set of inner blocks and adding/removing blocks from that set based on a template definition.

In our case, we're not synchronising. We're creating blocks **when the Inner Block template is empty.** Therefore, the simpler `createBlocksFromInnerBlocksTemplate` function is more appropriate. 

### Testing steps:

This is not a user-facing change. You can test that the blocks are created by:

- Inserting Checkout Block
- Switching to Code Editor
- Remove the contents of the fields block so you're left with:

```jsx
<!-- wp:woocommerce/checkout -->
<div class="wp-block-woocommerce-checkout wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block -->
<div class="wp-block-woocommerce-checkout-fields-block"></div>
<!-- /wp:woocommerce/checkout-fields-block -->

<!-- wp:woocommerce/checkout-totals-block -->
<div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block -->
<div class="wp-block-woocommerce-checkout-order-summary-block"></div>
<!-- /wp:woocommerce/checkout-order-summary-block --></div>
<!-- /wp:woocommerce/checkout-totals-block --></div>
<!-- /wp:woocommerce/checkout -->
```

- Save the page
- Switch back to visual editor then refresh the page.
- Confirm the inner blocks are repopulated.

### Changelog

> Replace `synchronizeBlocksWithTemplate` with `createBlocksFromInnerBlocksTemplate`