### PR TITLE
Downgrade @wordpress/scripts to 17.1.0 to fix dependency mistmach issue

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -72,7 +72,7 @@ Run `$ npm run package-plugin` to trigger install and build, and then create a z
 You can also do different variations of this command. By default it builds a production version of the plugin. You can also:
 
 -   Build a development version of the plugin: `$ npm run package-plugin:dev`
--   Just do a zip build of the current environment (useful when you already have built files for zipping): `$ npm run package-plugin:zip_only`
+-   Just do a zip build of the current environment (useful when you already have built files for zipping): `$ npm run package-plugin:zip-only`
 
 ## Linting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4950,11 +4950,52 @@
       "resolved": "https://registry.npmjs.org/@financial-times/origami-service-makefile/-/origami-service-makefile-7.0.3.tgz",
       "integrity": "sha512-aKe65sZ3XgZ/0Sm0MDLbGrcO3G4DRv/bVW4Gpmw68cRZV9IBE7h/pwfR3Rs7njNSZMFkjS4rPG/YySv9brQByA=="
     },
+    "@hapi/address": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+      "integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ==",
+      "dev": true
+    },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
     "@hapi/hoek": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
       "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==",
       "dev": true
+    },
+    "@hapi/joi": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "2.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
+        "@hapi/topo": "3.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "8.5.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+          "integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^8.3.0"
+          }
+        }
+      }
     },
     "@hapi/topo": {
       "version": "5.1.0",
@@ -8371,12 +8412,6 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
-    "@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true
-    },
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -8492,32 +8527,6 @@
       "requires": {
         "domhandler": "^2.4.0"
       }
-    },
-    "@types/eslint": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
-      "integrity": "sha512-KubbADPkfoU75KgKeKLsFHXnU4ipH7wYg0TRT33NK3N3yiu7jlFAAoygIWBV+KbuHx/G+AvuGX6DllnK35gfJA==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "@types/eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
-      "dev": true,
-      "requires": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
-      "dev": true
     },
     "@types/glob": {
       "version": "7.1.4",
@@ -9566,31 +9575,6 @@
         "@webassemblyjs/ast": "1.9.0"
       }
     },
-    "@webassemblyjs/helper-numbers": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
-      "integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
-        "@webassemblyjs/helper-api-error": "1.11.1",
-        "@xtuc/long": "4.2.2"
-      },
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
-          "integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-api-error": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-          "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-          "dev": true
-        }
-      }
-    },
     "@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
@@ -9712,27 +9696,6 @@
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "@webpack-cli/configtest": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
-      "integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-      "dev": true
-    },
-    "@webpack-cli/info": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.4.0.tgz",
-      "integrity": "sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==",
-      "dev": true,
-      "requires": {
-        "envinfo": "^7.7.3"
-      }
-    },
-    "@webpack-cli/serve": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
-      "integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-      "dev": true
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.5",
@@ -12576,62 +12539,63 @@
       }
     },
     "@wordpress/scripts": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-19.1.0.tgz",
