### PR TITLE
Add: Mini Cart template part area

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -57,6 +57,7 @@ class BlockTemplatesController {
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 		add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
+		add_filter( 'default_wp_template_part_areas', array( $this, 'add_template_part_areas' ) );
 	}
 
 	/**
@@ -450,5 +451,25 @@ class BlockTemplatesController {
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		}
+	}
+
+	/**
+	 * Add template part areas for our blocks.
+	 *
+	 * @param array $area_definitions An array of supported area objects.
+	 */
+	public function add_template_part_areas( $area_definitions ) {
+		return array_merge(
+			$area_definitions,
+			array(
+				array(
+					'area'        => 'mini-cart',
+					'label'       => __( 'Mini Cart', 'woo-gutenberg-products-block' ),
+					'description' => __( 'The Mini Cart template defines a page area that contains the content of the Mini Cart block.', 'woo-gutenberg-products-block' ),
+					'icon'        => 'sidebar',
+					'area_tag'    => 'div',
+				),
+			)
+		);
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5194

This PR adds the Mini Cart area so users can create multiple templates for Mini Cart content.

Some limitations:

- We can't set the custom area icon because it [isn't supported](https://github.com/WordPress/gutenberg/blob/c3c3466ef6cc04d590e03fba58f3997efc653cf6/packages/editor/src/utils/get-template-part-icon.js) yet. I'm using the sidebar icon for the area. We can also think about adding custom icon support to Gutenberg later.
- The area is available for any page. It means users can add it to the page without the Mini Cart block. Ideally, that area should be available for the Mini Cart view only. Hiding it from the blocks list is an option IMO. FYI, Header/Footer/Mini Cart is a variation of the Template Part block, which are registered [here](https://github.com/WordPress/gutenberg/blob/c3c3466ef6cc04d590e03fba58f3997efc653cf6/packages/block-library/src/template-part/index.php#L149-L158).

For now, we still should merge this PR to unblock other issues. We can go back and fix these limitations later.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
![image](https://user-images.githubusercontent.com/5423135/143052985-669d3393-e7b3-4537-a0bc-546484b41239.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Check out the latest `trunk` of `woocommerce` or install the [nightly build](https://github.com/woocommerce/woocommerce/releases/tag/nightly).
2. Check out the latest `trunk` of Gutenberg.
3. Go to Appearance > Editor (Beta).
4. Click on the W icon > Template Parts.
5. Click the Add new button on the top right corner.
6. See the Mini Cart area in the list.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.