### PR TITLE
Add basic taxonomy block templates

### DIFF
--- a/assets/js/blocks/legacy-template/constants.ts
+++ b/assets/js/blocks/legacy-template/constants.ts
@@ -3,13 +3,33 @@
  */
 import { __ } from '@wordpress/i18n';
 
-export const TEMPLATE_TITLES: Record< string, string > = {
-	'single-product': __(
-		'WooCommerce Single Product Template',
-		'woo-gutenberg-products-block'
-	),
-	'archive-product': __(
-		'WooCommerce Product Archive Template',
-		'woo-gutenberg-products-block'
-	),
+export const TEMPLATES: Record< string, Record< string, string > > = {
+	'single-product': {
+		title: __(
+			'WooCommerce Single Product Template',
+			'woo-gutenberg-products-block'
+		),
+		placeholder: 'single-product',
+	},
+	'archive-product': {
+		title: __(
+			'WooCommerce Product Archive Template',
+			'woo-gutenberg-products-block'
+		),
+		placeholder: 'archive-product',
+	},
+	'taxonomy-product_cat': {
+		title: __(
+			'WooCommerce Product Taxonomy Template',
+			'woo-gutenberg-products-block'
+		),
+		placeholder: 'archive-product',
+	},
+	'taxonomy-product_tag': {
+		title: __(
+			'WooCommerce Product Tag Template',
+			'woo-gutenberg-products-block'
+		),
+		placeholder: 'archive-product',
+	},
 };

--- a/assets/js/blocks/legacy-template/editor.scss
+++ b/assets/js/blocks/legacy-template/editor.scss
@@ -14,7 +14,7 @@
 	}
 }
 
