### PR TITLE
Product details component accepts `key` or `name` as props

### DIFF
--- a/assets/js/base/components/cart-checkout/product-details/index.tsx
+++ b/assets/js/base/components/cart-checkout/product-details/index.tsx
@@ -30,20 +30,22 @@ const ProductDetails = ( {
 	return (
 		<ul className="wc-block-components-product-details">
 			{ details.map( ( detail ) => {
-				const className = detail.name
+				// Support both `key` and `name` props
+				detail.key = detail.key ? detail.key : detail.name || '';
+				const className = detail.key
 					? `wc-block-components-product-details__${ kebabCase(
-							detail.name
+							detail.key
 					  ) }`
 					: '';
 				return (
 					<li
-						key={ detail.name + ( detail.display || detail.value ) }
+						key={ detail.key + ( detail.display || detail.value ) }
 						className={ className }
 					>
-						{ detail.name && (
+						{ detail.key && (
 							<>
 								<span className="wc-block-components-product-details__name">
-									{ decodeEntities( detail.name ) }:
+									{ decodeEntities( detail.key ) }:
 								</span>{ ' ' }
 							</>
 						) }

--- a/assets/js/base/components/cart-checkout/product-details/index.tsx
+++ b/assets/js/base/components/cart-checkout/product-details/index.tsx
@@ -31,21 +31,21 @@ const ProductDetails = ( {
 		<ul className="wc-block-components-product-details">
 			{ details.map( ( detail ) => {
 				// Support both `key` and `name` props
-				detail.key = detail.key ? detail.key : detail.name || '';
-				const className = detail.key
+				const name = detail?.key || detail.name || '';
+				const className = name
 					? `wc-block-components-product-details__${ kebabCase(
-							detail.key
+							name
 					  ) }`
 					: '';
 				return (
 					<li
-						key={ detail.key + ( detail.display || detail.value ) }
+						key={ name + ( detail.display || detail.value ) }
 						className={ className }
 					>
-						{ detail.key && (
+						{ name && (
 							<>
 								<span className="wc-block-components-product-details__name">
-									{ decodeEntities( detail.key ) }:
+									{ decodeEntities( name ) }:
 								</span>{ ' ' }
 							</>
 						) }

--- a/assets/js/base/components/cart-checkout/product-details/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/product-details/test/__snapshots__/index.js.snap
@@ -66,6 +66,7 @@ exports[`ProductDetails should render details 1`] = `
   <li
     className=""
   >
+    
     <span
       className="wc-block-components-product-details__value"
     >

--- a/assets/js/base/components/cart-checkout/product-metadata/index.tsx
+++ b/assets/js/base/components/cart-checkout/product-metadata/index.tsx
@@ -34,7 +34,7 @@ const ProductMetadata = ( {
 			<ProductDetails details={ itemData } />
 			<ProductDetails
 				details={ variation.map( ( { attribute = '', value } ) => ( {
-					name: attribute,
+					key: attribute,
 					value,
 				} ) ) }
 			/>

--- a/assets/js/types/type-defs/product-response.ts
+++ b/assets/js/types/type-defs/product-response.ts
@@ -16,13 +16,14 @@ export interface ProductResponseItemPrices extends CurrencyResponse {
 	};
 }
 
-export interface ProductResponseItemData {
-	name?: string;
-	key?: string;
+export interface ProductResponseItemBaseData {
 	value: string;
 	display?: string;
 	hidden?: boolean;
 }
+
+export type ProductResponseItemData = ProductResponseItemBaseData &
+	( { key: string; name?: never } | { key?: never; name: string } );
 
 export interface ProductResponseImageItem {
 	id: number;

--- a/assets/js/types/type-defs/product-response.ts
+++ b/assets/js/types/type-defs/product-response.ts
@@ -17,7 +17,8 @@ export interface ProductResponseItemPrices extends CurrencyResponse {
 }
 
 export interface ProductResponseItemData {
-	name: string;
+	name?: string;
+	key?: string;
 	value: string;
 	display?: string;
 	hidden?: boolean;


### PR DESCRIPTION
The PHP shortcode version of the product details metadata uses `key` instead of `name`. This PR allows the use of both, prioritising `key` as a default in order to keep consistent with the PHP shortcode and WooCommerce core.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #4400

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

## Screenshots
![Screenshot 2021-11-17 at 11 48 06](https://user-images.githubusercontent.com/3966773/142195297-81b68562-385f-4025-8493-70e1a8c03210.png)

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Add a product with a variant to your basket
2. Go to Cart page
3. Make sure the variant name is displayed
3. Repeat for Checkout page

<!-- If you can, add the appropriate labels -->

### Changelog

> Respect `key` attribute in product-details component over `name`