### PR TITLE
Fix: Mini Cart: don't allow users to create extra template parts in the Mini Cart template part area

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -57,7 +57,6 @@ class BlockTemplatesController {
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 		add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
-		add_filter( 'default_wp_template_part_areas', array( $this, 'add_template_part_areas' ) );
 	}
 
 	/**
@@ -438,23 +437,4 @@ class BlockTemplatesController {
 		}
 	}
 
-	/**
-	 * Add template part areas for our blocks.
-	 *
-	 * @param array $area_definitions An array of supported area objects.
-	 */
-	public function add_template_part_areas( $area_definitions ) {
-		return array_merge(
-			$area_definitions,
-			array(
-				array(
-					'area'        => 'mini-cart',
-					'label'       => __( 'Mini Cart', 'woo-gutenberg-products-block' ),
-					'description' => __( 'The Mini Cart template defines a page area that contains the content of the Mini Cart block.', 'woo-gutenberg-products-block' ),
-					'icon'        => 'sidebar',
-					'area_tag'    => 'div',
-				),
-			)
-		);
-	}
 }

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -58,7 +58,6 @@ class BlockTemplatesController {
 		add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 		add_filter( 'default_wp_template_part_areas', array( $this, 'add_template_part_areas' ) );
-		add_filter( 'wp_insert_post', array( $this, 'add_mini_cart_content_to_template_part' ), 10, 3 );
 	}
 
 	/**
@@ -457,70 +456,5 @@ class BlockTemplatesController {
 				),
 			)
 		);
-	}
-
-	/**
-	 * Add mini cart content block to new template part for Mini Cart area.
-	 *
-	 * @param int      $post_id Post ID.
-	 * @param \WP_Post $post    Post object.
-	 * @param bool     $update  Whether this is an existing post being updated.
-	 */
-	public function add_mini_cart_content_to_template_part( $post_id, $post, $update ) {
-		// We only inject the mini cart content when the template part is created.
-		if ( $update ) {
-			return;
-		}
-
-		// If by somehow, the template part was created with content, bail.
-		if ( ! empty( $post->content ) ) {
-			return;
-		}
-
-		if ( ! function_exists( 'get_block_file_template' ) ) {
-			return;
-		}
-
-		if ( 'wp_template_part' !== $post->post_type ) {
-			return;
-		}
-
-		$type_terms = get_the_terms( $post, 'wp_template_part_area' );
-
-		if ( is_wp_error( $type_terms ) || false === $type_terms ) {
-			return;
-		}
-
-		if ( 'mini-cart' !== $type_terms[0]->name ) {
-			return;
-		}
-
-		// Remove the filter temporarily for wp_update_post below.
-		remove_filter( 'wp_insert_post', array( $this, 'add_mini_cart_content_to_template_part' ), 10, 3 );
-
-		$block_template = null;
-
-		/**
-		 * We only use the mini cart content from file.
-		 */
-		if ( BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ) {
-			$template_id    = sprintf( '%s//mini-cart', wp_get_theme()->get_stylesheet() );
-			$block_template = get_block_file_template( $template_id, 'wp_template_part' );
-		} else {
-			$available_templates = $this->get_block_templates_from_woocommerce( array( 'mini-cart' ), array(), 'wp_template_part' );
-			if ( is_array( $available_templates ) && count( $available_templates ) > 0 ) {
-				$block_template = BlockTemplateUtils::gutenberg_build_template_result_from_file( $available_templates[0], $available_templates[0]->type );
-			}
-		}
-
-		if ( is_a( $block_template, 'WP_Block_Template' ) ) {
-			$post->post_content = $block_template->content;
-		} else { // Just for extra safety.
-			$post->post_content = '<!-- wp:woocommerce/mini-cart-contents /-->';
-		}
-
-		wp_update_post( $post );
-
-		add_filter( 'wp_insert_post', array( $this, 'add_mini_cart_content_to_template_part' ), 10, 3 );
 	}
 }

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -143,13 +143,7 @@ class BlockTemplateUtils {
 		$template->has_theme_file = true;
 		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
-		if ( 'wp_template_part' === $template_type ) {
-			if ( 'mini-cart' === $template_file->slug ) {
-				$template->area = 'mini-cart';
-			} else {
-				$template->area = 'uncategorized';
-			}
-		}
+		$template->area           = 'uncategorized';
 		return $template;
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5284.

This PR reverts changes in #5231 and #5221 to remove the template part area completely. So users can only modify the mini cart template part from the plugin/theme. This also closes #5232.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Check out the latest `trunk` of `woocommerce` or install the [nightly build](https://github.com/woocommerce/woocommerce/releases/tag/nightly).
2. Check out the latest `trunk` of Gutenberg.
3. Go to Appearance > Editor (Beta).
4. Click on the W icon > Template Parts.
5. Click the Add new button on the top right corner.
6. **Don't see** the Mini Cart area in the list.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.