### PR TITLE
Add missing Exception use statement in RoutesController

### DIFF
--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -1,9 +1,10 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\StoreApi;
 
-use Routes\AbstractRoute;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\OrderController;
+use Exception;
+use Routes\AbstractRoute;
 
 /**
  * RoutesController class.


### PR DESCRIPTION
A small fix. We're missing a `use` statement for Exception which would lead to the wrong error being thrown. I don't think this requires special testing because it's just a syntax issue.