### PR TITLE
Checkbox Component Styling Fix

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/editor.scss
@@ -12,10 +12,6 @@
 	}
 }
 
-.wc-block-components-checkbox {
-	margin-right: $gap;
-}
-
 .wc-block-checkout__terms_notice .components-notice__action {
 	margin-left: 0;
 }

--- a/packages/checkout/components/checkbox-control/index.tsx
+++ b/packages/checkout/components/checkbox-control/index.tsx
@@ -35,7 +35,7 @@ const CheckboxControl = ( {
 	const checkboxId = id || `checkbox-control-${ instanceId }`;
 
 	return (
-		<label
+		<div
 			className={ classNames(
 				'wc-block-components-checkbox',
 				{
@@ -43,31 +43,32 @@ const CheckboxControl = ( {
 				},
 				className
 			) }
-			htmlFor={ checkboxId }
 		>
-			<input
-				id={ checkboxId }
-				className="wc-block-components-checkbox__input"
-				type="checkbox"
-				onChange={ ( event ) => onChange( event.target.checked ) }
-				aria-invalid={ hasError === true }
-				{ ...rest }
-			/>
-			<svg
-				className="wc-block-components-checkbox__mark"
-				aria-hidden="true"
-				xmlns="http://www.w3.org/2000/svg"
-				viewBox="0 0 24 20"
-			>
-				<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
-			</svg>
-			{ label && (
-				<span className="wc-block-components-checkbox__label">
-					{ label }
-				</span>
-			) }
-			{ children }
-		</label>
+			<label htmlFor={ checkboxId }>
+				<input
+					id={ checkboxId }
+					className="wc-block-components-checkbox__input"
+					type="checkbox"
+					onChange={ ( event ) => onChange( event.target.checked ) }
+					aria-invalid={ hasError === true }
+					{ ...rest }
+				/>
+				<svg
+					className="wc-block-components-checkbox__mark"
+					aria-hidden="true"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 20"
+				>
+					<path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z" />
+				</svg>
+				{ label && (
+					<span className="wc-block-components-checkbox__label">
+						{ label }
+					</span>
+				) }
+				{ children }
+			</label>
+		</div>
 	);
 };
 

--- a/packages/checkout/components/checkbox-control/style.scss
+++ b/packages/checkout/components/checkbox-control/style.scss
@@ -87,6 +87,7 @@
 		margin-top: em(1px);
 		width: em(18px);
 		height: em(18px);
+		pointer-events: none;
 
 		.has-dark-controls & {
 			fill: #fff;

--- a/packages/checkout/components/checkbox-control/style.scss
+++ b/packages/checkout/components/checkbox-control/style.scss
@@ -1,9 +1,12 @@
 .wc-block-components-checkbox {
 	@include reset-typography();
-	align-items: flex-start;
-	display: flex;
-	position: relative;
 	margin-top: em($gap-large);
+
+	label {
+		align-items: flex-start;
+		display: flex;
+		position: relative;
+	}
 
 	.wc-block-components-checkbox__input[type="checkbox"] {
 		font-size: 1em;
@@ -14,6 +17,7 @@
 		height: em(24px);
 		width: em(24px);
 		margin: 0;
+		margin-right: $gap;
 		min-height: 24px;
 		min-width: 24px;
 		overflow: hidden;
@@ -91,7 +95,6 @@
 
 	> span,
 	.wc-block-components-checkbox__label {
-		padding-left: $gap;
 		vertical-align: middle;
 		line-height: em(24px);
 	}


### PR DESCRIPTION
I noticed 2 small issues with the checkbox component.

1. It was possible to accidentally click the label due to extra padding when it's the last element in a form step
2. Clicking the input lagged due to the SVG accepting pointer events

Fixed with CSS and a wrapping div.

### Testing

How to test the changes in this Pull Request:

1. Checkout https://github.com/mailpoet/mailpoet/pull/3778 and enable mailpoet
2. See checkbox added to contact step in checkout
3. Go to frontend. Check the spacing between the label and the checkbox, and then click below the label in the gap between form steps. The checkbox should not be triggered
4. Confirm you can still toggle the checkbox input

### Changelog

> Reduce the size of the checkbox component label to prevent accidental input
