### PR TITLE
Remove full-width mode from cart and checkout block

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -28,7 +28,7 @@ const settings = {
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __( 'Shopping cart.', 'woo-gutenberg-products-block' ),
 	supports: {
-		align: [ 'wide', 'full' ],
+		align: [ 'wide' ],
 		html: false,
 		multiple: false,
 		__experimentalExposeControlsToChildren: true,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/empty-cart-block/block.json
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/empty-cart-block/block.json
@@ -5,7 +5,7 @@
 	"description": "Contains blocks that are displayed when the cart is empty.",
 	"category": "woocommerce",
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [ "wide" ],
 		"html": false,
 		"multiple": false,
 		"reusable": false,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/filled-cart-block/block.json
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/filled-cart-block/block.json
@@ -5,7 +5,7 @@
 	"description": "Contains blocks that are displayed when the cart contains products.",
 	"category": "woocommerce",
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [ "wide" ],
 		"html": false,
 		"multiple": false,
 		"reusable": false,

--- a/assets/js/blocks/cart-checkout/checkout/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/index.tsx
@@ -27,7 +27,7 @@ const settings = {
 		'woo-gutenberg-products-block'
 	),
 	supports: {
-		align: [ 'wide', 'full' ],
+		align: [ 'wide' ],
 		html: false,
 		multiple: false,
 	},


### PR DESCRIPTION
Fixes #5010

Until now, it was possible to show the cart and the checkout block in full-width. However, there the cart block had no margin on the left hand-side margin and the checkout block had no margin on both sides. The screenshots on https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5010#:~:text=the%20browser%20border.-,Screenshots,-Cart%3A demonstrate this problem.

With this PR, I removed the full-width option so that these blocks can only use the wide option. When using the wide option, the margin problem no longer appears.

### Testing

1. Create a test page with the cart block. 
2. Verify that both the `Cart`, the `Filled Cart` and the `Empty Cart` only show the alignment options `None` and `Wide width`.
3. Create a test page with the checkout block.
4. Verify that only the alignment options `None` and `Wide width` are available.

### User Facing Testing

* [x] Same as above

### Changelog

> Fix cart and checkout margin problem by removing the full-width option.
