### PR TITLE
Update templates so Legacy Template blocks don't take all available width

### DIFF
--- a/templates/block-templates/archive-product.html
+++ b/templates/block-templates/archive-product.html
@@ -1,3 +1,5 @@
 <!-- wp:template-part {"slug":"header"} /-->
-<!-- wp:woocommerce/legacy-template {"template":"archive-product"} /-->
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"archive-product"} /--></div>
+<!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/block-templates/single-product.html
+++ b/templates/block-templates/single-product.html
@@ -1,3 +1,5 @@
 <!-- wp:template-part {"slug":"header"} /-->
-<!-- wp:woocommerce/legacy-template {"template":"single-product"} /-->
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"single-product"} /--></div>
+<!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Fixes #5092.

This PR updates the templates as described in #5092 so the Legacy Template block is rendered inside a Group block with attribute `{"layout":{"inherit":true}}`. That makes it so the block doesn't occupy the entire width.

### Screenshots

_Before:_

![Single product template](https://user-images.githubusercontent.com/3616980/140729832-8e953935-ea9a-474c-90d2-717b51ce8675.png)

_After:_

![Single product template](https://user-images.githubusercontent.com/3616980/140731022-5aabb42d-d55a-478f-bc41-577abb4098e7.png)

### Testing

1. Make sure your theme doesn't have any WC template and in Appearance > Templates you don't have any modified WC template either.
2. Go to the single product page or the shop page and verify the templates no longer take all available width, but instead they are constrained to the theme width (see screenshots above).