### PR TITLE
Fix label alignment of the product search in the editor

### DIFF
--- a/assets/js/blocks/product-search/editor.scss
+++ b/assets/js/blocks/product-search/editor.scss
@@ -1,7 +1,12 @@
 .wc-block-product-search__field.input-control {
 	color: #828b96 !important;
 	padding: 0;
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
 }
+
 .wc-block-product-search {
 	.wc-block-product-search__fields {
 		.block-editor-rich-text {

--- a/assets/js/blocks/product-search/editor.scss
+++ b/assets/js/blocks/product-search/editor.scss
@@ -1,5 +1,6 @@
 .wc-block-product-search__field.input-control {
 	color: #828b96 !important;
+	padding: 0;
 }
 .wc-block-product-search {
 	.wc-block-product-search__fields {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixed the `search` label alignment on the edit page for the block `Product Search`.


<!-- Reference any related issues or PRs here -->
Fixes #3083 


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

![image](https://user-images.githubusercontent.com/4463174/140319634-92a37482-d1a7-44a0-b26f-9885ecffeaa0.png)
*before - frontend page*

![image](https://user-images.githubusercontent.com/4463174/140319691-e5eb6314-fd05-46dd-96aa-0bd5e236a116.png)
*before - edit page*

![image](https://user-images.githubusercontent.com/4463174/140320318-eb0453d8-c8fa-40bc-a3cd-5117996463e9.png)
*current implementation - frontend page*

![image](https://user-images.githubusercontent.com/4463174/140322638-4e6102e8-38c2-4ad2-ac92-14e93c45ad31.png)
*current implementation - edit page*

### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Make sure you have Woo Blocks plugins installed
2. Create a new page and add the Product Search block
3. Save
4. Check if the label "Search" position is equal on frontend page and editor page

### Changelog

> Fix label alignment of the product search in the editor.