### PR TITLE
Create dev packages with a blocks.ini file

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -129,6 +129,10 @@ mkdir zip-file
 mkdir zip-file/build
 sh "$SOURCE_PATH/bin/copy-plugin-files.sh" "$SOURCE_PATH" "$SOURCE_PATH/zip-file"
 cd "$(pwd)/zip-file"
+if [ $TYPE = 'DEV' ]; then
+	touch blocks.ini
+	printf 'woocommerce_blocks_phase = 3\nwoocommerce_blocks_env = development' > blocks.ini
+fi
 zip -r ../woocommerce-gutenberg-products-block.zip ./
 cd ..
 rm -r zip-file


### PR DESCRIPTION
Fixes #5126.

### Manual Testing

1. Run `npm run package-plugin:dev` in the WC Blocks directory.
2. Verify the resulting zip contains a `blocks.ini` file.
3. Install the resulting zip in an external site without WC Blocks.
4. Notice all gated features are available (ie, the Mini Cart block).