### PR TITLE
Define chunkFilename with contenthash in lazy loaded assets

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -178,7 +178,7 @@ const getMainConfig = ( options = {} ) => {
 			// i18n system relies on the hash of the filename, so changing that frequently would result in broken
 			// translations which we must avoid.
 			// @see https://github.com/Automattic/jetpack/pull/20926
-			chunkFilename: `[name]-frontend${ fileSuffix }.js?ver=[contenthash]`,
+			chunkFilename: `[name]${ fileSuffix }.js?ver=[contenthash]`,
 			filename: `[name]${ fileSuffix }.js`,
 			library: [ 'wc', 'blocks', '[name]' ],
 			libraryTarget: 'this',

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -171,12 +171,22 @@ const getMainConfig = ( options = {} ) => {
 		output: {
 			devtoolNamespace: 'wc',
 			path: path.resolve( __dirname, '../build/' ),
+			// This is a cache busting mechanism which ensures that the script is loaded via the browser with a ?ver=hash
+			// string. The hash is based on the built file contents.
+			// @see https://github.com/webpack/webpack/issues/2329
+			// Using the ?ver string is needed here so the filename does not change between builds. The WordPress
+			// i18n system relies on the hash of the filename, so changing that frequently would result in broken
+			// translations which we must avoid.
+			// @see https://github.com/Automattic/jetpack/pull/20926
+			chunkFilename: `[name]-frontend${ fileSuffix }.js?ver=[contenthash]`,
 			filename: `[name]${ fileSuffix }.js`,
 			library: [ 'wc', 'blocks', '[name]' ],
 			libraryTarget: 'this',
 			// This fixes an issue with multiple webpack projects using chunking
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
+			// This can be removed when moving to webpack 5:
+			// https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-unique-naming
 			jsonpFunction: 'webpackWcBlocksJsonp',
 		},
 		module: {
@@ -280,10 +290,20 @@ const getFrontConfig = ( options = {} ) => {
 		output: {
 			devtoolNamespace: 'wc',
 			path: path.resolve( __dirname, '../build/' ),
+			// This is a cache busting mechanism which ensures that the script is loaded via the browser with a ?ver=hash
+			// string. The hash is based on the built file contents.
+			// @see https://github.com/webpack/webpack/issues/2329
+			// Using the ?ver string is needed here so the filename does not change between builds. The WordPress
+			// i18n system relies on the hash of the filename, so changing that frequently would result in broken
+			// translations which we must avoid.
+			// @see https://github.com/Automattic/jetpack/pull/20926
+			chunkFilename: `[name]-frontend${ fileSuffix }.js?ver=[contenthash]`,
 			filename: `[name]-frontend${ fileSuffix }.js`,
 			// This fixes an issue with multiple webpack projects using chunking
 			// overwriting each other's chunk loader function.
 			// See https://webpack.js.org/configuration/output/#outputjsonpfunction
+			// This can be removed when moving to webpack 5:
+			// https://webpack.js.org/blog/2020-10-10-webpack-5-release/#automatic-unique-naming
 			jsonpFunction: 'webpackWcBlocksJsonp',
 		},
 		module: {


### PR DESCRIPTION
This is a potential fix for issues like #4958 where we suspect errors are occurring due to cached lazy loaded scripts.

This busts the cache by appending a `?ver=` hash when webpack loads assets, without adding a hash to asset filenames.

![Screenshot 2021-11-08 at 12 55 08](https://user-images.githubusercontent.com/90977/140745594-6ba4ab47-f391-494f-9cd1-79b21bd6ead3.png)

### Testing

These are dev facing testing instructions.

1. Do a build and see the `build/checkout-blocks/` directory. Files should not have a `?ver` suffix.
2. View the checkout block on the frontend, and open up browser tools > network. Confirm that the files are loaded with a `?ver=` hash. This is the cache-busting mechanism at work.
3. Edit one of the lazy-loaded files. Make a note of the `?ver=` hash from the network inspector. Change the contents e.g. add a console.log, and rebuild. Confirm the hash changes.

How to test the changes in this Pull Request:

- Smoke test frontend functionality of cart/checkout blocks which lazy load inner blocks.

### Changelog

> Add cache-busting to lazy loaded checkout assets.
