### PR TITLE
Remove feature gate conditions for Store Editing Templates BlockTemplatesController

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -102,9 +102,7 @@ class Bootstrap {
 		$this->container->get( RestApi::class );
 		$this->container->get( GoogleAnalytics::class );
 		$this->container->get( BlockTypesController::class );
-		if ( $this->package->feature()->is_experimental_build() ) {
-			$this->container->get( BlockTemplatesController::class );
-		}
+		$this->container->get( BlockTemplatesController::class );
 		if ( $this->package->feature()->is_feature_plugin_build() ) {
 			$this->container->get( PaymentsApi::class );
 		}
@@ -231,14 +229,12 @@ class Bootstrap {
 				return new BlockTypesController( $asset_api, $asset_data_registry );
 			}
 		);
-		if ( $this->package->feature()->is_experimental_build() ) {
-			$this->container->register(
-				BlockTemplatesController::class,
-				function ( Container $container ) {
-					return new BlockTemplatesController();
-				}
-			);
-		}
+		$this->container->register(
+			BlockTemplatesController::class,
+			function ( Container $container ) {
+				return new BlockTemplatesController();
+			}
+		);
 		$this->container->register(
 			DraftOrders::class,
 			function( Container $container ) {


### PR DESCRIPTION
Removes the feature gate for the BlockTemplatesController class. This is required before release.

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5127

### Manual Testing

How to test the changes in this Pull Request:

We need to regression test the project to ensure it still loads as expected. You can do this choosing your own method(s) or follow the instructions below.

Before doing so please check the the Project Testing Notes [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4926)

1. Visit the direct URL of one of the WooCommerce block templates `/wp-admin/themes.php?page=gutenberg-edit-site&postId=woocommerce%2F%2Fsingle-product&postType=wp_template`
2. Cutomize the template and check the template is saved and appears in Appearance > Templates
2. Ensure it loads the correct template on the frontend.

### Changelog

> Remove conditionals around BlockTemplatesController class.
