### PR TITLE
Refactor: use StyleAttributesUtils to generate classes and styles

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -7,7 +7,7 @@ use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
-use Automattic\WooCommerce\Blocks\RestApi;
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
  * Mini Cart class.
@@ -306,8 +306,9 @@ class MiniCart extends AbstractBlock {
 		}
 
 		$wrapper_classes = 'wc-block-mini-cart  wp-block-woocommerce-mini-cart';
-		$classes         = '';
-		$style           = '';
+		$classes_styles  = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color' ) );
+		$classes         = $classes_styles['classes'];
+		$style           = $classes_styles['styles'];
 
 		if ( ! empty( $attributes['align'] ) ) {
 			$wrapper_classes .= ' align-' . $attributes['align'];
@@ -315,31 +316,6 @@ class MiniCart extends AbstractBlock {
 
 		if ( ! isset( $attributes['transparentButton'] ) || $attributes['transparentButton'] ) {
 			$wrapper_classes .= ' is-transparent';
-		}
-
-		/**
-		 * Get the color class and inline style.
-		 *
-		 * @todo refactor the logic of color class and style using StyleAttributesUtils.
-		 */
-		if ( ! empty( $attributes['textColor'] ) ) {
-			$classes .= sprintf(
-				' has-%s-color has-text-color',
-				esc_attr( $attributes['textColor'] )
-			);
-		} elseif ( ! empty( $attributes['style']['color']['text'] ) ) {
-			$style   .= 'color: ' . esc_attr( $attributes['style']['color']['text'] ) . ';';
-			$classes .= ' has-text-color';
-		}
-
-		if ( ! empty( $attributes['backgroundColor'] ) ) {
-			$classes .= sprintf(
-				' has-%s-background-color has-background',
-				esc_attr( $attributes['backgroundColor'] )
-			);
-		} elseif ( ! empty( $attributes['style']['color']['background'] ) ) {
-			$style   .= 'background-color: ' . esc_attr( $attributes['style']['color']['background'] ) . ';';
-			$classes .= ' has-background';
 		}
 
 		$aria_label = sprintf(

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -15,23 +15,20 @@ class StyleAttributesUtils {
 	 */
 	public static function get_font_size_class_and_style( $attributes ) {
 
-		$font_size = $attributes['fontSize'];
+		$font_size = $attributes['fontSize'] ?? '';
 
-		$custom_font_size = isset( $attributes['style']['typography']['fontSize'] ) ? $attributes['style']['typography']['fontSize'] : null;
+		$custom_font_size = $attributes['style']['typography']['fontSize'] ?? '';
 
-		if ( ! isset( $font_size ) && ! isset( $custom_font_size ) ) {
+		if ( ! $font_size && '' === $custom_font_size ) {
 			return null;
 		};
 
-		$has_named_font_size  = ! empty( $font_size );
-		$has_custom_font_size = isset( $custom_font_size );
-
-		if ( $has_named_font_size ) {
+		if ( $font_size ) {
 			return array(
 				'class' => sprintf( 'has-font-size has-%s-font-size', $font_size ),
 				'style' => null,
 			);
-		} elseif ( $has_custom_font_size ) {
+		} elseif ( '' !== $custom_font_size ) {
 			return array(
 				'class' => null,
 				'style' => sprintf( 'font-size: %s;', $custom_font_size ),
@@ -49,23 +46,20 @@ class StyleAttributesUtils {
 	 */
 	public static function get_text_color_class_and_style( $attributes ) {
 
-		$text_color = $attributes['textColor'];
+		$text_color = $attributes['textColor'] ?? '';
 
-		$custom_text_color = isset( $attributes['style']['color']['text'] ) ? $attributes['style']['color']['text'] : null;
+		$custom_text_color = $attributes['style']['color']['text'] ?? '';
 
-		if ( ! isset( $text_color ) && ! isset( $custom_text_color ) ) {
+		if ( ! $text_color && ! $custom_text_color ) {
 			return null;
 		};
 
-		$has_named_text_color  = ! empty( $text_color );
-		$has_custom_text_color = isset( $custom_text_color );
-
-		if ( $has_named_text_color ) {
+		if ( $text_color ) {
 			return array(
 				'class' => sprintf( 'has-text-color has-%s-color', $text_color ),
 				'style' => null,
 			);
-		} elseif ( $has_custom_text_color ) {
+		} elseif ( $custom_text_color ) {
 			return array(
 				'class' => null,
 				'style' => sprintf( 'color: %s;', $custom_text_color ),
@@ -117,18 +111,47 @@ class StyleAttributesUtils {
 	 */
 	public static function get_line_height_class_and_style( $attributes ) {
 
-		$line_height = isset( $attributes['style']['typography']['lineHeight'] ) ? $attributes['style']['typography']['lineHeight'] : null;
+		$line_height = $attributes['style']['typography']['lineHeight'] ?? '';
 
-		if ( ! isset( $line_height ) ) {
+		if ( ! $line_height ) {
 			return null;
 		};
 
-		$line_height_style = sprintf( 'line-height: %s;', $line_height );
-
 		return array(
 			'class' => null,
-			'style' => $line_height_style,
+			'style' => sprintf( 'line-height: %s;', $line_height ),
 		);
+	}
+
+	/**
+	 * Get class and style for background-color from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_background_color_class_and_style( $attributes ) {
+
+		$background_color = $attributes['backgroundColor'] ?? '';
+
+		$custom_background_color = $attributes['style']['color']['background'] ?? '';
+
+		if ( ! $background_color && '' === $custom_background_color ) {
+			return null;
+		};
+
+		if ( $background_color ) {
+			return array(
+				'class' => sprintf( 'has-background has-%s-background-color', $background_color ),
+				'style' => null,
+			);
+		} elseif ( '' !== $custom_background_color ) {
+			return array(
+				'class' => null,
+				'style' => sprintf( 'background-color: %s;', $custom_background_color ),
+			);
+		}
+		return null;
 	}
 
 	/**
@@ -141,10 +164,11 @@ class StyleAttributesUtils {
 	 */
 	public static function get_classes_and_styles_by_attributes( $attributes, $properties = array() ) {
 		$classes_and_styles = array(
-			'line_height' => self::get_line_height_class_and_style( $attributes ),
-			'text_color'  => self::get_text_color_class_and_style( $attributes ),
-			'font_size'   => self::get_font_size_class_and_style( $attributes ),
-			'link_color'  => self::get_link_color_class_and_style( $attributes ),
+			'line_height'      => self::get_line_height_class_and_style( $attributes ),
+			'text_color'       => self::get_text_color_class_and_style( $attributes ),
+			'font_size'        => self::get_font_size_class_and_style( $attributes ),
+			'link_color'       => self::get_link_color_class_and_style( $attributes ),
+			'background_color' => self::get_background_color_class_and_style( $attributes ),
 		);
 
 		if ( ! empty( $properties ) ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5175 

This PR makes use of `StyleAttributesUtils` to generate class and styles attributes for Mini Cart block. This also adds a new utility to generate the background color classes and styles.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Edit a page or header that contains the Mini Cart Block.
2. change block text color and background.
3. See the block style work as expected as the frontend as before refactoring.
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
