### PR TITLE
Fix state validation to compare state codes, and only validate if a country is given

### DIFF
--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -95,9 +95,8 @@ class BillingAddressSchema extends AbstractAddressSchema {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
 			$billing_country = $address->get_billing_country();
 			$billing_state   = $address->get_billing_state();
-			$valid_states    = $billing_country ? array_filter( (array) wc()->countries->get_states( $billing_country ) ) : [];
 
-			if ( ! empty( $billing_state ) && count( $valid_states ) && ! in_array( $billing_state, $valid_states, true ) ) {
+			if ( ! $this->validate_state( $billing_state, $billing_country ) ) {
 				$billing_state = '';
 			}
 

--- a/src/StoreApi/Schemas/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/BillingAddressSchema.php
@@ -95,7 +95,7 @@ class BillingAddressSchema extends AbstractAddressSchema {
 		if ( ( $address instanceof \WC_Customer || $address instanceof \WC_Order ) ) {
 			$billing_country = $address->get_billing_country();
 			$billing_state   = $address->get_billing_state();
-			$valid_states    = array_filter( (array) wc()->countries->get_states( $billing_country ) );
+			$valid_states    = $billing_country ? array_filter( (array) wc()->countries->get_states( $billing_country ) ) : [];
 
 			if ( ! empty( $billing_state ) && count( $valid_states ) && ! in_array( $billing_state, $valid_states, true ) ) {
 				$billing_state = '';

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -44,9 +44,8 @@ class ShippingAddressSchema extends AbstractAddressSchema {
 
 			$shipping_country = $address->get_shipping_country();
 			$shipping_state   = $address->get_shipping_state();
-			$valid_states     = $shipping_country ? array_filter( (array) wc()->countries->get_states( $shipping_country ) ) : [];
 
-			if ( ! empty( $shipping_state ) && count( $valid_states ) && ! in_array( $shipping_state, $valid_states, true ) ) {
+			if ( ! $this->validate_state( $shipping_state, $shipping_country ) ) {
 				$shipping_state = '';
 			}
 

--- a/src/StoreApi/Schemas/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/ShippingAddressSchema.php
@@ -44,7 +44,7 @@ class ShippingAddressSchema extends AbstractAddressSchema {
 
 			$shipping_country = $address->get_shipping_country();
 			$shipping_state   = $address->get_shipping_state();
-			$valid_states     = array_filter( (array) wc()->countries->get_states( $shipping_country ) );
+			$valid_states     = $shipping_country ? array_filter( (array) wc()->countries->get_states( $shipping_country ) ) : [];
 
 			if ( ! empty( $shipping_state ) && count( $valid_states ) && ! in_array( $shipping_state, $valid_states, true ) ) {
 				$shipping_state = '';


### PR DESCRIPTION
Reported in #5131, and introduced in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4844:

- if the country is not set for whatever reason, rather than just getting the subset of valid states for a country, `wc()->countries->get_states()` returns the states of all countries keyed by country code. 
- the validation logic was using state names rather than state codes

This avoids the issue by checking if there is a country before getting an array of states, and then doing the validation based on state code.

Closes #5131

### Testing

#5131 has testing steps but these only apply due to a separate bug where billing data is not populated (due to hydration). I tested this only by logging data in the route to ensure correct states were populated.

The validation changes can also be tested by making requests to the API to verify validation is working. First disable nonce checks with:

```php
add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
```

Then add something to cart in your rest api client, e.g. POST to `https://store.local/wp-json/wc/store/cart/add-item` with:

```json
{
	"id": 23,
	"quantity": 1
}
```

Then POST to checkout `https://store.local/wp-json/wc/store/checkout`:

```json
{
	"billing_address": {
		"first_name": "test",
		"last_name": "test",
		"company": "",
		"address_1": "test",
		"address_2": "",
		"city": "test",
		"state": "AL",
		"postcode": "90210",
		"country": "US",
		"phone": ""
	},
	"shipping_address": {
		"first_name": "test",
		"last_name": "test",
		"company": "",
		"address_1": "test",
		"address_2": "",
		"city": "test",
		"state": "INVALID-STATE",
		"postcode": "90210",
		"country": "US",
		"phone": ""
	},
	"payment_method": "bacs",
}
```

Try changing the state and ensure the response shows the parameter error.

### Changelog

> Fix state validation by only validating states in the API if a country is provided, and validating based on the state code.
