### PR TITLE
pass blockWrapper to forcedBlocks

### DIFF
--- a/assets/js/atomic/utils/render-parent-block.tsx
+++ b/assets/js/atomic/utils/render-parent-block.tsx
@@ -53,7 +53,9 @@ const renderForcedBlocks = (
 	block: string,
 	blockMap: Record< string, React.ReactNode >,
 	// Current children from the parent (siblings of the forced block)
-	blockChildren: HTMLCollection | null
+	blockChildren: HTMLCollection | null,
+	// Wrapper for inner components.
+	blockWrapper?: React.ElementType
 ) => {
 	if ( ! hasInnerBlocks( block ) ) {
 		return null;
@@ -74,15 +76,27 @@ const renderForcedBlocks = (
 			force === true && ! currentBlocks.includes( blockName )
 	);
 
-	return forcedBlocks.map(
-		( { blockName, component }, index: number ): JSX.Element | null => {
-			const ForcedComponent = component
-				? component
-				: getBlockComponentFromMap( blockName, blockMap );
-			return ForcedComponent ? (
-				<ForcedComponent key={ `${ blockName }_forced_${ index }` } />
-			) : null;
-		}
+	// This will wrap inner blocks with the provided wrapper. If no wrapper is provided, we default to Fragment.
+	const InnerBlockComponentWrapper = blockWrapper ? blockWrapper : Fragment;
+
+	return (
+		<InnerBlockComponentWrapper>
+			{ forcedBlocks.map(
+				(
+					{ blockName, component },
+					index: number
+				): JSX.Element | null => {
+					const ForcedComponent = component
+						? component
+						: getBlockComponentFromMap( blockName, blockMap );
+					return ForcedComponent ? (
+						<ForcedComponent
+							key={ `${ blockName }_forced_${ index }` }
+						/>
+					) : null;
+				}
+			) }
+		</InnerBlockComponentWrapper>
 	);
 };
 
@@ -208,7 +222,8 @@ const renderInnerBlocks = ( {
 							renderForcedBlocks(
 								blockName,
 								blockMap,
-								element.children
+								element.children,
+								blockWrapper
 							)
 						}
 					</InnerBlockComponent>


### PR DESCRIPTION
ForcedBlocks in frontend didn't have access to `blockWrapper`, and therefore, didn't have access to props that we pass to them like `cart`, `extensions,` and `checkoutExtensionData`. This PR fixes is.

### Testing steps
1. To test this, you need a forced block, edit the html of a checkout block and remove a core block.
2. Save without switching to visual editor.
3. Inside that block `block.js` component, console log `checkoutExtensionData` from its props.
4. Make sure it has a correct value and it's not undefined.