### PR TITLE
Wait until carts load before calling `canMakePayment`

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -106,7 +106,7 @@ export const defaultCartData: StoreCart = {
 	cartNeedsShipping: true,
 	cartItemErrors: EMPTY_CART_ITEM_ERRORS,
 	cartTotals: defaultCartTotals,
-	cartIsLoading: true,
+	cartIsLoading: false,
 	cartErrors: EMPTY_CART_ERRORS,
 	billingAddress: defaultBillingAddress,
 	shippingAddress: defaultShippingAddress,

--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -106,7 +106,7 @@ export const defaultCartData: StoreCart = {
 	cartNeedsShipping: true,
 	cartItemErrors: EMPTY_CART_ITEM_ERRORS,
 	cartTotals: defaultCartTotals,
-	cartIsLoading: false,
+	cartIsLoading: true,
 	cartErrors: EMPTY_CART_ERRORS,
 	billingAddress: defaultBillingAddress,
 	shippingAddress: defaultShippingAddress,

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts
@@ -53,7 +53,12 @@ const usePaymentMethodRegistration = (
 	const selectedShippingMethods = useShallowEqual( selectedRates );
 	const paymentMethodsOrder = useShallowEqual( paymentMethodsSortOrder );
 	const cart = useStoreCart();
-	const { cartTotals, cartNeedsShipping, paymentRequirements } = cart;
+	const {
+		cartTotals,
+		cartIsLoading,
+		cartNeedsShipping,
+		paymentRequirements,
+	} = cart;
 	const canPayArgument = useRef( {
 		cart,
 		cartTotals,
@@ -173,12 +178,15 @@ const usePaymentMethodRegistration = (
 	// shipping methods, cart or the billing data change.
 	// Some payment methods (e.g. COD) can be disabled for specific shipping methods.
 	useEffect( () => {
-		debouncedRefreshCanMakePayments();
+		if ( ! cartIsLoading ) {
+			debouncedRefreshCanMakePayments();
+		}
 	}, [
 		debouncedRefreshCanMakePayments,
 		cart,
 		selectedShippingMethods,
 		billingData,
+		cartIsLoading,
 	] );
 
 	return isInitialized;

--- a/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { previewCart } from '@woocommerce/resource-previews';
+import { dispatch } from '@wordpress/data';
+import { CART_STORE_KEY as storeKey } from '@woocommerce/block-data';
+import { default as fetchMock } from 'jest-fetch-mock';
 import {
 	registerPaymentMethod,
 	__experimentalDeRegisterPaymentMethod,
@@ -14,17 +18,8 @@ import {
 /**
  * Internal dependencies
  */
-import * as useStoreCartHook from '../../../../base/context/hooks/cart/use-store-cart';
-
-// Somewhere in your test case or test suite
-useStoreCartHook.useStoreCart = jest
-	.fn()
-	.mockReturnValue( useStoreCartHook.defaultCartData );
-
-/**
- * Internal dependencies
- */
 import PaymentMethods from '../payment-methods';
+import { defaultCartState } from '../../../../data/default-states';
 
 jest.mock( '../saved-payment-method-options', () => ( { onChange } ) => {
 	return (
@@ -73,6 +68,22 @@ const resetMockPaymentMethods = () => {
 };
 
 describe( 'PaymentMethods', () => {
+	beforeEach( () => {
+		fetchMock.mockResponse( ( req ) => {
+			if ( req.url.match( /wc\/store\/cart/ ) ) {
+				return Promise.resolve( JSON.stringify( previewCart ) );
+			}
+			return Promise.resolve( '' );
+		} );
+		// need to clear the store resolution state between tests.
+		dispatch( storeKey ).invalidateResolutionForStore();
+		dispatch( storeKey ).receiveCart( defaultCartState.cartData );
+	} );
+
+	afterEach( () => {
+		fetchMock.resetMocks();
+	} );
+
 	test( 'should show no payment methods component when there are no payment methods', async () => {
 		render(
 			<PaymentMethodDataProvider>
@@ -88,6 +99,8 @@ describe( 'PaymentMethods', () => {
 			// creates an extra `div` with the notice contents used for a11y.
 			expect( noPaymentMethods.length ).toBeGreaterThanOrEqual( 1 );
 		} );
+		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
+		expect( console ).toHaveWarned();
 	} );
 
 	test( 'selecting new payment method', async () => {


### PR DESCRIPTION
This PR fixes a new introduced issue with payment methods.

Recently, we updated the list of things we pass to payment methods `canMakePayment`, this resulted in us calling `canMakePayment` too many times so we debounced all calls to `canMakePayment` in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pul/4776

Debouncing resulted in `canMakePayment` initial call being delayed by 500ms, something we didn't wish to do. Having that delay broke our unit tests around payment methods. That was only visible once we updated our `react-testing-library` versions.

We changed that by calling the debounced `canMakePayment` directly (via `leading: true`), so it's not called at 0ms and at each 500ms max.

This fixed the broken tests, but introduced a new issue with actual payment methods that were reaching to an empty `cart` to initiate, and would produce an error because `cart` was missing currency data.

![image](https://user-images.githubusercontent.com/6165348/145195536-9f61807a-6b9f-4c37-9e40-e0fe426a4ab5.png)

In this PR, we delay the initial call for the debounced `canMakePayment` until cart is done loading, we also only call it when cart isn't loading.

I also updated the cart data in tests to use previewData, not defaultData. `defaultData` is meant to be used as a placeholder until we either load `previewData` or real data, therefore, it would have `isCartLoading` as true.

### Testing steps

1. Enable stripe express payment methods.
2. Load cart/checkout, express payments should load without an error.