### PR TITLE
Fix reverting WC templates

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -55,7 +55,7 @@ class BlockTemplatesController {
 	 */
 	protected function init() {
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
-		add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
+		add_filter( 'pre_get_block_file_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 		add_filter( 'get_block_templates', array( $this, 'add_block_templates' ), 10, 3 );
 	}
 
@@ -82,24 +82,24 @@ class BlockTemplatesController {
 		list( , $slug ) = $template_name_parts;
 
 		// Remove the filter at this point because if we don't then this function will infinite loop.
-		remove_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
+		remove_filter( 'pre_get_block_file_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 
 		// Check if the theme has a saved version of this template before falling back to the woo one. Please note how
 		// the slug has not been modified at this point, we're still using the default one passed to this hook.
 		$maybe_template = gutenberg_get_block_template( $id, $template_type );
 		if ( null !== $maybe_template ) {
-			add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
+			add_filter( 'pre_get_block_file_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 			return $maybe_template;
 		}
 
 		// Theme-based template didn't exist, try switching the theme to woocommerce and try again. This function has
 		// been unhooked so won't run again.
-		add_filter( 'get_block_template', array( $this, 'get_single_block_template' ), 10, 3 );
+		add_filter( 'get_block_file_template', array( $this, 'get_single_block_template' ), 10, 3 );
 		$maybe_template = gutenberg_get_block_template( 'woocommerce//' . $slug, $template_type );
 
 		// Re-hook this function, it was only unhooked to stop recursion.
-		add_filter( 'pre_get_block_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
-		remove_filter( 'get_block_template', array( $this, 'get_single_block_template' ), 10, 3 );
+		add_filter( 'pre_get_block_file_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
+		remove_filter( 'get_block_file_template', array( $this, 'get_single_block_template' ), 10, 3 );
 		if ( null !== $maybe_template ) {
 			return $maybe_template;
 		}


### PR DESCRIPTION
Fixes #5272.

We were hooking into the [`get_block_template()` function](https://github.com/WordPress/wordpress-develop/blob/8697aee5f9d834c1d7135524c7f13dc3c96f4d85/src/wp-includes/block-template-utils.php#L750), but when reverting a template, the function that is called is [`get_block_file_template()`](https://github.com/WordPress/wordpress-develop/blob/8697aee5f9d834c1d7135524c7f13dc3c96f4d85/src/wp-includes/block-template-utils.php#L821). In fact, `get_block_template` internally calls `get_block_file_template`, so moving our hooks into the latter would fix the issue and it shouldn't introduce any regressions. This PR implements that.

### Manual Testing

1. With WC 6.0 or later, Gutenberg and a block theme installed, go to Appearance > Editor.
2. Go to the Templates page and edit one of the WooCommerce templates (ie: Single Product Page).
3. In the frontend, verify the changes you just saved are applied.
4. Go back to the Templates page and press on _Clear Customizations_ of the template you just edited.
5. Verify there is no error and the changes have been reverted in the frontend.
6. Repeat the steps above with WP 5.9 beta without Gutenberg enabled.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Fix error when reverting WooCommerce templates.
