### PR TITLE
[Experiment] Try to memoize/cache filter results so that we don't call third party filters too often

### DIFF
--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -86,6 +86,21 @@ const getCheckoutFilters = ( filterName: string ): CheckoutFilterFunction[] => {
 	return filters;
 };
 
+const cachedFilterRuns: Record<
+	string,
+	Record< 'arg' | 'extensions', unknown >
+> = {};
+
+const updatePreviousFilterRun = (
+	filterName: string,
+	arg: CheckoutFilterArguments,
+	extensions: Record< string, unknown > | null
+): void => {
+	cachedFilterRuns[ filterName ] = {
+		arg,
+		extensions,
+	};
+};
 /**
  * Apply a filter.
  */

--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -5,6 +5,8 @@ import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import deprecated from '@wordpress/deprecated';
+import isShallowEqual, { ComparableObject } from '@wordpress/is-shallow-equal';
+import { isObject, objectHasProp } from '@woocommerce/types';
 
 /**
  * A function that always return true.
@@ -120,6 +122,41 @@ const checkMembersShallowEqual = <
 			)
 		);
 	} );
+
+const shouldReRunFilters = (
+	filterName: string,
+	arg: CheckoutFilterArguments,
+	extensions: Record< string, unknown > | null
+): boolean => {
+	const previousFilterRun = cachedFilterRuns[ filterName ];
+
+	if ( ! previousFilterRun ) {
+		// This is the first time the filter is running so let it continue;
+		updatePreviousFilterRun( filterName, arg, extensions );
+		return true;
+	}
+	const {
+		arg: previousArg = {},
+		extensions: previousExtensions = {},
+	} = previousFilterRun;
+
+	// Check length of arg and previousArg, and that all keys are present in both arg and previousArg
+	const argIsEqual = checkMembersShallowEqual( arg, previousArg );
+	if ( ! argIsEqual ) {
+		updatePreviousFilterRun( filterName, arg, extensions );
+		return true;
+	}
+
+	const extensionsIsEqual = checkMembersShallowEqual(
+		extensions,
+		previousExtensions
+	);
+	if ( ! extensionsIsEqual ) {
+		updatePreviousFilterRun( filterName, arg, extensions );
+		return true;
+	}
+	return false;
+};
 
 /**
  * Apply a filter.

--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -204,7 +204,7 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 	return useMemo( () => {
 		if (
 			! shouldReRunFilters( filterName, arg, extensions ) &&
-			cachedValues.current[ filterName ]
+			cachedValues.current[ filterName ] !== undefined
 		) {
 			return cachedValues.current[ filterName ];
 		}

--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import deprecated from '@wordpress/deprecated';
@@ -179,9 +179,16 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 	/** Function that needs to return true when the filtered value is passed in order for the filter to be applied. */
 	validation?: ( value: T ) => true | Error;
 } ): T => {
-	return useMemo( () => {
-		const filters = getCheckoutFilters( filterName );
+	const cachedValues = useRef< Record< string, T > >( {} );
 
+	return useMemo( () => {
+		if (
+			! shouldReRunFilters( filterName, arg, extensions ) &&
+			cachedValues.current[ filterName ]
+		) {
+			return cachedValues.current[ filterName ];
+		}
+		const filters = getCheckoutFilters( filterName );
 		let value = defaultValue;
 		filters.forEach( ( filter ) => {
 			try {
@@ -209,6 +216,7 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 				}
 			}
 		} );
+		cachedValues.current[ filterName ] = value;
 		return value;
 	}, [ filterName, defaultValue, extensions, arg, validation ] );
 };

--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -101,6 +101,26 @@ const updatePreviousFilterRun = (
 		extensions,
 	};
 };
+const checkMembersShallowEqual = <
+	T extends Record< string, unknown >,
+	U extends Record< string, unknown >
+>(
+	a: T,
+	b: U
+) =>
+	isObject( a ) &&
+	isObject( b ) &&
+	Object.keys( a ).length === Object.keys( b ).length &&
+	Object.keys( a ).every( ( aKey ) => {
+		return (
+			objectHasProp( b, aKey ) &&
+			isShallowEqual(
+				a[ aKey ] as ComparableObject,
+				b[ aKey ] as ComparableObject
+			)
+		);
+	} );
+
 /**
  * Apply a filter.
  */


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR was created while investigating #5000. 
Our code runs third party filters every time the cart rerenders. We do memoize this, but unfortunately we often get a cache miss due to the arguments being passed to the filters being objects (`cart`, `cartItem` and any arbitrary data added by extensions to `extensions`) - I think this causes an equality check to fail which means memoization doesn't work perfectly.

This PR ensures the functions registered for a filter only run once if the previous values passed to it are the same.

I took a more 'general' approach to solving this problem as I feel that we should not be prescriptive about what data will be passed to the filter in `arg`. This is because, depending on the filter, different data will be passed. Keeping track of what data we pass to every filter will be difficult to maintain, so a solution that works with any data in `arg` was preferred.

To summarise the changes:
- I added a `checkMembersShallowEqual` function which checks an object against another to see if their members are shallowly equal. It's a deep equality function that stops at depth 1 basically.
- Each time a filter is run, the values it was called with: `filterName`, `arg`, and `extensions` are cached. The next time the same filter is run, a check is made against the current values and previous values is done. If they are the same then the third party filters don't run. This check is done in `shouldReRunFilters`.
- I added `updatePreviousFilterRun` to prevent duplication of code.
- Cached the _result_ of each filter in a ref, this is to keep the variable in scope of the `__experimentalApplyCheckoutFilter` function.

<!-- Reference any related issues or PRs here -->
Relates to #5000

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

**IN TRUNK**
1. Check out trunk, add this code somewhere that will be executed
```js
let nameCalls = 0;
let priceCalls = 0;
__experimentalRegisterCheckoutFilters( 'my-text-extension', {
		itemName: ( name, arg, extensions ) => {
			nameCalls++;
			console.log( 'itemName filter:', nameCalls );
			return `${ name } + extra data!`;
		},
		cartItemPrice: ( name, arg, extensions ) => {
			priceCalls++;
			console.log( 'cartItemPrice filter:', priceCalls );
			return `${ name } + extra data!`;
		},
	} );
```
2. Add items to cart, and visit the Cart block.
3. Change the quantity of an item, notice that the console logs for both filters get called 22 times!
4. Go to the Checkout block, fill in some details. (Keep note of what you fill in so you can compare properly) - note how many times the filters get executed.

**ON THIS BRANCH**
1. Do the same steps, but notice how many fewer times the filters get executed.


### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [x] See steps below.

These instructions use WooCommerce Subscriptions as this is known to use several filters in different places.

1. Install WooCommerce Subscriptions and create a subscription product.
2. Add it to the cart.
3. Go to the Cart block and ensure it shows the details of the subscription product correctly:
![image](https://user-images.githubusercontent.com/5656702/141823330-a2eb8c95-2c65-473a-a3bf-bf9759e261d9.png)
4. Ensure you can still successfully check out and you are charged the amount you expect to be based on the item price in the database, what is displayed in the Cart block and what is displayed in the Checkout block.


<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
This will improve performance when a store has an extension that uses filters active.

### Changelog

>Improve performance of the Checkout and Cart blocks for stores using extensions make use of checkout filters.