### PR TITLE
Fix: Mini Cart block button should be disabled in the editor

### DIFF
--- a/assets/js/base/components/noninteractive/index.tsx
+++ b/assets/js/base/components/noninteractive/index.tsx
@@ -34,7 +34,7 @@ const Noninteractive = ( {
 	style = {},
 	...props
 }: {
-	children: React.ReactChildren;
+	children: React.ReactNode;
 	style?: Record< string, string >;
 } ): JSX.Element => {
 	const node = useRef< HTMLDivElement >( null );

--- a/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
 import { positionCenter, positionRight, positionLeft } from '@wordpress/icons';
 import classnames from 'classnames';
 import { isString } from '@woocommerce/types';
+import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
  * Internal dependencies
@@ -165,22 +166,24 @@ const MiniCartBlock = ( {
 						</PanelBody>
 					) }
 			</InspectorControls>
-			<button
-				className={ classnames(
-					'wc-block-mini-cart__button',
-					colorClassNames
-				) }
-				style={ colorStyle }
-			>
-				<span className="wc-block-mini-cart__amount">
-					{ formatPrice( productTotal ) }
-				</span>
-				<QuantityBadge
-					count={ productCount }
-					colorClassNames={ colorClassNames }
+			<Noninteractive>
+				<button
+					className={ classnames(
+						'wc-block-mini-cart__button',
+						colorClassNames
+					) }
 					style={ colorStyle }
-				/>
-			</button>
+				>
+					<span className="wc-block-mini-cart__amount">
+						{ formatPrice( productTotal ) }
+					</span>
+					<QuantityBadge
+						count={ productCount }
+						colorClassNames={ colorClassNames }
+						style={ colorStyle }
+					/>
+				</button>
+			</Noninteractive>
 			<CartCheckoutCompatibilityNotice blockName="mini-cart" />
 		</div>
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5274 

This PR utilizes the `Noninteractive` component introduced in #5157 to disable the Mini Cart block button in the editor.

This also changes the type for `children` of `<Noninteractive>` from `React.ReactChildren` to `React.ReactNode` to fix the exiting warnings of blocking using it.

### Screenshots


https://user-images.githubusercontent.com/5423135/144702515-a8f033a1-e9c9-43b8-992a-f141d6a0e047.mov

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Create a post or page.
2. Add a Mini Cart block.
3. Click on the Mini Cart **button**.
4. See the block border appear.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.