### PR TITLE
Set WooCommerce like the source of WC templates

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -133,7 +133,7 @@ class BlockTemplateUtils {
 		$template_content         = file_get_contents( $template_file->path );
 		$template                 = new \WP_Block_Template();
 		$template->id             = 'woocommerce//' . $template_file->slug;
-		$template->theme          = 'woocommerce';
+		$template->theme          = 'WooCommerce';
 		$template->content        = self::gutenberg_inject_theme_attribute_in_content( $template_content );
 		$template->source         = 'plugin';
 		$template->slug           = $template_file->slug;
@@ -141,6 +141,7 @@ class BlockTemplateUtils {
 		$template->title          = ! empty( $template_file->title ) ? $template_file->title : self::convert_slug_to_title( $template_file->slug );
 		$template->status         = 'publish';
 		$template->has_theme_file = true;
+		$template->origin         = 'plugin';
 		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 		if ( 'wp_template_part' === $template_type ) {


### PR DESCRIPTION
This PR sets WooCommerce like the source of WC templates.
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5271

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots


#### Before

![image](https://user-images.githubusercontent.com/4463174/144860300-a1e061e8-e3df-4c62-8027-4d01a6ab06f8.png)
![image](https://user-images.githubusercontent.com/4463174/144860346-e7c58aae-a0b6-4787-917c-e2210354557a.png)

#### Current implementation 

![image](https://user-images.githubusercontent.com/4463174/144860080-768de8ab-1570-4a17-aac6-94d55ffeb093.png)
![image](https://user-images.githubusercontent.com/4463174/144860196-eacb463a-8599-4b36-b9e2-c475cca8bd8e.png)

### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch. Be sure that you are using `Gutenberg trunk version`, `WC 6.0` and a block theme like `TTY Blocks`

1. Go to the Template page.
2. Notice the Added by column is filled for template that hadn't been modified by the user with `WooCommerce`. (check the image above)
3. Go to the Template parts page.
4. Notice the Added by column is filled for template that hadn't been modified by the user with `WooCommerce`. (check the image above)
