### PR TITLE
Remove obsolete files and folders from deploy zip

### DIFF
--- a/bin/copy-plugin-files.sh
+++ b/bin/copy-plugin-files.sh
@@ -23,8 +23,12 @@ rsync ./ "$2"/ --recursive --delete --delete-excluded \
 	--exclude=blocks.ini \
 	--exclude=docker-compose.yml \
 	--exclude=tsconfig.json \
+	--exclude=tsconfig.base.json \
 	--exclude=woocommerce-gutenberg-products-block.zip \
 	--exclude="zip-file/" \
-	--exclude=globals.d.ts \
+	--exclude=global.d.ts \
+	--exclude=packages/ \
+    --exclude=patches/ \
+    --exclude=reports/ \
 	--exclude=storybook/
 echo -e "\nDone copying files!\n"


### PR DESCRIPTION
Fixes #4928

### Notes

The current deploy zip, that is generated for testing purposes, contains various build files and folders such as `patches/` and `global.d.ts`. This PR aims to generate a deploy zip file that only contains files and folders that are needed for production. It shall not contain any build files and folders.

In addition to the files and folders mentioned in #4928, I also excluded the `reports/` folder which contains the e2e report file and is therefore not relevant for production/testing.

### Testing

1. Check out this PR.
2. Run `npm run package-plugin:deploy`.
3. Ensure that the created deploy zip does not contain any build files and folders.
4. Smoke test the deploy zip to ensure that all functionality still works as expected.
