### PR TITLE
Introduce 2 new hooks in Customer Update Route

### DIFF
--- a/bin/hook-docs/data/actions.json
+++ b/bin/hook-docs/data/actions.json
@@ -62,6 +62,54 @@
             }
         },
         {
+            "name": "woocommerce_after_main_content",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Hook: woocommerce_after_main_content.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_after_main_content",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Woocommerce_after_main_content hook.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_after_shop_loop",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Hook: woocommerce_after_shop_loop.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_pagination - 10"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
             "name": "woocommerce_applied_coupon",
             "file": "StoreApi/Utilities/CartController.php",
             "type": "action",
@@ -82,13 +130,90 @@
             }
         },
         {
-            "name": "woocommerce_blocks_cart_enqueue_data",
-            "file": "BlockTypes/Cart.php",
+            "name": "woocommerce_archive_description",
+            "file": "BlockTypes/LegacyTemplate.php",
             "type": "action",
             "doc": {
-                "description": "Fires after cart block data is registered.",
+                "description": "Hook: woocommerce_archive_description.",
                 "long_description": "",
-                "tags": [],
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_taxonomy_archive_description - 10"
+                    },
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_product_archive_description - 10"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_before_main_content",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Woocommerce_before_main_content hook.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)"
+                    },
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_breadcrumb - 20"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_before_main_content",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Hook: woocommerce_before_main_content.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)"
+                    },
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_breadcrumb - 20"
+                    },
+                    {
+                        "name": "hooked",
+                        "content": "WC_Structured_Data::generate_website_data() - 30"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_before_shop_loop",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Hook: woocommerce_before_shop_loop.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_output_all_notices - 10"
+                    },
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_result_count - 20"
+                    },
+                    {
+                        "name": "hooked",
+                        "content": "woocommerce_catalog_ordering - 30"
+                    }
+                ],
                 "long_description_html": ""
             }
         },
@@ -100,6 +225,81 @@
                 "description": "Fires after cart block data is registered.",
                 "long_description": "",
                 "tags": [],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_blocks_cart_enqueue_data",
+            "file": "BlockTypes/Cart.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires after cart block data is registered.",
+                "long_description": "",
+                "tags": [],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_blocks_cart_update_customer_from_request",
+            "file": "StoreApi/Routes/CartUpdateCustomer.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires when the Checkout Block/Store API updates a customer from the API request data.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "Customer object.",
+                        "types": [
+                            "\\WC_Customer"
+                        ],
+                        "variable": "$customer"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Full details about the request.",
+                        "types": [
+                            "\\WP_REST_Request"
+                        ],
+                        "variable": "$request"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_blocks_cart_update_order_from_customer_request",
+            "file": "StoreApi/Routes/CartUpdateCustomer.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires when the Checkout Block/Store API updates an existing draft order from customer data.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "Order object.",
+                        "types": [
+                            "\\WC_Order"
+                        ],
+                        "variable": "$draft_order"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Customer object.",
+                        "types": [
+                            "\\WC_Customer"
+                        ],
+                        "variable": "$customer"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Full details about the request.",
+                        "types": [
+                            "\\WP_REST_Request"
+                        ],
+                        "variable": "$request"
+                    }
+                ],
                 "long_description_html": ""
             }
         },
@@ -319,6 +519,22 @@
             }
         },
         {
+            "name": "woocommerce_no_products_found",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Hook: woocommerce_no_products_found.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "hooked",
+                        "content": "wc_no_products_found - 10"
+                    }
+                ],
+                "long_description_html": ""
+            }
+        },
+        {
             "name": "woocommerce_register_post",
             "file": "Domain/Services/CreateAccount.php",
             "type": "action",
@@ -390,6 +606,17 @@
                         "variable": "$payment_result"
                     }
                 ],
+                "long_description_html": ""
+            }
+        },
+        {
+            "name": "woocommerce_shop_loop",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "action",
+            "doc": {
+                "description": "Hook: woocommerce_shop_loop.",
+                "long_description": "",
+                "tags": [],
                 "long_description_html": ""
             }
         },

