### PR TITLE
Move Draft Order Handling to Shared Trait (DraftOrderTrait)

### DIFF
--- a/src/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/AbstractCartRoute.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\AbstractSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\DraftOrderTrait;
 
 /**
  * Abstract Cart Route
@@ -12,8 +11,6 @@ use Automattic\WooCommerce\Blocks\StoreApi\Utilities\DraftOrderTrait;
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractCartRoute extends AbstractRoute {
-	use DraftOrderTrait;
-
 	/**
 	 * Schema class for this route's response.
 	 *
@@ -113,21 +110,6 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		wc()->cart->calculate_fees();
 		wc()->cart->calculate_shipping();
 		wc()->cart->calculate_totals();
-	}
-
-	/**
-	 * If there is a draft order, releases stock.
-	 *
-	 * @return void
-	 */
-	protected function maybe_release_stock() {
-		$draft_order_id = $this->get_draft_order_id();
-
-		if ( ! $draft_order_id ) {
-			return;
-		}
-
-		wc_release_stock_for_order( $draft_order_id );
 	}
 
 	/**

--- a/src/StoreApi/Routes/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/AbstractCartRoute.php
@@ -1,9 +1,10 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\AbstractSchema;
 use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\DraftOrderTrait;
 
 /**
  * Abstract Cart Route
@@ -11,6 +12,8 @@ use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractCartRoute extends AbstractRoute {
+	use DraftOrderTrait;
+
 	/**
 	 * Schema class for this route's response.
 	 *
@@ -118,13 +121,13 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return void
 	 */
 	protected function maybe_release_stock() {
-		$draft_order = wc()->session->get( 'store_api_draft_order', 0 );
+		$draft_order_id = $this->get_draft_order_id();
 
-		if ( ! $draft_order ) {
+		if ( ! $draft_order_id ) {
 			return;
 		}
 
-		wc_release_stock_for_order( $draft_order );
+		wc_release_stock_for_order( $draft_order_id );
 	}
 
 	/**

--- a/src/StoreApi/Routes/CartRemoveItem.php
+++ b/src/StoreApi/Routes/CartRemoveItem.php
@@ -1,12 +1,16 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\DraftOrderTrait;
+
 /**
  * CartRemoveItem class.
  *
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartRemoveItem extends AbstractCartRoute {
+	use DraftOrderTrait;
+
 	/**
 	 * Get the path of this REST route.
 	 *
@@ -58,5 +62,20 @@ class CartRemoveItem extends AbstractCartRoute {
 		$this->maybe_release_stock();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+	}
+
+	/**
+	 * If there is a draft order, releases stock.
+	 *
+	 * @return void
+	 */
+	protected function maybe_release_stock() {
+		$draft_order_id = $this->get_draft_order_id();
+
+		if ( ! $draft_order_id ) {
+			return;
+		}
+
+		wc_release_stock_for_order( $draft_order_id );
 	}
 }

--- a/src/StoreApi/Routes/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/CartUpdateCustomer.php
@@ -1,9 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Routes;
 
