### PR TITLE
Prevent justified texts due to accessibility reasons

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/style.scss
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/style.scss
@@ -1,6 +1,5 @@
 .wc-block-checkout__terms {
 	margin: 1.5em 0;
-	text-align: justify;
 
 	textarea {
 		top: -5px;


### PR DESCRIPTION
Fixes #5119 

### Note

Currently, the terms and conditions text within the checkout block is justified. This makes the text less accessible as described on https://equalizedigital.com/accessibility-checker/justified-text/. The problem is less obvious when the site language is set to English, as English texts are rather short. However, the problem becomes more obvious when using a different site language, such as German.

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

<img width="545" alt="#5119-without-checkbox-before" src="https://user-images.githubusercontent.com/3323310/141049246-6fd8e096-1c4a-4951-962f-f0276a9d6c24.png">
</td>
<td>After:
<br><br>

<img width="570" alt="#5119-without-checkbox-after" src="https://user-images.githubusercontent.com/3323310/141049244-01d57e96-165c-4ff3-9147-ff6de3572839.png">
</td>
</tr>
</table>

<table>
<tr>
<td>Before:
<br><br>

<img width="558" alt="#5119-with-checkbox-before" src="https://user-images.githubusercontent.com/3323310/141049241-8e08d0f3-c854-4edc-b970-27f25adaa12c.png">
</td>
<td>After:
<br><br>

<img width="573" alt="#5119-with-checkbox-after" src="https://user-images.githubusercontent.com/3323310/141049232-665a11c4-8e58-42c1-991b-c1888f215b6d.png">
</td>
</tr>
</table>


### Testing

1. Check out the trunk.
2. Set the site language to German.
3. Create a test page, add the checkout block, save the page and look up the terms and conditions section within that block.
4. Verify that the text contains uneven spacing between the words both when requiring a checkbox or not.
4. Check out this PR.
5. Look up the test page again.
6. Verify that the terms and conditions text is left-aligned and contains even spacing between the words.

### Changelog

> Improve readability of terms and condition text by not displaying the text justified.