### PR TITLE
Fix Mini Cart block when Gutenberg is not enabled

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -308,8 +308,7 @@ class MiniCart extends AbstractBlock {
 
 		$template_part_contents = '';
 		if ( function_exists( 'gutenberg_get_block_template' ) ) {
-			$part          = 'mini-cart';
-			$template_part = gutenberg_get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
+			$template_part = gutenberg_get_block_template( get_stylesheet() . '//mini-cart', 'wp_template_part' );
 			if ( $template_part && ! empty( $template_part->content ) ) {
 				$template_part_contents = do_blocks( $template_part->content );
 			}

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -306,11 +306,19 @@ class MiniCart extends AbstractBlock {
 			</div>';
 		}
 
-		$part                   = 'mini-cart';
-		$template_part          = gutenberg_get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
 		$template_part_contents = '';
-		if ( $template_part && ! empty( $template_part->content ) ) {
-			$template_part_contents = do_blocks( $template_part->content );
+		if ( function_exists( 'gutenberg_get_block_template' ) ) {
+			$part          = 'mini-cart';
+			$template_part = gutenberg_get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
+			if ( $template_part && ! empty( $template_part->content ) ) {
+				$template_part_contents = do_blocks( $template_part->content );
+			}
+		}
+		if ( '' === $template_part_contents ) {
+			$template_part_contents = do_blocks(
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				file_get_contents( Package::get_path() . 'templates/block-template-parts/mini-cart.html' )
+			);
 		}
 
 		return '<div class="' . $wrapper_classes . '">

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -332,7 +332,7 @@ class MiniCart extends AbstractBlock {
 							</div>
 						</div>
 						<div class="wc-block-mini-cart__template-part">'
-						. $template_part_contents .
+						. wp_kses_post( $template_part_contents ) .
 						'</div>
 					</div>
 				</div>


### PR DESCRIPTION
Fixes a fatal in WP 5.8 (or lower) with Gutenberg disabled.

It also wraps Mini Cart contents with `wp_kses_post()` so contents are sanitized.

### Manual Testing

1. Make sure you are testing in a WP 5.8.x site with Gutenberg disabled.
2. Add the Mini Cart block to a post or page.
3. Visit it in the frontend.
4. Click on the Mini Cart button and verify the drawer opens and it contains the default template part.