### PR TITLE
Convert components to Typescript

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import { ValidatedTextInput } from '@woocommerce/base-components/text-input';
 import {
 	BillingCountryInput,
@@ -239,16 +238,6 @@ const AddressForm = ( {
 			} ) }
 		</div>
 	);
-};
-
-AddressForm.propTypes = {
-	onChange: PropTypes.func.isRequired,
-	values: PropTypes.object.isRequired,
-	fields: PropTypes.arrayOf(
-		PropTypes.oneOf( Object.keys( defaultAddressFields ) )
-	),
-	fieldConfig: PropTypes.object,
-	type: PropTypes.oneOf( [ 'billing', 'shipping' ] ),
 };
 
 export default withInstanceId( AddressForm );

--- a/assets/js/base/components/cart-checkout/form-step/index.tsx
+++ b/assets/js/base/components/cart-checkout/form-step/index.tsx
@@ -37,7 +37,7 @@ interface FormStepProps {
 	title?: string;
 	legend?: string;
 	description?: string;
-	children?: JSX.Element | JSX.Element[] | string | string[];
+	children?: React.ReactNode;
 	disabled?: boolean;
 	showStepNumber?: boolean;
 	stepHeadingContent?: () => JSX.Element | undefined;

--- a/assets/js/base/components/cart-checkout/form-step/index.tsx
+++ b/assets/js/base/components/cart-checkout/form-step/index.tsx
@@ -10,7 +10,12 @@ import Title from '@woocommerce/base-components/title';
  */
 import './style.scss';
 
-const StepHeading = ( { title, stepHeadingContent } ) => (
+interface StepHeadingProps {
+	title: string;
+	stepHeadingContent?: JSX.Element;
+}
+
+const StepHeading = ( { title, stepHeadingContent }: StepHeadingProps ) => (
 	<div className="wc-block-components-checkout-step__heading">
 		<Title
 			aria-hidden="true"
@@ -27,6 +32,18 @@ const StepHeading = ( { title, stepHeadingContent } ) => (
 	</div>
 );
 
+interface FormStepProps {
+	id: string;
+	className: string;
+	title?: string;
+	legend?: string;
+	description: string;
+	children: JSX.Element | JSX.Element[] | string | string[];
+	disabled: boolean;
+	showStepNumber: boolean;
+	stepHeadingContent: () => JSX.Element | undefined;
+}
+
 const FormStep = ( {
 	id,
 	className,
@@ -36,8 +53,8 @@ const FormStep = ( {
 	children,
 	disabled = false,
 	showStepNumber = true,
-	stepHeadingContent = () => {},
-} ) => {
+	stepHeadingContent = () => undefined,
+}: FormStepProps ): JSX.Element => {
 	// If the form step doesn't have a legend or title, render a <div> instead
 	// of a <fieldset>.
 	const Element = legend || title ? 'fieldset' : 'div';

--- a/assets/js/base/components/cart-checkout/form-step/index.tsx
+++ b/assets/js/base/components/cart-checkout/form-step/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 import Title from '@woocommerce/base-components/title';
 
 /**
@@ -33,15 +32,15 @@ const StepHeading = ( { title, stepHeadingContent }: StepHeadingProps ) => (
 );
 
 interface FormStepProps {
-	id: string;
-	className: string;
+	id?: string;
+	className?: string;
 	title?: string;
 	legend?: string;
-	description: string;
-	children: JSX.Element | JSX.Element[] | string | string[];
-	disabled: boolean;
-	showStepNumber: boolean;
-	stepHeadingContent: () => JSX.Element | undefined;
+	description?: string;
+	children?: JSX.Element | JSX.Element[] | string | string[];
+	disabled?: boolean;
+	showStepNumber?: boolean;
+	stepHeadingContent?: () => JSX.Element | undefined;
 }
 
 const FormStep = ( {
@@ -95,18 +94,6 @@ const FormStep = ( {
 			</div>
 		</Element>
 	);
-};
-
-FormStep.propTypes = {
-	id: PropTypes.string,
-	className: PropTypes.string,
-	title: PropTypes.string,
-	description: PropTypes.string,
-	children: PropTypes.node,
-	showStepNumber: PropTypes.bool,
-	stepHeadingContent: PropTypes.func,
-	disabled: PropTypes.bool,
-	legend: PropTypes.string,
 };
 
 export default FormStep;

--- a/assets/js/base/components/cart-checkout/order-summary/index.tsx
+++ b/assets/js/base/components/cart-checkout/order-summary/index.tsx
@@ -2,17 +2,23 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { useContainerWidthContext } from '@woocommerce/base-context';
 import { Panel } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
  */
-import OrderSummaryItem from './order-summary-item.js';
+import OrderSummaryItem from './order-summary-item';
 import './style.scss';
+import { CartItem } from '../../../../types/type-defs/cart';
 
-const OrderSummary = ( { cartItems = [] } ) => {
+interface OrderSummaryProps {
+	cartItems: CartItem[];
+}
+
+const OrderSummary = ( {
+	cartItems = [],
+}: OrderSummaryProps ): null | JSX.Element => {
 	const { isLarge, hasContainerWidth } = useContainerWidthContext();
 
 	if ( ! hasContainerWidth ) {
@@ -43,12 +49,6 @@ const OrderSummary = ( { cartItems = [] } ) => {
 			</div>
 		</Panel>
 	);
-};
-
-OrderSummary.propTypes = {
-	cartItems: PropTypes.arrayOf(
-		PropTypes.shape( { key: PropTypes.string.isRequired } )
-	),
 };
 
 export default OrderSummary;

--- a/assets/js/base/components/cart-checkout/order-summary/index.tsx
+++ b/assets/js/base/components/cart-checkout/order-summary/index.tsx
@@ -4,13 +4,13 @@
 import { __ } from '@wordpress/i18n';
 import { useContainerWidthContext } from '@woocommerce/base-context';
 import { Panel } from '@woocommerce/blocks-checkout';
+import type { CartItem } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
 import OrderSummaryItem from './order-summary-item';
 import './style.scss';
-import { CartItem } from '../../../../types/type-defs/cart';
 
 interface OrderSummaryProps {
 	cartItems: CartItem[];

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -14,7 +14,6 @@ import {
 	__experimentalApplyCheckoutFilter,
 	mustContain,
 } from '@woocommerce/blocks-checkout';
-import PropTypes from 'prop-types';
 import Dinero from 'dinero.js';
 import { getSetting } from '@woocommerce/settings';
 import { useMemo } from '@wordpress/element';
@@ -27,10 +26,16 @@ import ProductBackorderBadge from '../product-backorder-badge';
 import ProductImage from '../product-image';
 import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
+import { CartItem } from '../../../../types/type-defs/cart';
 
-const productPriceValidation = ( value ) => mustContain( value, '<price/>' );
+const productPriceValidation = ( value: string ): true | Error =>
+	mustContain( value, '<price/>' );
 
-const OrderSummaryItem = ( { cartItem } ) => {
+interface OrderSummaryProps {
+	cartItem: CartItem;
+}
+
+const OrderSummaryItem = ( { cartItem }: OrderSummaryProps ): JSX.Element => {
 	const {
 		images,
 		low_stock_remaining: lowStockRemaining,
@@ -72,13 +77,13 @@ const OrderSummaryItem = ( { cartItem } ) => {
 
 	const regularPriceSingle = Dinero( {
 		amount: parseInt( prices.raw_prices.regular_price, 10 ),
-		precision: parseInt( prices.raw_prices.precision, 10 ),
+		precision: prices.raw_prices.precision,
 	} )
 		.convertPrecision( priceCurrency.minorUnit )
 		.getAmount();
 	const priceSingle = Dinero( {
 		amount: parseInt( prices.raw_prices.price, 10 ),
-		precision: parseInt( prices.raw_prices.precision, 10 ),
+		precision: prices.raw_prices.precision,
 	} )
 		.convertPrecision( priceCurrency.minorUnit )
 		.getAmount();
@@ -126,7 +131,7 @@ const OrderSummaryItem = ( { cartItem } ) => {
 			<div className="wc-block-components-order-summary-item__image">
 				<div className="wc-block-components-order-summary-item__quantity">
 					<Label
-						label={ quantity }
+						label={ quantity.toString() }
 						screenReaderLabel={ sprintf(
 							/* translators: %d number of products of the same type in the cart */
 							_n(
@@ -201,22 +206,6 @@ const OrderSummaryItem = ( { cartItem } ) => {
 			</div>
 		</div>
 	);
-};
-
-OrderSummaryItem.propTypes = {
-	cartItems: PropTypes.shape( {
-		images: PropTypes.array,
-		low_stock_remaining: PropTypes.number,
-		name: PropTypes.string.isRequired,
-		permalink: PropTypes.string,
-		prices: PropTypes.shape( {
-			price: PropTypes.string,
-			regular_price: PropTypes.string,
-		} ),
-		quantity: PropTypes.number,
-		summary: PropTypes.string,
-		variation: PropTypes.array,
-	} ),
 };
 
 export default OrderSummaryItem;

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -85,7 +85,9 @@ const OrderSummaryItem = ( { cartItem }: OrderSummaryProps ): JSX.Element => {
 		.getAmount();
 	const priceSingle = Dinero( {
 		amount: parseInt( prices.raw_prices.price, 10 ),
-		precision: prices.raw_prices.precision,
+		precision: isString( prices.raw_prices.precision )
+			? parseInt( prices.raw_prices.precision, 10 )
+			: prices.raw_prices.precision,
 	} )
 		.convertPrecision( priceCurrency.minorUnit )
 		.getAmount();

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -18,6 +18,7 @@ import Dinero from 'dinero.js';
 import { getSetting } from '@woocommerce/settings';
 import { useMemo } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
+import type { CartItem } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -26,9 +27,8 @@ import ProductBackorderBadge from '../product-backorder-badge';
 import ProductImage from '../product-image';
 import ProductLowStockBadge from '../product-low-stock-badge';
 import ProductMetadata from '../product-metadata';
-import { CartItem } from '../../../../types/type-defs/cart';
 
-const productPriceValidation = ( value: string ): true | Error =>
+const productPriceValidation = ( value: string ): true | never =>
 	mustContain( value, '<price/>' );
 
 interface OrderSummaryProps {

--- a/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
+++ b/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx
@@ -18,7 +18,7 @@ import Dinero from 'dinero.js';
 import { getSetting } from '@woocommerce/settings';
 import { useMemo } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
-import type { CartItem } from '@woocommerce/types';
+import { CartItem, isString } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -77,7 +77,9 @@ const OrderSummaryItem = ( { cartItem }: OrderSummaryProps ): JSX.Element => {
 
 	const regularPriceSingle = Dinero( {
 		amount: parseInt( prices.raw_prices.regular_price, 10 ),
-		precision: prices.raw_prices.precision,
+		precision: isString( prices.raw_prices.precision )
+			? parseInt( prices.raw_prices.precision, 10 )
+			: prices.raw_prices.precision,
 	} )
 		.convertPrecision( priceCurrency.minorUnit )
 		.getAmount();

--- a/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
+++ b/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
@@ -10,7 +10,7 @@ import { Icon, arrowBack } from '@woocommerce/icons';
  */
 import './style.scss';
 
-const ReturnToCartButton = ( { link } ) => {
+const ReturnToCartButton = ( { link }: { link?: string } ): JSX.Element => {
 	return (
 		<a
 			href={ link || CART_URL }

--- a/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
+++ b/assets/js/base/components/cart-checkout/return-to-cart-button/index.tsx
@@ -10,7 +10,13 @@ import { Icon, arrowBack } from '@woocommerce/icons';
  */
 import './style.scss';
 
-const ReturnToCartButton = ( { link }: { link?: string } ): JSX.Element => {
+interface ReturnToCartButtonProps {
+	link?: string;
+}
+
+const ReturnToCartButton = ( {
+	link,
+}: ReturnToCartButtonProps ): JSX.Element => {
 	return (
 		<a
 			href={ link || CART_URL }

--- a/assets/js/base/components/formatted-monetary-amount/index.tsx
+++ b/assets/js/base/components/formatted-monetary-amount/index.tsx
@@ -7,11 +7,11 @@ import NumberFormat, {
 } from 'react-number-format';
 import classNames from 'classnames';
 import type { ReactElement } from 'react';
+import type { Currency } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
-import type { Currency } from '../../../types/type-defs/currency';
 import './style.scss';
 
 interface FormattedMonetaryAmountProps {
@@ -20,7 +20,7 @@ interface FormattedMonetaryAmountProps {
 	value: number | string; // Value of money amount.
 	currency: Currency | Record< string, never >; // Currency configuration object.
 	onValueChange?: ( unit: number ) => void; // Function to call when value changes.
-	style?: Record< string, unknown >;
+	style?: React.CSSProperties;
 	renderText?: ( value: string ) => JSX.Element;
 }
 

--- a/assets/js/base/components/formatted-monetary-amount/index.tsx
+++ b/assets/js/base/components/formatted-monetary-amount/index.tsx
@@ -6,12 +6,12 @@ import NumberFormat, {
 	NumberFormatProps,
 } from 'react-number-format';
 import classNames from 'classnames';
-import type { Currency } from '@woocommerce/price-format';
 import type { ReactElement } from 'react';
 
 /**
  * Internal dependencies
  */
+import type { Currency } from '../../../types/type-defs/currency';
 import './style.scss';
 
 interface FormattedMonetaryAmountProps {
@@ -20,6 +20,8 @@ interface FormattedMonetaryAmountProps {
 	value: number | string; // Value of money amount.
 	currency: Currency | Record< string, never >; // Currency configuration object.
 	onValueChange?: ( unit: number ) => void; // Function to call when value changes.
+	style?: Record< string, unknown >;
+	renderText?: ( value: string ) => JSX.Element;
 }
 
 /**

--- a/assets/js/base/components/product-price/index.tsx
+++ b/assets/js/base/components/product-price/index.tsx
@@ -17,8 +17,8 @@ interface PriceRangeProps {
 	currency: Currency | Record< string, never >; // Currency configuration object;
 	maxPrice: string | number;
 	minPrice: string | number;
-	priceClassName: string;
-	priceStyle: Record< string, string >;
+	priceClassName?: string;
+	priceStyle?: Record< string, string >;
 }
 
 const PriceRange = ( {
@@ -68,11 +68,11 @@ const PriceRange = ( {
 
 interface SalePriceProps {
 	currency: Currency | Record< string, never >; // Currency configuration object.
-	regularPriceClassName: string;
-	regularPriceStyle: Record< string, string >;
+	regularPriceClassName?: string;
+	regularPriceStyle?: Record< string, string >;
 	regularPrice: number | string;
-	priceClassName: string;
-	priceStyle: Record< string, string >;
+	priceClassName?: string;
+	priceStyle?: Record< string, string >;
 	price: number | string;
 }
 
@@ -129,18 +129,18 @@ const SalePrice = ( {
 };
 
 interface ProductPriceProps {
-	align: 'left' | 'center' | 'right';
-	className: string;
+	align?: 'left' | 'center' | 'right';
+	className?: string;
 	currency: Currency | Record< string, never >; // Currency configuration object.
 	format: string;
 	price: number | string;
-	priceClassName: string;
-	priceStyle: Record< string, string >;
-	maxPrice: number | string;
-	minPrice: number | string;
-	regularPrice: number | string;
-	regularPriceClassName: string;
-	regularPriceStyle: Record< string, string >;
+	priceClassName?: string;
+	priceStyle?: Record< string, string >;
+	maxPrice?: number | string;
+	minPrice?: number | string;
+	regularPrice?: number | string;
+	regularPriceClassName?: string;
+	regularPriceStyle?: Record< string, string >;
 }
 
 const ProductPrice = ( {
@@ -194,7 +194,7 @@ const ProductPrice = ( {
 				regularPriceStyle={ regularPriceStyle }
 			/>
 		);
-	} else if ( minPrice !== null && maxPrice !== null ) {
+	} else if ( minPrice && maxPrice ) {
 		priceComponent = (
 			<PriceRange
 				currency={ currency }
@@ -204,7 +204,7 @@ const ProductPrice = ( {
 				priceStyle={ priceStyle }
 			/>
 		);
-	} else if ( price !== null ) {
+	} else if ( price ) {
 		priceComponent = (
 			<FormattedMonetaryAmount
 				className={ classNames(

--- a/assets/js/base/components/product-price/index.tsx
+++ b/assets/js/base/components/product-price/index.tsx
@@ -6,12 +6,12 @@ import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-mone
 import classNames from 'classnames';
 import { formatPrice } from '@woocommerce/price-format';
 import { createInterpolateElement } from '@wordpress/element';
+import { Currency } from '@woocommerce/type-defs/currency';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { Currency } from '../../../types/type-defs/currency';
 
 interface PriceRangeProps {
 	currency: Currency | Record< string, never >; // Currency configuration object;

--- a/assets/js/base/components/product-price/index.tsx
+++ b/assets/js/base/components/product-price/index.tsx
@@ -6,7 +6,7 @@ import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-mone
 import classNames from 'classnames';
 import { formatPrice } from '@woocommerce/price-format';
 import { createInterpolateElement } from '@wordpress/element';
-import { Currency } from '@woocommerce/type-defs/currency';
+import type { Currency } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ interface PriceRangeProps {
 	maxPrice: string | number;
 	minPrice: string | number;
 	priceClassName?: string;
-	priceStyle?: Record< string, string >;
+	priceStyle?: React.CSSProperties;
 }
 
 const PriceRange = ( {

--- a/assets/js/base/components/product-price/index.tsx
+++ b/assets/js/base/components/product-price/index.tsx
@@ -194,7 +194,7 @@ const ProductPrice = ( {
 				regularPriceStyle={ regularPriceStyle }
 			/>
 		);
-	} else if ( minPrice && maxPrice ) {
+	} else if ( minPrice !== undefined && maxPrice !== undefined ) {
 		priceComponent = (
 			<PriceRange
 				currency={ currency }

--- a/assets/js/base/components/product-price/index.tsx
+++ b/assets/js/base/components/product-price/index.tsx
@@ -4,7 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import { formatPrice } from '@woocommerce/price-format';
 import { createInterpolateElement } from '@wordpress/element';
 
@@ -12,6 +11,15 @@ import { createInterpolateElement } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import { Currency } from '../../../types/type-defs/currency';
+
+interface PriceRangeProps {
+	currency: Currency | Record< string, never >; // Currency configuration object;
+	maxPrice: string | number;
+	minPrice: string | number;
+	priceClassName: string;
+	priceStyle: Record< string, string >;
+}
 
 const PriceRange = ( {
 	currency,
@@ -19,7 +27,7 @@ const PriceRange = ( {
 	minPrice,
 	priceClassName,
 	priceStyle,
-} ) => {
+}: PriceRangeProps ) => {
 	return (
 		<>
 			<span className="screen-reader-text">
@@ -58,6 +66,16 @@ const PriceRange = ( {
 	);
 };
 
+interface SalePriceProps {
+	currency: Currency | Record< string, never >; // Currency configuration object.
+	regularPriceClassName: string;
+	regularPriceStyle: Record< string, string >;
+	regularPrice: number | string;
+	priceClassName: string;
+	priceStyle: Record< string, string >;
+	price: number | string;
+}
+
 const SalePrice = ( {
 	currency,
 	regularPriceClassName,
@@ -66,7 +84,7 @@ const SalePrice = ( {
 	priceClassName,
 	priceStyle,
 	price,
-} ) => {
+}: SalePriceProps ) => {
 	return (
 		<>
 			<span className="screen-reader-text">
@@ -110,20 +128,35 @@ const SalePrice = ( {
 	);
 };
 
+interface ProductPriceProps {
+	align: 'left' | 'center' | 'right';
+	className: string;
+	currency: Currency | Record< string, never >; // Currency configuration object.
+	format: string;
+	price: number | string;
+	priceClassName: string;
+	priceStyle: Record< string, string >;
+	maxPrice: number | string;
+	minPrice: number | string;
+	regularPrice: number | string;
+	regularPriceClassName: string;
+	regularPriceStyle: Record< string, string >;
+}
+
 const ProductPrice = ( {
 	align,
 	className,
 	currency,
 	format = '<price/>',
-	maxPrice = null,
-	minPrice = null,
-	price = null,
+	maxPrice,
+	minPrice,
+	price,
 	priceClassName,
 	priceStyle,
 	regularPrice,
 	regularPriceClassName,
 	regularPriceStyle,
-} ) => {
+}: ProductPriceProps ): JSX.Element => {
 	const wrapperClassName = classNames(
 		className,
 		'price',
@@ -192,23 +225,6 @@ const ProductPrice = ( {
 			} ) }
 		</span>
 	);
-};
-
-ProductPrice.propTypes = {
-	align: PropTypes.oneOf( [ 'left', 'center', 'right' ] ),
-	className: PropTypes.string,
-	currency: PropTypes.object,
-	format: PropTypes.string,
-	price: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
-	priceClassName: PropTypes.string,
-	priceStyle: PropTypes.object,
-	// Range price props
-	maxPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
-	minPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
-	// On sale price props
-	regularPrice: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] ),
-	regularPriceClassName: PropTypes.string,
-	regularPriceStyle: PropTypes.object,
 };
 
 export default ProductPrice;

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -7,6 +7,8 @@ import {
 	ExtensionsData,
 } from './cart-response';
 
+import { ProductResponseItemData } from './product-response';
+
 export interface CurrencyInfo {
 	currency_code: string;
 	currency_symbol: string;
@@ -131,7 +133,7 @@ export interface CartItem {
 	prices: CartItemPrices;
 	totals: CartItemTotals;
 	extensions: ExtensionsData;
-	item_data: Record< string, unknown >[];
+	item_data: ProductResponseItemData[];
 }
 
 export interface CartTotalsTaxLineItem {

--- a/packages/checkout/utils/validation/index.ts
+++ b/packages/checkout/utils/validation/index.ts
@@ -9,7 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 export const mustContain = (
 	value: string,
 	requiredValue: string
-): true | Error => {
+): true | never => {
 	if ( ! value.includes( requiredValue ) ) {
 		throw Error(
 			sprintf(


### PR DESCRIPTION
Converted the following components (and their respective sub components) to Typescript:

- [x] ProductPrice
- [x] OrderSummary
- [x] FormStep
- [x] ReturnToCartButton

Some small changes to types in 
- [x] FormattedMonetaryAmount

Removed  redundant `propTypes` in 
- [x] AddressForm (see [this](https://a8c.slack.com/archives/C8X6Q7XQU/p1637758785345400) and [this](https://a8c.slack.com/archives/C8X6Q7XQU/p1637764581366600) slack conversation)

I'm new to TypeScript so I'm taking this as a learning opportunity. Please give me as much feedback as you can, I'm sure I've screwed up a thing or two :). More specifically, I'm interested to know how other people decide if the props for a component are required or not. I went for a mix of what made the most sense and the current implementation. As in, if a component has 10 props, and it's called with only 3 of them somewhere in the code at a minimum, then those 3 are required.
