### PR TITLE
Fix required scripts not loading for WC block templates.

### DIFF
--- a/src/BlockTypes/LegacyTemplate.php
+++ b/src/BlockTypes/LegacyTemplate.php
@@ -34,6 +34,14 @@ class LegacyTemplate extends AbstractDynamicBlock {
 			return;
 		}
 
+		// We need to load the scripts here because when using block templates wp_head() gets run after the block template.
+		// As a result we are trying to enqueue required scripts before we have even registered them.
+		// See here for more information: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447.
+		if ( class_exists( 'WC_Frontend_Scripts' ) ) {
+			$frontend_scripts = new \WC_Frontend_Scripts();
+			$frontend_scripts::load_scripts();
+		}
+
 		$archive_templates = array( 'archive-product', 'taxonomy-product_cat', 'taxonomy-product_tag' );
 
 		if ( 'single-product' === $attributes['template'] ) {


### PR DESCRIPTION
This fixes a problem with WC Core and block templates where we are attempting to enqueue scripts before we've registered them. Meaning they don't get enqueued at all. Read more about this [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447).

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5329

### Testing

### Manual Testing

**Important: Please check both linked issue and ensure you're able to reproduce them.**

How to test the changes in this Pull Request:

1. Checkout this branch
2. Install a Block Theme such as [TT1](https://en-gb.wordpress.org/themes/tt1-blocks/) and the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
3. Load the product page of a variable product.
4. Change some of the options (such as colour) on the variable product and check that the image in the product gallery updates to show the correct image for that variant.
4. Clicking "Add to cart" should successfully add the product to the cart.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.

### Changelog

> Fixed issue with variable products add to cart error, and gallery not updating to show correct product variant image.
