### PR TITLE
Make order note block removable

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
@@ -19,7 +19,7 @@
 		"lock": {
 			"type": "object",
 			"default": {
-				"remove": true,
+				"remove": false,
 				"move": true
 			}
 		}

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/block.json
@@ -8,8 +8,7 @@
 		"align": false,
 		"html": false,
 		"multiple": false,
-		"reusable": false,
-		"inserter": false
+		"reusable": false
 	},
 	"attributes": {
 		"className": {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Order Note block was introduced as locked in Checkout i2. Originally, it was shown via a settings, this PR makes the block removable so it can be removed just like the settings based option.
<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5121

### Manual Testing

How to test the changes in this Pull Request:

1. Insert Checkout block.
2. Remove Order note block. It should not be added back, save.
3. On frontend, you should not see teh block.

### Changelog

> Fix an issue in which merchants couldn't remove Order Note block.
