### PR TITLE
Fix sanitization callback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"wp-phpunit/wp-phpunit": "^5.4",
 		"woocommerce/woocommerce-sniffs": "0.1.0",
 		"yoast/phpunit-polyfills": "^1.0",
-		"johnbillion/wp-hooks-generator": "0.6.1"
+		"johnbillion/wp-hooks-generator": "0.6.1",
+		"mockery/mockery": "^1.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5f1120a4cf4a55d7e222625b06768c5",
+    "content-hash": "35125888589aa8a4adfdb2cdbc266442",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -400,6 +400,57 @@
             "time": "2019-12-30T22:54:17+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
             "name": "johnbillion/wp-hooks-generator",
             "version": "0.6.1",
             "source": {
@@ -496,6 +547,78 @@
                 "source": "https://github.com/johnbillion/wp-parser-lib/tree/1.1.0"
             },
             "time": "2021-01-06T22:49:12+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "e01123a0e847d52d186c5eb4b9bf58b0c6d00346"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/e01123a0e847d52d186c5eb4b9bf58b0c6d00346",
+                "reference": "e01123a0e847d52d186c5eb4b9bf58b0c6d00346",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/mockery/mockery/issues",
+                "source": "https://github.com/mockery/mockery/tree/1.4.4"
+            },
+            "time": "2021-09-13T15:28:59+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,7 +5,6 @@
 	<!-- Exclude paths -->
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>languages/woo-gutenberg-products-block.php</exclude-pattern>
 
 	<!-- Configs -->

