### PR TITLE
Update taxonomy templates so Legacy Template blocks don't take all available width

### DIFF
--- a/templates/block-templates/taxonomy-product_cat.html
+++ b/templates/block-templates/taxonomy-product_cat.html
@@ -1,4 +1,5 @@
 <!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_cat"} /--></div>
+<!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/block-templates/taxonomy-product_cat.html
+++ b/templates/block-templates/taxonomy-product_cat.html
@@ -1,3 +1,4 @@
 <!-- wp:template-part {"slug":"header"} /-->
-<!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_cat"} /-->
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_cat"} /--></div>
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/block-templates/taxonomy-product_tag.html
+++ b/templates/block-templates/taxonomy-product_tag.html
@@ -1,4 +1,5 @@
 <!-- wp:template-part {"slug":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_tag"} /--></div>
+<!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/block-templates/taxonomy-product_tag.html
+++ b/templates/block-templates/taxonomy-product_tag.html
@@ -1,3 +1,4 @@
 <!-- wp:template-part {"slug":"header"} /-->
-<!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_tag"} /-->
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/legacy-template {"template":"taxonomy-product_tag"} /--></div>
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
Fixes #5092.

Same as #5093 but for taxonomy templates.

### Screenshots

_Before:_

![Product category template](https://user-images.githubusercontent.com/3616980/140907587-817c0fde-d8c0-4f91-acb1-0c67552a9f8a.png)

_After:_

![Product category template](https://user-images.githubusercontent.com/3616980/140907360-18f399ea-e2bc-45b2-aea2-a380af483a66.png)

### Testing

1. Make sure your theme doesn't have any WC template and in Appearance > Templates you don't have any modified WC template either.
2. Go to the product category page (ie: `/product-category/clothing/`) and verify the templates no longer take all available width, but instead they are constrained to the theme width (see screenshots above).
3. If you want to test a product tag page you will need to assign some products to a specific tag (ie: _Recommended_) and then go to that tag page (ie: `/product-tag/recommended/`).