-      "integrity": "sha512-XIgFufYUV0WIuAEUjdou6UD7UY9fdcoBo9mb64ZpqAqmt4JJmzx8Qxdl+GKLlLw4uRZytxg5xAH2n6s/q3uvRA==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-17.1.0.tgz",
+      "integrity": "sha512-aiJjDVMYyGIP/bcOz9hj5PUWb/Z/qAr1zTQ0UMmlkP0Pc4vbaxUPgxts7GgrFNc7XoaUh8M3WnjtXicT3IW1+w==",
       "dev": true,
       "requires": {
-        "@svgr/webpack": "^5.5.0",
-        "@wordpress/babel-preset-default": "^6.3.4",
-        "@wordpress/browserslist-config": "^4.1.0",
+        "@svgr/webpack": "^5.2.0",
+        "@wordpress/babel-preset-default": "^6.3.1",
         "@wordpress/dependency-extraction-webpack-plugin": "^3.2.1",
-        "@wordpress/eslint-plugin": "^9.2.0",
-        "@wordpress/jest-preset-default": "^7.1.2",
+        "@wordpress/eslint-plugin": "^9.1.0",
+        "@wordpress/jest-preset-default": "^7.1.0",
         "@wordpress/npm-package-json-lint-config": "^4.1.0",
-        "@wordpress/postcss-plugins-preset": "^3.2.4",
-        "@wordpress/prettier-config": "^1.1.1",
+        "@wordpress/postcss-plugins-preset": "^3.2.0",
+        "@wordpress/prettier-config": "^1.1.0",
         "@wordpress/stylelint-config": "^19.1.0",
         "babel-jest": "^26.6.3",
         "babel-loader": "^8.2.2",
-        "browserslist": "^4.16.6",
         "chalk": "^4.0.0",
         "check-node-version": "^4.1.0",
         "clean-webpack-plugin": "^3.0.0",
         "cross-spawn": "^5.1.0",
-        "css-loader": "^6.2.0",
-        "cssnano": "^5.0.7",
+        "css-loader": "^5.1.3",
         "cwd": "^0.10.0",
         "dir-glob": "^3.0.1",
         "eslint": "^7.17.0",
         "eslint-plugin-markdown": "^2.2.0",
         "expect-puppeteer": "^4.4.0",
+        "file-loader": "^6.2.0",
         "filenamify": "^4.2.0",
+        "ignore-emit-webpack-plugin": "^2.0.6",
         "jest": "^26.6.3",
         "jest-circus": "^26.6.3",
-        "jest-dev-server": "^5.0.3",
+        "jest-dev-server": "^4.4.0",
         "jest-environment-node": "^26.6.2",
         "markdownlint": "^0.23.1",
         "markdownlint-cli": "^0.27.1",
         "merge-deep": "^3.0.3",
-        "mini-css-extract-plugin": "^2.1.0",
+        "mini-css-extract-plugin": "^1.3.9",
         "minimist": "^1.2.0",
         "npm-package-json-lint": "^5.0.0",
         "postcss": "^8.2.15",
-        "postcss-loader": "^6.1.1",
+        "postcss-loader": "^4.2.0",
         "prettier": "npm:wp-prettier@2.2.1-beta-1",
         "puppeteer-core": "^10.1.0",
         "read-pkg-up": "^1.0.1",
         "resolve-bin": "^0.4.0",
         "sass": "^1.35.2",
-        "sass-loader": "^12.1.0",
-        "source-map-loader": "^3.0.0",
+        "sass-loader": "^10.1.1",
+        "source-map-loader": "^0.2.4",
         "stylelint": "^13.8.0",
-        "terser-webpack-plugin": "^5.1.4",
+        "terser-webpack-plugin": "^3.0.3",
+        "thread-loader": "^3.0.1",
         "url-loader": "^4.1.1",
-        "webpack": "^5.47.1",
-        "webpack-bundle-analyzer": "^4.4.2",
-        "webpack-cli": "^4.7.2",
-        "webpack-livereload-plugin": "^3.0.1"
+        "webpack": "^4.46.0",
+        "webpack-bundle-analyzer": "^4.2.0",
+        "webpack-cli": "^3.3.11",
+        "webpack-livereload-plugin": "^2.3.0",
+        "webpack-sources": "^2.2.0"
       },
       "dependencies": {
         "@typescript-eslint/eslint-plugin": {
@@ -12715,135 +12679,6 @@
           "requires": {
             "@typescript-eslint/types": "4.33.0",
             "eslint-visitor-keys": "^2.0.0"
-          }
-        },
-        "@webassemblyjs/ast": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
-          "integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/helper-numbers": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
-          }
-        },
-        "@webassemblyjs/helper-api-error": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
-          "integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-buffer": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
-          "integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-wasm-bytecode": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
-          "integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-          "dev": true
-        },
-        "@webassemblyjs/helper-wasm-section": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
-          "integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-buffer": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/wasm-gen": "1.11.1"
-          }
-        },
-        "@webassemblyjs/ieee754": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
-          "integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
-          "dev": true,
-          "requires": {
-            "@xtuc/ieee754": "^1.2.0"
-          }
-        },
-        "@webassemblyjs/leb128": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
-          "integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
-          "dev": true,
-          "requires": {
-            "@xtuc/long": "4.2.2"
-          }
-        },
-        "@webassemblyjs/utf8": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
-          "integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-          "dev": true
-        },
-        "@webassemblyjs/wasm-edit": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
-          "integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-buffer": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/helper-wasm-section": "1.11.1",
-            "@webassemblyjs/wasm-gen": "1.11.1",
-            "@webassemblyjs/wasm-opt": "1.11.1",
-            "@webassemblyjs/wasm-parser": "1.11.1",
-            "@webassemblyjs/wast-printer": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wasm-gen": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
-          "integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/ieee754": "1.11.1",
-            "@webassemblyjs/leb128": "1.11.1",
-            "@webassemblyjs/utf8": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wasm-opt": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
-          "integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-buffer": "1.11.1",
-            "@webassemblyjs/wasm-gen": "1.11.1",
-            "@webassemblyjs/wasm-parser": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wasm-parser": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
-          "integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/helper-api-error": "1.11.1",
-            "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
-            "@webassemblyjs/ieee754": "1.11.1",
-            "@webassemblyjs/leb128": "1.11.1",
-            "@webassemblyjs/utf8": "1.11.1"
-          }
-        },
-        "@webassemblyjs/wast-printer": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
-          "integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
-          "dev": true,
-          "requires": {
-            "@webassemblyjs/ast": "1.11.1",
-            "@xtuc/long": "4.2.2"
           }
         },
         "@wordpress/babel-plugin-import-jsx-pragma": {
@@ -12939,9 +12774,9 @@
           "dev": true
         },
         "acorn": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-          "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
           "dev": true
         },
         "array-includes": {
@@ -12974,16 +12809,50 @@
             "es-abstract": "^1.19.0"
           }
         },
-        "colorette": {
-          "version": "2.0.16",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
-          "dev": true
+        "cacache": {
+          "version": "12.0.4",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+          "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "5.1.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+              "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+              "dev": true,
+              "requires": {
+                "yallist": "^3.0.2"
+              }
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+              "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+              "dev": true
+            }
+          }
         },
-        "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "dev": true
         },
         "comment-parser": {
@@ -13028,94 +12897,22 @@
             }
           }
         },
-        "css-color-names": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-1.0.1.tgz",
-          "integrity": "sha512-/loXYOch1qU1biStIFsHH8SxTmOseh1IJqFvy8IujXOm1h+QjUdDhkzOrR5HG8K8mlxREj0yfi8ewCHx0eMxzA==",
-          "dev": true
-        },
-        "css-declaration-sorter": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.1.3.tgz",
-          "integrity": "sha512-SvjQjNRZgh4ULK1LDJ2AduPKUKxIqmtU7ZAyi47BTV+M90Qvxr9AB6lKlLbDUfXqI9IQeYA8LbAsCZPpJEV3aA==",
-          "dev": true,
-          "requires": {
-            "timsort": "^0.3.0"
-          }
-        },
         "css-loader": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
