### PR TITLE
Change source value on WooCommerce block templates to be plugin

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -348,7 +348,7 @@ class BlockTemplatesController {
 				'path'        => $template_file,
 				'type'        => $template_type,
 				'theme'       => 'woocommerce',
-				'source'      => 'woocommerce',
+				'source'      => 'plugin',
 				'title'       => BlockTemplateUtils::convert_slug_to_title( $template_slug ),
 				'description' => '',
 				'post_types'  => array(), // Don't appear in any Edit Post template selector dropdown.

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -135,7 +135,7 @@ class BlockTemplateUtils {
 		$template->id             = 'woocommerce//' . $template_file->slug;
 		$template->theme          = 'woocommerce';
 		$template->content        = self::gutenberg_inject_theme_attribute_in_content( $template_content );
-		$template->source         = 'woocommerce';
+		$template->source         = 'plugin';
 		$template->slug           = $template_file->slug;
 		$template->type           = $template_type;
 		$template->title          = ! empty( $template_file->title ) ? $template_file->title : self::convert_slug_to_title( $template_file->slug );


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909

Change the `source` attribute of the templates to be consistent with its intended use, where in this case the value should be `plugin` instead of `woocommerce`

### Manual Testing

How to test the changes in this Pull Request:

1. Smoke test the Store Editing Templates project:
2. Follow prerequisite tests from the [epic](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4926).
3. Ensure templates load in the Site Editor.
4. Create templates inside the active themes `block-templates` directory to ensure the theme's template supersedes the plugins by loading it in the Site Editor and on the frontend
5. Ensure when editing and saving these templates they save correctly and are visible in Appearance > Templates. Check these correctly load in the Site Editor and render on the frontend.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.