### PR TITLE
Fix PHP fatal error on Product tag pages due to wrong function name

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -383,7 +383,7 @@ class BlockTemplatesController {
 		} elseif (
 			( is_product_taxonomy() && is_tax( 'product_tag' ) ) &&
 			! $this->theme_has_template( 'taxonomy-product_tag' ) &&
-			$this->default_block_template_is_available( 'taxonomy-product_tag' )
+			$this->block_template_is_available( 'taxonomy-product_tag' )
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		} elseif (


### PR DESCRIPTION
Small issue introduced in #5062. We were calling a function that was renamed so no longer existed with that name.

### Testing

Using a block theme:
1. Edit a product and assign a tag to it (ie: `Recommended`).
2. Go to the tag page (ie: `/product-tag/recommended/`).
3. Verify it renders correctly and there isn't any PHP error.