### PR TITLE
Don't run enqueue_assets on REST requests

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -81,7 +81,7 @@ abstract class AbstractBlock {
 	 */
 	public function render_callback( $attributes = [], $content = '' ) {
 		$render_callback_attributes = $this->parse_render_callback_attributes( $attributes );
-		if ( ! is_admin() ) {
+		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
 			$this->enqueue_assets( $render_callback_attributes );
 		}
 		return $this->render( $render_callback_attributes, $content );


### PR DESCRIPTION
Fixes #5173.

### Manual Testing

Smoke testing:

1. Copy the contents of this [gist](https://gist.github.com/Aljullu/d9c76ed510ae6973bd41dcc4184e8eb2), which includes all WC Blocks, and paste it into a post or page (via <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>V</kbd>).
2. Save it and verify there is no error.
3. Visit the post or page in the frontend and verify blocks are rendered correctly, except:
3.1 Product Search: you will need to remove it and add it again because it has the URL of the site hard-coded.
3.2 Filter Products by Attribute: there is an open issue for it: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5245.

### Changelog

> Avoid enqueueing block assets and data when not needed in REST requests (ie, when saving a post or page).
