### PR TITLE
Fix: When creating a template part for the Mini Cart area, it should be created already containing the Mini Cart Contents block

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -521,7 +521,7 @@ class BlockTemplatesController {
 			return;
 		}
 
-		// Remove the filter temporaryly for wp_update_post below.
+		// Remove the filter temporarily for wp_update_post below.
 		remove_filter( 'wp_insert_post', array( $this, 'add_mini_cart_content_to_template_part' ), 10, 3 );
 
 		$block_template = null;

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -58,6 +58,7 @@ class BlockTemplatesController {
 		add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'default_wp_template_part_areas', array( $this, 'add_template_part_areas' ) );
+		add_filter( 'wp_insert_post', array( $this, 'add_mini_cart_content_to_template_part' ), 10, 3 );
 	}
 
 	/**
@@ -298,7 +299,7 @@ class BlockTemplatesController {
 	 *
 	 * @param string[] $slugs An array of slugs to filter templates by. Templates whose slug does not match will not be returned.
 	 * @param array    $already_found_templates Templates that have already been found, these are customised templates that are loaded from the database.
-	 * @param array    $template_type wp_template or wp_template_part.
+	 * @param string   $template_type wp_template or wp_template_part.
 	 *
 	 * @return array Templates from the WooCommerce blocks plugin directory.
 	 */
@@ -400,6 +401,17 @@ class BlockTemplatesController {
 	}
 
 	/**
+	 * Check if the theme has a template. So we know if to load our own in or not.
+	 *
+	 * @param string $template_name name of the template file without .html extension e.g. 'single-product'.
+	 * @return boolean
+	 */
+	public function theme_has_template_part( $template_name ) {
+		return is_readable( get_template_directory() . '/block-template-parts/' . $template_name . '.html' ) ||
+			is_readable( get_stylesheet_directory() . '/block-template-parts/' . $template_name . '.html' );
+	}
+
+	/**
 	 * Checks whether a block template with that name exists in Woo Blocks
 	 *
 	 * @param string $template_name Template to check.
@@ -471,5 +483,70 @@ class BlockTemplatesController {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Add mini cart content block to new template part for Mini Cart area.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 * @param bool     $update  Whether this is an existing post being updated.
+	 */
+	public function add_mini_cart_content_to_template_part( $post_id, $post, $update ) {
+		// We only inject the mini cart content when the template part is created.
+		if ( $update ) {
+			return;
+		}
+
+		// If by somehow, the template part was created with content, bail.
+		if ( ! empty( $post->content ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'get_block_file_template' ) ) {
+			return;
+		}
+
+		if ( 'wp_template_part' !== $post->post_type ) {
+			return;
+		}
+
+		$type_terms = get_the_terms( $post, 'wp_template_part_area' );
+
+		if ( is_wp_error( $type_terms ) || false === $type_terms ) {
+			return;
+		}
+
+		if ( 'mini-cart' !== $type_terms[0]->name ) {
+			return;
+		}
+
+		// Remove the filter temporaryly for wp_update_post below.
+		remove_filter( 'wp_insert_post', array( $this, 'add_mini_cart_content_to_template_part' ), 10, 3 );
+
+		$block_template = null;
+
+		/**
+		 * We only use the mini cart content from file.
+		 */
+		if ( $this->theme_has_template_part( 'mini-cart' ) ) {
+			$template_id    = sprintf( '%s//mini-cart', wp_get_theme()->get_stylesheet() );
+			$block_template = get_block_file_template( $template_id, 'wp_template_part' );
+		} else {
+			$available_templates = $this->get_block_templates_from_woocommerce( array( 'mini-cart' ), array(), 'wp_template_part' );
+			if ( is_array( $available_templates ) && count( $available_templates ) > 0 ) {
+				$block_template = BlockTemplateUtils::gutenberg_build_template_result_from_file( $available_templates[0], $available_templates[0]->type );
+			}
+		}
+
+		if ( is_a( $block_template, 'WP_Block_Template' ) ) {
+			$post->post_content = $block_template->content;
+		} else { // Just for extra safety.
+			$post->post_content = '<!-- wp:woocommerce/mini-cart-contents /-->';
+		}
+
+		wp_update_post( $post );
+
+		add_filter( 'wp_insert_post', array( $this, 'add_mini_cart_content_to_template_part' ), 10, 3 );
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5196 
Depends on #5221

This PR adds the Mini Cart content to the template parts created for the Mini Cart area. Template content is taken dynamically from the template part file, and theme has a higher priority than plugin.

### Screenshots

Screen after adding a new Mini Cart template part:
![image](https://user-images.githubusercontent.com/5423135/143219074-c51d0460-6702-4a79-b153-7dc282d931fe.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Check out the latest `trunk` of `woocommerce` or install the [nightly build](https://github.com/woocommerce/woocommerce/releases/tag/nightly).
2. Check out the latest `trunk` of Gutenberg.
3. Remove mini-cart template part file from the active theme if exists.
3. Go to Appearance > Editor (Beta).
4. Click on the W icon > Template Parts.
5. Click the Add new button on the top right corner.
6. Select the Mini Cart area, and give the template part a random name.
7. Click `Create`, after the editor has been loaded, the template content should contain the Mini Cart Contents block.
8. Update the content of the `woocommerce-gutenberg-products-block/templates/block-template-parts/mini-cart.html` with the one below.
9. Repeat steps 4-7. See the content of the newly created template part is the updated one in the step 9.
10. Add mini-cart template to the active theme with the content below.
11. Repeat steps 4-7. See the content of the newly created template part is the updated one in the step 11, the teampate content is taken from theme now, not the plugin.
12. Repeat steps 4-5 then Edit the default Mini Cart template part.
13. Repeat steps 4-7. See the content of the newly created template part is the updated one in the step 11, the template content is taken from template file in theme, not the customized one in the database.
---
**woocommerce-gutenberg-products-block/templates/block-template-parts/mini-cart.html:**
```
<!-- wp:paragraph --> <p>WC Mini Cart content template</p> <!-- /wp:paragraph -->
<!-- wp:woocommerce/mini-cart-contents /-->
```
---
**theme-slug/block-template-parts/mini-cart.html:**
```
<!-- wp:paragraph --> <p>Theme Mini Cart content template</p> <!-- /wp:paragraph -->
<!-- wp:woocommerce/mini-cart-contents /-->
```