### PR TITLE
Add support for decimal and thousand separators in the `formatPrice` function

### DIFF
--- a/packages/prices/utils/price.ts
+++ b/packages/prices/utils/price.ts
@@ -76,11 +76,7 @@ export const getCurrencyFromPriceResponse = (
 		| Record< string, never >
 		| CartShippingPackageShippingRate
 ): Currency => {
-	if (
-		! currencyData ||
-		typeof currencyData !== 'object' ||
-		! currencyData?.currency_code
-	) {
+	if ( ! currencyData?.currency_code ) {
 		return siteCurrencySettings;
 	}
 

--- a/packages/prices/utils/price.ts
+++ b/packages/prices/utils/price.ts
@@ -66,6 +66,8 @@ const siteCurrencySettings: Currency = {
 
 /**
  * Gets currency information in normalized format from an API response or the server.
+ *
+ * If no currency was provided, or currency_code is empty, the default store currency will be used.
  */
 export const getCurrencyFromPriceResponse = (
 	// Currency data object, for example an API response containing currency formatting data.
@@ -74,7 +76,11 @@ export const getCurrencyFromPriceResponse = (
 		| Record< string, never >
 		| CartShippingPackageShippingRate
 ): Currency => {
-	if ( ! currencyData || typeof currencyData !== 'object' ) {
+	if (
+		! currencyData ||
+		typeof currencyData !== 'object' ||
+		! currencyData?.currency_code
+	) {
 		return siteCurrencySettings;
 	}
 
@@ -113,6 +119,28 @@ export const getCurrency = (
 	};
 };
 
+const applyThousandSeparator = (
+	numberString: string,
+	thousandSeparator: string
+): string => {
+	return numberString.replace( /\B(?=(\d{3})+(?!\d))/g, thousandSeparator );
+};
+
+const splitDecimal = (
+	numberString: string
+): {
+	beforeDecimal: string;
+	afterDecimal: string;
+} => {
+	const parts = numberString.split( '.' );
+	const beforeDecimal = parts[ 0 ];
+	const afterDecimal = parts[ 1 ] || '';
+	return {
+		beforeDecimal,
+		afterDecimal,
+	};
+};
+
 /**
  * Format a price, provided using the smallest unit of the currency, as a
  * decimal complete with currency symbols using current store settings.
@@ -134,9 +162,27 @@ export const formatPrice = (
 	}
 
 	const currency: Currency = getCurrency( currencyData );
-	const formattedPrice: number = priceInt / 10 ** currency.minorUnit;
-	const formattedValue: string =
-		currency.prefix + formattedPrice + currency.suffix;
+
+	const {
+		minorUnit,
+		prefix,
+		suffix,
+		decimalSeparator,
+		thousandSeparator,
+	} = currency;
+
+	const formattedPrice: number = priceInt / 10 ** minorUnit;
+
+	const { beforeDecimal, afterDecimal } = splitDecimal(
+		formattedPrice.toString()
+	);
+
+	const formattedValue = `${ prefix }${ applyThousandSeparator(
+		beforeDecimal,
+		thousandSeparator
+	) }${
+		afterDecimal ? `${ decimalSeparator }${ afterDecimal }` : ''
+	}${ suffix }`;
 
 	// This uses a textarea to magically decode HTML currency symbols.
 	const txt = document.createElement( 'textarea' );

--- a/packages/prices/utils/test/price.js
+++ b/packages/prices/utils/test/price.js
@@ -5,21 +5,46 @@ import { formatPrice, getCurrency } from '../price';
 
 describe( 'formatPrice', () => {
 	test.each`
-		value          | prefix   | suffix   | expected
-		${ 1000 }      | ${ '€' } | ${ '' }  | ${ '€10' }
-		${ 1000 }      | ${ '' }  | ${ '€' } | ${ '10€' }
-		${ 1000 }      | ${ '' }  | ${ '$' } | ${ '10$' }
-		${ '1000' }    | ${ '€' } | ${ '' }  | ${ '€10' }
-		${ 0 }         | ${ '€' } | ${ '' }  | ${ '€0' }
-		${ '' }        | ${ '€' } | ${ '' }  | ${ '' }
-		${ null }      | ${ '€' } | ${ '' }  | ${ '' }
-		${ undefined } | ${ '€' } | ${ '' }  | ${ '' }
+		value           | prefix   | suffix   | expected
+		${ 1000 }       | ${ '€' } | ${ '' }  | ${ '€10' }
+		${ 1000 }       | ${ '' }  | ${ '€' } | ${ '10€' }
+		${ 1000 }       | ${ '' }  | ${ '$' } | ${ '10$' }
+		${ '1000' }     | ${ '€' } | ${ '' }  | ${ '€10' }
+		${ 0 }          | ${ '€' } | ${ '' }  | ${ '€0' }
+		${ '' }         | ${ '€' } | ${ '' }  | ${ '' }
+		${ null }       | ${ '€' } | ${ '' }  | ${ '' }
+		${ undefined }  | ${ '€' } | ${ '' }  | ${ '' }
+		${ 100000 }     | ${ '€' } | ${ '' }  | ${ '€1,000' }
+		${ 1000000 }    | ${ '€' } | ${ '' }  | ${ '€10,000' }
+		${ 1000000000 } | ${ '€' } | ${ '' }  | ${ '€10,000,000' }
 	`(
-		'correctly formats price given "$value", "$prefix" prefix, and "$suffix" suffix',
+		'correctly formats price given "$value", "$prefix" prefix, and "$suffix" suffix as "$expected"',
 		( { value, prefix, suffix, expected } ) => {
 			const formattedPrice = formatPrice(
 				value,
 				getCurrency( { prefix, suffix } )
+			);
+
+			expect( formattedPrice ).toEqual( expected );
+		}
+	);
+
+	test.each`
+		value           | prefix   | decimalSeparator | thousandSeparator | expected
+		${ 1000000099 } | ${ '$' } | ${ '.' }         | ${ ',' }          | ${ '$10,000,000.99' }
+		${ 1000000099 } | ${ '$' } | ${ ',' }         | ${ '.' }          | ${ '$10.000.000,99' }
+	`(
+		'correctly formats price given "$value", "$prefix" prefix, "$decimalSeparator" decimal separator, "$thousandSeparator" thousand separator as "$expected"',
+		( {
+			value,
+			prefix,
+			decimalSeparator,
+			thousandSeparator,
+			expected,
+		} ) => {
+			const formattedPrice = formatPrice(
+				value,
+				getCurrency( { prefix, decimalSeparator, thousandSeparator } )
 			);
 
 			expect( formattedPrice ).toEqual( expected );
@@ -34,7 +59,7 @@ describe( 'formatPrice', () => {
 		${ null }      | ${ '' }
 		${ undefined } | ${ '' }
 	`(
-		'correctly formats price given "$value" only',
+		'correctly formats price given "$value" only as "$expected"',
 		( { value, expected } ) => {
 			const formattedPrice = formatPrice( value );
 


### PR DESCRIPTION
`formatPrice` ignores custom decimal and thousand symbols, instead defaulting to `.` for decimals.

This PR fixes this by formatting the values with the correct (based on the provided currency) symbols from settings.

Fixes #5018

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests

* [x] Changes in this PR are covered by Automated Tests.

### Manual Testing

How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings.
2. Change decimal separator to `,`
3. Change thousand separator to `.`
4. Save changes.
5. Add mini cart block to a page
6. Add something to your cart and view mini cart block.
7. Hover the button - the value should not change and should show correct decimal/thousand symbols
8. Re-rest with a cart qty > 1000 and ensure a thousand separator is used in the price (this does not affect non-prices)

### User Facing Testing

Same as above.

### Changelog

> Add support for decimal and thousand separators in the `formatPrice` function
