### PR TITLE
Refactor Mini Cart contents block unmount to fix ESLint warning

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/block.tsx
@@ -7,7 +7,7 @@ import {
 	RawHTML,
 	useState,
 	useEffect,
-	useRef,
+	useCallback,
 	unmountComponentAtNode,
 } from '@wordpress/element';
 import {
@@ -50,12 +50,17 @@ const MiniCartBlock = ( {
 	const [ skipSlideIn, setSkipSlideIn ] = useState< boolean >(
 		isInitiallyOpen
 	);
+	const [ contentsNode, setContentsNode ] = useState< HTMLDivElement | null >(
+		null
+	);
 
-	const contentsRef = useRef() as React.MutableRefObject< HTMLDivElement >;
+	const contentsRef = useCallback( ( node ) => {
+		setContentsNode( node );
+	}, [] );
 
 	useEffect( () => {
-		if ( contentsRef.current instanceof Element ) {
-			const container = contentsRef.current.querySelector(
+		if ( contentsNode instanceof Element ) {
+			const container = contentsNode.querySelector(
 				'.wc-block-mini-cart-contents'
 			);
 			if ( ! container ) {
@@ -66,16 +71,11 @@ const MiniCartBlock = ( {
 					Block: MiniCartContentsBlock,
 					container,
 				} );
-			} else {
-				unmountComponentAtNode( container );
 			}
 		}
-	}, [ isOpen ] );
 
-	useEffect( () => {
 		return () => {
-			const contentsNode = contentsRef.current as unknown;
-			if ( contentsNode instanceof Element ) {
+			if ( contentsNode instanceof Element && isOpen ) {
 				const container = contentsNode.querySelector(
 					'.wc-block-mini-cart-contents'
 				);
@@ -84,7 +84,7 @@ const MiniCartBlock = ( {
 				}
 			}
 		};
-	}, [] );
+	}, [ isOpen, contentsNode ] );
 
 	useEffect( () => {
 		const openMiniCart = () => {


### PR DESCRIPTION
It turns out we had this ESLint warning:

> [react-hooks/exhaustive-deps] The ref value 'contentsRef.current' will likely have changed by the time this effect cleanup function runs. If this ref points to a node rendered by React, copy 'contentsRef.current' to a variable inside the effect, and use that variable in the cleanup function.

in [assets/js/blocks/cart-checkout/mini-cart/block.tsx#L77](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/abc7b14dda5e34e2b386b7f18e7d4ec52601d3e6/assets/js/blocks/cart-checkout/mini-cart/block.tsx#L77).

While the current implementation seems to work, I refactored it using this [post from the React docs](https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node). In short: instead of using `useRef()` it uses `useCallback()`.

### Manual Testing

1. Add the Mini Cart block to a post or page.
2. In the frontend, verify you can click on the button and it opens the drawer.
3. Clicking outside (or on the close button) should close the drawer.
