### PR TITLE
Lazy load missing translation files

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"lint:js:report": "npm run lint:js -- --output-file eslint_report.json --ext=js,ts,tsx --format json",
 		"lint:js-fix": "eslint assets/js --ext=js,jsx,ts,tsx --fix",
 		"lint:php": "composer run-script phpcs ./src",
+		"lint:php-fix": "composer run-script phpcbf ./src",
 		"package-plugin": "rimraf woocommerce-gutenberg-products-block.zip && ./bin/build-plugin-zip.sh",
 		"package-plugin:dev": "rimraf woocommerce-gutenberg-products-block.zip && ./bin/build-plugin-zip.sh -d",
 		"package-plugin:zip-only": "rimraf woocommerce-gutenberg-products-block.zip && ./bin/build-plugin-zip.sh -z",

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -196,4 +196,23 @@ class Cart extends AbstractBlock {
 	protected function hydrate_from_api() {
 		$this->asset_data_registry->hydrate_api_request( '/wc/store/cart' );
 	}
+
+	/**
+	 * Register script and style assets for the block type before it is registered.
+	 *
+	 * This registers the scripts; it does not enqueue them.
+	 */
+	protected function register_block_type_assets() {
+		parent::register_block_type_assets();
+		$blocks = [
+			'cart-blocks/express-payment--checkout-blocks/express-payment--checkout-blocks/payment',
+			'cart-blocks/line-items',
+			'cart-blocks/order-summary',
+			'cart-blocks/order-summary--checkout-blocks/billing-address--checkout-blocks/shipping-address',
+			'cart-blocks/checkout-button-frontend.js',
+			'cart-blocks/express-payment',
+		];
+		$chunks = preg_filter( '/$/', '-frontend', $blocks );
+		$this->register_chunk_translations( $chunks );
+	}
 }

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -365,4 +365,27 @@ class Checkout extends AbstractBlock {
 		}
 		return $list_item;
 	}
+
+	/**
+	 * Register script and style assets for the block type before it is registered.
+	 *
+	 * This registers the scripts; it does not enqueue them.
+	 */
+	protected function register_block_type_assets() {
+		parent::register_block_type_assets();
+		$blocks = [
+			'checkout-blocks/express-payment',
+			'checkout-blocks/contact-information',
+			'checkout-blocks/shipping-address',
+			'checkout-blocks/billing-address',
+			'checkout-blocks/shipping-methods',
+			'checkout-blocks/payment',
+			'checkout-blocks/order-note',
+			'checkout-blocks/actions',
+			'checkout-blocks/terms',
+			'checkout-blocks/order-summary',
+		];
+		$chunks = preg_filter( '/$/', '-frontend', $blocks );
+		$this->register_chunk_translations( $chunks );
+	}
 }


### PR DESCRIPTION
Fixes #5005 | Related #5106

### Screenshots

#### Spanish: Terms and conditions

<table>
<tr>
<td valign="top">Before:
<br><br>

![#5005-Spanish-before](https://user-images.githubusercontent.com/3323310/140933148-bc0a0aff-4460-44d6-8e3e-3779b27a3bb1.png)
</td>
<td valign="top">After:
<br><br>

![#5005-Spanish-after](https://user-images.githubusercontent.com/3323310/140933124-619a9701-a74d-43d3-8a55-1540c4ff0de1.png)
</td>
</tr>
</table>

#### German: Shipping address description

<table>
<tr>
<td valign="top">Before:
<br><br>

![#5005-German-before](https://user-images.githubusercontent.com/3323310/140933196-97404cec-ac8e-46db-9b71-d9436bf00003.png)
</td>
<td valign="top">After:
<br><br>

![#5005-German-after](https://user-images.githubusercontent.com/3323310/140933183-0887538e-5c3a-4161-aef8-bd53ac8463dc.png)
</td>
</tr>
</table>

### Testing

1. Switch the site language to Spanish.
2. Update the translations via `WP Admin → Dashboard → Translations → Update Translations`.
3. Create a test page, add the checkout block and save it.
4. Ensure that the _"Terms and conditions"_ text in the editor is in Spanish.
5. Look up the frontend and verify that the _"Terms and conditions"_ text is in Spanish (see screenshots).
6. Switch the site language to German and repeat steps 2. until 5. (texts should then appear in German)

### Additional notes

Kindly note that I also added `"lint:php-fix": "composer run-script phpcbf ./src",` to `package.json` so that I could fix linting problems within PHP files.

### Changelog

> Lazy load missing translation files on frontend to ensure that all visible texts are translatable.