-          "integrity": "sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==",
+          "version": "5.2.7",
+          "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
+          "integrity": "sha512-Q7mOvpBNBG7YrVGMxRxcBJZFL75o+cH2abNASdibkj/fffYD8qWbInZrD0S9ccI6vZclF3DsHE7njGlLtaHbhg==",
           "dev": true,
           "requires": {
             "icss-utils": "^5.1.0",
+            "loader-utils": "^2.0.0",
             "postcss": "^8.2.15",
             "postcss-modules-extract-imports": "^3.0.0",
             "postcss-modules-local-by-default": "^4.0.0",
             "postcss-modules-scope": "^3.0.0",
             "postcss-modules-values": "^4.0.0",
             "postcss-value-parser": "^4.1.0",
+            "schema-utils": "^3.0.0",
             "semver": "^7.3.5"
-          }
-        },
-        "css-tree": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-          "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-          "dev": true,
-          "requires": {
-            "mdn-data": "2.0.14",
-            "source-map": "^0.6.1"
-          }
-        },
-        "cssnano": {
-          "version": "5.0.10",
-          "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.10.tgz",
-          "integrity": "sha512-YfNhVJJ04imffOpbPbXP2zjIoByf0m8E2c/s/HnvSvjXgzXMfgopVjAEGvxYOjkOpWuRQDg/OZFjO7WW94Ri8w==",
-          "dev": true,
-          "requires": {
-            "cssnano-preset-default": "^5.1.6",
-            "is-resolvable": "^1.1.0",
-            "lilconfig": "^2.0.3",
-            "yaml": "^1.10.2"
-          }
-        },
-        "cssnano-preset-default": {
-          "version": "5.1.6",
-          "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.6.tgz",
-          "integrity": "sha512-X2nDeNGBXc0486oHjT2vSj+TdeyVsxRvJUxaOH50hOM6vSDLkKd0+59YXpSZRInJ4sNtBOykS4KsPfhdrU/35w==",
-          "dev": true,
-          "requires": {
-            "css-declaration-sorter": "^6.0.3",
-            "cssnano-utils": "^2.0.1",
-            "postcss-calc": "^8.0.0",
-            "postcss-colormin": "^5.2.1",
-            "postcss-convert-values": "^5.0.2",
-            "postcss-discard-comments": "^5.0.1",
-            "postcss-discard-duplicates": "^5.0.1",
-            "postcss-discard-empty": "^5.0.1",
-            "postcss-discard-overridden": "^5.0.1",
-            "postcss-merge-longhand": "^5.0.3",
-            "postcss-merge-rules": "^5.0.2",
-            "postcss-minify-font-values": "^5.0.1",
-            "postcss-minify-gradients": "^5.0.3",
-            "postcss-minify-params": "^5.0.1",
-            "postcss-minify-selectors": "^5.1.0",
-            "postcss-normalize-charset": "^5.0.1",
-            "postcss-normalize-display-values": "^5.0.1",
-            "postcss-normalize-positions": "^5.0.1",
-            "postcss-normalize-repeat-style": "^5.0.1",
-            "postcss-normalize-string": "^5.0.1",
-            "postcss-normalize-timing-functions": "^5.0.1",
-            "postcss-normalize-unicode": "^5.0.1",
-            "postcss-normalize-url": "^5.0.2",
-            "postcss-normalize-whitespace": "^5.0.1",
-            "postcss-ordered-values": "^5.0.2",
-            "postcss-reduce-initial": "^5.0.1",
-            "postcss-reduce-transforms": "^5.0.1",
-            "postcss-svgo": "^5.0.3",
-            "postcss-unique-selectors": "^5.0.1"
           }
         },
         "doctrine": {
@@ -13125,16 +12922,6 @@
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
-          }
-        },
-        "enhanced-resolve": {
-          "version": "5.8.3",
-          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.3.tgz",
-          "integrity": "sha512-EGAbGvH7j7Xt2nc0E7D99La1OiEs8LnyimkRgwExpUMScN6O+3x9tIWs7PLQZVNx4YD+00skHXPXi1yQHpAmZA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.2.4",
-            "tapable": "^2.2.0"
           }
         },
         "es-abstract": {
@@ -13221,9 +13008,9 @@
           }
         },
         "eslint-plugin-import": {
-          "version": "2.25.2",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.2.tgz",
-          "integrity": "sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==",
+          "version": "2.25.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.3.tgz",
+          "integrity": "sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==",
           "dev": true,
           "requires": {
             "array-includes": "^3.1.4",
@@ -13231,9 +13018,9 @@
             "debug": "^2.6.9",
             "doctrine": "^2.1.0",
             "eslint-import-resolver-node": "^0.3.6",
-            "eslint-module-utils": "^2.7.0",
+            "eslint-module-utils": "^2.7.1",
             "has": "^1.0.3",
-            "is-core-module": "^2.7.0",
+            "is-core-module": "^2.8.0",
             "is-glob": "^4.0.3",
             "minimatch": "^3.0.4",
             "object.values": "^1.1.5",
@@ -13297,54 +13084,6 @@
             "eslint-visitor-keys": "^2.0.0"
           }
         },
-        "execa": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.0",
-            "human-signals": "^2.1.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.1",
-            "onetime": "^5.1.2",
-            "signal-exit": "^3.0.3",
-            "strip-final-newline": "^2.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-              "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-              "dev": true,
-              "requires": {
-                "path-key": "^3.1.0",
-                "shebang-command": "^2.0.0",
-                "which": "^2.0.1"
-              }
-            },
-            "shebang-command": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-              "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-              "dev": true,
-              "requires": {
-                "shebang-regex": "^3.0.0"
-              }
-            },
-            "which": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-              "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-              "dev": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
-        },
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -13353,18 +13092,6 @@
           "requires": {
             "locate-path": "^2.0.0"
           }
-        },
-        "get-stream": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-          "dev": true
-        },
-        "glob-to-regexp": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-          "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-          "dev": true
         },
         "globals": {
           "version": "12.4.0",
@@ -13388,18 +13115,6 @@
             "merge2": "^1.3.0",
             "slash": "^3.0.0"
           }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "human-signals": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-          "dev": true
         },
         "icss-utils": {
           "version": "5.1.0",
@@ -13438,12 +13153,6 @@
             "has-tostringtag": "^1.0.0"
           }
         },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-          "dev": true
-        },
         "is-string": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -13452,6 +13161,12 @@
           "requires": {
             "has-tostringtag": "^1.0.0"
           }
+        },
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+          "dev": true
         },
         "jest-circus": {
           "version": "26.6.3",
@@ -13480,17 +13195,6 @@
             "pretty-format": "^26.6.2",
             "stack-utils": "^2.0.2",
             "throat": "^5.0.0"
-          }
-        },
-        "jest-worker": {
-          "version": "27.3.1",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
-          "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*",
-            "merge-stream": "^2.0.0",
-            "supports-color": "^8.0.0"
           }
         },
         "json5": {
@@ -13535,12 +13239,6 @@
             }
           }
         },
