### PR TITLE
Fix Featured Product Search not working for large stores

### DIFF
--- a/assets/js/hocs/with-searched-products.tsx
+++ b/assets/js/hocs/with-searched-products.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useState, useCallback } from '@wordpress/element';
+import { useEffect, useState, useCallback, useRef } from '@wordpress/element';
 import { blocksConfig } from '@woocommerce/block-settings';
 import { getProducts } from '@woocommerce/editor-components/utils';
 import { useDebouncedCallback } from 'use-debounce';
@@ -41,14 +41,16 @@ const withSearchedProducts = (
 			setIsLoading( false );
 		};
 
+		const selectedRef = useRef( selected );
+
 		useEffect( () => {
-			getProducts( { selected } )
+			getProducts( { selected: selectedRef.current } )
 				.then( ( results ) => {
 					setProductsList( results as ProductResponseItem[] );
 					setIsLoading( false );
 				} )
 				.catch( setErrorState );
-		}, [] );
+		}, [ selectedRef ] );
 
 		const [ debouncedSearch ] = useDebouncedCallback(
 			( search: string ) => {

--- a/assets/js/hocs/with-searched-products.tsx
+++ b/assets/js/hocs/with-searched-products.tsx
@@ -48,7 +48,7 @@ const withSearchedProducts = (
 					setIsLoading( false );
 				} )
 				.catch( setErrorState );
-		}, [ selected ] );
+		}, [] );
 
 		const [ debouncedSearch ] = useDebouncedCallback(
 			( search: string ) => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
On the editor, after inserting a featured product block, the search does not return any results for large stores (with more than 100 products currently). This is due to the behaviour of the [`WithSearchedProducts`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/hocs/with-searched-products.tsx) higher order component. This generates a request to fetch products, both on a user searching, and every time the user changes a selection.  

What's happening is [this useEffect](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/hocs/with-searched-products.tsx#L44) is ran on (almost) every render, because `selected` is an array that is checked by reference and it will have a different array instance each time the component is invoked, even if the value of the array hasn't changed.

The solution proposed here simply removes `selected` from the dependency array so that `getProducts` will only run once on the first render. From what I can see, there is no need to `getProducts` after each selection, and there is a [separate call to `getProducts` in the `onSearch` callback](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/hocs/with-searched-products.tsx#L53). This looks to me like the intended behaviour but please point out if I'm missing something.

I've also explored memoizing the `selected` array with `useMemo()` but this still doesn't work, presumably because it's a different array each time.

Yet another solution would be to use `JSON.stringify(selected)` to check for the change in value of the `selected` array as described [here](https://github.com/facebook/react/issues/14476#issuecomment-471199055). We could do this if this `useEffect` needs to run on every product selection.

Also eslint is throwing a warning about `React Hook useEffect has a missing dependency: 'selected'. Either include it or remove the dependency array`. But for this situation I think this is the right setting so I would disable the warning for this line but wanted to check first. Open to suggestions on this.


<!-- Reference any related issues or PRs here -->
Fixes #4983

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
Before: 
![image](https://user-images.githubusercontent.com/3966773/142018256-33f2ad3d-4cb2-4db2-87dd-0d62e5fcfb52.png)

After: 
![image](https://user-images.githubusercontent.com/3966773/142017933-d7b9df77-944b-45fd-8032-57ad28280705.png)


### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Have a large catalog, or edit [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/editor-components/utils/index.js#L24) and [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/assets/js/editor-components/utils/index.js#L24) and set 100 to 5 say
2. Insert Featured Product Block in the editor
3. Enter a search term for a product not visible in the list
4. Should see relevant search results based on search

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fixed Featured Product Block search not working for large stores
