### PR TITLE
Move Checkout i1 -> i2 migration code to registerBlockType 

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/index.tsx
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { Icon, fields } from '@woocommerce/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+import { BlockInstance, createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -46,6 +47,92 @@ const settings = {
 							attributes.className
 						) }
 					/>
+				);
+			},
+			migrate: ( attributes: {
+				showOrderNotes: boolean;
+				showPolicyLinks: boolean;
+				showReturnToCart: boolean;
+				cartPageId: number;
+			} ) => {
+				const {
+					showOrderNotes,
+					showPolicyLinks,
+					showReturnToCart,
+					cartPageId,
+				} = attributes;
+				return [
+					attributes,
+					[
+						createBlock(
+							'woocommerce/checkout-fields-block',
+							{},
+							[
+								createBlock(
+									'woocommerce/checkout-express-payment-block',
+									{},
+									[]
+								),
+								createBlock(
+									'woocommerce/checkout-contact-information-block',
+									{},
+									[]
+								),
+								createBlock(
+									'woocommerce/checkout-shipping-address-block',
+									{},
+									[]
+								),
+								createBlock(
+									'woocommerce/checkout-billing-address-block',
+									{},
+									[]
+								),
+								createBlock(
+									'woocommerce/checkout-shipping-methods-block',
+									{},
+									[]
+								),
+								createBlock(
+									'woocommerce/checkout-payment-block',
+									{},
+									[]
+								),
+								showOrderNotes
+									? createBlock(
+											'woocommerce/checkout-order-note-block',
+											{},
+											[]
+									  )
+									: false,
+								showPolicyLinks
+									? createBlock(
+											'woocommerce/checkout-terms-block',
+											{},
+											[]
+									  )
+									: false,
+								createBlock(
+									'woocommerce/checkout-actions-block',
+									{
+										showReturnToCart,
+										cartPageId,
+									},
+									[]
+								),
+							].filter( Boolean ) as BlockInstance[]
+						),
+						createBlock( 'woocommerce/checkout-totals-block', {} ),
+					],
+				];
+			},
+			isEligible: (
+				attributes: Record< string, unknown >,
+				innerBlocks: BlockInstance[]
+			) => {
+				return ! innerBlocks.some(
+					( block: { name: string } ) =>
+						block.name === 'woocommerce/checkout-fields-block'
 				);
 			},
 		},

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -10,10 +10,7 @@ import type { TemplateArray } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import {
-	useCheckoutBlockControlsContext,
-	useCheckoutBlockContext,
-} from '../../context';
+import { useCheckoutBlockControlsContext } from '../../context';
 import { useForcedLayout, getAllowedBlocks } from '../../../shared';
 import './style.scss';
 
@@ -32,12 +29,6 @@ export const Edit = ( {
 			attributes?.className
 		),
 	} );
-	const {
-		showOrderNotes,
-		showPolicyLinks,
-		showReturnToCart,
-		cartPageId,
-	} = useCheckoutBlockContext();
 	const allowedBlocks = getAllowedBlocks( innerBlockAreas.CHECKOUT_FIELDS );
 
 	const {
@@ -51,20 +42,9 @@ export const Edit = ( {
 		[ 'woocommerce/checkout-billing-address-block', {}, [] ],
 		[ 'woocommerce/checkout-shipping-methods-block', {}, [] ],
 		[ 'woocommerce/checkout-payment-block', {}, [] ],
-		showOrderNotes
-			? [ 'woocommerce/checkout-order-note-block', {}, [] ]
-			: false,
-		showPolicyLinks
-			? [ 'woocommerce/checkout-terms-block', {}, [] ]
-			: false,
-		[
-			'woocommerce/checkout-actions-block',
-			{
-				showReturnToCart,
-				cartPageId,
-			},
-			[],
-		],
+		[ 'woocommerce/checkout-order-note-block', {}, [] ],
+		[ 'woocommerce/checkout-terms-block', {}, [] ],
+		[ 'woocommerce/checkout-actions-block', {}, [] ],
 	].filter( Boolean ) as unknown ) as TemplateArray;
 
 	useForcedLayout( {

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -97,8 +97,8 @@ class Checkout extends AbstractBlock {
 					<div data-block-name="woocommerce/checkout-billing-address-block" class="wp-block-woocommerce-checkout-billing-address-block"></div>
 					<div data-block-name="woocommerce/checkout-shipping-methods-block" class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
 					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>' .
-					( false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
-					( false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
+					( isset( $attributes['showOrderNotes'] ) && false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
+					( isset( $attributes['showPolicyLinks'] ) && false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
 					'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
 				</div>
 				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -96,10 +96,10 @@ class Checkout extends AbstractBlock {
 					<div data-block-name="woocommerce/checkout-shipping-address-block" class="wp-block-woocommerce-checkout-shipping-address-block"></div>
 					<div data-block-name="woocommerce/checkout-billing-address-block" class="wp-block-woocommerce-checkout-billing-address-block"></div>
 					<div data-block-name="woocommerce/checkout-shipping-methods-block" class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
-					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>
-					<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>
-					<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>
-					<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
+					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>' .
+					( $attributes['showOrderNotes'] ? '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' : '' ) .
+					( $attributes['showOrderNotes'] ? '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' : '' ) .
+					'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
 				</div>
 				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">
 					<div data-block-name="woocommerce/checkout-order-summary-block" class="wp-block-woocommerce-checkout-order-summary-block"></div>

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -97,8 +97,8 @@ class Checkout extends AbstractBlock {
 					<div data-block-name="woocommerce/checkout-billing-address-block" class="wp-block-woocommerce-checkout-billing-address-block"></div>
 					<div data-block-name="woocommerce/checkout-shipping-methods-block" class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
 					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>' .
-					( $attributes['showOrderNotes'] ? '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' : '' ) .
-					( $attributes['showOrderNotes'] ? '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' : '' ) .
+					( false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
+					( false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
 					'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
 				</div>
 				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">


### PR DESCRIPTION
This issue was spun from #5139

We had some Checkout i1 -> i2 related logic in edit.js, this could be a confusing given it's migration related only, so I moved the code to `registerBlockType`, `migrate` function allows us to do just that.

I also respected some attributes in frontend so Order Note and Terms blocks are not force shown on frontend if the settings are false.

### Testing

1. Checkout an old tag `git checkout v5.9.1-dev`
2. Insert two pages of Checkout:
    1. "Checkout", don't change any attributes, leave as is.
    2. "Checkout - modified" change attributes like show order note (to false) and show policy (to false). Save both.
3. Checkout this branch and build.
4. Visit "Checkout" on frontend, you should see the terms and condition block, the order note block.
5. Visit "Checkout - modified" on frontend, you should not see the terms and order note blocks.
6. Visit "Checkout" on the editor, it should be a Checkout i2 now, with terms and order note blocks present.
7. Visit "Checkout - modified" on the editor, it should be a Checkout i2 now, with terms and order note removed, you can insert them.
