### PR TITLE
Fix Mini Cart template part link on WP 5.9

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
@@ -150,9 +150,8 @@ const MiniCartBlock = ( {
 						>
 							<ExternalLink
 								href={ addQueryArgs(
-									`${ ADMIN_URL }themes.php`,
+									`${ ADMIN_URL }site-editor.php`,
 									{
-										page: 'gutenberg-edit-site',
 										postId: `${ themeSlug }//mini-cart`,
 										postType: 'wp_template_part',
 									}

--- a/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
@@ -58,7 +58,7 @@ const MiniCartBlock = ( {
 
 	const themeSlug = getSetting( 'themeSlug', '' );
 
-	const isSiteEditorAvailable = getSetting( 'isSiteEditorAvailable', false );
+	const isBlockTheme = getSetting( 'isBlockTheme', false );
 
 	/**
 	 * @todo Replace `getColorClassName` and manual style manipulation with
@@ -139,7 +139,7 @@ const MiniCartBlock = ( {
 						}
 					/>
 				</PanelBody>
-				{ isSiteEditorAvailable &&
+				{ isBlockTheme &&
 					isString( themeSlug ) &&
 					themeSlug.length > 0 && (
 						<PanelBody

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -178,13 +178,13 @@ class MiniCart extends AbstractBlock {
 
 		if ( function_exists( 'wp_is_block_theme' ) ) {
 			$this->asset_data_registry->add(
-				'isSiteEditorAvailable',
+				'isBlockTheme',
 				wp_is_block_theme(),
 				true
 			);
 		} else {
 			$this->asset_data_registry->add(
-				'isSiteEditorAvailable',
+				'isBlockTheme',
 				false,
 				true
 			);

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -176,10 +176,10 @@ class MiniCart extends AbstractBlock {
 			''
 		);
 
-		if ( function_exists( 'gutenberg_experimental_is_site_editor_available' ) ) {
+		if ( function_exists( 'wp_is_block_theme' ) ) {
 			$this->asset_data_registry->add(
 				'isSiteEditorAvailable',
-				gutenberg_experimental_is_site_editor_available(),
+				wp_is_block_theme(),
 				false
 			);
 		} else {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -180,13 +180,13 @@ class MiniCart extends AbstractBlock {
 			$this->asset_data_registry->add(
 				'isSiteEditorAvailable',
 				wp_is_block_theme(),
-				false
+				true
 			);
 		} else {
 			$this->asset_data_registry->add(
 				'isSiteEditorAvailable',
 				false,
-				false
+				true
 			);
 		}
 


### PR DESCRIPTION
Originally mentioned in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5347#pullrequestreview-827560158.

The Mini Cart block link to the template part was not working on WP 5.9 beta 2 when Gutenberg was disabled. This PR fixes that:

* 7d481a58a5eab971f7e1f00723137614da88a390 fixes the link. Instead of `themes.php`, now it's in `site-editor.php`.
* 5a2095553193efbd0bd1254ddf782125028ddb7a replaces `gutenberg_experimental_is_site_editor_available` with `wp_is_block_theme`. Notice they [are equivalent](https://github.com/WordPress/gutenberg/blob/7762302a2aacd1da09d7c848ce009598aca21ef9/lib/global-styles.php#L161-L163), but only the latter is in WP 5.9.
* a5920eef059f50e7e51074d083aade90008a4ad0 adds [protection](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/6bd222805ba1fecab71a520d4da2f087827f8473/src/Assets/AssetDataRegistry.php#L276-L277) against overriding `isSiteEditorAvailable`. I don't think there was any need to remove that protection.
* 2bcc3d0a0ea411de00923022cb258185c6f945d3 renames `isSiteEditorAvailable` to `isBlockTheme` to match the WP function name.

### Manual Testing

How to test the changes in this Pull Request:

1. With the last version of Gutenberg installed.
2. Add Mini Cart block to a page.
3. Select the block, click on the `Edit template part` link in the sidebar.
4. See site editor loaded with the plugin template part.
5. Disable Gutenberg and make sure you are running WP 5.9 beta 2.
6. Repeat steps 2-4.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.
