### PR TITLE
Fix: loading WC Blocks templates content

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -118,7 +118,9 @@ class BlockTemplatesController {
 		}
 
 		$available_templates = $this->get_block_templates( array( $slug ) );
-		return ( is_array( $available_templates ) && count( $available_templates ) > 0 ) ? (object) $available_templates[0] : $template;
+		return ( is_array( $available_templates ) && count( $available_templates ) > 0 )
+			? BlockTemplateUtils::gutenberg_build_template_result_from_file( $available_templates[0], $available_templates[0]->type )
+			: $template;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5110

This PR fixes the template loading of WC Blocks templates in the Template Editor by building the proper `WP_Block_Template` object for the `get_block_template` filter.

### Screenshots

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/5423135/140931573-ac528a4e-8d94-4e84-84e1-d4958c832244.png">
	<td><img src="https://user-images.githubusercontent.com/5423135/140931796-fc8d8863-e2c2-461b-87d6-74191f6951e3.png">

<tr>
	<td><img src="https://user-images.githubusercontent.com/5423135/140930687-13da62bd-ef91-41e1-88f6-c310e0bbec9a.png">
	<td><img src="https://user-images.githubusercontent.com/5423135/140931820-1d5a0d3c-252a-499d-883c-4cdc0df978a1.png">
</table>

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Install a FSE theme, i.e. TT1 Blocks, or Tove.
2. Make make sure you have [this change applied in your WooCommerce plugin](https://github.com/woocommerce/woocommerce/pull/30997/files).
The block theme needs to declare `add_theme_support( 'woocommerce' );` in the `functions.php` file.
3. Update to the latest Gutenberg `trunk`.
1. Make sure there isn't any WC block template overridden by the theme or customized using the Template Editor.
2. Edit the `single-product` template by this edit link: `/wp-admin/themes.php?page=gutenberg-edit-site&postId=woocommerce%2F%2Fsingle-product&postType=wp_template` (Prepend your test domain).
3. See the template loads properly.
