### PR TITLE
Remove feature gate condition for Legacy Template block

### DIFF
--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import {
-	registerExperimentalBlockType,
-	WC_BLOCKS_IMAGE_URL,
-} from '@woocommerce/block-settings';
+import { registerBlockType } from '@wordpress/blocks';
+import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -57,7 +55,7 @@ const Edit = ( { attributes }: Props ) => {
 	);
 };
 
-registerExperimentalBlockType( 'woocommerce/legacy-template', {
+registerBlockType( 'woocommerce/legacy-template', {
 	title: __( 'WooCommerce Legacy Template', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce',
 	apiVersion: 2,


### PR DESCRIPTION
Discovered while testing 6.3.0: the Legacy Template block was not available.

### Manual Testing

1. Run `npm run package-plugin`.
2. Install the generated ZIP into a site with Gutenberg 11.8.3 and a block theme (like [Quadrat](https://wordpress.org/themes/quadrat/)).
2. Go to Site Editor > General templates > Single Product Page and verify the block renders correctly.