-use Automattic\WooCommerce\Blocks\StoreApi\Schemas\CartSchema;
-use Automattic\WooCommerce\Blocks\StoreApi\Schemas\BillingAddressSchema;
-use Automattic\WooCommerce\Blocks\StoreApi\Schemas\ShippingAddressSchema;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\DraftOrderTrait;
 
 /**
  * CartUpdateCustomer class.
@@ -13,6 +11,8 @@ use Automattic\WooCommerce\Blocks\StoreApi\Schemas\ShippingAddressSchema;
  * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartUpdateCustomer extends AbstractCartRoute {
+	use DraftOrderTrait;
+
 	/**
 	 * Get the namespace for this route.
 	 *
@@ -128,13 +128,13 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	}
 
 	/**
-	 * If there is a draft order, update customer data there also.
+	 * If there is a draft order, update the customer data within that also so the
+	 * cart and order are kept in sync.
 	 *
 	 * @return void
 	 */
 	protected function maybe_update_order() {
-		$draft_order_id = wc()->session->get( 'store_api_draft_order', 0 );
-		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : false;
+		$draft_order = $this->get_draft_order();
 
 		if ( ! $draft_order ) {
 			return;

--- a/src/StoreApi/Routes/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/CartUpdateCustomer.php
@@ -75,25 +75,27 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		$cart     = $this->cart_controller->get_cart_instance();
-		$billing  = isset( $request['billing_address'] ) ? $request['billing_address'] : [];
-		$shipping = isset( $request['shipping_address'] ) ? $request['shipping_address'] : [];
+		$customer = wc()->customer;
+		$billing  = $request['billing_address'] ?? [];
+		$shipping = $request['shipping_address'] ?? [];
 
 		// If the cart does not need shipping, shipping address is forced to match billing address unless defined.
 		if ( ! $cart->needs_shipping() && ! isset( $request['shipping_address'] ) ) {
-			$shipping = isset( $request['billing_address'] ) ? $request['billing_address'] : [
-				'first_name' => wc()->customer->get_billing_first_name(),
-				'last_name'  => wc()->customer->get_billing_last_name(),
-				'company'    => wc()->customer->get_billing_company(),
-				'address_1'  => wc()->customer->get_billing_address_1(),
-				'address_2'  => wc()->customer->get_billing_address_2(),
-				'city'       => wc()->customer->get_billing_city(),
-				'state'      => wc()->customer->get_billing_state(),
-				'postcode'   => wc()->customer->get_billing_postcode(),
-				'country'    => wc()->customer->get_billing_country(),
-				'phone'      => wc()->customer->get_billing_phone(),
+			$shipping = $request['billing_address'] ?? [
+				'first_name' => $customer->get_billing_first_name(),
+				'last_name'  => $customer->get_billing_last_name(),
+				'company'    => $customer->get_billing_company(),
+				'address_1'  => $customer->get_billing_address_1(),
+				'address_2'  => $customer->get_billing_address_2(),
+				'city'       => $customer->get_billing_city(),
+				'state'      => $customer->get_billing_state(),
+				'postcode'   => $customer->get_billing_postcode(),
+				'country'    => $customer->get_billing_country(),
+				'phone'      => $customer->get_billing_phone(),
 			];
 		}
-		wc()->customer->set_props(
+
+		$customer->set_props(
 			array(
 				'billing_first_name'  => $billing['first_name'] ?? null,
 				'billing_last_name'   => $billing['last_name'] ?? null,
@@ -119,10 +121,18 @@ class CartUpdateCustomer extends AbstractCartRoute {
 			)
 		);
 
-		wc()->customer->save();
+		/**
+		 * Fires when the Checkout Block/Store API updates a customer from the API request data.
+		 *
+		 * @param \WC_Customer $order Order object.
+		 * @param \WP_REST_Request $request Full details about the request.
+		 */
+		do_action( 'woocommerce_blocks_cart_update_customer_from_request', $customer, $request );
+
+		$customer->save();
 
 		$this->calculate_totals();
-		$this->maybe_update_order();
+		$this->maybe_update_order_from_customer();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
 	}
@@ -133,7 +143,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 *
 	 * @return void
 	 */
-	protected function maybe_update_order() {
+	protected function maybe_update_order_from_customer() {
 		$draft_order = $this->get_draft_order();
 
 		if ( ! $draft_order ) {

--- a/src/StoreApi/Routes/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/CartUpdateCustomer.php
@@ -75,27 +75,25 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		$cart     = $this->cart_controller->get_cart_instance();
-		$customer = wc()->customer;
-		$billing  = $request['billing_address'] ?? [];
-		$shipping = $request['shipping_address'] ?? [];
+		$billing  = isset( $request['billing_address'] ) ? $request['billing_address'] : [];
+		$shipping = isset( $request['shipping_address'] ) ? $request['shipping_address'] : [];
 
 		// If the cart does not need shipping, shipping address is forced to match billing address unless defined.
 		if ( ! $cart->needs_shipping() && ! isset( $request['shipping_address'] ) ) {
-			$shipping = $request['billing_address'] ?? [
-				'first_name' => $customer->get_billing_first_name(),
-				'last_name'  => $customer->get_billing_last_name(),
-				'company'    => $customer->get_billing_company(),
-				'address_1'  => $customer->get_billing_address_1(),
-				'address_2'  => $customer->get_billing_address_2(),
-				'city'       => $customer->get_billing_city(),
-				'state'      => $customer->get_billing_state(),
-				'postcode'   => $customer->get_billing_postcode(),
-				'country'    => $customer->get_billing_country(),
-				'phone'      => $customer->get_billing_phone(),
+			$shipping = isset( $request['billing_address'] ) ? $request['billing_address'] : [
+				'first_name' => wc()->customer->get_billing_first_name(),
+				'last_name'  => wc()->customer->get_billing_last_name(),
+				'company'    => wc()->customer->get_billing_company(),
+				'address_1'  => wc()->customer->get_billing_address_1(),
+				'address_2'  => wc()->customer->get_billing_address_2(),
+				'city'       => wc()->customer->get_billing_city(),
+				'state'      => wc()->customer->get_billing_state(),
+				'postcode'   => wc()->customer->get_billing_postcode(),
+				'country'    => wc()->customer->get_billing_country(),
+				'phone'      => wc()->customer->get_billing_phone(),
 			];
 		}
-
-		$customer->set_props(
+		wc()->customer->set_props(
 			array(
 				'billing_first_name'  => $billing['first_name'] ?? null,
 				'billing_last_name'   => $billing['last_name'] ?? null,
@@ -121,18 +119,10 @@ class CartUpdateCustomer extends AbstractCartRoute {
 			)
 		);
 
-		/**
-		 * Fires when the Checkout Block/Store API updates a customer from the API request data.
-		 *
-		 * @param \WC_Customer $order Order object.
-		 * @param \WP_REST_Request $request Full details about the request.
-		 */
-		do_action( 'woocommerce_blocks_cart_update_customer_from_request', $customer, $request );
-
-		$customer->save();
+		wc()->customer->save();
 
 		$this->calculate_totals();
-		$this->maybe_update_order_from_customer();
+		$this->maybe_update_order();
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
 	}
@@ -143,7 +133,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 *
 	 * @return void
 	 */
-	protected function maybe_update_order_from_customer() {
+	protected function maybe_update_order() {
 		$draft_order = $this->get_draft_order();
 
 		if ( ! $draft_order ) {

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -40,14 +40,14 @@ class RoutesController {
 	/**
 	 * Get a route class instance.
 	 *
-	 * @throws Exception If the schema does not exist.
+	 * @throws \Exception If the schema does not exist.
 	 *
 	 * @param string $name Name of schema.
 	 * @return AbstractRoute
 	 */
 	public function get( $name ) {
 		if ( ! isset( $this->routes[ $name ] ) ) {
-			throw new Exception( $name . ' route does not exist' );
+			throw new \Exception( $name . ' route does not exist' );
 		}
 		return $this->routes[ $name ];
 	}

--- a/src/StoreApi/Schemas/CartItemSchema.php
+++ b/src/StoreApi/Schemas/CartItemSchema.php
@@ -1,8 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi\Schemas;
 
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
-
 /**
  * CartItemSchema class.
  *
@@ -10,6 +10,8 @@ use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
  * @since 2.5.0
  */
 class CartItemSchema extends ProductSchema {
+	use DraftOrderTrait;
+
 	/**
 	 * The schema item name.
 	 *
@@ -374,9 +376,8 @@ class CartItemSchema extends ProductSchema {
 			return null;
 		}
 
-		$draft_order    = wc()->session->get( 'store_api_draft_order', 0 );
 		$reserve_stock  = new ReserveStock();
-		$reserved_stock = $reserve_stock->get_reserved_stock( $product, $draft_order );
+		$reserved_stock = $reserve_stock->get_reserved_stock( $product, $this->get_draft_order_id() );
 
 		return $product->get_stock_quantity() - $reserved_stock;
 	}

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
 
 use Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException;
+use Automattic\WooCommerce\Blocks\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\NoticeHandler;
 use Automattic\WooCommerce\Blocks\Utils\ArrayUtils;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
@@ -15,6 +16,8 @@ use WP_Error;
  * @since 2.5.0
  */
 class CartController {
+	use DraftOrderTrait;
+
 	/**
 	 * Makes the cart and sessions available to a route by loading them from core.
 	 */
@@ -963,8 +966,7 @@ class CartController {
 	 */
 	protected function get_remaining_stock_for_product( $product ) {
 		$reserve_stock = new ReserveStock();
-		$draft_order   = wc()->session->get( 'store_api_draft_order', 0 );
-		$qty_reserved  = $reserve_stock->get_reserved_stock( $product, $draft_order );
+		$qty_reserved  = $reserve_stock->get_reserved_stock( $product, $this->get_draft_order_id() );
 
 		return $product->get_stock_quantity() - $qty_reserved;
 	}

--- a/src/StoreApi/Utilities/DraftOrderTrait.php
+++ b/src/StoreApi/Utilities/DraftOrderTrait.php
@@ -1,0 +1,64 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\StoreApi\Utilities;
+
+/**
+ * DraftOrderTrait
+ *
+ * Shared functionality for getting and setting draft order IDs from session.
+ */
+trait DraftOrderTrait {
+	/**
+	 * Gets draft order data from the customer session.
+	 *
+	 * @return integer
+	 */
+	protected function get_draft_order_id() {
+		return wc()->session->get( 'store_api_draft_order', 0 );
+	}
+
+	/**
+	 * Updates draft order data in the customer session.
+	 *
+	 * @param integer $order_id Draft order ID.
+	 */
+	protected function set_draft_order_id( $order_id ) {
+		wc()->session->set( 'store_api_draft_order', $order_id );
+	}
+
+	/**
+	 * Uses the draft order ID to return an order object, if valid.
+	 *
+	 * @return \WC_Order|null;
+	 */
+	protected function get_draft_order() {
+		$draft_order_id = $this->get_draft_order_id();
+		$draft_order    = $draft_order_id ? wc_get_order( $draft_order_id ) : false;
+
+		return $this->is_valid_draft_order( $draft_order ) ? $draft_order : null;
+	}
+
+	/**
+	 * Whether the passed argument is a draft order or an order that is
+	 * pending/failed and the cart hasn't changed.
+	 *
+	 * @param \WC_Order $order_object Order object to check.
+	 * @return boolean Whether the order is valid as a draft order.
+	 */
+	protected function is_valid_draft_order( $order_object ) {
+		if ( ! $order_object instanceof \WC_Order ) {
+			return false;
+		}
+
+		// Draft orders are okay.
+		if ( $order_object->has_status( 'checkout-draft' ) ) {
+			return true;
+		}
+
+		// Pending and failed orders can be retried if the cart hasn't changed.
+		if ( $order_object->needs_payment() && $order_object->has_cart_hash( wc()->cart->get_cart_hash() ) ) {
+			return true;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
Moves draft order handling (order ID and order object lookup + validation) to a shared trait called `DraftOrderTrait`. This allows Store API routes that require the draft order (to lookup data or do updates to it) to use the same shared code instead of implementing session handling online.

## Testing

Smoke test a new order to ensure this is still functional.

API routes have test coverage so confirm tests pass.

## Changelog

> Refactor shared draft order handling in StoreAPI