### PR TITLE
Remove extra padding for cart sidebar to fix visual regression bug

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/style.scss
@@ -238,13 +238,6 @@ table.wc-block-cart-items {
 		}
 	}
 
-	.wc-block-cart__sidebar {
-		& > div:not(.wc-block-components-totals-wrapper) {
-			margin-left: $gap;
-			margin-right: $gap;
-		}
-	}
-
 	.wc-block-components-radio-control__input {
 		left: 0;
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When upgrading the cart, there was an extra left and right margin added to the Cart page sidebar. I'm not sure if this was intentional, however it causes a [visual regression bug with the points and rewards plugin](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5152) where the input box and the button don't line up properly (see issue for screenshots). 

This fixes #5152 

### Testing

How to test the changes in this Pull Request:

1. Install WooCommerce Points and Rewards, go to WooCommerce > Points and Rewards and add points to your user.
2. Go to WooCommerce > Points and Rewards > Settings and enable "Allow partial redemption"
3. Go to Cart and see the input to redeem points is showing
4. The text input should be inline with the "Apply Discount" button

<!-- If you can, add the appropriate labels -->

### Changelog

> Fixed a visual bug (#5152) with the points and rewards plugin
