### PR TITLE
Checkout Terms Block: Fix Terms and Conditions checkbox position in editor (#5150)

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/editor.scss
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/editor.scss
@@ -12,6 +12,10 @@
 	}
 }
 
+.wc-block-components-checkbox {
+	margin-top: 0;
+}
+
 .wc-block-checkout__terms_notice .components-notice__action {
 	margin-left: 0;
 }


### PR DESCRIPTION
Within the editor, the checkbox appeared aligned at the bottom of the paragraph, while on the front-end it would appear aligned at the top. The alignment was actually correct but a top margin was assigned to checkboxes in the backend.

Instead of removing that globally, this commit resets it for checkboxes within the checkout block.

Fixes #5150

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

*Editor (before):*

![Screen Shot 2021-11-18 at 23 34 28](https://user-images.githubusercontent.com/1847066/142507641-85ea4b37-a0f2-49b1-aaf6-a294e482eb85.png)

*Editor (after):*

![Screen Shot 2021-11-18 at 23 34 05](https://user-images.githubusercontent.com/1847066/142507675-5cd34956-8bdf-41b2-9f3d-eff00928f548.png)

*Reference (front-end):*

![fe](https://user-images.githubusercontent.com/3616980/141969754-38e06e73-59eb-4ba2-9706-ddcb4771f6d5.png)

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Go to the editor
2. Add checkout block
3. Select **Terms and Conditions** child block
4. Activate `Require checkbox` display option
5. Confirm that the checkbox is aligned to the top of the paragraph

### User Facing Testing
Same as above

### Changelog

> Correctly align Terms and Conditions block checkbox in Checkout block