### PR TITLE
Fix Block Templates being rendered correctly

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -111,6 +111,7 @@ class BlockTemplatesController {
 			}
 
 			$new_template_item = array(
+				'title' => BlockTemplateUtils::convert_slug_to_title( $template_slug ),
 				'slug'  => $template_slug,
 				'path'  => $template_file,
 				'theme' => get_template_directory(),

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -53,10 +53,37 @@ class BlockTemplatesController {
 			return $query_result;
 		}
 
+		$post_type      = isset( $query['post_type'] ) ? $query['post_type'] : '';
 		$template_files = $this->get_block_templates();
 
+		// @todo: Add apply_filters to _gutenberg_get_template_files() in Gutenberg to prevent duplication of logic.
 		foreach ( $template_files as $template_file ) {
-			$query_result[] = BlockTemplateUtils::gutenberg_build_template_result_from_file( $template_file, 'wp_template' );
+			$template = BlockTemplateUtils::gutenberg_build_template_result_from_file( $template_file, 'wp_template' );
+
+			if ( $post_type && ! $template->is_custom ) {
+				continue;
+			}
+
+			if ( $post_type &&
+				isset( $template->post_types ) &&
+				! in_array( $post_type, $template->post_types, true )
+			) {
+				continue;
+			}
+
+			$is_not_custom   = false === array_search(
+				wp_get_theme()->get_stylesheet() . '//' . $template_file['slug'],
+				array_column( $query_result, 'id' ),
+				true
+			);
+			$fits_slug_query =
+				! isset( $query['slug__in'] ) || in_array( $template_file['slug'], $query['slug__in'], true );
+			$fits_area_query =
+				! isset( $query['area'] ) || $template_file['area'] === $query['area'];
+			$should_include  = $is_not_custom && $fits_slug_query && $fits_area_query;
+			if ( $should_include ) {
+				$query_result[] = $template;
+			}
 		}
 
 		return $query_result;
@@ -84,7 +111,6 @@ class BlockTemplatesController {
 			}
 
 			$new_template_item = array(
-				'title' => ucwords( str_replace( '-', ' ', $template_slug ) ),
 				'slug'  => $template_slug,
 				'path'  => $template_file,
 				'theme' => get_template_directory(),
@@ -92,7 +118,6 @@ class BlockTemplatesController {
 			);
 			$templates[]       = $new_template_item;
 		}
-
 		return $templates;
 	}
 
@@ -135,6 +160,18 @@ class BlockTemplatesController {
 			is_singular( 'product' ) &&
 			! $this->theme_has_template( 'single-product' ) &&
 			$this->default_block_template_is_available( 'single-product' )
+		) {
+			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+		} elseif (
+			is_tax() &&
+			! $this->theme_has_template( 'taxonomy-product_cat' ) &&
+			$this->default_block_template_is_available( 'taxonomy-product_cat' )
+		) {
+			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+		} elseif (
+			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) &&
+			! $this->theme_has_template( 'archive-product' ) &&
+			$this->default_block_template_is_available( 'archive-product' )
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -128,4 +128,24 @@ class BlockTemplateUtils {
 		}
 		return $path_list;
 	}
+
+	/**
+	 * Converts template slugs into readable titles.
+	 *
+	 * @param string $template_slug The templates slug (e.g. single-product).
+	 * @return string Human friendly title converted from the slug.
+	 */
+	public static function convert_slug_to_title( $template_slug ) {
+		switch ( $template_slug ) {
+			case 'single-product':
+				return 'Single Product Page';
+			case 'archive-product':
+				return 'Product Archive Page';
+			case 'taxonomy-product_cat':
+				return 'Product Taxonomy Page';
+			default:
+				// Replace all hyphens and underscores with spaces.
+				return ucwords( preg_replace( '/[\-_]/', ' ', $template_slug ) );
+		}
+	}
 }

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -138,11 +138,11 @@ class BlockTemplateUtils {
 	public static function convert_slug_to_title( $template_slug ) {
 		switch ( $template_slug ) {
 			case 'single-product':
-				return 'Single Product Page';
+				return __( 'Single Product Page', 'woo-gutenberg-products-block' );
 			case 'archive-product':
-				return 'Product Archive Page';
+				return __( 'Product Archive Page', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_cat':
-				return 'Product Taxonomy Page';
+				return __( 'Product Taxonomy Page', 'woo-gutenberg-products-block' );
 			default:
 				// Replace all hyphens and underscores with spaces.
 				return ucwords( preg_replace( '/[\-_]/', ' ', $template_slug ) );

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -93,7 +93,7 @@ class BlockTemplateUtils {
 		$template->theme          = $theme;
 		$template->content        = self::gutenberg_inject_theme_attribute_in_content( $template_content );
 		$template->slug           = $template_file['slug'];
-		$template->source         = 'theme';
+		$template->source         = 'woocommerce';
 		$template->type           = $template_type;
 		$template->title          = ! empty( $template_file['title'] ) ? $template_file['title'] : $template_file['slug'];
 		$template->status         = 'publish';


### PR DESCRIPTION
Copy logic from [Gutenberg](https://github.com/WordPress/gutenberg/blob/trunk/lib/full-site-editing/block-templates.php#L417-L445) to ensure the correct templates are being included in the get_block_templates query

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5046

### Manual Testing

How to test the changes in this Pull Request:

**Prerequisite**: Please ensure you have a Block Template Theme activated such as TT1 and also the Gutenberg Plugin installed.

1. Download the [Archive.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/7459684/Archive.zip) file and unzip. Put the containing .html files in `woo-blocks/templates/block-templates/`
2. Load Product Page (e.g. `/product/album/`) and ensure the `single-product.html` template is rendered.
3. Load Taxonomy Page (e.g. `/product-category/clothing/`) and ensure the `taxonomy-product_cat.html` template is rendered
4. Load the Shop/Archive page and ensure the `archive-product.html` template is rendered.
5. Load Site Editor and ensure templates are also present here.

Once you have followed the above steps, add the same template files to your `theme-dir/block-templates` and change the file contents so you can differentiate the Woo Block template and the Theme template. Repeat the above steps starting from Step 2 and confirm the Theme template is preferred over the Woo Blocks template

