### PR TITLE
Update icon of legacy template block

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -48,6 +48,15 @@
 	}
 }
 
+// Display white icon when block is selected in list view.
+.block-editor-list-view-leaf.is-selected {
+	.block-editor-list-view-block-contents {
+		svg {
+			fill: #fff;
+		}
+	}
+}
+
 // Selectors with extra specificity to override some editor styles.
 .woocommerce-search-list__list.woocommerce-search-list__list {
 	box-sizing: border-box;

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -6,7 +6,7 @@ import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { box } from '@wordpress/icons';
+import { box, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ const Edit = ( { attributes }: Props ) => {
 
 registerBlockType( 'woocommerce/legacy-template', {
 	title: __( 'WooCommerce Legacy Template', 'woo-gutenberg-products-block' ),
-	icon: box,
+	icon: <Icon icon={ box } color="#7f54b3" />,
 	category: 'woocommerce',
 	apiVersion: 2,
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -6,7 +6,7 @@ import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { page } from '@wordpress/icons';
+import { box } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ const Edit = ( { attributes }: Props ) => {
 	return (
 		<div { ...blockProps }>
 			<Placeholder
-				icon={ page }
+				icon={ box }
 				label={ templateTitle }
 				className="wp-block-woocommerce-legacy-template__placeholder"
 			>
@@ -57,6 +57,7 @@ const Edit = ( { attributes }: Props ) => {
 
 registerBlockType( 'woocommerce/legacy-template', {
 	title: __( 'WooCommerce Legacy Template', 'woo-gutenberg-products-block' ),
+	icon: box,
 	category: 'woocommerce',
 	apiVersion: 2,
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],


### PR DESCRIPTION
Currently, the Legacy Template Blocks have been using the `default` and the `page` icon. This PR replaces the current icons with a `box` icon.

Fixes #5269

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#5269-before](https://user-images.githubusercontent.com/3323310/144832277-f8f005f1-8640-44ce-b82b-8a9d3cfd9d67.png)
</td>
<td>After:
<br><br>

![#5269-after](https://user-images.githubusercontent.com/3323310/144832283-330f42bd-5ad7-4f56-b975-023fd49e1a05.png)
</td>
</tr>
</table>

### Testing

To test this PR, you need WooCommerce 6.0 or higher, Gutenberg and a FSE-theme, e.g. TT1 Blocks.

1. Go to `Appearance » Editor`.
2. Click on the `W` icon in the upper-left corner.
3. Go to `General templates`.
4. Open one of the product templates.
5. Click on the `Legacy Template Block` and open the `List View`.
6. Verify that the correct icon is visible in the `List View`, the block toolbar and the block itself.