### PR TITLE
Add a placeholder to the product search block editor

### DIFF
--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -104,6 +104,7 @@ const Edit = ( {
 					<TextControl
 						className="wc-block-product-search__field input-control"
 						value={ placeholder }
+						placeholder="Enter search placeholder text"
 						onChange={ ( value ) =>
 							setAttributes( { placeholder: value } )
 						}

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -104,7 +104,10 @@ const Edit = ( {
 					<TextControl
 						className="wc-block-product-search__field input-control"
 						value={ placeholder }
-						placeholder="Enter search placeholder text"
+						placeholder={ __(
+							'Enter search placeholder text',
+							'woo-gutenberg-products-block'
+						) }
 						onChange={ ( value ) =>
 							setAttributes( { placeholder: value } )
 						}


### PR DESCRIPTION
The product search block, when added to a page in the editor, has a Search field with the initial value "Search products...". This represents the placeholder that will appear on the front end, but is not immediately clear to the user. We've added a placeholder to this search input to state this is the case, if the user deletes the initial value.


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Related to #5078

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader

### Screenshots
![image](https://user-images.githubusercontent.com/3966773/141113438-8a80ce26-3d3e-4654-bba1-da33f562f8e9.png)

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Add the Product Search block to any page in the editor
2. Delete the "Search Products..." value from the Search input
3. "Enter search placeholder text" should be displayed in the input as a placeholder
4. The text should disappear as you start typing


<!-- If you can, add the appropriate labels -->

### Changelog

> Add placeholder text when modifying product search input in the editor.
