### PR TITLE
Fix: Mini Cart block: Edit template part link doesn't work for themes don't have mini cart template part.

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
  * Mini Cart class.
@@ -172,7 +173,7 @@ class MiniCart extends AbstractBlock {
 
 		$this->asset_data_registry->add(
 			'themeSlug',
-			wp_get_theme()->get_stylesheet(),
+			BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : 'woocommerce',
 			''
 		);
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5314 

This PR checks if the current theme has mini-cart template then returns the correct theme slug, which is used to build the edit template part link in the Inspector setting of the Mini Cart block.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Make sure the current theme doesn't have mini-cart template part file.
2. Add Mini Cart block to a page.
3. Select the block, click on the `Edit template part` link in the sidebar.
4. See site editor loaded with the plugin template part is being edited in the next tab.
5. Add mini-cart template part to the current theme.
6. Add Mini Cart block to a page, select then click on the `Edit template part` link in the sidebar.
7. See site editor loaded with the theme template part is being edited in the next tab.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.
