### PR TITLE
Re-add experimental discounts meta slot to checkout

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
@@ -14,6 +14,7 @@ import {
 	TotalsTaxes,
 	ExperimentalOrderMeta,
 	TotalsWrapper,
+	ExperimentalDiscountsMeta,
 } from '@woocommerce/blocks-checkout';
 
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
@@ -90,6 +91,7 @@ const Block = ( {
 					/>
 				</TotalsWrapper>
 			) }
+			<ExperimentalDiscountsMeta.Slot { ...slotFillProps } />
 			{ ! getSetting( 'displayCartPricesIncludingTax', false ) &&
 				parseInt( cartTotals.total_tax, 10 ) > 0 && (
 					<TotalsWrapper>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
It seems the  `<ExperimentalDiscountsMeta.Slot { ...discountsSlotFillProps } />` was removed from the Checkout Order Summary.

This breaks the Points and Rewards integration.

cc @layoutd thanks for reporting this :)

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Install WooCommerce Points and Rewards, go to `WooCommerce > Points and Rewards` and add points to your user.
2. Go to `WooCommerce > Points and Rewards > Settings` and enable "Allow partial redemption"
3. Go to Cart and see the input to redeem points is showing
4. Go to Checkout and see that the same input shows in the order summary sidebar.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above