-        "loader-runner": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
-          "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
-          "dev": true
-        },
         "locate-path": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -13551,19 +13249,36 @@
             "path-exists": "^3.0.0"
           }
         },
-        "mdn-data": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-          "dev": true
-        },
         "mini-css-extract-plugin": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.4.4.tgz",
-          "integrity": "sha512-UJ+aNuFQaQaECu7AamlWOBLj2cJ6XSGU4zNiqXeZ7lZLe5VD0DoSPWFbWArXueo+6FZVbgHzpX9lUIaBIDLuYg==",
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-1.6.2.tgz",
+          "integrity": "sha512-WhDvO3SjGm40oV5y26GjMJYjd2UMqrLAGKy5YS2/3QKJy2F7jgynuHTir/tgUUOiNQu5saXHdc8reo7YuhhT4Q==",
           "dev": true,
           "requires": {
-            "schema-utils": "^3.1.0"
+            "loader-utils": "^2.0.0",
+            "schema-utils": "^3.0.0",
+            "webpack-sources": "^1.1.0"
+          },
+          "dependencies": {
+            "webpack-sources": {
+              "version": "1.4.3",
+              "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+              "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+              "dev": true,
+              "requires": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -13577,15 +13292,6 @@
           "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
           "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
           "dev": true
-        },
-        "npm-run-path": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.0.0"
-          }
         },
         "object-inspect": {
           "version": "1.11.0",
@@ -13628,12 +13334,6 @@
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
           "dev": true
         },
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
         "picocolors": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -13664,139 +13364,6 @@
             "nanoid": "^3.1.30",
             "picocolors": "^1.0.0",
             "source-map-js": "^0.6.2"
