### PR TITLE
Add version to doing it wrong calls

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -107,7 +107,7 @@ abstract class AbstractBlock {
 	 */
 	protected function initialize() {
 		if ( empty( $this->block_name ) ) {
-			_doing_it_wrong( __METHOD__, esc_html( __( 'Block name is required.', 'woo-gutenberg-products-block' ) ), '4.5.0' );
+			_doing_it_wrong( __METHOD__, esc_html__( 'Block name is required.', 'woo-gutenberg-products-block' ), '4.5.0' );
 			return false;
 		}
 		$this->integration_registry->initialize( $this->block_name . '_block' );

--- a/src/Integrations/IntegrationRegistry.php
+++ b/src/Integrations/IntegrationRegistry.php
@@ -32,7 +32,7 @@ class IntegrationRegistry {
 		}
 
 		if ( empty( $this->registry_identifier ) ) {
-			_doing_it_wrong( __METHOD__, esc_html( __( 'Integration registry requires an identifier.', 'woo-gutenberg-products-block' ) ) );
+			_doing_it_wrong( __METHOD__, esc_html__( 'Integration registry requires an identifier.', 'woo-gutenberg-products-block' ), '4.6.0' );
 			return false;
 		}
 
@@ -64,7 +64,7 @@ class IntegrationRegistry {
 
 		if ( $this->is_registered( $name ) ) {
 			/* translators: %s: Integration name. */
-			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( '"%s" is already registered.', 'woo-gutenberg-products-block' ), $name ) ) );
+			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( '"%s" is already registered.', 'woo-gutenberg-products-block' ), $name ) ), '4.6.0' );
 			return false;
 		}
 
@@ -95,7 +95,7 @@ class IntegrationRegistry {
 
 		if ( ! $this->is_registered( $name ) ) {
 			/* translators: %s: Integration name. */
-			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Integration "%s" is not registered.', 'woo-gutenberg-products-block' ), $name ) ) );
+			_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Integration "%s" is not registered.', 'woo-gutenberg-products-block' ), $name ) ), '4.6.0' );
 			return false;
 		}
 


### PR DESCRIPTION
Some environments report an error when `_doing_it_wrong` is called without a `$version`. This PR adds a version to each call to mitigate. 

Fixes #5074

I used `4.6.0` for the missing versions which was the version [this PR was part of which last touched them](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3829).

### Testing

These are only triggered by integrations that are doing something wrong, so there is nothing user-facing to test here and just requires code review.
