### PR TITLE
Add error message for fetch errors on checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ project.properties
 .sublimelinterrc
 
 # Grunt
-node_modules/
+/node_modules/
 none
 
 # Sass

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ project.properties
 .sublimelinterrc
 
 # Grunt
-/node_modules/
+node_modules/
 none
 
 # Sass

--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import triggerFetch from '@wordpress/api-fetch';
 import {
 	useEffect,
@@ -211,34 +211,51 @@ const CheckoutProcessor = () => {
 				}
 				return response.json();
 			} )
-			.then( ( response ) => {
-				dispatchActions.setAfterProcessing( response );
+			.then( ( responseJson ) => {
+				dispatchActions.setAfterProcessing( responseJson );
 				setIsProcessingOrder( false );
 			} )
-			.catch( ( fetchResponse ) => {
-				processCheckoutResponseHeaders(
-					fetchResponse.headers,
-					dispatchActions
+			.catch( ( errorResponse ) => {
+				let errorNotice = sprintf(
+					// Translators: %s Error text.
+					__(
+						'Error: %s Please try placing your order again.',
+						'woo-gutenberg-products-block'
+					),
+					errorResponse?.message ??
+						__(
+							'Something went wrong.',
+							'woo-gutenberg-products-block'
+						)
 				);
-				fetchResponse.json().then( ( response ) => {
-					// If updated cart state was returned, update the store.
-					if ( response.data?.cart ) {
-						receiveCart( response.data.cart );
+
+				try {
+					if ( errorResponse?.headers ) {
+						processCheckoutResponseHeaders(
+							errorResponse.headers,
+							dispatchActions
+						);
 					}
-					addErrorNotice( formatStoreApiErrorMessage( response ), {
-						id: 'checkout',
-					} );
-					response.additional_errors?.forEach?.(
-						( additionalError ) => {
-							addErrorNotice( additionalError.message, {
-								id: additionalError.error_code,
-							} );
+					// This attempts to parse a JSON error response where the status code was 4xx/5xx.
+					errorResponse.json().then( ( response ) => {
+						// If updated cart state was returned, update the store.
+						if ( response.data?.cart ) {
+							receiveCart( response.data.cart );
 						}
-					);
-					dispatchActions.setHasError( true );
-					dispatchActions.setAfterProcessing( response );
-					setIsProcessingOrder( false );
-				} );
+						errorNotice = formatStoreApiErrorMessage( response );
+						response.additional_errors?.forEach?.(
+							( additionalError ) => {
+								addErrorNotice( additionalError.message, {
+									id: additionalError.error_code,
+								} );
+							}
+						);
+						dispatchActions.setAfterProcessing( response );
+					} );
+				} catch {}
+				dispatchActions.setHasError( true );
+				setIsProcessingOrder( false );
+				addErrorNotice( errorNotice, { id: 'checkout' } );
 			} );
 	}, [
 		isProcessingOrder,

--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.js
@@ -219,7 +219,7 @@ const CheckoutProcessor = () => {
 				let errorNotice = sprintf(
 					// Translators: %s Error text.
 					__(
-						'Error: %s Please try placing your order again.',
+						'Something went wrong. %s Please try placing your order again.',
 						'woo-gutenberg-products-block'
 					),
 					errorResponse?.message ??

--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.js
@@ -216,19 +216,6 @@ const CheckoutProcessor = () => {
 				setIsProcessingOrder( false );
 			} )
 			.catch( ( errorResponse ) => {
-				let errorNotice = sprintf(
-					// Translators: %s Error text.
-					__(
-						'Something went wrong. %s Please try placing your order again.',
-						'woo-gutenberg-products-block'
-					),
-					errorResponse?.message ??
-						__(
-							'Something went wrong.',
-							'woo-gutenberg-products-block'
-						)
-				);
-
 				try {
 					if ( errorResponse?.headers ) {
 						processCheckoutResponseHeaders(
@@ -242,8 +229,11 @@ const CheckoutProcessor = () => {
 						if ( response.data?.cart ) {
 							receiveCart( response.data.cart );
 						}
-						errorNotice = formatStoreApiErrorMessage( response );
-						response.additional_errors?.forEach?.(
+						addErrorNotice(
+							formatStoreApiErrorMessage( response ),
+							{ id: 'checkout' }
+						);
+						response?.additional_errors?.forEach?.(
 							( additionalError ) => {
 								addErrorNotice( additionalError.message, {
 									id: additionalError.error_code,
@@ -252,10 +242,25 @@ const CheckoutProcessor = () => {
 						);
 						dispatchActions.setAfterProcessing( response );
 					} );
-				} catch {}
+				} catch {
+					addErrorNotice(
+						sprintf(
+							// Translators: %s Error text.
+							__(
+								'%s Please try placing your order again.',
+								'woo-gutenberg-products-block'
+							),
+							errorResponse?.message ??
+								__(
+									'Something went wrong.',
+									'woo-gutenberg-products-block'
+								)
+						),
+						{ id: 'checkout' }
+					);
+				}
 				dispatchActions.setHasError( true );
 				setIsProcessingOrder( false );
-				addErrorNotice( errorNotice, { id: 'checkout' } );
 			} );
 	}, [
 		isProcessingOrder,


### PR DESCRIPTION
Adds handling for network errors during the request to `/wc/store/checkout`. Currently it handles API errors (4xx/5xx) but does not factor in other errors like failed requests and offline browsers.

Fixes #4894

### Screenshots

In offline mode, this is now shown:

![Screenshot 2021-12-08 at 14 37 51](https://user-images.githubusercontent.com/90977/145229493-b45dfb47-9416-4822-a535-f106142346e5.png)

### Testing

How to test the changes in this Pull Request:

1. Go to checkout and open network tools
2. Place an order using an invalid postcode so that an error is returned. Confirm postcode error is shown.
3. Right click the checkout/ request and block it (I used firefox)
4. Place order again and it should give you a network error

### User Facing Testing

1. Confirm that you can placing an order without inputting an address shows an error notice at the top of the checkout page
2. Confirm that you can place an order successfully with a valid address

### Changelog

> Add error handling for network errors during checkout.