-          }
-        },
-        "postcss-calc": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.0.0.tgz",
-          "integrity": "sha512-5NglwDrcbiy8XXfPM11F3HeC6hoT9W7GUH/Zi5U/p7u3Irv4rHhdDcIZwG0llHXV4ftsBjpfWMXAnXNl4lnt8g==",
-          "dev": true,
-          "requires": {
-            "postcss-selector-parser": "^6.0.2",
-            "postcss-value-parser": "^4.0.2"
-          }
-        },
-        "postcss-colormin": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.1.tgz",
-          "integrity": "sha512-VVwMrEYLcHYePUYV99Ymuoi7WhKrMGy/V9/kTS0DkCoJYmmjdOMneyhzYUxcNgteKDVbrewOkSM7Wje/MFwxzA==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.6",
-            "caniuse-api": "^3.0.0",
-            "colord": "^2.9.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-convert-values": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.2.tgz",
-          "integrity": "sha512-KQ04E2yadmfa1LqXm7UIDwW1ftxU/QWZmz6NKnHnUvJ3LEYbbcX6i329f/ig+WnEByHegulocXrECaZGLpL8Zg==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-discard-comments": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
-          "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-          "dev": true
-        },
-        "postcss-discard-duplicates": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
-          "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-          "dev": true
-        },
-        "postcss-discard-empty": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
-          "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-          "dev": true
-        },
-        "postcss-discard-overridden": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
-          "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-          "dev": true
-        },
-        "postcss-loader": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-6.2.0.tgz",
-          "integrity": "sha512-H9hv447QjQJVDbHj3OUdciyAXY3v5+UDduzEytAlZCVHCpNAAg/mCSwhYYqZr9BiGYhmYspU8QXxZwiHTLn3yA==",
-          "dev": true,
-          "requires": {
-            "cosmiconfig": "^7.0.0",
-            "klona": "^2.0.4",
-            "semver": "^7.3.5"
-          }
-        },
-        "postcss-merge-longhand": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.3.tgz",
-          "integrity": "sha512-kmB+1TjMTj/bPw6MCDUiqSA5e/x4fvLffiAdthra3a0m2/IjTrWsTmD3FdSskzUjEwkj5ZHBDEbv5dOcqD7CMQ==",
-          "dev": true,
-          "requires": {
-            "css-color-names": "^1.0.1",
-            "postcss-value-parser": "^4.1.0",
-            "stylehacks": "^5.0.1"
-          }
-        },
-        "postcss-merge-rules": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.2.tgz",
-          "integrity": "sha512-5K+Md7S3GwBewfB4rjDeol6V/RZ8S+v4B66Zk2gChRqLTCC8yjnHQ601omj9TKftS19OPGqZ/XzoqpzNQQLwbg==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.6",
-            "caniuse-api": "^3.0.0",
-            "cssnano-utils": "^2.0.1",
-            "postcss-selector-parser": "^6.0.5",
-            "vendors": "^1.0.3"
-          }
-        },
-        "postcss-minify-font-values": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.0.1.tgz",
-          "integrity": "sha512-7JS4qIsnqaxk+FXY1E8dHBDmraYFWmuL6cgt0T1SWGRO5bzJf8sUoelwa4P88LEWJZweHevAiDKxHlofuvtIoA==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-minify-gradients": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.3.tgz",
-          "integrity": "sha512-Z91Ol22nB6XJW+5oe31+YxRsYooxOdFKcbOqY/V8Fxse1Y3vqlNRpi1cxCqoACZTQEhl+xvt4hsbWiV5R+XI9Q==",
-          "dev": true,
-          "requires": {
-            "colord": "^2.9.1",
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-minify-params": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.0.1.tgz",
-          "integrity": "sha512-4RUC4k2A/Q9mGco1Z8ODc7h+A0z7L7X2ypO1B6V8057eVK6mZ6xwz6QN64nHuHLbqbclkX1wyzRnIrdZehTEHw==",
-          "dev": true,
-          "requires": {
-            "alphanum-sort": "^1.0.2",
-            "browserslist": "^4.16.0",
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0",
-            "uniqs": "^2.0.0"
-          }
-        },
-        "postcss-minify-selectors": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.1.0.tgz",
-          "integrity": "sha512-NzGBXDa7aPsAcijXZeagnJBKBPMYLaJJzB8CQh6ncvyl2sIndLVWfbcDi0SBjRWk5VqEjXvf8tYwzoKf4Z07og==",
-          "dev": true,
-          "requires": {
-            "alphanum-sort": "^1.0.2",
-            "postcss-selector-parser": "^6.0.5"
           }
         },
         "postcss-modules-extract-imports": {
@@ -13832,141 +13399,6 @@
           "dev": true,
           "requires": {
             "icss-utils": "^5.0.0"
-          }
-        },
-        "postcss-normalize-charset": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
-          "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-          "dev": true
-        },
-        "postcss-normalize-display-values": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.1.tgz",
-          "integrity": "sha512-uupdvWk88kLDXi5HEyI9IaAJTE3/Djbcrqq8YgjvAVuzgVuqIk3SuJWUisT2gaJbZm1H9g5k2w1xXilM3x8DjQ==",
-          "dev": true,
-          "requires": {
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-normalize-positions": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.0.1.tgz",
-          "integrity": "sha512-rvzWAJai5xej9yWqlCb1OWLd9JjW2Ex2BCPzUJrbaXmtKtgfL8dBMOOMTX6TnvQMtjk3ei1Lswcs78qKO1Skrg==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-normalize-repeat-style": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.1.tgz",
-          "integrity": "sha512-syZ2itq0HTQjj4QtXZOeefomckiV5TaUO6ReIEabCh3wgDs4Mr01pkif0MeVwKyU/LHEkPJnpwFKRxqWA/7O3w==",
-          "dev": true,
-          "requires": {
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-normalize-string": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.0.1.tgz",
-          "integrity": "sha512-Ic8GaQ3jPMVl1OEn2U//2pm93AXUcF3wz+OriskdZ1AOuYV25OdgS7w9Xu2LO5cGyhHCgn8dMXh9bO7vi3i9pA==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-normalize-timing-functions": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.1.tgz",
-          "integrity": "sha512-cPcBdVN5OsWCNEo5hiXfLUnXfTGtSFiBU9SK8k7ii8UD7OLuznzgNRYkLZow11BkQiiqMcgPyh4ZqXEEUrtQ1Q==",
-          "dev": true,
-          "requires": {
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-normalize-unicode": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.1.tgz",
-          "integrity": "sha512-kAtYD6V3pK0beqrU90gpCQB7g6AOfP/2KIPCVBKJM2EheVsBQmx/Iof+9zR9NFKLAx4Pr9mDhogB27pmn354nA==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.0",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-normalize-url": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.2.tgz",
-          "integrity": "sha512-k4jLTPUxREQ5bpajFQZpx8bCF2UrlqOTzP9kEqcEnOfwsRshWs2+oAFIHfDQB8GO2PaUaSE0NlTAYtbluZTlHQ==",
-          "dev": true,
-          "requires": {
-            "is-absolute-url": "^3.0.3",
-            "normalize-url": "^6.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-normalize-whitespace": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.1.tgz",
-          "integrity": "sha512-iPklmI5SBnRvwceb/XH568yyzK0qRVuAG+a1HFUsFRf11lEJTiQQa03a4RSCQvLKdcpX7XsI1Gen9LuLoqwiqA==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-ordered-values": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.2.tgz",
-          "integrity": "sha512-8AFYDSOYWebJYLyJi3fyjl6CqMEG/UVworjiyK1r573I56kb3e879sCJLGvR3merj+fAdPpVplXKQZv+ey6CgQ==",
-          "dev": true,
-          "requires": {
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-reduce-initial": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.0.1.tgz",
-          "integrity": "sha512-zlCZPKLLTMAqA3ZWH57HlbCjkD55LX9dsRyxlls+wfuRfqCi5mSlZVan0heX5cHr154Dq9AfbH70LyhrSAezJw==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.0",
-            "caniuse-api": "^3.0.0"
-          }
-        },
-        "postcss-reduce-transforms": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.1.tgz",
-          "integrity": "sha512-a//FjoPeFkRuAguPscTVmRQUODP+f3ke2HqFNgGPwdYnpeC29RZdCBvGRGTsKpMURb/I3p6jdKoBQ2zI+9Q7kA==",
-          "dev": true,
-          "requires": {
-            "cssnano-utils": "^2.0.1",
-            "postcss-value-parser": "^4.1.0"
-          }
-        },
-        "postcss-svgo": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.3.tgz",
-          "integrity": "sha512-41XZUA1wNDAZrQ3XgWREL/M2zSw8LJPvb5ZWivljBsUQAGoEKMYm6okHsTjJxKYI4M75RQEH4KYlEM52VwdXVA==",
-          "dev": true,
-          "requires": {
-            "postcss-value-parser": "^4.1.0",
-            "svgo": "^2.7.0"
-          }
-        },
-        "postcss-unique-selectors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.0.1.tgz",
-          "integrity": "sha512-gwi1NhHV4FMmPn+qwBNuot1sG1t2OmacLQ/AX29lzyggnjd+MnVD5uqQmpXO3J17KGL2WAxQruj1qTd3H0gG/w==",
-          "dev": true,
-          "requires": {
-            "alphanum-sort": "^1.0.2",
-            "postcss-selector-parser": "^6.0.5",
-            "uniqs": "^2.0.0"
           }
         },
         "postcss-value-parser": {
@@ -14072,14 +13504,26 @@
           "integrity": "sha512-k519uI04Z3SaY0fLX843MRXnDeG2+vHOFsyhiPZvNLe7r8rD2YNRjq4BQLZZ0oAr2NrtvZlICsXysGNFPGa3CQ==",
           "dev": true
         },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "sass-loader": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.3.0.tgz",
