### PR TITLE
Fix WC templates loading for WP 5.9 without Gutenberg plugin

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -153,7 +153,10 @@ class BlockTemplatesController {
 	 * @return array
 	 */
 	public function add_block_templates( $query_result, $query, $template_type ) {
-		if ( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() ) {
+		if (
+			( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) &&
+			( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() )
+		) {
 			return $query_result;
 		}
 
@@ -406,7 +409,11 @@ class BlockTemplatesController {
 	 * Renders the default block template from Woo Blocks if no theme templates exist.
 	 */
 	public function render_block_template() {
-		if ( is_embed() || ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() ) {
+		if (
+			is_embed() ||
+			( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) &&
+			( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Modified to use an additional check from Core as well as Gutenberg when determining if we are able to add WC block templates. This is so that it's compatible with 5.9 _without_ needing Gutenberg installed.

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5336

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Check out this branch
2. Install WordPress 5.9 beta1 by following [these instructions](https://wordpress.org/news/2021/11/wordpress-5-9-beta-1/)
3. Install a Block Theme such as [TT1](https://en-gb.wordpress.org/themes/tt1-blocks/)
4. Go to `/wp-includes/themes.php` and check at the bottom of the file if you have the function `wp_is_block_template_theme`. If you do, please duplicate this function and name this `wp_is_block_theme`. This is the function name that Core will be using as seen [here](https://github.com/WordPress/wordpress-develop/pull/2014).
5. Go to the URL `/wp-admin/site-editor.php?postType=wp_template` and check that the WC templates are loading.
6. Now install and activate the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
7. Reload `/wp-admin/site-editor.php?postType=wp_template` and check that the WC templates are still loading.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [x] See steps below.

1. Make sure you have WP 5.9 or above.
2. Install a Block Theme such as [TT1](https://en-gb.wordpress.org/themes/tt1-blocks/).
3. Go to the URL `/wp-admin/site-editor.php?postType=wp_template` and check that the WC templates are loading.

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: WooCommerce block templates loading for WP 5.9 without Gutenberg plugin
