### PR TITLE
Add `totalDescription` filter to cart/checkout totals component

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/index.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import {
 	__experimentalApplyCheckoutFilter,
 	TotalsItem,
+	mustContain,
 } from '@woocommerce/blocks-checkout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { getSetting } from '@woocommerce/settings';
@@ -37,34 +38,46 @@ const TotalsFooterItem = ( { currency, values } ) => {
 
 	const parsedTaxValue = parseInt( totalTax, 10 );
 
+	const TaxLabel = ( SHOW_TAXES && parsedTaxValue !== 0 && (
+		<p className="wc-block-components-totals-footer-item-tax">
+			{ createInterpolateElement(
+				__(
+					'Including <TaxAmount/> in taxes',
+					'woo-gutenberg-products-block'
+				),
+				{
+					TaxAmount: (
+						<FormattedMonetaryAmount
+							className="wc-block-components-totals-footer-item-tax-value"
+							currency={ currency }
+							value={ parsedTaxValue }
+						/>
+					),
+				}
+			) }
+		</p>
+	) ) || <></>;
+
+	const filteredTotalDescription = createInterpolateElement(
+		__experimentalApplyCheckoutFilter( {
+			filterName: 'totalDescription',
+			defaultValue: __( '<TaxLabel/>', 'woo-gutenberg-products-block' ),
+			extensions: cart.extensions,
+			arg: { cart },
+			validation: ( value ) => mustContain( value, '<TaxLabel/>' ),
+		} ),
+		{
+			TaxLabel,
+		}
+	);
+
 	return (
 		<TotalsItem
 			className="wc-block-components-totals-footer-item"
 			currency={ currency }
 			label={ label }
 			value={ parseInt( totalPrice, 10 ) }
-			description={
-				SHOW_TAXES &&
-				parsedTaxValue !== 0 && (
-					<p className="wc-block-components-totals-footer-item-tax">
-						{ createInterpolateElement(
-							__(
-								'Including <TaxAmount/> in taxes',
-								'woo-gutenberg-products-block'
-							),
-							{
-								TaxAmount: (
-									<FormattedMonetaryAmount
-										className="wc-block-components-totals-footer-item-tax-value"
-										currency={ currency }
-										value={ parsedTaxValue }
-									/>
-								),
-							}
-						) }
-					</p>
-				)
-			}
+			description={ filteredTotalDescription }
 		/>
 	);
 };

--- a/packages/checkout/utils/validation/index.ts
+++ b/packages/checkout/utils/validation/index.ts
@@ -18,8 +18,8 @@ export const mustContain = (
 					'Returned value must include %1$s, you passed "%2$s"',
 					'woo-gutenberg-products-block'
 				),
-				value,
-				requiredValue
+				requiredValue,
+				value
 			)
 		);
 	}

--- a/packages/checkout/utils/validation/index.ts
+++ b/packages/checkout/utils/validation/index.ts
@@ -18,8 +18,8 @@ export const mustContain = (
 					'Returned value must include %1$s, you passed "%2$s"',
 					'woo-gutenberg-products-block'
 				),
-				requiredValue,
-				value
+				value,
+				requiredValue
 			)
 		);
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will add a new filter, 'totalDescription' to the `TotalsFooterItem` component - this will allow extensions to alter the value of the `description` prop passed to the `TotalsItem` which renders the price.

Two questions came up when creating this PR:
1. Do we want to enable a filter for every `TotalsItem` that gets rendered, e.g. the ones in Shipping, Fees, and Tax, or only the "grand total" one?
2. Is the name `totalDescription` ok or is there a better one?

**Todo: Add docs for this filter if the approach here is approved**
#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<img src="https://user-images.githubusercontent.com/5656702/141988195-d0cbcfa4-8efd-4943-919a-229c35b2a4b4.png" width=350 />

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add this code somewhere that'll be executed
```js
__experimentalRegisterCheckoutFilters( 'my-test-extension', {
		totalDescription: ( value ) => {
			return `${ value } Charged October 25th`;
		},
	} );
```
2. Go to the Cart and Checkout blocks, verify the `Charged October 25th` text appears under the grand total
3. Enable taxes and set it so they appear under the total too, (WooCommerce > Settings > Tax > `Yes, I will enter prices inclusive of tax` and `Display prices during basket and checkout: including tax`.
4. Ensure the `Charged October 25th` appears below the tax total.
5. Change the filter code above to
```js
__experimentalRegisterCheckoutFilters( 'my-test-extension', {
		totalDescription: ( value ) => {
			return `Charged October 25th${ value }`;
		},
	} );
```
6. Ensure the tax comes _after_ the Charged October 25th text now.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [x] See steps below.

1. Enable taxes and set it so they appear under the total too, (WooCommerce > Settings > Tax > `Yes, I will enter prices inclusive of tax` and `Display prices during basket and checkout: including tax`.
2. Add items to your cart and go through the Cart -> Checkout flow.
3. Ensure the totals and the tax description display correctly in Cart and Checkout.

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add a filter to allow modification of the description label of the cart total in the Cart and Checkout blocks.
