### PR TITLE
Fix JS error in Filter Products by Attribute block

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -162,35 +162,6 @@ const AttributeFilterBlock = ( {
 		queryState.attributes,
 	] );
 
-	const checkedQuery = useMemo( () => {
-		return productAttributesQuery
-			.filter(
-				( { attribute } ) => attribute === attributeObject?.taxonomy
-			)
-			.flatMap( ( { slug } ) => slug );
-	}, [ productAttributesQuery, attributeObject?.taxonomy ] );
-
-	const currentCheckedQuery = useShallowEqual( checkedQuery );
-	const previousCheckedQuery = usePrevious( currentCheckedQuery );
-	// Track ATTRIBUTES QUERY changes so the block reflects current filters.
-	useEffect( () => {
-		if (
-			! isShallowEqual( previousCheckedQuery, currentCheckedQuery ) && // checked query changed
-			! isShallowEqual( checked, currentCheckedQuery ) // checked query doesn't match the UI
-		) {
-			setChecked( currentCheckedQuery );
-			if ( ! blockAttributes.showFilterButton ) {
-				onSubmit( currentCheckedQuery );
-			}
-		}
-	}, [
-		checked,
-		currentCheckedQuery,
-		previousCheckedQuery,
-		onSubmit,
-		blockAttributes.showFilterButton,
-	] );
-
 	/**
 	 * Returns an array of term objects that have been chosen via the checkboxes.
 	 */
@@ -229,6 +200,35 @@ const AttributeFilterBlock = ( {
 			blockAttributes.queryType,
 		]
 	);
+
+	const checkedQuery = useMemo( () => {
+		return productAttributesQuery
+			.filter(
+				( { attribute } ) => attribute === attributeObject?.taxonomy
+			)
+			.flatMap( ( { slug } ) => slug );
+	}, [ productAttributesQuery, attributeObject?.taxonomy ] );
+
+	const currentCheckedQuery = useShallowEqual( checkedQuery );
+	const previousCheckedQuery = usePrevious( currentCheckedQuery );
+	// Track ATTRIBUTES QUERY changes so the block reflects current filters.
+	useEffect( () => {
+		if (
+			! isShallowEqual( previousCheckedQuery, currentCheckedQuery ) && // checked query changed
+			! isShallowEqual( checked, currentCheckedQuery ) // checked query doesn't match the UI
+		) {
+			setChecked( currentCheckedQuery );
+			if ( ! blockAttributes.showFilterButton ) {
+				onSubmit( currentCheckedQuery );
+			}
+		}
+	}, [
+		checked,
+		currentCheckedQuery,
+		previousCheckedQuery,
+		onSubmit,
+		blockAttributes.showFilterButton,
+	] );
 
 	const multiple =
 		blockAttributes.displayStyle !== 'dropdown' ||


### PR DESCRIPTION
Fixes #5245.

Since we migrated to a diferent Babel config in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5212, there has been a JS error in the Filter Products by Attribute block which caused the block not to render at all.

This PR fixes it simply reordering a couple of functions. ~It also adds some basic e2e tests, copied from the Filter Products by Stock block.~ (I removed them for now because I had issues running them locally)

### Screenshots

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/3616980/144582378-3b275e23-8184-4dd1-b85a-d3bb98f83faf.png" width="279" alt=""> | <img src="https://user-images.githubusercontent.com/3616980/144582293-a5455dd7-1058-4760-b2e1-eb9c1a79812f.png" width="281" alt=""> |

### Testing

#### Manual Testing

1. Create a post or page and add the Filter Products by Attribute and the All Products blocks.
2. Verify the Filter Products by Attribute block renders correctly in the editor.
3. Go to the frontend and verify the Filter Products by Attribute block renders correctly there too.
