### PR TITLE
Hide WooCommmerce block templates from Edit Post template dropdown

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -36,9 +36,9 @@ class BlockTemplatesController {
 	 * Initialization method.
 	 */
 	protected function init() {
-		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 		add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
+		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 	}
 
 	/**
@@ -156,6 +156,16 @@ class BlockTemplatesController {
 				continue;
 			}
 
+			// If the current $post_type is set (e.g. on an Edit Post screen), and isn't included in the available post_types
+			// on the template file, then lets skip it so that it doesn't get added. This is typically used to hide templates
+			// in the template dropdown on the Edit Post page.
+			if ( $post_type &&
+				isset( $template_file->post_types ) &&
+				! in_array( $post_type, $template_file->post_types, true )
+			) {
+				continue;
+			}
+
 			// It would be custom if the template was modified in the editor, so if it's not custom we can load it from
 			// the filesystem.
 			if ( 'custom' !== $template_file->source ) {
@@ -163,13 +173,6 @@ class BlockTemplatesController {
 			} else {
 				$template_file->title = BlockTemplateUtils::convert_slug_to_title( $template_file->slug );
 				$query_result[]       = $template_file;
-				continue;
-			}
-
-			if ( $post_type &&
-				isset( $template->post_types ) &&
-				! in_array( $post_type, $template->post_types, true )
-			) {
 				continue;
 			}
 
@@ -317,6 +320,7 @@ class BlockTemplatesController {
 				'source'      => 'woocommerce',
 				'title'       => BlockTemplateUtils::convert_slug_to_title( $template_slug ),
 				'description' => '',
+				'post_types'  => array(), // Don't appear in any Edit Post template selector dropdowns.
 			);
 			$templates[]       = (object) $new_template_item;
 		}

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -320,7 +320,7 @@ class BlockTemplatesController {
 				'source'      => 'woocommerce',
 				'title'       => BlockTemplateUtils::convert_slug_to_title( $template_slug ),
 				'description' => '',
-				'post_types'  => array(), // Don't appear in any Edit Post template selector dropdowns.
+				'post_types'  => array(), // Don't appear in any Edit Post template selector dropdown.
 			);
 			$templates[]       = (object) $new_template_item;
 		}

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -108,6 +108,7 @@ class BlockTemplateUtils {
 		$template->status         = $post->post_status;
 		$template->has_theme_file = $has_theme_file;
 		$template->is_custom      = true;
+		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 
 		return $template;
 	}
@@ -135,6 +136,7 @@ class BlockTemplateUtils {
 		$template->status         = 'publish';
 		$template->has_theme_file = true;
 		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
+		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 		return $template;
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5170

### Screenshots

**Before**
<img width="1790" alt="Screenshot 2021-11-17 at 13 33 08" src="https://user-images.githubusercontent.com/8639742/142210347-963c21b4-189e-480d-a101-383020cee4e8.png">

**After**
<img width="1792" alt="Screenshot 2021-11-17 at 13 32 41" src="https://user-images.githubusercontent.com/8639742/142210371-4e8c5f12-8caf-40f4-9571-bfa1c37ea88f.png">

### Manual Testing

How to test the changes in this Pull Request:

1. Follow the testing notes on the [Epic](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4926)
2. Checkout this branch
3. Edit a Post or Page and ensure in the Template dropdown the WooCommerce templates do not appear
4. Customise a template via the Site Editor and save it, check this also does not appear in the Template dropdown on the Edit Post/Page
5. Check these templates still work/load in the Site Editor and load on the frontend as expected.

### Changelog

> Removed WooCommerce block templates from appearing in the template dropdown for a page or post as these are only relevant in the context of WooCommerce and shouldn't be selectable to apply here
