### PR TITLE
Add hydration for product data for Single Product block

### DIFF
--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -13,6 +13,17 @@ class SingleProduct extends AbstractBlock {
 	protected $block_name = 'single-product';
 
 	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_assets( array $attributes ) {
+		parent::enqueue_assets( $attributes );
+		$product_id = $attributes['productId'];
+		$this->hydrate_from_api( $product_id );
+	}
+
+	/**
 	 * Get the editor script handle for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.
@@ -25,5 +36,14 @@ class SingleProduct extends AbstractBlock {
 			'dependencies' => [ 'wc-blocks' ],
 		];
 		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
+	 * Hydrate the cart block with data from the API.
+	 *
+	 * @param int $product_id ID of the product.
+	 */
+	protected function hydrate_from_api( int $product_id ) {
+		$this->asset_data_registry->hydrate_api_request( "/wc/store/products/$product_id" );
 	}
 }

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -19,7 +19,7 @@ class SingleProduct extends AbstractBlock {
 	 */
 	protected function enqueue_assets( array $attributes ) {
 		parent::enqueue_assets( $attributes );
-		$product_id = $attributes['productId'];
+		$product_id = intval( $attributes['productId'] );
 		$this->hydrate_from_api( $product_id );
 	}
 


### PR DESCRIPTION
Add hydration for product data for Single Product Block

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #2698 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing


### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Make sure you have Woo Blocks plugins installed
2. Create a new page and add the Single Product block
3. Save
4. Open the saved page
5. Check that browser doesn't do any request to `wc/store/products/${id}` endpoint

### Changelog

> Improve rendering performance for Single Product block.