### PR TITLE
Set is_custom property on template and remove redundant code

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -111,7 +111,6 @@ class BlockTemplatesController {
 			}
 
 			$new_template_item = array(
-				'title' => BlockTemplateUtils::convert_slug_to_title( $template_slug ),
 				'slug'  => $template_slug,
 				'path'  => $template_file,
 				'theme' => get_template_directory(),

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -80,10 +80,9 @@ class BlockTemplateUtils {
 	 * @param array $template_file Theme file.
 	 * @param array $template_type wp_template or wp_template_part.
 	 *
-	 * @return WP_Block_Template Template.
+	 * @return \WP_Block_Template Template.
 	 */
 	public static function gutenberg_build_template_result_from_file( $template_file, $template_type ) {
-		$default_template_types = function_exists( 'gutenberg_get_default_template_types' ) ? gutenberg_get_default_template_types() : array();
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$template_content = file_get_contents( $template_file['path'] );
 		$theme            = wp_get_theme()->get_stylesheet();
@@ -98,15 +97,8 @@ class BlockTemplateUtils {
 		$template->title          = ! empty( $template_file['title'] ) ? $template_file['title'] : $template_file['slug'];
 		$template->status         = 'publish';
 		$template->has_theme_file = true;
-
-		if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
-			$template->description = $default_template_types[ $template_file['slug'] ]['description'];
-			$template->title       = $default_template_types[ $template_file['slug'] ]['title'];
-		}
-
-		if ( 'wp_template_part' === $template_type && isset( $template_file['area'] ) ) {
-			$template->area = $template_file['area'];
-		}
+		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
+		$template->title          = self::convert_slug_to_title( $template_file['slug'] );
 
 		return $template;
 	}


### PR DESCRIPTION
* Set `is_custom` property on `$template` to `false`. This will always be false as it's being loaded from the filesystem. Only templates that are edited and therefore saved in the database are considered custom.
* Removed redundant if statement code since `$default_template_types` only contains core WordPress default templates (not WooCommerce) so the removed if statements would never resolve.
* Removed second redundant if statement code since `$template_type` is always going to be `wp_template` and not `wp_template_part`

### Testing

### Manual Testing

This will mainly be regression testing.

**Prerequisite**: Please ensure you have a Block Template Theme activated such as TT1 and also the Gutenberg Plugin installed.

1. Load the Site Editor (Appearance > Editor) and select the Single Product Page template from the `General templates` section.
2. Confirm you can load the template and it looks as expected in large/small viewports.
3. Confirm the template is being loaded on the frontend.

Once you have followed the above steps, add the same template files to your `theme-dir/block-templates` and change the file contents so you can differentiate between the Woo Block template and the Theme template. Repeat the above steps starting from Step 2 and confirm the Theme template is preferred over the Woo Blocks template

### Changelog

> FSE: Fix missing `is_custom` property for WooCommerce block template objects.
