### PR TITLE
Fix text domain validation problems

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/edit.js
+++ b/assets/js/atomic/blocks/product-elements/price/edit.js
@@ -36,7 +36,7 @@ const TextControl = ( {
 			<ColorPalette
 				value={ color.color }
 				onChange={ setColor }
-				label={ __( 'Color' ) }
+				label={ __( 'Color', 'woo-gutenberg-products-block' ) }
 			/>
 		</BaseControl>
 	</>

--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -111,7 +111,7 @@ const FeaturedCategory = ( {
 					controls={ [
 						{
 							icon: 'edit',
-							title: __( 'Edit' ),
+							title: __( 'Edit', 'woo-gutenberg-products-block' ),
 							onClick: () =>
 								setAttributes( { editMode: ! editMode } ),
 							isActive: editMode,
@@ -175,7 +175,10 @@ const FeaturedCategory = ( {
 							/>
 							{ focalPointPickerExists && (
 								<FocalPointPicker
-									label={ __( 'Focal Point Picker' ) }
+									label={ __(
+										'Focal Point Picker',
+										'woo-gutenberg-products-block'
+									) }
 									url={ url }
 									value={ focalPoint }
 									onChange={ ( value ) =>

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -161,7 +161,7 @@ const FeaturedProduct = ( {
 					controls={ [
 						{
 							icon: 'edit',
-							title: __( 'Edit' ),
+							title: __( 'Edit', 'woo-gutenberg-products-block' ),
 							onClick: () =>
 								setAttributes( { editMode: ! editMode } ),
 							isActive: editMode,
@@ -237,7 +237,10 @@ const FeaturedProduct = ( {
 							/>
 							{ focalPointPickerExists && (
 								<FocalPointPicker
-									label={ __( 'Focal Point Picker' ) }
+									label={ __(
+										'Focal Point Picker',
+										'woo-gutenberg-products-block'
+									) }
 									url={ url }
 									value={ focalPoint }
 									onChange={ ( value ) =>

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -169,7 +169,10 @@ class ProductsBlock extends Component {
 						controls={ [
 							{
 								icon: 'edit',
-								title: __( 'Edit' ),
+								title: __(
+									'Edit',
+									'woo-gutenberg-products-block'
+								),
 								onClick: () =>
 									setAttributes( { editMode: ! editMode } ),
 								isActive: editMode,

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -290,7 +290,10 @@ class ProductByCategoryBlock extends Component {
 						controls={ [
 							{
 								icon: 'edit',
-								title: __( 'Edit' ),
+								title: __(
+									'Edit',
+									'woo-gutenberg-products-block'
+								),
 								onClick: () =>
 									isEditing
 										? this.stopEditing()

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -272,7 +272,10 @@ class ProductsByTagBlock extends Component {
 						controls={ [
 							{
 								icon: 'edit',
-								title: __( 'Edit' ),
+								title: __(
+									'Edit',
+									'woo-gutenberg-products-block'
+								),
 								onClick: () =>
 									isEditing
 										? this.stopEditing()

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -170,7 +170,10 @@ class ProductsByAttributeBlock extends Component {
 						controls={ [
 							{
 								icon: 'edit',
-								title: __( 'Edit' ),
+								title: __(
+									'Edit',
+									'woo-gutenberg-products-block'
+								),
 								onClick: () =>
 									setAttributes( { editMode: ! editMode } ),
 								isActive: editMode,

--- a/assets/js/editor-components/heading-toolbar/index.js
+++ b/assets/js/editor-components/heading-toolbar/index.js
@@ -21,8 +21,11 @@ class HeadingToolbar extends Component {
 		const isActive = targetLevel === selectedLevel;
 		return {
 			icon: <HeadingLevelIcon level={ targetLevel } />,
-			/* translators: %s: heading level e.g: "2", "3", "4" */
-			title: sprintf( __( 'Heading %d' ), targetLevel ),
+			title: sprintf(
+				/* translators: %s: heading level e.g: "2", "3", "4" */
+				__( 'Heading %d', 'woo-gutenberg-products-block' ),
+				targetLevel
+			),
 			isActive,
 			onClick: () => onChange( targetLevel ),
 		};

--- a/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/payment-request/use-initialization.js
@@ -190,6 +190,7 @@ export const useInitialization = ( {
 					paymentMethod.source.card.funding
 				) {
 					setExpressPaymentError(
+						/* eslint-disable-next-line @wordpress/i18n-text-domain */
 						__(
 							"Sorry, we're not accepting prepaid cards at this time.",
 							'woocommerce-gateway-stripe'

--- a/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
+++ b/assets/js/payment-method-extensions/payment-methods/stripe/stripe-utils/utils.js
@@ -164,6 +164,7 @@ const isNonFriendlyError = ( type ) =>
 
 const getErrorMessageForCode = ( code ) => {
 	const messages = {
+		/* eslint-disable @wordpress/i18n-text-domain */
 		[ errorCodes.INVALID_NUMBER ]: __(
 			'The card number is not a valid credit card number.',
 			'woocommerce-gateway-stripe'
@@ -224,6 +225,7 @@ const getErrorMessageForCode = ( code ) => {
 			'An error occurred while processing the card.',
 			'woocommerce-gateway-stripe'
 		),
+		/* eslint-enable @wordpress/i18n-text-domain */
 	};
 	return messages[ code ] || null;
 };


### PR DESCRIPTION
Fixes #5091

### Notes

In #5021, I've added a text domain validation to .eslintrc.js. During the implementation, I noticed that a few strings do not have a text domain. While a few of these problems had been addressed in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5020, some problems remains. This PR aims to eliminate all text domain related validation prolems.

### Screenshots

#### Before

![Screen Shot 2021-11-08 at 20 31 04](https://user-images.githubusercontent.com/3323310/140750595-40e2f59f-dc1b-43cd-88cb-5d2f1a7b1ea7.png)

#### After

![Screen Shot 2021-11-08 at 20 28 25](https://user-images.githubusercontent.com/3323310/140750229-de991290-2f23-4d8b-a43f-65e8b0f8832c.png)

### Testing

1. Check out the trunk.
2. Run `npm run lint:js`.
3. Verify that you see both missing and invalid text domains.
4. Check out this PR.
5. Run `npm run lint:js` again.
6. Verify that no more missing or invalid text domains occur.