--- a/tests/php/StoreApi/Routes/Checkout.php
+++ b/tests/php/StoreApi/Routes/Checkout.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Controller Tests.
+ */
+
+namespace Automattic\WooCommerce\Blocks\Tests\StoreApi\Routes;
+
+use Automattic\WooCommerce\Blocks\Domain\Services\ExtendRestApi;
+use Automattic\WooCommerce\Blocks\Domain\Package as DomainPackage;
+use Automattic\WooCommerce\Blocks\StoreApi\Formatters;
+use Automattic\WooCommerce\Blocks\StoreApi\Formatters\MoneyFormatter;
+use Automattic\WooCommerce\Blocks\StoreApi\Formatters\HtmlFormatter;
+use Automattic\WooCommerce\Blocks\StoreApi\Formatters\CurrencyFormatter;
+use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
+use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CheckoutSchema;
+use Automattic\WooCommerce\Blocks\Tests\StoreApi\Routes\ControllerTestCase;
+use Automattic\WooCommerce\Blocks\Tests\Helpers\FixtureData;
+use Automattic\WooCommerce\Blocks\StoreApi\Routes\Checkout as CheckoutRoute;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\OrderController;
+use Automattic\WooCommerce\Blocks\StoreApi\SchemaController;
+
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+/**
+ * Checkout Controller Tests.
+ */
+class Checkout extends MockeryTestCase {
+	/**
+	 * Setup test products data. Called before every test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new \Spy_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		$formatters = new Formatters();
+		$formatters->register( 'money', MoneyFormatter::class );
+		$formatters->register( 'html', HtmlFormatter::class );
+		$formatters->register( 'currency', CurrencyFormatter::class );
+
+		$this->mock_extend = new ExtendRestApi( new DomainPackage( '', '', new FeatureGating( 2 ) ), $formatters );
+		$this->mock_extend->register_endpoint_data(
+			array(
+				'endpoint'        => CheckoutSchema::IDENTIFIER,
+				'namespace'       => 'extension_namespace',
+				'schema_callback' => function() {
+					return array(
+						'extension_key' => array(
+							'description' => 'Test key',
+							'type'        => 'boolean',
+						),
+					);
+				},
+			)
+		);
+		$schema_controller = new SchemaController( $this->mock_extend );
+		$route             = new CheckoutRoute( $schema_controller->get( 'cart' ), $schema_controller->get( 'checkout' ), new CartController(), new OrderController() );
+		register_rest_route( $route->get_namespace(), $route->get_path(), $route->get_args(), true );
+
+		$fixtures = new FixtureData();
+		$fixtures->shipping_add_flat_rate();
+		$this->products = array(
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 1',
+					'stock_status'  => 'instock',
+					'regular_price' => 10,
+					'weight'        => 10,
+				)
+			),
+			$fixtures->get_simple_product(
+				array(
+					'name'          => 'Test Product 2',
+					'stock_status'  => 'instock',
+					'regular_price' => 10,
+					'weight'        => 10,
+				)
+			),
+		);
+		wc_empty_cart();
+		$this->keys   = array();
+		$this->keys[] = wc()->cart->add_to_cart( $this->products[0]->get_id(), 2 );
+		$this->keys[] = wc()->cart->add_to_cart( $this->products[1]->get_id(), 1 );
+	}
+
+	/**
+	 * Tear down Rest API server.
+	 */
+	protected function tearDown(): void {
+		parent::tearDown();
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	/**
+	 * Test route registration.
+	 */
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/wc/store/checkout', $routes );
+	}
+
+	/**
+	 * Ensure that registered extension data is correctly shown on options requests.
+	 */
+	public function test_options_extension_data() {
+		$request  = new \WP_REST_Request( 'OPTIONS', '/wc/store/checkout' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertEquals(
+			array(
+				'description' => 'Test key',
+				'type'        => 'boolean',
+			),
+			$data['schema']['properties']['extensions']['properties']['extension_namespace']['properties']['extension_key']
+		);
+	}
+
+	/**
+	 * Ensure that registered extension data is correctly posted and visible on the server after sanitization.
+	 */
+	public function test_post_extension_data() {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/checkout' );
+		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+					'email'      => 'test@test.com',
+				),
+				'shipping_address' => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+				),
+				'payment_method'   => 'bacs',
+				'extensions'       => array(
+					'extension_namespace' => array(
+						'extension_key' => true,
+					),
+				),
+			)
+		);
+		$action_callback = \Mockery::mock( 'ActionCallback' );
+		$action_callback->shouldReceive( 'do_callback' )->withArgs(
+			array(
+				\Mockery::any(),
+				\Mockery::on(
+					function ( $argument ) {
+						return true === $argument['extensions']['extension_namespace']['extension_key'];
+					}
+				),
+			)
+		)->once();
+		add_action( 'woocommerce_blocks_checkout_update_order_from_request', array( $action_callback, 'do_callback' ), 10, 2 );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		remove_action( 'woocommerce_blocks_checkout_update_order_from_request', array( $action_callback, 'do_callback' ), 10, 2 );
+	}
+
+	/**
+	 * Ensure that registered extension data is correctly posted and visible on the server after sanitization.
+	 */
+	public function test_post_invalid_extension_data() {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/checkout' );
+		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+					'email'      => 'test@test.com',
+				),
+				'shipping_address' => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+				),
+				'payment_method'   => 'bacs',
+				'extensions'       => array(
+					'extension_namespace' => array(
+						'extension_key' => 'invalid-string',
+					),
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'rest_invalid_param', $response->get_data()['code'] );
+	}
+}


### PR DESCRIPTION
This PR is cherry-picked from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5045

This fixed an error where data passed to the Store API via post would be incorrectly represented in the $request object after data sanitization. 

Previously it would look over all items in the object recursively but due to this condition, would return the first sanitized value:

```
if ( isset( $property_value['properties'] ) ) {
					$sanitize_callback = $this->get_recursive_sanitize_callback( $property_value['properties'] );
					return $sanitize_callback( $current_value, $request, $param . ' > ' . $property_key );
}
```

Other data in the `extensions` object would then be skipped. 

The fix is to place all values into an array and return them once all properties have been sanitized.

### Testing steps

Since these changes only impact developers, there are no user facing testing steps to perform. I have however added a test case to confirm nested properties are no longer destroyed. Ensure php tests pass with this change.

### Changelog
> Fix an issue with sanitization callbacks.