### PR TITLE
Fix sale badge alignment on smaller screen

### DIFF
--- a/assets/js/base/components/product-list/style.scss
+++ b/assets/js/base/components/product-list/style.scss
@@ -134,9 +134,6 @@
 				}
 				.wc-block-grid__product:nth-child(even) {
 					padding-left: $gap*0.5;
-					.wc-block-grid__product-onsale {
-						left: $gap*0.5;
-					}
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixes a not polished style for the sale badge alignment on a smaller screen (480px to 600px)

<!-- Reference any related issues or PRs here -->
Fixes #3601 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
![image](https://user-images.githubusercontent.com/4463174/140051345-bcd816ff-cd39-4347-a935-5064513251c4.png)
*Before the fix*

![image](https://user-images.githubusercontent.com/4463174/140051489-e206af04-5a65-4af3-aeaa-7de9128bb7f5.png)
*Current implementation*

### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch.

1. Make sure you have Woo Blocks plugins installed and some products on sale
2. Create a new page and add the All Products block
3. Save the page and go to the site
4. Simulate a screen that has a viewport between 480px and 600px
5. Check if the sale badge alignment keep staying on the right (check the image on top)

### Changelog

> Fix sale badge alignment on smaller screen.