### PR TITLE
Check that functions gutenberg_supports_block_templates and gutenberg…

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -54,6 +54,9 @@ class BlockTemplatesController {
 	 * @return mixed|\WP_Block_Template|\WP_Error
 	 */
 	public function maybe_return_blocks_template( $template, $id, $template_type ) {
+		if ( ! function_exists( 'gutenberg_get_block_template' ) ) {
+			return $template;
+		}
 		$template_name_parts = explode( '//', $id );
 		if ( count( $template_name_parts ) < 2 ) {
 			return $template;
@@ -132,7 +135,7 @@ class BlockTemplatesController {
 	 * @return array
 	 */
 	public function add_block_templates( $query_result, $query, $template_type ) {
-		if ( ! gutenberg_supports_block_templates() || 'wp_template' !== $template_type ) {
+		if ( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() || 'wp_template' !== $template_type ) {
 			return $query_result;
 		}
 


### PR DESCRIPTION
Check for Gutenberg functions' existence before usages within the `BlockTemplateController.php` class.

### Manual Testing

**How to reproduce the critical error we're fixing in this PR:**

1.) Make sure Gutenberg is NOT active on your site
2.) Install the [WordPress Beta Tester plugin](https://wordpress.org/plugins/wordpress-beta-tester/) 
3.) Go to Tools > Beta Testing and select "Bleeding edge"
4.) Go to Dashboard > Updates and click "Update to latest 5.9 nightly"
5.) After updating to e.g. WP 5.9-alpha-52211 navigate to `/shop`. You will see a critical error.

**How to test the changes in this Pull Request:**
1. Smoke test the Store Editing Templates project...
2. Follow prerequisite tests from the [epic](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4926).
3. Ensure templates load in the Site Editor.
4. Create templates inside the active themes `block-templates` directory to ensure the theme's template supersedes the plugins by loading it in the Site Editor and on the frontend
5. Ensure when editing and saving these templates they save correctly and are visible in Appearance > Templates. Check these correctly load in the Site Editor and render on the frontend.
6. Go through the steps listed above for reproducing the critical error. Confirm the error doesn't occur anymore with these changes applied.

### Changelog

> Fix fatal error in certain WP 5.9 pre-release versions.