-          "integrity": "sha512-6l9qwhdOb7qSrtOu96QQ81LVl8v6Dp9j1w3akOm0aWHyrTYtagDt5+kS32N4yq4hHk3M+rdqoRMH+lIdqvW6HA==",
+          "version": "10.2.0",
+          "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-10.2.0.tgz",
+          "integrity": "sha512-kUceLzC1gIHz0zNJPpqRsJyisWatGYNFRmv2CKZK2/ngMJgLqxTbXwe/hJ85luyvZkgqU3VlJ33UVF2T/0g6mw==",
           "dev": true,
           "requires": {
             "klona": "^2.0.4",
-            "neo-async": "^2.6.2"
+            "loader-utils": "^2.0.0",
+            "neo-async": "^2.6.2",
+            "schema-utils": "^3.0.0",
+            "semver": "^7.3.2"
           }
         },
         "scheduler": {
@@ -14113,19 +13557,13 @@
           }
         },
         "serialize-javascript": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
           "dev": true,
           "requires": {
             "randombytes": "^2.1.0"
           }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
         },
         "slash": {
           "version": "3.0.0",
@@ -14139,104 +13577,13 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
-        "source-map-support": {
-          "version": "0.5.20",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-          "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+        "ssri": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+          "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        },
-        "stylehacks": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.1.tgz",
-          "integrity": "sha512-Es0rVnHIqbWzveU1b24kbw92HsebBepxfcqe5iix7t9j0PQqhs0IxXVXv0pY2Bxa08CgMkzD6OWql7kbGOuEdA==",
-          "dev": true,
-          "requires": {
-            "browserslist": "^4.16.0",
-            "postcss-selector-parser": "^6.0.4"
-          }
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "svgo": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-          "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
-          "dev": true,
-          "requires": {
-            "@trysound/sax": "0.2.0",
-            "commander": "^7.2.0",
-            "css-select": "^4.1.3",
-            "css-tree": "^1.1.3",
-            "csso": "^4.2.0",
-            "picocolors": "^1.0.0",
-            "stable": "^0.1.8"
-          }
-        },
-        "tapable": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-          "dev": true
-        },
-        "terser": {
-          "version": "5.9.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-          "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
-          "dev": true,
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.7.2",
-            "source-map-support": "~0.5.20"
-          },
-          "dependencies": {
-            "commander": {
-              "version": "2.20.3",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-              "dev": true
-            },
-            "source-map": {
-              "version": "0.7.3",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-              "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-              "dev": true
-            }
-          }
-        },
-        "terser-webpack-plugin": {
-          "version": "5.2.4",
-          "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
-          "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
-          "dev": true,
-          "requires": {
-            "jest-worker": "^27.0.6",
-            "p-limit": "^3.1.0",
-            "schema-utils": "^3.1.1",
-            "serialize-javascript": "^6.0.0",
-            "source-map": "^0.6.1",
-            "terser": "^5.7.2"
-          },
-          "dependencies": {
-            "p-limit": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-              "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-              "dev": true,
-              "requires": {
-                "yocto-queue": "^0.1.0"
-              }
-            }
+            "figgy-pudding": "^3.5.1"
           }
         },
         "tsconfig-paths": {
@@ -14251,73 +13598,107 @@
             "strip-bom": "^3.0.0"
           }
         },
-        "watchpack": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-          "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
-          "dev": true,
-          "requires": {
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.1.2"
-          }
-        },
         "webpack": {
-          "version": "5.62.1",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.62.1.tgz",
-          "integrity": "sha512-jNLtnWChS2CMZ7vqWtztv0G6fYB5hz11Zsadp5tE7e4/66zVDj7/KUeQZOsOl8Hz5KrLJH1h2eIDl6AnlyE12Q==",
+          "version": "4.46.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.46.0.tgz",
+          "integrity": "sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==",
           "dev": true,
           "requires": {
-            "@types/eslint-scope": "^3.7.0",
-            "@types/estree": "^0.0.50",
-            "@webassemblyjs/ast": "1.11.1",
-            "@webassemblyjs/wasm-edit": "1.11.1",
-            "@webassemblyjs/wasm-parser": "1.11.1",
-            "acorn": "^8.4.1",
-            "acorn-import-assertions": "^1.7.6",
-            "browserslist": "^4.14.5",
+            "@webassemblyjs/ast": "1.9.0",
+            "@webassemblyjs/helper-module-context": "1.9.0",
+            "@webassemblyjs/wasm-edit": "1.9.0",
+            "@webassemblyjs/wasm-parser": "1.9.0",
+            "acorn": "^6.4.1",
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1",
             "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.8.3",
-            "es-module-lexer": "^0.9.0",
-            "eslint-scope": "5.1.1",
-            "events": "^3.2.0",
-            "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.4",
+            "enhanced-resolve": "^4.5.0",
+            "eslint-scope": "^4.0.3",
             "json-parse-better-errors": "^1.0.2",
-            "loader-runner": "^4.2.0",
-            "mime-types": "^2.1.27",
-            "neo-async": "^2.6.2",
-            "schema-utils": "^3.1.0",
-            "tapable": "^2.1.1",
-            "terser-webpack-plugin": "^5.1.3",
-            "watchpack": "^2.2.0",
-            "webpack-sources": "^3.2.0"
-          }
-        },
-        "webpack-cli": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.9.1.tgz",
-          "integrity": "sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==",
-          "dev": true,
-          "requires": {
-            "@discoveryjs/json-ext": "^0.5.0",
-            "@webpack-cli/configtest": "^1.1.0",
-            "@webpack-cli/info": "^1.4.0",
-            "@webpack-cli/serve": "^1.6.0",
-            "colorette": "^2.0.14",
-            "commander": "^7.0.0",
-            "execa": "^5.0.0",
-            "fastest-levenshtein": "^1.0.12",
-            "import-local": "^3.0.2",
-            "interpret": "^2.2.0",
-            "rechoir": "^0.7.0",
-            "webpack-merge": "^5.7.3"
+            "loader-runner": "^2.4.0",
+            "loader-utils": "^1.2.3",
+            "memory-fs": "^0.4.1",
+            "micromatch": "^3.1.10",
+            "mkdirp": "^0.5.3",
+            "neo-async": "^2.6.1",
+            "node-libs-browser": "^2.2.1",
+            "schema-utils": "^1.0.0",
+            "tapable": "^1.1.3",
+            "terser-webpack-plugin": "^1.4.3",
+            "watchpack": "^1.7.4",
+            "webpack-sources": "^1.4.1"
+          },
+          "dependencies": {
+            "eslint-scope": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+              "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+              "dev": true,
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "loader-utils": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+              "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+              "dev": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^1.0.1"
+              }
+            },
+            "schema-utils": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+              "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+              "dev": true,
+              "requires": {
+                "ajv": "^6.1.0",
+                "ajv-errors": "^1.0.0",
+                "ajv-keywords": "^3.1.0"
+              }
+            },
+            "terser-webpack-plugin": {
+              "version": "1.4.5",
+              "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+              "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+              "dev": true,
+              "requires": {
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
+                "is-wsl": "^1.1.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^4.0.0",
+                "source-map": "^0.6.1",
+                "terser": "^4.1.2",
+                "webpack-sources": "^1.4.0",
+                "worker-farm": "^1.7.0"
+              }
+            },
+            "webpack-sources": {
+              "version": "1.4.3",
+              "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+              "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+              "dev": true,
+              "requires": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+              }
+            }
           }
         },
         "webpack-sources": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-          "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
