### PR TITLE
[PHP 8.1] Fix code that causes a deprecation notice in BlockTypesController

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -76,7 +76,7 @@ final class BlockTypesController {
 	 */
 	public function add_data_attributes( $content, $block ) {
 		$block_name      = $block['blockName'];
-		$block_namespace = strtok( $block_name, '/' );
+		$block_namespace = strtok( $block_name ?? '', '/' );
 
 		/**
 		 * Filters the list of allowed block namespaces.


### PR DESCRIPTION
This pull request just fixes one small part of the code that causes a deprecation notice under PHP 8.1 (caused by passing `null` to `strtok`) when running the WooCommerce core unit tests. See [the fix pull request in WooCommerce core](https://github.com/woocommerce/woocommerce/pull/31333).
