### PR TITLE
Fix manual entry within Quantity Inputs

### DIFF
--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -6,7 +6,6 @@ import { speak } from '@wordpress/a11y';
 import classNames from 'classnames';
 import { useCallback } from '@wordpress/element';
 import { DOWN, UP } from '@wordpress/keycodes';
-import { isNumber } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -84,7 +83,8 @@ const QuantitySelector = ( {
 				onKeyDown={ quantityInputOnKeyDown }
 				onChange={ ( event ) => {
 					let value =
-						! isNumber( event.target.value ) || ! event.target.value
+						Number.isNaN( event.target.value ) ||
+						! event.target.value
 							? 0
 							: parseInt( event.target.value, 10 );
 					if ( hasMaximum ) {

--- a/assets/js/types/type-guards/index.ts
+++ b/assets/js/types/type-guards/index.ts
@@ -3,7 +3,7 @@ export const isNull = < T >( term: T | null ): term is null => {
 };
 
 export const isNumber = < U >( term: number | U ): term is number => {
-	return typeof term === 'number';
+	return ! Number.isNaN( term );
 };
 
 export const isString = < U >( term: string | U ): term is string => {

--- a/assets/js/types/type-guards/index.ts
+++ b/assets/js/types/type-guards/index.ts
@@ -3,7 +3,7 @@ export const isNull = < T >( term: T | null ): term is null => {
 };
 
 export const isNumber = < U >( term: number | U ): term is number => {
-	return ! Number.isNaN( term );
+	return typeof term === 'number';
 };
 
 export const isString = < U >( term: string | U ): term is string => {


### PR DESCRIPTION
Typing into quantity inputs is currently not possible because the `isNumber` type check does not convert string-based numbers into actual numbers.

This fixes the problem by using `Number.isNaN` instead.
 
Fixes #5187

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

Same as below.

### User Facing Testing

- Go to the cart page with an item in the cart
- Try typing a quantity into the line item
- Totals should update
- Try typing a letter. Input should be ignored and reset to `1`

### Changelog

> Fix manual entry within Quantity Inputs in Cart block