-          "dev": true
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
+          "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
+          "dev": true,
+          "requires": {
+            "source-list-map": "^2.0.1",
+            "source-map": "^0.6.1"
+          }
         },
         "yallist": {
           "version": "2.1.2",
@@ -14776,12 +14157,6 @@
         "acorn": "^7.1.1",
         "acorn-walk": "^7.1.1"
       }
-    },
-    "acorn-import-assertions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
-      "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -17903,12 +17278,6 @@
         "simple-swizzle": "^0.2.2"
       }
     },
-    "colord": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.1.tgz",
-      "integrity": "sha512-4LBMSt09vR0uLnPVkOUBnmxgoaeN4ewRbx801wY/bXcltXfpR/G46OdWn96XpYmCWuYvO46aBZP4NgX8HpNAcw==",
-      "dev": true
-    },
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
@@ -19205,12 +18574,6 @@
       "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
       "dev": true
     },
-    "cssnano-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
-      "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true
-    },
     "csso": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
@@ -19717,9 +19080,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.883894",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.883894.tgz",
-      "integrity": "sha512-33idhm54QJzf3Q7QofMgCvIVSd2o9H3kQPWaKT/fhoZh+digc+WSiMhbkeG3iN79WY4Hwr9G05NpbhEVrsOYAg==",
+      "version": "0.0.901419",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.901419.tgz",
+      "integrity": "sha512-4INMPwNm9XRpBukhNbF7OB6fNTTCaI8pzy/fXg0xQzAy5h3zL1P8xT3QazgKqBrb/hAYwIBizqDBZ7GtJE74QQ==",
       "dev": true
     },
     "diff-sequences": {
@@ -20274,12 +19637,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
       "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
-    "envinfo": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
-      "dev": true
-    },
     "enzyme": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
@@ -20423,12 +19780,6 @@
           "dev": true
         }
       }
-    },
-    "es-module-lexer": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
-      "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-      "dev": true
     },
     "es-to-primitive": {
       "version": "1.2.1",
@@ -23975,6 +23326,12 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "ignore-emit-webpack-plugin": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/ignore-emit-webpack-plugin/-/ignore-emit-webpack-plugin-2.0.6.tgz",
+      "integrity": "sha512-/zC18RWCC2wz4ZwnS4UoujGWzvSKy28DLjtE+jrGBOXej6YdmityhBDzE8E0NlktEqi4tgdNbydX8B6G4haHSQ==",
+      "dev": true
+    },
     "ignore-loader": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ignore-loader/-/ignore-loader-0.1.2.tgz",
@@ -25970,18 +25327,69 @@
       }
     },
     "jest-dev-server": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-5.0.3.tgz",
-      "integrity": "sha512-aJR3a5KdY18Lsz+VbREKwx2HM3iukiui+J9rlv9o6iYTwZCSsJazSTStcD9K1q0AIF3oA+FqLOKDyo/sc7+fJw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-4.4.0.tgz",
+      "integrity": "sha512-STEHJ3iPSC8HbrQ3TME0ozGX2KT28lbT4XopPxUm2WimsX3fcB3YOptRh12YphQisMhfqNSNTZUmWyT3HEXS2A==",
       "dev": true,
       "requires": {
-        "chalk": "^4.1.1",
+        "chalk": "^3.0.0",
         "cwd": "^0.10.0",
-        "find-process": "^1.4.4",
-        "prompts": "^2.4.1",
-        "spawnd": "^5.0.0",
+        "find-process": "^1.4.3",
+        "prompts": "^2.3.0",
+        "spawnd": "^4.4.0",
         "tree-kill": "^1.2.2",
-        "wait-on": "^5.3.0"
+        "wait-on": "^3.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -27671,12 +27079,6 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
-    },
-    "lilconfig": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.4.tgz",
-      "integrity": "sha512-bfTIN7lEsiooCocSISTWXkiWJkRqtL9wYtYy+8EK3Y41qh3mpwPU0ycTOgjdY9ErwXCc8QyrQp82bdL0Xkm9yA==",
-      "dev": true
     },
     "line-height": {
       "version": "0.3.1",
@@ -33871,13 +33273,13 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer-core": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-10.1.0.tgz",
-      "integrity": "sha512-x2yDSJI/PRiWhDqAt1jd4rhTotxwjwKzHLIIqD2MlJ+TmzGJfBY9snAGIVXJwkWfKJg+Ef5xupdK0EbHDqBpFw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-10.4.0.tgz",
+      "integrity": "sha512-KU8zyb7AIOqNjLCN3wkrFXxh+EVaG+zrs2P03ATNjc3iwSxHsu5/EvZiREpQ/IJiT9xfQbDVgKcsvRuzLCxglQ==",
       "dev": true,
       "requires": {
         "debug": "4.3.1",
-        "devtools-protocol": "0.0.883894",
+        "devtools-protocol": "0.0.901419",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.0",
         "node-fetch": "2.6.1",
@@ -34960,15 +34362,6 @@
         "reakit-utils": "^0.15.2"
       }
     },
