### PR TITLE
Legacy Template Block: Remove the deletion lock (#5166)

### DIFF
--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -84,12 +84,6 @@ registerBlockType( 'woocommerce/legacy-template', {
 			type: 'string',
 			default: 'any',
 		},
-		lock: {
-			type: 'object',
-			default: {
-				remove: true,
-			},
-		},
 	},
 	edit: Edit,
 	save: () => null,


### PR DESCRIPTION
Previously, our legacy template block was locked to prevent the users from removing it. The block could however be removed by erasing the parent, so this change allows the user to directly remove the block itself.

The standing issue is that if the user removes the block, they can't add it back through the block inserter. However, they can revert their change by deleting the locally saved template (from Appearance → Templates). 

For the entire context: see #5166
Closes #5166
Closes #5163
Closes #5109

### Screenshots

![can-remove](https://user-images.githubusercontent.com/1847066/142233632-e6f469a5-8a0f-4c54-88db-ae881817e45f.png)

![remove-template](https://user-images.githubusercontent.com/1847066/142233665-1ea22bff-b2a7-4666-9e0c-80af821846e1.png)


### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Go to Appearance → Editor
2. Open the sidebar and select General templates → Product Archive Page
3. Select the Legacy Template Block and click “Remove WooCommerce Legacy Template” (screenshot above)
4. Confirm that the block gets deleted without errors in the console

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).

See steps below.

1. Go to Appearance → Editor
2. Open the sidebar and select General templates → Product Archive Page
3. Select the Legacy Template Block and click “Remove WooCommerce Legacy Template” (screenshot above)
4. Confirm that the block gets deleted in the editor

### Changelog

> Legacy Template Block: allow users to delete the block.
