### PR TITLE
Expose withFilteredAttributes to extensions

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/frontend.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/frontend.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 
 /**
  * Internal dependencies

--- a/assets/js/atomic/blocks/product-elements/image/frontend.js
+++ b/assets/js/atomic/blocks/product-elements/image/frontend.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 
 /**
  * Internal dependencies

--- a/assets/js/atomic/blocks/product-elements/title/frontend.ts
+++ b/assets/js/atomic/blocks/product-elements/title/frontend.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 
 /**
  * Internal dependencies

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/frontend.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 
 /**
  * Internal dependencies

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/proceed-to-checkout-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/proceed-to-checkout-block/frontend.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 
 /**
  * Internal dependencies

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/frontend.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 
 /**
  * Internal dependencies

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
 

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
@@ -3,7 +3,7 @@
  */
 import classnames from 'classnames';
 import { useStoreCart, useEmitResponse } from '@woocommerce/base-context/hooks';
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import {
 	useCheckoutContext,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/frontend.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import withFilteredAttributes from '@woocommerce/base-hocs/with-filtered-attributes';
+import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutContext } from '@woocommerce/base-context';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';

--- a/assets/js/shared/hocs/index.js
+++ b/assets/js/shared/hocs/index.js
@@ -1,1 +1,2 @@
 export * from './with-product-data-context';
+export * from './with-filtered-attributes';

--- a/assets/js/shared/hocs/with-filtered-attributes.js
+++ b/assets/js/shared/hocs/with-filtered-attributes.js
@@ -8,7 +8,9 @@ import { getValidBlockAttributes } from '@woocommerce/base-utils';
  *
  * @param {Object} blockAttributes Component being wrapped.
  */
-const withFilteredAttributes = ( blockAttributes ) => ( OriginalComponent ) => {
+export const withFilteredAttributes = ( blockAttributes ) => (
+	OriginalComponent
+) => {
 	return ( ownProps ) => {
 		const validBlockAttributes = getValidBlockAttributes(
 			blockAttributes,
@@ -20,5 +22,3 @@ const withFilteredAttributes = ( blockAttributes ) => ( OriginalComponent ) => {
 		);
 	};
 };
-
-export default withFilteredAttributes;


### PR DESCRIPTION
This PR moves `withFilteredAttributes` to `shared-hocs` package.

### Motivation behind this:
- Third-party blocks wishing to use attributes in frontend will have to render in them in the saved HTML. A limitation there is that default attributes are not available in PHP, meaning they can't be appended in HTML and can't be accessed in frontend.
- To fix the issue above, you need to register your block in PHP, and register your attributes there.
- This solution works fine if all of your attributes are in `block.json`, but for some blocks, default value of attributes is dynamic and coming from settings or something.
- So you need to duplicate the default logic in PHP and JS.
- To avoid doing that, `withFilteredAttributes` takes your default attributes in JS and pass them to your frontend block, it's the cleanest solution.