-    "rechoir": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
-      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.9.0"
-      }
-    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
@@ -35750,6 +35143,12 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
       "integrity": "sha1-QAwJ6+kU57F+C27zJjQA/Cq8fLM="
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
     },
     "rxjs": {
       "version": "6.6.7",
@@ -36549,14 +35948,44 @@
       "dev": true
     },
     "source-map-loader": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.0.tgz",
-      "integrity": "sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.4.tgz",
+      "integrity": "sha512-OU6UJUty+i2JDpTItnizPrlpOIBLmQbWMuBg9q5bVtnHACqw1tn9nNwqJLbv0/00JjnJb/Ee5g5WS5vrRv7zIQ==",
       "dev": true,
       "requires": {
-        "abab": "^2.0.5",
-        "iconv-lite": "^0.6.2",
-        "source-map-js": "^0.6.2"
+        "async": "^2.5.0",
+        "loader-utils": "^1.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+          "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        }
       }
     },
     "source-map-resolve": {
@@ -36603,15 +36032,15 @@
       "dev": true
     },
     "spawnd": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-5.0.0.tgz",
-      "integrity": "sha512-28+AJr82moMVWolQvlAIv3JcYDkjkFTEmfDc503wxrF5l2rQ3dFz6DpbXp3kD4zmgGGldfM4xM4v1sFj/ZaIOA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-4.4.0.tgz",
+      "integrity": "sha512-jLPOfB6QOEgMOQY15Z6+lwZEhH3F5ncXxIaZ7WHPIapwNNLyjrs61okj3VJ3K6tmP5TZ6cO0VAu9rEY4MD4YQg==",
       "dev": true,
       "requires": {
         "exit": "^0.1.2",
-        "signal-exit": "^3.0.3",
+        "signal-exit": "^3.0.2",
         "tree-kill": "^1.2.2",
-        "wait-port": "^0.2.9"
+        "wait-port": "^0.2.7"
       }
     },
     "spdx-correct": {
@@ -38348,6 +37777,38 @@
       "integrity": "sha1-g0L/I55OhDwoel9TlW+w3HtgX+4=",
       "dev": true
     },
+    "thread-loader": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/thread-loader/-/thread-loader-3.0.4.tgz",
+      "integrity": "sha512-ByaL2TPb+m6yArpqQUZvP+5S1mZtXsEP7nWKKlAUTm7fCml8kB5s1uI3+eHRP2bk5mVYfRSBI7FFf+tWEyLZwA==",
+      "dev": true,
+      "requires": {
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^4.1.0",
+        "loader-utils": "^2.0.0",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "loader-runner": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
+          "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
     "throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -39393,16 +38854,24 @@
       }
     },
     "wait-on": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.3.0.tgz",
-      "integrity": "sha512-DwrHrnTK+/0QFaB9a8Ol5Lna3k7WvUR4jzSKmz0YaPBpuN2sACyiPVKVfj6ejnjcajAcvn3wlbTyMIn9AZouOg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-3.3.0.tgz",
+      "integrity": "sha512-97dEuUapx4+Y12aknWZn7D25kkjMk16PbWoYzpSdA8bYpVfS6hpl2a2pOWZ3c+Tyt3/i4/pglyZctG3J4V1hWQ==",
       "dev": true,
       "requires": {
-        "axios": "^0.21.1",
-        "joi": "^17.3.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.5",
-        "rxjs": "^6.6.3"
+        "@hapi/joi": "^15.0.3",
+        "core-js": "^2.6.5",
+        "minimist": "^1.2.0",
+        "request": "^2.88.0",
+        "rx": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        }
       }
     },
     "wait-port": {
@@ -39991,14 +39460,13 @@
       }
     },
     "webpack-livereload-plugin": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-3.0.2.tgz",
-      "integrity": "sha512-5JeZ2dgsvSNG+clrkD/u2sEiPcNk4qwCVZZmW8KpqKcNlkGv7IJjdVrq13+etAmMZYaCF1EGXdHkVFuLgP4zfw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.3.0.tgz",
+      "integrity": "sha512-vVBLQLlNpElt2sfsBG+XLDeVbQFS4RrniVU8Hi1/hX5ycSfx6mtW8MEEITr2g0Cvo36kuPWShFFDuy+DS7KFMA==",
       "dev": true,
       "requires": {
         "anymatch": "^3.1.1",
         "portfinder": "^1.0.17",
-        "schema-utils": ">1.0.0",
         "tiny-lr": "^1.1.1"
       },
       "dependencies": {
@@ -40030,16 +39498,6 @@
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
-      }
-    },
-    "webpack-merge": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
-      "dev": true,
-      "requires": {
-        "clone-deep": "^4.0.1",
-        "wildcard": "^2.0.0"
       }
     },
     "webpack-rtl-plugin": {
@@ -40372,12 +39830,6 @@
           }
         }
       }
-    },
-    "wildcard": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
-      "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
-      "dev": true
     },
     "window-size": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 		"@wordpress/html-entities": "3.2.1",
 		"@wordpress/i18n": "4.2.1",
 		"@wordpress/is-shallow-equal": "4.2.0",
-		"@wordpress/scripts": "19.1.0",
+		"@wordpress/scripts": "17.1.0",
 		"autoprefixer": "10.3.7",
 		"axios": "0.21.4",
 		"babel-plugin-transform-async-generator-functions": "6.24.1",


### PR DESCRIPTION
After the changes introduced in #5096, I wasn't able to run `npm run package-plugin` successfully. Instead, I was getting a dependency mismatch error. That was caused because `@wordpress/scripts` 19.1.0 depends on Webpack 5 while we use Webpack 4. For now, I downgraded `@wordpress/scripts` to 17.1.0, which is the last version that depended on Webpack 4.

### Testing

1. Run `npm run package-plugin` and verify it generates a ZIP instead of displaying an error.
