### PR TITLE
Feature gate WC Block Templates to WC v6.0.0

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -42,9 +42,12 @@ class BlockTemplatesController {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->templates_directory      = plugin_dir_path( __DIR__ ) . 'templates/' . self::TEMPLATES_DIR_NAME;
-		$this->template_parts_directory = plugin_dir_path( __DIR__ ) . 'templates/' . self::TEMPLATE_PARTS_DIR_NAME;
-		$this->init();
+		// This feature is gated for WooCommerce versions 6.0.0 and above.
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '6.0.0', '>=' ) ) {
+			$this->templates_directory      = plugin_dir_path( __DIR__ ) . 'templates/' . self::TEMPLATES_DIR_NAME;
+			$this->template_parts_directory = plugin_dir_path( __DIR__ ) . 'templates/' . self::TEMPLATE_PARTS_DIR_NAME;
+			$this->init();
+		}
 	}
 
 	/**


### PR DESCRIPTION
This gates the WC Store Block Templates to only work on WooCommerce versions 6.0.0 and above.

<!-- Reference any related issues or PRs here -->
Related to https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5199

### Manual Testing

1. Without checking out this branch, install WC 5.9.0 and verify you can reproduce the linked issue.
2. Check out this branch and check that block templates are no longer loading (thus you are not able to reproduce the linked issue anymore)
3. Also check the templates are not loading in the Site Editor
4. Checkout WooCommerce `trunk` (at the time of writing this is v6.1.0) and check that block templates are now loading, and the linked issue has been fixed.

### Changelog

> Gate WC template editing (FSE) to versions of WC 6.0 or higher