### PR TITLE
Add global style for Product Categories List block

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import {
@@ -183,8 +183,12 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 		);
 	};
 
+	const blockProps = useBlockProps( {
+		className: 'wc-block-product-categories',
+	} );
+
 	return (
-		<>
+		<div { ...blockProps }>
 			{ getInspectorControls() }
 			<Disabled>
 				<ServerSideRender
@@ -193,7 +197,7 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 					EmptyResponsePlaceholder={ EmptyPlaceholder }
 				/>
 			</Disabled>
-		</>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -13,6 +13,7 @@ import './style.scss';
 import Block from './block.js';
 
 registerBlockType( 'woocommerce/product-categories', {
+	apiVersion: 2,
 	title: __( 'Product Categories List', 'woo-gutenberg-products-block' ),
 	icon: {
 		src: <Icon srcElement={ list } />,
@@ -27,6 +28,14 @@ registerBlockType( 'woocommerce/product-categories', {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
+		color: {
+			background: false,
+			link: true,
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+		},
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { Icon, list } from '@woocommerce/icons';
 
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 /**
  * Internal dependencies
  */
@@ -28,14 +29,16 @@ registerBlockType( 'woocommerce/product-categories', {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
-		color: {
-			background: false,
-			link: true,
-		},
-		typography: {
-			fontSize: true,
-			lineHeight: true,
-		},
+		...( isFeaturePluginBuild() && {
+			color: {
+				background: false,
+				link: true,
+			},
+			typography: {
+				fontSize: true,
+				lineHeight: true,
+			},
+		} ),
 	},
 	example: {
 		attributes: {

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -84,9 +84,13 @@ class ProductCategories extends AbstractDynamicBlock {
 			}
 		}
 
-		$classes_and_styles = $this->get_container_classes_and_styles( $attributes );
-		$classes            = $classes_and_styles[0];
-		$styles             = $classes_and_styles[1];
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes(
+			$attributes,
+			array( 'line_height', 'text_color', 'font_size' )
+		);
+
+		$classes = $this->get_container_classes( $attributes ) . ' ' . $classes_and_styles['classes'];
+		$styles  = $classes_and_styles['styles'];
 
 		$output  = '<div class="wp-block-woocommerce-product-categories ' . esc_attr( $classes ) . '" style="' . esc_attr( $styles ) . '">';
 		$output .= ! empty( $attributes['isDropdown'] ) ? $this->renderDropdown( $categories, $attributes, $uid ) : $this->renderList( $categories, $attributes, $uid );
@@ -96,12 +100,12 @@ class ProductCategories extends AbstractDynamicBlock {
 	}
 
 	/**
-	 * Get the list of classes and styles to apply to this block.
+	 * Get the list of classes to apply to this block.
 	 *
 	 * @param array $attributes Block attributes. Default empty array.
-	 * @return array space-separated list of classes and space-separated list of inline styles.
+	 * @return string space-separated list of classes.
 	 */
-	protected function get_container_classes_and_styles( $attributes = array() ) {
+	protected function get_container_classes( $attributes = array() ) {
 
 		$classes = array( 'wc-block-product-categories' );
 
@@ -119,30 +123,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			$classes[] = 'is-list';
 		}
 
-		$line_height_class_and_style = StyleAttributesUtils::get_line_height_class_and_style( $attributes );
-		$text_color_class_and_style  = StyleAttributesUtils::get_text_color_class_and_style( $attributes );
-		$font_size_class_and_style   = StyleAttributesUtils::get_font_size_class_and_style( $attributes );
-
-		$line_height_class = isset( $line_height_class_and_style['class'] ) ? $line_height_class_and_style['class'] : null;
-		$text_color_class  = isset( $text_color_class_and_style['class'] ) ? $text_color_class_and_style['class'] : null;
-		$font_size_class   = isset( $font_size_class_and_style['class'] ) ? $font_size_class_and_style['class'] : null;
-
-		$classes = array_filter(
-			array( $line_height_class, $text_color_class, $font_size_class )
-		);
-
-		$line_height_style = isset( $line_height_class_and_style['style'] ) ? $line_height_class_and_style['style'] : null;
-		$text_color_style  = isset( $text_color_class_and_style['style'] ) ? $text_color_class_and_style['style'] : null;
-		$font_size_style   = isset( $font_size_class_and_style['style'] ) ? $font_size_class_and_style['style'] : null;
-
-		$styles = array_filter(
-			array( $line_height_style, $text_color_style, $font_size_style )
-		);
-
-		$string_classes = implode( ' ', $classes );
-		$string_styles  = implode( ' ', $styles );
-
-		return array( $string_classes, $string_styles );
+		return implode( ' ', $classes );
 	}
 
 	/**

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -99,7 +99,7 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * Get the list of classes to apply to this block.
 	 *
 	 * @param array $attributes Block attributes. Default empty array.
-	 * @return array space-separated list of classes.
+	 * @return array space-separated list of classes and space-separated list of inline styles.
 	 */
 	protected function get_container_classes_and_styles( $attributes = array() ) {
 

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -3,7 +3,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
-
 /**
  * ProductCategories class.
  */
@@ -50,7 +49,6 @@ class ProductCategories extends AbstractDynamicBlock {
 				'fontSize'       => $this->get_schema_string(),
 				'lineHeight'     => $this->get_schema_string(),
 				'style'          => array( 'type' => 'object' ),
-
 			)
 		);
 	}
@@ -86,7 +84,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			}
 		}
 
-		$classes_and_styles = $this->get_container_classes( $attributes );
+		$classes_and_styles = $this->get_container_classes_and_styles( $attributes );
 		$classes            = $classes_and_styles[0];
 		$styles             = $classes_and_styles[1];
 
@@ -101,9 +99,9 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * Get the list of classes to apply to this block.
 	 *
 	 * @param array $attributes Block attributes. Default empty array.
-	 * @return string space-separated list of classes.
+	 * @return array space-separated list of classes.
 	 */
-	protected function get_container_classes( $attributes = array() ) {
+	protected function get_container_classes_and_styles( $attributes = array() ) {
 
 		$classes = array( 'wc-block-product-categories' );
 
@@ -130,7 +128,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		$font_size_class   = isset( $font_size_class_and_style['class'] ) ? $font_size_class_and_style['class'] : null;
 
 		$classes = array_filter(
-			[ $line_height_class, $text_color_class, $font_size_class ]
+			array( $line_height_class, $text_color_class, $font_size_class )
 		);
 
 		$line_height_style = isset( $line_height_class_and_style['style'] ) ? $line_height_class_and_style['style'] : null;
@@ -138,7 +136,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		$font_size_style   = isset( $font_size_class_and_style['style'] ) ? $font_size_class_and_style['style'] : null;
 
 		$styles = array_filter(
-			[ $line_height_style, $text_color_style, $font_size_style ]
+			array( $line_height_style, $text_color_style, $font_size_style )
 		);
 
 		$string_classes = implode( ' ', $classes );
@@ -146,8 +144,6 @@ class ProductCategories extends AbstractDynamicBlock {
 
 		return array( $string_classes, $string_styles );
 	}
-
-
 
 	/**
 	 * Get categories (terms) from the db.
@@ -340,12 +336,12 @@ class ProductCategories extends AbstractDynamicBlock {
 
 		$link_color_class_and_style = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
 
-		$link_color_style = $link_color_class_and_style['style'];
+		$link_color_style = isset( $link_color_class_and_style['style'] ) ? $link_color_class_and_style['style'] : '';
 
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
-				<a style="' . esc_attr( $link_color_style ) . '" href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
+					<a style="' . esc_attr( $link_color_style ) . '" href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
 				' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
 				</li>

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -90,7 +90,7 @@ class ProductCategories extends AbstractDynamicBlock {
 		$classes            = $classes_and_styles[0];
 		$styles             = $classes_and_styles[1];
 
-		$output  = '<div class="' . esc_attr( $classes ) . '" style="' . esc_attr( $styles ) . '">';
+		$output  = '<div class="wp-block-woocommerce-product-categories ' . esc_attr( $classes ) . '" style="' . esc_attr( $styles ) . '">';
 		$output .= ! empty( $attributes['isDropdown'] ) ? $this->renderDropdown( $categories, $attributes, $uid ) : $this->renderList( $categories, $attributes, $uid );
 		$output .= '</div>';
 
@@ -338,10 +338,14 @@ class ProductCategories extends AbstractDynamicBlock {
 	protected function renderListItems( $categories, $attributes, $uid, $depth = 0 ) {
 		$output = '';
 
+		$link_color_class_and_style = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
+
+		$link_color_style = $link_color_class_and_style['style'];
+
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
-				<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
+				<a style="' . esc_attr( $link_color_style ) . '" href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
 				' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
 				</li>

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -96,7 +96,7 @@ class ProductCategories extends AbstractDynamicBlock {
 	}
 
 	/**
-	 * Get the list of classes to apply to this block.
+	 * Get the list of classes and styles to apply to this block.
 	 *
 	 * @param array $attributes Block attributes. Default empty array.
 	 * @return array space-separated list of classes and space-separated list of inline styles.

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -1,10 +1,14 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+
+
 /**
  * ProductCategories class.
  */
 class ProductCategories extends AbstractDynamicBlock {
+
 
 	/**
 	 * Block name.
@@ -42,6 +46,11 @@ class ProductCategories extends AbstractDynamicBlock {
 				'hasEmpty'       => $this->get_schema_boolean( false ),
 				'isDropdown'     => $this->get_schema_boolean( false ),
 				'isHierarchical' => $this->get_schema_boolean( true ),
+				'textColor'      => $this->get_schema_string(),
+				'fontSize'       => $this->get_schema_string(),
+				'lineHeight'     => $this->get_schema_string(),
+				'style'          => array( 'type' => 'object' ),
+
 			)
 		);
 	}
@@ -77,9 +86,11 @@ class ProductCategories extends AbstractDynamicBlock {
 			}
 		}
 
-		$classes = $this->get_container_classes( $attributes );
+		$classes_and_styles = $this->get_container_classes( $attributes );
+		$classes            = $classes_and_styles[0];
+		$styles             = $classes_and_styles[1];
 
-		$output  = '<div class="' . esc_attr( $classes ) . '">';
+		$output  = '<div class="' . esc_attr( $classes ) . '" style="' . esc_attr( $styles ) . '">';
 		$output .= ! empty( $attributes['isDropdown'] ) ? $this->renderDropdown( $categories, $attributes, $uid ) : $this->renderList( $categories, $attributes, $uid );
 		$output .= '</div>';
 
@@ -93,6 +104,7 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return string space-separated list of classes.
 	 */
 	protected function get_container_classes( $attributes = array() ) {
+
 		$classes = array( 'wc-block-product-categories' );
 
 		if ( isset( $attributes['align'] ) ) {
@@ -109,8 +121,33 @@ class ProductCategories extends AbstractDynamicBlock {
 			$classes[] = 'is-list';
 		}
 
-		return implode( ' ', $classes );
+		$line_height_class_and_style = StyleAttributesUtils::get_line_height_class_and_style( $attributes );
+		$text_color_class_and_style  = StyleAttributesUtils::get_text_color_class_and_style( $attributes );
+		$font_size_class_and_style   = StyleAttributesUtils::get_font_size_class_and_style( $attributes );
+
+		$line_height_class = isset( $line_height_class_and_style['class'] ) ? $line_height_class_and_style['class'] : null;
+		$text_color_class  = isset( $text_color_class_and_style['class'] ) ? $text_color_class_and_style['class'] : null;
+		$font_size_class   = isset( $font_size_class_and_style['class'] ) ? $font_size_class_and_style['class'] : null;
+
+		$classes = array_filter(
+			[ $line_height_class, $text_color_class, $font_size_class ]
+		);
+
+		$line_height_style = isset( $line_height_class_and_style['style'] ) ? $line_height_class_and_style['style'] : null;
+		$text_color_style  = isset( $text_color_class_and_style['style'] ) ? $text_color_class_and_style['style'] : null;
+		$font_size_style   = isset( $font_size_class_and_style['style'] ) ? $font_size_class_and_style['style'] : null;
+
+		$styles = array_filter(
+			[ $line_height_style, $text_color_style, $font_size_style ]
+		);
+
+		$string_classes = implode( ' ', $classes );
+		$string_styles  = implode( ' ', $styles );
+
+		return array( $string_classes, $string_styles );
 	}
+
+
 
 	/**
 	 * Get categories (terms) from the db.
@@ -304,8 +341,8 @@ class ProductCategories extends AbstractDynamicBlock {
 		foreach ( $categories as $category ) {
 			$output .= '
 				<li class="wc-block-product-categories-list-item">
-					<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
-					' . $this->getCount( $category, $attributes ) . '
+				<a href="' . esc_attr( get_term_link( $category->term_id, 'product_cat' ) ) . '">' . $this->get_image_html( $category, $attributes ) . esc_html( $category->name ) . '</a>
+				' . $this->getCount( $category, $attributes ) . '
 					' . ( ! empty( $category->children ) ? $this->renderList( $category->children, $attributes, $uid, $depth + 1 ) : '' ) . '
 				</li>
 			';

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -76,6 +76,41 @@ class StyleAttributesUtils {
 
 	}
 
+	/**
+	 * Get class and style for link-color from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_link_color_class_and_style( $attributes ) {
+
+		if ( ! isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
+			return null;
+		};
+
+		$link_color = $attributes['style']['elements']['link']['color']['text'];
+
+		// If the link color is selected from the theme color picker, the value of $link_color is var:preset|color|slug.
+		// If the link color is selected from the core color picker, the value of $link_color is an hex value.
+		// When the link color is a string var:preset|color|slug we parsed it for get the slug, otherwise we use the hex value.
+		$index_named_link_color = strrpos( $link_color, '|' );
+
+		if ( ! empty( $index_named_link_color ) ) {
+			$parsed_named_link_color = substr( $link_color, $index_named_link_color + 1 );
+			return array(
+				'class' => null,
+				'style' => sprintf( 'color: %s;', $parsed_named_link_color ),
+			);
+		} else {
+			return array(
+				'class' => null,
+				'style' => sprintf( 'color: %s;', $link_color ),
+			);
+		}
+
+	}
+
 
 	/**
 	 * Get class and style for line height from attributes.
@@ -112,6 +147,7 @@ class StyleAttributesUtils {
 			line_height => self::get_line_height_class_and_style( $attributes ),
 			text_color  => self::get_text_color_class_and_style( $attributes ),
 			font_size   => self::get_font_size_class_and_style( $attributes ),
+			link_color  => self::get_link_color_class_and_style( $attributes ),
 		);
 
 		return array_filter(

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -17,7 +17,7 @@ class StyleAttributesUtils {
 
 		$font_size = $attributes['fontSize'];
 
-		$custom_font_size = isset( $attributes['style']['color']['fontSize'] ) ? $attributes['style']['color']['fontSize'] : null;
+		$custom_font_size = isset( $attributes['style']['typography']['fontSize'] ) ? $attributes['style']['typography']['fontSize'] : null;
 
 		if ( ! isset( $font_size ) && ! isset( $custom_font_size ) ) {
 			return null;
@@ -117,7 +117,7 @@ class StyleAttributesUtils {
 	 */
 	public static function get_line_height_class_and_style( $attributes ) {
 
-		$line_height = isset( $attributes['style']['color']['lineHeight'] ) ? $attributes['style']['color']['lineHeight'] : null;
+		$line_height = isset( $attributes['style']['typography']['lineHeight'] ) ? $attributes['style']['typography']['lineHeight'] : null;
 
 		if ( ! isset( $line_height ) ) {
 			return null;
@@ -135,10 +135,11 @@ class StyleAttributesUtils {
 	 * Get classes and styles from attributes.
 	 *
 	 * @param array $attributes Block attributes.
+	 * @param array $properties Properties to get classes/styles from.
 	 *
 	 * @return array
 	 */
-	public static function get_classes_and_styles_by_attributes( $attributes ) {
+	public static function get_classes_and_styles_by_attributes( $attributes, $properties = array() ) {
 		$classes_and_styles = array(
 			'line_height' => self::get_line_height_class_and_style( $attributes ),
 			'text_color'  => self::get_text_color_class_and_style( $attributes ),
@@ -146,8 +147,64 @@ class StyleAttributesUtils {
 			'link_color'  => self::get_link_color_class_and_style( $attributes ),
 		);
 
-		return array_filter(
+		if ( ! empty( $properties ) ) {
+			foreach ( $classes_and_styles as $key => $value ) {
+				if ( ! in_array( $key, $properties, true ) ) {
+					unset( $classes_and_styles[ $key ] );
+				}
+			}
+		}
+
+		$classes_and_styles = array_filter( $classes_and_styles );
+
+		$classes = array_map(
+			function( $item ) {
+				return $item['class'];
+			},
 			$classes_and_styles
 		);
+
+		$styles = array_map(
+			function( $item ) {
+				return $item['style'];
+			},
+			$classes_and_styles
+		);
+
+		$classes = array_filter( $classes );
+		$styles  = array_filter( $styles );
+
+		return array(
+			'classes' => implode( ' ', $classes ),
+			'styles'  => implode( ' ', $styles ),
+		);
+	}
+
+	/**
+	 * Get space-separated classes from block attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @param array $properties Properties to get classes from.
+	 *
+	 * @return string Space-separated classes.
+	 */
+	public static function get_classes_by_attributes( $attributes, $properties = array() ) {
+		$classes_and_styles = self::get_classes_and_styles_by_attributes( $attributes, $properties );
+
+		return $classes_and_styles['classes'];
+	}
+
+	/**
+	 * Get space-separated style rules from block attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @param array $properties Properties to get styles from.
+	 *
+	 * @return string Space-separated style rules.
+	 */
+	public static function get_styles_by_attributes( $attributes, $properties = array() ) {
+		$classes_and_styles = self::get_classes_and_styles_by_attributes( $attributes, $properties );
+
+		return $classes_and_styles['styles'];
 	}
 }

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -1,0 +1,124 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+/**
+ * StyleAttributesUtils class used for getting class and style from attributes.
+ */
+class StyleAttributesUtils {
+
+
+	/**
+	 * Get class and style for font-size from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_font_size_class_and_style( $attributes ) {
+
+		$font_size = $attributes['fontSize'];
+
+		$custom_font_size = isset( $attributes['style']['color']['fontSize'] ) ? $attributes['style']['color']['fontSize'] : null;
+
+		if ( ! isset( $font_size ) && ! isset( $custom_font_size ) ) {
+			return null;
+		};
+
+		$has_named_font_size  = ! empty( $font_size );
+		$has_custom_font_size = isset( $custom_font_size );
+
+		if ( $has_named_font_size ) {
+			return array(
+				'class' => sprintf( 'has-font-size has-%s-font-size', $font_size ),
+				'style' => null,
+			);
+		} elseif ( $has_custom_font_size ) {
+			return array(
+				'class' => null,
+				'style' => sprintf( 'font-size: %s;', $custom_font_size ),
+			);
+		}
+		return null;
+	}
+
+	/**
+	 * Get class and style for text-color from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_text_color_class_and_style( $attributes ) {
+
+		$text_color = $attributes['textColor'];
+
+		$custom_text_color = isset( $attributes['style']['color']['text'] ) ? $attributes['style']['color']['text'] : null;
+
+		if ( ! isset( $text_color ) && ! isset( $custom_text_color ) ) {
+			return null;
+		};
+
+		$has_named_text_color  = ! empty( $text_color );
+		$has_custom_text_color = isset( $custom_text_color );
+
+		if ( $has_named_text_color ) {
+			return array(
+				'class' => sprintf( 'has-text-color has-%s-color', $text_color ),
+				'style' => null,
+			);
+		} elseif ( $has_custom_text_color ) {
+			return array(
+				'class' => null,
+				'style' => sprintf( 'color: %s;', $custom_text_color ),
+			);
+		}
+		return null;
+
+	}
+
+
+	/**
+	 * Get class and style for line height from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_line_height_class_and_style( $attributes ) {
+
+		$line_height = isset( $attributes['style']['color']['lineHeight'] ) ? $attributes['style']['color']['lineHeight'] : null;
+
+		if ( ! isset( $line_height ) ) {
+			return null;
+		};
+
+		$line_height_style = sprintf( 'line-height: %s;', $line_height );
+
+		return array(
+			'class' => null,
+			'style' => $line_height_style,
+		);
+	}
+
+	/**
+	 * Get classes and styles from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return array
+	 */
+	public static function get_classes_and_styles_by_attributes( $attributes ) {
+		$classes_and_styles = array(
+			line_height => self::get_line_height_class_and_style( $attributes ),
+			text_color  => self::get_text_color_class_and_style( $attributes ),
+			font_size   => self::get_font_size_class_and_style( $attributes ),
+		);
+
+		return array_filter(
+			$classes_and_styles
+		);
+
+	}
+
+
+}

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -6,7 +6,6 @@ namespace Automattic\WooCommerce\Blocks\Utils;
  */
 class StyleAttributesUtils {
 
-
 	/**
 	 * Get class and style for font-size from attributes.
 	 *
@@ -73,7 +72,6 @@ class StyleAttributesUtils {
 			);
 		}
 		return null;
-
 	}
 
 	/**
@@ -108,9 +106,7 @@ class StyleAttributesUtils {
 				'style' => sprintf( 'color: %s;', $link_color ),
 			);
 		}
-
 	}
-
 
 	/**
 	 * Get class and style for line height from attributes.
@@ -144,17 +140,14 @@ class StyleAttributesUtils {
 	 */
 	public static function get_classes_and_styles_by_attributes( $attributes ) {
 		$classes_and_styles = array(
-			line_height => self::get_line_height_class_and_style( $attributes ),
-			text_color  => self::get_text_color_class_and_style( $attributes ),
-			font_size   => self::get_font_size_class_and_style( $attributes ),
-			link_color  => self::get_link_color_class_and_style( $attributes ),
+			'line_height' => self::get_line_height_class_and_style( $attributes ),
+			'text_color'  => self::get_text_color_class_and_style( $attributes ),
+			'font_size'   => self::get_font_size_class_and_style( $attributes ),
+			'link_color'  => self::get_link_color_class_and_style( $attributes ),
 		);
 
 		return array_filter(
 			$classes_and_styles
 		);
-
 	}
-
-
 }


### PR DESCRIPTION
This is a part of #4965.

This PR:

- Adds text color support
- Adds link color support (WIP)
- Adds option to change font size (works but there is a problem)
- Adds option to change line-height

### What missing

#### Link color support

~The link color support doesn't work with theme colors. We are investigating this problem (internal discussion `p1636652209321000-slack-C02FL3X7KR6`)~

With `useBlockProps` hook, I managed to make link color work 👍 

#### Font size 

~When the user changes the font size, the updated block is not rendered. We are investigating this problem (internal discussion `p1636643690311900-slack-C02FL3X7KR6`)~

~When the user changes the font size from the post/page editor everything works correctly. It seems that it doesn't work when the user changes the font size from the site editor (the font size is not applied to any element on the page)~

With the last version of Gutenberg, I'm not able to reproduce this problem 👍 



<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

![image](https://user-images.githubusercontent.com/4463174/141459762-1304417f-37ad-4684-88f5-697bb2f3678f.png)
*before - editor*
![image](https://user-images.githubusercontent.com/4463174/141459915-692400e8-e0ce-4be7-8cb1-c93e71c6f330.png)
*before - page*


![image](https://user-images.githubusercontent.com/4463174/141459386-1dd574ce-7b14-4d63-b69e-f962107e8cb5.png)
*current implementation - new options in the editor*
![image](https://user-images.githubusercontent.com/4463174/141459549-6b967deb-7153-4c61-abeb-d8a8f636bf78.png)
*current implementation - new options in the editor*


![image](https://user-images.githubusercontent.com/4463174/141459623-c5d5f137-98f1-4835-b466-0cf8a23ff9a0.png)
*current implementation - block with custom styles*

### Testing


### Manual Testing

How to test the changes in this PR:

Check out this branch:

1. Install and enable `Gutenberg` plugin
2. Install and enable `TT1 Blocks` theme
3. Add the All Product Categories list block to a post
4. Verify you can change the text color, font size, and line-height
5. Save
6. Go on the page and check if there are changes
7. Reset to default
8. Go to admin panel and click `Site Editor` 
9. Click on the Global styles icon 
10. Verify the Product Categories List block is shown and you can tweak its styles
11. Save 
12. Go on the page created earlier and check if all styles are applied correctly
10. Edit previous post/page again
11. Change again text color, font size, and line-height
12. Save
13. Check if these styles have priority over the styles from the Site editor.




### Changelog

> Added global styles (text color, link color, line height, and font size) to the Product Title block.
