### PR TITLE
Add new Slot - `ExperimentalFooterTotalMeta` to the bottom of the Cart/Checkout sidebars

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/footer-item/index.js
+++ b/assets/js/base/components/cart-checkout/totals/footer-item/index.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import {
 	__experimentalApplyCheckoutFilter,
 	TotalsItem,
+	ExperimentalFooterTotalMeta,
 } from '@woocommerce/blocks-checkout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { getSetting } from '@woocommerce/settings';
@@ -38,34 +39,36 @@ const TotalsFooterItem = ( { currency, values } ) => {
 	const parsedTaxValue = parseInt( totalTax, 10 );
 
 	return (
-		<TotalsItem
-			className="wc-block-components-totals-footer-item"
-			currency={ currency }
-			label={ label }
-			value={ parseInt( totalPrice, 10 ) }
-			description={
-				SHOW_TAXES &&
-				parsedTaxValue !== 0 && (
-					<p className="wc-block-components-totals-footer-item-tax">
-						{ createInterpolateElement(
-							__(
-								'Including <TaxAmount/> in taxes',
-								'woo-gutenberg-products-block'
-							),
-							{
-								TaxAmount: (
-									<FormattedMonetaryAmount
-										className="wc-block-components-totals-footer-item-tax-value"
-										currency={ currency }
-										value={ parsedTaxValue }
-									/>
+		<ExperimentalFooterTotalMeta>
+			<TotalsItem
+				className="wc-block-components-totals-footer-item totals-footer-item"
+				currency={ currency }
+				label={ label }
+				value={ parseInt( totalPrice, 10 ) }
+				description={
+					SHOW_TAXES &&
+					parsedTaxValue !== 0 && (
+						<p className="wc-block-components-totals-footer-item-tax">
+							{ createInterpolateElement(
+								__(
+									'Including <TaxAmount/> in taxes',
+									'woo-gutenberg-products-block'
 								),
-							}
-						) }
-					</p>
-				)
-			}
-		/>
+								{
+									TaxAmount: (
+										<FormattedMonetaryAmount
+											className="wc-block-components-totals-footer-item-tax-value"
+											currency={ currency }
+											value={ parsedTaxValue }
+										/>
+									),
+								}
+							) }
+						</p>
+					)
+				}
+			/>
+		</ExperimentalFooterTotalMeta>
 	);
 };
 

--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -45,12 +45,14 @@
 .is-large {
 	.wc-block-components-sidebar {
 		.wc-block-components-totals-item,
-		.wc-block-components-panel {
+		.wc-block-components-panel,
+		.wc-block-components-footer-total-meta {
 			padding-left: $gap;
 			padding-right: $gap;
 		}
 
-		.wc-block-components-panel {
+		.wc-block-components-panel,
+		.wc-block-components-footer-total-meta {
 			.wc-block-components-totals-item {
 				padding: 0;
 			}

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
@@ -15,6 +15,7 @@ import {
 	TotalsWrapper,
 	ExperimentalOrderMeta,
 	ExperimentalDiscountsMeta,
+	ExperimentalFooterTotalMeta,
 } from '@woocommerce/blocks-checkout';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import {
@@ -109,10 +110,12 @@ const Block = ( {
 					</TotalsWrapper>
 				) }
 			<TotalsWrapper>
+				{ /* This TotalsFooterItem renders into the slot below */ }
 				<TotalsFooterItem
 					currency={ totalsCurrency }
 					values={ cartTotals }
 				/>
+				<ExperimentalFooterTotalMeta.Slot { ...slotFillProps } />
 			</TotalsWrapper>
 
 			<ExperimentalOrderMeta.Slot { ...slotFillProps } />

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
@@ -15,6 +15,7 @@ import {
 	ExperimentalOrderMeta,
 	TotalsWrapper,
 	ExperimentalDiscountsMeta,
+	ExperimentalFooterTotalMeta,
 } from '@woocommerce/blocks-checkout';
 
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
@@ -103,10 +104,12 @@ const Block = ( {
 					</TotalsWrapper>
 				) }
 			<TotalsWrapper>
+				{ /* This TotalsFooterItem renders into the slot below */ }
 				<TotalsFooterItem
 					currency={ totalsCurrency }
 					values={ cartTotals }
 				/>
+				<ExperimentalFooterTotalMeta.Slot { ...slotFillProps } />
 			</TotalsWrapper>
 			<ExperimentalOrderMeta.Slot { ...slotFillProps } />
 		</div>

--- a/packages/checkout/components/footer-total-meta/index.js
+++ b/packages/checkout/components/footer-total-meta/index.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  * Internal dependencies
  */
 import { createSlotFill, hasValidFills, useSlot } from '../../slot';
-import './style.scss';
 
 const slotName = '__experimentalFooterTotalMeta';
 

--- a/packages/checkout/components/footer-total-meta/index.js
+++ b/packages/checkout/components/footer-total-meta/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import { createSlotFill, hasValidFills, useSlot } from '../../slot';
+import './style.scss';
+
+const slotName = '__experimentalFooterTotalMeta';
+
+const {
+	Fill: ExperimentalFooterTotalMeta,
+	Slot: FooterTotalMetaSlot,
+} = createSlotFill( slotName );
+
+const Slot = ( { className, extensions, cart } ) => {
+	const { fills } = useSlot( slotName );
+	return (
+		hasValidFills( fills ) && (
+			<FooterTotalMetaSlot
+				className={ classnames(
+					className,
+					'wc-block-components-footer-total-meta'
+				) }
+				fillProps={ { extensions, cart } }
+			/>
+		)
+	);
+};
+
+ExperimentalFooterTotalMeta.Slot = Slot;
+
+export default ExperimentalFooterTotalMeta;

--- a/packages/checkout/components/footer-total-meta/style.scss
+++ b/packages/checkout/components/footer-total-meta/style.scss
@@ -1,3 +1,0 @@
-.wc-block-components-footer-total-meta {
-	padding: 0 $gap;
-}

--- a/packages/checkout/components/footer-total-meta/style.scss
+++ b/packages/checkout/components/footer-total-meta/style.scss
@@ -1,0 +1,3 @@
+.wc-block-components-footer-total-meta {
+	padding: 0 $gap;
+}

--- a/packages/checkout/components/index.js
+++ b/packages/checkout/components/index.js
@@ -2,6 +2,7 @@ export * from './totals';
 export { default as TotalsWrapper } from './totals-wrapper';
 export { default as ExperimentalOrderMeta } from './order-meta';
 export { default as ExperimentalDiscountsMeta } from './discounts-meta';
+export { default as ExperimentalFooterTotalMeta } from './footer-total-meta';
 export { default as ExperimentalOrderShippingPackages } from './order-shipping-packages';
 export { default as Panel } from './panel';
 export { default as Button } from './button';


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Alternative to #5153

This PR adds a Slot called `ExperimentalFooterTotalMeta` in the Cart and Checkout sidebars where the "Total" (rendered by the `TotalsFooterItem`) used to be.

Because of this change, we're also dogfooding our own extension API by rendering the `TotalsFooterItem` within the slot.

I removed padding from the `TotalsItem` if it was within the `ExperimentalFooterTotalMeta`. This lets us keep padding consistent within this area of the sidebar.

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots
<img src="https://user-images.githubusercontent.com/5656702/142473791-d2a82420-8e53-45fb-876c-008ae61ffc93.png" width=400 />


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Render the following onto a page, somewhere:
```jsx
<ExperimentalFooterTotalMeta>
  <div>Order will be billed on 25th October 2021</div>
</ExperimentalFooterTotalMeta>		
```
2. Go to the cart and ensure you see `Order will be billed on 25th October 2021` rendered underneath the Cart total.
3. Verify the same happens in the Checkout block.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [x] See steps below.

1. Ensure the totals in the Cart and Checkout blocks are correct and as you expect them to be.

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add the ExperimentalFooterTotalMeta Slot/Fill to the bottom of the sidebar/order summary in the Cart and Checkout blocks.