--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -840,6 +840,17 @@
             }
         },
         {
+            "name": "woocommerce_show_page_title",
+            "file": "BlockTypes/LegacyTemplate.php",
+            "type": "filter",
+            "doc": {
+                "description": "",
+                "long_description": "",
+                "tags": [],
+                "long_description_html": ""
+            }
+        },
+        {
             "name": "woocommerce_store_api_disable_nonce_check",
             "file": "StoreApi/Routes/AbstractCartRoute.php",
             "type": "filter",

--- a/docs/extensibility/actions.md
+++ b/docs/extensibility/actions.md
@@ -8,9 +8,18 @@
 
 
  - [woocommerce_add_to_cart](#woocommerce_add_to_cart)
+ - [woocommerce_after_main_content](#woocommerce_after_main_content)
+ - [woocommerce_after_main_content](#woocommerce_after_main_content-1)
+ - [woocommerce_after_shop_loop](#woocommerce_after_shop_loop)
  - [woocommerce_applied_coupon](#woocommerce_applied_coupon)
+ - [woocommerce_archive_description](#woocommerce_archive_description)
+ - [woocommerce_before_main_content](#woocommerce_before_main_content)
+ - [woocommerce_before_main_content](#woocommerce_before_main_content-1)
+ - [woocommerce_before_shop_loop](#woocommerce_before_shop_loop)
  - [woocommerce_blocks_cart_enqueue_data](#woocommerce_blocks_cart_enqueue_data)
  - [woocommerce_blocks_cart_enqueue_data](#woocommerce_blocks_cart_enqueue_data-1)
+ - [woocommerce_blocks_cart_update_customer_from_request](#woocommerce_blocks_cart_update_customer_from_request)
+ - [woocommerce_blocks_cart_update_order_from_customer_request](#woocommerce_blocks_cart_update_order_from_customer_request)
  - [woocommerce_blocks_checkout_enqueue_data](#woocommerce_blocks_checkout_enqueue_data)
  - [woocommerce_blocks_checkout_order_processed](#woocommerce_blocks_checkout_order_processed)
  - [woocommerce_blocks_checkout_update_order_from_request](#woocommerce_blocks_checkout_update_order_from_request)
@@ -23,8 +32,10 @@
  - [woocommerce_blocks_{$this->registry_identifier}_registration](#woocommerce_blocks_-this--registry_identifier-_registration)
  - [woocommerce_check_cart_items](#woocommerce_check_cart_items)
  - [woocommerce_created_customer](#woocommerce_created_customer)
+ - [woocommerce_no_products_found](#woocommerce_no_products_found)
  - [woocommerce_register_post](#woocommerce_register_post)
  - [woocommerce_rest_checkout_process_payment_with_context](#woocommerce_rest_checkout_process_payment_with_context)
+ - [woocommerce_shop_loop](#woocommerce_shop_loop)
  - [wooocommerce_store_api_validate_add_to_cart](#wooocommerce_store_api_validate_add_to_cart)
  - [wooocommerce_store_api_validate_cart_item](#wooocommerce_store_api_validate_cart_item)
 
@@ -61,6 +72,54 @@ File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartCont
 
 ---
 
+## woocommerce_after_main_content
+
+
+Hook: woocommerce_after_main_content.
+
+```php
+do_action( 'woocommerce_after_main_content' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+
+---
+
+## woocommerce_after_main_content
+
+
+Woocommerce_after_main_content hook.
+
+```php
+do_action( 'woocommerce_after_main_content' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+
+---
+
+## woocommerce_after_shop_loop
+
+
+Hook: woocommerce_after_shop_loop.
+
+```php
+do_action( 'woocommerce_after_shop_loop' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+
+---
+
 ## woocommerce_applied_coupon
 
 
@@ -83,19 +142,67 @@ File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartCont
 
 ---
 
-## woocommerce_blocks_cart_enqueue_data
+## woocommerce_archive_description
 
 
-Fires after cart block data is registered.
+Hook: woocommerce_archive_description.
 
 ```php
-do_action( 'woocommerce_blocks_cart_enqueue_data' )
+do_action( 'woocommerce_archive_description' )
 ```
 
 ### Source
 
 
-File: [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+
+---
+
+## woocommerce_before_main_content
+
+
+Woocommerce_before_main_content hook.
+
+```php
+do_action( 'woocommerce_before_main_content' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+
+---
+
+## woocommerce_before_main_content
+
+
+Hook: woocommerce_before_main_content.
+
+```php
+do_action( 'woocommerce_before_main_content' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+
+---
+
+## woocommerce_before_shop_loop
+
+
+Hook: woocommerce_before_shop_loop.
+
+```php
+do_action( 'woocommerce_before_shop_loop' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -112,6 +219,69 @@ do_action( 'woocommerce_blocks_cart_enqueue_data' )
 
 
 File: [BlockTypes/MiniCart.php](../src/BlockTypes/MiniCart.php)
+
+---
+
+## woocommerce_blocks_cart_enqueue_data
+
+
+Fires after cart block data is registered.
+
+```php
+do_action( 'woocommerce_blocks_cart_enqueue_data' )
+```
+
+### Source
+
+
+File: [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
+
+---
+
+## woocommerce_blocks_cart_update_customer_from_request
+
+
+Fires when the Checkout Block/Store API updates a customer from the API request data.
+
+```php
+do_action( 'woocommerce_blocks_cart_update_customer_from_request', \WC_Customer $customer, \WP_REST_Request $request )
+```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $customer | \WC_Customer | Customer object. |
+| $request | \WP_REST_Request | Full details about the request. |
+
+### Source
+
+
+File: [StoreApi/Routes/CartUpdateCustomer.php](../src/StoreApi/Routes/CartUpdateCustomer.php)
+
+---
+
+## woocommerce_blocks_cart_update_order_from_customer_request
+
+
+Fires when the Checkout Block/Store API updates an existing draft order from customer data.
+
+```php
+do_action( 'woocommerce_blocks_cart_update_order_from_customer_request', \WC_Order $draft_order, \WC_Customer $customer, \WP_REST_Request $request )
+```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $draft_order | \WC_Order | Order object. |
+| $customer | \WC_Customer | Customer object. |
+| $request | \WP_REST_Request | Full details about the request. |
+
+### Source
+
+
+File: [StoreApi/Routes/CartUpdateCustomer.php](../src/StoreApi/Routes/CartUpdateCustomer.php)
 
 ---
 
@@ -391,6 +561,22 @@ File: [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.p
 
 ---
 
+## woocommerce_no_products_found
+
+
+Hook: woocommerce_no_products_found.
+
+```php
+do_action( 'woocommerce_no_products_found' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+
+---
+
 ## woocommerce_register_post
 
 
@@ -444,6 +630,22 @@ do_action_ref_array( 'woocommerce_rest_checkout_process_payment_with_context', [
 
 
 File: [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
+
+---
+
+## woocommerce_shop_loop
+
+
+Hook: woocommerce_shop_loop.
+
+```php
+do_action( 'woocommerce_shop_loop' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 

--- a/docs/extensibility/filters.md
+++ b/docs/extensibility/filters.md
@@ -30,6 +30,7 @@
  - [woocommerce_registration_errors](#woocommerce_registration_errors)
  - [woocommerce_shared_settings](#-woocommerce_shared_settings)
  - [woocommerce_shipping_package_name](#woocommerce_shipping_package_name)
+ - [woocommerce_show_page_title](#woocommerce_show_page_title)
  - [woocommerce_store_api_disable_nonce_check](#woocommerce_store_api_disable_nonce_check)
  - [woocommerce_store_api_product_quantity_limit](#woocommerce_store_api_product_quantity_limit)
  - [woocommerce_variation_option_name](#woocommerce_variation_option_name)
@@ -730,6 +731,22 @@ apply_filters( 'woocommerce_shipping_package_name', string $shipping_package_nam
 
 
 File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+
+---
+
+## woocommerce_show_page_title
+
+
+
+
+```php
+apply_filters( 'woocommerce_show_page_title' )
+```
+
+### Source
+
+
+File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 

--- a/src/StoreApi/Routes/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/CartUpdateCustomer.php
@@ -75,8 +75,8 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
 		$cart     = $this->cart_controller->get_cart_instance();
-		$billing  = isset( $request['billing_address'] ) ? $request['billing_address'] : [];
-		$shipping = isset( $request['shipping_address'] ) ? $request['shipping_address'] : [];
+		$billing  = $request['billing_address'] ?? [];
+		$shipping = $request['shipping_address'] ?? [];
 		$customer = wc()->customer;
 
 		if ( ! $cart->needs_shipping() && ! isset( $request['shipping_address'] ) ) {
@@ -121,7 +121,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 		$customer->save();
 
 		$this->calculate_totals();
-		$this->maybe_update_order_from_customer();
+		$this->maybe_update_order_from_customer( $customer, $request );
 
 		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
 	}
@@ -151,9 +151,10 @@ class CartUpdateCustomer extends AbstractCartRoute {
 	 * If there is a draft order, update the customer data within that also so the
 	 * cart and order are kept in sync.
 	 *
-	 * @return void
+	 * @param \WC_Customer     $customer Customer object.
+	 * @param \WP_REST_Request $request Request object.
 	 */
-	protected function maybe_update_order_from_customer() {
+	protected function maybe_update_order_from_customer( \WC_Customer $customer, \WP_REST_Request $request ) {
 		$draft_order = $this->get_draft_order();
 
 		if ( ! $draft_order ) {
@@ -162,29 +163,38 @@ class CartUpdateCustomer extends AbstractCartRoute {
 
 		$draft_order->set_props(
 			[
-				'billing_first_name'  => wc()->customer->get_billing_first_name(),
-				'billing_last_name'   => wc()->customer->get_billing_last_name(),
-				'billing_company'     => wc()->customer->get_billing_company(),
-				'billing_address_1'   => wc()->customer->get_billing_address_1(),
-				'billing_address_2'   => wc()->customer->get_billing_address_2(),
-				'billing_city'        => wc()->customer->get_billing_city(),
-				'billing_state'       => wc()->customer->get_billing_state(),
-				'billing_postcode'    => wc()->customer->get_billing_postcode(),
-				'billing_country'     => wc()->customer->get_billing_country(),
-				'billing_email'       => wc()->customer->get_billing_email(),
-				'billing_phone'       => wc()->customer->get_billing_phone(),
-				'shipping_first_name' => wc()->customer->get_shipping_first_name(),
-				'shipping_last_name'  => wc()->customer->get_shipping_last_name(),
-				'shipping_company'    => wc()->customer->get_shipping_company(),
-				'shipping_address_1'  => wc()->customer->get_shipping_address_1(),
-				'shipping_address_2'  => wc()->customer->get_shipping_address_2(),
-				'shipping_city'       => wc()->customer->get_shipping_city(),
-				'shipping_state'      => wc()->customer->get_shipping_state(),
-				'shipping_postcode'   => wc()->customer->get_shipping_postcode(),
-				'shipping_country'    => wc()->customer->get_shipping_country(),
-				'shipping_phone'      => wc()->customer->get_shipping_phone(),
+				'billing_first_name'  => $customer->get_billing_first_name(),
+				'billing_last_name'   => $customer->get_billing_last_name(),
+				'billing_company'     => $customer->get_billing_company(),
+				'billing_address_1'   => $customer->get_billing_address_1(),
+				'billing_address_2'   => $customer->get_billing_address_2(),
+				'billing_city'        => $customer->get_billing_city(),
+				'billing_state'       => $customer->get_billing_state(),
+				'billing_postcode'    => $customer->get_billing_postcode(),
+				'billing_country'     => $customer->get_billing_country(),
+				'billing_email'       => $customer->get_billing_email(),
+				'billing_phone'       => $customer->get_billing_phone(),
+				'shipping_first_name' => $customer->get_shipping_first_name(),
+				'shipping_last_name'  => $customer->get_shipping_last_name(),
+				'shipping_company'    => $customer->get_shipping_company(),
+				'shipping_address_1'  => $customer->get_shipping_address_1(),
+				'shipping_address_2'  => $customer->get_shipping_address_2(),
+				'shipping_city'       => $customer->get_shipping_city(),
+				'shipping_state'      => $customer->get_shipping_state(),
+				'shipping_postcode'   => $customer->get_shipping_postcode(),
+				'shipping_country'    => $customer->get_shipping_country(),
+				'shipping_phone'      => $customer->get_shipping_phone(),
 			]
 		);
+
+		/**
+		 * Fires when the Checkout Block/Store API updates an existing draft order from customer data.
+		 *
+		 * @param \WC_Order $draft_order Order object.
+		 * @param \WC_Customer $customer Customer object.
+		 * @param \WP_REST_Request $request Full details about the request.
+		 */
+		do_action( 'woocommerce_blocks_cart_update_order_from_customer_request', $draft_order, $customer, $request );
 
 		$draft_order->save();
 	}


### PR DESCRIPTION
Adds 2 new action hooks to allow vendors to edit order/customer data when customers are updated via the API.

| Hook      | Description | Params | 
| ----------- | ----------- | ----------- |
| `woocommerce_blocks_cart_update_customer_from_request`      | Fires when the Checkout Block/Store API updates a customer from the API request data. | `\WC_Customer $customer`, `\WP_REST_Request $request`       |
| `woocommerce_blocks_cart_update_order_from_customer_request`   | Fires when the Checkout Block/Store API updates an existing draft order from customer data.        | `\WC_Order $draft_order`, `\WC_Customer $customer`, `\WP_REST_Request $request`       |

Fixes #5202

### Testing

No user facing tests. Unit test coverage added to confirm hooks fire.

### Changelog

> StoreAPI - Introduce `woocommerce_blocks_cart_update_customer_from_request` and `woocommerce_blocks_cart_update_order_from_customer_request` hooks in the StoreAPI.
