### PR TITLE
Improve title for edit button 

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -111,7 +111,10 @@ const FeaturedCategory = ( {
 					controls={ [
 						{
 							icon: 'edit',
-							title: __( 'Edit', 'woo-gutenberg-products-block' ),
+							title: __(
+								'Edit selected category',
+								'woo-gutenberg-products-block'
+							),
 							onClick: () =>
 								setAttributes( { editMode: ! editMode } ),
 							isActive: editMode,

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -161,7 +161,10 @@ const FeaturedProduct = ( {
 					controls={ [
 						{
 							icon: 'edit',
-							title: __( 'Edit', 'woo-gutenberg-products-block' ),
+							title: __(
+								'Edit selected product',
+								'woo-gutenberg-products-block'
+							),
 							onClick: () =>
 								setAttributes( { editMode: ! editMode } ),
 							isActive: editMode,

--- a/assets/js/blocks/handpicked-products/block.js
+++ b/assets/js/blocks/handpicked-products/block.js
@@ -170,7 +170,7 @@ class ProductsBlock extends Component {
 							{
 								icon: 'edit',
 								title: __(
-									'Edit',
+									'Edit selected products',
 									'woo-gutenberg-products-block'
 								),
 								onClick: () =>

--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -291,7 +291,7 @@ class ProductByCategoryBlock extends Component {
 							{
 								icon: 'edit',
 								title: __(
-									'Edit',
+									'Edit selected categories',
 									'woo-gutenberg-products-block'
 								),
 								onClick: () =>

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -273,7 +273,7 @@ class ProductsByTagBlock extends Component {
 							{
 								icon: 'edit',
 								title: __(
-									'Edit',
+									'Edit selected tags',
 									'woo-gutenberg-products-block'
 								),
 								onClick: () =>

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -171,7 +171,7 @@ class ProductsByAttributeBlock extends Component {
 							{
 								icon: 'edit',
 								title: __(
-									'Edit',
+									'Edit selected attributes',
 									'woo-gutenberg-products-block'
 								),
 								onClick: () =>

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -171,7 +171,7 @@ class ProductsByAttributeBlock extends Component {
 							{
 								icon: 'edit',
 								title: __(
-									'Edit selected attributes',
+									'Edit selected attribute',
 									'woo-gutenberg-products-block'
 								),
 								onClick: () =>

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -148,7 +148,10 @@ class Editor extends Component {
 					controls={ [
 						{
 							icon: 'edit',
-							title: __( 'Edit', 'woo-gutenberg-products-block' ),
+							title: __(
+								'Rearrange inner blocks',
+								'woo-gutenberg-products-block'
+							),
 							onClick: () => this.togglePreview(),
 							isActive: isEditing,
 						},

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -149,7 +149,7 @@ class Editor extends Component {
 						{
 							icon: 'edit',
 							title: __(
-								'Rearrange inner blocks',
+								'Edit inner product layout',
 								'woo-gutenberg-products-block'
 							),
 							onClick: () => this.togglePreview(),

--- a/assets/js/blocks/reviews/edit-utils.js
+++ b/assets/js/blocks/reviews/edit-utils.js
@@ -14,13 +14,13 @@ import { BlockControls } from '@wordpress/block-editor';
 import { getAdminLink, getSetting } from '@woocommerce/settings';
 import ToggleButtonControl from '@woocommerce/editor-components/toggle-button-control';
 
-export const getBlockControls = ( editMode, setAttributes ) => (
+export const getBlockControls = ( editMode, setAttributes, buttonTitle ) => (
 	<BlockControls>
 		<ToolbarGroup
 			controls={ [
 				{
 					icon: 'edit',
-					title: __( 'Edit', 'woo-gutenberg-products-block' ),
+					title: buttonTitle,
 					onClick: () => setAttributes( { editMode: ! editMode } ),
 					isActive: editMode,
 				},

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -139,9 +139,14 @@ const ReviewsByCategoryEditor = ( {
 		return renderEditMode();
 	}
 
+	const buttonTitle = __(
+		'Edit selected categories',
+		'woo-gutenberg-products-block'
+	);
+
 	return (
 		<>
-			{ getBlockControls( editMode, setAttributes ) }
+			{ getBlockControls( editMode, setAttributes, buttonTitle ) }
 			{ getInspectorControls() }
 			<EditorContainerBlock
 				attributes={ attributes }

--- a/assets/js/blocks/reviews/reviews-by-product/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.js
@@ -162,9 +162,14 @@ const ReviewsByProductEditor = ( {
 		return renderEditMode();
 	}
 
+	const buttonTitle = __(
+		'Edit selected product',
+		'woo-gutenberg-products-block'
+	);
+
 	return (
 		<>
-			{ getBlockControls( editMode, setAttributes ) }
+			{ getBlockControls( editMode, setAttributes, buttonTitle ) }
 			{ getInspectorControls() }
 			<EditorContainerBlock
 				attributes={ attributes }

--- a/assets/js/blocks/single-product/edit/editor-block-controls.js
+++ b/assets/js/blocks/single-product/edit/editor-block-controls.js
@@ -19,7 +19,10 @@ const EditorBlockControls = ( { isEditing, setIsEditing } ) => {
 				controls={ [
 					{
 						icon: 'edit',
-						title: __( 'Edit', 'woo-gutenberg-products-block' ),
+						title: __(
+							'Edit selected product',
+							'woo-gutenberg-products-block'
+						),
 						onClick: () => setIsEditing( ! isEditing ),
 						isActive: isEditing,
 					},


### PR DESCRIPTION
Improve title for edit button on specific blocks (check the issue for the list)

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #1689 


### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Make sure you have Woo Blocks plugins installed
2. Create a page
3. Add blocks that should have a different title on the edit button (check the list in the issue)
4. Check that the title corresponds to the value in the table

### Changelog

> Improve accessibility by using self-explaining edit button titles.
