### PR TITLE
Fix: use custom compatibility notice style

### DIFF
--- a/assets/js/editor-components/compatibility-notices/cart-checkout-compatibility-notice.tsx
+++ b/assets/js/editor-components/compatibility-notices/cart-checkout-compatibility-notice.tsx
@@ -28,7 +28,7 @@ export function CartCheckoutCompatibilityNotice( {
 
 	return (
 		<Guide
-			className="edit-post-welcome-guide"
+			className="wc-block-welcome-guide"
 			contentLabel={ __(
 				'Compatibility notice',
 				'woo-gutenberg-products-block'
@@ -40,13 +40,13 @@ export function CartCheckoutCompatibilityNotice( {
 					image: <WooImage />,
 					content: (
 						<>
-							<h1 className="edit-post-welcome-guide__heading">
+							<h1 className="wc-block-welcome-guide__heading">
 								{ __(
 									'Compatibility notice',
 									'woo-gutenberg-products-block'
 								) }
 							</h1>
-							<p className="edit-post-welcome-guide__text">
+							<p className="wc-block-welcome-guide__text">
 								{ createInterpolateElement(
 									__(
 										'This block may not be compatible with <em>all</em> checkout extensions and integrations.',
@@ -57,7 +57,7 @@ export function CartCheckoutCompatibilityNotice( {
 									}
 								) }
 							</p>
-							<p className="edit-post-welcome-guide__text">
+							<p className="wc-block-welcome-guide__text">
 								{ createInterpolateElement(
 									__(
 										'We recommend reviewing our <a>expanding list</a> of compatible extensions prior to using this block on a live store.',

--- a/assets/js/editor-components/compatibility-notices/style.scss
+++ b/assets/js/editor-components/compatibility-notices/style.scss
@@ -1,0 +1,31 @@
+.wc-block-welcome-guide {
+	width: 312px;
+
+	&.components-modal__frame.components-guide {
+		height: auto;
+	}
+
+	&__image {
+		background: #00a0d2;
+		margin: 0 0 $gap;
+	}
+
+	&__heading {
+		font-size: 24px;
+		line-height: 1.4;
+		margin: $gap 0;
+		padding: 0 $gap-large;
+	}
+
+	&__text {
+		font-size: 13px;
+		line-height: 1.4;
+		margin: 0 0 $gap-large;
+		padding: 0 $gap-large;
+	}
+
+	&__inserter-icon {
+		margin: 0 4px;
+		vertical-align: text-top;
+	}
+}

--- a/assets/js/editor-components/compatibility-notices/woo-image.js
+++ b/assets/js/editor-components/compatibility-notices/woo-image.js
@@ -1,6 +1,6 @@
 const WooImage = ( props ) => (
 	<div
-		className="edit-post-welcome-guide__image edit-post-welcome-guide__image__prm-np"
+		className="wc-block-welcome-guide__image"
 		style={ {
 			display: 'flex',
 			justifyContent: 'center',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #4954

The reason for the styling issue is the style for the compatibility notice is loaded in the Site Editor. This PR fixes that issue by adding custom style for our compatibility notice, so it can work in both post editor and site editor.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img src="https://user-images.githubusercontent.com/5423135/141930747-0b7a5a17-f07c-4dc0-b810-326542ad5f33.png">
	<td><img src="https://user-images.githubusercontent.com/5423135/141930857-3542a618-d603-4b4b-a8ee-75bb1b52cf0d.png">

</table>

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Remove the localStorage key to display the compatibility notice by opening the browser console and running this code `localStorage.removeItem('wc-blocks_dismissed_compatibility_notices')`.
2. Remove Mini Cart block from the homepage if it's added before.
3. Go to the Site Editor. Add Mini Cart block to the header.
4. See the notice styled correctly.
5. Don't dismiss the notice, close the Site Editor without saving. Edit or add a new page, edit the page using post blocks editor.
6. Add the Mini Cart block to the page.
7. See the notice styled correctly and match the notice in the Site Editor.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above
