### PR TITLE
Fix conflict between Mini Cart and Navigation blocks #4592

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart/frontend.ts
@@ -15,7 +15,7 @@ interface dependencyData {
 }
 
 // eslint-disable-next-line @wordpress/no-global-event-listener
-window.onload = () => {
+window.addEventListener( 'load', () => {
 	const miniCartBlocks = document.querySelectorAll( '.wc-block-mini-cart' );
 	let wasLoadScriptsCalled = false;
 
@@ -153,4 +153,4 @@ window.onload = () => {
 			);
 		}
 	} );
-};
+} );


### PR DESCRIPTION
Fix conflict between Mini Cart and Navigation blocks.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #4952 
<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Manual Testing

How to test the changes in this Pull Request

Check out this branch
1. Make sure you have Gutenberg and Woo Blocks plugins installed
2. Create a new page and add the Mini cart block first
3. Save the page and go to the site to see the Mini cart block working
4. Go back and add the Navigation block after the mini cart
5. Save the page and go to the front-end to see the page
6. Notice that the Mini Cart & Navigation blocks work as expected.

