### PR TITLE
Remove woocommerce_sidebar

### DIFF
--- a/src/BlockTypes/LegacyTemplate.php
+++ b/src/BlockTypes/LegacyTemplate.php
@@ -80,13 +80,6 @@ class LegacyTemplate extends AbstractDynamicBlock {
 		 */
 		do_action( 'woocommerce_after_main_content' );
 
-		/**
-		 * Woocommerce_sidebar hook.
-		 *
-		 * @hooked woocommerce_get_sidebar - 10
-		 */
-		do_action( 'woocommerce_sidebar' );
-
 		wp_reset_postdata();
 
 		return ob_get_clean();
@@ -175,13 +168,6 @@ class LegacyTemplate extends AbstractDynamicBlock {
 		 * @hooked woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)
 		 */
 		do_action( 'woocommerce_after_main_content' );
-
-		/**
-		 * Hook: woocommerce_sidebar.
-		 *
-		 * @hooked woocommerce_get_sidebar - 10
-		 */
-		do_action( 'woocommerce_sidebar' );
 
 		wp_reset_postdata();
 		return ob_get_clean();


### PR DESCRIPTION
#### Description
Remove the `do_action( 'woocommerce_sidebar' );` action from the `LegacyTemplate.php` block

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5077

### Testing

How to test the changes in this Pull Request:

2. Make sure you have[ this change](https://github.com/woocommerce/woocommerce/pull/30997/files) and [this change](https://github.com/woocommerce/woocommerce/pull/31094) applied in your WooCommerce plugin.
3. Install and activate the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/) (not the latest built version of `trunk` from the repo)
4. Install and activate a FSE enabled theme such as [Tove](https://en-gb.wordpress.org/themes/tove/)
5. Load the Shop page
6. Ensure no sidebar loads
7. Enable Debug mode in WordPress and ensure the error message shown in the linked issue also does not appear.
8. Do the same with the Product Page

### Changelog

> FSE: Remove the `do_action( 'woocommerce_sidebar' );` action from the `LegacyTemplate.php` block.
