### PR TITLE
Fix wc-settings not loading when a script that depend on it is in the header

### DIFF
--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -67,8 +67,8 @@ class AssetDataRegistry {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_data_script' ) );
-		add_action( 'wp_print_scripts', array( $this, 'enqueue_asset_data' ), 1 );
 		add_action( 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 1 );
+		add_action( 'admin_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 1 );
 	}
 
 	/**
@@ -340,7 +340,7 @@ class AssetDataRegistry {
 	 * happen for routes that need it.
 	 */
 	public function enqueue_asset_data() {
-		if ( wp_script_is( $this->handle, 'enqueued' ) && ! wp_script_is( $this->handle, 'done' ) ) {
+		if ( wp_script_is( $this->handle, 'enqueued' ) ) {
 			$this->initialize_core_data();
 			$this->execute_lazy_data();
 

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -67,8 +67,8 @@ class AssetDataRegistry {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_data_script' ) );
+		add_action( 'wp_print_scripts', array( $this, 'enqueue_asset_data' ), 1 );
 		add_action( 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 1 );
-		add_action( 'admin_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 1 );
 	}
 
 	/**
@@ -340,7 +340,7 @@ class AssetDataRegistry {
 	 * happen for routes that need it.
 	 */
 	public function enqueue_asset_data() {
-		if ( wp_script_is( $this->handle, 'enqueued' ) ) {
+		if ( wp_script_is( $this->handle, 'enqueued' ) && ! wp_script_is( $this->handle, 'done' ) ) {
 			$this->initialize_core_data();
 			$this->execute_lazy_data();
 

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -38,8 +38,8 @@ final class AssetsController {
 		add_action( 'body_class', array( $this, 'add_theme_body_class' ), 1 );
 		add_action( 'admin_body_class', array( $this, 'add_theme_body_class' ), 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_block_style_dependencies' ), 20 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'update_block_settings_dependencies' ), 1 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'update_block_settings_dependencies' ), 1 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'update_block_settings_dependencies' ), 100 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'update_block_settings_dependencies' ), 100 );
 	}
 
 	/**

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -177,8 +177,7 @@ final class AssetsController {
 				// Show a warning.
 				$error_handle  = 'wc-settings-dep-in-header';
 				$used_deps     = implode( ', ', array_intersect( $known_packages, $script->deps ) );
-				$error_message = "scripts that has a depenency on [ {$used_deps} ] must be loaded in the footer, {$handle} was loaded in the header but was moved to the footer. See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5059";
-
+				$error_message = "Scripts that have a dependency on [$used_deps] must be loaded in the footer, {$handle} was registered to load in the header, but has been switched to load in the footer instead. See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5059";
 				// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter,WordPress.WP.EnqueuedResourceParameters.MissingVersion
 				wp_register_script( $error_handle, '' );
 				wp_enqueue_script( $error_handle );

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -39,6 +39,7 @@ final class AssetsController {
 		add_action( 'admin_body_class', array( $this, 'add_theme_body_class' ), 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_block_style_dependencies' ), 20 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'update_block_settings_dependencies' ), 1 );
+		add_action( 'admin_enqueue_scripts', array( $this, 'update_block_settings_dependencies' ), 1 );
 	}
 
 	/**


### PR DESCRIPTION
This PR is cherry-picked from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5045

The goal of it is to fix an issue in which a script:
- Is loaded in the header (blocks from `register_block_type( block.json )`  for example).
- Depend on `wc-settings` or something that depend on it like `wc-blocks-checkout`, `wc-price-format`.
would break the page because `wc-settings` inline script would not load.

This PR (by @mikejolley) fixes the issue by forcing scripts that depend on `wc-settings` to print in the footer.

### Testing steps

1. This PR is meant to fix a regression in third party blocks, so you can test it by loading AutomateWoo newsletter block, MailPoet block, or create a new block `npx wp-create-block test-block` and include something from `@woocommerce/blocks-checkout` or `@woocommerce/price-format`.
2. The block should load fine in the editor with Cart and Checkout.
3. Inspect the page, you should have a single `wc-settings` script enqueued.

### Changelog

> Scripts using `wc-settings` or script that depend on it would be enqueued in the footer if they're enqueued in the header.