-.editor-styles-wrapper .wp-block-woocommerce-legacy-template__placeholder-image {
+.wp-block-woocommerce-legacy-template__placeholder .wp-block-woocommerce-legacy-template__placeholder-image {
 	display: none;
 	width: 100%;
 	height: auto;

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -14,7 +14,7 @@ import { page } from '@wordpress/icons';
  * Internal dependencies
  */
 import './editor.scss';
-import { TEMPLATE_TITLES } from './constants';
+import { TEMPLATES } from './constants';
 
 interface Props {
 	attributes: {
@@ -25,7 +25,9 @@ interface Props {
 const Edit = ( { attributes }: Props ) => {
 	const blockProps = useBlockProps();
 	const templateTitle =
-		TEMPLATE_TITLES[ attributes.template ] ?? attributes.template;
+		TEMPLATES[ attributes.template ]?.title ?? attributes.template;
+	const templatePlaceholder =
+		TEMPLATES[ attributes.template ]?.placeholder ?? 'fallback';
 	return (
 		<div { ...blockProps }>
 			<Placeholder
@@ -46,7 +48,7 @@ const Edit = ( { attributes }: Props ) => {
 				<div className="wp-block-woocommerce-legacy-template__placeholder-wireframe">
 					<img
 						className="wp-block-woocommerce-legacy-template__placeholder-image"
-						src={ `${ WC_BLOCKS_IMAGE_URL }template-placeholders/${ attributes.template }.svg` }
+						src={ `${ WC_BLOCKS_IMAGE_URL }template-placeholders/${ templatePlaceholder }.svg` }
 						alt={ templateTitle }
 					/>
 				</div>

--- a/images/template-placeholders/fallback.svg
+++ b/images/template-placeholders/fallback.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="250" xml:space="preserve">
+  <path style="stroke:#99076d;stroke-width:0;stroke-dasharray:none;stroke-linecap:butt;stroke-dashoffset:0;stroke-linejoin:miter;stroke-miterlimit:4;fill:#e5e5e5;fill-rule:nonzero;opacity:1" vector-effect="non-scaling-stroke" transform="translate(4.71 3.93)" d="M0 0h490v241H0z"/>
+</svg>

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -164,9 +164,15 @@ class BlockTemplatesController {
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		} elseif (
-			is_tax() &&
+			( is_product_taxonomy() && is_tax( 'product_cat' ) ) &&
 			! $this->theme_has_template( 'taxonomy-product_cat' ) &&
 			$this->default_block_template_is_available( 'taxonomy-product_cat' )
+		) {
+			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+		} elseif (
+			( is_product_taxonomy() && is_tax( 'product_tag' ) ) &&
+			! $this->theme_has_template( 'taxonomy-product_tag' ) &&
+			$this->default_block_template_is_available( 'taxonomy-product_tag' )
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		} elseif (

--- a/src/BlockTypes/LegacyTemplate.php
+++ b/src/BlockTypes/LegacyTemplate.php
@@ -36,7 +36,7 @@ class LegacyTemplate extends AbstractDynamicBlock {
 
 		if ( 'single-product' === $attributes['template'] ) {
 			return $this->render_single_product();
-		} elseif ( 'archive-product' === $attributes['template'] ) {
+		} elseif ( 'archive-product' === $attributes['template'] || 'taxonomy-product_cat' === $attributes['template'] || 'taxonomy-product_tag' === $attributes['template'] ) {
 			return $this->render_archive_product();
 		} else {
 			ob_start();

--- a/src/BlockTypes/LegacyTemplate.php
+++ b/src/BlockTypes/LegacyTemplate.php
@@ -34,9 +34,11 @@ class LegacyTemplate extends AbstractDynamicBlock {
 			return;
 		}
 
+		$archive_templates = array( 'archive-product', 'taxonomy-product_cat', 'taxonomy-product_tag' );
+
 		if ( 'single-product' === $attributes['template'] ) {
 			return $this->render_single_product();
-		} elseif ( 'archive-product' === $attributes['template'] || 'taxonomy-product_cat' === $attributes['template'] || 'taxonomy-product_tag' === $attributes['template'] ) {
+		} elseif ( in_array( $attributes['template'], $archive_templates, true ) ) {
 			return $this->render_archive_product();
 		} else {
 			ob_start();

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -142,7 +142,7 @@ class BlockTemplateUtils {
 			case 'archive-product':
 				return __( 'Product Archive Page', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_cat':
-				return __( 'Product Taxonomy Page', 'woo-gutenberg-products-block' );
+				return __( 'Product Category Page', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_tag':
 				return __( 'Product Tag Page', 'woo-gutenberg-products-block' );
 			default:

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -143,6 +143,8 @@ class BlockTemplateUtils {
 				return __( 'Product Archive Page', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_cat':
 				return __( 'Product Taxonomy Page', 'woo-gutenberg-products-block' );
+			case 'taxonomy-product_tag':
+				return __( 'Product Tag Page', 'woo-gutenberg-products-block' );
 			default:
 				// Replace all hyphens and underscores with spaces.
 				return ucwords( preg_replace( '/[\-_]/', ' ', $template_slug ) );

--- a/templates/block-templates/taxonomy-product_cat.html
+++ b/templates/block-templates/taxonomy-product_cat.html
@@ -1,0 +1,3 @@
+<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_cat"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/block-templates/taxonomy-product_tag.html
+++ b/templates/block-templates/taxonomy-product_tag.html
@@ -1,0 +1,3 @@
+<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_tag"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
For WooCommerce merchants to be able to fully utilize block themes, we need the most important WooCommerce core PHP templates to be available as block templates.

This PR adds a block template version of the [taxonomy-product-cat.php](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/taxonomy-product-cat.php) and [taxonomy-product-tag.php](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/taxonomy-product-tag.php) templates.

Note that both templates are a special case in the sense that they utilize the `archive-product` template.

Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5034
Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5035

### Manual Testing

How to test the changes in this Pull Request:

**Prerequisite**: Please ensure you have a Block Template Theme activated such as TT1 and also the Gutenberg Plugin installed.

1. Load the Site Editor (Appearance > Editor) and select the `Product Category Page` template from the `General templates` section.
2. Confirm you can load the template and it looks as expected in large/small viewports.
3. Confirm the behavior on the Frontend on a category page e.g. `/product-category/clothing/` is identical to the behavior the same page without this PR applied.
4. Repeat at 1. for the `Product Tag Page` template (e.g. `/product-tag/merch/`)

Once you have followed the above steps, add the same template files to your `theme-dir/block-templates` and change the file contents so you can differentiate between the Woo Block template and the Theme template. Repeat the above steps starting from Step 2 and confirm the Theme template is preferred over the Woo Blocks template

### Changelog

> FSE: Add basic taxonomy block templates.
