### PR TITLE
Rollback checkout status to started instead of pristine in case of error

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/payment-methods/constants.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/constants.ts
@@ -8,6 +8,7 @@ import type {
 
 export enum STATUS {
 	PRISTINE = 'pristine',
+	IDLE = 'idle',
 	STARTED = 'started',
 	PROCESSING = 'processing',
 	ERROR = 'has_error',
@@ -38,6 +39,7 @@ export const DEFAULT_PAYMENT_DATA_CONTEXT_STATE: PaymentMethodDataContextState =
 export const DEFAULT_PAYMENT_METHOD_DATA: PaymentMethodDataContextType = {
 	setPaymentStatus: () => ( {
 		pristine: () => void null,
+		idle: () => void null,
 		started: () => void null,
 		processing: () => void null,
 		completed: () => void null,
@@ -50,6 +52,7 @@ export const DEFAULT_PAYMENT_METHOD_DATA: PaymentMethodDataContextType = {
 	currentStatus: {
 		isPristine: true,
 		isStarted: false,
+		isIdle: false,
 		isProcessing: false,
 		isFinished: false,
 		hasError: false,

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/payment-method-data-context.tsx
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/payment-method-data-context.tsx
@@ -222,7 +222,7 @@ export const PaymentMethodDataProvider = ( {
 	// When checkout is returned to idle, set payment status to pristine but only if payment status is already not finished.
 	useEffect( () => {
 		if ( checkoutIsIdle && ! currentStatus.isSuccessful ) {
-			setPaymentStatus().pristine();
+			setPaymentStatus().started();
 		}
 	}, [ checkoutIsIdle, currentStatus.isSuccessful, setPaymentStatus ] );
 

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/payment-method-data-context.tsx
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/payment-method-data-context.tsx
@@ -222,7 +222,7 @@ export const PaymentMethodDataProvider = ( {
 	// When checkout is returned to idle, set payment status to pristine but only if payment status is already not finished.
 	useEffect( () => {
 		if ( checkoutIsIdle && ! currentStatus.isSuccessful ) {
-			setPaymentStatus().started();
+			setPaymentStatus().idle();
 		}
 	}, [ checkoutIsIdle, currentStatus.isSuccessful, setPaymentStatus ] );
 

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/reducer.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/reducer.ts
@@ -99,6 +99,15 @@ const reducer = (
 				},
 				shouldSavePaymentMethod: state.shouldSavePaymentMethod,
 			};
+		case STATUS.IDLE:
+			return {
+				...state,
+				currentStatus: STATUS.IDLE,
+				paymentMethodData: paymentMethodData || state.paymentMethodData,
+				hasSavedToken: hasSavedPaymentToken(
+					paymentMethodData || state.paymentMethodData
+				),
+			};
 		case ACTION.SET_REGISTERED_PAYMENT_METHODS:
 			return {
 				...state,

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/types.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/types.ts
@@ -40,6 +40,7 @@ export interface PaymentStatusDispatchers {
 	started: ( paymentMethodData?: ObjectType | EmptyObjectType ) => void;
 	processing: () => void;
 	completed: () => void;
+	idle: () => void;
 	error: ( error: string ) => void;
 	failed: (
 		error?: string,
@@ -66,6 +67,8 @@ export interface PaymentMethodDataContextState {
 export type PaymentMethodCurrentStatusType = {
 	// If true then the payment method state in checkout is pristine.
 	isPristine: boolean;
+	// If true then the payment method state in checkout is modified, but isn't doing anyting.
+	isIdle: boolean;
 	// If true then the payment method has been initialized and has started.
 	isStarted: boolean;
 	// If true then the payment method is processing payment.

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-dispatchers.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-dispatchers.ts
@@ -45,6 +45,7 @@ export const usePaymentMethodDataDispatchers = (
 	const setPaymentStatus = useCallback(
 		(): PaymentStatusDispatchers => ( {
 			pristine: () => dispatch( actions.statusOnly( STATUS.PRISTINE ) ),
+			idle: () => dispatch( actions.statusOnly( STATUS.IDLE ) ),
 			started: ( paymentMethodData ) => {
 				dispatch(
 					actions.started( {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

When checkouts runs into an error (local validation for example), its status is rolled back to pristine, causing payment saved data to unload. For some reasoning, fixing errors and hitting submit again doesn't reset saved payment methods, @alexflorisca and I had two solutions:

- Make sure going to pristine preserve saved tokens (not a great solution given pristine should be empty).
- Don't roll back to pristine, roll back to started (the solution we did).
- Make sure saved payment methods are still picked up again later when you hit Place Order (not sure how to do this).
- 
<!-- Reference any related issues or PRs here -->
Fixes #5296

### Testing

How to test the changes in this Pull Request:

1. Make sure you have a saved payment.
2. On Checkout, don't check terms block, or clear postcode, just make sure there's an error.
3. Place order, you have an error.
4. Fix the error, place again, it should work.
5. The original code has something to do with express payment methods (not sure what is it @mikejolley) so make sure they're also working fine.

### Changelog

> Fix a certain use case error with saved payment methods.
