### PR TITLE
Fix 'Country is required' error on the Cart block when updating shipping address

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -116,6 +116,7 @@ export const defaultCartData: StoreCart = {
 	paymentRequirements: EMPTY_PAYMENT_REQUIREMENTS,
 	receiveCart: () => undefined,
 	extensions: EMPTY_EXTENSIONS,
+	cartIsHydrated: false,
 };
 
 /**
@@ -138,6 +139,7 @@ export const useStoreCart = (
 	const previewCart = previewData?.previewCart;
 	const { shouldSelect } = options;
 	const currentResults = useRef();
+	const cartIsHydrated = useRef< boolean >( false );
 
 	// This will keep track of jQuery and DOM events triggered by other blocks
 	// or components and will invalidate the store resolution accordingly.
@@ -174,6 +176,7 @@ export const useStoreCart = (
 						typeof previewCart?.receiveCart === 'function'
 							? previewCart.receiveCart
 							: () => undefined,
+					cartIsHydrated: true,
 				};
 			}
 
@@ -184,6 +187,14 @@ export const useStoreCart = (
 			const cartIsLoading = ! store.hasFinishedResolution(
 				'getCartData'
 			);
+
+			if (
+				! cartIsHydrated.current &&
+				store.hasFinishedResolution( 'getCartData' )
+			) {
+				cartIsHydrated.current = true;
+			}
+
 			const shippingRatesLoading = store.isCustomerDataUpdating();
 			const { receiveCart } = dispatch( storeKey );
 			const billingAddress = decodeValues( cartData.billingAddress );
@@ -230,6 +241,7 @@ export const useStoreCart = (
 				cartHasCalculatedShipping: cartData.hasCalculatedShipping,
 				paymentRequirements: cartData.paymentRequirements,
 				receiveCart,
+				cartIsHydrated: cartIsHydrated.current,
 			};
 		},
 		[ shouldSelect ]

--- a/assets/js/base/context/hooks/use-customer-data.ts
+++ b/assets/js/base/context/hooks/use-customer-data.ts
@@ -82,8 +82,10 @@ export const useCustomerData = (): {
 	const {
 		billingAddress: initialBillingAddress,
 		shippingAddress: initialShippingAddress,
+		cartIsHydrated,
 	}: Omit< CustomerData, 'billingData' > & {
 		billingAddress: CartResponseBillingAddress;
+		cartIsHydrated: boolean;
 	} = useStoreCart();
 
 	// State of customer data is tracked here from this point, using the initial values from the useStoreCart hook.
@@ -103,29 +105,18 @@ export const useCustomerData = (): {
 	>( false );
 
 	useEffect( () => {
-		if (
-			! hasCustomerDataSynced &&
-			( ! isShallowEqual(
-				customerData.billingData,
-				initialBillingAddress
-			) ||
-				! isShallowEqual(
-					customerData.shippingAddress,
-					initialShippingAddress
-				) )
-		) {
-			setHasCustomerDataSynced( true );
+		if ( cartIsHydrated && ! hasCustomerDataSynced ) {
 			const newCustomerData = {
 				shippingAddress: initialShippingAddress,
 				billingData: initialBillingAddress,
 			};
-			previousCustomerData.current = newCustomerData;
 			setCustomerData( newCustomerData );
+			setHasCustomerDataSynced( true );
 		}
 	}, [
+		cartIsHydrated,
 		initialBillingAddress,
 		initialShippingAddress,
-		customerData,
 		hasCustomerDataSynced,
 	] );
 	// Debounce updates to the customerData state so it's not triggered excessively.

--- a/assets/js/types/type-defs/hooks.ts
+++ b/assets/js/types/type-defs/hooks.ts
@@ -51,4 +51,5 @@ export interface StoreCart {
 	cartHasCalculatedShipping: boolean;
 	paymentRequirements: Array< string >;
 	receiveCart: ( cart: CartResponse ) => void;
+	cartIsHydrated: boolean;
 }


### PR DESCRIPTION
This fixes an error on the cart page that was causing a 'Country is required' error to show up once a customer updates their shipping address. 

The main issue is that the default state of wc/store/cart has an empty billing address. This then gets hydrated by the client with JSON data that is injected onto the page by the API. This contains the country code set in WooCommerce settings. So initially, the billing address is empty, then gets populated with a country code. Between these two steps, the 
[use-customer-data](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/base/context/hooks/use-customer-data.ts) hook takes the value from wc/store/cart and assigns it to a [local state variable](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/base/context/hooks/use-customer-data.ts#L90). This means this local state variable `customerData` is out of sync with the wc/store/cart value. When a user updates their shipping address, an empty billing address is sent through the API call, and the server returns a "Country is required" error.

To solve this, we've used a [`useEffect()`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/base/context/hooks/use-customer-data.ts#L90) function to set the local state variable `customerData` to the shipping and billing addresses from wc/store/cart whenever they change. This only needs to run once, as any subsequent time will be the result of this effect or client side changes.

Fixes #5070 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots
![Screenshot 2021-11-09 at 17 08 46](https://user-images.githubusercontent.com/3966773/140971363-4fdeaeaf-aa96-48b7-91b0-4c758450546d.png)


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:
1. Open up the cart page
2. Change the shipping address in the shipping calculator and click Update
3. You should NOT see an error and the address should update to match what you entered
4. Go to Checkout and make sure the address that you entered has persisted in the checkout form
5. Complete checkout and make sure the address is correct on the order

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or


<!-- If you can, add the appropriate labels -->
### Changelog

> Fixed an issue that was causing an error when updating the address in the Cart block's shipping calculator.