### PR TITLE
refactor StyleAttributesUtils

### DIFF
--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -84,9 +84,13 @@ class ProductCategories extends AbstractDynamicBlock {
 			}
 		}
 
-		$classes_and_styles = $this->get_container_classes_and_styles( $attributes );
-		$classes            = $classes_and_styles[0];
-		$styles             = $classes_and_styles[1];
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes(
+			$attributes,
+			array( 'line_height', 'text_color', 'font_size' )
+		);
+
+		$classes = $this->get_container_classes( $attributes ) . ' ' . $classes_and_styles['classes'];
+		$styles  = $classes_and_styles['styles'];
 
 		$output  = '<div class="wp-block-woocommerce-product-categories ' . esc_attr( $classes ) . '" style="' . esc_attr( $styles ) . '">';
 		$output .= ! empty( $attributes['isDropdown'] ) ? $this->renderDropdown( $categories, $attributes, $uid ) : $this->renderList( $categories, $attributes, $uid );
@@ -96,12 +100,12 @@ class ProductCategories extends AbstractDynamicBlock {
 	}
 
 	/**
-	 * Get the list of classes and styles to apply to this block.
+	 * Get the list of classes to apply to this block.
 	 *
 	 * @param array $attributes Block attributes. Default empty array.
-	 * @return array space-separated list of classes and space-separated list of inline styles.
+	 * @return string space-separated list of classes.
 	 */
-	protected function get_container_classes_and_styles( $attributes = array() ) {
+	protected function get_container_classes( $attributes = array() ) {
 
 		$classes = array( 'wc-block-product-categories' );
 
@@ -119,30 +123,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			$classes[] = 'is-list';
 		}
 
-		$line_height_class_and_style = StyleAttributesUtils::get_line_height_class_and_style( $attributes );
-		$text_color_class_and_style  = StyleAttributesUtils::get_text_color_class_and_style( $attributes );
-		$font_size_class_and_style   = StyleAttributesUtils::get_font_size_class_and_style( $attributes );
-
-		$line_height_class = isset( $line_height_class_and_style['class'] ) ? $line_height_class_and_style['class'] : null;
-		$text_color_class  = isset( $text_color_class_and_style['class'] ) ? $text_color_class_and_style['class'] : null;
-		$font_size_class   = isset( $font_size_class_and_style['class'] ) ? $font_size_class_and_style['class'] : null;
-
-		$classes = array_filter(
-			array( $line_height_class, $text_color_class, $font_size_class )
-		);
-
-		$line_height_style = isset( $line_height_class_and_style['style'] ) ? $line_height_class_and_style['style'] : null;
-		$text_color_style  = isset( $text_color_class_and_style['style'] ) ? $text_color_class_and_style['style'] : null;
-		$font_size_style   = isset( $font_size_class_and_style['style'] ) ? $font_size_class_and_style['style'] : null;
-
-		$styles = array_filter(
-			array( $line_height_style, $text_color_style, $font_size_style )
-		);
-
-		$string_classes = implode( ' ', $classes );
-		$string_styles  = implode( ' ', $styles );
-
-		return array( $string_classes, $string_styles );
+		return implode( ' ', $classes );
 	}
 
 	/**

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -17,7 +17,7 @@ class StyleAttributesUtils {
 
 		$font_size = $attributes['fontSize'];
 
-		$custom_font_size = isset( $attributes['style']['color']['fontSize'] ) ? $attributes['style']['color']['fontSize'] : null;
+		$custom_font_size = isset( $attributes['style']['typography']['fontSize'] ) ? $attributes['style']['typography']['fontSize'] : null;
 
 		if ( ! isset( $font_size ) && ! isset( $custom_font_size ) ) {
 			return null;
@@ -117,7 +117,7 @@ class StyleAttributesUtils {
 	 */
 	public static function get_line_height_class_and_style( $attributes ) {
 
-		$line_height = isset( $attributes['style']['color']['lineHeight'] ) ? $attributes['style']['color']['lineHeight'] : null;
+		$line_height = isset( $attributes['style']['typography']['lineHeight'] ) ? $attributes['style']['typography']['lineHeight'] : null;
 
 		if ( ! isset( $line_height ) ) {
 			return null;
@@ -135,10 +135,11 @@ class StyleAttributesUtils {
 	 * Get classes and styles from attributes.
 	 *
 	 * @param array $attributes Block attributes.
+	 * @param array $properties Properties to get classes/styles from.
 	 *
 	 * @return array
 	 */
-	public static function get_classes_and_styles_by_attributes( $attributes ) {
+	public static function get_classes_and_styles_by_attributes( $attributes, $properties = array() ) {
 		$classes_and_styles = array(
 			'line_height' => self::get_line_height_class_and_style( $attributes ),
 			'text_color'  => self::get_text_color_class_and_style( $attributes ),
@@ -146,8 +147,64 @@ class StyleAttributesUtils {
 			'link_color'  => self::get_link_color_class_and_style( $attributes ),
 		);
 
-		return array_filter(
+		if ( ! empty( $properties ) ) {
+			foreach ( $classes_and_styles as $key => $value ) {
+				if ( ! in_array( $key, $properties, true ) ) {
+					unset( $classes_and_styles[ $key ] );
+				}
+			}
+		}
+
+		$classes_and_styles = array_filter( $classes_and_styles );
+
+		$classes = array_map(
+			function( $item ) {
+				return $item['class'];
+			},
 			$classes_and_styles
 		);
+
+		$styles = array_map(
+			function( $item ) {
+				return $item['style'];
+			},
+			$classes_and_styles
+		);
+
+		$classes = array_filter( $classes );
+		$styles  = array_filter( $styles );
+
+		return array(
+			'classes' => implode( ' ', $classes ),
+			'styles'  => implode( ' ', $styles ),
+		);
+	}
+
+	/**
+	 * Get space-separated classes from block attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @param array $properties Properties to get classes from.
+	 *
+	 * @return string Space-separated classes.
+	 */
+	public static function get_classes_by_attributes( $attributes, $properties = array() ) {
+		$classes_and_styles = self::get_classes_and_styles_by_attributes( $attributes, $properties );
+
+		return $classes_and_styles['classes'];
+	}
+
+	/**
+	 * Get space-separated style rules from block attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @param array $properties Properties to get styles from.
+	 *
+	 * @return string Space-separated style rules.
+	 */
+	public static function get_styles_by_attributes( $attributes, $properties = array() ) {
+		$classes_and_styles = self::get_classes_and_styles_by_attributes( $attributes, $properties );
+
+		return $classes_and_styles['styles'];
 	}
 }


### PR DESCRIPTION
This PR refactor the `StyleAttributesUtils` introduced in #5133. The issue with the original implementation to me is, we still need a lot of code to get the space-separated classes/styles - which is the main use-case of the utils. This PR refactor it so we can get desired properties in an immutable way without complex calculation in the markup.